### PR TITLE
SyncProviderFromFind can work on providers from different recruitment cycles

### DIFF
--- a/app/models/find_api/provider.rb
+++ b/app/models/find_api/provider.rb
@@ -12,8 +12,8 @@ module FindAPI
     # elegant way, feel free.
     class Subject < FindAPI::Resource; end
 
-    def self.current_cycle
-      where(recruitment_cycle_year: RecruitmentCycle.current_year)
+    def self.recruitment_cycle(year)
+      where(recruitment_cycle_year: year)
     end
   end
 end

--- a/app/services/sync_all_providers_from_find.rb
+++ b/app/services/sync_all_providers_from_find.rb
@@ -4,7 +4,7 @@ class SyncAllProvidersFromFind
     #
     # For the full response, see:
     # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers
-    find_providers = FindAPI::Provider.current_cycle.all
+    find_providers = FindAPI::Provider.recruitment_cycle(RecruitmentCycle.current_year).all
 
     sync_providers(find_providers)
 
@@ -18,6 +18,7 @@ class SyncAllProvidersFromFind
       SyncProviderFromFind.call(
         provider_name: find_provider.provider_name,
         provider_code: find_provider.provider_code,
+        provider_recruitment_cycle_year: find_provider.recruitment_cycle_year,
       )
     end
   end

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -1,14 +1,15 @@
 class SyncProviderFromFind
-  def self.call(provider_code:, provider_name: nil, sync_courses: false)
-    new(provider_code, provider_name, sync_courses).call
+  def self.call(provider_code:, provider_name: nil, provider_recruitment_cycle_year:, sync_courses: false)
+    new(provider_code, provider_name, provider_recruitment_cycle_year, sync_courses).call
   end
 
-  attr_reader :provider_code, :provider_name
+  attr_reader :provider_code, :provider_name, :provider_recruitment_cycle_year
   attr_accessor :provider
 
-  def initialize(provider_code, provider_name, sync_courses)
+  def initialize(provider_code, provider_name, provider_recruitment_cycle_year, sync_courses)
     @provider_code = provider_code
     @provider_name = provider_name
+    @provider_recruitment_cycle_year = provider_recruitment_cycle_year
     @sync_courses = sync_courses
   end
 
@@ -71,7 +72,7 @@ private
     # For the full response, see:
     # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers/1N1/?include=sites,courses.sites
     FindAPI::Provider
-      .current_cycle
+      .recruitment_cycle(provider_recruitment_cycle_year)
       .includes(:sites, courses: [:sites, :subjects, site_statuses: [:site]])
       .find(provider_code)
       .first

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SyncProviderFromFind do
   describe '.call' do
     context 'ingesting a brand new provider' do
       it 'just creates the provider without any courses' do
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         provider = Provider.find_by_code('ABC')
         expect(provider).to be_present
@@ -22,7 +22,7 @@ RSpec.describe SyncProviderFromFind do
       it 'correctly updates the provider but does not import any courses' do
         stub_find_api_provider_200(provider_code: 'ABC', findable: true)
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         expect(@existing_provider.reload.courses).to be_blank
         expect(@existing_provider.reload.name).to eq 'ABC College'
@@ -41,15 +41,15 @@ RSpec.describe SyncProviderFromFind do
           findable: true,
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         course_option = CourseOption.last
         expect(course_option.course.provider.code).to eq 'ABC'
         expect(course_option.course.code).to eq '9CBA'
         expect(course_option.course.exposed_in_find).to be true
-        expect(course_option.course.recruitment_cycle_year).to eql RecruitmentCycle.current_year
+        expect(course_option.course.recruitment_cycle_year).to eql stubbed_recruitment_cycle_year
         expect(course_option.course.description).to eq 'PGCE with QTS full time'
-        expect(course_option.course.start_date).to eq Time.zone.local(2020, 10, 31)
+        expect(course_option.course.start_date).to eq Time.zone.local(stubbed_recruitment_cycle_year, 10, 31)
         expect(course_option.course.course_length).to eq 'OneYear'
         expect(course_option.course.age_range).to eq '4 to 8'
         expect(course_option.site.name).to eq 'Main site'
