### PR TITLE
check memory usage of containers post deployment

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -178,7 +178,7 @@ jobs:
                   $fullDeployment = $true
                   Write-Host "Full ARM deployment required as $resourceGroupName not found in subscription."
                 }
-                
+                Write-Host "##vso[task.setvariable variable=deploymentStartTime]$(Get-Date)"
                 Write-Host "##vso[task.setvariable variable=fullDeployment]$fullDeployment"
 
           - task: AzureResourceGroupDeployment@2
@@ -348,3 +348,15 @@ jobs:
               azureSubscription: ${{parameters.subscriptionName}}
               resourceGroup: $(resourceGroupName)
               appService: $(appServiceName)
+
+          - template: metrics-check-template.yml
+            parameters:
+              azureSubscription: ${{ parameters.subscriptionName }}
+              resourceGroup: $(resourceGroupName)
+              containerName: ${{ format('{0}-{1}', variables.containerInstanceNamePrefix,'wkr') }}
+          
+          - template: metrics-check-template.yml
+            parameters:
+              azureSubscription: ${{ parameters.subscriptionName }}
+              resourceGroup: $(resourceGroupName)
+              containerName: ${{ format('{0}-{1}', variables.containerInstanceNamePrefix,'clk') }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
 - name: pipelineDockerCachePath
   value: $(Pipeline.Workspace)/.docker
 - name: debug
-  value: true
+  value: false
 - name: deployOnly
   value: false
 - name: buildCancelled

--- a/metrics-check-template.yml
+++ b/metrics-check-template.yml
@@ -1,0 +1,51 @@
+parameters:
+  - name: azureSubscription
+    type: string
+  - name: resourceGroup
+    type: string
+  - name: containerName
+    type: string
+
+steps:
+  - task: AzurePowerShell@4
+    displayName: Check Memory Usage in ${{ parameters.containerName }}
+    condition: and(succeeded(), eq(variables['buildCancelled'], false))
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: inlineScript
+      azurePowerShellVersion: latestVersion
+      inline: |
+        $fromDateTime = "$(deploymentStartTime)"
+        $toDateTime = Get-Date
+        $container = "${{ parameters.containerName }}"
+        $resourceGroup = "${{ parameters.resourceGroup }}"
+        Write-Host "fromDateTime : $fromDateTime"
+        Write-Host "toDateTime   : $toDateTime"
+
+        $containerResourceId = $(Get-AzContainerGroup -ResourceGroupName $resourceGroup -Name $container).Id
+        $memoryUsage = (Get-AzMetric -ResourceId $containerResourceId `
+                      -TimeGrain 00:01:00 `
+                      -StartTime $fromDateTime `
+                      -EndTime $toDateTime `
+                      -MetricName MemoryUsage 3>&1).Data
+
+        $memoryUsage | Format-Table TimeStamp, Average -AutoSize
+        $avgMemoryUsage = @{ beforeDeployment=$memoryUsage[0].Average 
+                              afterDeployment=$memoryUsage[$memoryUsage.Length -1].Average }
+        $avgMemoryUsage | Format-Table -AutoSize
+
+        if($avgMemoryUsage.beforeDeployment -eq 0){
+          #indicates a new deployment.
+          Write-Host "memoryUsageBeforeDeployment is 0"
+          exit 0
+        }
+        if($avgMemoryUsage.afterDeployment -eq 0){
+          Write-Host "##vso[task.logissue type=error;]Memory Usage after deployment in $($container) is 0!"
+          exit 1
+        }
+        $magnitudeChange = [Math]::Abs([Math]::Floor([Math]::Log10($avgMemoryUsage.afterDeployment)) - [Math]::Floor([Math]::Log10($avgMemoryUsage.beforeDeployment)))
+        if($magnitudeChange -gt 0){
+          Write-Host "##vso[task.logissue type=error;]Memory Usage change after deployment in $($container) is abnormal!"
+          exit 1
+        }
+        exit 0


### PR DESCRIPTION
compare the average memory usage of the clk & wkr containers post deployment.
fail the build if the memory consumption is 0 or if the difference in memory consumption is >20%.

## Context
Automate the process of checking for memory consumption of the containers as indicators of a successful deployment and that the containers are running.

## Changes proposed in this pull request
Check avg memory consumption of clock and worker containers pre & post deployment and 
fail build if there is an abnormal difference in values.

## Guidance to review

## Link to Trello card

https://trello.com/c/DbHkxC5o/2265-spike-azure-apis-and-service-account-for-checking-metrics-post-deployment

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
