### PR TITLE
Update the degree type page to use HESA data

### DIFF
--- a/app/controllers/candidate_interface/degrees/type_controller.rb
+++ b/app/controllers/candidate_interface/degrees/type_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   module Degrees
     class TypeController < CandidateInterfaceController
       before_action :redirect_to_dashboard_if_submitted
+      before_action :set_degree_type_names
 
       def new
         @degree_type_form = DegreeTypeForm.new
@@ -35,6 +36,10 @@ module CandidateInterface
       end
 
     private
+
+      def set_degree_type_names
+        @degree_types = Hesa::DegreeType.abbreviations_and_names
+      end
 
       def degree_type_params
         params

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -4,6 +4,7 @@ import { initAll as govUKFrontendInitAll } from "govuk-frontend";
 import initNationalityAutocomplete from "./nationality-autocomplete";
 import initCoursesAutocomplete from "./courses-autocomplete";
 import initProvidersAutocomplete from "./providers-autocomplete";
+import initDegreeTypeAutocomplete from "./degree-type-autocomplete";
 import initWarnOnUnsavedChanges from "./warn-on-unsaved-changes";
 import providerFilter from "./provider-filter";
 
@@ -14,5 +15,6 @@ govUKFrontendInitAll();
 initNationalityAutocomplete();
 initProvidersAutocomplete();
 initCoursesAutocomplete();
+initDegreeTypeAutocomplete();
 initWarnOnUnsavedChanges();
 providerFilter();

