### PR TITLE
Add `date` attribute to rejection object in the vendor api

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -59,10 +59,12 @@ module VendorAPI
       if application_choice.rejection_reason?
         {
           reason: application_choice.rejection_reason,
+          date: application_choice.rejected_at,
         }
       elsif application_choice.offer_withdrawal_reason?
         {
           reason: application_choice.offer_withdrawal_reason,
+          date: application_choice.offer_withdrawn_at,
         }
       end
     end

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 30th June 2020
+
+New attributes:
+
+- `Rejection` now has a `date` attribute of type string.
+
 ### 24th June 2020
 
 Changes to existing attributes:
@@ -20,7 +26,7 @@ New attributes:
 
 New attributes:
 
-- `ApplicationAttributes` now has an `support_reference` attribute of type string.
+- `ApplicationAttributes` now has a `support_reference` attribute of type string.
 
 ### 20th May 2020
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -751,12 +751,18 @@ components:
       additionalProperties: false
       required:
       - reason
+      - date
       properties:
         reason:
           type: string
           description: The reason for rejection or offer withdrawal
           maxLength: 10240
           example: Does not meet minimum GCSE requirements
+        date:
+          type: string
+          format: date-time
+          description: Time of the rejection or offer withdrawal
+          example: '2019-09-18T15:33:49.216Z'
     Withdrawal:
       type: object
       additionalProperties: false

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
-      expect(response[:attributes][:rejection]).to eq(reason: 'Course full')
+      expect(response[:attributes][:rejection]).to eq(reason: 'Course full', date: '2019-01-01T00:00:00+00:00')
     end
   end
 
@@ -36,7 +36,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
-      expect(response[:attributes][:rejection]).to eq(reason: 'Course full')
+      expect(response[:attributes][:rejection]).to eq(reason: 'Course full', date: '2019-01-01T00:00:00+00:00')
     end
   end
 


### PR DESCRIPTION
## Context

Rejection entity in the API doesn't include rejection date. We should include it like we do in Withdrawal.

## Changes proposed in this pull request

This updates the Rejection entity in API responses to include `date` which is consistent with the way we present other dates (eg in Withdrawal).

## Guidance to review

- GET /applications/{application_id} of an application with rejection of offer_withdrawal returns `date`
- API docs are updated: http://localhost:3000/api-docs/reference#rejection-object
- Release notes are updated: http://localhost:3000/api-docs/release-notes

## Link to Trello card

https://trello.com/c/rIcWaVtG/2359-add-a-date-to-the-rejection-object-in-the-api-response

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
