### PR TITLE
Bug fix - candidates can submit incomplete 'other' qualifications

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -1,3 +1,6 @@
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent.new(section: :other_qualifications, section_path: candidate_interface_review_other_qualifications_path, error: @missing_error)) %>
+<% end %>
 <% @qualifications.each do |qualification| %>
   <%= render(SummaryCardComponent.new(rows: other_qualifications_rows(qualification), editable: @editable)) do %>
     <%= render(SummaryCardHeaderComponent.new(title: qualification.title, heading_level: @heading_level)) do %>

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -23,12 +23,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      @submitting_application && @qualifications.any? do |qualification|
-        qualification.qualification_type.nil? ||
-          qualification.subject.nil? ||
-          qualification.grade.nil? ||
-          qualification.institution_name.nil?
-      end
+      @submitting_application && @application_form.application_qualifications.other.any?(&:incomplete_other_qualification?)
     end
 
   private

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class OtherQualificationsReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, heading_level: 2, missing_error: false)
+    def initialize(application_form:, editable: true, heading_level: 2, missing_error: false, submitting_application: false)
       @application_form = application_form
       @qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(
         @application_form,
@@ -10,6 +10,7 @@ module CandidateInterface
       @editable = editable
       @heading_level = heading_level
       @missing_error = missing_error
+      @submitting_application = submitting_application
     end
 
     def other_qualifications_rows(qualification)
@@ -19,6 +20,15 @@ module CandidateInterface
         award_year_row(qualification),
         grade_row(qualification),
       ]
+    end
+
+    def show_missing_banner?
+      @submitting_application && @qualifications.any? do |qualification|
+        qualification.qualification_type.nil? ||
+          qualification.subject.nil? ||
+          qualification.grade.nil? ||
+          qualification.institution_name.nil?
+      end
     end
 
   private

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -8,6 +8,14 @@ class ApplicationQualification < ApplicationRecord
     award_year
   ].freeze
 
+  EXPECTED_OTHER_QUALIFICATION_DATA = %i[
+    qualification_type
+    subject
+    grade
+    institution_name
+    award_year
+  ].freeze
+
   belongs_to :application_form, touch: true
 
   scope :degrees, -> { where level: 'degree' }
@@ -35,5 +43,13 @@ class ApplicationQualification < ApplicationRecord
     end
 
     false
+  end
+
+  def incomplete_other_qualification?
+    return false unless other?
+
+    EXPECTED_OTHER_QUALIFICATION_DATA.any? do |field_name|
+      send(field_name).blank?
+    end
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -261,13 +261,7 @@ module CandidateInterface
     end
 
     def no_incomplete_qualifications?
-      incomplete_qualifications = @application_form.application_qualifications.other.select do |qualification|
-        qualification.qualification_type.nil? ||
-          qualification.subject.nil? ||
-          qualification.grade.nil? ||
-          qualification.institution_name.nil?
-      end
-
+      incomplete_qualifications = @application_form.application_qualifications.other.select(&:incomplete_other_qualification?)
       incomplete_qualifications.blank?
     end
 

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -26,7 +26,7 @@ module CandidateInterface
         [:maths_gcse, maths_gcse_completed?],
         [:english_gcse, english_gcse_completed?],
         ([:science_gcse, science_gcse_completed?] if @application_form.science_gcse_needed?),
-        # "Other qualifications" is intentionally omitted, since it's optional
+        [:other_qualifications, no_incomplete_qualifications?],
 
         # "Personal statement and interview" section
         [:becoming_a_teacher, becoming_a_teacher_completed?],
@@ -258,6 +258,17 @@ module CandidateInterface
         @application_form.no_safeguarding_issues_to_declare? ||
           @application_form.has_safeguarding_issues_to_declare?
       end
+    end
+
+    def no_incomplete_qualifications?
+      incomplete_qualifications = @application_form.application_qualifications.other.select do |qualification|
+        qualification.qualification_type.nil? ||
+          qualification.subject.nil? ||
+          qualification.grade.nil? ||
+          qualification.institution_name.nil?
+      end
+
+      incomplete_qualifications.blank?
     end
 
   private

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -62,7 +62,7 @@
 
 <h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>
 
-<%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error)) %>
+<%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
 

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -34,3 +34,5 @@ en:
       incomplete: Work history is not marked as completed
     safeguarding:
       incomplete: Safeguarding information not entered
