### PR TITLE
Sort by reject by default date

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -32,7 +32,7 @@
       <div class="app-application-card__secondary">
         <div class="app-application-card__date">
           <dt class="govuk-visually-hidden">Date:</dt>
-          <dd class="govuk-body">Changed <%= changed_at %></dd>
+          <dd class="govuk-body"><%= contextual_date %></dd>
         </div>
       </div>
     </div>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -20,6 +20,7 @@ module ProviderInterface
 
     def contextual_date
       return changed_at_date unless sort_by && sort_by == 'Days left to respond'
+      return changed_at_date unless application_choice.status == 'awaiting_provider_decision'
       return changed_at_date unless reject_by_default_in_future?
 
       return '1 day to respond' if days_to_respond == 1

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -4,9 +4,9 @@ module ProviderInterface
 
     attr_accessor :accredited_provider, :application_choice, :application_choice_path,
                   :candidate_name, :course_name_and_code, :course_provider_name, :changed_at,
-                  :most_recent_note, :site_name_and_code
+                  :most_recent_note, :site_name_and_code, :sort_by
 
-    def initialize(application_choice:)
+    def initialize(application_choice:, sort_by: nil)
       @accredited_provider = application_choice.accredited_provider
       @application_choice = application_choice
       @candidate_name = application_choice.application_form.full_name
@@ -15,6 +15,32 @@ module ProviderInterface
       @changed_at = application_choice.updated_at.to_s(:govuk_date_and_time)
       @site_name_and_code = application_choice.site.name_and_code
       @most_recent_note = application_choice.notes.order('created_at DESC').first
+      @sort_by = sort_by
+    end
+
+    def contextual_date
+      return changed_at_date unless sort_by && sort_by == 'Days left to respond'
+      return changed_at_date unless reject_by_default_in_future?
+
+      return '1 day to respond' if days_to_respond == 1
+      return 'Less than 1 day to respond' if days_to_respond < 1
+
+      "#{days_to_respond} days to respond"
+    end
+
+  private
+
+    def changed_at_date
+      "Changed #{changed_at}"
+    end
+
+    def reject_by_default_in_future?
+      application_choice.reject_by_default_at.present? &&
+        application_choice.reject_by_default_at > Time.current
+    end
+
+    def days_to_respond
+      @days_to_respond ||= (application_choice.reject_by_default_at.to_date - Date.current).to_i
     end
   end
 end

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -4,9 +4,9 @@ module ProviderInterface
 
     attr_accessor :accredited_provider, :application_choice, :application_choice_path,
                   :candidate_name, :course_name_and_code, :course_provider_name, :changed_at,
-                  :most_recent_note, :site_name_and_code, :sort_by
+                  :most_recent_note, :site_name_and_code, :show_date
 
-    def initialize(application_choice:, sort_by: nil)
+    def initialize(application_choice:, show_date: :updated_at)
       @accredited_provider = application_choice.accredited_provider
       @application_choice = application_choice
       @candidate_name = application_choice.application_form.full_name
@@ -15,11 +15,11 @@ module ProviderInterface
       @changed_at = application_choice.updated_at.to_s(:govuk_date_and_time)
       @site_name_and_code = application_choice.site.name_and_code
       @most_recent_note = application_choice.notes.order('created_at DESC').first
-      @sort_by = sort_by
+      @show_date = show_date
     end
 
     def contextual_date
-      return changed_at_date unless sort_by && sort_by == 'Days left to respond'
+      return changed_at_date unless show_date == :reject_by_default_at
       return changed_at_date unless application_choice.status == 'awaiting_provider_decision'
       return changed_at_date unless reject_by_default_in_future?
 

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -6,7 +6,7 @@ module ProviderInterface
                   :candidate_name, :course_name_and_code, :course_provider_name, :changed_at,
                   :most_recent_note, :site_name_and_code, :show_date
 
-    def initialize(application_choice:, show_date: :updated_at)
+    def initialize(application_choice:, show_date: 'last_changed')
       @accredited_provider = application_choice.accredited_provider
       @application_choice = application_choice
       @candidate_name = application_choice.application_form.full_name
@@ -19,7 +19,7 @@ module ProviderInterface
     end
 
     def contextual_date
-      return changed_at_date unless show_date == :reject_by_default_at
+      return changed_at_date unless show_date == 'days_left_to_respond'
       return changed_at_date unless application_choice.status == 'awaiting_provider_decision'
       return changed_at_date unless reject_by_default_in_future?
 

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -38,6 +38,8 @@
 
       <div class="moj-filter__options">
         <form method="get">
+          <%= hidden_field_tag :sort_by, page_state.sort_by %>
+
           <%= submit_tag "Apply filters", class: "govuk-button" %>
 
           <% filters.each do |filter, idx| %>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -17,7 +17,7 @@
             </div>
             <div class="moj-filter__heading-action">
               <p class="govuk-body">
-              <%= link_to "Clear", provider_interface_applications_path %>
+              <%= link_to "Clear", provider_interface_applications_path(sort_by: @page_state.sort_by) %>
               </p>
             </div>
           </div>

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ViewHelper
 
     attr_reader :page_state
-    delegate :filters, to: :page_state
+    delegate :filters, :sort_by, to: :page_state
 
     def initialize(page_state:)
       @page_state = page_state
@@ -24,12 +24,14 @@ module ProviderInterface
 
     def remove_checkbox_tag_link(name, value)
       params = filters_to_params(filters)
+      params[:sort_by] = sort_by if sort_by
       params[name].reject! { |val| val == value }
       '?' + params.to_query
     end
 
     def remove_search_tag_link(name)
       params = filters_to_params(filters)
+      params[:sort_by] = sort_by if sort_by
       params.delete(name)
       '?' + params.to_query
     end

