### PR TITLE
Rename repo to apply-for-teacher-training

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@
 - [ ] This code doesn't rely on migrations in the same Pull Request
 - [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
 - [ ] API release notes have been updated if necessary
-- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
+- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COVERAGE_RESULT_PATH=/app/coverage
 
 define copy_to_host
 	## Obtains the results folder from within the stopped container and copies it to the local file system on the agent.
-	container_id=$$(docker ps -a --no-trunc | grep apply-for-postgraduate-teacher-training | head -1 | cut -d ' ' -f1); \
+	container_id=$$(docker ps -a --no-trunc | grep apply-for-teacher-training | head -1 | cut -d ' ' -f1); \
 	docker cp $$container_id:$(1)/ testArtifacts/
 endef
 

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -110,11 +110,11 @@ jobs:
                   #RG exists, proceed with other checks
                   #Get array of deployment files, which if changed, should trigger a full ARM deployment.
                   #Add pipeline files to array
-                  $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/contents?ref=$env:COMMIT_HASH"
+                  $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training/contents?ref=$env:COMMIT_HASH"
                   $gitApiResponse = Invoke-RestMethod -Method Get -Uri $gitContentsUri -Headers @{Authorization = $encodedAccessToken}
                   $deploymentFiles = $gitApiResponse | Where-Object {$_.name -like "azure-pipelines*.yml"} | Select-Object -ExpandProperty Name
                   #Add ARM template files to array
-                  $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/contents/azure?ref=$env:COMMIT_HASH"
+                  $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training/contents/azure?ref=$env:COMMIT_HASH"
                   $gitApiResponse = Invoke-RestMethod -Method Get -Uri $gitContentsUri -Headers @{Authorization = $encodedAccessToken}
                   $deploymentFiles += $gitApiResponse | Where-Object {$_.name -like "*.json"} | Select-Object -ExpandProperty Name | Foreach-Object { "azure/$_" }
                   write-host ("DEBUG - Deployment files to compare changes against: {0}" -f [system.string]::Join(", ", $deploymentFiles))
@@ -140,9 +140,9 @@ jobs:
 
                   #Get the list of files changed in the commit the build was triggered from. If this is a re-run of the same build we will just look at the files changed in that commit"
                   if ( $currentDeployedCommit -eq $env:COMMIT_HASH ) {
-                    $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/commits/$env:COMMIT_HASH"
+                    $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training/commits/$env:COMMIT_HASH"
                   } else {
-                    $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/compare/$currentDeployedCommit...$env:COMMIT_HASH"
+                    $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training/compare/$currentDeployedCommit...$env:COMMIT_HASH"
                   }
                   $gitChangedFiles = (Invoke-RestMethod -Method Get -Uri $gitCompareUri -Headers @{Authorization = $encodedAccessToken}).files.filename
                   if ( $gitChangedFiles.length -gt 0 ) {

--- a/azure/template.json
+++ b/azure/template.json
@@ -388,7 +388,7 @@
     },
     "variables": {
         "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
-        "deploymentUrlBaseLocal": "[concat('https://raw.githubusercontent.com/DFE-Digital/apply-for-postgraduate-teacher-training/', parameters('localBranchName'),'/azure/')]",
+        "deploymentUrlBaseLocal": "[concat('https://raw.githubusercontent.com/DFE-Digital/apply-for-teacher-training/', parameters('localBranchName'),'/azure/')]",
         "resourceNamePrefix": "[toLower(concat(parameters('subscriptionPrefix'), parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",

--- a/cancel-build-if-not-latest-template.yml
+++ b/cancel-build-if-not-latest-template.yml
@@ -15,8 +15,8 @@ steps:
       $azureDevOpsAuthorizationHeader = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
       $gitHubApiHeader = @{ Accept = "application/vnd.github.v3+json" }
       $azurePipelinesBuildApi = "$($env:COLLECTION_URL)$env:PROJECT_ID/_apis/build/builds/$($env:BUILD_ID)?api-version=5.1"
-      $gitHubGetCurrentCommitApi = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/git/commits/$($env:COMMIT_ID)"
-      $gitHubGetNewCommitsToMasterApi = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/commits?sha=$($env:SOURCE_BRANCH)"
+      $gitHubGetCurrentCommitApi = "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training/git/commits/$($env:COMMIT_ID)"
+      $gitHubGetNewCommitsToMasterApi = "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training/commits?sha=$($env:SOURCE_BRANCH)"
       
       Write-Debug "azurePipelinesBuildApi is $azurePipelinesBuildApi"
       Write-Debug "gitHubGetCurrentCommitApi is $gitHubGetCurrentCommitApi"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,9 +2,9 @@
 
 The apply build and release process is split into two separate Azure DevOps pipelines.
 
-- [apply-for-postgraduate-teacher-training](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary): This is the main development CI pipeline which will automatically trigger a build from a commit to any branch within the Apply GitHub code repository. When commits are made to the master branch, this pipeline will also deploy the application to the QA infrastructure environment in Azure automatically.
+- [apply-for-teacher-training](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary): This is the main development CI pipeline which will automatically trigger a build from a commit to any branch within the Apply GitHub code repository. When commits are made to the master branch, this pipeline will also deploy the application to the QA infrastructure environment in Azure automatically.
 
-- [apply-for-postgraduate-teacher-training-releases](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary): This is the main release pipeline that is used to deploy to all other Azure environments except QA. Releases are triggered manually and the target environments can be chosen prior to deployment.
+- [apply-for-teacher-training-releases](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary): This is the main release pipeline that is used to deploy to all other Azure environments except QA. Releases are triggered manually and the target environments can be chosen prior to deployment.
 
 All members of the Apply development team are able to deploy into any of the environments.
 

--- a/docs/new-environment.md
+++ b/docs/new-environment.md
@@ -1,6 +1,6 @@
 # Creating and Deploying to a new environment in Azure
 
-All the steps required to create and deploy to an Azure environment are written in the [Pipelines deploy template file](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/azure-pipelines-deploy-template.yml). This template is referenced inside the main Azure Pipelines configuration file and reused with appropriate parameters for the required environment.
+All the steps required to create and deploy to an Azure environment are written in the [Pipelines deploy template file](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/azure-pipelines-deploy-template.yml). This template is referenced inside the main Azure Pipelines configuration file and reused with appropriate parameters for the required environment.
 
 ## Configure Variable Groups in Azure DevOps
 For deploying to a new environment, we need to configure the required variables in a variable group that will hold the values to be passed as parameters to the pipeline deployment steps.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apply-for-postgraduate-teacher-training",
+  "name": "apply-for-teacher-training",
   "private": true,
   "dependencies": {
     "@ministryofjustice/frontend": "^0.0.19-alpha",


### PR DESCRIPTION
##  Context

We've renamed this repo.

## Changes proposed in this pull request

This updates docs and the CI/deploy script.

The only thing I haven't renamed is the Docker image, because I don't know the impact of that. We can do that at some point in the future.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/AtVtze9J/299-rename-the-repository-to-apply-for-teacher-training

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
