### PR TITLE
Replace course no longer available on Apply, but on UCAS

### DIFF
--- a/app/components/candidate_interface/replacement_action_component.html.erb
+++ b/app/components/candidate_interface/replacement_action_component.html.erb
@@ -10,7 +10,12 @@
       <%= t('page_titles.pick_replacement_action') %>
     </h1>
 
-    <% if @course_choice.course.withdrawn %>
+    <% if course_only_available_on_ucas? %>
+      <p class='govuk-body'><%= provider_name %> has said they do not want to get applications for <%= course_name_and_code %> through Apply for teacher training at the moment.</p>
+      <p class='govuk-body'>You can contact your provider to find out if they’re still willing to consider your application through this service, or you can apply through UCAS Teacher Training instead.</p>
+      <p class='govuk-body'>Alternatively, choose another course.</p>
+      <p class='govuk-body'>Make a decision now: if you do nothing, we’ll send your application to <%= provider_name %> when your references come in.</p>
+    <% elsif @course_choice.course.withdrawn %>
       <p class='govuk-body'><%= course_name_and_code %> is not running anymore.</p>
     <% elsif other_locations_available? && other_study_mode && other_study_mode.vacancies? %>
       <p class='govuk-body'> There are no more <%= study_mode %> places for <%= course_name_and_code %> at your choice of location.</p>
@@ -22,18 +27,26 @@
       <p class='govuk-body'><%= course_name_and_code %> is now full.</p>
     <% end %>
 
-    <p class='govuk-body'>Update your course choice now: when your references come in we’ll send your application to your <%= pluralize_provider %>.</p>
+    <% unless course_only_available_on_ucas? %>
+      <p class='govuk-body'>Update your course choice now: when your references come in we’ll send your application to your <%= pluralize_provider %>.</p>
+    <% end %>
 
     <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: 'What do you want to do?' } do %>
-      <% if other_locations_available? %>
-        <%= f.govuk_radio_button :replacement_action, 'replace_location', label: { text: 'Choose a different location' } %>
-      <% end %>
-      <% if other_study_mode && other_study_mode.vacancies? %>
-        <%= f.govuk_radio_button :replacement_action, 'replace_study_mode', label: { text: "Study #{other_study_mode.study_mode.humanize.downcase} instead" } %>
-      <% end %>
-        <%= f.govuk_radio_button :replacement_action, 'replace_course', label: { text: 'Choose a different course' } %>
-        <%= f.govuk_radio_button :replacement_action, 'remove_course', label: { text: 'Remove course from application' } %>
+      <% if course_only_available_on_ucas? %>
+        <%= f.govuk_radio_button :replacement_action, 'apply_through_ucas', label: { text: "Apply for this course through UCAS" } %>
+        <%= f.govuk_radio_button :replacement_action, 'replace_course', label: { text: 'Choose a different course on Apply for teacher training' } %>
         <%= f.govuk_radio_button :replacement_action, 'keep_choice', label: { text: 'Keep this course choice anyway' }, hint_text: "When your references come in we'll send your application to #{provider_name}, but there’s no guarantee they’ll consider it." %>
+      <% else %>
+        <% if other_locations_available? %>
+          <%= f.govuk_radio_button :replacement_action, 'replace_location', label: { text: 'Choose a different location' } %>
+        <% end %>
+        <% if other_study_mode && other_study_mode.vacancies? %>
+          <%= f.govuk_radio_button :replacement_action, 'replace_study_mode', label: { text: "Study #{other_study_mode.study_mode.humanize.downcase} instead" } %>
+        <% end %>
+          <%= f.govuk_radio_button :replacement_action, 'replace_course', label: { text: 'Choose a different course' } %>
+          <%= f.govuk_radio_button :replacement_action, 'remove_course', label: { text: 'Remove course from application' } %>
+          <%= f.govuk_radio_button :replacement_action, 'keep_choice', label: { text: 'Keep this course choice anyway' }, hint_text: "When your references come in we'll send your application to #{provider_name}, but there’s no guarantee they’ll consider it." %>
+      <% end %>
     <% end %>
 
     <%= f.govuk_submit 'Continue' %>

--- a/app/components/candidate_interface/replacement_action_component.rb
+++ b/app/components/candidate_interface/replacement_action_component.rb
@@ -50,5 +50,9 @@ module CandidateInterface
     def other_study_mode
       @course_choice.course_option.get_alternative_study_mode
     end
+
+    def course_only_available_on_ucas?
+      @course_choice.course.exposed_in_find && !@course_choice.course.open_on_apply
+    end
   end
 end

--- a/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
@@ -31,6 +31,7 @@ module CandidateInterface
               @course_choice.id,
               @course_choice.provider.id,
               @course_choice.course.id,
+              choose_action: true,
             )
           elsif !@pick_replacement_action.valid?
             flash[:warning] = 'Please select an option to update your course choice.'

--- a/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
@@ -26,6 +26,12 @@ module CandidateInterface
             redirect_to candidate_interface_confirm_cancel_full_course_choice_path
           elsif @pick_replacement_action.replacement_action == 'replace_course'
             redirect_to candidate_interface_replace_course_choices_choose_path(@course_choice.id)