--- a/app/components/provider_interface/sort_order_component.html.erb
+++ b/app/components/provider_interface/sort_order_component.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-form-group govuk-!-margin-bottom-2">
+  <form method="get">
+    <% page_state.applied_filters.each do |k,v| %>
+      <% if v.is_a?(Array) %>
+        <% v.each do |val| %>
+          <%= hidden_field_tag "#{k}[]", val %>
+        <% end %>
+      <% else %>
+        <%= hidden_field_tag "#{k}", v %>
+      <% end %>
+    <% end %>
+    <label class="govuk-label govuk-visually-hidden" for="sort_by">Sorted by</label>
+    <%= select_tag(
+      :sort_by,
+      options_for_select(page_state.sort_options, selected: page_state.sort_by),
+      id: "sort_by",
+      class: "govuk-select sortby-selector",
+    ) %>
+    <%= submit_tag 'Sort', class: 'govuk-button govuk-buton--secondary govuk-!-margin-bottom-2', data: { module: 'govuk-button' } %>
+  </form>
+</div>

--- a/app/components/provider_interface/sort_order_component.rb
+++ b/app/components/provider_interface/sort_order_component.rb
@@ -1,0 +1,9 @@
+module ProviderInterface
+  class SortOrderComponent < ViewComponent::Base
+    attr_reader :page_state
+
+    def initialize(page_state:)
+      @page_state = page_state
+    end
+  end
+end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -17,7 +17,11 @@ module ProviderInterface
         filters: @page_state.applied_filters,
       )
 
-      application_choices = application_choices.order(@page_state.sort_order)
+      application_choices = ProviderInterface::SortApplicationChoices.call(
+        application_choices: application_choices,
+        sort_by: @page_state.sort_by,
+      )
+
       @application_choices = application_choices.page(params[:page] || 1).per(15)
     end
 

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -17,7 +17,7 @@ module ProviderInterface
         filters: @page_state.applied_filters,
       )
 
-      application_choices = application_choices.order('application_choices.updated_at' => :desc)
+      application_choices = application_choices.order(@page_state.sort_order)
       @application_choices = application_choices.page(params[:page] || 1).per(15)
     end
 

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -23,6 +23,10 @@ module ProviderInterface
       sort_options.include?(@params[:sort_by]) ? @params[:sort_by] : 'Last changed'
     end
 
+    def sort_by_attribute
+      sort_by == 'Days left to respond' ? :reject_by_default_at : :updated_at
+    end
+
     def sort_options
       ['Last changed', 'Days left to respond']
     end

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -20,32 +20,11 @@ module ProviderInterface
     end
 
     def sort_by
-      sort_options.include?(@params[:sort_by]) ? @params[:sort_by] : 'Last changed'
-    end
-
-    def sort_by_attribute
-      sort_by == 'Days left to respond' ? :reject_by_default_at : :updated_at
+      sort_options.map(&:last).flatten.include?(@params[:sort_by]) ? @params[:sort_by] : 'last_changed'
     end
 
     def sort_options
-      ['Last changed', 'Days left to respond']
-    end
-
-    def sort_order
-      return { updated_at: :desc } if sort_by != 'Days left to respond'
-
-      Arel.sql(
-        <<-ORDER_BY.strip_heredoc,
-        (
-          CASE
-            WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > NOW())) THEN 1
-            ELSE 0
-          END
-        ) DESC,
-        reject_by_default_at ASC,
-        application_choices.updated_at DESC
-        ORDER_BY
-      )
+      [['Last changed', 'last_changed'], ['Days left to respond', 'days_left_to_respond']]
     end
 
   private

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -16,7 +16,21 @@ module ProviderInterface
     end
 
     def applied_filters
-      @params.permit(:candidate_name, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
+      @params.permit(:candidate_name, :sort_by, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
+    end
+
+    def sort_by
+      sort_options.include?(@params[:sort_by]) ? @params[:sort_by] : 'Last changed'
+    end
+
+    def sort_options
+      ['Last changed', 'Days left to respond']
+    end
+
+    def sort_order
+      return { reject_by_default_at: :desc, updated_at: :desc } if sort_by == 'Days left to respond'
+
+      { updated_at: :desc }
     end
 
   private

--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -1,0 +1,24 @@
+module ProviderInterface
+  class SortApplicationChoices
+    def self.call(application_choices:, sort_by:)
+      application_choices.order(sort_order(sort_by))
+    end
+
+    def self.sort_order(sort_by)
+      return { updated_at: :desc } if sort_by != 'days_left_to_respond'
+
+      Arel.sql(
+        <<-ORDER_BY.strip_heredoc,
+        (
+          CASE
+            WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > NOW())) THEN 1
+            ELSE 0
+          END
+        ) DESC,
+        reject_by_default_at ASC,
+        application_choices.updated_at DESC
+        ORDER_BY
+      )
+    end
+  end
+end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -45,7 +45,7 @@
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>
-          <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, show_date: @page_state.sort_by_attribute) %>
+          <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, show_date: @page_state.sort_by) %>
         <% end %>
       </div>
     <% elsif @page_state.filtered? %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -42,7 +42,29 @@
       <div class="moj-action-bar__filter">
         <div class="filter-toggle-button"></div>
       </div>
