### PR TITLE
Create course choice withdrawal survey export

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -74,6 +74,19 @@ module SupportInterface
       send_data csv, filename: "tad-provider-performance-#{Time.zone.today}.csv", disposition: :attachment
     end
 
+    def course_choice_withdrawal
+      answers = SupportInterface::CourseChoiceWithdrawalSurveyExport.call
+
+      if answers.present?
+        csv = to_csv(answers)
+        send_data csv, filename: "course-choice_withdrawl-survey-#{Time.zone.today}.csv", disposition: :attachment
+      else
+        flash[:warning] = 'No candidates have filled in the survey'
+
+        redirect_to support_interface_performance_path
+      end
+    end
+
   private
 
     def to_csv(objects, header_row = nil)

--- a/app/services/support_interface/course_choice_withdrawal_survey_export.rb
+++ b/app/services/support_interface/course_choice_withdrawal_survey_export.rb
@@ -1,0 +1,21 @@
+module SupportInterface
+  class CourseChoiceWithdrawalSurveyExport
+    def self.call
+      application_choices = ApplicationChoice.where.not(withdrawal_feedback: nil)
+
+      output = []
+
+      application_choices.includes(:application_form).each do |application_choice|
+        survey = application_choice.withdrawal_feedback
+
+        answer = {
+          'Name' => application_choice.application_form.full_name,
+        }.merge(survey)
+
+        output << answer
+      end
+
+      output
+    end
+  end
+end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -87,6 +87,14 @@
   <%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %>
 </p>
 
+<h3 class="govuk-heading-m">Candidate course choice withdrawal survey</h3>
+
+<p class="govuk-body">A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download course choice withdrawal survey results (CSV)', support_interface_course_choice_withdrawal_survey_path %>
+</p>
+
 <h3 class="govuk-heading-m">Provider performance for TAD</h3>
 
 <p class="govuk-body">A list of all application/offered/accepted counts for all courses in Apply</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -586,6 +586,7 @@ Rails.application.routes.draw do
     get '/performance/applications-export-for-ucas', to: 'performance#applications_export_for_ucas', as: :applications_export_for_ucas
     get '/performance/active-provider-users', to: 'performance#active_provider_users', as: :active_provider_users
     get '/performance/tad-provider-performance', to: 'performance#tad_provider_performance', as: :tad_provider_performance
+    get '/performance/course-choice-withdrawal', to: 'performance#course_choice_withdrawal', as: :course_choice_withdrawal_survey
 
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -368,6 +368,19 @@ FactoryBot.define do
       status { :application_complete }
     end
 
+    trait :withdrawn_with_survey_completed do
+      association :application_form, factory: %i[completed_application_form with_completed_references ready_to_send_to_provider]
+      status { :withdrawn }
+      withdrawal_feedback do
+        {
+          CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION => 'yes',
+          'Explanation' => Faker::Lorem.paragraph_by_chars(number: 300),
+          CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => 'yes',
+          'Contact details' => Faker::PhoneNumber.cell_phone,
+        }
+      end
+    end
+
     trait :with_rejection do
       status { 'rejected' }
       rejection_reason { Faker::Lorem.paragraph_by_chars(number: 300) }

--- a/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
@@ -30,18 +30,18 @@ RSpec.describe CandidateInterface::WithdrawalFeedbackForm, type: :model do
     it 'updates the withdrawl feedback column if valid' do
       application_choice = create(:application_choice, status: 'withdrawn')
       withdrawal_feedback = described_class.new(
-        feedback: true,
+        feedback: 'yes',
         explanation: 'I do not want to travel that far.',
-        consent_to_be_contacted: true,
+        consent_to_be_contacted: 'yes',
         contact_details: 'Anytime. 012345 678900',
       )
 
       expect(withdrawal_feedback.save(application_choice)).to eq(true)
       expect(application_choice.withdrawal_feedback).to eq(
         {
-          CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION => true,
+          CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION => 'yes',
           'Explanation' => 'I do not want to travel that far.',
-          CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => true,
+          CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => 'yes',
           'Contact details' => 'Anytime. 012345 678900',
         },
       )

