### PR TITLE
Fix a cycle-related bug in GetApplicationChoicesForProviders

### DIFF
--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -19,7 +19,7 @@ class GetApplicationChoicesForProviders
     ApplicationChoice.includes(*includes)
       .where('courses.provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.current_year)
       .or(ApplicationChoice.includes(*includes)
-        .where('courses.accredited_provider_id' => providers))
+        .where('courses.accredited_provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.current_year))
       .where('status IN (?)', ApplicationStateChange.states_visible_to_provider).includes([:accredited_provider])
   end
 end


### PR DESCRIPTION
## Context

We made this query cycle-aware... but we missed a bit.

## Changes proposed in this pull request

See commit.

## Link to Trello card

Spotted while working on https://trello.com/c/sCTl8idK/2333-review-access-controls-in-preparation-for-launch

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