@@ -69,13 +69,13 @@ RSpec.describe SyncProviderFromFind do
           site_address_line2: nil,
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         course_option = CourseOption.last
         expect(course_option.course.provider.code).to eq 'ABC'
         expect(course_option.course.code).to eq '9CBA'
         expect(course_option.course.exposed_in_find).to be true
-        expect(course_option.course.recruitment_cycle_year).to eql RecruitmentCycle.current_year
+        expect(course_option.course.recruitment_cycle_year).to eql stubbed_recruitment_cycle_year
         expect(course_option.site.name).to eq 'Main site'
         expect(course_option.site.address_line1).to eq 'Gorse SCITT'
         expect(course_option.site.address_line2).to be_nil
@@ -90,11 +90,11 @@ RSpec.describe SyncProviderFromFind do
           course_code: '9CBA',
           findable: true,
         )
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
         CourseOption.first.update!(vacancy_status: 'no_vacancies')
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
         expect(CourseOption.first.vacancy_status).to eq 'vacancies'
       end
@@ -105,11 +105,11 @@ RSpec.describe SyncProviderFromFind do
           course_code: '9CBA',
           content_status: 'withdrawn',
         )
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         expect(CourseOption.count).to eq 1
         Course.first.update!(withdrawn: false)
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         expect(Course.first.withdrawn).to eq true
       end
 
@@ -122,7 +122,7 @@ RSpec.describe SyncProviderFromFind do
           accredited_provider_name: 'Test Accredited Provider',
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         course_option = CourseOption.last
         expect(course_option.course.accredited_provider.code).to eq 'DEF'
@@ -139,7 +139,7 @@ RSpec.describe SyncProviderFromFind do
         )
 
         expect {
-          SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+          SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         }.to change(ProviderInterface::TrainingProviderPermissions, :count).by(1)
          .and change(ProviderInterface::AccreditedBodyPermissions, :count).by(1)
 
@@ -162,7 +162,7 @@ RSpec.describe SyncProviderFromFind do
         )
 
         expect {
-          SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+          SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         }.to change(ProviderInterface::TrainingProviderPermissions, :count).by(0)
          .and change(ProviderInterface::AccreditedBodyPermissions, :count).by(0)
       end
@@ -174,7 +174,7 @@ RSpec.describe SyncProviderFromFind do
           study_mode: 'full_time_or_part_time',
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         course = Provider.find_by_code('ABC').courses.find_by_code('9CBA')
         expect(course.study_mode).to eq 'full_time_or_part_time'
@@ -187,7 +187,7 @@ RSpec.describe SyncProviderFromFind do
           study_mode: 'full_time_or_part_time',
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         provider = Provider.find_by_code('ABC')
         course_options = provider.courses.find_by_code('9CBA').course_options
@@ -206,7 +206,7 @@ RSpec.describe SyncProviderFromFind do
           findable: true,
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         expect(@existing_provider.reload.region_code).to eq 'north_west'
       end
@@ -219,9 +219,12 @@ RSpec.describe SyncProviderFromFind do
           findable: true,
         )
         allow(Raven).to receive(:capture_message)
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
+
         expect(Course.count).to eq 1
         expect(CourseOption.count).to eq 1
+
         course = Course.first
         valid_course_option = course.course_options.first
 
@@ -234,7 +237,8 @@ RSpec.describe SyncProviderFromFind do
 
         create(:application_choice, course_option: invalid_course_option_two)
         create(:application_choice, course_option: valid_course_option, offered_course_option: invalid_course_option_three)
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
 
         expect(CourseOption.exists?(invalid_course_option_one.id)).to eq false
         expect(invalid_course_option_two.reload).not_to be_site_still_valid
@@ -249,7 +253,7 @@ RSpec.describe SyncProviderFromFind do
           findable: true,
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         course_option = CourseOption.last
 
         expect(course_option.course.subject_codes).to eq(%w[08])
