### PR TITLE
Replace course study mode and site flow (replace course 3 of 3)

### DIFF
--- a/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module CourseChoices
     module ReplaceChoices
       class BaseController < CandidateInterfaceController
-        before_action :render_404_if_flag_is_inactive
+        before_action :render_404_if_flag_is_inactive, :redirect_to_dashboard_if_no_choices_need_replacing
 
         def pick_choice_to_replace
           if only_one_course_choice_needs_replacing?
@@ -33,6 +33,10 @@ module CandidateInterface
 
         def render_404_if_flag_is_inactive
           render_404 and return unless FeatureFlag.active?('replace_full_or_withdrawn_application_choices')
+        end
+
+        def redirect_to_dashboard_if_no_choices_need_replacing
+          redirect_to candidate_interface_application_complete_path if current_application.course_choices_that_need_replacing.blank?
         end
 
         def only_one_course_choice_needs_replacing?

--- a/app/controllers/candidate_interface/course_choices/replace_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/course_selection_controller.rb
@@ -41,14 +41,14 @@ module CandidateInterface
               @pick_course.course_id,
             )
           elsif @pick_course.single_site?
-            course_option = CourseOption.where(course_id: @pick_course.course.id).first
-            PickCourseOption.new(
-              course_id,
-              course_option.id,
-              current_application,
-              params.fetch(:provider_id),
-              self,
-            ).call
+            @replacement_course_option_id = CourseOption.find(params['course_id']).id
+
+            redirect_to candidate_interface_confirm_replacement_course_choice_path(
+              @course_choice.id,
+              @replacement_course_option_id,
+              provider_id: params['provider_id'],
+              course_id: params['course_id'],
+            )
           else
             redirect_to candidate_interface_replace_course_choice_location_path(
               @course_choice.id,

--- a/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
           @course_choice = current_application.application_choices.find(params['id'])
 
           if @pick_replacement_action.replacement_action == 'replace_location'
-            redirect_to candidate_interface_replace_course_choice_location_path(@course_choice.id)
+            redirect_to candidate_interface_replace_course_choice_update_location_path(@course_choice.id)
           elsif @pick_replacement_action.replacement_action == 'replace_study_mode'
             replacement_course_option_id = @course_choice.course_option.get_alternative_study_mode.id
 

--- a/app/controllers/candidate_interface/course_choices/replace_choices/review_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/review_controller.rb
@@ -14,12 +14,12 @@ module CandidateInterface
 
           if @pick_site.valid?
             @course_choice.update!(course_option_id: @replacement_course_option_id)
-            flash[:success] = 'Your application has been updated.'
+            flash[:success] = 'Your application has been successfully updated.'
 
             redirect_to candidate_interface_application_complete_path
           else
             flash[:warning] = 'Please select a new location.'
-            redirect_to candidate_interface_replace_course_choice_location_path(@course_choice.id)
+            redirect_to candidate_interface_replace_course_choice_update_location_path(@course_choice.id)
           end
         end
       end

--- a/app/controllers/candidate_interface/course_choices/replace_choices/review_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/review_controller.rb
@@ -5,6 +5,11 @@ module CandidateInterface
         def confirm_choice
           @course_choice = current_application.application_choices.find(params['id'])
           @replacement_course_option = CourseOption.find(params['course_option_id'])
+          @single_site_course =  if params['study_mode'].present?
+                                   CourseOption.where(course_id: params['course_id'], study_mode: params['study_mode']).one?
+                                 elsif params['course_id'].present?
+                                   CourseOption.where(course_id: params['course_id']).one?
+                                 end
         end
 
         def update_choice

--- a/app/controllers/candidate_interface/course_choices/replace_choices/site_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/site_selection_controller.rb
@@ -2,9 +2,22 @@ module CandidateInterface
   module CourseChoices
     module ReplaceChoices
       class SiteSelectionController < BaseController
-        def replace_location
+        def new
+          if candidate_has_already_chosen_this_course
+            redirect_to candidate_interface_replace_course_choice_course_path(params['id'], params['provider_id'])
+          else
+            @pick_site = PickSiteForm.new(
+              provider_id: params.fetch(:provider_id),
+              course_id: params.fetch(:course_id),
+              study_mode: params.fetch(:study_mode),
+            )
+          end
+        end
+
+        def update
           @course_choice = current_application.application_choices.find(params['id'])
           @pick_site = create_pick_site_form(@course_choice, @course_choice.course_option.id)
+          @study_mode = params['study_mode']
         end
 
         def validate_location
@@ -12,11 +25,38 @@ module CandidateInterface
           @replacement_course_option_id = params.dig('candidate_interface_pick_site_form', 'course_option_id')
           @pick_site = create_pick_site_form(@course_choice, @replacement_course_option_id)
 
-          if @pick_site.valid?
+          if params['provider_id'].present? && @pick_site.valid?
+            redirect_to candidate_interface_confirm_replacement_course_choice_path(
+              @course_choice.id,
+              @replacement_course_option_id,
+              provider_id: params['provider_id'],
+              course_id: params['course_id'],
+              study_mode: params['study_mode'],
+            )
+          elsif @pick_site.valid?
             redirect_to candidate_interface_confirm_replacement_course_choice_path(@course_choice.id, @replacement_course_option_id)
           else
             flash[:warning] = 'Please select a new location.'
-            redirect_to candidate_interface_replace_course_choice_location_path(@course_choice.id)
+            redirect_to candidate_interface_replace_course_choice_update_location_path(@course_choice.id)
+          end
+        end
+
+      private
+
+        def candidate_has_already_chosen_this_course
+          provider = Provider.find(params.fetch(:provider_id))
+          course = provider.courses.find(params.fetch(:course_id))
+
+          course_already_chosen = current_application
+            .application_choices
+            .includes([:course])
+            .any? { |application_choice| application_choice.course == course }
+
+          if course_already_chosen
+            flash[:warning] = I18n.t!('errors.application_choices.already_added', course_name_and_code: course.name_and_code)
+            true
+          else
+            false
           end
         end
       end

--- a/app/controllers/candidate_interface/course_choices/replace_choices/study_mode_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/study_mode_selection_controller.rb
@@ -1,0 +1,45 @@
+module CandidateInterface
+  module CourseChoices
+    module ReplaceChoices
+      class StudyModeSelectionController < BaseController
+        def new
+          @course_choice = current_application.application_choices.find(params['id'])
+          @pick_study_mode = PickStudyModeForm.new(
+            provider_id: params.fetch(:provider_id),
+            course_id: params.fetch(:course_id),
+          )
+        end
+
+        def create
+          @course_choice = current_application.application_choices.find(params['id'])
+          @pick_study_mode = PickStudyModeForm.new(
+            provider_id: params.fetch(:provider_id),
+            course_id: params.fetch(:course_id),
+            study_mode: params.dig(
+              :candidate_interface_pick_study_mode_form,
+              :study_mode,
+            ),
+          )
+          render :new and return unless @pick_study_mode.valid?
+
+          if @pick_study_mode.single_site_course?
+            PickCourseOption.new(
+              @pick_study_mode.course_id,
+              @pick_study_mode.first_site_id,
+              current_application,
+              params.fetch(:provider_id),
+              self,
+            ).call
+          else
+            redirect_to candidate_interface_replace_course_choice_location_path(
+              @course_choice.id,
+              @pick_study_mode.provider_id,
+              @pick_study_mode.course_id,
+              @pick_study_mode.study_mode,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/course_choices/replace_choices/study_mode_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/study_mode_selection_controller.rb
@@ -23,13 +23,15 @@ module CandidateInterface
           render :new and return unless @pick_study_mode.valid?
 
           if @pick_study_mode.single_site_course?
-            PickCourseOption.new(
-              @pick_study_mode.course_id,
-              @pick_study_mode.first_site_id,
-              current_application,
-              params.fetch(:provider_id),
-              self,
-            ).call
+            @replacement_course_option_id = CourseOption.find(params['course_id']).id
+
+            redirect_to candidate_interface_confirm_replacement_course_choice_path(
+              @course_choice.id,
+              @replacement_course_option_id,
+              provider_id: params['provider_id'],
+              course_id: params['course_id'],
+              study_mode: @pick_study_mode.study_mode,
+            )
           else
             redirect_to candidate_interface_replace_course_choice_location_path(
               @course_choice.id,

--- a/app/views/candidate_interface/course_choices/replace_choices/review/confirm_choice.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/review/confirm_choice.html.erb
@@ -1,6 +1,10 @@
 <% content_for :title, t('page_titles.confirm_replacement_course_choice') %>
-<% if params['provider_id'].present? %>
+<% if params['study_mode'].present? && @single_site_course %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_study_mode_path(@course_choice.id, params['provider_id'], params['course_id'])) %>
+<% elsif params['study_mode'].present? %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_location_path(@course_choice.id, params['provider_id'], params['course_id'], params['study_mode'])) %>
+<% elsif params['course_code'].present? %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_course_path(@course_choice.id, params['provider_id'], params['course_id'])) %>
 <% else %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_path(@course_choice.id)) %>
 <% end %>

