### PR TITLE
Sync 2021 courses when the feature flag is on

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -100,6 +100,10 @@ class Course < ApplicationRecord
     "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{code}"
   end
 
+  def in_previous_cycle
+    Course.find_by(recruitment_cycle_year: recruitment_cycle_year - 1, provider_id: provider_id, code: code)
+  end
+
   def application_forms
     ApplicationForm
       .includes(:candidate, :application_choices)

--- a/app/services/sync_all_providers_from_find.rb
+++ b/app/services/sync_all_providers_from_find.rb
@@ -4,7 +4,11 @@ class SyncAllProvidersFromFind
     #
     # For the full response, see:
     # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers
-    find_providers = FindAPI::Provider.recruitment_cycle(RecruitmentCycle.current_year).all
+    find_providers = if FeatureFlag.active?(:switch_to_2021_recruitment_cycle)
+                       FindAPI::Provider.recruitment_cycle(2021).all
+                     else
+                       FindAPI::Provider.recruitment_cycle(RecruitmentCycle.current_year).all
+                     end
 
     sync_providers(find_providers)
 

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -79,7 +79,17 @@ private
   end
 
   def create_or_update_course(find_course)
-    course = provider.courses.find_or_create_by(code: find_course.course_code)
+    course = provider.courses.find_or_create_by(
+      code: find_course.course_code,
+      recruitment_cycle_year: find_course.recruitment_cycle_year,
+    ) do |new_course|
+      new_course.open_on_apply = if new_course.in_previous_cycle&.open_on_apply
+                                   true
+                                 else
+                                   false
+                                 end
+    end
+
     assign_course_attributes_from_find(course, find_course)
     add_accredited_provider(course, find_course[:accrediting_provider])
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -53,4 +53,21 @@ RSpec.describe Course, type: :model do
       end
     end
   end
+
+  describe '#in_previous_cycle' do
+    it 'returns nil when there is no equivalent in the previous cycle' do
+      course = create(:course)
+
+      expect(course.in_previous_cycle).to be_nil
+    end
+
+    it 'returns the equivalent in the previous cycle when there is one' do
+      provider = create(:provider)
+      course_in_previous_cycle = create(:course, code: 'ABC', provider: provider, recruitment_cycle_year: 2019)
+
+      course = create(:course, code: 'ABC', provider: provider, recruitment_cycle_year: 2020)
+
+      expect(course.in_previous_cycle).to eq course_in_previous_cycle
+    end
+  end
 end


### PR DESCRIPTION
## Context

We need to be able to sync 2021 courses.

## Changes proposed in this pull request

- introduce a new rule that when a course is first synced, it inherits open_on_apply status from its predecessor
- the `switch_to_2021_recruitment_cycle` feature flag changes SyncAllProvidersFromFind to use the 2021 cycle

## Link to Trello card

https://trello.com/c/Tgq41OB9/2253-rollover-start-syncing-dummy-2021-data

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
