### PR TITLE
Graph provider relationships

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -48,6 +48,10 @@ module SupportInterface
       update_provider('Successfully updated provider') { |provider| provider.update!(sync_courses: true) }
     end
 
+    def relationships
+      @diagram = SupportInterface::ProviderRelationshipsDiagram.new
+    end
+
   private
 
     def update_provider(success_message)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -7,6 +7,8 @@ class Provider < ApplicationRecord
 
   has_many :provider_permissions, dependent: :destroy
   has_many :provider_users, through: :provider_permissions
+  has_many :training_provider_permissions, foreign_key: :training_provider_id
+  has_many :ratifying_provider_permissions, foreign_key: :ratifying_provider_id
   has_many :provider_agreements
 
   enum region_code: {

--- a/app/presenters/support_interface/provider_relationships_diagram.rb
+++ b/app/presenters/support_interface/provider_relationships_diagram.rb
@@ -1,0 +1,74 @@
+module SupportInterface
+  class ProviderRelationshipsDiagram
+    def svg
+      graph = GraphViz.new('G', rankdir: 'TB', ratio: 'fill')
+
+      providers_with_relationships.each do |provider|
+        graph.add_nodes(
+          "Provider##{provider.id}",
+          label: provider.name_and_code,
+          width: '0.1',
+          height: '0.5',
+          shape: 'rect',
+          style: 'filled',
+          color: '#1d70b8',
+          fontcolor: '#ffffff',
+          fontname: 'Arial',
+          fontsize: 11,
+          margin: 0.1,
+          URL: Rails.application.routes.url_helpers.support_interface_provider_path(provider),
+        )
+
+        provider.training_provider_permissions.each do |perm|
+          graph.add_edges(
+            "Provider##{perm.training_provider_id}",
+            "Provider##{perm.ratifying_provider_id}",
+            label: "#{translate_permissions(perm)} for courses ratified by",
+            fontname: 'Arial',
+            color: '#0b0c0c',
+            fontcolor: '#0b0c0c',
+            fontsize: 11,
+          )
+        end
+
+        provider.ratifying_provider_permissions.each do |perm|
+          graph.add_edges(
+            "Provider##{perm.ratifying_provider_id}",
+            "Provider##{perm.training_provider_id}",
+            label: "#{translate_permissions(perm)} for courses run by",
+            fontname: 'Arial',
+            color: '#0b0c0c',
+            fontcolor: '#0b0c0c',
+            fontsize: 12,
+          )
+        end
+      end
+
+      graph[:rankdir] = 'LR'
+
+      graph.output(svg: String).force_encoding('UTF-8').html_safe
+    end
+
+    def providers_without_relationships
+      providers - providers_with_relationships
+    end
+
+  private
+
+    def providers_with_relationships
+      @providers_with_relationships ||= providers.select { |provider| provider.training_provider_permissions.any? || provider.ratifying_provider_permissions.any? }
+    end
+
+    def providers
+      Provider.includes(
+        :training_provider_permissions,
+        :ratifying_provider_permissions,
+        :courses,
+      )
+    end
+
+    def translate_permissions(permission)
+      "#{permission.view_safeguarding_information ? '✅ view safeguarding' : '❌ view safeguarding'} #{permission.view_safeguarding_information ? '✅ make decisions' : '❌ make decisions'}"
+    end
+  end
+end

--- a/app/views/support_interface/providers/relationships.html.erb
+++ b/app/views/support_interface/providers/relationships.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, 'Provider relationships' %>
+
+<%= @diagram.svg %>
+
+<h2 class='govuk-heading-m'>Providers without relationships</h2>
+
+<p class='govuk-body'>
+  Providers that do not have a relationship aren't visible in the diagram. These are:
+</p>
+
+<ul class='govuk-list govuk-list--bullet'>
+  <% @diagram.providers_without_relationships.each do |provider| %>
+    <li><%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -584,6 +584,7 @@ Rails.application.routes.draw do
 
     get '/providers' => 'providers#index', as: :providers
     get '/providers/other' => 'providers#other_providers', as: :other_providers
+    get '/providers/relationships' => 'providers#relationships', as: :provider_relationships
 
     get '/providers/:provider_id' => 'providers#show', as: :provider
     get '/providers/:provider_id/courses' => 'providers#courses', as: :provider_courses


### PR DESCRIPTION
## Context

We're working on implementing provider-to-provider permissions. We don't have a way to see what permissions exist between providers at the moment. I'm playing around with the code and data to get a better understanding of the domain.

## Changes proposed in this pull request

This generates a diagram that shows the relationships and permissions that exist. It may be useful to get an idea about the relationship between providers. It's very MVP and doesn't have any tests - I'd like to see this in qa/prod first.

![image](https://user-images.githubusercontent.com/233676/86463975-7b1b1200-bd26-11ea-99be-aba0ec844166.png)


## Guidance to review

https://apply-for-te-graph-prov-rycd5a.herokuapp.com/support/providers/relationships

## Link to Trello card

https://trello.com/c/sCTl8idK/2333-review-access-controls-in-preparation-for-launch

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
