### PR TITLE
Fix first login 'Access Denied' bug when other org setups are pending

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -73,22 +73,23 @@ module ProviderInterface
       return unless current_provider_user
       return if performing_provider_organisation_setup?
 
-      if provider_permissions_need_setup?
-        redirect_to provider_interface_provider_relationship_permissions_setup_path
+      if (provider_id = next_training_provider_to_setup&.id)
+        redirect_to provider_interface_provider_relationship_permissions_setup_path(training_provider_id: provider_id)
       end
     end
 
-    def provider_permissions_need_setup?
+    def next_training_provider_to_setup
       permissions = TrainingProviderPermissions.find_by(
         setup_at: nil,
         training_provider: current_provider_user.providers,
       )
 
-      return false if permissions.blank?
+      if permissions.present?
+        auth = ProviderAuthorisation.new(actor: current_provider_user)
 
-      ProviderAuthorisation.new(actor: current_provider_user).can_manage_organisation?(
-        provider: permissions.training_provider,
-      )
+        training_provider = permissions.training_provider
+        training_provider if auth.can_manage_organisation?(provider: training_provider)
+      end
     end
 
     def performing_provider_organisation_setup?

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -4,7 +4,7 @@ module ProviderInterface
     before_action :render_403_unless_access_permitted
 
     def setup
-      @training_provider_permissions = TrainingProviderPermissions.where(
+      @relationships_pending_setup = TrainingProviderPermissions.where(
         setup_at: nil,
         training_provider: current_provider_user.providers,
       ).includes(%i[training_provider ratifying_provider]).order(:created_at)

--- a/app/views/provider_interface/provider_relationship_permissions/setup.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/setup.html.erb
@@ -14,7 +14,7 @@
     <p>You can change these settings at any time.</p>
     <h2 class="govuk-heading-m">Your organisations that need setting up</h2>
 
-    <% @training_provider_permissions.each do |permission| %>
+    <% @relationships_pending_setup.each do |permission| %>
       <div class="app-application-card govuk-!-margin-bottom-7">
         <div>
           <h2 class="govuk-heading-s govuk-!-margin-bottom-0"><%= permission.training_provider.name %></h2>
@@ -29,8 +29,8 @@
     <%= govuk_link_to(
       'Continue',
       provider_interface_edit_provider_relationship_permissions_path(
-        ratifying_provider_id: @training_provider_permissions.first.ratifying_provider.id,
-        training_provider_id: @training_provider_permissions.first.training_provider.id,
+        ratifying_provider_id: @relationships_pending_setup.first.ratifying_provider.id,
+        training_provider_id: @relationships_pending_setup.first.training_provider.id,
       ),
       class: "govuk-button",
     ) %>

--- a/spec/requests/provider_interface/provider_relationship_permissions_setup_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_setup_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'ProviderRelationshipPermissions setup', type: :request do
         get provider_interface_applications_path
 
         expect(response.status).to eq(302)
-        expect(response.redirect_url).to eq(provider_interface_provider_relationship_permissions_setup_url)
+        expect(response.redirect_url).to eq(provider_interface_provider_relationship_permissions_setup_url(training_provider_id: provider.id))
       end
     end
 


### PR DESCRIPTION
## Context

There is a weird bug affecting provider users with `manage_organisations` permission when they try to log in when the `:enforce_provider_to_provider_permissions` flag is active, serving them Access Denied. Full steps to reproduce the this error can be found below.

## Changes proposed in this pull request

Specify the `training_provider_id` when redirecting provider users to the org-level permissions setup page. The previous code was picking up organisations unrelated to the user.

## Guidance to review

Steps to reproduce bug and verify the fix:
- Clear your local data.
- Recreate and seed the database (e.g. `setup_local_dev_data`)
- Use the support console to add Oriel High School to the providers
- Add an Oriel High School user (e.g. `oriel@example.com`)
- Switch the `:enforce_provider_to_provider_permissions` feature flag on
- Log into the provider interfaces as the Oriel High School user
- Accept the Data Sharing Agreement
- What do you see next? Access Denied or the organisation permissions setup page? 

I've added `training_provider_id` as a query param. Should it be part of the url?

## Link to Trello card

https://trello.com/c/TfyXM7kv

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