--- a/app/views/candidate_interface/course_choices/replace_choices/review/confirm_choice.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/review/confirm_choice.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, t('page_titles.confirm_replacement_course_choice') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_path(@course_choice.id)) %>
+<% if params['provider_id'].present? %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_location_path(@course_choice.id, params['provider_id'], params['course_id'], params['study_mode'])) %>
+<% else %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_path(@course_choice.id)) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/course_choices/replace_choices/site_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/site_selection/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.which_location'), @pick_site.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_study_mode_path(params['id'], params['provider_id'], params['course_id'])) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @pick_site, url: candidate_interface_replace_course_choice_validate_location_path(
+      params['id'],
+      provider_id: params['provider_id'],
+      course_id: params['course_id'],
+      study_mode: params['study_mode']
+    ), ) do |f| %>
+      <%= render partial: 'candidate_interface/course_choices/shared/site_fields', locals: { f: f }  %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/replace_choices/site_selection/update.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/site_selection/update.html.erb
@@ -3,9 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(model: @pick_site, url: candidate_interface_validate_new_course_choice_location_path) do |f| %>
+    <%= form_with(model: @pick_site, url: candidate_interface_replace_course_choice_validate_location_path) do |f| %>
       <%= render partial: 'candidate_interface/course_choices/shared/site_fields', locals: { f: f }  %>
