### PR TITLE
Introduce a real "offer withdrawn" status

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -8,8 +8,6 @@ module CandidateInterface
     end
 
     def text
-      return t('candidate_application_states.offer_withdrawn') if application_choice.offer_withdrawn?
-
       t("candidate_application_states.#{application_choice.status}")
     end
 
@@ -21,7 +19,7 @@ module CandidateInterface
         :purple
       when 'offer'
         :turquoise
-      when 'rejected'
+      when 'rejected', 'offer_withdrawn'
         :pink
       when 'pending_conditions'
         :blue

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -8,8 +8,6 @@ module ProviderInterface
     end
 
     def text
-      return t('provider_application_states.offer_withdrawn') if application_choice.offer_withdrawn?
-
       I18n.t!("provider_application_states.#{status}")
     end
 
@@ -25,7 +23,7 @@ module ProviderInterface
         :blue
       when 'recruited'
         :green
-      when 'rejected', 'conditions_not_met'
+      when 'rejected', 'conditions_not_met', 'offer_withdrawn'
         :orange
       when 'declined', 'withdrawn'
         :red

--- a/app/components/provider_interface/status_box_components/offer_withdrawn_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_withdrawn_component.html.erb
@@ -1,0 +1,3 @@
+<h2 class="govuk-heading-l">Offer</h2>
+<%= render SummaryListComponent.new(rows: offer_withdrawn_rows) %>
+<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/status_box_components/offer_withdrawn_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_withdrawn_component.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   module StatusBoxComponents
-    class RejectedComponent < ViewComponent::Base
+    class OfferWithdrawnComponent < ViewComponent::Base
       include ViewHelper
       include StatusBoxComponents::CourseRows
 
@@ -12,21 +12,21 @@ module ProviderInterface
       end
 
       def render?
-        application_choice.rejected? || \
+        application_choice.offer_withdrawn? || \
           raise(ProviderInterface::StatusBoxComponent::ComponentMismatchError)
       end
 
-      def rejected_rows
+      def offer_withdrawn_at
+        application_choice.offer_withdrawn_at.to_s(:govuk_date)
+      end
+
+      def offer_withdrawn_rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
+            key: 'Offer withdrawn',
+            value: offer_withdrawn_at,
           },
-          {
-            key: 'Application rejected',
-            value: application_choice.rejected_at.to_s(:govuk_date),
-          },
-        ]
+        ] + course_rows(course_option: application_choice.offered_option)
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/rejected_component.html.erb
+++ b/app/components/provider_interface/status_box_components/rejected_component.html.erb
@@ -1,8 +1,2 @@
-<% if offer_withdrawn_at %>
-  <h2 class="govuk-heading-l">Offer</h2>
-  <%= render SummaryListComponent.new(rows: offer_withdrawn_rows) %>
-  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
-<% else %>
-  <h2 class="govuk-heading-l">Candidate’s application rejected</h2>
-  <%= render SummaryListComponent.new(rows: rejected_rows) %>
-<% end %>
+<h2 class="govuk-heading-l">Candidate’s application rejected</h2>
+<%= render SummaryListComponent.new(rows: rejected_rows) %>

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -23,7 +23,7 @@ module SupportInterface
         :blue
       when 'recruited'
         :green
-      when 'conditions_not_met', 'declined', 'rejected', 'withdrawn', 'cancelled'
+      when 'conditions_not_met', 'declined', 'rejected', 'offer_withdrawn', 'withdrawn', 'cancelled'
         :red
       when 'enrolled'
         :default

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -26,16 +26,11 @@ class ApplicationChoice < ApplicationRecord
     recruited: 'recruited',
     enrolled: 'enrolled',
     rejected: 'rejected',
+    offer_withdrawn: 'offer_withdrawn',
     declined: 'declined',
     withdrawn: 'withdrawn',
     conditions_not_met: 'conditions_not_met',
   }