-      <p class='govuk-body applications-sorted-by-explanation'>Sorted by: last changed</p>
+      <div class="govuk-form-group govuk-!-margin-bottom-2">
+        <form method="get">
+          <% @page_state.applied_filters.each do |k,v| %>
+            <% if v.is_a?(Array) %>
+              <% v.each do |val| %>
+                <%= hidden_field_tag "#{k}[]", val %>
+              <% end %>
+            <% else %>
+              <%= hidden_field_tag "#{k}", v %>
+            <% end %>
+          <% end %>
+          <label class="govuk-label govuk-visually-hidden" for="sort_by">Sorted by</label>
+          <%= select_tag(
+            :sort_by,
+            options_for_select(@page_state.sort_options, selected: @page_state.sort_by),
+            id: "sort_by",
+            class: "govuk-select sortby-selector",
+          ) %>
+          <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" type="submit" data-module="govuk-button">
+            Sort
+          </button>
+        </form>
+      </div>
     </div>
     <% if @application_choices.any? %>
       <div class="app-application-cards">

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -34,37 +34,13 @@
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <div class='moj-filter-layout'>
-  <%= render ProviderInterface::FilterComponent.new(
-    page_state: @page_state,
-  ) %>
+  <%= render ProviderInterface::FilterComponent.new(page_state: @page_state) %>
   <div class='moj-filter-layout__content'>
     <div class="moj-action-bar">
       <div class="moj-action-bar__filter">
         <div class="filter-toggle-button"></div>
       </div>
-      <div class="govuk-form-group govuk-!-margin-bottom-2">
-        <form method="get">
-          <% @page_state.applied_filters.each do |k,v| %>
-            <% if v.is_a?(Array) %>
-              <% v.each do |val| %>
-                <%= hidden_field_tag "#{k}[]", val %>
-              <% end %>
-            <% else %>
-              <%= hidden_field_tag "#{k}", v %>
-            <% end %>
-          <% end %>
-          <label class="govuk-label govuk-visually-hidden" for="sort_by">Sorted by</label>
-          <%= select_tag(
-            :sort_by,
-            options_for_select(@page_state.sort_options, selected: @page_state.sort_by),
-            id: "sort_by",
-            class: "govuk-select sortby-selector",
-          ) %>
-          <button class="govuk-button govuk-buton--secondary govuk-!-margin-bottom-2" type="submit" data-module="govuk-button">
-            Sort
-          </button>
-        </form>
-      </div>
+      <%= render(ProviderInterface::SortOrderComponent.new(page_state: @page_state)) %>
     </div>
     <% if @application_choices.any? %>
       <div class="app-application-cards">

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -45,7 +45,10 @@
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>
-          <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, sort_by: @page_state.sort_by) %>
+          <%= render ProviderInterface::ApplicationCardComponent.new(
+            application_choice: choice,
+            show_date: @page_state.sort_by == 'Days left to respond' ? :reject_by_default_at : :updated_at,
+          ) %>
         <% end %>
       </div>
     <% elsif @page_state.filtered? %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -45,10 +45,7 @@
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>
-          <%= render ProviderInterface::ApplicationCardComponent.new(
-            application_choice: choice,
-            show_date: @page_state.sort_by == 'Days left to respond' ? :reject_by_default_at : :updated_at,
-          ) %>
+          <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, show_date: @page_state.sort_by_attribute) %>
         <% end %>
       </div>
     <% elsif @page_state.filtered? %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -69,7 +69,7 @@
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>
-          <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
+          <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, sort_by: @page_state.sort_by) %>
         <% end %>
       </div>
     <% elsif @page_state.filtered? %>

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -109,4 +109,69 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       end
     end
   end
+
+  describe '#contextual_date' do
+    let(:reject_by_default_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
+    let(:updated_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
+    let(:application_choice) do
+      build_stubbed(
+        :application_choice,
+        reject_by_default_at: reject_by_default_at,
+        updated_at: updated_at,
+        course_option: course_option,
+      )
+    end
+    let(:sort_by) { 'Days left to respond' }
+
+    subject(:component) { described_class.new(application_choice: application_choice, sort_by: sort_by) }
+
+    context 'when not sorting by reject by default date' do
+      let(:sort_by) { 'foo' }
+
+      it 'presents the last changed date' do
+        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
+        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
+      end
+    end
+
+    context 'when reject_by_default_at is nil' do
+      let(:reject_by_default_at) { nil }
+
+      it 'presents the last changed date' do
+        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
+      end
+    end
+
+    context 'when reject_by_default_at is in the past' do
+      let(:reject_by_default_at) { 1.day.ago }
+
+      it 'presents the last changed date' do
+        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
+      end
+    end
+
+    context 'when reject_by_default_at is less than a day away' do
+      let(:reject_by_default_at) { 1.hour.from_now }
+
+      it 'presents "Less than 1 day to respond"' do
+        expect(described_class.new(application_choice: application_choice, sort_by: sort_by).contextual_date).to eq('Less than 1 day to respond')
+      end
+    end
+
+    context 'when reject_by_default_at is a day away' do
+      let(:reject_by_default_at) { 1.day.from_now }
+
+      it 'presents "1 day to respond"' do
+        expect(described_class.new(application_choice: application_choice, sort_by: sort_by).contextual_date).to eq('1 day to respond')
+      end
+    end
+
+    context 'when reject_by_default_at is more than a day away' do
+      let(:reject_by_default_at) { 5.days.from_now }
+
+      it 'presents the number of days left to respond' do
+        expect(described_class.new(application_choice: application_choice, sort_by: sort_by).contextual_date).to eq('5 days to respond')
+      end
+    end
+  end
 end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -4,37 +4,49 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
   include CourseOptionHelpers
 
   let(:current_provider) do
-    create(:provider,
-           :with_signed_agreement,
-           code: 'ABC',
-           name: 'Hoth Teacher Training')
+    create(
+      :provider,
+      :with_signed_agreement,
+      code: 'ABC',
+      name: 'Hoth Teacher Training',
+    )
   end
 
   let(:accredited_provider) do
-    create(:provider,
-           :with_signed_agreement,
-           code: 'XYZ',
-           name: 'Yavin University')
+    create(
+      :provider,
+      :with_signed_agreement,
+      code: 'XYZ',
+      name: 'Yavin University',
+    )
   end
 
   let(:course_option) do
-    course_option_for_provider(provider: current_provider,
-                               course: create(:course,
-                                              name: 'Alchemy',
-                                              provider: current_provider,
-                                              accredited_provider: accredited_provider))
+    course_option_for_provider(
+      provider: current_provider,
+      course: create(
+        :course,
+        name: 'Alchemy',
+        provider: current_provider,
+        accredited_provider: accredited_provider,
+      ),
+    )
   end
 
   let(:application_choice) do
-    create(:application_choice,
-           :awaiting_provider_decision,
-           course_option: course_option,
-           status: 'withdrawn',
-           application_form: create(:application_form,
-                                    first_name: 'Jim',
-                                    last_name: 'James'),
-           site: create(:site, code: 'L123', name: 'Skywalker Training'),
-           updated_at: Date.parse('25-03-2020'))
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option,
+      status: 'withdrawn',
+      application_form: create(
+        :application_form,
+        first_name: 'Jim',
+        last_name: 'James',
+      ),
+      site: create(:site, code: 'L123', name: 'Skywalker Training'),
+      updated_at: Date.parse('25-03-2020'),
+    )
   end
 
   let(:note) do
@@ -86,20 +98,29 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
     context 'when there is no accredited provider' do
       let(:course_option_without_accredited_provider) do
-        course_option_for_provider(provider: current_provider,
-                                   course: create(:course,
-                                                  name: 'Baking',
-                                                  provider: current_provider))
+        course_option_for_provider(
+          provider: current_provider,
+          course: create(
+            :course,
+            name: 'Baking',
+            provider: current_provider,
+          ),
+        )
       end
 
       let(:application_choice_without_accredited_provider) do
-        create(:application_choice,
-               :awaiting_provider_decision,
-               course_option: course_option_without_accredited_provider,
-               status: 'withdrawn', application_form: create(:application_form,
-                                                             first_name: 'Jim',
-                                                             last_name: 'James'),
-               updated_at: Date.parse('25-03-2020'))
+        create(
+          :application_choice,
+          :awaiting_provider_decision,
+          course_option: course_option_without_accredited_provider,
+          status: 'withdrawn',
+          application_form: create(
+            :application_form,
+            first_name: 'Jim',
+            last_name: 'James',
+          ),
+          updated_at: Date.parse('25-03-2020'),
+        )
       end
 
       let(:result) { render_inline described_class.new(application_choice: application_choice_without_accredited_provider) }

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -146,62 +146,48 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       )
     end
 
