### PR TITLE
Add withdrawal feedback questionnaire

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -50,12 +50,26 @@ module CandidateInterface
     end
 
     def feedback
+      @withdrawal_feedback_form = WithdrawalFeedbackForm.new
       @provider = @application_choice.provider
       @course = @application_choice.course
     end
 
     def confirm_feedback
-    end 
+      @withdrawal_feedback_form = WithdrawalFeedbackForm.new(withdrawl_feedback_params)
+
+      if @withdrawal_feedback_form.save(@application_choice)
+        flash[:success] = 'Thank you for your feedback.'
+
+        redirect_to candidate_interface_application_complete_path
+      else
+        track_validation_error(@withdrawal_feedback_form)
+        @provider = @application_choice.provider
+        @course = @application_choice.course
+
+        render :feedback
+      end
+    end
 
   private
 
@@ -88,6 +102,10 @@ module CandidateInterface
 
     def check_that_candidate_has_an_offer
       render_404 unless @application_choice.offer?
+    end
+
+    def withdrawl_feedback_params
+      params.fetch(:candidate_interface_withdrawal_feedback_form, {}).permit(:feedback, :explanation, :consent_to_be_contacted, :contact_details)
     end
 
     def course_choice_rows

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -46,8 +46,12 @@ module CandidateInterface
       withdrawal = WithdrawApplication.new(application_choice: @application_choice)
       withdrawal.save!
 
-      flash[:success] = 'Your application has been withdrawn'
-      redirect_to candidate_interface_application_form_path
+      redirect_to candidate_interface_withdraw_feedback_path
+    end
+
+    def feedback
+      @provider = @application_choice.provider
+      @course = @application_choice.course
     end
 
   private

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -54,6 +54,9 @@ module CandidateInterface
       @course = @application_choice.course
     end
 
+    def confirm_feedback
+    end 
+
   private
 
     def set_application_choice

--- a/app/forms/candidate_interface/withdrawal_feedback_form.rb
+++ b/app/forms/candidate_interface/withdrawal_feedback_form.rb
@@ -1,0 +1,36 @@
+module CandidateInterface
+  class WithdrawalFeedbackForm
+    include ActiveModel::Model
+
+    attr_accessor :feedback, :explanation, :consent_to_be_contacted, :contact_details
+
+    validates :feedback, :consent_to_be_contacted, presence: true
+    validates :explanation, presence: true, if: :feedback?
+    validates :contact_details, presence: true, if: :consent_to_be_contacted?
+
+    def save(application_choice)
+      if valid?
+        questionnaire = {
+          CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION => feedback,
+          'Explanation' => explanation,
+          CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => consent_to_be_contacted,
+          'Contact details' => contact_details,
+        }
+
+        application_choice.update!(withdrawal_feedback: questionnaire)
+      else
+        false
+      end
+    end
+
+  private
+
+    def feedback?
+      feedback == 'yes'
+    end
+
+    def consent_to_be_contacted?
+      consent_to_be_contacted == 'yes'
+    end
+  end
+end

--- a/app/models/candidate_interface/withdrawal_questionnaire.rb
+++ b/app/models/candidate_interface/withdrawal_questionnaire.rb
@@ -1,0 +1,6 @@
+module CandidateInterface
+  class WithdrawalQuestionnaire
+    EXPLANATION_QUESTION = 'Do you have a reason for withdrawing?'.freeze
+    CONSENT_TO_BE_CONTACTED_QUESTION = 'Can we contact you about your experience of using this service?'.freeze
+  end
+end

--- a/app/views/candidate_interface/decisions/feedback.html.erb
+++ b/app/views/candidate_interface/decisions/feedback.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, t('page_titles.withdraw_feedback') %>
+
+<div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
+  <h1 class="govuk-panel__title">
+    <%= t('page_titles.withdraw_feedback') %>
+  </h1>
+
+  <div class="govuk-panel__body">
+      We will let <%= @provider.name %> know that you have withdrawn your application for <%= @course.name_and_code %>
+  </div>
+</div>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @withdrawal_feedback_form, url: candidate_interface_confirm_withdraw_path do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :withdrawl_reason, legend: { text: 'Do you have a reason for withdrawing?', tag: 'span' } do %>
+
+        <%= f.govuk_radio_button :feedback, 'yes', label: { text: 'Yes. I’d like to share my reason with the Department for Education' } do %>
+          <%= f.govuk_text_area :explanation, label: { text: 'Please explain your reason for withdrawing from this course.' }, hint_text: 'Your provider will not see this feedback.' %>
+        <% end %>
+
+        <%= f.govuk_radio_button :feedback, 'no', label: { text: 'I’d prefer not to say' } %>
+      <% end %>
+
+
+      <%= f.govuk_radio_buttons_fieldset :can_be_contacted,
+                                          legend: { text: 'Can we contact you about your experience of using this service?', tag: 'span' },
+                                          hint_text: 'We’d ideally like to speak on the phone for half an hour.' do %>
+
+        <%= f.govuk_radio_button :consent_to_be_contacted, 'yes', label: { text: 'Yes, you can contact me' } do %>
+          <%= f.govuk_text_area :contact_details, label: { text: 'Please let us know when you’re available and give a phone number.' } %>
+        <% end %>
+
+        <%= f.govuk_radio_button :consent_to_be_contacted, 'no', label: { text: 'I’d prefer not to say' } %>
+      <% end %>
+
+      <%= f.submit 'Continue', class: 'govuk-button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/decisions/feedback.html.erb
+++ b/app/views/candidate_interface/decisions/feedback.html.erb
@@ -1,5 +1,4 @@
-<% content_for :title, t('page_titles.withdraw_feedback') %>
-
+<% content_for :title, title_with_error_prefix(t('page_titles.withdraw_feedback'),  @withdrawal_feedback_form.errors.any?) %>
 <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
   <h1 class="govuk-panel__title">
     <%= t('page_titles.withdraw_feedback') %>
