### PR TITLE
fix deploy template path in release pipeline.

### DIFF
--- a/azure/pipelines/release.yml
+++ b/azure/pipelines/release.yml
@@ -48,7 +48,7 @@ stages:
   variables:
   - group: APPLY - ENV - Staging
   jobs:
-  - template: templates/azure-pipelines-deploy-template.yml
+  - template: templates/deploy.yml
     parameters:
       debug: $(debug)
       subscriptionPrefix: 's106'
@@ -107,7 +107,7 @@ stages:
   variables:
   - group: APPLY - ENV - Sandbox
   jobs:
-  - template: templates/azure-pipelines-deploy-template.yml
+  - template: templates/deploy.yml
     parameters:
       debug: $(debug)
       subscriptionPrefix: 's106'
@@ -165,7 +165,7 @@ stages:
   variables:
   - group: APPLY - ENV - Production
   jobs:
-  - template: templates/azure-pipelines-deploy-template.yml
+  - template: templates/deploy.yml
     parameters:
       debug: $(debug)
       subscriptionPrefix: 's106'


### PR DESCRIPTION
azure-pipelines-deploy-template.yml was renamed and moved to
azure/pipelines/templates/deploy.yml

## Context

#2442 

## Changes proposed in this pull request


## Guidance to review


## Link to Trello card


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