-      <%= f.govuk_error_summary %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/replace_choices/study_mode_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/study_mode_selection/new.html.erb
@@ -1,14 +1,14 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.which_study_mode'), @pick_study_mode.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(@pick_study_mode.provider_id)) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(params['id'], params['provider_id'])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
           model: @pick_study_mode,
-          url: candidate_interface_course_choices_study_mode_path(
-            provider_id: @pick_study_mode.provider_id,
-            course_id: @pick_study_mode.course_id,
-            course_choice_id: @course_choice_id,
+          url: candidate_interface_replace_course_choice_study_mode_path(
+            params['id'],
+            params['provider_id'],
+            params['course_id'],
           ),
         ) do |f| %>
 

--- a/app/views/candidate_interface/course_choices/shared/_site_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/shared/_site_fields.html.erb
@@ -1,3 +1,4 @@
+<%= f.govuk_error_summary %>
 <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location') } do %>
   <div class="govuk-!-margin-top-6">
     <% @pick_site.available_sites.each_with_index do |option, i| %>

--- a/app/views/candidate_interface/course_choices/shared/_study_mode_fields.html.erb
+++ b/app/views/candidate_interface/course_choices/shared/_study_mode_fields.html.erb
@@ -1,0 +1,6 @@
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_radio_buttons_fieldset :study_mode, legend: { size: 'xl', text: t('page_titles.which_study_mode'), tag: 'h2' } do %>
+  <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' } %>
+  <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
+<% end %>

