### PR TITLE
pipeline to build a base docker image with gem node installed for reducing main CI build times

### DIFF
--- a/.github/workflows/run-gems-node-modules-build.yml
+++ b/.github/workflows/run-gems-node-modules-build.yml
@@ -1,0 +1,17 @@
+name: Trigger gem-node-modules image build
+
+# On new branch creation
+on:
+  create
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Trigger gem-node-modules build
+      uses: Azure/pipelines@v1
+      with:
+        azure-devops-project-url: 'https://dev.azure.com/dfe-ssp/Become-A-Teacher'
+        azure-pipeline-name: 'build-gems-node-modules-image'
+        azure-devops-token: '${{ secrets.AZURE_DEVOPS_TOKEN }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,61 +1,86 @@
-#### Common Build Image Stage ####
+# To use or update to a ruby version, change {BASE_RUBY_IMAGE}
+ARG BASE_RUBY_IMAGE=ruby:2.7.1-alpine
+# BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES will default to apply-for-teacher-training-gems-node-modules
+# building all layers above it if a value is not specidied during the build
+ARG BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES=apply-for-teacher-training-gems-node-modules
 
-FROM ruby:2.7.1-alpine AS common-build
+# Stage 1: install-gems-node-modules, download gems and node modules.
+FROM ${BASE_RUBY_IMAGE} AS install-gems-node-modules
 
-ARG BUILD_DEPS="git gcc libc-dev make nodejs yarn postgresql-dev graphviz-dev graphviz-doc build-base libxml2-dev libxslt-dev ttf-ubuntu-font-family"
-ARG bundleWithout=""
-
-# These variables are required for running Rails processes like assets:precompile
-ENV BUNDLE_WITHOUT=${bundleWithout} \
-    WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
-    RAILS_ENV=test \
-    GOVUK_NOTIFY_API_KEY=TestKey \
-    AUTHORISED_HOSTS=127.0.0.1 \
-    SECRET_KEY_BASE=TestKey \
-    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey
+ARG BUILD_DEPS="git gcc libc-dev make nodejs yarn postgresql-dev build-base libxml2-dev libxslt-dev ttf-ubuntu-font-family"
+ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine
 
 WORKDIR /app
 
-COPY . .
+COPY Gemfile Gemfile.lock package.json yarn.lock ./
 
-RUN apk update && \
-    apk upgrade && \
-    apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz  && \
+RUN apk -U upgrade && \
     apk add --update --no-cache --virtual .gem-installdeps $BUILD_DEPS && \
     gem update --system && \
     find / -wholename '*default/bundler-*.gemspec' -delete && \
     rm -rf /usr/local/bin/bundle && \
     gem install bundler -v 2.1.4 && \
-    bundle install --no-binstubs --retry=5 && \
+    bundler -v && \
+    bundle config set no-cache 'true' && \
+    bundle config set no-binstubs 'true' && \
+    bundle --retry=5 --jobs=4 --without=development && \
     yarn install --check-files && \
-    rm -rf yarn.lock && \
-    bundle exec rake assets:precompile && \
     apk del .gem-installdeps && \
-    rm -rf tmp log node_modules && \
     rm -rf /usr/local/bundle/cache && \
     find /usr/local/bundle/gems -name "*.c" -delete && \
     find /usr/local/bundle/gems -name "*.h" -delete && \
-    find /usr/local/bundle/gems -name "*.o" -delete && \
-    echo "Europe/London" > /etc/timezone && \
-    cp /usr/share/zoneinfo/Europe/London /etc/localtime
+    find /usr/local/bundle/gems -name "*.o" -delete
 
-FROM ruby:2.7.1-alpine AS prod-build
+# Stage 2: apply-for-teacher-training-gems-node-modules, reduce size of gems-node-modules and only keep required files.
+# published as dfedigital/apply-for-teacher-training-gems-node-modules
+FROM ${BASE_RUBY_IMAGE} AS apply-for-teacher-training-gems-node-modules
 
 ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
-    RAILS_ENV=test \
+    RAILS_ENV=production \
     GOVUK_NOTIFY_API_KEY=TestKey \
     AUTHORISED_HOSTS=127.0.0.1 \
     SECRET_KEY_BASE=TestKey \
     GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey
 