--- a/spec/services/support_interface/course_choice_withdrawal_survey_export_spec.rb
+++ b/spec/services/support_interface/course_choice_withdrawal_survey_export_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CourseChoiceWithdrawalSurveyExport do
+  describe '#call' do
+    it 'returns a hash of candidates course choice withdrawal survey answers' do
+      application_choice1 = create(:application_choice, :withdrawn_with_survey_completed)
+      application_choice2 = create(:application_choice, :withdrawn_with_survey_completed)
+      application_choice3 = create(:application_choice, :withdrawn_with_survey_completed)
+      create(:application_choice)
+
+      expect(described_class.call).to match_array([return_expected_hash(application_choice1), return_expected_hash(application_choice2), return_expected_hash(application_choice3)])
+    end
+  end
+
+private
+
+  def return_expected_hash(application_choice)
+    survey = application_choice.withdrawal_feedback
+    {
+      'Name' => application_choice.application_form.full_name,
+      CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION => 'yes',
+      'Explanation' => survey['Explanation'],
+      CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => 'yes',
+      'Contact details' => survey['Contact details'],
+    }
+  end
+end

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -124,9 +124,9 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def when_i_fill_in_my_feedback
     choose 'Yes, I’d like to share my reason with the Department for Education'
-    fill_in :explanation, with: 'I don’t want to go there.'
+    fill_in 'candidate-interface-withdrawal-feedback-form-explanation-field', with: 'I don’t want to go there.'
     choose 'Yes, you can contact me'
-    fill_in :contact_details, with: 'Anytime, 012345 678900'
+    fill_in 'candidate-interface-withdrawal-feedback-form-contact-details-field', with: 'Anytime, 012345 678900'
   end
 
   def and_i_click_continue

--- a/spec/system/support_interface/course_choice_withdrawal_survey_csv_spec.rb
+++ b/spec/system/support_interface/course_choice_withdrawal_survey_csv_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.feature 'Course choice withdrawal survey CSV' do
+  include DfESignInHelpers
+
+  scenario 'support user can download a CSV with the course choice withdrawal survey results' do
+    given_i_am_a_support_user
+
+    when_i_visit_the_service_performance_page
+    and_i_click_on_download_course_choice_withdrawl_survey_results
+    then_i_should_be_informed_there_are_no_survey_results
+
+    given_there_are_candidate_survey_results
+
+    when_i_visit_the_service_performance_page
+    and_i_click_on_download_course_choice_withdrawl_survey_results
+    then_i_should_be_able_to_download_a_csv
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def when_i_visit_the_service_performance_page
+    visit support_interface_performance_path
+  end
+
+  def and_i_click_on_download_course_choice_withdrawl_survey_results
+    click_link 'Download course choice withdrawal survey results (CSV)'
+  end
+
+  def then_i_should_be_informed_there_are_no_survey_results
+    expect(page).to have_content('No candidates have filled in the survey')
+  end
+
+  def given_there_are_candidate_survey_results
+    create_list(:application_choice, 3, :withdrawn, :with_survey_completed)
+  end
+
+  def then_i_should_be_able_to_download_a_csv
+    expect(page).to have_content ApplicationChoice.first.application_form.full_name
+    expect(page).to have_content ApplicationChoice.second.application_form.full_name
+    expect(page).to have_content ApplicationChoice.third.application_form.full_name
+  end
+end

--- a/spec/system/support_interface/course_choice_withdrawal_survey_csv_spec.rb
+++ b/spec/system/support_interface/course_choice_withdrawal_survey_csv_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Course choice withdrawal survey CSV' do
   end
 
   def given_there_are_candidate_survey_results
-    create_list(:application_choice, 3, :withdrawn, :with_survey_completed)
+    create_list(:application_choice, 3, :withdrawn_with_survey_completed)
   end
 
   def then_i_should_be_able_to_download_a_csv


### PR DESCRIPTION
## Context

First PR is #2355. It adds the course choice withdrawal questionnaire.

Once candidates have provided feedback on why they have withdrawn their course choice and whether they have been contacted, we will need to be able to access their answers.

This PR creates a csv export of their responses.

## Changes proposed in this pull request

- Create a survey export for course choices withdrawal feedback 

![image](https://user-images.githubusercontent.com/42515961/85710341-10daef80-b6de-11ea-8e55-27cd5a7495fb.png)


## Link to Trello card

https://trello.com/c/fHkzCjyC/1702-dev-reasons-for-candidate-withdrawing-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
