### PR TITLE
Cancel running build and retrigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,3 @@
-# this build, apply-for-teacher-training will be triggered as a downstream build to Apply/build-gems-node-modules-image
-resources:
-  pipelines:
-    - pipeline: gems_node_modules_build_pipeline
-      source: Apply/build-gems-node-modules-image
-      trigger:
-        branches:
-          include:
-            - "*"
 trigger:
   batch: true
   branches:
@@ -24,6 +15,11 @@ pr:
   branches:
     include:
       - master
+    exclude:
+      - Gemfile
+      - Gemfile.lock
+      - package.json
+      - yarn.lock
 
 variables:
 - group: Docker Shared variables

--- a/build-gems-node-modules-pipeline.yml
+++ b/build-gems-node-modules-pipeline.yml
@@ -7,6 +7,17 @@ trigger:
       - Gemfile.lock
       - package.json
       - yarn.lock
+      - build-gems-node-modules-pipeline.yml
+
+pr:
+  paths:
+    include:
+      - Dockerfile
+      - Gemfile
+      - Gemfile.lock
+      - package.json
+      - yarn.lock
+      - build-gems-node-modules-pipeline.yml
 
 pool:
   vmImage: 'Ubuntu-16.04'
@@ -26,8 +37,43 @@ steps:
     DEPENDENCIES_SHA=$(echo $GEM_NODE_PACKAGE_FILES_SHA | sha1sum | cut -c 1-7)
     echo "##vso[task.setvariable variable=DEPENDENCIES_SHA]$DEPENDENCIES_SHA"
     echo "##[command]$DEPENDENCIES_SHA"
+    docker pull $(dockerHubUsername)/$(gemsNodeModulesImageName):$DEPENDENCIES_SHA && IMAGE_EXISTS_IN_HUB=true || IMAGE_EXISTS_IN_HUB=false
+    echo "##vso[task.setvariable variable=IMAGE_EXISTS_IN_HUB]$IMAGE_EXISTS_IN_HUB"
+    echo "##[command]$IMAGE_EXISTS_IN_HUB"
   displayName: Prepare environment variables
 
+- powershell: |
+    $azureDevOpsAuthorizationHeader = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+    # APPLY_TEACHER_TRAINING_BUILD_DEFINITION: 49
+    $getApplyTeacherTrainingBuildApi = "$($env:COLLECTION_URL)$env:PROJECT_ID/_apis/build/builds?definitions=49&branchName=$($env:SOURCE_BRANCH)&sourceVersion=$($env:SOURCE_VERSION)&statusFilter=inProgress&api-version=5.1"
+    $applyTeacherTrainingBuilds = Invoke-RestMethod -Uri $getApplyTeacherTrainingBuildApi -Headers $azureDevOpsAuthorizationHeader -Method Get -ErrorAction Stop -ErrorVariable $errorVariable
+    Write-Host $applyTeacherTrainingBuilds | ConvertTo-Json
+    if($applyTeacherTrainingBuilds.count -gt 0){
+      foreach($build in $applyTeacherTrainingBuilds.value){
+        echo "##[command]Cancelling Build $($build.id)"
+        $requestBody = @{
+          buildNumber = $build.buildNumber
+          id = $build.id
+          status = "cancelling"
+        } | ConvertTo-Json
+        # cancel the build, it will be resumed once the $(gemsNodeModulesImageName) image will be built
+        $azurePipelinesBuildApi = "$($build._links.self.href)?api-version=5.1"
+        Invoke-RestMethod -Uri $azurePipelinesBuildApi -Headers $azureDevOpsAuthorizationHeader -Method Patch -Body $requestBody -ContentType "application/json" -ErrorAction SilentlyContinue
+        echo "##[command]Cancelled $($build._links.web.href)"
+      }
+    }
+  condition: and(succeeded(), eq(variables['IMAGE_EXISTS_IN_HUB'], false))
+  displayName: Cancel apply-for-teacher-training CI build
+  continueOnError: true
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    ORGANISATION_ID: $(System.CollectionId)
+    COLLECTION_URL: $(System.TeamFoundationCollectionUri)
+    COMMIT_ID: $(Build.SourceVersion)
+    SOURCE_BRANCH: $(Build.SourceBranch)
+    SOURCE_VERSION: $(Build.SourceVersion)
+    PROJECT_ID: $(System.TeamProjectId)
+   
 - bash: |
     set -eux
     echo "gemsNodeModulesImageName is $(gemsNodeModulesImageName)"
@@ -36,9 +82,11 @@ steps:
     -t $(dockerHubUsername)/$(gemsNodeModulesImageName):$(DEPENDENCIES_SHA) \
     "."
   displayName: Build ${{ variables.dockerHubUsername }}/${{ variables.gemsNodeModulesImageName }}
+  condition: and(succeeded(), eq(variables['IMAGE_EXISTS_IN_HUB'], false))
 
 - task: Docker@2
   displayName: Docker Login
+  condition: and(succeeded(), eq(variables['IMAGE_EXISTS_IN_HUB'], false))
   inputs:
     containerRegistry: 'DfE Docker Hub'
     command: 'login'
@@ -48,9 +96,36 @@ steps:
     docker images
     docker push $(dockerHubUsername)/$(gemsNodeModulesImageName):$(DEPENDENCIES_SHA)
   displayName: Docker Push ${{ variables.dockerHubUsername }}/${{ variables.gemsNodeModulesImageName }}
+  condition: and(succeeded(), eq(variables['IMAGE_EXISTS_IN_HUB'], false))
 
 - task: Docker@2
   displayName: Docker Logout
+  condition: and(succeeded(), eq(variables['IMAGE_EXISTS_IN_HUB'], false))
   inputs:
     containerRegistry: 'DfE Docker Hub'
     command: 'logout'
+
+- powershell: |
+    $azureDevOpsAuthorizationHeader = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+    $newBuild = @{
+      definition = @{
+        id = 49
+      }
+      sourceVersion = $env:SOURCE_VERSION
+      sourceBranch = $env:SOURCE_BRANCH
+    }
+    $requestBody = $newBuild | ConvertTo-Json
+    $requestBody
+    $azurePipelinesBuildApi = "$($env:COLLECTION_URL)$env:PROJECT_ID/_apis/build/builds?api-version=5.1"
+    Invoke-RestMethod -Uri $azurePipelinesBuildApi -Headers $azureDevOpsAuthorizationHeader -Method Post -Body $requestBody -ContentType "application/json" -ErrorAction SilentlyContinue
+  condition: and(succeeded(), eq(variables['IMAGE_EXISTS_IN_HUB'], false))
+  displayName: Trigger apply-for-teacher-training build
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    ORGANISATION_ID: $(System.CollectionId)
+    COLLECTION_URL: $(System.TeamFoundationCollectionUri)
+    COMMIT_ID: $(Build.SourceVersion)
+    SOURCE_BRANCH: $(Build.SourceBranch)
+    SOURCE_VERSION: $(Build.SourceVersion)
+    PROJECT_ID: $(System.TeamProjectId)  
+    BUILD_ID: $(Build.BuildId)


### PR DESCRIPTION
## Context

#2332 introduces a new build to build a base gems and node modules image which is running multiple times and causing multiple runs of the main CI pipeline.

## Changes proposed in this pull request

Build the base `gems-node-modules` image only if a image for the hash doesn't already exist in DockerHub.
Remove resource trigger from main CI pipeline and trigger it conditionally at the end of the `gems-node-modules` build
if a new image has been published.

## Guidance to review

per commit

## Link to Trello card


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