@@ -265,7 +269,7 @@ RSpec.describe SyncProviderFromFind do
           findable: true,
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         course_option = CourseOption.last
 
         expect(course_option.course.qualifications).to be_nil
@@ -279,7 +283,7 @@ RSpec.describe SyncProviderFromFind do
           findable: true,
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         course_option = CourseOption.last
 
         expect(course_option.course.qualifications).to eq(%w[PG PF])
@@ -293,7 +297,7 @@ RSpec.describe SyncProviderFromFind do
           program_type: 'SD',
         )
 
-        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         course_option = CourseOption.last
 
         # the enum field converts the value from the short code to the expanded value

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -1,4 +1,12 @@
 module FindAPIHelper
+  def set_stubbed_recruitment_cycle_year!(year)
+    @stubbed_recruitment_cycle_year = year
+  end
+
+  def stubbed_recruitment_cycle_year
+    @stubbed_recruitment_cycle_year || 2020
+  end
+
   def stub_find_api_provider_200(
     provider_code: 'ABC',
     provider_name: 'Dummy Provider',
@@ -7,7 +15,7 @@ module FindAPIHelper
     findable: true,
     study_mode: 'full_time',
     description: 'PGCE with QTS full time',
-    start_date: Time.zone.local(2020, 10, 31),
+    start_date: Time.zone.local(stubbed_recruitment_cycle_year, 10, 31),
     course_length: 'OneYear',
     region_code: 'north_west',
     site_address_line2: 'C/O The Bruntcliffe Academy',
@@ -67,7 +75,7 @@ module FindAPIHelper
                 'description': description,
                 'start_date': start_date,
                 'course_length': course_length,
-                'recruitment_cycle_year': '2020',
+                'recruitment_cycle_year': stubbed_recruitment_cycle_year.to_s,
                 'findable?': findable,
                 'accrediting_provider': nil,
                 'funding_type': funding_type,
@@ -138,7 +146,7 @@ module FindAPIHelper
     findable: true,
     study_mode: 'full_time',
     description: 'PGCE with QTS full time',
-    start_date: Time.zone.local(2020, 10, 31),
+    start_date: Time.zone.local(stubbed_recruitment_cycle_year, 10, 31),
     course_length: 'OneYear',
     region_code: 'north_west',
     age_range_in_years: '4 to 8',
@@ -195,7 +203,7 @@ module FindAPIHelper
                 'description': description,
                 'start_date': start_date,
                 'course_length': course_length,
-                'recruitment_cycle_year': '2020',
+                'recruitment_cycle_year': stubbed_recruitment_cycle_year.to_s,
                 'findable?': findable,
                 'content_status': content_status,
                 'accrediting_provider': {
@@ -254,7 +262,7 @@ module FindAPIHelper
     findable: true,
     study_mode: 'full_time_or_part_time',
     description: 'PGCE with QTS full time',
-    start_date: Time.zone.local(2020, 10, 31),
+    start_date: Time.zone.local(stubbed_recruitment_cycle_year, 10, 31),
     course_length: 'OneYear',
     region_code: 'north_west',
     age_range_in_years: '4 to 8',
@@ -325,7 +333,7 @@ module FindAPIHelper
               'description': description,
               'start_date': start_date,
               'course_length': course_length,
-              'recruitment_cycle_year': '2020',
+              'recruitment_cycle_year': stubbed_recruitment_cycle_year.to_s,
               'findable?': findable,
               'accrediting_provider': nil,
               'funding_type': 'fee',
@@ -403,7 +411,7 @@ module FindAPIHelper
         attributes: {
           provider_code: attributes[:provider_code],
           provider_name: attributes[:name],
-          recruitment_cycle_year: '2020',
+          recruitment_cycle_year: stubbed_recruitment_cycle_year.to_s,
         },
         relationships: {
           courses: {
@@ -475,7 +483,7 @@ module FindAPIHelper
 
   def stub_find_api_course(provider_code, course_code)
     stub_request(:get, ENV.fetch('FIND_BASE_URL') +
-      'recruitment_cycles/2020' \
+      "recruitment_cycles/#{stubbed_recruitment_cycle_year}" \
       "/providers/#{provider_code}" \
       "/courses/#{course_code}")
   end
@@ -488,7 +496,7 @@ module FindAPIHelper
     findable: true,
     study_mode: 'full_time',
     description: 'PGCE with QTS full time',
-    start_date: Time.zone.local(2020, 10, 31),
+    start_date: Time.zone.local(stubbed_recruitment_cycle_year, 10, 31),
     course_length: 'OneYear',
     region_code: 'north_west',
     site_address_line2: 'C/O The Bruntcliffe Academy',
@@ -550,7 +558,7 @@ module FindAPIHelper
                 'description': description,
                 'start_date': start_date,
                 'course_length': course_length,
-                'recruitment_cycle_year': '2020',
+                'recruitment_cycle_year': stubbed_recruitment_cycle_year.to_s,
                 'findable?': findable,
                 'accrediting_provider': nil,
                 'funding_type': funding_type,
@@ -618,13 +626,13 @@ private
   def stub_find_api_all_providers
     stub_request(
       :get,
-      "#{ENV.fetch('FIND_BASE_URL')}recruitment_cycles/2020/providers",
+      "#{ENV.fetch('FIND_BASE_URL')}recruitment_cycles/#{stubbed_recruitment_cycle_year}/providers",
     )
   end
 
   def stub_find_api_provider(provider_code)
     stub_request(:get, ENV.fetch('FIND_BASE_URL') +
-      'recruitment_cycles/2020' \
+      "recruitment_cycles/#{stubbed_recruitment_cycle_year}" \
       "/providers/#{provider_code}?include=sites,courses.sites,courses.subjects,courses.site_statuses.site")
   end
 end

--- a/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
+++ b/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Sync from find' do
   end
 
   def when_sync_provider_from_find_is_called
-    SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', sync_courses: true)
+    SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year, sync_courses: true)
   end
 
   def then_the_correct_course_options_are_created_on_apply

--- a/spec/system/sync_provider_from_find/study_mode_changes_spec.rb
+++ b/spec/system/sync_provider_from_find/study_mode_changes_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Sync from find' do
   end
 
   def when_sync_provider_from_find_is_called
-    SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', sync_courses: true)
+    SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year, sync_courses: true)
   end
 
   def then_the_correct_course_option_is_created_on_apply


### PR DESCRIPTION
## Context

Syncing providers has two steps:

1. getting the list of providers for the current recruitment cycle
2. loading the courses, sites etc for each provider we got in step 1. This operation needs to know which recruitment cycle the provider is in

We want to be able to handle syncing courses for two cycles at the same time as this will mean we can properly test the cycles living side by side in our database. And hopefully, in the future, Find will be able to publish courses as they roll over, rather than in a block, as they plan to this year.

## Changes proposed in this pull request

So far we've always been in the 2020 cycle, so we've been able to use `RecruitmentCycle.current_year` inside `SyncAllProvidersFromFind` (which does step 1)  and `SyncProviderFromFind` (which does step 2).

This PR is about pulling that hardcoded value out of those places and turning it into an argument. 
- A lot of specs need to be changed to pass the new arg, but they're all changing in the same way.
- Stubs are going to need to be aware of which recruitment cycle to put their fake responses in. In a spec with `FindAPIHelper` included you can call `recruitment_cycle_year` to get the currently-stubbed recruitment cycle, and `set_stubbed_recruitment_cycle_year!` to set it. (Which doesn't happen in this PR, but will happen in the next one). I preferred `set_stubbed_recruitment_cycle_year!` as just `stubbed_recruitment_cycle_year = whatever` feels weird & magical.

The next PR will start syncing 2021 courses and handling the carrying over of "open_on_apply" status from cycle to cycle.

## Guidance to review

Does it make sense? Are there any references left to `current_year`?

## Link to Trello card

https://trello.com/c/Tgq41OB9/2253-rollover-start-syncing-dummy-2021-data

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
