### PR TITLE
Remove SupportUser clauses in ProviderAuthorisation

### DIFF
--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -6,8 +6,6 @@ class ProviderAuthorisation
   end
 
   def can_make_offer?(application_choice:, course_option_id:)
-    return true if @actor.is_a?(SupportUser)
-
     course_option = CourseOption.find(course_option_id)
     training_provider = course_option.provider
     ratifying_provider = course_option.course.accredited_provider
@@ -50,8 +48,6 @@ class ProviderAuthorisation
   end
 
   def can_manage_organisation?(provider:)
-    return true if @actor.is_a?(SupportUser)
-
     @actor.provider_permissions.exists?(provider: provider, manage_organisations: true)
   end
 


### PR DESCRIPTION
##  Context

The ProviderAuthorisation class is quite complicated already. As far as I can see, we aren't actually using the class in the Support UI, so removing these statements will be fine, and makes the class smaller.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/sCTl8idK

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