--- a/app/views/candidate_interface/course_choices/site_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/new.html.erb
@@ -9,8 +9,6 @@
             params[:provider_id], params[:course_id], params[:study_mode], course_choice_id: @course_choice_id
           ),
         ) do |f| %>
-        <%= f.govuk_error_summary %>
-
         <%= render partial: 'candidate_interface/course_choices/shared/site_fields', locals: { f: f }  %>
         <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,15 +232,15 @@ Rails.application.routes.draw do
         get '/complete_selection/:course_id', to: redirect('/candidate/application/courses/complete-selection/%{course_id}')
 
         scope '/replace' do
-          get '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#ask', as: :replace_course_choices_choose
-          post '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#decide'
-          get '/:id/find-a-course' => 'course_choices/replace_choices/have_you_chosen#go_to_find', as: :replace_go_to_find
-
           get '/' => 'course_choices/replace_choices/base#pick_choice_to_replace', as: :replace_course_choices
           post '/' => 'course_choices/replace_choices/base#picked_choice'
 
           get '/:id' => 'course_choices/replace_choices/decision#choose_action', as: :replace_course_choice
           post '/:id' => 'course_choices/replace_choices/decision#route_action'
+
+          get '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#ask', as: :replace_course_choices_choose
+          post '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#decide'
+          get '/:id/find-a-course' => 'course_choices/replace_choices/have_you_chosen#go_to_find', as: :replace_go_to_find
 
           get '/:id/provider' => 'course_choices/replace_choices/provider_selection#new', as: :replace_course_choice_provider
           post '/:id/provider' => 'course_choices/replace_choices/provider_selection#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,40 +230,44 @@ Rails.application.routes.draw do
         get '/confirm_selection/:course_id', to: redirect('/candidate/application/courses/confirm-selection/%{course_id}')
         post '/complete-selection/:course_id' => 'find_course_selections#complete_selection', as: :course_complete_selection
         get '/complete_selection/:course_id', to: redirect('/candidate/application/courses/complete-selection/%{course_id}')
-      end
 
-      scope '/replace' do
-        get '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#ask', as: :replace_course_choices_choose
-        post '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#decide'
-        get '/:id/find-a-course' => 'course_choices/replace_choices/have_you_chosen#go_to_find', as: :replace_go_to_find
+        scope '/replace' do
+          get '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#ask', as: :replace_course_choices_choose
+          post '/:id/choose' => 'course_choices/replace_choices/have_you_chosen#decide'
+          get '/:id/find-a-course' => 'course_choices/replace_choices/have_you_chosen#go_to_find', as: :replace_go_to_find
 
-        get '/' => 'course_choices/replace_choices/base#pick_choice_to_replace', as: :replace_course_choices
-        post '/' => 'course_choices/replace_choices/base#picked_choice'
+          get '/' => 'course_choices/replace_choices/base#pick_choice_to_replace', as: :replace_course_choices
+          post '/' => 'course_choices/replace_choices/base#picked_choice'
 
-        get '/:id' => 'course_choices/replace_choices/decision#choose_action', as: :replace_course_choice
-        post '/:id' => 'course_choices/replace_choices/decision#route_action'
+          get '/:id' => 'course_choices/replace_choices/decision#choose_action', as: :replace_course_choice
+          post '/:id' => 'course_choices/replace_choices/decision#route_action'
 
-        get '/:id/provider' => 'course_choices/replace_choices/provider_selection#new', as: :replace_course_choice_provider
-        post '/:id/provider' => 'course_choices/replace_choices/provider_selection#create'
+          get '/:id/provider' => 'course_choices/replace_choices/provider_selection#new', as: :replace_course_choice_provider
+          post '/:id/provider' => 'course_choices/replace_choices/provider_selection#create'
 
