### PR TITLE
Explicitly assign permissions from pairing

### DIFF
--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -7,14 +7,14 @@ module ProviderInterface
     end
 
     def show
-      @ratifying_permissions = ProviderRelationshipPermissions
-        .includes(:training_provider, :ratifying_provider)
-        .where(ratifying_provider: provider)
-        .group_by(&:training_provider_id)
-      @training_permissions = ProviderRelationshipPermissions
-        .includes(:training_provider, :ratifying_provider)
-        .where(training_provider: provider)
-        .group_by(&:ratifying_provider_id)
+      scope = ProviderRelationshipPermissions.includes(:training_provider, :ratifying_provider)
+
+      @ratifying_permissions = ProviderRelationshipPermissionsPair.pairs_from_collection(
+        scope.where(ratifying_provider: provider),
+      )
+      @training_permissions = ProviderRelationshipPermissionsPair.pairs_from_collection(
+        scope.where(training_provider: provider),
+      )
     end
 
   private

--- a/app/models/provider_interface/provider_relationship_permissions_pair.rb
+++ b/app/models/provider_interface/provider_relationship_permissions_pair.rb
@@ -1,0 +1,19 @@
+module ProviderInterface
+  class ProviderRelationshipPermissionsPair
+    attr_reader :ratifying_provider_permissions, :training_provider_permissions
+
+    def initialize(ratifying_provider_permissions:, training_provider_permissions:)
+      @ratifying_provider_permissions = ratifying_provider_permissions
+      @training_provider_permissions = training_provider_permissions
+    end
+
+    def self.pairs_from_collection(collection)
+      collection.group_by { |p| [p.ratifying_provider_id, p.training_provider_id] }.map do |_key, ary|
+        new(
+          ratifying_provider_permissions: ary.find { |prp| prp.type == 'ProviderInterface::AccreditedBodyPermissions' },
+          training_provider_permissions: ary.find { |prp| prp.type == 'ProviderInterface::TrainingProviderPermissions' },
+        )
+      end
+    end
+  end
+end

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -1,8 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= @provider.name %></h1>
-    <% @ratifying_permissions.each do |_id, permissions| %>
-      <% ratifying_permission, training_permission = permissions %>
+    <% @ratifying_permissions.each do |permissions_pair| %>
+      <%
+        ratifying_permission = permissions_pair.ratifying_provider_permissions
+        training_permission = permissions_pair.training_provider_permissions
+      -%>
       <h2 class="govuk-heading-m">
         For courses ratified by <%= ratifying_permission.ratifying_provider.name %> and run by <%= ratifying_permission.training_provider.name %>
       </h2>
@@ -22,8 +25,11 @@
       <%= render 'permissions_list', permission: training_permission %>
     <% end %>
 
-    <% @training_permissions.each do |_id, permissions| %>
-      <% ratifying_permission, training_permission = permissions %>
+    <% @training_permissions.each do |permissions_pair| %>
+      <%
+        ratifying_permission = permissions_pair.ratifying_provider_permissions
+        training_permission = permissions_pair.training_provider_permissions
+      -%>
       <h2 class="govuk-heading-m">
         For courses run by <%= training_permission.training_provider.name %> and ratified by <%= training_permission.ratifying_provider.name %>
       </h2>

--- a/spec/models/provider_interface/provider_relationship_permissions_pair_spec.rb
+++ b/spec/models/provider_interface/provider_relationship_permissions_pair_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderRelationshipPermissionsPair do
+  describe '.pairs_from_collection' do
+    let(:tpp1) { build_stubbed(:training_provider_permissions, ratifying_provider_id: 9, training_provider_id: 2) }
+    let(:rpp1) { build_stubbed(:accredited_body_permissions, ratifying_provider_id: 9, training_provider_id: 2) }
+    let(:tpp2) { build_stubbed(:training_provider_permissions, ratifying_provider_id: 9, training_provider_id: 1) }
+    let(:rpp2) { build_stubbed(:accredited_body_permissions, ratifying_provider_id: 9, training_provider_id: 1) }
+
+    let(:collection) { [tpp2, rpp1, tpp1, rpp2] }
+
+    it 'groups a collection of ProviderRelationshipPermissions into relationship pairings' do
+      pairings = described_class.pairs_from_collection(collection)
+
+      expect(pairings.first.training_provider_permissions).to eq(tpp2)
+      expect(pairings.first.ratifying_provider_permissions).to eq(rpp2)
+
+      expect(pairings.last.training_provider_permissions).to eq(tpp1)
+      expect(pairings.last.ratifying_provider_permissions).to eq(rpp1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We retrieve permissions in pairs for each provider relationship. The underlying query doesn't have a consistent order so
be explicit and use the type when setting this variables.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Assign the local view variables based on the permissions type as this is more explicit and obvious than relying on query ordering.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/k5hlzAcA/2348-organisation-pages-permissions-are-displayed-in-reverse-for-training-and-ratifying-providers
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
