### PR TITLE
Correctly display interview preferences and training with disability

### DIFF
--- a/app/components/interview_preferences_component.rb
+++ b/app/components/interview_preferences_component.rb
@@ -1,11 +1,13 @@
 class InterviewPreferencesComponent < ViewComponent::Base
-  delegate :interview_preferences, to: :application_form
+  attr_reader :application_form
 
   def initialize(application_form:)
     @application_form = application_form
   end
 
-private
+  def interview_preferences
+    return application_form.interview_preferences if application_form.interview_preferences.present?
 
-  attr_reader :application_form
+    'No preferences.'
+  end
 end

--- a/app/components/provider_interface/training_with_disability_component.rb
+++ b/app/components/provider_interface/training_with_disability_component.rb
@@ -8,12 +8,10 @@ module ProviderInterface
       @application_form = application_form
     end
 
-    def render?
-      application_form.disclose_disability? && disability_disclosure.present?
-    end
-
     def disability_disclosure
-      @application_form.disability_disclosure
+      return application_form.disability_disclosure if application_form.disclose_disability? && application_form.disability_disclosure.present?
+
+      'No information shared.'
     end
   end
 end

--- a/spec/components/interview_preferences_component_spec.rb
+++ b/spec/components/interview_preferences_component_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe InterviewPreferencesComponent do
+  it 'renders `No preferences` if `#interview_preferences` is nil' do
+    application_form = instance_double(
+      ApplicationForm,
+      interview_preferences: nil,
+    )
+    result = render_inline(described_class.new(application_form: application_form))
+    expect(result.text).to include('No preferences.')
+  end
+
+  it 'renders `No preferences` if `#interview_preferences` is blank' do
+    application_form = instance_double(
+      ApplicationForm,
+      interview_preferences: '',
+    )
+    result = render_inline(described_class.new(application_form: application_form))
+    expect(result.text).to include('No preferences.')
+  end
+
+  it 'renders interview preferences if there are any' do
+    application_form = instance_double(
+      ApplicationForm,
+      interview_preferences: 'Fridays are best for me.',
+    )
+    result = render_inline(described_class.new(application_form: application_form))
+    expect(result.text).to include('Fridays are best for me.')
+  end
+end

--- a/spec/components/provider_interface/training_with_disability_component_spec.rb
+++ b/spec/components/provider_interface/training_with_disability_component_spec.rb
@@ -1,27 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::TrainingWithDisabilityComponent do
-  it 'renders nothing if `#disclose_disability` is false' do
+  it 'renders `No information shared` if `#disclose_disability` is false' do
     application_form = instance_double(
       ApplicationForm,
       disclose_disability?: false,
-      disability_disclosure: 'I am hard of hearing',
+      disability_disclosure: nil,
     )
     result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to eq ''
+    expect(result.text).to include('No information shared.')
   end
 
-  it 'renders nothing if `#disclose_disability` is true but there is no disclosure' do
+  it 'renders `No information shared` if `#disclose_disability` is true but there is no disclosure' do
     application_form = instance_double(
       ApplicationForm,
       disclose_disability?: true,
       disability_disclosure: '',
     )
     result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to eq ''
+    expect(result.text).to include('No information shared.')
   end
 
-  it 'renders heading and disclosure if `#disclose_disability` is true' do
+  it 'renders `No information shared` if `#disclose_disability` is nil' do
+    application_form = instance_double(
+      ApplicationForm,
+      disclose_disability?: nil,
+      disability_disclosure: nil,
+    )
+    result = render_inline(described_class.new(application_form: application_form))
+    expect(result.text).to include('No information shared.')
+  end
+
+  it 'renders disclosure if `#disclose_disability` is true' do
     application_form = instance_double(
       ApplicationForm,
       disclose_disability?: true,


### PR DESCRIPTION
## Context

In the providers interface, when viewing an application without the `disability disclosure` or` interview_preferences` filled in, this section is empty. We should display something in this section so it's consistent with the candidate side.

## Changes proposed in this pull request
- Disability, access and other needs section
  - display "No information shared." when there is no disability_disclosure to show
- Interview section
  - display "No preferences." when it's blank

| Interview  | Disability, access and other needs |
| ------------- | ------------- |
| <img width="569" alt="Screenshot 2020-06-29 at 12 02 51" src="https://user-images.githubusercontent.com/38078064/86003837-4b0ffe00-ba0a-11ea-83ac-5338ec6d5112.png"> | <img width="583" alt="Screenshot 2020-06-29 at 12 03 31" src="https://user-images.githubusercontent.com/38078064/86003471-be654000-ba09-11ea-9206-7d8e44e453c9.png"> |
| <img width="565" alt="Screenshot 2020-06-29 at 12 02 20" src="https://user-images.githubusercontent.com/38078064/86003866-5a8f4700-ba0a-11ea-82c2-e9f3e774597d.png"> | <img width="578" alt="Screenshot 2020-06-29 at 12 23 46" src="https://user-images.githubusercontent.com/38078064/86003497-c624e480-ba09-11ea-8229-3b1f9f09faef.png"> |


## Guidance to review
- view a single application

## Link to Trello card

- https://trello.com/c/hspD0sTb/2327-correctly-display-the-disability-disclosure-section-when-there-is-no-information-provided-or-the-answer-is-nothing-to-disclose
- https://trello.com/c/ut2DqScb/2357-correctly-display-the-interview-preferences-field-in-manage-when-no-preferences-are-provided

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
