### PR TITLE
Update copy for interview needs page

### DIFF
--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -9,26 +9,32 @@
       <h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>
 
       <p class="govuk-body">
-        Interviews usually take place over the course of a day.
-        You’ll need to attend in person.
+        Providers do not usually have much flexibility when setting a date
+        and time for interview unless you need adjustments due to a
+        <%=
+          govuk_link_to(
+            'health condition or disability',
+            candidate_interface_training_with_a_disability_edit_path,
+          )
+        %>
       </p>
 
       <p class="govuk-body">
-        Training providers might not have much flexibility when setting a date
-        and time for interview.
+        However, if you need flexibility for other reasons you can tell us about it here.
       </p>
 
       <p class="govuk-body">
-        If there’s a reason why you need some flexibility you can tell us about
-        it here.
+        For example: you have commitments like caring responsibilities or employment.
       </p>
 
-      <p class="govuk-body">For example:</p>
+      <p class="govuk-body">
+        Interview processes might be different at the moment because of
+        coronavirus (COVID-19).
+      </p>
 
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-        <li>you have commitments such as employment or caring responsibilities</li>
-        <li>you’ll be travelling a long way to get to the interview</li>
-      </ul>
+      <p class="govuk-body">
+        Contact your provider if you're concerned about the interview process.
+      </p>
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>


### PR DESCRIPTION
## Context

Interview processes are different now because of coronavirus.

We need to change the content on the 'interview needs' page so that it's still correct.

## Changes proposed in this pull request

Update to the copy for the _Interview needs_ page:

<img width="629" alt="image" src="https://user-images.githubusercontent.com/450843/85688559-c2bbf100-b6c9-11ea-8029-57bdba24ebc4.png">

## Guidance to review

Does the copy look the way it should?

## Link to Trello card

https://trello.com/c/vr3pSDAL/1734-dev-replace-content-on-interview-needs-page

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
