### PR TITLE
Remove redundant test

### DIFF
--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -229,14 +229,5 @@ RSpec.describe ApplicationForm do
 
       expect(application_form.course_choices_that_need_replacing).to match_array [application_choice1, application_choice2, application_choice4]
     end
-
-    it 'does not return application_choices that have been withdrawn' do
-      application_form = create(:application_form)
-      course = create(:course, withdrawn: false)
-      course_option = create(:course_option, course: course, vacancy_status: 'vacancies')
-      create(:application_choice, application_form: application_form, course_option: course_option)
-
-      expect(application_form.course_choices_that_need_replacing).to eq []
-    end
   end
 end


### PR DESCRIPTION
## Context

An additional bit of logic was added to test whether a course was open on Apply which is making this test flaky.

This test is actually redundant though as all it is testing is that a course that has not been withdrawn and has vacancies is not returned. This is tested in the above test anyway. Not sure why it was even there in the first place tbh.

## Changes proposed in this pull request

- Remove the test

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