-    subject(:component) { described_class.new(application_choice: application_choice, show_date: show_date) }
+    subject(:contextual_date) { described_class.new(application_choice: application_choice, show_date: show_date).contextual_date }
 
     context 'when not sorting by reject by default date' do
       let(:show_date) { :updated_at }
 
-      it 'presents the last changed date' do
-        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
-      end
+      it { is_expected.to eq('Changed  2 June 2020 at  9:05am') }
     end
 
     context 'when application is not in awaiting_provider_decision state' do
       let(:status) { 'withdrawn' }
 
-      it 'presents the last changed date' do
-        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
-      end
+      it { is_expected.to eq('Changed  2 June 2020 at  9:05am') }
     end
 
     context 'when reject_by_default_at is nil' do
       let(:reject_by_default_at) { nil }
 
-      it 'presents the last changed date' do
-        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
-      end
+      it { is_expected.to eq('Changed  2 June 2020 at  9:05am') }
     end
 
     context 'when reject_by_default_at is in the past' do
       let(:reject_by_default_at) { 1.day.ago }
 
-      it 'presents the last changed date' do
-        expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
-      end
+      it { is_expected.to eq('Changed  2 June 2020 at  9:05am') }
     end
 
     context 'when reject_by_default_at is less than a day away' do
       let(:reject_by_default_at) { 1.hour.from_now }
 
-      it 'presents "Less than 1 day to respond"' do
-        expect(described_class.new(application_choice: application_choice, show_date: show_date).contextual_date).to eq('Less than 1 day to respond')
-      end
+      it { is_expected.to eq('Less than 1 day to respond') }
     end
 
     context 'when reject_by_default_at is a day away' do
       let(:reject_by_default_at) { 1.day.from_now }
 
-      it 'presents "1 day to respond"' do
-        expect(described_class.new(application_choice: application_choice, show_date: show_date).contextual_date).to eq('1 day to respond')
-      end
+      it { is_expected.to eq('1 day to respond') }
     end
 
     context 'when reject_by_default_at is more than a day away' do
       let(:reject_by_default_at) { 5.days.from_now }
 
