### PR TITLE
Interview preferences content update - add missing full stop

### DIFF
--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -16,7 +16,7 @@
             'health condition or disability',
             candidate_interface_training_with_a_disability_edit_path,
           )
-        %>
+        %>.
       </p>
 
       <p class="govuk-body">


### PR DESCRIPTION
## Context

Interview processes are different now because of coronavirus. We need to change the content on the 'interview needs' page so that it's still correct. This PR is a correction to the earlier https://github.com/DFE-Digital/apply-for-teacher-training/pull/2354

## Changes proposed in this pull request

Just adds a full-stop.

<img width="665" alt="image" src="https://user-images.githubusercontent.com/450843/86109963-dd70da00-babc-11ea-93df-caf764ba9dd5.png">

## Guidance to review

## Link to Trello card

https://trello.com/c/vr3pSDAL/1734-dev-replace-content-on-interview-needs-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
