### PR TITLE
Create method for `assert_can_make_offer!`

### DIFF
--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -1,6 +1,4 @@
 class ProviderAuthorisation
-  PERMISSION_METHOD_REGEXP = /^can_(\w+)\?$/.freeze
-
   def initialize(actor:)
     @actor = actor
   end
@@ -55,13 +53,10 @@ class ProviderAuthorisation
     @actor.provider_permissions.exists?(provider: provider, manage_organisations: true)
   end
 
-  # automatically generates assert_can...! methods e.g. #assert_can_make_offer! for #can_make_offer?
-  instance_methods.select { |m| m.match PERMISSION_METHOD_REGEXP }.each do |method|
-    permission_name = method.to_s.scan(PERMISSION_METHOD_REGEXP).last.first
+  def assert_can_make_offer!(application_choice:, course_option_id:)
+    return if can_make_offer?(application_choice: application_choice, course_option_id: course_option_id)
 
-    define_method("assert_can_#{permission_name}!") do |**keyword_args|
-      raise(ProviderAuthorisation::NotAuthorisedError, method.to_s) unless send(method, **keyword_args)
-    end
+    raise NotAuthorisedError, 'You are not allowed to make this offer'
   end
 
   class NotAuthorisedError < StandardError; end

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'can_make_offer? failed'
+      expect(error_response['message']).to match 'You are not allowed to make this offer'
     end
 
     it 'returns an error when specifying a course that is not open on Apply' do

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe ProviderAuthorisation do
   include CourseOptionHelpers
 
-  describe 'assert! methods' do
-    it 'raise errors if the corresponding permission methods return false' do
+  describe '#assert_can_make_offer!' do
+    it 'raises an error if the actor cannot make offers' do
       auth_context = ProviderAuthorisation.new(actor: nil)
       allow(auth_context).to receive(:can_make_offer?).and_return(true)
       expect { auth_context.assert_can_make_offer!(application_choice: nil, course_option_id: nil) }.not_to raise_error


### PR DESCRIPTION
##  Context

This instead of the metaprogramming, implement the class directly. This saves a bit mental overhead and improves greppability.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/sCTl8idK

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