+          elsif @pick_replacement_action.replacement_action == 'apply_through_ucas'
+            redirect_to candidate_interface_replace_course_choice_ucas_with_course_path(
+              @course_choice.id,
+              @course_choice.provider.id,
+              @course_choice.course.id,
+            )
           elsif !@pick_replacement_action.valid?
             flash[:warning] = 'Please select an option to update your course choice.'
 

--- a/app/controllers/candidate_interface/course_choices/replace_choices/ucas_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/ucas_controller.rb
@@ -11,6 +11,7 @@ module CandidateInterface
           @course_choice = current_application.application_choices.find(params[:id])
           @provider = Provider.find_by!(id: params[:provider_id])
           @course = Course.find_by!(id: params[:course_id])
+          @choose_action = params['choose_action']
         end
       end
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -171,7 +171,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def course_choices_that_need_replacing
-    (withdrawn_course_choices + full_course_choices).flatten.uniq.select(&:awaiting_references?)
+    (withdrawn_course_choices + full_course_choices + courses_not_on_apply).flatten.uniq.select(&:awaiting_references?)
   end
 
   def incomplete_degree_information?
@@ -190,5 +190,9 @@ private
 
   def full_course_choices
     application_choices.includes(%i[course_option]).select { |choice| choice.course_option.no_vacancies? }
+  end
+
+  def courses_not_on_apply
+    application_choices.includes(%i[course]).reject { |choice| choice.course.open_on_apply }
   end
 end

--- a/app/views/candidate_interface/course_choices/replace_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/ucas/with_course.html.erb
@@ -1,4 +1,8 @@
 <% content_for :title, t('page_titles.apply_to_course_on_ucas') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_course_path(@course_choice.id, @provider.id)) %>
+<% if @choose_action %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_path(@course_choice.id)) %>
+<% else %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_replace_course_choice_course_path(@course_choice.id, @provider.id)) %>
+<% end %>
 
 <%= render partial: 'candidate_interface/course_choices/shared/with_course'  %>

--- a/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
+++ b/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
@@ -6,9 +6,19 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
 
     before { FeatureFlag.activate('replace_full_or_withdrawn_application_choices') }
 
+
     context 'when a course has been withdrawn and the candidate is awaiting their references' do
       it 'renders the component' do
-        course = create(:course, withdrawn: true)
+        course = create(:course, withdrawn: false, open_on_apply: false)
+        create(:application_choice, application_form: application_form, status: 'awaiting_references')
+
+        expect(described_class.new(application_form: application_form).render?).to be_truthy
+      end
+    end
+
+    context 'when a course has been withdrawn and the candidate is awaiting their references' do
+      it 'renders the component' do
+        course = create(:course, withdrawn: true, open_on_apply: true)
         course_option = create(:course_option, course: course)
         create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
@@ -18,7 +28,7 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
 
     context 'when a course has been withdrawn and the candidates application is complete' do
       it 'does not render the componen' do
-        course = create(:course, withdrawn: true)
+        course = create(:course, withdrawn: true, open_on_apply: true)
         course_option = create(:course_option, course: course)
         create(:application_choice, application_form: application_form, course_option: course_option, status: 'application_complete')
 
@@ -28,7 +38,7 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
 
     context 'when a course has not been withdrawn' do
       it 'does not render the component' do
-        course = create(:course, withdrawn: false)
+        course = create(:course, withdrawn: false, open_on_apply: true)
         course_option = create(:course_option, course: course)
         create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
@@ -38,7 +48,8 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
 
     context 'when a course choice has become full' do
       it 'renders the component' do
-        course_option = build(:course_option, vacancy_status: 'no_vacancies')
+        course = create(:course, withdrawn: false, open_on_apply: true)
+        course_option = build(:course_option, vacancy_status: 'no_vacancies', course: course)
         create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
         expect(described_class.new(application_form: application_form).render?).to be_truthy
@@ -47,7 +58,8 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
 
     context 'when a course choice still has vacancies' do
       it 'does not render the component' do
-        course_option = build(:course_option, vacancy_status: 'vacancies')
+        course = create(:course, withdrawn: false, open_on_apply: true)
+        course_option = build(:course_option, vacancy_status: 'vacancies', course: course)
         create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
         expect(described_class.new(application_form: application_form).render?).to be_falsey

--- a/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
+++ b/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
@@ -6,10 +6,9 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
 
     before { FeatureFlag.activate('replace_full_or_withdrawn_application_choices') }
 
-
-    context 'when a course has been withdrawn and the candidate is awaiting their references' do
+    context 'when a course is only available on ucas and the candidate is awaiting their references' do
       it 'renders the component' do
-        course = create(:course, withdrawn: false, open_on_apply: false)
+        create(:course, withdrawn: false, open_on_apply: false)
         create(:application_choice, application_form: application_form, status: 'awaiting_references')
 
         expect(described_class.new(application_form: application_form).render?).to be_truthy

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -210,21 +210,24 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#course_choices_that_need_replacing' do
-    it 'returns course_choices whose courses have been withdrawn or course_option has become full' do
+    it 'returns course_choices that are not on apply, whose courses have been withdrawn or course_option has become full' do
       application_form = create(:application_form)
