### PR TITLE
Show degree subject HESA code in support section

### DIFF
--- a/app/components/qualification_row_component.html.erb
+++ b/app/components/qualification_row_component.html.erb
@@ -1,5 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell"><%= render QualificationTitleComponent.new(qualification: qualification) %></td>
+  <td class="govuk-table__cell"><%= render QualificationSubjectComponent.new(qualification: qualification) %></td>
   <% if qualification.missing_qualification? %>
     <td colspan="2" class="govuk-table__cell"><%= qualification.missing_explanation %></td>
   <% else %>

--- a/app/components/qualification_subject_component.html.erb
+++ b/app/components/qualification_subject_component.html.erb
@@ -1,0 +1,4 @@
+<%= subject %>
+<% if hesa_code %>
+  </br>(<%= hesa_code %>)
+<% end %>

--- a/app/components/qualification_subject_component.html.erb
+++ b/app/components/qualification_subject_component.html.erb
@@ -1,4 +1,4 @@
 <%= subject %>
 <% if hesa_code %>
-  </br>(<%= hesa_code %>)
+  <span class='govuk-hint govuk-!-margin-bottom-1 govuk-!-font-size-16'>(<%= hesa_code %>)</span>
 <% end %>

--- a/app/components/qualification_subject_component.rb
+++ b/app/components/qualification_subject_component.rb
@@ -1,0 +1,13 @@
+class QualificationSubjectComponent < ViewComponent::Base
+  def initialize(qualification:)
+    @qualification = qualification
+  end
+
+  def subject
+    @qualification.subject&.titleize
+  end
+
+  def hesa_code
+    @qualification.subject_hesa_code
+  end
+end

--- a/app/components/qualification_title_component.html.erb
+++ b/app/components/qualification_title_component.html.erb
@@ -1,4 +1,4 @@
 <%= qualification_type %>
 <% if hesa_code %>
-  </br>(<%= hesa_code %>)
+  <span class='govuk-hint govuk-!-margin-bottom-1 govuk-!-font-size-16'>(<%= hesa_code %>)</span>
 <% end %>

--- a/app/components/qualification_title_component.html.erb
+++ b/app/components/qualification_title_component.html.erb
@@ -1,1 +1,4 @@
-<%= qualification_type %> <%= @qualification.subject&.titleize %>
+<%= qualification_type %>
+<% if hesa_code %>
+  </br>(<%= hesa_code %>)
+<% end %>

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -9,9 +9,24 @@ class QualificationTitleComponent < ViewComponent::Base
       return type_for_other_uk_qualification if @qualification.other_uk_qualification_type.present?
 
       return type_for_gcse
+    elsif @qualification.degree?
+      return type_for_degree
     end
 
     @qualification.qualification_type
+  end
+
+  def type_for_degree
+    hesa_degree_type = Hesa::DegreeType.find_by_hesa_code(hesa_code)
+    if hesa_degree_type
+      hesa_degree_type.shortest_display_name
+    else
+      @qualification.qualification_type
+    end
+  end
+
+  def hesa_code
+    @qualification.qualification_type_hesa_code
   end
 
 private

--- a/app/components/qualifications_table_component.html.erb
+++ b/app/components/qualifications_table_component.html.erb
@@ -2,10 +2,11 @@
   <table class="govuk-table" data-qa="qualifications-table-<%= type_label.parameterize %>">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half"><%= type_label %></th>
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Started</th>
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Awarded</th>
-        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Grade</th>
+        <th class="govuk-table__header govuk-table__header"><%= type_label %></th>
+        <th class="govuk-table__header govuk-table__header">Subject</th>
+        <th class="govuk-table__header govuk-table__header">Started</th>
+        <th class="govuk-table__header govuk-table__header">Awarded</th>
+        <th class="govuk-table__header govuk-table__header">Grade</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">

--- a/app/lib/hesa/degree_type.rb
+++ b/app/lib/hesa/degree_type.rb
@@ -1,6 +1,10 @@
 module Hesa
   class DegreeType
-    DegreeTypeStruct = Struct.new(:hesa_code, :abbreviation, :name, :level)
+    DegreeTypeStruct = Struct.new(:hesa_code, :abbreviation, :name, :level) do
+      def shortest_display_name
+        abbreviation || name
+      end
+    end
     UNDERGRADUATE_LEVELS = %i[bachelor master].freeze
 
     class << self
@@ -22,6 +26,10 @@ module Hesa
 
       def find_by_name(name)
         all.find { |type| type.name == name }
+      end
+
+      def find_by_hesa_code(code)
+        all.find { |type| type.hesa_code == code }
       end
     end
   end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -62,7 +62,8 @@
   <% end %>
 <% end %>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
+<h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-1" id="qualifications">Qualifications</h2>
+<p class='govuk-body'>(HESA codes in brackets, where relevant)</p>
 
 <%= render QualificationsComponent.new(application_form: @application_form) %>
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -63,7 +63,7 @@
 <% end %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-1" id="qualifications">Qualifications</h2>
