### PR TITLE
rename image name in makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COVERAGE_RESULT_PATH=/app/coverage
 
 define copy_to_host
 	## Obtains the results folder from within the stopped container and copies it to the local file system on the agent.
-	container_id=$$(docker ps -a --no-trunc | grep apply-for-teacher-training | head -1 | cut -d ' ' -f1); \
+	container_id=$$(docker ps -a --no-trunc | grep apply-for-postgraduate-teacher-training | head -1 | cut -d ' ' -f1); \
 	docker cp $$container_id:$(1)/ testArtifacts/
 endef
 


### PR DESCRIPTION
see https://github.com/DFE-Digital/apply-for-teacher-training/commit/605c59101fd6b696594fa4c7c50e451c7c78f29e

## Context

Earlier rename left out `docker-compose` file.

## Changes proposed in this pull request

rename image name in makefile to `apply-for-postgraduate-teacher-training` to reflect current image name.
Will rename image in a later PR once #2332 is merged.

## Guidance to review


## Link to Trello card


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
