### PR TITLE
Don't test ordering in ActiveProviderUsersExport

### DIFF
--- a/spec/services/support_interface/active_provider_users_export_spec.rb
+++ b/spec/services/support_interface/active_provider_users_export_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SupportInterface::ActiveProviderUsersExport do
       provider_user3 = create(:provider_user, providers: [provider1, provider2], last_signed_in_at: 5.days.ago)
       create(:provider_user, providers: [provider1])
 
-      expect(described_class.call).to eq([
+      expect(described_class.call).to match_array([
         {
           name: provider_user1.full_name,
           email_address: provider_user1.email_address,


### PR DESCRIPTION
https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1593679987166700

We don't mind the ordering of these rows, but sometimes the DB gives
them back in an order we don't expect in the matcher. Use match_array to
allow any order.