-<p class='govuk-body'>(HESA codes in brackets, where relevant)</p>
+<p class='govuk-hint govuk-!-margin-top-0'>(HESA codes in brackets, where relevant)</p>
 
 <%= render QualificationsComponent.new(application_form: @application_form) %>
 

--- a/spec/components/qualification_row_component_spec.rb
+++ b/spec/components/qualification_row_component_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('BSc Psychology')
+    expect(result.text).to include('BSc')
+    expect(result.text).to include('Psychology')
     expect(result.text).to include('2015')
     expect(result.text).to include('2018')
     expect(result.text).to include('2:1')
@@ -34,7 +35,8 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('MEng Engineering')
+    expect(result.text).to include('MEng')
+    expect(result.text).to include('Engineering')
     expect(result.text).to include('2020')
     expect(result.text).to include('First (predicted)')
   end
@@ -52,7 +54,8 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('BSc Chemistry')
+    expect(result.text).to include('BSc')
+    expect(result.text).to include('Chemistry')
     expect(result.text).to include('2001')
     expect(result.text).to include('I did my best')
   end
@@ -70,7 +73,8 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('GCSE Maths')
+    expect(result.text).to include('GCSE')
+    expect(result.text).to include('Maths')
     expect(result.text).to include('I am taking the exam this summer')
   end
 end

--- a/spec/components/qualification_subject_component_spec.rb
+++ b/spec/components/qualification_subject_component_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe QualificationSubjectComponent, type: :component do
+  context 'given a degree' do
+    let(:qualification) do
+      build_stubbed(
+        :application_qualification,
+        level: :degree,
+        qualification_type: 'BSc',
+        subject: 'psychology',
+      )
+    end
+
+    it 'correctly renders the subject' do
+      result = render_inline(described_class.new(qualification: qualification))
+
+      expect(result.text).to include('Psychology')
+    end
+
+    it 'correctly renders the HESA code if present' do
+      qualification.subject_hesa_code = 22
+
+      result = render_inline(described_class.new(qualification: qualification))
+
+      expect(result.text).to include('Psychology')
+      expect(result.text).to include('(22)')
+    end
+  end
+
+  context 'given a GCSE' do
+    let(:qualification) do
+      build_stubbed(
+        :application_qualification,
+        level: :degree,
+        qualification_type: 'BSc',
+        subject: 'psychology',
+      )
+    end
+
+    it 'correctly renders the subject' do
+      result = render_inline(described_class.new(qualification: qualification))
+
+      expect(result.text).to include('Psychology')
+    end
+  end
+end

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -11,7 +11,22 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('BSc Psychology')
+    expect(result.text).to include('BSc')
+  end
+
+  it 'renders the correct title for a degree with HESA degree type data' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :degree,
+      qualification_type: 'BA with intercalated PGCE',
+      qualification_type_hesa_code: 12,
+      subject: 'Psychology',
+    )
+
+    result = render_inline(described_class.new(qualification: qualification))
+
+    expect(result.text).to include('BA with intercalated PGCE')
+    expect(result.text).to include('(12)')
   end
 
   it 'renders the correct title for a GCSE' do
@@ -24,7 +39,7 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('GCSE English')
+    expect(result.text).to include('GCSE')
   end
 
   it 'renders the correct title for an other_uk GCSE equivalent' do
@@ -37,7 +52,7 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('Other UK Maths')
+    expect(result.text).to include('Other UK')
   end
 
   it 'renders the correct title for an other_uk GCSE equivalent with a specified type' do
@@ -51,6 +66,6 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('Other UK qualification: A Level Maths')
+    expect(result.text).to include('Other UK qualification: A Level')
   end
 end

--- a/spec/lib/hesa/degree_type_spec.rb
+++ b/spec/lib/hesa/degree_type_spec.rb
@@ -63,4 +63,22 @@ RSpec.describe Hesa::DegreeType do
       end
     end
   end
+
+  describe '.find_by_hesa_code' do
+    context 'given a valid code' do
+      it 'returns the matching struct' do
+        result = described_class.find_by_hesa_code(51)
+
+        expect(result.abbreviation).to eq 'BA'
+      end
+    end
+
+    context 'given an unrecognised code' do
+      it 'returns nil' do
+        result = described_class.find_by_hesa_code(99999999)
+
+        expect(result).to eq nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to start displaying HESA codes in the support section to easily check if the feature is working as we roll it out.
## Changes proposed in this pull request
- Add a subject column to the qualifications table and move the subject over from the degree column.
- Add the degree type and subject HESA codes (if available) to the table.
<!-- If there are UI changes, please include Before and After screenshots. -->

![Screenshot_20200629_144656](https://user-images.githubusercontent.com/519250/86013955-a5638b80-ba17-11ea-8873-1011a74209fb.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/PYf7wdSf
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
