### PR TITLE
SPIKE signing out of DSI when we sign out of support or Manage

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -28,13 +28,12 @@ class DfESignInController < ActionController::Base
 
   alias_method :bypass_callback, :callback
 
-  # This is called by a redirect from DfE Sign-in after visiting
-  # DfESignInUser#logout_url_for(interface: (provider|support)).
+  # This is called by a redirect from DfE Sign-in after visiting the signout
+  # link on DSI. We tell DSI to redirect here using the
+  # post_logout_redirect_uri parameter - see DfESignInUser#dsi_logout_url
   #
-  # The given interface will appear here in the :state param.
-  def callback_after_signout
-    DfESignInUser.end_session!(session)
-
+  # The interface we signed out from will appear here in the :state param.
+  def redirect_after_dsi_signout
     if params[:state] == 'support'
       redirect_to support_interface_path
     else

--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -28,6 +28,20 @@ class DfESignInController < ActionController::Base
 
   alias_method :bypass_callback, :callback
 
+  # This is called by a redirect from DfE Sign-in after visiting
+  # DfESignInUser#logout_url_for(interface: (provider|support)).
+  #
+  # The given interface will appear here in the :state param.
+  def callback_after_signout
+    DfESignInUser.end_session!(session)
+
+    if params[:state] == 'support'
+      redirect_to support_interface_path
+    else
+      redirect_to provider_interface_path
+    end
+  end
+
 private
 
   def send_support_sign_in_confirmation_email

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -10,9 +10,14 @@ module ProviderInterface
     end
 
     def destroy
-      dsi_logout_url = dfe_sign_in_user.provider_interface_dsi_logout_url
+      post_signout_redirect = if dfe_sign_in_user.needs_dsi_signout?
+                                dfe_sign_in_user.provider_interface_dsi_logout_url
+                              else
+                                provider_interface_path
+                              end
+
       DfESignInUser.end_session!(session)
-      redirect_to dsi_logout_url
+      redirect_to post_signout_redirect
     end
 
     def sign_in_by_email

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -10,7 +10,9 @@ module ProviderInterface
     end
 
     def destroy
-      redirect_to dfe_sign_in_user.provider_interface_logout_url
+      dsi_logout_url = dfe_sign_in_user.provider_interface_dsi_logout_url
+      DfESignInUser.end_session!(session)
+      redirect_to dsi_logout_url
     end
 
     def sign_in_by_email

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -10,9 +10,7 @@ module ProviderInterface
     end
 
     def destroy
-      DfESignInUser.end_session!(session)
-
-      redirect_to action: :new
+      redirect_to dfe_sign_in_user.provider_interface_logout_url
     end
 
     def sign_in_by_email

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -10,9 +10,7 @@ module SupportInterface
     end
 
     def destroy
-      DfESignInUser.end_session!(session)
-
-      redirect_to action: :new
+      redirect_to dfe_sign_in_user.support_interface_logout_url
     end
 
     def sign_in_by_email

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -10,7 +10,9 @@ module SupportInterface
     end
 
     def destroy
-      redirect_to dfe_sign_in_user.support_interface_logout_url
+      dsi_logout_url = dfe_sign_in_user.support_interface_dsi_logout_url
+      DfESignInUser.end_session!(session)
+      redirect_to dsi_logout_url
     end
 
     def sign_in_by_email

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -10,9 +10,14 @@ module SupportInterface
     end
 
     def destroy
-      dsi_logout_url = dfe_sign_in_user.support_interface_dsi_logout_url
+      post_signout_redirect = if dfe_sign_in_user.needs_dsi_signout?
+                                dfe_sign_in_user.support_interface_dsi_logout_url
+                              else
+                                provider_interface_path
+                              end
+
       DfESignInUser.end_session!(session)
-      redirect_to dsi_logout_url
+      redirect_to post_signout_redirect
     end
 
     def sign_in_by_email

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -21,6 +21,10 @@ class DfESignInUser
     dsi_logout_url(interface: :support)
   end
 
+  def needs_dsi_signout?
+    @id_token.present?
+  end
+
   def self.begin_session!(session, omniauth_payload)
     session['dfe_sign_in_user'] = {
       'email_address' => omniauth_payload['info']['email'],

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -2,11 +2,23 @@ class DfESignInUser
   attr_reader :email_address, :dfe_sign_in_uid
   attr_accessor :first_name, :last_name
 
-  def initialize(email_address:, dfe_sign_in_uid:, first_name:, last_name:)
+  # we need to be able to redirect back to our sign-out callback path
+  include Rails.application.routes.url_helpers
+
+  def initialize(email_address:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil)
     @email_address = email_address&.downcase
     @dfe_sign_in_uid = dfe_sign_in_uid
     @first_name = first_name
     @last_name = last_name
+    @id_token = id_token
+  end
+
+  def provider_interface_logout_url
+    logout_url_for(interface: :provider)
+  end
+
+  def support_interface_logout_url
+    logout_url_for(interface: :support)
   end
 
   def self.begin_session!(session, omniauth_payload)
@@ -16,6 +28,7 @@ class DfESignInUser
       'first_name' => omniauth_payload['info']['first_name'],
       'last_name' => omniauth_payload['info']['last_name'],
       'last_active_at' => Time.zone.now,
+      'id_token' => omniauth_payload['credentials']['id_token'],
     }
   end
 
