### PR TITLE
Return a validation error when vendors submit outlandish timestamps on the since param

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -23,7 +23,9 @@ module VendorAPI
     end
 
     def since_param
-      params.fetch(:since).to_datetime
+      params.fetch(:since).to_datetime.tap do |since|
+        raise ParameterInvalid, 'Parameter is invalid (date is nonsense): since' unless since.year.positive?
+      end
     rescue ArgumentError
       raise ParameterInvalid, 'Parameter is invalid (should be ISO8601): since'
     end

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -71,6 +71,16 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
   end
 
+  it 'returns HTTP status 422 given a parseable but nonsensensical `since` date value' do
+    get_api_request '/api/v1/applications?since=-004713-03-23T11:52:19.448Z' # this happened
+
+    expect(response).to have_http_status(422)
+
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+
+    expect(error_response['message']).to eql('Parameter is invalid (date is nonsense): since')
+  end
+
   it 'returns applications that are in a viewable state' do
     create_list(
       :submitted_application_choice,

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -9,11 +9,13 @@ module VendorAPISpecHelpers
   }.freeze
 
   def get_api_request(url, options = {})
-    get url, {
+    headers_and_params = {
       headers: {
         'Authorization' => auth_header,
       },
     }.deep_merge(options)
+
+    get url, **headers_and_params
   end
 
   def post_api_request(url, options = {})
@@ -29,7 +31,7 @@ module VendorAPISpecHelpers
 
     headers_and_params[:params] = headers_and_params[:params].to_json
 
-    post url, headers_and_params
+    post url, **headers_and_params
   end
 
   def auth_header


### PR DESCRIPTION
## Context

Vendors were triggering 500s in the Sandbox by submitting negative (but ISO8601-valid!) dates on the `since=` param.

https://sentry.io/organizations/dfe-bat/issues/1704738155/?referrer=slack

## Changes proposed in this pull request

Look at the parsed date from the `since` param. if it's negative, it's obviously nonsense, so raise a `ParameterError`.

## Link to Trello card

https://trello.com/c/miufGreD/2372-return-a-validation-error-when-vendors-submit-outlandish-timestamps-on-the-since-param

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