-      course1 = create(:course, withdrawn: true)
-      course2 = create(:course, withdrawn: false)
-      course3 = create(:course, withdrawn: false)
+      course1 = create(:course, withdrawn: true, open_on_apply: true)
+      course2 = create(:course, withdrawn: false, open_on_apply: true)
+      course3 = create(:course, withdrawn: false, open_on_apply: true)
+      course4 = create(:course, withdrawn: false, open_on_apply: false)
 
       course_option1 = create(:course_option, course: course1, vacancy_status: 'no_vacancies')
       course_option2 = create(:course_option, course: course2, vacancy_status: 'no_vacancies')
       course_option3 = create(:course_option, course: course3, vacancy_status: 'vacancies')
+      course_option4 = create(:course_option, course: course4, vacancy_status: 'vacancies')
 
       application_choice1 = create(:application_choice, status: :awaiting_references, application_form: application_form, course_option: course_option1)
       application_choice2 = create(:application_choice, status: :awaiting_references, application_form: application_form, course_option: course_option2)
       create(:application_choice, application_form: application_form, course_option: course_option3)
+      application_choice4 = create(:application_choice, status: :awaiting_references, application_form: application_form, course_option: course_option4)
 
-      expect(application_form.course_choices_that_need_replacing).to match_array [application_choice1, application_choice2]
+      expect(application_form.course_choices_that_need_replacing).to match_array [application_choice1, application_choice2, application_choice4]
     end
 
     it 'does not return application_choices that have been withdrawn' do

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -7,6 +7,19 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   scenario 'when a candidate arrives at the dashboard they can follow the replace course flow' do
     given_the_replace_full_or_withdrawn_application_choices_is_active?
     and_i_have_submitted_my_application
+    and_my_course_is_only_available_on_ucas
+
+    when_i_arrive_at_my_application_dashboard
+    then_i_see_that_one_of_my_choices_in_not_available
+
+    when_i_click_update_my_course_choice
+    then_i_arrive_at_the_replace_course_choice_page
+
+    when_i_choose_to_apply_through_ucas
+    and_click_continue
+    then_i_arrive_at_the_ucas_with_course_page
+
+    given_the_course_becomes_available_on_apply
     and_one_of_my_application_choices_has_become_full
     and_there_is_another_location_available
 
@@ -87,10 +100,27 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   def and_i_have_submitted_my_application
     candidate_completes_application_form
     candidate_submits_application
+    @course_option = @application.application_choices.first.course_option
+  end
+
+  def and_my_course_is_only_available_on_ucas
+    @removed_course = @application.application_choices.first.course
+    @removed_course.update!(open_on_apply: false)
+  end
+
+  def when_i_choose_to_apply_through_ucas
+    choose 'Apply for this course through UCAS'
+  end
+
+  def then_i_arrive_at_the_ucas_with_course_page
+    expect(page).to have_current_path candidate_interface_course_choices_ucas_with_course_path(@application.application_choices.first.id, @removed_course.provider.id, @removed_course.id)
+  end
+
+  def given_the_course_becomes_available_on_apply
+    @removed_course.update!(open_on_apply: true)
   end
 
   def and_one_of_my_application_choices_has_become_full
-    @course_option = @application.application_choices.first.course_option
     @course_option.no_vacancies!
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -113,7 +113,11 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   end
 
   def then_i_arrive_at_the_ucas_with_course_page
-    expect(page).to have_current_path candidate_interface_course_choices_ucas_with_course_path(@application.application_choices.first.id, @removed_course.provider.id, @removed_course.id)
+    expect(page).to have_current_path candidate_interface_replace_course_choice_ucas_with_course_path(
+      @application.application_choices.first.id,
+      @removed_course.provider.id,
+      @removed_course.id,
+    )
   end
 
   def given_the_course_becomes_available_on_apply

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
       @application.application_choices.first.id,
       @removed_course.provider.id,
       @removed_course.id,
+      choose_action: true,
     )
   end
 


### PR DESCRIPTION
## Context

Some Providers have chosen to close some Courses on Apply, but leave them open on UCAS. In this situation, we should tell a candidate and give them the option to apply via UCAS or replace the course.

## Changes proposed in this pull request

- present different content and options for course choices that are available on UCAS but not Apply
- direct users to the ucas_with_courses page if they choose to apply through UCAS
![image](https://user-images.githubusercontent.com/42515961/85995262-fbbfd280-b9f5-11ea-9c04-8147fa326864.png)


## Guidance to review

Designs can be found here https://docs.google.com/document/d/1FwPaGSYzSViXtbB2INHwO7bdxr0fFFUpVs4z978tW9Q/edit#

## Link to Trello card

https://trello.com/c/DUd3Do0F/1738-dev-courses-closed-on-apply-but-open-on-ucas

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
