### PR TITLE
Add provider account page

### DIFF
--- a/app/components/provider_interface/provider_account_component.html.erb
+++ b/app/components/provider_interface/provider_account_component.html.erb
@@ -1,0 +1,1 @@
+<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/provider_account_component.html.erb
+++ b/app/components/provider_interface/provider_account_component.html.erb
@@ -1,1 +1,3 @@
 <%= render SummaryListComponent.new(rows: rows) %>
+
+<%= govuk_link_to 'Change your details in DfE Sign-in', dsi_profile_url %>

--- a/app/components/provider_interface/provider_account_component.rb
+++ b/app/components/provider_interface/provider_account_component.rb
@@ -1,0 +1,33 @@
+module ProviderInterface
+  class ProviderAccountComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :current_provider_user
+
+    def initialize(current_provider_user:)
+      @current_provider_user = current_provider_user
+    end
+
+    def rows
+      [
+        { key: 'First name', value: current_provider_user.first_name },
+        { key: 'Last name', value: current_provider_user.last_name },
+        { key: 'Email address', value: current_provider_user.email_address },
+        organisations_row,
+      ]
+    end
+
+  private
+
+    def organisations_row
+      {
+        key: 'Organisations you have access to',
+        value: organisations,
+      }
+    end
+
+    def organisations
+      current_provider_user.providers.map(&:name)
+    end
+  end
+end

--- a/app/components/provider_interface/provider_account_component.rb
+++ b/app/components/provider_interface/provider_account_component.rb
@@ -17,6 +17,12 @@ module ProviderInterface
       ]
     end
 
+    def dsi_profile_url
+      return 'https://test-profile.signin.education.gov.uk' if HostingEnvironment.qa?
+
+      'https://profile.signin.education.gov.uk'
+    end
+
   private
 
     def organisations_row

--- a/app/controllers/provider_interface/account_controller.rb
+++ b/app/controllers/provider_interface/account_controller.rb
@@ -1,0 +1,5 @@
+module ProviderInterface
+  class AccountController < ProviderInterfaceController
+    def show; end
+  end
+end

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -49,6 +49,7 @@ class NavigationItems
         items << NavigationItem.new('Users', provider_interface_provider_users_path, false)
       end
 
+      items << NavigationItem.new('Account', provider_interface_account_path, false)
       items << NavigationItem.new('Sign out', provider_interface_sign_out_path, false)
     end
 

--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -1,0 +1,7 @@
+<%= content_for :title, "Account" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Account</h1>
+  </div>
+</div>

--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -3,5 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Account</h1>
+    <%= render ProviderInterface::ProviderAccountComponent.new(current_provider_user: current_provider_user) %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -496,6 +496,7 @@ Rails.application.routes.draw do
 
     post '/candidates/:candidate_id/impersonate' => 'candidates#impersonate', as: :impersonate_candidate
 
+    get '/account' => 'account#show'
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
 

--- a/spec/components/provider_interface/provider_account_component_spec.rb
+++ b/spec/components/provider_interface/provider_account_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderAccountComponent do
+  let(:provider1) { build(:provider) }
+  let(:provider2) { build(:provider) }
+  let(:current_provider_user) { build(:provider_user, providers: [provider1, provider2]) }
+
+  subject(:result) { render_inline(described_class.new(current_provider_user: current_provider_user)) }
+
+  it 'renders first name, last name and email address' do
+    expect(result.css('.govuk-summary-list__key').text).to include('First name')
+    expect(result.css('.govuk-summary-list__value').text).to include(current_provider_user.first_name)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Last name')
+    expect(result.css('.govuk-summary-list__value').text).to include(current_provider_user.last_name)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Email address')
+    expect(result.css('.govuk-summary-list__value').text).to include(current_provider_user.email_address)
+  end
+
+  it 'renders organisations user has access to' do
+    expect(result.css('.govuk-summary-list__key').text).to include('Organisations you have access to')
+    expect(result.css('.govuk-summary-list__value').text).to include(provider1.name, provider2.name)
+  end
+end

--- a/spec/components/provider_interface/provider_account_component_spec.rb
+++ b/spec/components/provider_interface/provider_account_component_spec.rb
@@ -22,4 +22,14 @@ RSpec.describe ProviderInterface::ProviderAccountComponent do
     expect(result.css('.govuk-summary-list__key').text).to include('Organisations you have access to')
     expect(result.css('.govuk-summary-list__value').text).to include(provider1.name, provider2.name)
   end
