### PR TITLE
Add provider mailer previews

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -90,6 +90,24 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def application_submitted_over_5_days_ago(provider_user, application_choice)
+    @application = map_application_choice_params(application_choice)
+    email_for_provider(
+      provider_user,
+      application_choice.application_form,
+      subject: I18n.t!('provider_mailer.application_submitted_over_5_days.subject'),
+    )
+  end
+
+  def application_submitted_with_safeguarding(provider_user, application_choice)
+    @application = map_application_choice_params(application_choice)
+    email_for_provider(
+      provider_user,
+      application_choice.application_form,
+      subject: I18n.t!('provider_mailer.application_submitted_with_safeguarding.subject'),
+    )
+  end
+
 private
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/views/provider_mailer/application_submitted_over_5_days_ago.text.erb
+++ b/app/views/provider_mailer/application_submitted_over_5_days_ago.text.erb
@@ -1,0 +1,27 @@
+Dear <%= @provider_user_name || 'colleague' %>
+
+# Application submitted more than 5 days ago
+
+<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> more than 5 days ago. So far, you haven't responded.
+
+# Next steps
+
+Log in to Manage teacher training applications to respond:
+
+<%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
+
+<% if FeatureFlag.active?('covid_19') %>
+
+We’ll reject the application automatically if you have not responded by <%= @application.rbd_date.to_s(:govuk_date).strip %>.
+
+<% else %>
+
+We’ll reject the application on your behalf <%= @application.rbd_days %> working days after the date of submission.
+
+<% end %>
+
+# Get help, give feedback or report a problem
+
+Check our [Service guidance for training providers](https://www.apply-for-teacher-training.education.gov.uk/provider/service-guidance) to get an overview of Manage teacher training applications.
+
+You can also contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/app/views/provider_mailer/application_submitted_with_safeguarding.text.erb
+++ b/app/views/provider_mailer/application_submitted_with_safeguarding.text.erb
@@ -1,0 +1,31 @@
+Dear <%= @provider_user_name || 'colleague' %>
+
+# Application submitted with safeguarding issues disclosed
+
+<%= @application.candidate_name %> has submitted an application for <%= @application.course_name_and_code %>.
+
+Their application contains information related to ‘Criminal convictions and professional misconduct’.
+
+The information can be viewed by users on your team with permission to read sensitive material.
+
+# Next steps
+
+Log in to Manage teacher training applications to respond:
+
+<%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
+
+<% if FeatureFlag.active?('covid_19') %>
+
+We’ll reject the application automatically if you have not responded by <%= @application.rbd_date.to_s(:govuk_date).strip %>.
+
+<% else %>
+
+We’ll reject the application on your behalf after <%= @application.rbd_days %> working days.
+
+<% end %>
+
+# Get help, give feedback or report a problem
+
+Check our [Service guidance for training providers](https://www.apply-for-teacher-training.education.gov.uk/provider/service-guidance) to get an overview of Manage teacher training applications.
+
+You can also contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -6,3 +6,7 @@ en:
       subject: '%{candidate_name}’s application withdrawn automatically'
     declined:
       subject: '%{candidate_name} declined an offer'
+    application_submitted_over_5_days:
+      subject: Application submitted more than 5 days ago
+    application_submitted_with_safeguarding:
+      subject: Application submitted with safeguarding issues disclosed

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -32,6 +32,14 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.declined(provider_user, application_choice)
   end
 
+  def application_submitted_over_5_days_ago
+    ProviderMailer.application_submitted_over_5_days_ago(provider_user, application_choice)
+  end
+
+  def application_submitted_with_safeguarding
+    ProviderMailer.application_submitted_with_safeguarding(provider_user, application_choice)
+  end
+
   def fallback_sign_in_email
     ProviderMailer.fallback_sign_in_email(
       FactoryBot.build_stubbed(:provider_user),

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -36,6 +36,8 @@ RSpec.feature 'Docs' do
       provider_mailer-fallback_sign_in_email
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification
+      provider_mailer-application_submitted_over_5_days_ago
+      provider_mailer-application_submitted_with_safeguarding
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

We need previews for two new emails:
https://github.com/DFE-Digital/apply-for-teacher-training/compare/Content-emails-to-providers-edits-and-additions

## Changes proposed in this pull request

add email previews for:
- application_submitted_over_5_days 
- application_submitted_with_safeguarding

## Guidance to review

We should probably review the structure of locales at some point. We have `provider_notifications.yml` and `provider_mailer.yml`.

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1593511297345500

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
