### PR TITLE
Course choices link should redirect to the course choices review path

### DIFF
--- a/app/components/candidate_interface/application_form_course_choices_component.rb
+++ b/app/components/candidate_interface/application_form_course_choices_component.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
     def view_courses_path
       if completed?
-        candidate_interface_application_review_path
+        candidate_interface_course_choices_review_path
       else
         candidate_interface_course_choices_index_path
       end

--- a/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
       it 'renders expected content' do
         expect(heading(result)).to eq 'Course choices'
         expect(link_text(result)).to eq 'Course choices'
-        expect(href(result)).to eq '/candidate/application/review'
+        expect(href(result)).to eq '/candidate/application/courses/review'
         expect(status_text(result)).to eq 'Completed'
         expect(first_paragraph(result)).not_to be_present
       end


### PR DESCRIPTION
## Context

When a user clicks on the course choices link on the application show page it redirects them to  the application form review page. It should be directing them to the course choices review page.

## Changes proposed in this pull request

- Change the path of the 'Course choices' link to the course choices review path if they have already selected a choice.

## Link to Trello card

https://trello.com/c/1RuDBPI3/1578-application-choices-links-to-application-review-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
