### PR TITLE
Limit degree type autocomplete values when adding undergraduate degree

### DIFF
--- a/app/controllers/candidate_interface/degrees/type_controller.rb
+++ b/app/controllers/candidate_interface/degrees/type_controller.rb
@@ -2,11 +2,11 @@ module CandidateInterface
   module Degrees
     class TypeController < CandidateInterfaceController
       before_action :redirect_to_dashboard_if_submitted
-      before_action :set_degree_type_names
+      before_action :set_degree_type_names, only: %i[edit update]
 
       def new
         @degree_type_form = DegreeTypeForm.new
-        degree_already_added? ? render('add_another') : render('new')
+        conditionally_render_new_degree_type_form
       end
 
       def create
@@ -16,7 +16,7 @@ module CandidateInterface
             @degree_type_form.degree,
           )
         else
-          render :new
+          conditionally_render_new_degree_type_form
         end
       end
 
@@ -39,6 +39,16 @@ module CandidateInterface
 
       def set_degree_type_names
         @degree_types = Hesa::DegreeType.abbreviations_and_names
+      end
+
+      def conditionally_render_new_degree_type_form
+        if degree_already_added?
+          @degree_types = Hesa::DegreeType.abbreviations_and_names
+          render :add_another
+        else
+          @degree_types = Hesa::DegreeType.abbreviations_and_names(level: :undergraduate)
+          render :new
+        end
       end
 
       def degree_type_params

--- a/app/lib/hesa/degree_type.rb
+++ b/app/lib/hesa/degree_type.rb
@@ -1,20 +1,27 @@
 module Hesa
   class DegreeType
     DegreeTypeStruct = Struct.new(:hesa_code, :abbreviation, :name, :level)
+    UNDERGRADUATE_LEVELS = %i[bachelor master].freeze
 
     class << self
       def all
         HESA_DEGREE_TYPES.map { |type_data| DegreeTypeStruct.new(*type_data) }
       end
 
-      def abbreviations_and_names
-        all.map do |degree_type|
-          "#{degree_type.abbreviation}|#{degree_type.name}"
+      def abbreviations_and_names(level: :all)
+        case level
+        when :all
+          all
+            .map { |type| "#{type.abbreviation}|#{type.name}" }
+        when :undergraduate
+          all
+            .select { |type| type.level.in? UNDERGRADUATE_LEVELS }
+            .map { |type| "#{type.abbreviation}|#{type.name}" }
         end
       end
 
       def find_by_name(name)
-        all.find { |degree_type| degree_type.name == name }
+        all.find { |type| type.name == name }
       end
     end
   end

--- a/config/initializers/hesa_degree_types.rb
+++ b/config/initializers/hesa_degree_types.rb
@@ -82,5 +82,4 @@ HESA_DEGREE_TYPES = [
   [400, nil, 'First Degree', :other],
   [401, nil, 'Higher Degree', :other],
   [402, nil, 'Degree equivalent', :other],
-  [999, nil, 'Unknown', :other],
 ].freeze

--- a/spec/lib/hesa/degree_type_spec.rb
+++ b/spec/lib/hesa/degree_type_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hesa::DegreeType do
     it 'returns a list of HESA degree type structs' do
       degree_types = described_class.all
 
-      expect(degree_types.size).to eq 81
+      expect(degree_types.size).to eq 80
       ba = degree_types.find { |dt| dt.hesa_code == 51 }
       expect(ba.hesa_code).to eq 51
       expect(ba.abbreviation).to eq 'BA'
@@ -19,7 +19,29 @@ RSpec.describe Hesa::DegreeType do
       abbreviations_and_names = described_class.abbreviations_and_names
 
       expect(abbreviations_and_names.first).to eq '|BEd'
-      expect(abbreviations_and_names[6]).to eq 'BA|Bachelor of Arts'
+      expect(abbreviations_and_names[60]).to eq 'MTheol|Master of Theology'
+    end
+
+    context 'when specifying undergraduate level' do
+      let(:abbreviations_and_names) do
+        described_class.abbreviations_and_names(level: :undergraduate)
+      end
+
+      it 'returns the abbreviations and names scoped to undergraduate degrees' do
+        expect(
+          abbreviations_and_names.find { |descriptor| descriptor.include? 'Bachelor' },
+        ).not_to be_nil
+        expect(
+          abbreviations_and_names.find { |descriptor| descriptor.include? 'Master' },
+        ).not_to be_nil
+
+        expect(
+          abbreviations_and_names.find { |descriptor| descriptor.include? 'Doctor' },
+        ).to be_nil
+        expect(
+          abbreviations_and_names.find { |descriptor| descriptor.include? 'Degree equivalent' },
+        ).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
To meet the following success criteria:

- Candidates can choose from underdraguate and postgraduate HESA degree types when they add their undergraduate degree
- Candidates can choose from all degree types, including doctorates, when adding another degree
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
- Update the `Hesa::DegreeTypes#abbreviations_and_names` method to return different lists depending on the passed in arg.
- Update the controller to set the correct degree types list depending on whether an undergruate degree is being added, or 'another' degree.
## Guidance to review
- A whole-diff review is fairly easy to parse.
- Is the naming clear enough? 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/rXUPhuBC
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
