### PR TITLE
Choose a course first copy tweak

### DIFF
--- a/app/views/candidate_interface/application_form/before_you_start.html.erb
+++ b/app/views/candidate_interface/application_form/before_you_start.html.erb
@@ -5,6 +5,7 @@
     <p class="govuk-body"><%= t('service_name.apply') %> is a new service that will eventually replace UCAS Teacher Training.</p>
     <p class="govuk-body">For now, you can only apply to some courses using <%= t('service_name.apply') %>.</p>
     <p class="govuk-body">Choose a course first to check it’s available on <%= t('service_name.apply') %> before you do your application.</p>
+    <p class="govuk-body">If your course is not available, we’ll send you to UCAS to apply there.</p>
 
     <hr class="govuk-section-break govuk-section-break--m">
 


### PR DESCRIPTION
## Context

Adds missed paragraph from the change made in #2375:

> If your course is not available, we’ll send you to UCAS to apply there.
