### PR TITLE
Update content suggesting choosing a course first

### DIFF
--- a/app/views/candidate_interface/application_form/before_you_start.html.erb
+++ b/app/views/candidate_interface/application_form/before_you_start.html.erb
@@ -1,19 +1,15 @@
 <h1 class="govuk-heading-xl">We suggest you choose a course first</h1>
 
 <div class="govuk-grid-row">
-
   <div class="govuk-grid-column-two-thirds">
-
-    <p class="govuk-body">Apply for teacher training is a new GOV.UK service that will eventually replace UCAS. For now, you can only apply to some courses using this service.</p>
-    <p class="govuk-body">By choosing a course first, you can check it’s available before you complete the rest of your application.</p>
-    <p class="govuk-body">If you choose a course which is not available on Apply for teacher training, you’ll be guided back to UCAS to make an application.</p>
+    <p class="govuk-body"><%= t('service_name.apply') %> is a new service that will eventually replace UCAS Teacher Training.</p>
+    <p class="govuk-body">For now, you can only apply to some courses using <%= t('service_name.apply') %>.</p>
+    <p class="govuk-body">Choose a course first to check it’s available on <%= t('service_name.apply') %> before you do your application.</p>
 
     <hr class="govuk-section-break govuk-section-break--m">
 
     <%= govuk_link_to 'Choose a course', candidate_interface_course_choices_index_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
-
     <p class="govuk-body">or</p>
-
     <%= govuk_link_to 'Go to your application form', candidate_interface_application_form_path, class: 'govuk-body' %>
   </div>
 </div>


### PR DESCRIPTION
## Context

From @EmmaFrith:

> The changes to the content reflect the following issues:
>
> - 'you'll be guided back' to UCAS - who is to say they were ever at UCAS? we should also use more active language where possible
> - 'by choosing a course first' - we should be explicit in what we want the user to do, rather than saying it in a round-about way 
> - UCAS should be UCAS Teacher Training on first mention because Apply isn't replacing the whole of UCAS
> - 'you can only apply for some courses using this service' - it is not clear to which service this refers because 'UCAS' immediately precedes this 
> - we use plain English where possible, so rather than 'make an application', we'd say 'do an application' 

## Changes proposed in this pull request

Before:
![Before](https://user-images.githubusercontent.com/813383/85859021-7ac5c880-b7b4-11ea-95fe-bb1ccfd340f3.png)

After:
![After](https://user-images.githubusercontent.com/813383/85859029-7dc0b900-b7b4-11ea-8a11-e6d02f5a2bdc.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/JkxCQhyX

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
