### PR TITLE
Correctly render 500 for non-HTML requests

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -18,6 +18,6 @@ class ErrorsController < ApplicationController
   end
 
   def internal_server_error
-    render status: :internal_server_error
+    render 'internal_server_error.html', status: :internal_server_error
   end
 end


### PR DESCRIPTION
## Context

If you request https://www.apply-for-teacher-training.education.gov.uk/500.txt you'll see an unstyled error page, and a Sentry error is raised (https://sentry.io/organizations/dfe-bat/issues/1740977660). That's because we don't have a text variant of the 500 error.

## Changes proposed in this pull request

This forces Rails to always return the 500 HTML response, no matter the request format. We already do that for 404s and other errors.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/4sp8N2av/1742-deal-with-pentest-outcomes

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