@@ -36,11 +49,28 @@ class DfESignInUser
       dfe_sign_in_uid: dfe_sign_in_session['dfe_sign_in_uid'],
       first_name: dfe_sign_in_session['first_name'],
       last_name: dfe_sign_in_session['last_name'],
+      id_token: dfe_sign_in_session['id_token'],
     )
   end
 
   def self.end_session!(session)
     session.delete('post_dfe_sign_in_path')
     session.delete('dfe_sign_in_user')
+  end
+
+private
+
+  # a URL the user can visit to log them out of DSI and be redirected to our
+  # after-sign-out path where we'll delete their local session
+  def logout_url_for(interface:)
+    dsi_logout_url = URI.parse("#{ENV.fetch('DFE_SIGN_IN_ISSUER')}/session/end").tap do |url|
+      url.query = {
+        post_logout_redirect_uri: auth_dfe_sign_out_url,
+        id_token_hint: @id_token,
+        state: interface,
+      }.to_query
+    end
+
+    dsi_logout_url.to_s
   end
 end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -13,12 +13,12 @@ class DfESignInUser
     @id_token = id_token
   end
 
-  def provider_interface_logout_url
-    logout_url_for(interface: :provider)
+  def provider_interface_dsi_logout_url
+    dsi_logout_url(interface: :provider)
   end
 
-  def support_interface_logout_url
-    logout_url_for(interface: :support)
+  def support_interface_dsi_logout_url
+    dsi_logout_url(interface: :support)
   end
 
   def self.begin_session!(session, omniauth_payload)
@@ -62,8 +62,8 @@ private
 
   # a URL the user can visit to log them out of DSI and be redirected to our
   # after-sign-out path where we'll delete their local session
-  def logout_url_for(interface:)
-    dsi_logout_url = URI.parse("#{ENV.fetch('DFE_SIGN_IN_ISSUER')}/session/end").tap do |url|
+  def dsi_logout_url(interface:)
+    logout_url = URI.parse("#{ENV.fetch('DFE_SIGN_IN_ISSUER')}/session/end").tap do |url|
       url.query = {
         post_logout_redirect_uri: auth_dfe_sign_out_url,
         id_token_hint: @id_token,
@@ -71,6 +71,6 @@ private
       }.to_query
     end
 
-    dsi_logout_url.to_s
+    logout_url.to_s
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -527,6 +527,7 @@ Rails.application.routes.draw do
   end
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'
+  get '/auth/dfe/sign-out' => 'dfe_sign_in#callback_after_signout'
   post '/auth/developer/callback' => 'dfe_sign_in#bypass_callback'
 
   namespace :integrations, path: '/integrations' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -527,8 +527,8 @@ Rails.application.routes.draw do
   end
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'
-  get '/auth/dfe/sign-out' => 'dfe_sign_in#callback_after_signout'
   post '/auth/developer/callback' => 'dfe_sign_in#bypass_callback'
+  get '/auth/dfe/sign-out' => 'dfe_sign_in#redirect_after_dsi_signout'
 
   namespace :integrations, path: '/integrations' do
     post '/notify/callback' => 'notify#callback'


### PR DESCRIPTION
Proof of concept — not for merging!

## Context

When a user signs out of Support or Manage, they stay signed in to DfE Sign-in. This means it's possible to log back in as them by clicking on the "Sign in with DfE Sign-in" button — DSI recognises them and forwards them back to us for a new session.

We would like to sign them out of DSI at the same time. Thankfully, TVS are doing this already so we can look at their work to see what we need to do.

The process is outlined in the (draft!) OpenID Connect spec here: https://openid.net/specs/openid-connect-session-1_0.html#RPLogout.

The basic idea is that when we sign a user out, we send them to DfE Sign-in first, then DSI sends the user back to us for a final logout.

I've attempted this in the following way:

**Add two methods to DfESignInUser: `logout_url_for_support_interface` and `logout_url_for_provider_interface`**. These return the special sign-me-out path on DfE Sign-in, which will sign the user and and then redirect them to us. We have separate methods because this can happen in two contexts, and we need to know which context we started in so we can send the user to the appropriate 'just signed out' page. We persist this information using the `state` param on the DSI URL.

**When we hit the `destroy` actions in `SupportInterface::SessionsController` or `ProviderInterface::SessionsController` we redirect immediately to DSI's sign-me-out path**. I preferred to leave these actions in the controllers rather than write the DSI urls directly into the template as we want to continue to support bypass mode and authentication by email. **These modes are both broken by this PR** — fixing the `destroy` actions should make them work again. Maybe we could still "optimistically" destroy the session in those actions.

**After DSI has signed us out, it sends the user to `DfESignInController#callback_after_signout`**. This destroys the session on our side (but see above) and redirects to the right page using the `state` param we passed earlier.

ALSO

We store `id_token` in the DSI user details in the session. This is "recommended" in the spec and TVS do it, but I'm not sure what happens if it's missing. We could well have user sessions in an `id_token`-less state when we first ship this.