-      it 'presents the number of days left to respond' do
-        expect(described_class.new(application_choice: application_choice, show_date: show_date).contextual_date).to eq('5 days to respond')
-      end
+      it { is_expected.to eq('5 days to respond') }
     end
   end
 end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -134,15 +134,17 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
   describe '#contextual_date' do
     let(:reject_by_default_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
     let(:updated_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
+    let(:status) { 'awaiting_provider_decision' }
+    let(:sort_by) { 'Days left to respond' }
     let(:application_choice) do
       build_stubbed(
         :application_choice,
         reject_by_default_at: reject_by_default_at,
         updated_at: updated_at,
         course_option: course_option,
+        status: status,
       )
     end
-    let(:sort_by) { 'Days left to respond' }
 
     subject(:component) { described_class.new(application_choice: application_choice, sort_by: sort_by) }
 
@@ -151,6 +153,13 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
       it 'presents the last changed date' do
         expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
+      end
+    end
+
+    context 'when application is not in awaiting_provider_decision state' do
+      let(:status) { 'withdrawn' }
+
+      it 'presents the last changed date' do
         expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
       end
     end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     let(:reject_by_default_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
     let(:updated_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
     let(:status) { 'awaiting_provider_decision' }
-    let(:sort_by) { 'Days left to respond' }
+    let(:show_date) { :reject_by_default_at }
     let(:application_choice) do
       build_stubbed(
         :application_choice,
@@ -146,10 +146,10 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       )
     end
 
-    subject(:component) { described_class.new(application_choice: application_choice, sort_by: sort_by) }
+    subject(:component) { described_class.new(application_choice: application_choice, show_date: show_date) }
 
     context 'when not sorting by reject by default date' do
-      let(:sort_by) { 'foo' }
+      let(:show_date) { :updated_at }
 
       it 'presents the last changed date' do
         expect(component.contextual_date).to eq('Changed  2 June 2020 at  9:05am')
@@ -184,7 +184,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       let(:reject_by_default_at) { 1.hour.from_now }
 
       it 'presents "Less than 1 day to respond"' do
-        expect(described_class.new(application_choice: application_choice, sort_by: sort_by).contextual_date).to eq('Less than 1 day to respond')
+        expect(described_class.new(application_choice: application_choice, show_date: show_date).contextual_date).to eq('Less than 1 day to respond')
       end
     end
 
@@ -192,7 +192,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       let(:reject_by_default_at) { 1.day.from_now }
 
       it 'presents "1 day to respond"' do
-        expect(described_class.new(application_choice: application_choice, sort_by: sort_by).contextual_date).to eq('1 day to respond')
+        expect(described_class.new(application_choice: application_choice, show_date: show_date).contextual_date).to eq('1 day to respond')
       end
     end
 
@@ -200,7 +200,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       let(:reject_by_default_at) { 5.days.from_now }
 
       it 'presents the number of days left to respond' do
-        expect(described_class.new(application_choice: application_choice, sort_by: sort_by).contextual_date).to eq('5 days to respond')
+        expect(described_class.new(application_choice: application_choice, show_date: show_date).contextual_date).to eq('5 days to respond')
       end
     end
   end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     let(:reject_by_default_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
     let(:updated_at) { DateTime.parse('2020-06-02T09:05:00+01:00') }
     let(:status) { 'awaiting_provider_decision' }
-    let(:show_date) { :reject_by_default_at }
+    let(:show_date) { 'days_left_to_respond' }
     let(:application_choice) do
       build_stubbed(
         :application_choice,
@@ -149,7 +149,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     subject(:contextual_date) { described_class.new(application_choice: application_choice, show_date: show_date).contextual_date }
 
     context 'when not sorting by reject by default date' do
-      let(:show_date) { :updated_at }
+      let(:show_date) { 'last_changed' }
 
       it { is_expected.to eq('Changed  2 June 2020 at  9:05am') }
     end

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -98,4 +98,27 @@ RSpec.describe ProviderInterface::FilterComponent do
 
     expect(result.text).not_to include('Selected filters')
   end
+
+  it 'preserves sort order in filter tag links' do
+    page_state = ProviderInterface::ProviderApplicationsPageState.new(
+      params: ActionController::Parameters.new({ sort_by: 'Last changed' }),
+      provider_user: current_provider_user,
+    )
+
+    component = described_class.new(page_state: page_state)
+
+    expect(component.remove_checkbox_tag_link('status', 'accepted')).to include('sort_by=Last+changed')
+    expect(component.remove_search_tag_link('candidate_name')).to include('sort_by=Last+changed')
+  end
+
+  it 'preserves sort order in filtering form' do
+    page_state = ProviderInterface::ProviderApplicationsPageState.new(
+      params: ActionController::Parameters.new({ sort_by: 'Last changed' }),
+      provider_user: current_provider_user,
+    )
+
+    result = render_inline described_class.new(page_state: page_state)
+
+    expect(result.css('input[name=sort_by][type=hidden]').attr('value').value).to eq('Last changed')
+  end
 end

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -101,24 +101,24 @@ RSpec.describe ProviderInterface::FilterComponent do
 
   it 'preserves sort order in filter tag links' do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
-      params: ActionController::Parameters.new({ sort_by: 'Last changed' }),
+      params: ActionController::Parameters.new({ sort_by: 'last_changed' }),
       provider_user: current_provider_user,
     )
 
     component = described_class.new(page_state: page_state)
 
-    expect(component.remove_checkbox_tag_link('status', 'accepted')).to include('sort_by=Last+changed')
-    expect(component.remove_search_tag_link('candidate_name')).to include('sort_by=Last+changed')
+    expect(component.remove_checkbox_tag_link('status', 'accepted')).to include('sort_by=last_changed')
+    expect(component.remove_search_tag_link('candidate_name')).to include('sort_by=last_changed')
   end
 
   it 'preserves sort order in filtering form' do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
-      params: ActionController::Parameters.new({ sort_by: 'Last changed' }),
+      params: ActionController::Parameters.new({ sort_by: 'last_changed' }),
       provider_user: current_provider_user,
     )
 
     result = render_inline described_class.new(page_state: page_state)
 
-    expect(result.css('input[name=sort_by][type=hidden]').attr('value').value).to eq('Last changed')
+    expect(result.css('input[name=sort_by][type=hidden]').attr('value').value).to eq('last_changed')
   end
 end

--- a/spec/components/provider_interface/sort_order_component_spec.rb
+++ b/spec/components/provider_interface/sort_order_component_spec.rb
@@ -12,23 +12,22 @@ RSpec.describe ProviderInterface::SortOrderComponent do
     let(:page_state) do
       ProviderInterface::ProviderApplicationsPageState.new(params: params, provider_user: provider_user)
     end
-    let(:rendered_component) { render_inline(component) }
 
-    subject(:component) { described_class.new(page_state: page_state) }
+    subject(:rendered_result) { render_inline(described_class.new(page_state: page_state)) }
 
     it 'renders sorting ordering options' do
-      expect(rendered_component.css('select').text).to include('Last changed')
-      expect(rendered_component.css('select').text).to include('Days left to respond')
+      expect(rendered_result.css('select').text).to include('Last changed')
+      expect(rendered_result.css('select').text).to include('Days left to respond')
     end
 
     it 'renders a sort button' do
-      expect(rendered_component.css('input[type=submit]').attr('value').value).to include('Sort')
+      expect(rendered_result.css('input[type=submit]').attr('value').value).to include('Sort')
     end
 
     it 'renders applied filters as hidden fields' do
-      expect(rendered_component.css('input[type=hidden][name="status[]"]').first.attr('value')).to eq('awaiting_provider_decision')
-      expect(rendered_component.css('input[type=hidden][name="status[]"]').last.attr('value')).to eq('pending_conditions')
-      expect(rendered_component.css('input[type=hidden][name=candidate_name]').attr('value').value).to eq('Susan')
+      expect(rendered_result.css('input[type=hidden][name="status[]"]').first.attr('value')).to eq('awaiting_provider_decision')
+      expect(rendered_result.css('input[type=hidden][name="status[]"]').last.attr('value')).to eq('pending_conditions')
+      expect(rendered_result.css('input[type=hidden][name=candidate_name]').attr('value').value).to eq('Susan')
     end
   end
 end

--- a/spec/components/provider_interface/sort_order_component_spec.rb
+++ b/spec/components/provider_interface/sort_order_component_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SortOrderComponent do
+  describe 'rendering' do
+    let(:provider_user) { build_stubbed(:provider_user) }
+    let(:params) do
+      ActionController::Parameters.new({
+        'status' => %w[awaiting_provider_decision pending_conditions],
+        'candidate_name' => 'Susan',
+      })
+    end
+    let(:page_state) do
+      ProviderInterface::ProviderApplicationsPageState.new(params: params, provider_user: provider_user)
+    end
+    let(:rendered_component) { render_inline(component) }
+
+    subject(:component) { described_class.new(page_state: page_state) }
+
+    it 'renders sorting ordering options' do
+      expect(rendered_component.css('select').text).to include('Last changed')
+      expect(rendered_component.css('select').text).to include('Days left to respond')
+    end
+
+    it 'renders a sort button' do
+      expect(rendered_component.css('input[type=submit]').attr('value').value).to include('Sort')
+    end
+
+    it 'renders applied filters as hidden fields' do
+      expect(rendered_component.css('input[type=hidden][name="status[]"]').first.attr('value')).to eq('awaiting_provider_decision')
+      expect(rendered_component.css('input[type=hidden][name="status[]"]').last.attr('value')).to eq('pending_conditions')
+      expect(rendered_component.css('input[type=hidden][name=candidate_name]').attr('value').value).to eq('Susan')
+    end
+  end
+end

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
   describe '#filters' do
     it 'calculates a correct list of possible filters' do
-      page_state = described_class.new(params: ActionController::Parameters.new,
-                                       provider_user: provider_user)
+      page_state = described_class.new(
+        params: ActionController::Parameters.new,
+        provider_user: provider_user,
+      )
 
       expected_number_of_filters = 3
       providers_array_index = 2
@@ -30,8 +32,10 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'does not include providers if avaible providers is < 2' do
-      page_state = described_class.new(params: ActionController::Parameters.new,
-                                       provider_user: another_provider_user)
+      page_state = described_class.new(
+        params: ActionController::Parameters.new,
+        provider_user: another_provider_user,
+      )
 
       expected_number_of_filters = 2
 
@@ -42,9 +46,10 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'can return filter config for a list of provider locations' do
-      page_state = described_class.new(params: ActionController::Parameters.new({ provider: [provider1.id] }),
-
-                                       provider_user: another_provider_user)
+      page_state = described_class.new(
+        params: ActionController::Parameters.new({ provider: [provider1.id] }),
+        provider_user: another_provider_user,
+      )
 
       headings = page_state.filters.map { |filter| filter[:heading] }
 
@@ -63,17 +68,12 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
   describe '#applied_filters' do
     let(:params) do
-      ActionController::Parameters.new({ 'status' => %w[
-        awaiting_provider_decision
-        pending_conditions
-        recruited
-        declined
-      ],
-                                         'weekdays' => %w[
-                                           wed
-                                           thurs
-                                           mon
-                                         ] })
+      ActionController::Parameters.new(
+        {
+          'status' => %w[awaiting_provider_decision pending_conditions recruited declined],
+          'weekdays' => %w[wed thurs mon],
+        },
+      )
     end
 
     it 'returns a has of permitted parameters' do
@@ -87,12 +87,9 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
   describe '#filtered?' do
     let(:params) do
-      ActionController::Parameters.new({ 'status' => %w[
-        awaiting_provider_decision
-        pending_conditions
-        recruited
-        declined
-      ] })
+      ActionController::Parameters.new({
+        'status' => %w[awaiting_provider_decision pending_conditions recruited declined],
+      })
     end
 
     let(:empty_params) { ActionController::Parameters.new }

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -151,10 +151,22 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
   describe '#sort_options' do
     let(:params) { ActionController::Parameters.new }
 
-    subject(:page_state) { described_class.new(params: params, provider_user: provider_user) }
+    subject(:sort_options) { described_class.new(params: params, provider_user: provider_user).sort_options }
 
-    it 'returns an array of sort options' do
-      expect(page_state.sort_options).to eq(['Last changed', 'Days left to respond'])
+    it { is_expected.to eq(['Last changed', 'Days left to respond']) }
+  end
+
+  describe '#sort_by_attribute' do
+    let(:params) { ActionController::Parameters.new }
+
+    subject(:sort_by_attribute) { described_class.new(params: params, provider_user: provider_user).sort_by_attribute }
+
+    it { is_expected.to eq(:updated_at) }
+
+    context 'when params contain a valid sort option' do
+      let(:params) { ActionController::Parameters.new({ 'sort_by' => 'Days left to respond' }) }
+
+      it { is_expected.to eq(:reject_by_default_at) }
     end
   end
 end

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -122,7 +122,18 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       end
 
       it 'returns reject_by_default_date and updated_at descending' do
-        expect(page_state.sort_order).to eq({ reject_by_default_at: :desc, updated_at: :desc })
+        expect(page_state.sort_order).to eq(
+          <<-ORDER_BY.strip_heredoc,
+          (
+            CASE
+              WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > NOW())) THEN 1
+              ELSE 0
+            END
+          ) DESC,
+          reject_by_default_at ASC,
+          application_choices.updated_at DESC
+          ORDER_BY
+        )
       end
     end
 

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -104,4 +104,46 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       expect(page_state.filtered?).to be(false)
     end
   end
+
+  describe '#sort_order' do
+    let(:params) { ActionController::Parameters.new }
+
+    subject(:page_state) { described_class.new(params: params, provider_user: provider_user) }
+
+    context 'when no sort params are present' do
+      it 'defaults to updated_at descending' do
+        expect(page_state.sort_order).to eq({ updated_at: :desc })
+      end
+    end
+
+    context 'when sort param is RBD date' do
+      let(:params) do
+        ActionController::Parameters.new({ 'sort_by' => 'Days left to respond' })
+      end
+
+      it 'returns reject_by_default_date and updated_at descending' do
+        expect(page_state.sort_order).to eq({ reject_by_default_at: :desc, updated_at: :desc })
+      end
+    end
+
+    context 'when sort param is Last changed' do
+      let(:params) do
+        ActionController::Parameters.new({ 'sort_by' => 'Last changed' })
+      end
+
+      it 'returns updated_at descending' do
+        expect(page_state.sort_order).to eq({ updated_at: :desc })
+      end
+    end
+  end
+
+  describe '#sort_options' do
+    let(:params) { ActionController::Parameters.new }
+
+    subject(:page_state) { described_class.new(params: params, provider_user: provider_user) }
+
+    it 'returns an array of sort options' do
+      expect(page_state.sort_options).to eq(['Last changed', 'Days left to respond'])
+    end
+  end
 end

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -105,68 +105,25 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
   end
 
-  describe '#sort_order' do
-    let(:params) { ActionController::Parameters.new }
-
-    subject(:page_state) { described_class.new(params: params, provider_user: provider_user) }
-
-    context 'when no sort params are present' do
-      it 'defaults to updated_at descending' do
-        expect(page_state.sort_order).to eq({ updated_at: :desc })
-      end
-    end
-
-    context 'when sort param is RBD date' do
-      let(:params) do
-        ActionController::Parameters.new({ 'sort_by' => 'Days left to respond' })
-      end
-
-      it 'returns reject_by_default_date and updated_at descending' do
-        expect(page_state.sort_order).to eq(
-          <<-ORDER_BY.strip_heredoc,
-          (
-            CASE
-              WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > NOW())) THEN 1
-              ELSE 0
-            END
-          ) DESC,
-          reject_by_default_at ASC,
-          application_choices.updated_at DESC
-          ORDER_BY
-        )
-      end
-    end
-
-    context 'when sort param is Last changed' do
-      let(:params) do
-        ActionController::Parameters.new({ 'sort_by' => 'Last changed' })
-      end
-
-      it 'returns updated_at descending' do
-        expect(page_state.sort_order).to eq({ updated_at: :desc })
-      end
-    end
-  end
-
   describe '#sort_options' do
     let(:params) { ActionController::Parameters.new }
 
     subject(:sort_options) { described_class.new(params: params, provider_user: provider_user).sort_options }
 
