### PR TITLE
Disallow UCAS data download in production

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -47,10 +47,7 @@ module SupportInterface
 
     def applications_export_for_ucas
       if HostingEnvironment.production?
-        # The unauthorized page expects an instance var that's only set in
-        # the dfe_sign_in_controller
-        @dfe_sign_in_user = dfe_sign_in_user
-        render 'support_interface/unauthorized', status: :forbidden
+        render_404
       else
         applications = ApplicationsExportForUCAS.new.applications
         header_row = ApplicationsExportForUCAS.csv_header(applications)

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -46,17 +46,17 @@ module SupportInterface
     end
 
     def applications_export_for_ucas
-      if FeatureFlag.active?('download_dataset1_from_support_page')
+      if HostingEnvironment.production?
+        # The unauthorized page expects an instance var that's only set in
+        # the dfe_sign_in_controller
+        @dfe_sign_in_user = dfe_sign_in_user
+        render 'support_interface/unauthorized', status: :forbidden
+      else
         applications = ApplicationsExportForUCAS.new.applications
         header_row = ApplicationsExportForUCAS.csv_header(applications)
         csv = to_csv(applications, header_row)
 
         send_data csv, filename: "dfe_apply_itt_applications_#{Time.zone.now.iso8601}.csv", disposition: :attachment
-      else
-        # The unauthorized page expects an instance var that's only set in
-        # the dfe_sign_in_controller
-        @dfe_sign_in_user = dfe_sign_in_user
-        render 'support_interface/unauthorized', status: :forbidden
       end
     end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,7 +23,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:download_dataset1_from_support_page, 'Enables the application CSV download from the support interface', 'Al Davidson'],
     [:provider_add_provider_users, 'Allows provider users to invite other provider users', 'Steve Laing'],
     [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],
     [:provider_view_safeguarding, 'Allows providers to see whether a candidate has declared safeguarding issues', 'Will McBrien'],

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -64,7 +64,7 @@
   <%= govuk_link_to 'Download candidate survey results (CSV)', support_interface_candidate_survey_path %>
 </p>
 
-<%- if FeatureFlag.active?('download_dataset1_from_support_page') %>
+<% unless HostingEnvironment.production? %>
   <h3 class='govuk-heading-m'>Applications export for UCAS</h3>
 
   <p class='govuk-body'>
@@ -77,7 +77,7 @@
   <p class='govuk-body'>
     <%= govuk_link_to 'Download Dataset 1 (CSV)', support_interface_applications_export_for_ucas_path %>
   </p>
-<%- end %>
+<% end %>
 
 <h3 class="govuk-heading-m">Active provider users</h3>
 

--- a/spec/system/support_interface/exporting_applications_for_ucas_spec.rb
+++ b/spec/system/support_interface/exporting_applications_for_ucas_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Exporting applications for UCAS as CSV' do
 
     given_i_am_a_support_user
     and_if_i_try_to_download_it_directly
-    then_i_should_get_a_forbidden_error
+    then_i_should_get_a_404
 
     when_i_am_on_a_test_environment
     and_i_visit_the_service_performance_page
@@ -56,8 +56,8 @@ RSpec.feature 'Exporting applications for UCAS as CSV' do
     visit support_interface_applications_export_for_ucas_path
   end
 
-  def then_i_should_get_a_forbidden_error
-    expect(page.status_code).to eq(403)
+  def then_i_should_get_a_404
+    expect(page.status_code).to eq(404)
   end
 
   def when_i_click_on_download_dataset_1

--- a/spec/system/support_interface/exporting_applications_for_ucas_spec.rb
+++ b/spec/system/support_interface/exporting_applications_for_ucas_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Exporting applications for UCAS as CSV' do
     given_i_am_a_support_user
     and_there_are_submitted_applications
 
-    when_the_feature_is_not_enabled
+    when_i_am_on_production
     and_i_visit_the_service_performance_page
     then_i_should_not_see_a_link_to_download_dataset_1
 
@@ -15,7 +15,7 @@ RSpec.feature 'Exporting applications for UCAS as CSV' do
     and_if_i_try_to_download_it_directly
     then_i_should_get_a_forbidden_error
 
-    when_the_feature_is_enabled
+    when_i_am_on_a_test_environment
     and_i_visit_the_service_performance_page
     then_i_should_see_a_link_to_download_dataset_1
     when_i_click_on_download_dataset_1
@@ -36,12 +36,12 @@ RSpec.feature 'Exporting applications for UCAS as CSV' do
     visit support_interface_performance_path
   end
 
-  def when_the_feature_is_not_enabled
-    FeatureFlag.deactivate('download_dataset1_from_support_page')
+  def when_i_am_on_production
+    ENV['HOSTING_ENVIRONMENT_NAME'] = 'production'
   end
 
-  def when_the_feature_is_enabled
-    FeatureFlag.activate('download_dataset1_from_support_page')
+  def when_i_am_on_a_test_environment
+    ENV['HOSTING_ENVIRONMENT_NAME'] = 'test'
   end
 
   def then_i_should_see_a_link_to_download_dataset_1


### PR DESCRIPTION
##  Context

We allow support users to check the UCAS export via a download. This is currently behind a feature flag, so it would still allow it to be used on production if ever activated. We don't want that because it contains sensitive info.

## Changes proposed in this pull request

Change the feature flag into a check on environment.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
