### PR TITLE
Give dev-provider and dev-support names

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -1,15 +1,30 @@
 desc 'Set up your local development environment with data from Find'
 task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses] do
   puts 'Creating a provider-only user with DfE Sign-in UID `dev-provider` and email `provider@example.com`...'
-  ProviderUser.find_or_create_by!(dfe_sign_in_uid: 'dev-provider', email_address: 'provider@example.com') do |u|
+  ProviderUser.create!(
+    dfe_sign_in_uid: 'dev-provider',
+    email_address: 'provider@example.com',
+    first_name: 'Peter',
+    last_name: 'Rovider',
+  ) do |u|
     u.providers = Provider.where(code: '1JA').all
   end
 
   puts 'Creating a support & provider user with DfE Sign-in UID `dev-support` and email `support@example.com`...'
 
-  SupportUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com')
+  SupportUser.create!(
+    dfe_sign_in_uid: 'dev-support',
+    email_address: 'support@example.com',
+    first_name: 'Susan',
+    last_name: 'Upport',
+  )
 
-  admin_provider_user = ProviderUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com') do |u|
+  admin_provider_user = ProviderUser.create!(
+    dfe_sign_in_uid: 'dev-support',
+    email_address: 'support@example.com',
+    first_name: 'Susan',
+    last_name: 'Upport',
+  ) do |u|
     u.providers = Provider.where(code: %w[1JA 24J]).all
   end
 


### PR DESCRIPTION
## Context

Noticed as part of reviewing access controls.

## Changes proposed in this pull request

Give them names when we create them in `setup_local_dev_data`. This means they display properly in the manage-users UI

![Screenshot 2020-06-30 at 12 46 15](https://user-images.githubusercontent.com/642279/86122575-f767e800-bacf-11ea-8305-2a46659ca77d.png)


## Link to Trello card

https://trello.com/c/sCTl8idK/2333-review-ac
