### PR TITLE
Fail early if we're missing DSI_API_* variables

### DIFF
--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -5,6 +5,8 @@ class InviteProviderUser
 
   def initialize(provider_user:)
     @provider_user = provider_user
+    @dsi_api_url = ENV.fetch('DSI_API_URL')
+    @dsi_api_secret = ENV.fetch('DSI_API_SECRET')
   end
 
   def call!
@@ -14,17 +16,14 @@ class InviteProviderUser
   end
 
   def dfe_invite_url
-    baseurl = ENV.fetch('DSI_API_URL')
-    if baseurl.present?
-      "#{baseurl}/services/apply/invitations"
-    end
+    "#{@dsi_api_url}/services/apply/invitations"
   end
 
 private
 
   def invite_user_to_dfe_sign_in
     jwt_payload = { iss: 'apply', aud: 'signin.education.gov.uk' }
-    token = JWT.encode jwt_payload, ENV['DSI_API_SECRET'], DSI_JWT_HMAC
+    token = JWT.encode jwt_payload, @dsi_api_secret, DSI_JWT_HMAC
     auth_string = "Bearer #{token}"
     request_params = {
       sourceId: @provider_user.id,

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe InviteProviderUser, sidekiq: true do
       expect { InviteProviderUser.new }.to raise_error(ArgumentError)
       expect { InviteProviderUser.new(provider_user: ProviderUser.new) }.not_to raise_error
     end
+
+    it 'blows up when DSI_API_URL ENV var is missing' do
+      ClimateControl.modify(DSI_API_SECRET: 'something', DSI_API_URL: nil) do
+        expect { InviteProviderUser.new(provider_user: ProviderUser.new) }.to raise_error(KeyError, /DSI_API_URL/)
+      end
+    end
+
+    it 'blows up when DSI_API_SECRET ENV var is missing' do
+      ClimateControl.modify(DSI_API_SECRET: nil, DSI_API_URL: 'something') do
+        expect { InviteProviderUser.new(provider_user: ProviderUser.new) }.to raise_error(KeyError, /DSI_API_SECRET/)
+      end
+    end
   end
 
   describe '#call! if API response is successful' do


### PR DESCRIPTION
Raise an exception as soon as we know we're missing one of these values (ie when we construct the object that needs them).

Remove an if statement which looked at the return value of `ENV.fetch`, which is guaranteed not to be nil.

Allowing `DSI_API_SECRET` to be nil gives a confusing error in development.

<img width="962" alt="Screenshot 2020-06-23 at 12 24 41" src="https://user-images.githubusercontent.com/642279/85406414-b022aa00-b559-11ea-9653-f96735fb3a4e.png">

## Guidance to review

Does this break anything?

## Link to Trello card

N/A

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
