### PR TITLE
Add international candidates feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -37,6 +37,7 @@ class FeatureFlag
     [:unavailable_course_notifications, 'Candidates with applications waiting for references receive an email notification if their course choice is withdrawn has no vacancies', 'Steve Hook'],
     [:hesa_degree_data, 'Use structured HESA data to autocomplete certain parts of the add degree flow', 'Malcolm Baig'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
+    [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|


### PR DESCRIPTION
## Context

We need a feature flag to put our work improving the application form for international candidates behind.

## Changes proposed in this pull request

- Add the flag

## Guidance to review

I know that the work in my card can't be switched on until another card is completed. I assume this will be the case for a few so I'm thinking it should probably sit behind one flag rather than multiple. Thoughts?

## Link to Trello card

https://trello.com/c/AsOuRv9u/1760-dev-%F0%9F%8C%90-international-residency-visa-status

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
