### PR TITLE
Show DSA signed date in the providers list in support

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -1,7 +1,9 @@
 module SupportInterface
   class ProvidersController < SupportInterfaceController
     def index
-      @providers = Provider.where(sync_courses: true).includes(:sites, :courses).order(:name)
+      @providers = Provider.where(sync_courses: true)
+        .includes(:sites, :courses, :provider_agreements)
+        .order(:name)
     end
 
     def other_providers

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -11,8 +11,9 @@
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>
       <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Provider Name</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Courses</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Sites</th>
+      <th scope='col' class='govuk-table__header'>Courses</th>
+      <th scope='col' class='govuk-table__header'>Sites</th>
+      <th scope='col' class='govuk-table__header'>DSA signed date</th>
     </tr>
   </thead>
 
@@ -28,6 +29,13 @@
         </td>
         <td class='govuk-table__cell'>
           <%= provider.sites.size %>
+        </td>
+        <td class='govuk-table__cell'>
+          <% if provider.provider_agreements.data_sharing_agreements.any? %>
+            <%= provider.provider_agreements.data_sharing_agreements.first.accepted_at.to_s(:govuk_date) %>
+          <% else %>
+            Not accepted yet
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/spec/system/support_interface/see_providers_spec.rb
+++ b/spec/system/support_interface/see_providers_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.feature 'See providers' do
+  include DfESignInHelpers
+  include FindAPIHelper
+
+  scenario 'User visits providers page' do
+    given_i_am_a_support_user
+    and_there_are_providers_in_the_system
+
+    when_i_visit_the_providers_page
+    and_i_should_see_the_list_of_providers
+    and_i_should_see_providers_course_count
+    and_i_should_see_providers_sites_count
+
+    and_when_i_click_the_other_providers_tab
+    and_i_should_see_the_list_of_other_providers
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_providers_in_the_system
+    @provider = create(:provider, sync_courses: true, name: 'ABC')
+    @provider_with_courses = create(:provider, courses: [create(:course)], sync_courses: true, name: 'BCD')
+    @provider_with_sites = create(:provider, sites: [create(:site)], sync_courses: true, name: 'CDE')
+    @provider_with_signed_agreement = create(:provider, :with_signed_agreement, sync_courses: true, name: 'DEF')
+    @other_provider = create(:provider, name: 'XYZ')
+  end
+
+  def when_i_visit_the_providers_page
+    visit support_interface_providers_path
+  end
+
+  def and_i_should_see_the_list_of_providers
+    expect(page).to have_content(@provider.name)
+    expect(page).to have_content(@provider_with_courses.name)
+    expect(page).to have_content(@provider_with_sites.name)
+    expect(page).to have_content(@provider_with_signed_agreement.name)
+  end
+
+  def and_i_should_see_providers_course_count
+    @first_provider_cells = find('table').all('tr')[1].all('td')
+    @second_provider_cells = find('table').all('tr')[2].all('td')
+    @third_provider_cells = find('table').all('tr')[3].all('td')
+    @fourth_provider_cells = find('table').all('tr')[4].all('td')
+
+    expect(@first_provider_cells[1].text).to eq('0 courses 0 on DfE Apply')
+    expect(@second_provider_cells[1].text).to eq('1 course 0 on DfE Apply')
+    expect(@third_provider_cells[1].text).to eq('0 courses 0 on DfE Apply')
+    expect(@fourth_provider_cells[1].text).to eq('0 courses 0 on DfE Apply')
+  end
+
+  def and_i_should_see_providers_sites_count
+    expect(@first_provider_cells[2].text).to eq('0')
+    expect(@second_provider_cells[2].text).to eq('0')
+    expect(@third_provider_cells[2].text).to eq('1')
+    expect(@fourth_provider_cells[2].text).to eq('0')
+  end
+
+  def and_when_i_click_the_other_providers_tab
+    within('.govuk-tabs__list') { click_link 'Other providers' }
+  end
+
+  def and_i_should_see_the_list_of_other_providers
+    expect(page).to have_content(@other_provider.name)
+  end
+end

--- a/spec/system/support_interface/see_providers_spec.rb
+++ b/spec/system/support_interface/see_providers_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'See providers' do
     and_i_should_see_the_list_of_providers
     and_i_should_see_providers_course_count
     and_i_should_see_providers_sites_count
+    and_i_should_see_providers_dsa_signed_date
 
     and_when_i_click_the_other_providers_tab
     and_i_should_see_the_list_of_other_providers
@@ -57,6 +58,13 @@ RSpec.feature 'See providers' do
     expect(@second_provider_cells[2].text).to eq('0')
     expect(@third_provider_cells[2].text).to eq('1')
     expect(@fourth_provider_cells[2].text).to eq('0')
+  end
+
+  def and_i_should_see_providers_dsa_signed_date
+    expect(@first_provider_cells[3].text).to eq('Not accepted yet')
+    expect(@second_provider_cells[3].text).to eq('Not accepted yet')
+    expect(@third_provider_cells[3].text).to eq('Not accepted yet')
+    expect(@fourth_provider_cells[3].text).to eq(Time.zone.today.to_s(:govuk_date))
   end
 
   def and_when_i_click_the_other_providers_tab


### PR DESCRIPTION
## Context

This will help the transition team see at a glance which providers are yet to sign the Data Sharing Agreement.

## Changes proposed in this pull request

Add a `DSA signed date` to the table on the providers page in support interface which shows.

<kbd><img width="980" alt="Screenshot 2020-06-25 at 16 48 41" src="https://user-images.githubusercontent.com/38078064/85771959-4ef30600-b714-11ea-8bbf-88d537d34057.png"></kbd>

## Guidance to review

- visit http://localhost:3000/support/providers

Notes: not sure how to test this since the action of accepting DSA is done in provider interface and the results of it are are visible in support interface. We only seem to be testing if syncing from Find worked in support interface. 

## Link to Trello card

https://trello.com/c/pdAy717B/2299-show-dsa-signed-date-in-the-provider-list-in-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
