### PR TITLE
remove pentest references

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The Provider interface at `/provider` and Support interface at
 
 ### Environments
 
-In development, QA, and pentest we use the **Test** environment of DfE Sign-in:
+In development and QA we use the **Test** environment of DfE Sign-in:
 
 [Manage console (test)](https://test-manage.signin.education.gov.uk)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,13 +45,13 @@ Summarise what you're deploying and tell the team in Slack on the `#twd_apply` c
 
 Follow the testing instructions for staging in the [post-deployment checklist](deployment_checklist.md).
 
-## 5. Deploy to production, sandbox and pentest
+## 5. Deploy to production, sandbox
 
 1. Load the [apply-for-teacher-training-releases](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary) page in Azure DevOps.
 1. Click the blue "Run pipeline" button (sometimes it says "Queue") at the top right of the page which will open the run pipeline menu.
 1. Ensure the branch is set to "master".
 1. Specify the commit again - **don't forget this**
-1. Under the Variables section set `deploy_staging` to `false` and `deploy_pentest`, `deploy_production` and `deploy_sandbox` to `true`.
+1. Under the Variables section set `deploy_staging` to `false` and `deploy_production` and `deploy_sandbox` to `true`.
 1. Click the Run button to start the deployment
 
 ## 6. Test on production

--- a/docs/new-environment.md
+++ b/docs/new-environment.md
@@ -10,7 +10,6 @@ The groups with `APPLY - ENV` prefix hold environment specific values.
 Variable Groups |
 ------------ |
 APPLY - ENV - DevOps |
-APPLY - ENV - Pentest |
 APPLY - ENV - Production |
 APPLY - ENV - QA |
 APPLY - ENV - Sandbox |


### PR DESCRIPTION
## Context

we no longer maintain a separate pen test environment.

## Changes proposed in this pull request

Remove pen test references in environment documents.
Have removed library group and variables in Azure Pipelines.

## Guidance to review


## Link to Trello card

https://trello.com/c/DG9KTVxc/2390-remove-pen-test-resourcegroup-in-azure

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
