### PR TITLE
use job attempt suffix for test artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -293,19 +293,21 @@ stages:
       condition: succeededOrFailed()
       inputs:
         path: '$(System.DefaultWorkingDirectory)/testArtifacts/'
-        artifactName: 'cucumber-results'
+        artifactName: 'cucumber-results-$(System.JobAttempt)'
 
   - template: rspec-job-template.yml
     parameters:
       testCommand: 'integration-tests'
       displayName: 'Integration Tests'
       jobId: 'integration_tests'
+      jobAttempt: $(System.JobAttempt)
         
   - template: rspec-job-template.yml
     parameters:
       testCommand: 'unit-tests'
       displayName: 'Unit Tests'
       jobId: 'unit_tests'
+      jobAttempt: $(System.JobAttempt)
 
 
 - stage: deploy_qa

--- a/rspec-job-template.yml
+++ b/rspec-job-template.yml
@@ -4,7 +4,9 @@ parameters:
   - name: displayName
     type: string
   - name: jobId
-    type: string    
+    type: string
+  - name: jobAttempt
+    type: string 
 
 jobs:
 - job: ${{ parameters.jobId }}
@@ -64,4 +66,4 @@ jobs:
     displayName: 'Publish Test Artifacts'
     inputs:
       path: '$(System.DefaultWorkingDirectory)/testArtifacts/'
-      artifactName: ${{ format('rspec-{0}', parameters.testCommand) }}
+      artifactName: ${{ format('rspec-{0}-{1}', parameters.testCommand, parameters.jobAttempt) }}


### PR DESCRIPTION
prevents artifact already exists error in case of reruns.

## Context

If a test job is re-run in case of failures the job will eventually fail in the 'Publish artifacts' step as the it tries to publish the artifact with the same name as before.

## Changes proposed in this pull request

suffix the job attempt number to the published artifact name to avoid collissions.

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