-    it { is_expected.to eq(['Last changed', 'Days left to respond']) }
+    it { is_expected.to eq([['Last changed', 'last_changed'], ['Days left to respond', 'days_left_to_respond']]) }
   end
 
-  describe '#sort_by_attribute' do
+  describe '#sort_by' do
     let(:params) { ActionController::Parameters.new }
 
-    subject(:sort_by_attribute) { described_class.new(params: params, provider_user: provider_user).sort_by_attribute }
+    subject(:sort_by) { described_class.new(params: params, provider_user: provider_user).sort_by }
 
-    it { is_expected.to eq(:updated_at) }
+    it { is_expected.to eq('last_changed') }
 
-    context 'when params contain a valid sort option' do
-      let(:params) { ActionController::Parameters.new({ 'sort_by' => 'Days left to respond' }) }
+    context 'with a valid sort option' do
+      let(:params) { ActionController::Parameters.new({ 'sort_by' => 'days_left_to_respond' }) }
 
-      it { is_expected.to eq(:reject_by_default_at) }
+      it { is_expected.to eq('days_left_to_respond') }
     end
   end
 end

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SortApplicationChoices do
+  describe '#sort_order' do
+    let(:sort_by) { nil }
+
+    subject(:sort_order) { described_class.sort_order(sort_by) }
+
+    it { is_expected.to eq({ updated_at: :desc }) }
+
+    context 'when sort_by is RBD date' do
+      let(:sort_by) { 'days_left_to_respond' }
+
+      it 'returns reject_by_default_date and updated_at descending' do
+        expect(sort_order).to eq(
+          <<-ORDER_BY.strip_heredoc,
+          (
+            CASE
+              WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > NOW())) THEN 1
+              ELSE 0
+            END
+          ) DESC,
+          reject_by_default_at ASC,
+          application_choices.updated_at DESC
+          ORDER_BY
+        )
+      end
+    end
+
+    context 'when sort param is last changed' do
+      let(:sort_by) { 'last_changed' }
+
+      it { is_expected.to eq({ updated_at: :desc }) }
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Providers should be able to sort applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'by column headings' do
+  scenario 'by sort options' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_my_organisation_has_courses_with_applications
@@ -12,11 +12,14 @@ RSpec.feature 'Providers should be able to sort applications' do
 
     when_i_visit_the_provider_page
     then_i_should_see_the_applications_in_descending_date_order
