### PR TITLE
Only assign valid permissions for providers

### DIFF
--- a/app/forms/provider_interface/provider_user_form.rb
+++ b/app/forms/provider_interface/provider_user_form.rb
@@ -64,7 +64,7 @@ module ProviderInterface
           provider_user_id: provider_user&.id,
         )
 
-        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+        valid_permissions.each do |permission_name|
           permission.send("#{permission_name}=", form.provider_permission.fetch(permission_name, false))
         end
 
@@ -104,6 +104,10 @@ module ProviderInterface
     def provider_permissions_valid?
       providers_for_permissions = provider_permissions.map(&:provider)
       providers_for_permissions & possible_permissions.map(&:provider) == providers_for_permissions
+    end
+
+    def valid_permissions
+      ProviderPermissions::VALID_PERMISSIONS.reject { |p| p == :manage_organisations }
     end
   end
 end

--- a/spec/forms/provider_interface/provider_user_form_spec.rb
+++ b/spec/forms/provider_interface/provider_user_form_spec.rb
@@ -131,4 +131,33 @@ RSpec.describe ProviderInterface::ProviderUserForm do
       end
     end
   end
+
+  describe '#provider_permissions=' do
+    let(:provider_permissions_attrs) do
+      {
+        provider.id => {
+          provider_permission: {
+            provider_id: provider.id,
+            provider_user_id: provider_user.id,
+            manage_users: 'true',
+          },
+          active: true,
+        },
+      }
+    end
+
+    let(:provider_permission) { provider_user.provider_permissions.find_by(provider: provider, provider_user: provider_user) }
+
+    before do
+      provider_permission.update!(manage_organisations: true)
+    end
+
+    it 'only assigns permissions valid for the provider interface' do
+      provider_user_form.provider_permissions = provider_permissions_attrs
+      assigned_permission = provider_user_form.provider_permissions.find { |p| p.provider_user_id = provider_user.id && p.provider_id == provider.id }
+
+      expect(assigned_permission.manage_users).to be true
+      expect(assigned_permission.manage_organisations).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Context

The provider interface does not allow a user to assign the "manage organisations" permission. If this permission is switched on via the support UI, it can be un-set via the provider UI by editing user permissions.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Omit `manage_organisations` from the permissions assignment method on the provider UI provider user form.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/aq7F3NF6/2358-bug-manage-organisations-permission-is-unset-by-editing-user-permissions
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