-
-  scope :offer_withdrawn, -> { where(status: 'rejected').where.not(offer_withdrawn_at: nil) }
-
-  def offer_withdrawn?
-    rejected? && !offer_withdrawn_at.nil?
-  end
 
   def offered_option
     offered_course_option || course_option

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -11,7 +11,7 @@ module VendorAPI
         type: 'application',
         attributes: {
           support_reference: application_form.support_reference,
-          status: application_choice.status,
+          status: status,
           phase: application_form.phase,
           updated_at: application_choice.updated_at.iso8601,
           submitted_at: application_form.submitted_at.iso8601,
@@ -54,6 +54,15 @@ module VendorAPI
   private
 
     attr_reader :application_choice, :application_form
+
+    # V2: for backwards compatibility `offer_withdrawn` state is displayed as `rejected` in the API.
+    def status
+      if application_choice.offer_withdrawn?
+        'rejected'
+      else
+        application_choice.status
+      end
+    end
 
     def get_rejection
       if application_choice.rejection_reason?

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -46,10 +46,14 @@ class ApplicationStateChange
 
     state :offer do
       event :make_offer, transitions_to: :offer
-      event :reject, transitions_to: :rejected
+      event :reject, transitions_to: :offer_withdrawn
       event :accept, transitions_to: :pending_conditions
       event :decline, transitions_to: :declined
       event :decline_by_default, transitions_to: :declined
+    end
+
+    state :offer_withdrawn do
+      event :make_offer, transitions_to: :offer
     end
 
     state :declined

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -17,15 +17,7 @@ class FilterApplicationChoicesForProviders
     def status(application_choices, statuses)
       return application_choices if statuses.blank?
 
-      filtered_application_choices = application_choices.where(status: statuses)
-
-      if statuses.include?('offer_withdrawn')
-        filtered_application_choices = filtered_application_choices.or(application_choices.offer_withdrawn)
-      elsif statuses.include?('rejected')
-        filtered_application_choices = filtered_application_choices.where(offer_withdrawn_at: nil)
-      end
-
-      filtered_application_choices
+      application_choices.where(status: statuses)
     end
 
     def provider(application_choices, providers)

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -158,6 +158,13 @@ en:
       description: |
         The provider has rejected the candidate’s application.
 
+    offer_withdrawn:
+      name: Offer withdrawn
+      description: |
+        The provider has made an offer but withdrew it later.
+
+        This is called `rejected` in the API.
+
     withdrawn:
       name: Withdrawn
       description: |
@@ -350,6 +357,15 @@ en:
         - provider_mailer-application_withdrawn
 
     rejected-make_offer:
+      name: Provider makes offer
+      by: provider
+      description: ""
+      emails:
+        - candidate_mailer-new_offer_single_offer
+        - candidate_mailer-new_offer_multiple_offers
+        - candidate_mailer-new_offer_decisions_pending
+
+    offer_withdrawn-make_offer:
       name: Provider makes offer
       by: provider
       description: ""

--- a/db/migrate/20200630141828_update_application_status_to_offer_withdrawn.rb
+++ b/db/migrate/20200630141828_update_application_status_to_offer_withdrawn.rb
@@ -1,0 +1,13 @@
+class UpdateApplicationStatusToOfferWithdrawn < ActiveRecord::Migration[6.0]
+  def change
+    ApplicationChoice
+      .where(status: 'rejected')
+      .where.not(offer_withdrawn_at: nil)
+      .each do |application_choice|
+        application_choice.update!(
+          status: 'offer_withdrawn',
+          audit_comment: 'Data migration to introduce the "offer_withdrawn" state',
+        )
+      end
+  end
+end

--- a/features/successful_application_statuses.feature
+++ b/features/successful_application_statuses.feature
@@ -17,7 +17,7 @@ Feature: successful application statuses
       | offer                      | candidate | accept                 | pending conditions         |
       | offer                      | candidate | decline                | declined                   |
       | offer                      | provider  | make offer             | offer                      |
-      | offer                      | provider  | reject                 | rejected                   |
+      | offer                      | provider  | reject                 | offer_withdrawn            |
       | rejected                   | provider  | make offer             | offer                      |
       | pending conditions         | provider  | confirm conditions met | recruited                  |
       | pending conditions         | candidate | withdraw               | withdrawn                  |

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       create(
         :application_choice,
         application_form: application_form,
-        status: 'rejected',
+        status: 'offer_withdrawn',
         offer_withdrawn_at: Time.zone.now,
         offer_withdrawal_reason: 'Course full',
       )

--- a/spec/components/previews/provider_interface/status_box_component_preview.rb
+++ b/spec/components/previews/provider_interface/status_box_component_preview.rb
@@ -39,11 +39,11 @@ module ProviderInterface
     end
 
     def application_withdrawn
-      render_component_for choices: ApplicationChoice.where(status: :withdrawn, offer_withdrawn_at: nil)
+      render_component_for choices: ApplicationChoice.where(status: :withdrawn)
     end
 
     def offer_withdrawn
-      render_component_for choices: ApplicationChoice.where(status: :rejected).where.not(offer_withdrawn_at: nil)
+      render_component_for choices: ApplicationChoice.where(status: :offer_withdrawn)
     end
 
   private

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -130,13 +130,4 @@ RSpec.describe ApplicationChoice, type: :model do
       end
     end
   end
-
-  describe 'offer_withdrawn scope' do
-    it 'returns offer withdrawn application choices' do
-      create(:application_choice, status: 'rejected', offer_withdrawn_at: nil)
-      offer_withdraw_application_choice = create(:application_choice, status: 'rejected', offer_withdrawn_at: 2.days.ago)
-      expect(described_class.offer_withdrawn.count).to eq 1
-      expect(described_class.offer_withdrawn).to eq [offer_withdraw_application_choice]
-    end
-  end
 end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe ApplicationStateChange do
       expect(ApplicationStateChange.valid_states)
         .to match_array(I18n.t('application_states').keys)
 
-      expect(ApplicationStateChange.valid_states + [:offer_withdrawn])
+      expect(ApplicationStateChange.valid_states)
         .to match_array(I18n.t('candidate_application_states').keys)
 
-      expect(ApplicationStateChange.valid_states + [:offer_withdrawn])
+      expect(ApplicationStateChange.valid_states)
         .to match_array(I18n.t('provider_application_states').keys)
     end
 
@@ -23,7 +23,7 @@ RSpec.describe ApplicationStateChange do
     it 'has corresponding entries in the OpenAPI spec' do
       valid_states_in_openapi = VendorAPISpecification.as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
-      expect(ApplicationStateChange.states_visible_to_provider)
+      expect(ApplicationStateChange.states_visible_to_provider - %i[offer_withdrawn])
         .to match_array(valid_states_in_openapi.map(&:to_sym))
     end
   end

--- a/spec/services/provider_interface/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/provider_interface/filter_application_choices_for_providers_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe FilterApplicationChoicesForProviders do
     let(:declined_application_choice) { create(:application_choice, :with_declined_offer, status: 'declined') }
     let(:application_withdrawn_application_choice) { create(:application_choice, status: 'withdrawn') }
     let(:conditions_not_met_application_choice) { create(:application_choice, status: 'conditions_not_met') }
-    let(:withdrawn_by_us_application_choice) { create(:application_choice, status: 'rejected', offer_withdrawn_at: 2.days.ago) }
+    let(:withdrawn_by_us_application_choice) { create(:application_choice, status: 'offer_withdrawn', offer_withdrawn_at: 2.days.ago) }
 
     context 'when filtering by status' do
       let(:application_choices) { ApplicationChoice.all }
@@ -46,24 +46,6 @@ RSpec.describe FilterApplicationChoicesForProviders do
 
           expect(returned_application_choices).to eq([ordered_expected_application_choices[index]])
         end
-      end
-
-      it 'combined Submitted and Rejected filters return submitted and rejected application choices' do
-        filters = { status: %w[awaiting_provider_decision rejected] }
-        returned_application_choices = described_class.call(
-          application_choices: application_choices,
-          filters: filters,
-        )
-        expect(returned_application_choices).to match_array([submitted_application_choice, rejected_application_choice])
-      end
-
-      it 'combined Submitted and Offer withdrawn filters return submitted and withdrawn application choices' do
-        filters = { status: %w[awaiting_provider_decision offer_withdrawn] }
-        returned_application_choices = described_class.call(
-          application_choices: application_choices,
-          filters: filters,
-        )
-        expect(returned_application_choices).to match_array([submitted_application_choice, withdrawn_by_us_application_choice])
       end
     end
   end

--- a/spec/services/withdraw_offer_spec.rb
+++ b/spec/services/withdraw_offer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe WithdrawOffer do
       withdrawal_reason = 'We are so sorry...'
       WithdrawOffer.new(application_choice: application_choice, offer_withdrawal_reason: withdrawal_reason).save
 
-      expect(application_choice.reload.status).to eq 'rejected'
+      expect(application_choice.reload.status).to eq 'offer_withdrawn'
     end
 
     it 'does not change the state of the application_choice to "rejected" without a valid reason' do

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -203,7 +203,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_seven, status: 'declined', application_form:
            create(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
 
-    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'rejected', offer_withdrawn_at: 2.days.ago, application_form:
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer_withdrawn', offer_withdrawn_at: 2.days.ago, application_form:
            create(:application_form, first_name: 'John', last_name: 'Smith'), updated_at: 8.days.ago)
   end
 


### PR DESCRIPTION
## Context

When a provider has made an offer, they can withdraw it. The application is then in a "rejected" state. This was for practical reasons (we didn't have to have a new event and state for this process) and for backwards compatibility in the API (a new status constitutes a breaking change). However, since the functionality was introduced it turns out we want to treat applications with a withdraw offer different from rejected applications - we've introduced the `offer_withdrawn` state as a kind of virtual state dependent on the `offer_withdrawn_at` attribute. This makes things inconsistent, and introduces a lot of `if` statements everywhere. Recently, it made https://github.com/DFE-Digital/apply-for-teacher-training/pull/2379 weird.

## Changes proposed in this pull request

Introduce a real "offer withdrawn" state, and convert any existing applications to it. Make an exception for the API - we'll expose the real status in v2.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/b/aRydsKwk/apply-tech

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
