### PR TITLE
Add an STI alias for TrainingProviderPermissions

### DIFF
--- a/app/models/training_provider_permissions.rb
+++ b/app/models/training_provider_permissions.rb
@@ -1,2 +1,6 @@
 class TrainingProviderPermissions < ProviderRelationshipPermissions
 end
+
+# Backwards compatibility for any existing db records using the old STI class name.
+# This can be removed once records are migrated.
+ProviderInterface::TrainingProviderPermissions = TrainingProviderPermissions


### PR DESCRIPTION
## Context

https://sentry.io/organizations/dfe-bat/issues/1755553851/?project=1765973&referrer=slack

There are `ProviderRelationshipPermissions` records in the db using the STI type name `ProviderInterface::TrainingProviderPermissions` but this class has been demodulized.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Add an alias from `ProviderInterface::TrainingProviderPermissions` to `TrainingProviderPermssions` until we have migrated existing records.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