-        get '/:id/apply-on-ucas/provider/:provider_id' => 'course_choices/replace_choices/ucas#no_courses', as: :replace_course_choice_ucas_no_courses
-        get '/:id/apply-on-ucas/provider/:provider_id/course/:course_id' => 'course_choices/replace_choices/ucas#with_course', as: :replace_course_choice_ucas_with_course
+          get '/:id/apply-on-ucas/provider/:provider_id' => 'course_choices/replace_choices/ucas#no_courses', as: :replace_course_choice_ucas_no_courses
+          get '/:id/apply-on-ucas/provider/:provider_id/course/:course_id' => 'course_choices/replace_choices/ucas#with_course', as: :replace_course_choice_ucas_with_course
 
-        get '/:id/provider/:provider_id/course' => 'course_choices/replace_choices/course_selection#new', as: :replace_course_choice_course
-        post '/:id/provider/:provider_id/course' => 'course_choices/replace_choices/course_selection#create'
-        get '/:id/provider/:provider_id/courses/:course_id/full' => 'course_choices/replace_choices/course_selection#full', as: :replace_course_choice_full
+          get '/:id/provider/:provider_id/course' => 'course_choices/replace_choices/course_selection#new', as: :replace_course_choice_course
+          post '/:id/provider/:provider_id/course' => 'course_choices/replace_choices/course_selection#create'
+          get '/:id/provider/:provider_id/courses/:course_id/full' => 'course_choices/replace_choices/course_selection#full', as: :replace_course_choice_full
 
-        get '/replace/:id/location' => 'course_choices/replace_choices/site_selection#replace_location', as: :replace_course_choice_location
-        post '/replace/:id/location' => 'course_choices/replace_choices/site_selection#validate_location', as: :validate_new_course_choice_location
+          get '/:id/provider/:provider_id/course/:course_id/study_mode' => 'course_choices/replace_choices/study_mode_selection#new', as: :replace_course_choice_study_mode
+          post '/:id/provider/:provider_id/course/:course_id/study_mode' => 'course_choices/replace_choices/study_mode_selection#create'
 
-        get '/:id/confirm_cancel' => 'course_choices/replace_choices/cancel#confirm_cancel', as: :confirm_cancel_full_course_choice
-        post '/:id/cancel' => 'course_choices/replace_choices/cancel#cancel', as: :cancel_full_course_choice
+          get '/:id/provider/:provider_id/course/:course_id/:study_mode/location' => 'course_choices/replace_choices/site_selection#new', as: :replace_course_choice_location
+          get '/:id/location' => 'course_choices/replace_choices/site_selection#update', as: :replace_course_choice_update_location
+          post '/:id/location' => 'course_choices/replace_choices/site_selection#validate_location', as: :replace_course_choice_validate_location
 
-        get '/:id/confirm_withdraw' => 'course_choices/replace_choices/cancel#confirm_withdraw', as: :confirm_withdraw_full_course_choice
-        post '/:id/withdraw' => 'course_choices/replace_choices/cancel#withdraw', as: :withdraw_full_course_choice
+          get '/:id/confirm_cancel' => 'course_choices/replace_choices/cancel#confirm_cancel', as: :confirm_cancel_full_course_choice
+          post '/:id/cancel' => 'course_choices/replace_choices/cancel#cancel', as: :cancel_full_course_choice
 
-        get '/:id/confirm/:course_option_id' => 'course_choices/replace_choices/review#confirm_choice', as: :confirm_replacement_course_choice
-        get '/:id/update/:course_option_id' => 'course_choices/replace_choices/review#update_choice', as: :update_replacement_course_choice
+          get '/:id/confirm_withdraw' => 'course_choices/replace_choices/cancel#confirm_withdraw', as: :confirm_withdraw_full_course_choice
+          post '/:id/withdraw' => 'course_choices/replace_choices/cancel#withdraw', as: :withdraw_full_course_choice
+
+          get '/:id/confirm/:course_option_id' => 'course_choices/replace_choices/review#confirm_choice', as: :confirm_replacement_course_choice
+          get '/:id/update/:course_option_id' => 'course_choices/replace_choices/review#update_choice', as: :update_replacement_course_choice
+        end
       end
 
       scope '/choice/:id' do

