### PR TITLE
Account for duplicates which may exist for RatifyingProviderPermissions

### DIFF
--- a/db/migrate/20200701072718_migrate_provider_relationship_permissions_sti_records.rb
+++ b/db/migrate/20200701072718_migrate_provider_relationship_permissions_sti_records.rb
@@ -1,7 +1,20 @@
+ProviderInterface::AccreditedBodyPermissions = RatifyingProviderPermissions
+
 class MigrateProviderRelationshipPermissionsStiRecords < ActiveRecord::Migration[6.0]
   def change
-    ProviderRelationshipPermissions.where(type: 'ProviderInterface::AccreditedBodyPermissions')
-      .update_all(type: 'RatifyingProviderPermissions')
+    ProviderRelationshipPermissions.where(type: 'ProviderInterface::AccreditedBodyPermissions').each do |permissions|
+      existing_record = ProviderRelationshipPermissions.exists?(
+        type: 'RatifyingProviderPermissions',
+        ratifying_provider: permissions.ratifying_provider,
+        training_provider: permissions.training_provider,
+      )
+
+      if existing_record
+        permissions.delete
+      else
+        permissions.update(type: 'RatifyingProviderPermissions')
+      end
+    end
 
     ProviderRelationshipPermissions.where(type: 'ProviderInterface::TrainingProviderPermissions')
       .update_all(type: 'TrainingProviderPermissions')


### PR DESCRIPTION
## Context

Records created by the sync from Find may have used the new STI type `RatifyingProviderPermissions` effectively creating new records which will have the same foreign keys as existing records using the STI type `ProviderInterface::AccreditedBodyPermissions`
Attempts to update them to the use the new STI type will fail on the `[type, ratifying_provider_id, training_provider_id]` uniqueness constraint. 
This currently causes the migration to fail.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This commit checks for the existence of a newer record (using the RatifyingProviderPermissions type) and either disgards the old
record or updates it depending on whether a 'duplicate' exists.


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
