### PR TITLE
Add feature flag for HESA degree data

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,6 +34,7 @@ class FeatureFlag
     [:mark_every_section_complete, 'Each section of the application form should have to be explicitly completed', 'David Gisbey'],
     [:replace_full_or_withdrawn_application_choices, 'Allows candidates to replace full or withdrawn application choices post-submission', 'David Gisbey'],
     [:unavailable_course_notifications, 'Candidates with applications waiting for references receive an email notification if their course choice is withdrawn has no vacancies', 'Steve Hook'],
+    [:hesa_degree_data, 'Use structured HESA data to autocomplete certain parts of the add degree flow', 'Malcolm Baig'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
For placing the HESA structured degree data changes behind.

## Changes proposed in this pull request
- A single feature flag called `hesa_degree_data`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Opting for one flag for all of the HESA changes planned for the degree flow. Any reason we might want one flag per data type?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/rXUPhuBC
## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