-    and_the_sorted_by_explanation_line_should_be_present
+    and_the_sorted_by_option_should_be_present
+
+    when_i_sort_by_days_left_to_respond
+    then_i_should_see_the_applications_in_descending_reject_by_default_date_order
   end
 
-  def and_the_sorted_by_explanation_line_should_be_present
-    expect(page).to have_content('Sorted by: last changed')
+  def and_the_sorted_by_option_should_be_present
+    expect(page).to have_select(:sort_by, selected: 'Last changed')
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -34,17 +37,45 @@ RSpec.feature 'Providers should be able to sort applications' do
     course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
     course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
 
-    create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
-           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option_one,
+      status: 'withdrawn',
+      application_form: create(:application_form, first_name: 'Jim', last_name: 'James'),
+      reject_by_default_at: 1.day.from_now,
+      updated_at: 1.day.ago,
+    )
 
-    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
-           create(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option_two,
+      status: 'offer',
+      application_form: create(:application_form, first_name: 'Adam', last_name: 'Jones'),
+      reject_by_default_at: 5.days.from_now,
+      updated_at: 2.days.ago,
+    )
 
-    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
-           create(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option_two,
+      status: 'offer',
+      application_form: create(:application_form, first_name: 'Tom', last_name: 'Jones'),
+      reject_by_default_at: 10.days.from_now,
+      updated_at: 2.days.ago,
+    )
 
