### PR TITLE
Fix two bugs with provider pagination

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -17,8 +17,8 @@ module ProviderInterface
         filters: @page_state.applied_filters,
       )
 
-      application_choices = application_choices.page(params[:page] || 1).limit(5)
-      @application_choices = application_choices.order('application_choices.updated_at' => :desc)
+      application_choices = application_choices.order('application_choices.updated_at' => :desc)
+      @application_choices = application_choices.page(params[:page] || 1).per(15)
     end
 
     def show

--- a/spec/system/provider_interface/provider_applications_pagination_spec.rb
+++ b/spec/system/provider_interface/provider_applications_pagination_spec.rb
@@ -7,13 +7,13 @@ RSpec.feature 'Providers should be able to sort applications' do
   scenario 'viewing applications one page at a time' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
-    and_my_organisation_has_less_than_25_applications
+    and_my_organisation_has_fewer_than_15_applications
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_provider_applications_page
     then_i_should_not_see_a_paginator
 
-    given_my_organisation_has_more_than_25_applications
+    given_my_organisation_has_more_than_15_applications
     when_i_visit_the_provider_applications_page
     then_i_should_see_a_paginator
 
@@ -30,7 +30,7 @@ RSpec.feature 'Providers should be able to sort applications' do
     provider_user_exists_in_apply_database
   end
 
-  def and_my_organisation_has_less_than_25_applications
+  def and_my_organisation_has_fewer_than_15_applications
     current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
 
     @course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
@@ -59,10 +59,10 @@ RSpec.feature 'Providers should be able to sort applications' do
     expect(page).not_to have_content('Showing 1 to')
   end
 
-  def given_my_organisation_has_more_than_25_applications
+  def given_my_organisation_has_more_than_15_applications
     create_list(
       :application_choice,
-      25,
+      15,
       :awaiting_provider_decision,
       course_option: @course_option_one,
       application_form: create(:application_form),
@@ -91,7 +91,7 @@ RSpec.feature 'Providers should be able to sort applications' do
   def then_i_should_see_a_paginator_for_page_2
     expect(page).to have_link('Previous')
     expect(page).to have_link('1')
-    expect(page).to have_content('Showing 26 to')
+    expect(page).to have_content('Showing 16 to')
   end
 
   def then_i_should_not_see_a_paginator


### PR DESCRIPTION

## Context

@paulrobertlloyd noticed pagination was... very odd. See https://trello.com/c/0O7NDV2z/2352-pagination-goes-%F0%9F%A4%AA-in-manage

## Changes proposed in this pull request

- paginate after sorting, or we might end up with unstable pages
- `limit(5)` makes no sense without also setting the page size, which defaults to 25 - `per(15)` does the right thing

## Guidance to review

Does this work properly now?

## Link to Trello card

https://trello.com/c/0O7NDV2z/2352-pagination-goes-%F0%9F%A4%AA-in-manage

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
