### PR TITLE
trigger apply CI from if gems-node-modules is built from master

### DIFF
--- a/azure/pipelines/build-gems-node-modules.yml
+++ b/azure/pipelines/build-gems-node-modules.yml
@@ -118,7 +118,7 @@ steps:
     $requestBody
     $azurePipelinesBuildApi = "$($env:COLLECTION_URL)$env:PROJECT_ID/_apis/build/builds?api-version=5.1"
     Invoke-RestMethod -Uri $azurePipelinesBuildApi -Headers $azureDevOpsAuthorizationHeader -Method Post -Body $requestBody -ContentType "application/json" -ErrorAction SilentlyContinue
-  condition: and(succeeded(), eq(variables['IMAGE_EXISTS_IN_HUB'], false))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['IMAGE_EXISTS_IN_HUB'], false)))
   displayName: Trigger apply-for-teacher-training build
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure/pipelines/build-gems-node-modules.yml
+++ b/azure/pipelines/build-gems-node-modules.yml
@@ -7,7 +7,7 @@ trigger:
       - Gemfile.lock
       - package.json
       - yarn.lock
-      - build-gems-node-modules.yml
+      - azure/pipelines/build-gems-node-modules.yml
 
 pr:
   paths:
@@ -17,7 +17,7 @@ pr:
       - Gemfile.lock
       - package.json
       - yarn.lock
-      - build-gems-node-modules.yml
+      - azure/pipelines/build-gems-node-modules.yml
 
 pool:
   vmImage: 'Ubuntu-16.04'


### PR DESCRIPTION
## Context

trigger the apply CI build if gems-node-modules build is triggered from
master, even if the gems-node-modules image was not rebuilt.
Because the base image could have been built as part of a PR build, so
we still need to trigger a build in master after the PR merge.
The apply CI build would not been automatically triggered because the changes were only to Gem/Yarn files.

## Changes proposed in this pull request

trigger apply CI from gems-node-modules pipeline if source branch is
master i.e a run after a PR merge to Gemfile/Yarn file changes.

## Guidance to review


## Link to Trello card


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
