### PR TITLE
Change the way we pass in offer conditions

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -51,7 +51,7 @@ module ProviderInterface
     end
 
     def create_offer
-      offer_conditions_array = JSON.parse(params.dig(:offer_conditions))
+      offer_conditions_array = params.dig(:offer_conditions)
       course_option = CourseOption.find(params[:course_option_id])
 
       @application_offer = MakeAnOffer.new(

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -51,14 +51,13 @@ module ProviderInterface
     end
 
     def create_offer
-      offer_conditions_array = params.dig(:offer_conditions)
       course_option = CourseOption.find(params[:course_option_id])
 
       @application_offer = MakeAnOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
         course_option: course_option,
-        offer_conditions: offer_conditions_array,
+        offer_conditions: params.dig(:offer_conditions),
       )
 
       if @application_offer.save

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -42,7 +42,11 @@
       </p>
 
       <%= hidden_field_tag :course_option_id, @application_offer.course_option.id %>
-      <%= hidden_field_tag :offer_conditions, @application_offer.offer_conditions.to_json %>
+
+      <% @application_offer.offer_conditions.each do |condition| %>
+        <%= hidden_field_tag :"offer_conditions[]", condition %>
+      <% end %>
+
       <%= f.govuk_submit 'Make offer' %>
 
       <p class="govuk-body">

--- a/spec/requests/provider_interface/audit_trail_spec.rb
+++ b/spec/requests/provider_interface/audit_trail_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Provider interface - audit trail', type: :request, with_audited:
       post provider_interface_application_choice_create_offer_path(
         application_choice_id: application_choice.id,
         course_option_id: course_option.id,
-      ), params: { offer_conditions: '["must be clever"]' }
+      ), params: { offer_conditions: ['must be clever'] }
     }.to(change { application_choice.audits.count })
 
     expect(application_choice.audits.last.user_id).to eq provider_user.id


### PR DESCRIPTION
## Context

During the pentest we saw this error https://sentry.io/organizations/dfe-bat/issues/1742105751 being caused by an incorrect JSON payload.

## Changes proposed in this pull request

This prevents that error by changing the way we pass in the values to the form. Instead of JSON serialising/deserialising we use an array in the form. This feels more canonical.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/4sp8N2av/1742-deal-with-pentest-outcomes

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
