### PR TITLE
Consider "offer withdrawn" as an unsuccesful state + other fixes

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -13,6 +13,7 @@ module ProviderInterface
       'awaiting_provider_decision' => 'Application submitted',
       'withdrawn' => 'Application withdrawn',
       'rejected' => 'Application rejected',
+      'offer_withdrawn' => 'Offer withdrawn',
       'offer' => 'Offer made',
       'pending_conditions' => 'Offer accepted',
       'declined' => 'Offer declined',

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -20,7 +20,6 @@ class ApplicationForm < ApplicationRecord
 
   MINIMUM_COMPLETE_REFERENCES = 2
   MAXIMUM_REFERENCES = 10
-  DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
   EQUALITY_AND_DIVERSITY_MINIMAL_ATTR = %w[sex disabilities ethnic_group].freeze
 
   def equality_and_diversity_answers_provided?
@@ -100,7 +99,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def all_provider_decisions_made?
-    application_choices.any? && (application_choices.map(&:status) & DECISION_PENDING_STATUSES).empty?
+    application_choices.any? && (application_choices.map(&:status) & ApplicationStateChange::DECISION_PENDING_STATUSES).empty?
   end
 
   def all_choices_withdrawn?

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -17,7 +17,7 @@ class PerformanceStatistics
             WHEN 'enrolled' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['9', 'enrolled']
             WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['8', 'recruited']
             WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'pending_conditions']
-            WHEN ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_AGG(DISTINCT ch.status), 'cancelled'), 'withdrawn'), 'rejected'), 'declined'), 'conditions_not_met') = '{}' THEN ARRAY['5', 'ended_without_success']
+            WHEN ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_AGG(DISTINCT ch.status), 'cancelled'), 'withdrawn'), 'offer_withdrawn'), 'rejected'), 'declined'), 'conditions_not_met') = '{}' THEN ARRAY['5', 'ended_without_success']
             ELSE ARRAY['10', 'unknown_state']
           END status
       FROM

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -3,7 +3,8 @@ class ApplicationStateChange
 
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete cancelled].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited enrolled].freeze
-  OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer]).freeze
+  OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
+  UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn].freeze
 
   attr_reader :application_choice
 
@@ -75,8 +76,6 @@ class ApplicationStateChange
 
     state :cancelled
   end
-
-  UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met].freeze
 
   def load_workflow_state
     application_choice.status

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -5,6 +5,7 @@ class ApplicationStateChange
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited enrolled].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn].freeze
+  DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
 
   attr_reader :application_choice
 

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -82,7 +82,7 @@ class ProcessState
       :recruited
     elsif any_state_is?('pending_conditions')
       :pending_conditions
-    elsif (states.uniq - %w[withdrawn cancelled rejected declined conditions_not_met]).empty?
+    elsif (states.uniq - ApplicationStateChange::UNSUCCESSFUL_END_STATES).empty?
       :ended_without_success
     else
       :unknown_state

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -91,4 +91,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include '11 Feb 2020'
     end
   end
+
+  it 'has a title for all state transitions' do
+    expect(ApplicationStateChange.states_visible_to_provider).to match_array(ProviderInterface::ApplicationTimelineComponent::TITLES.keys.map(&:to_sym))
+  end
 end


### PR DESCRIPTION
## Context

This is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/2406 to fix some things that I missed.

## Changes proposed in this pull request

- Consider this state as "unsuccesful" end state, just like "rejected" was
- Fix the timeline for this new state + add a test
- Do some driveby refactoring to group constants

## Guidance to review

_Per commit_

Anything else I missed?

## Link to Trello card

https://trello.com/c/wNkQdYUH/1783-make-offerwithdrawn-into-a-real-status

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