+
+  it 'renders correct link to the DfE Sign-in profile page in qa' do
+    ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'qa' do
+      expect(result.css('.govuk-link').attribute('href').value).to eq('https://test-profile.signin.education.gov.uk')
+    end
+  end
+
+  it 'renders correct link to the DfE Sign-in profile page in non-qa environments' do
+    expect(result.css('.govuk-link').attribute('href').value).to eq('https://profile.signin.education.gov.uk')
+  end
 end

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -30,10 +30,13 @@ module DfESignInHelpers
     support_user_signs_in_using_dfe_sign_in
   end
 
-  def provider_user_exists_in_apply_database
+  def provider_user_exists_in_apply_database(email_address: 'email@provider.ac.uk')
     provider_one = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Example Provider')
     provider_two = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Another Provider')
-    create(:provider_user, providers: [provider_one, provider_two], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    create(:provider_user,
+           providers: [provider_one, provider_two],
+           dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+           email_address: email_address)
   end
 
   def provider_user_exists_in_apply_database_with_multiple_providers

--- a/spec/system/provider_interface/provider_views_account_page.rb
+++ b/spec/system/provider_interface/provider_views_account_page.rb
@@ -10,6 +10,7 @@ RSpec.feature 'Managing provider user permissions' do
 
     when_i_click_on_the_account_link
     then_i_see_account_page_with_user_details
+    and_i_see_a_link_to_dfe_signin_to_change_details
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -35,5 +36,9 @@ RSpec.feature 'Managing provider user permissions' do
     expect(rows[1].text).to eq(@user.last_name)
     expect(rows[2].text).to eq(@user.email_address)
     expect(rows[3].text).to include(@example_provider.name, @another_provider.name)
+  end
+
+  def and_i_see_a_link_to_dfe_signin_to_change_details
+    expect(page).to have_link('Change your details in DfE Sign-in', href: 'https://profile.signin.education.gov.uk')
   end
 end

--- a/spec/system/provider_interface/provider_views_account_page.rb
+++ b/spec/system/provider_interface/provider_views_account_page.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider user permissions' do
+  include DfESignInHelpers
+
+  scenario 'Provider manages permissions for users' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_applications_for_two_providers
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_click_on_the_account_link
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @example_provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def when_i_click_on_the_account_link
+    within('#navigation') do
+      click_on('Account')
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_views_account_page.rb
+++ b/spec/system/provider_interface/provider_views_account_page.rb
@@ -9,6 +9,7 @@ RSpec.feature 'Managing provider user permissions' do
     and_i_sign_in_to_the_provider_interface
 
     when_i_click_on_the_account_link
+    then_i_see_account_page_with_user_details
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -26,5 +27,13 @@ RSpec.feature 'Managing provider user permissions' do
     within('#navigation') do
       click_on('Account')
     end
+  end
+
+  def then_i_see_account_page_with_user_details
+    rows = find('div .govuk-summary-list').all('dd')
+    expect(rows[0].text).to eq(@user.first_name)
+    expect(rows[1].text).to eq(@user.last_name)
+    expect(rows[2].text).to eq(@user.email_address)
+    expect(rows[3].text).to include(@example_provider.name, @another_provider.name)
   end
 end


### PR DESCRIPTION
## Context

As part of the work on notifications, we need to offer users Notification Settings where they can control whether or not they receive emails (Provider users can choose whether or not they receive emails from Apply). This settings page will live under the "Account" menu item in the header.
Since the header was redesigned we have lost the user's email address from the header. Users now have no way to see who they are logged in as.

## Changes proposed in this pull request

- Add account page
<kbd><img width="911" alt="Screenshot 2020-07-02 at 13 58 48" src="https://user-images.githubusercontent.com/38078064/86362365-1485ed80-bc6d-11ea-9f99-a6999c66e6cc.png"></kbd>

## Guidance to review

- When I am logged in as a provider user, I can see an "Account" link in the page header
- When I visit the "Account" page I can see my name, email address and organisations I'm associated with
- There is link to DfE Sign-in to change my name or email address (https://profile.signin.education.gov.uk/ in prod, staging, sandbox, https://test-profile.signin.education.gov.uk/ in QA)
Add an item

Q: Does it need a component?

## Link to Trello card

https://trello.com/c/fqHGxrsR/2374-add-account-page

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