-    create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
-           create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+    create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option_three,
+      status: 'declined',
+      application_form: create(:application_form, first_name: 'Bill', last_name: 'Bones'),
+      reject_by_default_at: 1.day.ago,
+      updated_at: 3.days.ago,
+    )
   end
 
   def when_i_visit_the_provider_page
@@ -57,4 +88,33 @@ RSpec.feature 'Providers should be able to sort applications' do
     expect('Tom Jones').to appear_before('Bill Bones')
   end
   # rubocop:enable RSpec/ExpectActual
+
+  def when_i_sort_by_days_left_to_respond
+    select 'Days left to respond', from: :sort_by
+    click_on 'Sort'
+  end
+
+  def then_i_should_see_the_applications_in_descending_reject_by_default_date_order
+    cards = all('.app-application-card')
+
+    within(cards[0]) do
+      expect(page).to have_content('Tom Jones')
+      expect(page).to have_content('10 days to respond')
+    end
+
+    within(cards[1]) do
+      expect(page).to have_content('Adam Jones')
+      expect(page).to have_content('5 days to respond')
+    end
+
+    within(cards[2]) do
+      expect(page).to have_content('Jim James')
+      expect(page).to have_content('1 day to respond')
+    end
+
+    within(cards[3]) do
+      expect(page).to have_content('Bill Bones')
+      expect(page).to have_content(3.days.ago.to_s(:govuk_date))
+    end
+  end
 end

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -41,7 +41,6 @@ RSpec.feature 'Providers should be able to sort applications' do
       :application_choice,
       :awaiting_provider_decision,
       course_option: course_option_one,
-      status: 'withdrawn',
       application_form: create(:application_form, first_name: 'Jim', last_name: 'James'),
       reject_by_default_at: 1.day.from_now,
       updated_at: 1.day.ago,
@@ -51,7 +50,6 @@ RSpec.feature 'Providers should be able to sort applications' do
       :application_choice,
       :awaiting_provider_decision,
       course_option: course_option_two,
-      status: 'offer',
       application_form: create(:application_form, first_name: 'Adam', last_name: 'Jones'),
       reject_by_default_at: 5.days.from_now,
       updated_at: 2.days.ago,
@@ -61,7 +59,6 @@ RSpec.feature 'Providers should be able to sort applications' do
       :application_choice,
       :awaiting_provider_decision,
       course_option: course_option_two,
-      status: 'offer',
       application_form: create(:application_form, first_name: 'Tom', last_name: 'Jones'),
       reject_by_default_at: 10.days.from_now,
       updated_at: 2.days.ago,
@@ -71,7 +68,6 @@ RSpec.feature 'Providers should be able to sort applications' do
       :application_choice,
       :awaiting_provider_decision,
       course_option: course_option_three,
-      status: 'declined',
       application_form: create(:application_form, first_name: 'Bill', last_name: 'Bones'),
       reject_by_default_at: 1.day.ago,
       updated_at: 3.days.ago,
@@ -98,8 +94,8 @@ RSpec.feature 'Providers should be able to sort applications' do
     cards = all('.app-application-card')
 
     within(cards[0]) do
-      expect(page).to have_content('Tom Jones')
-      expect(page).to have_content('10 days to respond')
+      expect(page).to have_content('Jim James')
+      expect(page).to have_content('1 day to respond')
     end
 
     within(cards[1]) do
@@ -108,8 +104,8 @@ RSpec.feature 'Providers should be able to sort applications' do
     end
 
     within(cards[2]) do
-      expect(page).to have_content('Jim James')
-      expect(page).to have_content('1 day to respond')
+      expect(page).to have_content('Tom Jones')
+      expect(page).to have_content('10 days to respond')
     end
 
     within(cards[3]) do


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds sorting options to allow sorting applications by RBD date.

<!-- If there are UI changes, please include Before and After screenshots. -->

#### Sort options select

![image](https://user-images.githubusercontent.com/93511/86363845-51eb7a80-bc6f-11ea-8b74-1c691f301c9f.png)


#### Formatting of application dates...

![image](https://user-images.githubusercontent.com/93511/86363719-29fc1700-bc6f-11ea-87a7-756307539969.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/kUuiiWro/2373-implement-rbd-sorting
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
