### PR TITLE
Return a 404 when trying to access the fallback sign in without token

### DIFF
--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -37,7 +37,9 @@ module ProviderInterface
     def authenticate_with_token
       redirect_to action: :new and return unless FeatureFlag.active?('dfe_sign_in_fallback')
 
-      provider_user = ProviderInterface::MagicLinkAuthentication.get_user_from_token!(token: params.fetch(:token))
+      render_404 and return unless params[:token]
+
+      provider_user = ProviderInterface::MagicLinkAuthentication.get_user_from_token!(token: params[:token])
 
       SlackNotificationWorker.perform_async(
         "Provider user #{provider_user.first_name} has signed in via the fallback mechanism",


### PR DESCRIPTION
##  Context

We're seeing this page visited without a token, which results in a 500 and a Sentry error (https://sentry.io/organizations/dfe-bat/issues/1741798579). 

## Changes proposed in this pull request

This changes it to a 404 so we don't get notified of the error anymore.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/1KWg2n91

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