-RUN apk update && \
-    apk upgrade && \
+RUN apk -U upgrade && \
+    apk add --update --no-cache nodejs yarn tzdata libpq libxml2 libxslt graphviz && \
+    echo "Europe/London" > /etc/timezone && \
+    cp /usr/share/zoneinfo/Europe/London /etc/localtime
+
+COPY --from=install-gems-node-modules /app /app
+COPY --from=install-gems-node-modules /usr/local/bundle/ /usr/local/bundle/
+
+# Stage 3: assets-precompile, precomple assets and remove compile dependencies.
+FROM ${BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES} AS assets-precompile
+
+WORKDIR /app
+COPY . .
+
+RUN bundle exec rake assets:precompile && \
+    apk del nodejs yarn && \
+    rm -rf yarn.lock && \
+    rm -rf tmp/* log/* node_modules /usr/local/share/.cache /tmp/*
+
+# Stage 4: production, copy application code and compiled assets to base ruby image.
+# Depends on assets-precompile stage which can be cached from a pre-built image 
+# by specifying a fully qualified image name or will default to packages-prod thereby rebuilding all 3 stages above.
+# If a existing base image name is specified Stage 1 & 2 will not be built and gems and dev packages will be used from the supplied image.
+FROM ${BASE_RUBY_IMAGE} AS production
+
+ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
+    RAILS_ENV=production \
+    GOVUK_NOTIFY_API_KEY=TestKey \
+    AUTHORISED_HOSTS=127.0.0.1 \
+    SECRET_KEY_BASE=TestKey \
+    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey
+
+RUN apk -U upgrade && \
     apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz && \
     echo "Europe/London" > /etc/timezone && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime
 
-COPY --from=common-build /app /app
-COPY --from=common-build /usr/local/bundle/ /usr/local/bundle/
+COPY --from=assets-precompile /app /app
+COPY --from=assets-precompile /usr/local/bundle/ /usr/local/bundle/
 
 WORKDIR /app
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,24 @@
+# this build, apply-for-teacher-training will be triggered as a downstream build to Apply/build-gems-node-modules-image
+resources:
+  pipelines:
+    - pipeline: gems_node_modules_build_pipeline
+      source: Apply/build-gems-node-modules-image
+      trigger:
+        branches:
+          include:
+            - "*"
 trigger:
   batch: true
   branches:
     include:
       - "*"
+  # excluding CI trigger for these paths as this build will be trigged as downstream build after creating base packages image.
+  paths:
+    exclude:
+      - Gemfile
+      - Gemfile.lock
+      - package.json
+      - yarn.lock
 
 pr:
   branches:
@@ -14,8 +30,8 @@ variables:
 - group: APPLY - Shared Variables
 - name: imageName
   value: 'apply-for-postgraduate-teacher-training'
-- name: pipelineDockerCachePath
-  value: $(Pipeline.Workspace)/.docker
+- name: gemsNodeModulesImageName
+  value: 'apply-for-teacher-training-gems-node-modules'
 - name: debug
   value: false
 - name: deployOnly
@@ -44,11 +60,18 @@ stages:
     steps:
     - script: |
         GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
+        GEM_NODE_PACKAGE_FILES_SHA=$(sha1sum Gemfile Gemfile.lock Dockerfile package.json yarn.lock)
+        echo $GEM_NODE_PACKAGE_FILES_SHA
+        DEPENDENCIES_SHA=$(echo $GEM_NODE_PACKAGE_FILES_SHA | sha1sum | cut -c 1-7)
         echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
         echo '##vso[task.setvariable variable=COMPOSE_FILE]docker-compose.yml:docker-compose.azure.yml'
         docker_path=$(dockerHubUsername)/$(imageName)
-        echo "##vso[task.setvariable variable=docker_path;]$docker_path"
-        mkdir $(pipelineDockerCachePath)
+        echo "##vso[task.setvariable variable=docker_path]$docker_path"
+
+        DEPENDENCIES_PACKAGE_IMAGE=$(dockerHubUsername)/$(gemsNodeModulesImageName):$DEPENDENCIES_SHA
+        docker pull $DEPENDENCIES_PACKAGE_IMAGE || DEPENDENCIES_PACKAGE_IMAGE=$(gemsNodeModulesImageName)
+        echo "##vso[task.setvariable variable=gemsNodeModulesImageName]$DEPENDENCIES_PACKAGE_IMAGE"
+        echo "##[command]$DEPENDENCIES_PACKAGE_IMAGE"
       displayName: 'Configure build environment'
 
     - template: cancel-build-if-not-latest-template.yml
@@ -65,6 +88,7 @@ stages:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         dockerHubImageTag: $(Build.BuildNumber)
+        gemsNodeModulesImageName: $(gemsNodeModulesImageName)
         railsSecretKeyBase: $(railsSecretKeyBase)
         RAILS_ENV: test
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)

--- a/build-gems-node-modules-pipeline.yml
+++ b/build-gems-node-modules-pipeline.yml
@@ -1,0 +1,56 @@
+trigger:
+  batch: true
+  paths:
+    include:
+      - Dockerfile
+      - Gemfile
+      - Gemfile.lock
+      - package.json
+      - yarn.lock
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+variables:
+  dockerHubUsername: dfedigital
+  gemsNodeModulesImageName: 'apply-for-teacher-training-gems-node-modules'
+  
+steps:
+- task: DockerInstaller@0
+  inputs:
+    dockerVersion: '19.03.9'
+
+- bash: |
+    GEM_NODE_PACKAGE_FILES_SHA=$(sha1sum Gemfile Gemfile.lock Dockerfile package.json yarn.lock)
+    echo $GEM_NODE_PACKAGE_FILES_SHA
+    DEPENDENCIES_SHA=$(echo $GEM_NODE_PACKAGE_FILES_SHA | sha1sum | cut -c 1-7)
+    echo "##vso[task.setvariable variable=DEPENDENCIES_SHA]$DEPENDENCIES_SHA"
+    echo "##[command]$DEPENDENCIES_SHA"
+  displayName: Prepare environment variables
+
+- bash: |
+    set -eux
+    echo "gemsNodeModulesImageName is $(gemsNodeModulesImageName)"
+    docker build \
+    --target $(gemsNodeModulesImageName) \
+    -t $(dockerHubUsername)/$(gemsNodeModulesImageName):$(DEPENDENCIES_SHA) \
+    "."
+  displayName: Build ${{ variables.dockerHubUsername }}/${{ variables.gemsNodeModulesImageName }}
+
+- task: Docker@2
+  displayName: Docker Login
+  inputs:
+    containerRegistry: 'DfE Docker Hub'
+    command: 'login'
+
+- bash: |
+    set -eux
+    docker images
+    docker push $(dockerHubUsername)/$(gemsNodeModulesImageName):$(DEPENDENCIES_SHA)
+  displayName: Docker Push ${{ variables.dockerHubUsername }}/${{ variables.gemsNodeModulesImageName }}
+
+- task: Docker@2
+  displayName: Docker Logout
+  inputs:
+    containerRegistry: 'DfE Docker Hub'
+    command: 'logout'

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -2,9 +2,10 @@ version: "3.6"
 services:
   web:
     build:
-      target: prod-build
+      target: production
       args:
         bundleWithout: 'development'
+        BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES: ${gemsNodeModulesImageName:-apply-for-teacher-training-gems-node-modules}
     image: ${dockerHubUsername}/${dockerHubImageName}:${dockerHubImageTag}
     environment:
       - RAILS_ENV


### PR DESCRIPTION
## Context

Current docker build takes ~5 mins, it can be reduced by using a cached image with gems and node modules pre-installed.

## Changes proposed in this pull request

refactor Dockerfile into stages to use cached layers.
new pipeline to build gem-node-dependencies images on change to any of Gemfile, Gemfile.lock, yarn.lock and package.json
new Github action to tigger a new build of gem-node-dependencies when a new branch is created.
use this base image in the man CI pipeline to build the final application image.

## Guidance to review

## Link to Trello card

https://trello.com/c/6oJaGrIC/2320-create-a-base-image-with-gem-npm-dependencies-to-reduce-build-times

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