@@ -14,7 +13,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @withdrawal_feedback_form, url: candidate_interface_confirm_feedback_path do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :withdrawal_reason, legend: { text: 'Do you have a reason for withdrawing?', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :withdrawal_reason, legend: { text: CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION, tag: 'span' } do %>
 
         <%= f.govuk_radio_button :feedback, 'yes', label: { text: 'Yes, I’d like to share my reason with the Department for Education' } do %>
           <%= f.govuk_text_area :explanation, label: { text: 'Please explain your reason for withdrawing from this course.' }, hint_text: 'Your provider will not see this feedback.' %>
@@ -25,7 +24,7 @@
 
 
       <%= f.govuk_radio_buttons_fieldset :can_be_contacted,
-                                          legend: { text: 'Can we contact you about your experience of using this service?', tag: 'span' },
+                                          legend: { text: CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION, tag: 'span' },
                                           hint_text: 'We’d ideally like to speak on the phone for half an hour.' do %>
 
         <%= f.govuk_radio_button :consent_to_be_contacted, 'yes', label: { text: 'Yes, you can contact me' } do %>

--- a/app/views/candidate_interface/decisions/feedback.html.erb
+++ b/app/views/candidate_interface/decisions/feedback.html.erb
@@ -13,10 +13,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @withdrawal_feedback_form, url: candidate_interface_confirm_withdraw_path do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :withdrawl_reason, legend: { text: 'Do you have a reason for withdrawing?', tag: 'span' } do %>
+    <%= form_with model: @withdrawal_feedback_form, url: candidate_interface_confirm_feedback_path do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :withdrawal_reason, legend: { text: 'Do you have a reason for withdrawing?', tag: 'span' } do %>
 
-        <%= f.govuk_radio_button :feedback, 'yes', label: { text: 'Yes. I’d like to share my reason with the Department for Education' } do %>
+        <%= f.govuk_radio_button :feedback, 'yes', label: { text: 'Yes, I’d like to share my reason with the Department for Education' } do %>
           <%= f.govuk_text_area :explanation, label: { text: 'Please explain your reason for withdrawing from this course.' }, hint_text: 'Your provider will not see this feedback.' %>
         <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
     course_choice: Course choice
     full_course: You cannot apply to this course because it has no vacancies
     withdraw_course_choice: Withdrawal
+    withdraw_feedback: Course choice withdrawn 
     destroy_course_choice: Are you sure you want to delete this choice?
     have_you_chosen: Have you chosen a course to apply to?
     find_a_course: Find a course

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,9 @@ Rails.application.routes.draw do
 
         get '/withdraw' => 'decisions#withdraw', as: :withdraw
         post '/withdraw' => 'decisions#confirm_withdraw'
+
+        get '/withdraw/feedback' => 'decisions#feedback', as: :withdraw_feedback
+        post '/withdraw/confirm' => 'decisions#confirm_withdraw', as: :confirm_withdraw
       end
 
       scope '/other-qualifications' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,7 +260,7 @@ Rails.application.routes.draw do
         post '/withdraw' => 'decisions#confirm_withdraw'
 
         get '/withdraw/feedback' => 'decisions#feedback', as: :withdraw_feedback
-        post '/withdraw/confirm' => 'decisions#confirm_withdraw', as: :confirm_withdraw
+        post '/withdraw/confirm-feedback' => 'decisions#confirm_feedback', as: :confirm_feedback
       end
 
       scope '/other-qualifications' do

--- a/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::WithdrawalFeedbackForm, type: :model do
+  describe 'validations' do
+    let(:form) { subject }
+
+    it { is_expected.to validate_presence_of(:feedback) }
+    it { is_expected.to validate_presence_of(:consent_to_be_contacted) }
+
+    context 'if the candidate selects they want to give feedback' do
+      before { allow(form).to receive(:feedback?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:explanation) }
+    end
+
+    context 'if the candidate selects can be contacted' do
+      before { allow(form).to receive(:consent_to_be_contacted?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:contact_details) }
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      withdrawal_feedback = described_class.new
+
+      expect(withdrawal_feedback.save(ApplicationChoice.new)).to eq(false)
+    end
+
+    it 'updates the withdrawl feedback column if valid' do
+      application_choice = create(:application_choice, status: 'withdrawn')
+      withdrawal_feedback = described_class.new(
+        feedback: true,
+        explanation: 'I do not want to travel that far.',
+        consent_to_be_contacted: true,
+        contact_details: 'Anytime. 012345 678900',
+      )
+
+      expect(withdrawal_feedback.save(application_choice)).to eq(true)
+      expect(application_choice.withdrawal_feedback).to eq(
+        {
+          CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION => true,
+          'Explanation' => 'I do not want to travel that far.',
+          CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => true,
+          'Contact details' => 'Anytime. 012345 678900',
+        },
+      )
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -26,10 +26,16 @@ RSpec.feature 'A candidate withdraws her application' do
     then_i_see_a_confirmation_page
 
     when_i_click_to_confirm_withdrawal
-    then_my_application_should_be_withdrawn
-    and_i_do_not_see_the_covid_19_guidance
+    then_i_see_the_withdraw_choice_feedback_page
+    and_my_application_should_be_withdrawn
     and_a_slack_notification_is_sent
     and_the_provider_has_received_an_email
+
+    when_i_fill_in_my_feedback
+    and_i_click_continue
+    then_i_see_my_application_dashboard
+    and_i_am_thanked_for_my_feedback
+    and_i_do_not_see_the_covid_19_guidance
 
     when_i_try_to_visit_the_withdraw_page
     then_i_see_the_page_not_found
@@ -83,8 +89,16 @@ RSpec.feature 'A candidate withdraws her application' do
     click_button 'Yes I’m sure - withdraw this course choice'
   end
 
-  def then_my_application_should_be_withdrawn
+  def then_i_see_the_withdraw_choice_feedback_page
+    expect(page).to have_current_path candidate_interface_withdraw_feedback_path
+  end
+
+  def and_my_application_should_be_withdrawn
     expect(page).to have_content('Your application has been withdrawn')
+  end
+
+  def then_my_application_should_be_withdrawn
+    and_my_application_should_be_withdrawn
   end
 
   def and_i_do_not_see_the_covid_19_guidance
@@ -106,6 +120,25 @@ RSpec.feature 'A candidate withdraws her application' do
   def and_the_provider_has_received_an_email
     open_email(@provider_user.email_address)
     expect(current_email.subject).to have_content "#{@application_choice.application_form.full_name} withdrew their application"
+  end
+
+  def when_i_fill_in_my_feedback
+    choose 'Yes, I’d like to share my reason with the Department for Education'
+    fill_in :reason_explanation, with: 'I don’t want to go there.'
+    choose 'Yes, you can contact me'
+    fill_in :contact_details, with: 'Anytime, 012345 678900'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_my_application_dashboard
+    expect(page).to have_current_path candidate_interface_application_complete_path
+  end
+
+  def and_i_am_thanked_for_my_feedback
+    expect(page).to have_content 'Thank you for your feedback.'
   end
 
   def and_the_candidate_has_received_an_email_with_information_on_apply_again

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -90,11 +90,11 @@ RSpec.feature 'A candidate withdraws her application' do
   end
 
   def then_i_see_the_withdraw_choice_feedback_page
-    expect(page).to have_current_path candidate_interface_withdraw_feedback_path
+    expect(page).to have_current_path candidate_interface_withdraw_feedback_path(@application_choice.id)
   end
 
   def and_my_application_should_be_withdrawn
-    expect(page).to have_content('Your application has been withdrawn')
+    expect(page).to have_content('Course choice withdrawn')
   end
 
   def then_my_application_should_be_withdrawn
@@ -124,7 +124,7 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def when_i_fill_in_my_feedback
     choose 'Yes, I’d like to share my reason with the Department for Education'
-    fill_in :reason_explanation, with: 'I don’t want to go there.'
+    fill_in :explanation, with: 'I don’t want to go there.'
     choose 'Yes, you can contact me'
     fill_in :contact_details, with: 'Anytime, 012345 678900'
   end

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -124,9 +124,9 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def when_i_fill_in_my_feedback
     choose 'Yes, I’d like to share my reason with the Department for Education'
-    fill_in :explanation, with: 'I don’t want to go there.'
+    fill_in 'candidate-interface-withdrawal-feedback-form-explanation-field', with: 'I don’t want to go there.'
     choose 'Yes, you can contact me'
-    fill_in :contact_details, with: 'Anytime, 012345 678900'
+    fill_in 'candidate-interface-withdrawal-feedback-form-contact-details-field', with: 'Anytime, 012345 678900'
   end
 
   def and_i_click_continue


### PR DESCRIPTION
## Context

We would like information on why a candidate has chosen to withdraw their course choice.

This PR adds a questionnaire for the candidate to complete upon withdrawing their course choicce.


## Changes proposed in this pull request

- Add a withdrawal feedback page

![image](https://user-images.githubusercontent.com/42515961/85689346-758c4f00-b6ca-11ea-94f6-f7984bc2df7d.png)

## Guidance to review

The CSV export will come in another PR.
 
## Link to Trello card

https://trello.com/c/fHkzCjyC/1702-dev-reasons-for-candidate-withdrawing-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
