### PR TITLE
API docs reflect our change-offer behaviour

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,10 @@
+### 2nd July 2020
+
+The documentation around the `/offer` endpoint has been clarified to show that:
+
+- it is possible to change the offer by POSTing to that endpoint again
+- for the time being, a changed offer must have a changed course, not just changed conditions
+
 ### 30th June 2020
 
 New attributes:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -74,6 +74,10 @@ paths:
         Make an offer to the candidate.
 
         This will transition the application to the [offer state](/api-docs/lifecycle#offer).
+
+        If the application has already received an offer, POSTing a second offer will change that offer.
+
+        The replacement offer must be for a different course to that originally offered.
       parameters:
       - "$ref": "#/components/parameters/application_id"
       requestBody:


### PR DESCRIPTION
It's not currently possible to change the conditions of an offer without changing the course.

This is a bit weird and I think it's a defect in the system, but we'll tackle it when we cover the individual conditions workflow.

## Context

UCB's developer was confused by the docs, which implied he would be able to change the conditions on an existing offer.

## Changes proposed in this pull request

Clarify this behaviour in the API docs.

## Link to Trello card

https://trello.com/c/LTwAEdTO/2384-update-api-documentation-on-changing-offers-to-clarify-how-changing-an-offer-works

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
