### PR TITLE
Vendor API updates for international addresses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -188,7 +188,14 @@ module VendorAPI
     end
 
     def contact_details
-      if application_form.uk?
+      if application_form.international? && FeatureFlag.active?(:international_addresses)
+        {
+          phone_number: application_form.phone_number,
+          address_line1: application_form.international_address,
+          country: application_form.country,
+          email: application_form.candidate.email_address,
+        }
+      else
         {
           phone_number: application_form.phone_number,
           address_line1: application_form.address_line1,
@@ -196,13 +203,6 @@ module VendorAPI
           address_line3: application_form.address_line3,
           address_line4: application_form.address_line4,
           postcode: application_form.postcode,
-          country: application_form.country,
-          email: application_form.candidate.email_address,
-        }
-      else
-        {
-          phone_number: application_form.phone_number,
-          address_line1: application_form.international_address,
           country: application_form.country,
           email: application_form.candidate.email_address,
         }

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -30,16 +30,7 @@ module VendorAPI
             other_languages: application_form.other_language_details,
             disability_disclosure: application_form.disability_disclosure,
           },
-          contact_details: {
-            phone_number: application_form.phone_number,
-            address_line1: application_form.address_line1,
-            address_line2: application_form.address_line2,
-            address_line3: application_form.address_line3,
-            address_line4: application_form.address_line4,
-            postcode: application_form.postcode,
-            country: application_form.country,
-            email: application_form.candidate.email_address,
-          },
+          contact_details: contact_details,
           course: course_info_for(application_choice.course_option),
           references: references,
           qualifications: qualifications,
@@ -194,6 +185,28 @@ module VendorAPI
 
     def personal_statement
       "Why do you want to become a teacher?: #{application_form.becoming_a_teacher} \n What is your subject knowledge?: #{application_form.subject_knowledge}"
+    end
+
+    def contact_details
+      if application_form.uk?
+        {
+          phone_number: application_form.phone_number,
+          address_line1: application_form.address_line1,
+          address_line2: application_form.address_line2,
+          address_line3: application_form.address_line3,
+          address_line4: application_form.address_line4,
+          postcode: application_form.postcode,
+          country: application_form.country,
+          email: application_form.candidate.email_address,
+        }
+      else
+        {
+          phone_number: application_form.phone_number,
+          address_line1: application_form.international_address,
+          country: application_form.country,
+          email: application_form.candidate.email_address,
+        }
+      end
     end
 
     def offered_course

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 24th June 2020
+
+Changes to existing attributes:
+
+- `ApplicationForm` attributes `address_line1`, `address_line2`, `address_line3` and `postcode` are no longer required attributes.
+
 ### 16th June 2020
 
 Sandbox changes:

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -2,7 +2,7 @@
 
 Changes to existing attributes:
 
-- `ApplicationForm` attributes `address_line1`, `address_line2`, `address_line3` and `postcode` are no longer required attributes.
+- `ContactDetails` attributes `address_line1`, `address_line2`, `address_line3` and `postcode` are no longer required attributes.
 
 ### 16th June 2020
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -528,10 +528,6 @@ components:
       additionalProperties: false
       required:
       - address_line1
-      - address_line2
-      - address_line3
-      - address_line4
-      - postcode
       - country
       - email
       - phone_number
@@ -546,21 +542,25 @@ components:
           description: The candidate’s address line 2
           maxLength: 50
           example: Stockport
+          nullable: true
         address_line3:
           type: string
           description: The candidate’s address line 3
           maxLength: 50
           example: Greater Manchester
+          nullable: true
         address_line4:
           type: string
           description: The candidate’s address line 4
           maxLength: 50
           example: England
+          nullable: true
         postcode:
           type: string
           description: The candidate’s postcode
           maxLength: 8
           example: SK2 6AA
+          nullable: true
         country:
           type: string
           maxLength: 2

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -526,6 +526,9 @@ components:
     ContactDetails:
       type: object
       additionalProperties: false
+      description: UK addresses have country code 'GB' and `address_line1`, `address_line2`,
+        `address_line3`, `address_line4` and `postcode` attributes. International addresses have
+        a valid `country` value and the address itself is serialised to `address_line1`.
       required:
       - address_line1
       - country

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -145,6 +145,49 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.candidate.contact_details' do
+    it 'returns contact details in correct format for UK addresses' do
+      contact_detail_attributes = {
+        phone_number: '07700 900 982',
+        address_type: 'uk',
+        address_line1: '42',
+        address_line2: 'Much Wow Street',
+        address_line3: 'London',
+        address_line4: 'England',
+        country: 'United Kingdom',
+        postcode: 'SW1P 3BT',
+      }
+      application_form = create(:completed_application_form, :with_completed_references, contact_detail_attributes)
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.to_json).to be_valid_against_openapi_schema('Application')
+      expect(response.dig(:attributes, :contact_details)).to eq contact_detail_attributes
+    end
+
+    it 'returns contact details in correct format for international addresses' do
+      contact_detail_attributes = {
+        phone_number: '07700 900 982',
+        address_type: 'international',
+        international_address: '456 Marine Drive, Mumbai',
+        country: 'India',
+      }
+      application_form = create(:completed_application_form, :with_completed_references, contact_detail_attributes)
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.to_json).to be_valid_against_openapi_schema('Application')
+      expect(response.dig(:attributes, :contact_details)).to eq({
+        phone_number: '07700 900 982',
+        address_line1: '456 Marine Drive, Mumbai',
+        country: 'India',
+        email: application_form.candidate.email_address,
+      })
+    end
+  end
+
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
       let(:application_choice) do


### PR DESCRIPTION
## Context

Candidates who live overseas need to provide postal address in a localised format so that providers can contact them by post.

The upstream PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/2320 implements the main part of this feature. This PR just updates the Vendor API so that vendors have access to international addresses.

## Changes proposed in this pull request

- [x] Update the `SingleApplicationPresenter` to serialize international addresses - the address body is output to the `address_line1` field to avoid making any significant changes to the schema.
- [x] Update schema to allow nil values for UK-specific address fields.
- [x] Update release notes.
- [x] Rebase onto `master`

## Guidance to review

- This is designed to be a non-breaking change to the API and vendor applications. Is this true?

## Link to Trello card

https://trello.com/c/BUYJXkju/1735-extend-vendor-api-to-support-international-addresses

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