+    other_qualifications:
+      incomplete: Your Other Qualifications section has an incomplete qualification

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -101,4 +101,34 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.other_qualification.delete'))
     end
   end
+
+  describe '#show_missing_banner?' do
+    context 'when they have not added an other qualification and are submitting the application' do
+      it 'returns false' do
+        application_form = build_stubbed(:application_form)
+        expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq false
+      end
+    end
+
+    context 'when they have fully completed their other qualifications and are submitting their application' do
+      it 'returns false' do
+        expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq false
+      end
+    end
+
+    context 'when they have an incomplete qualification and are submtting their application' do
+      let(:qualification2) do
+        build_stubbed(
+          :application_qualification,
+          level: 'other',
+          qualification_type: nil,
+          subject: nil,
+        )
+      end
+
+      it 'returns true' do
+        expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq true
+      end
+    end
+  end
 end

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
     )
   end
 
-  before do
-    allow(application_form).to receive(:application_qualifications).and_return(
-      ActiveRecordRelationStub.new(ApplicationQualification, [qualification1, qualification2], scopes: [:other]),
-    )
-  end
-
   context 'when other qualifications are editable' do
+    before do
+      allow(application_form).to receive(:application_qualifications).and_return(
+        ActiveRecordRelationStub.new(ApplicationQualification, [qualification1, qualification2], scopes: [:other]),
+      )
+    end
+
     it 'renders component with correct values for a qualification' do
       result = render_inline(described_class.new(application_form: application_form))
 
@@ -103,30 +103,24 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
   end
 
   describe '#show_missing_banner?' do
+    let(:application_form) { create(:application_form) }
+
     context 'when they have not added an other qualification and are submitting the application' do
       it 'returns false' do
-        application_form = build_stubbed(:application_form)
         expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq false
       end
     end
 
     context 'when they have fully completed their other qualifications and are submitting their application' do
       it 'returns false' do
+        create(:other_qualification, application_form: application_form)
         expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq false
       end
     end
 
     context 'when they have an incomplete qualification and are submtting their application' do
-      let(:qualification2) do
-        build_stubbed(
-          :application_qualification,
-          level: 'other',
-          qualification_type: nil,
-          subject: nil,
-        )
-      end
-
       it 'returns true' do
+        create(:other_qualification, application_form: application_form, award_year: nil)
         expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq true
       end
     end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -80,4 +80,29 @@ RSpec.describe ApplicationQualification, type: :model do
       end
     end
   end
+
+  describe '#incomplete_other_qualification?' do
+    it 'returns false if not an other_qualification' do
+      qualification = build_stubbed(:gcse_qualification)
+
+      expect(qualification.incomplete_other_qualification?).to eq false
+    end
+
+    it 'returns false if all expected information is present' do
+      qualification = build_stubbed(:other_qualification)
+
+      expect(qualification.incomplete_other_qualification?).to eq false
+    end
+
+    it 'returns true if any expected information is missing' do
+      qualification = build_stubbed(:other_qualification)
+
+      ApplicationQualification::EXPECTED_OTHER_QUALIFICATION_DATA.each do |field|
+        qualification.send("#{field}=", nil)
+        expect(qualification.incomplete_other_qualification?).to eq true
+        qualification.send("#{field}=", '')
+        expect(qualification.incomplete_other_qualification?).to eq true
+      end
+    end
+  end
 end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -493,4 +493,23 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       expect(presenter).not_to be_interview_preferences_completed
     end
   end
+
+  describe '#no_incomplete_qualifications?' do
+    it 'returns true if there are no incomplete qualifications' do
+      application_form = create(:application_form)
+      create(:other_qualification, application_form: application_form)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_no_incomplete_qualifications
+    end
+
+    it 'returns false if there is an incomplete qualification' do
+      application_form = create(:application_form)
+      create(:application_qualification, application_form: application_form, level: 'other', grade: nil)
+
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_no_incomplete_qualifications
+    end
+  end
 end


### PR DESCRIPTION
## Context

If a candidate tries to complete the Other Qualification section with an incomplete qualification they hit validation errors. 

However, if they click the homepage and then submit their application, there is nothing in place to check for these incomplete qualifications.   

While this section is optional. Completing the section incorrectly should not be.

## Changes proposed in this pull request

- Add a validation which checks for incomplete 'other' qualifications. 

## Link to Trello card

https://trello.com/c/ryypPDfh/1609-candidates-can-press-back-button-when-entering-other-qualifications-to-submit-empty-qualifications

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
