### PR TITLE
Change ‘Rejected’ status in candidate facing UI to ‘Unsuccessful‘

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -150,7 +150,7 @@ module CandidateInterface
               when 'offer'
                 :green
               when 'rejected'
-                :red
+                :pink
               when 'pending_conditions'
                 :turquoise
               when 'declined', 'withdrawn', 'cancelled'

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -20,7 +20,7 @@ module ProviderInterface
       when 'offer'
         :green
       when 'rejected'
-        :red
+        :pink
       when 'pending_conditions'
         :turquoise
       when 'declined'

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -18,7 +18,7 @@ module SupportInterface
       when 'offer'
         :green
       when 'rejected'
-        :red
+        :pink
       when 'pending_conditions'
         :turquoise
       when 'declined', 'withdrawn', 'cancelled'

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -53,7 +53,7 @@ en:
     offer_withdrawn: Offer withdrawn
     pending_conditions: Accepted
     recruited: Conditions met
-    rejected: Rejected
+    rejected: Unsuccessful
     unsubmitted: Not submitted yet
     withdrawn: Withdrawn
     conditions_not_met: Conditions not met

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Rejected')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Unsuccessful')
       expect(result.css('.govuk-summary-list__key').text).to include('Reason for rejection')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
     end


### PR DESCRIPTION
## Context

* Change ‘Rejected’ status to ‘Unsuccessful’ (candidate UI only)
* Change rejected status tag colour to pink (candidate, provider and support UIs)

## Changes proposed in this pull request

Draft as unable to test this locally yet for reasons…

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/zRx5awLK/1739-dev-change-reject-state-to-unsuccessful

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
