### PR TITLE
Extract class for determining authorisation of offer

### DIFF
--- a/app/services/offer_authorisation.rb
+++ b/app/services/offer_authorisation.rb
@@ -1,0 +1,74 @@
+class OfferAuthorisation
+  def initialize(actor:)
+    @actor = actor
+  end
+
+  def can_make_offer?(application_choice:, course_option_id:)
+    return true if @actor.is_a?(SupportUser)
+
+    course_option = CourseOption.find(course_option_id)
+    training_provider = course_option.provider
+    ratifying_provider = course_option.course.accredited_provider
+
+    # enforce org-level 'make_decisions' restriction
+    return false if ratifying_provider &&
+      FeatureFlag.active?(:enforce_provider_to_provider_permissions) &&
+      FeatureFlag.active?('provider_make_decisions_restriction') &&
+      provider_relationship_permissions_for_actor(
+        training_provider: training_provider,
+        ratifying_provider: ratifying_provider,
+      ).none?(&:make_decisions)
+
+    # enforce user-level 'make_decisions' restriction
+    related_providers = [training_provider, ratifying_provider].compact
+    return false if
+      FeatureFlag.active?('provider_make_decisions_restriction') &&
+        !actor_has_permission_to_make_decisions?(providers: related_providers)
+
+    # check (indirect) relationship between course_option and @actor
+    if course_option_id != application_choice.course_option.id
+      application_choice_visible_to_user?(application_choice: application_choice) &&
+        course_option_belongs_to_user_providers?(course_option: course_option)
+    else
+      application_choice_visible_to_user?(application_choice: application_choice)
+    end
+  end
+
+private
+
+  def course_option_belongs_to_user_providers?(course_option:)
+    @actor.providers.include?(course_option.course.provider)
+  end
+
+  def application_choice_visible_to_user?(application_choice:)
+    GetApplicationChoicesForProviders.call(providers: @actor.providers).include?(application_choice)
+  end
+
+  def actor_has_permission_to_make_decisions?(providers:)
+    return true if @actor.is_a?(VendorApiUser)
+
+    providers.any? do |provider|
+      provider.users_with_make_decisions.include? @actor
+    end
+  end
+
+  def provider_relationship_permissions_for_actor(training_provider:, ratifying_provider:)
+    permissions = []
+
+    if @actor.providers.include?(training_provider)
+      permissions.push TrainingProviderPermissions.find_by(
+        training_provider: training_provider,
+        ratifying_provider: ratifying_provider,
+      )
+    end
+
+    if ratifying_provider && @actor.providers.include?(ratifying_provider)
+      permissions.push RatifyingProviderPermissions.find_by(
+        training_provider: training_provider,
+        ratifying_provider: ratifying_provider,
+      )
+    end
+
+    permissions.compact
+  end
+end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -6,34 +6,7 @@ class ProviderAuthorisation
   end
 
   def can_make_offer?(application_choice:, course_option_id:)
-    return true if @actor.is_a?(SupportUser)
-
-    course_option = CourseOption.find(course_option_id)
-    training_provider = course_option.provider
-    ratifying_provider = course_option.course.accredited_provider
-
-    # enforce org-level 'make_decisions' restriction
-    return false if ratifying_provider &&
-      FeatureFlag.active?(:enforce_provider_to_provider_permissions) &&
-      FeatureFlag.active?('provider_make_decisions_restriction') &&
-      provider_relationship_permissions_for_actor(
-        training_provider: training_provider,
-        ratifying_provider: ratifying_provider,
-      ).none?(&:make_decisions)
-
-    # enforce user-level 'make_decisions' restriction
-    related_providers = [training_provider, ratifying_provider].compact
-    return false if
-      FeatureFlag.active?('provider_make_decisions_restriction') &&
-        !actor_has_permission_to_make_decisions?(providers: related_providers)
-
-    # check (indirect) relationship between course_option and @actor
-    if course_option_id != application_choice.course_option.id
-      application_choice_visible_to_user?(application_choice: application_choice) &&
-        course_option_belongs_to_user_providers?(course_option: course_option)
-    else
-      application_choice_visible_to_user?(application_choice: application_choice)
-    end
+    OfferAuthorisation.new(actor: @actor).can_make_offer?(application_choice: application_choice, course_option_id: course_option_id)
   end
 
   def can_view_safeguarding_information?(course:)
@@ -68,34 +41,6 @@ class ProviderAuthorisation
 
 private
 
-  def application_choice_visible_to_user?(application_choice:)
-    GetApplicationChoicesForProviders.call(providers: @actor.providers).include?(application_choice)
-  end
-
-  def course_option_belongs_to_user_providers?(course_option:)
-    @actor.providers.include?(course_option.course.provider)
-  end
-
-  def provider_relationship_permissions_for_actor(training_provider:, ratifying_provider:)
-    permissions = []
-
-    if @actor.providers.include?(training_provider)
-      permissions.push TrainingProviderPermissions.find_by(
-        training_provider: training_provider,
-        ratifying_provider: ratifying_provider,
-      )
-    end
-
-    if ratifying_provider && @actor.providers.include?(ratifying_provider)
-      permissions.push RatifyingProviderPermissions.find_by(
-        training_provider: training_provider,
-        ratifying_provider: ratifying_provider,
-      )
-    end
-
-    permissions.compact
-  end
-
   def ratifying_provider_can_view_safeguarding_information?(course:)
     @actor.providers.include?(course.accredited_provider) &&
       RatifyingProviderPermissions
@@ -108,13 +53,5 @@ private
       TrainingProviderPermissions
         .view_safeguarding_information
         .exists?(ratifying_provider: course.accredited_provider, training_provider: course.provider)
-  end
-
-  def actor_has_permission_to_make_decisions?(providers:)
-    return true if @actor.is_a?(VendorApiUser)
-
-    providers.any? do |provider|
-      provider.users_with_make_decisions.include? @actor
-    end
   end
 end


### PR DESCRIPTION
##  Context

This extracts the offer logic into a separate class, so that it can be more easily refactored.

## Changes proposed in this pull request

Extract offer-related methods into an `OfferAuthorisation` class.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/sCTl8idK/2333-review-access-controls-in-preparation-for-launch

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
