### PR TITLE
Add summer recruitment banner and feature flag to provider_interface

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -18,6 +18,7 @@ class FeatureFlag
     [:dfe_sign_in_fallback, 'Use this when DfE Sign-in is down', 'Tijmen Brommet'],
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
+    [:summer_recruitment_banner, 'Displays an information banner related to RBD during the summer months', 'Michael Nacos'],
     [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
   ].freeze
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -17,6 +17,20 @@
   </div>
 <% end %>
 
+<% if FeatureFlag.active?('summer_recruitment_banner') %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+        <div class="app-banner__message">
+          <h2 class="govuk-heading-m" id="summer-recruitment-message">
+            Summer deadlines for reject by default: providers have 20 working days to respond to applications received between 1 July 2020 and 3 October 2020
+          </h2>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <div class='moj-filter-layout'>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -35,6 +35,18 @@
   </div>
 <% end %>
 
+<% if FeatureFlag.active?('summer_recruitment_banner') %>
+  <div class="govuk-width-container">
+    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="summer-recruitment-message" >
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m" id="summer-recruitment-message">
+          Summer deadlines for reject by default: providers have 20 working days to respond to applications received between 1 July 2020 and 3 October 2020
+        </h2>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-width-container">
   <section class="app-product-section">
     <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

We need to show a banner to provider users advising them about the new RBD rules for the summer months.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/107591/85428865-c0488280-b575-11ea-84e2-3c88168ddc93.png)
![image](https://user-images.githubusercontent.com/107591/85428826-adce4900-b575-11ea-95c8-aba55992db44.png)

## Guidance to review

Review the code.

## Link to Trello card

https://trello.com/c/6FunXJfD

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
