### PR TITLE
Don't send Slack messages for the fallback sign in mechanism

### DIFF
--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -23,11 +23,6 @@ module ProviderInterface
 
       if provider_user && provider_user.dfe_sign_in_uid.present?
         ProviderInterface::MagicLinkAuthentication.send_token!(provider_user: provider_user)
-
-        SlackNotificationWorker.perform_async(
-          "Provider user #{provider_user.first_name} has requested a fallback sign in link",
-          edit_support_interface_provider_user_url(provider_user),
-        )
       end
 
       redirect_to provider_interface_check_your_email_path
@@ -39,11 +34,6 @@ module ProviderInterface
       redirect_to action: :new and return unless FeatureFlag.active?('dfe_sign_in_fallback')
 
       provider_user = ProviderInterface::MagicLinkAuthentication.get_user_from_token!(token: params.fetch(:token))
-
-      SlackNotificationWorker.perform_async(
-        "Provider user #{provider_user.first_name} has signed in via the fallback mechanism",
-        edit_support_interface_provider_user_url(provider_user),
-      )
 
       # Equivalent to calling DfESignInUser.begin_session!
       session['dfe_sign_in_user'] = {

--- a/spec/system/provider_interface/authentication_fallback_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_spec.rb
@@ -85,8 +85,4 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
       expect(page).not_to have_content @email
     end
   end
-
-  def and_we_have_been_notified
-    expect_slack_message_with_text "Provider user #{@provider_user.first_name} has signed in via the fallback mechanism"
-  end
 end


### PR DESCRIPTION
## Context

These existed because we wanted to see that they were working. Now that we know it works we can drop these messages.

## Changes proposed in this pull request

Remove the Slack message and a test that wasn't actually run.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/1KWg2n91

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