--- a/app/frontend/packs/degree-type-autocomplete.js
+++ b/app/frontend/packs/degree-type-autocomplete.js
@@ -19,28 +19,35 @@ const initDegreeTypeAutocomplete = () => {
   }
 
   try {
-    const inputId = "degree-type";
-    const input = document.getElementById(inputId);
-    const containerId = "degree-type-autocomplete";
-    const container = document.getElementById(containerId);
+    const inputIds = [
+      "candidate-interface-degree-type-form-type-description-field",
+      "candidate-interface-degree-type-form-type-description-field-error"
+    ];
 
-    if (!container) return;
+    inputIds.forEach(inputId => {
+      const input = document.getElementById(inputId);
+      if (!input) return;
 
-    const sourceData = JSON.parse(container.dataset.source);
+      const containerId = "degree-type-autocomplete";
+      const container = document.getElementById(containerId);
+      if (!container) return;
 
-    accessibleAutocomplete({
-      element: container,
-      id: inputId,
-      name: input.name,
-      source: sourceData,
-      showNoOptionsFound: true,
-      templates: {
-        inputValue: inputTemplate,
-        suggestion: suggestionTemplate
-      }
+      const sourceData = JSON.parse(container.dataset.source);
+
+      accessibleAutocomplete({
+        element: container,
+        id: inputId,
+        name: input.name,
+        source: sourceData,
+        showNoOptionsFound: true,
+        templates: {
+          inputValue: inputTemplate,
+          suggestion: suggestionTemplate
+        }
+      });
+
+      input.remove();
     });
-
-    input.remove();
 
   } catch (err) {
     console.error("Could not enhance degree type input:", err);

--- a/app/frontend/packs/degree-type-autocomplete.js
+++ b/app/frontend/packs/degree-type-autocomplete.js
@@ -2,20 +2,15 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initDegreeTypeAutocomplete = () => {
   function inputTemplate(result) {
-    if (result) {
-      const descriptor = result.split('|');
-
-      return descriptor[1]
-    }
+    return result ? result.split('|').pop() : '';
   }
 
   function suggestionTemplate(result) {
     const descriptor = result.split('|');
 
-    if (descriptor[0]) {
-      return `<strong>${descriptor[0]}</strong> <span class="autocomplete__option--hint">${descriptor[1]}</span>`
-    }
-    return `<strong>${descriptor[1]}</strong>`
+    return descriptor.length === 1
+      ? `<strong>${descriptor[0]}</strong>`
+      : `<strong>${descriptor[0]}</strong> <span class="autocomplete__option--hint">${descriptor[1]}</span>`
   }
 
   try {
@@ -40,6 +35,7 @@ const initDegreeTypeAutocomplete = () => {
         name: input.name,
         source: sourceData,
         showNoOptionsFound: true,
+        defaultValue: input.value,
         templates: {
           inputValue: inputTemplate,
           suggestion: suggestionTemplate

--- a/app/frontend/packs/degree-type-autocomplete.js
+++ b/app/frontend/packs/degree-type-autocomplete.js
@@ -1,6 +1,23 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 
 const initDegreeTypeAutocomplete = () => {
+  function inputTemplate(result) {
+    if (result) {
+      const descriptor = result.split('|');
+
+      return descriptor[1]
+    }
+  }
+
+  function suggestionTemplate(result) {
+    const descriptor = result.split('|');
+
+    if (descriptor[0]) {
+      return `<strong>${descriptor[0]}</strong> <span class="autocomplete__option--hint">${descriptor[1]}</span>`
+    }
+    return `<strong>${descriptor[1]}</strong>`
+  }
+
   try {
     const inputId = "degree-type";
     const input = document.getElementById(inputId);
@@ -10,25 +27,6 @@ const initDegreeTypeAutocomplete = () => {
     if (!container) return;
 
     const sourceData = JSON.parse(container.dataset.source);
-
-    function inputTemplate(result) {
-      if (result) {
-        const descriptor = result.split('|');
-
-        return descriptor[1]
-      }
-    }
-
-    function suggestionTemplate(result) {
-      const descriptor = result.split('|');
-
-      if (descriptor[0]) {
-        return `<strong>${descriptor[0]}</strong> <span class="autocomplete__option--hint">${descriptor[1]}</span>`
-      }
-      return `<strong>${descriptor[1]}</strong>`
-    }
-
-    input.remove();
 
     accessibleAutocomplete({
       element: container,
@@ -41,6 +39,9 @@ const initDegreeTypeAutocomplete = () => {
         suggestion: suggestionTemplate
       }
     });
+
+    input.remove();
+
   } catch (err) {
     console.error("Could not enhance degree type input:", err);
   }

--- a/app/frontend/packs/degree-type-autocomplete.js
+++ b/app/frontend/packs/degree-type-autocomplete.js
@@ -6,6 +6,9 @@ const initDegreeTypeAutocomplete = () => {
     const input = document.getElementById(inputId);
     const containerId = "degree-type-autocomplete";
     const container = document.getElementById(containerId);
+
+    if (!container) return;
+
     const sourceData = JSON.parse(container.dataset.source);
 
     function inputTemplate(result) {
@@ -24,8 +27,6 @@ const initDegreeTypeAutocomplete = () => {
       }
       return `<strong>${descriptor[1]}</strong>`
     }
-
-    if (!container) return;
 
     input.remove();
 

--- a/app/frontend/packs/degree-type-autocomplete.js
+++ b/app/frontend/packs/degree-type-autocomplete.js
@@ -1,0 +1,48 @@
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const initDegreeTypeAutocomplete = () => {
+  try {
+    const inputId = "degree-type";
+    const input = document.getElementById(inputId);
+    const containerId = "degree-type-autocomplete";
+    const container = document.getElementById(containerId);
+    const sourceData = JSON.parse(container.dataset.source);
+
+    function inputTemplate(result) {
+      if (result) {
+        const descriptor = result.split('|');
+
+        return descriptor[1]
+      }
+    }
+
+    function suggestionTemplate(result) {
+      const descriptor = result.split('|');
+
+      if (descriptor[0]) {
+        return `<strong>${descriptor[0]}</strong> <span class="autocomplete__option--hint">${descriptor[1]}</span>`
+      }
+      return `<strong>${descriptor[1]}</strong>`
+    }
+
+    if (!container) return;
+
+    input.remove();
+
+    accessibleAutocomplete({
+      element: container,
+      id: inputId,
+      name: input.name,
+      source: sourceData,
+      showNoOptionsFound: true,
+      templates: {
+        inputValue: inputTemplate,
+        suggestion: suggestionTemplate
+      }
+    });
+  } catch (err) {
+    console.error("Could not enhance degree type input:", err);
+  }
+};
+
+export default initDegreeTypeAutocomplete;

--- a/app/lib/hesa/degree_type.rb
+++ b/app/lib/hesa/degree_type.rb
@@ -1,0 +1,21 @@
+module Hesa
+  class DegreeType
+    DegreeTypeStruct = Struct.new(:hesa_code, :abbreviation, :name, :level)
+
+    class << self
+      def all
+        HESA_DEGREE_TYPES.map { |type_data| DegreeTypeStruct.new(*type_data) }
+      end
+
+      def abbreviations_and_names
+        all.map do |degree_type|
+          "#{degree_type.abbreviation}|#{degree_type.name}"
+        end
+      end
+
+      def find_by_name(name)
+        all.find { |degree_type| degree_type.name == name }
+      end
+    end
+  end
+end

--- a/app/models/candidate_interface/degree_type_form.rb
+++ b/app/models/candidate_interface/degree_type_form.rb
@@ -10,21 +10,51 @@ module CandidateInterface
 
     def save
       return false unless valid?
+      return false unless application_form_present?
 
       self.degree = application_form.application_qualifications.degree.create!(
         qualification_type: type_description,
+        qualification_type_hesa_code: hesa_code,
       )
     end
 
     def update
       return false unless valid?
+      return false unless degree_present?
 
-      degree.update!(qualification_type: type_description)
+      degree.update!(
+        qualification_type: type_description,
+        qualification_type_hesa_code: hesa_code,
+      )
     end
 
     def fill_form_values
       self.type_description = degree.qualification_type
       self
+    end
+
+  private
+
+    def hesa_code
+      Hesa::DegreeType.find_by_name(type_description)&.hesa_code
+    end
+
+    def application_form_present?
+      if application_form.present?
+        true
+      else
+        errors.add(:application_form, 'is missing')
+        false
+      end
+    end
+
+    def degree_present?
+      if degree.present?
+        true
+      else
+        errors.add(:degree, 'is missing')
+        false
+      end
     end
   end
 end

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -1,7 +1,9 @@
 <%= f.govuk_text_field(
   :type_description,
+  id: 'degree-type',
   label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
   hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
 ) %>
+<%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
 
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -1,6 +1,5 @@
 <%= f.govuk_text_field(
   :type_description,
-  id: 'degree-type',
   label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
   hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
 ) %>

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -4,6 +4,7 @@
   label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
   hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
 ) %>
-<%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
-
+<% if FeatureFlag.active? :hesa_degree_data %>
+  <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
+<% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::DegreeTypeForm do
+  describe '#save' do
+    context 'when the description matches an entry in the HESA data' do
+      let(:form) do
+        described_class.new(
+          type_description: 'Doctor of Divinity',
+          application_form: create(:application_form),
+        )
+      end
+
+      it 'persists both type description and HESA code' do
+        form.save
+
+        expect(form.application_form.application_qualifications.degree.size).to eq 1
+        degree = form.application_form.application_qualifications.degree.first
+        expect(degree.qualification_type).to eq 'Doctor of Divinity'
+        expect(degree.qualification_type_hesa_code).to eq 300
+      end
+    end
+
+    context 'when the description does not match an entry in the HESA data' do
+      let(:form) do
+        described_class.new(
+          type_description: 'Doctor of Rap Battles',
+          application_form: create(:application_form),
+        )
+      end
+
+      it 'persists type description but no HESA code' do
+        form.save
+
+        degree = form.application_form.application_qualifications.degree.first
+        expect(degree.qualification_type).to eq 'Doctor of Rap Battles'
+        expect(degree.qualification_type_hesa_code).to eq nil
+      end
+    end
+
+    context 'when missing type_description' do
+      let(:form) { described_class.new(application_form: build(:application_form)) }
+
+      it 'returns false and has errors' do
+        expect(form.save).to eq false
+        expect(form.errors.full_messages).to eq ['Type description Enter your degree type']
+      end
+    end
+
+    context 'when missing application_form' do
+      let(:form) { described_class.new(type_description: 'BSc') }
+
+      it 'returns false and has errors' do
+        expect(form.save).to eq false
+        expect(form.errors.full_messages).to eq ['Application form is missing']
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when the type description matches an entry in the HESA data' do
+      let(:degree) do
+        create(
+          :degree_qualification,
+          application_form: create(:application_form),
+          qualification_type: 'BSc',
+        )
+      end
+      let(:form) do
+        described_class.new(degree: degree, type_description: 'Doctor of Divinity')
+      end
+
+      it 'updates the qualification_type and HESA code' do
+        form.update
+
+        expect(degree.qualification_type).to eq 'Doctor of Divinity'
+        expect(degree.qualification_type_hesa_code).to eq 300
+      end
+    end
+
+    context 'when the type description does not match an entry in the HESA data' do
+      let(:degree) do
+        create(
+          :degree_qualification,
+          application_form: create(:application_form),
+          qualification_type: 'BSc',
+        )
+      end
+      let(:form) do
+        described_class.new(degree: degree, type_description: 'Doctor of Rap Battles')
+      end
+
+      it 'updates the qualification_type' do
+        form.update
+
+        expect(degree.qualification_type).to eq 'Doctor of Rap Battles'
+        expect(degree.qualification_type_hesa_code).to eq nil
+      end
+    end
+
+    context 'when missing type_description' do
+      let(:form) { described_class.new(degree: build(:degree_qualification)) }
+
+      it 'returns false and has errors' do
+        expect(form.update).to eq false
+        expect(form.errors.full_messages).to eq ['Type description Enter your degree type']
+      end
+    end
+
+    context 'when missing application_form' do
+      let(:form) { described_class.new(type_description: 'BSc') }
+
+      it 'returns false and has errors' do
+        expect(form.update).to eq false
+        expect(form.errors.full_messages).to eq ['Degree is missing']
+      end
+    end
+  end
+end

--- a/spec/lib/hesa/degree_type_spec.rb
+++ b/spec/lib/hesa/degree_type_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Hesa::DegreeType do
+  describe '.all' do
+    it 'returns a list of HESA degree type structs' do
+      degree_types = described_class.all
+
+      expect(degree_types.size).to eq 81
+      ba = degree_types.find { |dt| dt.hesa_code == 51 }
+      expect(ba.hesa_code).to eq 51
+      expect(ba.abbreviation).to eq 'BA'
+      expect(ba.name).to eq 'Bachelor of Arts'
+      expect(ba.level).to eq :bachelor
+    end
+  end
+
+  describe '.abbreviations_and_names' do
+    it 'returns a list of concatenated abbreviations and names' do
+      abbreviations_and_names = described_class.abbreviations_and_names
+
+      expect(abbreviations_and_names.first).to eq '|BEd'
+      expect(abbreviations_and_names[6]).to eq 'BA|Bachelor of Arts'
+    end
+  end
+
+  describe '.find_by_name' do
+    context 'given a valid name' do
+      it 'returns the matching struct' do
+        result = described_class.find_by_name('Bachelor of Divinity')
+
+        expect(result.abbreviation).to eq 'BD'
+        expect(result.name).to eq 'Bachelor of Divinity'
+      end
+    end
+
+    context 'given an unrecognised name' do
+      it 'returns nil' do
+        result = described_class.find_by_name('Master of Conjuration')
+
+        expect(result).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We need to allow users to choose from HESA options when they choose degree type during the 'add degree' flow.

## Changes proposed in this pull request

- Make degree type HESA data available to the frontend by rendering it into a data attribute on the page.
- Add JS to enhance the existing degree type input field with autocomplete based on this data.
- Allow the user to submit their own custom type description in addition to selecting a HESA type.
- Ensure we store the HESA code if the candidate selects one of the HESA options.
- Add a model (`Hesa::DegreeType`) to ease the process of retrieving and querying the degree type data.

<!-- If there are UI changes, please include Before and After screenshots. -->

### Before

---
<img width="684" alt="Screenshot 2020-06-24 at 09 21 20" src="https://user-images.githubusercontent.com/519250/85521416-211a9e00-b5fc-11ea-9bd2-2a82588ced79.png">

---

### After

---
<img width="724" alt="Screenshot 2020-06-24 at 09 21 01" src="https://user-images.githubusercontent.com/519250/85521431-25df5200-b5fc-11ea-9822-402d887e8d82.png">

---

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

- Per-commit recommended, followed by a quick check of the review app.
- Does the model around the HESA data make sense? Is there anything you'd change about its API?
- Missing from this PR is the scoping by undergrad/postgrad described on the card. This will follow in its own PR shortly.

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/rXUPhuBC
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
