### PR TITLE
rename image name to apply-for-teacher-training

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COVERAGE_RESULT_PATH=/app/coverage
 
 define copy_to_host
 	## Obtains the results folder from within the stopped container and copies it to the local file system on the agent.
-	container_id=$$(docker ps -a --no-trunc | grep apply-for-postgraduate-teacher-training | head -1 | cut -d ' ' -f1); \
+	container_id=$$(docker ps -a --no-trunc | grep apply-for-teacher-training | head -1 | cut -d ' ' -f1); \
 	docker cp $$container_id:$(1)/ testArtifacts/
 endef
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -6,7 +6,7 @@ variables:
 - group: Docker Shared variables
 - group: APPLY - Shared Variables
 - name: imageName
-  value: 'apply-for-postgraduate-teacher-training'
+  value: 'apply-for-teacher-training'
 - name: debug
   value: true
 - name: buildCancelled

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ variables:
 - group: Docker Shared variables
 - group: APPLY - Shared Variables
 - name: imageName
-  value: 'apply-for-postgraduate-teacher-training'
+  value: 'apply-for-teacher-training'
 - name: gemsNodeModulesImageName
   value: 'apply-for-teacher-training-gems-node-modules'
 - name: debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     image: redis:alpine
   web:
     build: .
-    image: apply-for-postgraduate-teacher-training
+    image: apply-for-teacher-training
     ports:
       - "3000:3000"
     depends_on:
@@ -28,7 +28,7 @@ services:
       - .env
     command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0"
   worker:
-    image: apply-for-postgraduate-teacher-training
+    image: apply-for-teacher-training
     working_dir: /app
     depends_on:
       - db


### PR DESCRIPTION
## Context

follow up to #2328 , renaming the docker image name to `apply-for-teacher-training`

Please note, the release pipeline won't be able to deploy an SHA built using the previous name following this change.

## Changes proposed in this pull request

Rename in docker-compose and azure-pipeline files.
Have deployed image to DevOps env.

## Guidance to review


## Link to Trello card

https://trello.com/c/OGaS5YcN/2353-rename-docker-image

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
