### PR TITLE
Add text warning to withdraw offer confirmation page

### DIFF
--- a/app/components/warning_text_component.html.erb
+++ b/app/components/warning_text_component.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    <%= text %>
+  </strong>
+</div>

--- a/app/components/warning_text_component.rb
+++ b/app/components/warning_text_component.rb
@@ -1,0 +1,9 @@
+class WarningTextComponent < ViewComponent::Base
+  def initialize(text:)
+    @text = text
+  end
+
+private
+
+  attr_reader :text
+end

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -20,13 +20,7 @@
 
       <%= f.hidden_field :rejection_reason %>
 
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          We’ll tell the candidate you rejected their application, and share your reasons.
-        </strong>
-      </div>
+      <%= render WarningTextComponent.new(text: 'We’ll tell the candidate you rejected their application, and share your reasons.') %>
 
       <%= f.govuk_submit 'Reject application' %>
 

--- a/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
@@ -21,6 +21,8 @@
         { key: 'Reasons for withdrawal', value: @withdraw_offer.offer_withdrawal_reason },
       ]) %>
 
+      <%= render WarningTextComponent.new(text: 'We’ll tell the candidate you withdrew your offer, and share your reasons.') %>
+
       <%= f.hidden_field :offer_withdrawal_reason %>
       <%= f.govuk_submit 'Withdraw offer', warning: true %>
 

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -11,16 +11,9 @@
     <p class="govuk-body">This will toggle every course on this provider to be available through Apply.</p>
 
     <% unless @provider.all_associated_accredited_providers_onboarded? %>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          Some of this provider’s courses are ratified by an accredited body
-          which does not yet participate in the beta. The accredited body might
-          expect to manage applications to those courses. Check before clicking
-          this button.
-        </strong>
-      </div>
+      <%= render WarningTextComponent.new(
+        text: 'Some of this provider’s courses are ratified by an accredited body which does not yet participate in the beta. The accredited body might expect to manage applications to those courses. Check before clicking this button.')
+      %>
     <% end %>
     <%= f.govuk_submit "Open #{pluralize(@provider.courses.size, 'course')}" %>
   <% end %>

--- a/spec/components/warning_text_component_spec.rb
+++ b/spec/components/warning_text_component_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe WarningTextComponent do
+  let(:text) { 'We’ll tell the candidate' }
+
+  it 'renders the warning text' do
+    result = render_inline(described_class.new(text: text))
+
+    expect(result.css('.govuk-warning-text__text').text).to include('We’ll tell the candidate')
+  end
+
+  it 'renders the warning icon' do
+    result = render_inline(described_class.new(text: text))
+
+    expect(result.css('.govuk-warning-text__icon')).to be_present
+  end
+end


### PR DESCRIPTION
## Context

Providers currently see a note on the textarea they type the reasons for offer
withdrawal in. We need to remind providers on the confirmation page that we'll
notify the candidate when providers confirm withdrawal of an offer

## Changes proposed in this pull request

- add WarningTextComponent since it's used 3 times
- Add warning message to Withdraw your offer confirmation page

| Before  | After |
| ------------- | ------------- |
|<img width="604" alt="Screenshot 2020-07-03 at 12 06 54" src="https://user-images.githubusercontent.com/38078064/86466874-59bd2480-bd2c-11ea-8134-4625aa124114.png">|<img width="616" alt="Screenshot 2020-07-03 at 12 06 37" src="https://user-images.githubusercontent.com/38078064/86466860-545fda00-bd2c-11ea-96b3-c6df4fdb5625.png"> |

## Guidance to review

- find application with "offered" status
- click "Withdraw offer" (_provider/applications/:id/offer/new_withdraw_)
- write a reason, click Continue

## Link to Trello card

https://trello.com/c/0fhktCbx/2029-remind-providers-that-well-notify-the-candidate-when-providers-confirm-withdrawal-of-an-offer

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