--- a/spec/system/candidate_interface/course_selection/candidate_replaces_a_full_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_replaces_a_full_course_spec.rb
@@ -46,6 +46,25 @@ RSpec.feature 'Selecting a course' do
 
     when_i_click_back
     then_i_see_the_pick_replacment_course_page
+
+    when_i_choose_a_course
+    then_i_see_the_pick_replacement_study_mode_page
+
+    when_i_choose_full_time
+    then_i_see_the_replace_location_page
+
+    when_i_choose_a_location
+    then_i_see_the_confirm_replacement_page
+
+    when_i_click_back
+    then_i_see_the_replace_location_page
+
+    when_i_choose_a_location
+    and_i_click_replace_course_choice
+    then_i_arrive_at_my_application_dashboard
+    and_i_am_told_my_application_has_been_updated
+    and_i_see_my_new_course_choice
+    and_i_cannot_see_my_old_course_choice
   end
 
   def given_the_replace_full_or_withdrawn_application_choices_is_active
@@ -167,5 +186,63 @@ RSpec.feature 'Selecting a course' do
   def then_i_see_the_replace_course_choice_full_page
     expect(page).to have_content t('page_titles.full_course')
     expect(page).to have_current_path candidate_interface_replace_course_choice_full_path(@course_choice.id, @provider.id, @full_course.id)
+  end
+
+  def when_i_choose_a_course
+    choose @course.name_and_code
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_pick_replacement_study_mode_page
+    expect(page).to have_current_path candidate_interface_replace_course_choice_study_mode_path(@course_choice.id, @provider.id, @course.id)
+  end
+
+  def when_i_choose_full_time
+    choose 'Full time'
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_replace_location_page
+    expect(page).to have_current_path candidate_interface_replace_course_choice_location_path(@course_choice.id, @provider.id, @course.id, @full_time_course_option.study_mode)
+  end
+
+  def and_i_see_the_address
+    expect(page).to have_content(@site.name_and_address)
+  end
+
+  def when_i_choose_a_location
+    choose @site.name
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_confirm_replacement_page
+    expect(page).to have_current_path candidate_interface_confirm_replacement_course_choice_path(
+      @course_choice.id,
+      @full_time_course_option.id,
+      provider_id: @provider.id,
+      course_id: @course.id,
+      study_mode: @full_time_course_option.study_mode,
+    )
+  end
+
+  def and_i_click_replace_course_choice
+    click_link 'Replace course choice'
+  end
+
+  def then_i_arrive_at_my_application_dashboard
+    expect(page).to have_current_path candidate_interface_application_complete_path
+  end
+
+  def and_i_am_told_my_application_has_been_updated
+    expect(page).to have_content 'Your application has been successfully updated.'
+  end
+
+  def and_i_see_my_new_course_choice
+    expect(page).to have_content @course.name
+    expect(page).to have_content @site.name
+  end
+
+  def and_i_cannot_see_my_old_course_choice
+    expect(page).not_to have_content @course_choice.site.name_and_address
   end
 end


### PR DESCRIPTION
## Context

The first PR covers adding a provider #2316
The second PR covers adding a course #2317 

This PR covers the final sections of the flow. Adding a study mode and a location.

## Changes proposed in this pull request

Adds the study mode page

![image](https://user-images.githubusercontent.com/42515961/85264896-52169980-b469-11ea-8c96-d4deea343c6d.png)

Adds the location page

![image](https://user-images.githubusercontent.com/42515961/85265021-8722ec00-b469-11ea-9c18-0c28b9ce8575.png)


## Guidance to review

I've gone through and manually tested this quite a bit. It would be great if someone could test it locally too in case I've missed anything.

## Link to Trello card

https://trello.com/c/kUjDNNbH/1646-dev-update-course-choices-if-course-becomes-full-while-waiting-for-references

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
