### PR TITLE
Candidate see the before you start page (pick a course) when applying again

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
 
       DuplicateApplication.new(current_application).duplicate
       flash[:success] = 'Your new application is ready for editing'
-      redirect_to candidate_interface_application_form_path
+      redirect_to candidate_interface_before_you_start_path
     end
 
     def review

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
     when_i_visit_my_application_complete_page
     and_i_click_on_apply_again
     and_i_click_on_start_now
+    and_i_click_go_to_my_application_form
 
     then_i_can_see_my_previous_rejection_reasons
   end
@@ -37,6 +38,10 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
 
   def and_i_click_on_start_now
     click_button 'Start now'
+  end
+
+  def and_i_click_go_to_my_application_form
+    click_link 'Go to your application form'
   end
 
   def then_i_can_see_my_previous_rejection_reasons

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -12,7 +12,9 @@ RSpec.feature 'Candidate applying again' do
     and_i_visit_the_application_dashboard
     and_i_click_on_apply_again
     and_i_click_on_start_now
+    and_i_am_told_my_new_application_is_ready_to_edit
 
+    when_i_click_go_to_my_application_form
     then_i_see_a_copy_of_my_application
 
     when_i_view_referees
@@ -64,8 +66,16 @@ RSpec.feature 'Candidate applying again' do
     click_on 'Start now'
   end
 
-  def then_i_see_a_copy_of_my_application
+  def and_i_am_told_my_new_application_is_ready_to_edit
     expect(page).to have_content('Your new application is ready for editing')
+  end
+
+  def when_i_click_go_to_my_application_form
+    click_link 'Go to your application form'
+  end
+
+  def then_i_see_a_copy_of_my_application
+    expect(page).to have_title('Your application')
   end
 
   def when_i_view_referees

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -12,9 +12,11 @@ RSpec.feature 'Candidate with unsuccessful application' do
     and_i_visit_the_application_dashboard
     and_i_click_on_apply_again
     and_i_click_on_start_now
-    then_i_see_a_copy_of_my_application
+    then_i_see_the_before_you_start_page
+    and_i_am_told_my_new_application_is_ready_to_edit
 
-    when_i_click_on_the_link_to_my_previous_application
+    when_i_click_go_to_my_application_form
+    and_i_click_on_the_link_to_my_previous_application
     then_i_see_the_review_previous_application_page
 
     when_i_click_back
@@ -74,11 +76,23 @@ RSpec.feature 'Candidate with unsuccessful application' do
     click_on 'Start now'
   end
 
-  def then_i_see_a_copy_of_my_application
+  def and_i_click_go_to_my_application_form
+    click_link 'Go to your application form'
+  end
+
+  def then_i_see_the_before_you_start_page
+    expect(page).to have_current_path candidate_interface_before_you_start_path
+  end
+
+  def and_i_am_told_my_new_application_is_ready_to_edit
     expect(page).to have_content('Your new application is ready for editing')
   end
 
-  def when_i_click_on_the_link_to_my_previous_application
+  def when_i_click_go_to_my_application_form
+    click_link 'Go to your application form'
+  end
+
+  def and_i_click_on_the_link_to_my_previous_application
     click_link 'First application'
   end
 


### PR DESCRIPTION
## Context

When a candidate applies again they should be encouraged to pick a course before they begin to edit their application.

This is so they don't waste their time if the course they want to select is only available on UCAS.

## Changes proposed in this pull request

- After the app is duped they are redirected to the before you start page

## Guidance to review

I spoke to Emma and Paul who said they don't think there need to be any content changes.


## Link to Trello card

https://trello.com/c/mmOdK32J/1596-dev-ask-users-to-select-a-course-before-they-start-an-application-for-apply-again-not-mvp

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
