### PR TITLE
Add International candidates nationalities page

### DIFF
--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -4,7 +4,11 @@ module CandidateInterface
       before_action :redirect_to_dashboard_if_submitted
 
       def new
-        @nationalities_form = NationalitiesForm.build_from_application(current_application)
+        if Featureflag.active?('international_personal_details')
+          @nationalities_form =  NationalitiesForm.new
+        else
+          @nationalities_form = NationalitiesForm.build_from_application(current_application)
+        end 
       end
 
       def create

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -4,15 +4,16 @@ module CandidateInterface
       before_action :redirect_to_dashboard_if_submitted
 
       def new
-        if Featureflag.active?('international_personal_details')
-          @nationalities_form =  NationalitiesForm.new
-        else
-          @nationalities_form = NationalitiesForm.build_from_application(current_application)
-        end 
+        @nationalities_form = if FeatureFlag.active?('international_personal_details')
+                                NationalitiesForm.new
+                              else
+                                NationalitiesForm.build_from_application(current_application)
+                              end
       end
 
       def create
         @application_form = current_application
+
         @nationalities_form = NationalitiesForm.new(nationalities_params)
 
         if @nationalities_form.save(current_application)
@@ -47,7 +48,7 @@ module CandidateInterface
 
       def nationalities_params
         params.require(:candidate_interface_nationalities_form).permit(
-          :first_nationality, :second_nationality
+          :first_nationality, :second_nationality, :other_nationality, :multiple_nationalities
         )
       end
     end

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
 
       def edit
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
+        set_first_nationality_to_other_if_non_uk_or_irish_nationality if FeatureFlag.active?('international_personal_details')
       end
 
       def update
@@ -40,6 +41,7 @@ module CandidateInterface
           redirect_to candidate_interface_personal_details_show_path
         else
           track_validation_error(@nationalities_form)
+          set_first_nationality_to_other_if_non_uk_or_irish_nationality if FeatureFlag.active?('international_personal_details')
           render :edit
         end
       end
@@ -50,6 +52,12 @@ module CandidateInterface
         params.require(:candidate_interface_nationalities_form).permit(
           :first_nationality, :second_nationality, :other_nationality, :multiple_nationalities
         )
+      end
+
+      def set_first_nationality_to_other_if_non_uk_or_irish_nationality
+        @nationalities_form.first_nationality = 'Other' if @nationalities_form.first_nationality != 'British' &&
+          @nationalities_form.first_nationality != 'Irish' &&
+          @nationalities_form.first_nationality != 'Multiple'
       end
     end
   end

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -3,12 +3,21 @@ module CandidateInterface
     include ActiveModel::Model
     include ValidationUtils
 
-    attr_accessor :first_nationality, :second_nationality
+    attr_accessor :first_nationality, :second_nationality, :other_nationality, :multiple_nationalities
 
     validates :first_nationality, presence: true
 
+    validates :other_nationality, presence: true, if: :first_nationality_is_other?
+
+    validates :multiple_nationalities, presence: true, if: :multiple_nationalities_selected?
+
     validates :first_nationality, :second_nationality,
-              inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true }
+              inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true },
+              unless: :international_flag_is_on?
+
+    validates :other_nationality,
+              inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true },
+              if: :international_flag_is_on?
 
     def self.build_from_application(application_form)
       new(
@@ -20,10 +29,42 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      application_form.update(
-        first_nationality: first_nationality,
-        second_nationality: second_nationality,
-      )
+      if FeatureFlag.active?('international_personal_details')
+        application_form.update(
+          first_nationality: nationality,
+          multiple_nationalities_details: multiple_nationalities,
+        )
+      else
+        application_form.update(
+          first_nationality: first_nationality,
+          second_nationality: second_nationality,
+        )
+      end
+    end
+
+  private
+
+    def first_nationality_is_other?
+      first_nationality == 'other'
+    end
+
+    def multiple_nationalities_selected?
+      first_nationality == 'multiple'
+    end
+
+    def nationality
+      case first_nationality
+      when 'other'
+        other_nationality
+      when 'multiple'
+        first_nationality
+      else
+        first_nationality.capitalize
+      end
+    end
+
+    def international_flag_is_on?
+      FeatureFlag.active?('international_personal_details')
     end
   end
 end

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -25,6 +25,8 @@ module CandidateInterface
       new(
         first_nationality: application_form.first_nationality,
         second_nationality: application_form.second_nationality,
+        multiple_nationalities: application_form.multiple_nationalities_details,
+        other_nationality: application_form.return_other_nationality,
       )
     end
 
@@ -34,7 +36,7 @@ module CandidateInterface
       if FeatureFlag.active?('international_personal_details')
         application_form.update(
           first_nationality: nationality,
-          multiple_nationalities_details: multiple_nationalities,
+          multiple_nationalities_details: populate_multiple_nationalties,
         )
       else
         application_form.update(
@@ -56,18 +58,15 @@ module CandidateInterface
     end
 
     def nationality
-      case first_nationality
-      when 'Other'
-        other_nationality
-      when 'Multiple'
-        first_nationality
-      else
-        first_nationality.capitalize
-      end
+      first_nationality_is_other? ? other_nationality : first_nationality
     end
 
     def populate_multiple_nationalties
-      "#{first_nationality} and #{second_nationality}" if second_nationality.present?
+      if FeatureFlag.active?('international_personal_details') && multiple_nationalities_selected?
+        multiple_nationalities
+      elsif second_nationality.present?
+        "#{first_nationality} and #{second_nationality}"
+      end
     end
 
     def international_flag_is_on?

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -40,6 +40,7 @@ module CandidateInterface
         application_form.update(
           first_nationality: first_nationality,
           second_nationality: second_nationality,
+          multiple_nationalities_details: populate_multiple_nationalties,
         )
       end
     end
@@ -63,6 +64,10 @@ module CandidateInterface
       else
         first_nationality.capitalize
       end
+    end
+
+    def populate_multiple_nationalties
+      "#{first_nationality} and #{second_nationality}" if second_nationality.present?
     end
 
     def international_flag_is_on?

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -48,18 +48,18 @@ module CandidateInterface
   private
 
     def first_nationality_is_other?
-      first_nationality == 'other'
+      first_nationality == 'Other'
     end
 
     def multiple_nationalities_selected?
-      first_nationality == 'multiple'
+      first_nationality == 'Multiple'
     end
 
     def nationality
       case first_nationality
-      when 'other'
+      when 'Other'
         other_nationality
-      when 'multiple'
+      when 'Multiple'
         first_nationality
       else
         first_nationality.capitalize

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -11,6 +11,8 @@ module CandidateInterface
 
     validates :multiple_nationalities, presence: true, if: :multiple_nationalities_selected?
 
+    validates :multiple_nationalities, length: { maximum: 200 }
+
     validates :first_nationality, :second_nationality,
               inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true },
               unless: :international_flag_is_on?

--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -7,6 +7,8 @@ const initNationalityAutocomplete = () => {
       "#candidate-interface-nationalities-form-first-nationality-field-error",
       "#candidate-interface-nationalities-form-second-nationality-field",
       "#candidate-interface-nationalities-form-second-nationality-field-error",
+      "#candidate-interface-nationalities-form-other-nationality-field",
+      "#candidate-interface-nationalities-form-other-nationality-field-error",
       "#candidate-interface-contact-details-form-country-field",
       "#candidate-interface-contact-details-form-country-field-error",
     ].forEach(id => {

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -188,6 +188,10 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
+  def return_other_nationality
+    first_nationality if first_nationality != 'British' && first_nationality != 'Irish' && first_nationality != 'Multiple'
+  end
+
 private
 
   def enough_references_have_been_provided?

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -83,12 +83,18 @@ module CandidateInterface
     end
 
     def formatted_nationalities
-      [
-        @nationalities_form.first_nationality,
-        @nationalities_form.second_nationality,
-      ]
+      if @nationalities_form.multiple_nationalities.present?
+        @nationalities_form.multiple_nationalities
+      elsif FeatureFlag.active?('international_personal_details')
+        @nationalities_form.first_nationality
+      else
+        [
+          @nationalities_form.first_nationality,
+          @nationalities_form.second_nationality,
+        ]
         .reject(&:blank?)
         .to_sentence
+      end
     end
   end
 end

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -1,20 +1,36 @@
 <%= f.govuk_error_summary %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.nationalities') %>
-</h1>
+<% if FeatureFlag.active?('international_personal_details') %>
 
-<%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+  <%= f.govuk_radio_buttons_fieldset :nationality, legend: { size: 'xl', text: t('page_titles.nationalities'), tag: 'h2' } do %>
+    <%= f.govuk_radio_button :first_nationality, :british, label: { text: 'British' } %>
+    <%= f.govuk_radio_button :first_nationality, :irish, label: { text: 'Irish' } %>
+    <%= f.govuk_radio_button :first_nationality, :other, label: { text: 'Other' } do %>
+      <%= f.govuk_collection_select :other_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+    <% end %>
+    <%= f.govuk_radio_button :first_nationality, :multiple, label: { text: 'I have multiple nationalities' } do %>
+      <%= f.govuk_text_area :multiple_nationalities, label: { text: 'Give details' } %>
+    <% end %>
+  <% end %>
 
-<details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>>
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      Add another nationality
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <%= f.govuk_collection_select :second_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.second_nationality.label') } %>
-  </div>
-</details>
+<% else %>
+
+  <h1 class="govuk-heading-xl">
+    <%= t('page_titles.nationalities') %>
+  </h1>
+
+  <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+
+  <details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>>
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Add another nationality
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <%= f.govuk_collection_select :second_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.second_nationality.label') } %>
+    </div>
+  </details>
+<% end %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -4,12 +4,12 @@
 
   <%= f.govuk_radio_buttons_fieldset :nationality, legend: { size: 'xl', text: t('page_titles.nationalities'), tag: 'h2' } do %>
     <%= f.govuk_radio_button :first_nationality, :British, label: { text: 'British' } %>
-    <%= f.govuk_radio_button :first_nationality, 'Irish', label: { text: 'Irish' } %>
+    <%= f.govuk_radio_button :first_nationality, :Irish, label: { text: 'Irish' } %>
     <%= f.govuk_radio_button :first_nationality, 'Other', label: { text: 'Other' } do %>
-      <%= f.govuk_collection_select :other_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+      <%= f.govuk_collection_select :other_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm'}%>
     <% end %>
     <%= f.govuk_radio_button :first_nationality, 'Multiple', label: { text: 'I have multiple nationalities' } do %>
-      <%= f.govuk_text_area :multiple_nationalities, label: { text: 'Give details' } %>
+      <%= f.govuk_text_area :multiple_nationalities, label: { text: 'Give details' }, value: @nationalities_form.multiple_nationalities %>
     <% end %>
   <% end %>
 
@@ -21,7 +21,7 @@
 
   <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
 
-  <details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>>
+    <details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
         Add another nationality

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -3,12 +3,12 @@
 <% if FeatureFlag.active?('international_personal_details') %>
 
   <%= f.govuk_radio_buttons_fieldset :nationality, legend: { size: 'xl', text: t('page_titles.nationalities'), tag: 'h2' } do %>
-    <%= f.govuk_radio_button :first_nationality, :british, label: { text: 'British' } %>
-    <%= f.govuk_radio_button :first_nationality, :irish, label: { text: 'Irish' } %>
-    <%= f.govuk_radio_button :first_nationality, :other, label: { text: 'Other' } do %>
+    <%= f.govuk_radio_button :first_nationality, :British, label: { text: 'British' } %>
+    <%= f.govuk_radio_button :first_nationality, 'Irish', label: { text: 'Irish' } %>
+    <%= f.govuk_radio_button :first_nationality, 'Other', label: { text: 'Other' } do %>
       <%= f.govuk_collection_select :other_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
     <% end %>
-    <%= f.govuk_radio_button :first_nationality, :multiple, label: { text: 'I have multiple nationalities' } do %>
+    <%= f.govuk_radio_button :first_nationality, 'Multiple', label: { text: 'I have multiple nationalities' } do %>
       <%= f.govuk_text_area :multiple_nationalities, label: { text: 'Give details' } %>
     <% end %>
   <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -429,6 +429,9 @@ en:
               inclusion: Select your nationality from the list
             second_nationality:
               inclusion: Select your second nationality from the list
+            other_nationality:
+              blank: Select your nationality from the list
+              inclusion: Select your nationality from the list
         candidate_interface/languages_form:
           attributes:
             english_main_language:

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -82,13 +82,14 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
       end
     end
 
-    context 'with the international_personal_details flag off' do
-      it 'updates the provided ApplicationForm if valid' do
+    context 'with the international_personal_details flag off and a candidate has multiple nationalities' do
+      it 'updates the provided ApplicationForm if valid and populates multiple_nationalities_details' do
         application_form = FactoryBot.create(:application_form)
         nationalities = CandidateInterface::NationalitiesForm.new(form_data)
 
         expect(nationalities.save(application_form)).to eq(true)
         expect(application_form).to have_attributes(data)
+        expect(application_form.multiple_nationalities_details).to eq "#{data[:first_nationality]} and #{data[:second_nationality]}"
       end
     end
   end

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
     end
 
     context 'when first nationality is british and the international_personal_details flag on' do
-      let(:form_data) { { first_nationality: 'british' } }
+      let(:form_data) { { first_nationality: 'British' } }
 
       it 'updates the provided ApplicationForm if valid' do
         FeatureFlag.activate('international_personal_details')
@@ -66,7 +66,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
     context 'when first nationality is multiple and the international_personal_details flag on' do
       let(:form_data) do
         {
-          first_nationality: 'multiple',
+          first_nationality: 'Multiple',
           multiple_nationalities: 'German and Austrian',
         }
       end

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
     context 'when first nationality is other and the international_personal_details flag on' do
       let(:form_data) do
         {
-          first_nationality: 'other',
+          first_nationality: 'Other',
           other_nationality: 'German',
         }
       end
@@ -77,7 +77,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
         nationalities = CandidateInterface::NationalitiesForm.new(form_data)
 
         expect(nationalities.save(application_form)).to eq(true)
-        expect(application_form.first_nationality).to eq 'multiple'
+        expect(application_form.first_nationality).to eq 'Multiple'
         expect(application_form.multiple_nationalities_details).to eq 'German and Austrian'
       end
     end
@@ -134,7 +134,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
       it 'validates nationalities against the NATIONALITY_DEMONYMS list' do
         details_with_invalid_nationality = CandidateInterface::NationalitiesForm.new(
-          first_nationality: 'other',
+          first_nationality: 'Other',
           other_nationality: 'Tralfamadorian',
         )
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -268,4 +268,34 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#return_other_nationality' do
+    context 'when the first_nationality is British' do
+      it 'returns nil' do
+        application_form = build_stubbed(:application_form, first_nationality: 'British')
+        expect(application_form.return_other_nationality).to eq nil
+      end
+    end
+
+    context 'when the first_nationality is Irish' do
+      it 'returns nil' do
+        application_form = build_stubbed(:application_form, first_nationality: 'Irish')
+        expect(application_form.return_other_nationality).to eq nil
+      end
+    end
+
+    context 'when the first_nationality is Multiple' do
+      it 'returns nil' do
+        application_form = build_stubbed(:application_form, first_nationality: 'Multiple')
+        expect(application_form.return_other_nationality).to eq nil
+      end
+    end
+
+    context 'when the first_nationality any other value' do
+      it 'returns the value' do
+        application_form = build_stubbed(:application_form, first_nationality: 'German')
+        expect(application_form.return_other_nationality).to eq 'German'
+      end
+    end
+  end
 end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -73,6 +73,19 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
         )
       end
+
+      it 'includes a hash using the multiple_nationalities details if present' do
+        nationalities_form = build(
+          :nationalities_form,
+          first_nationality: 'multiple',
+          second_nationality: nil,
+          multiple_nationalities: 'British and Spanish',
+        )
+
+        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+          row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
+        )
+      end
     end
 
     context 'when presenting English as the main language' do

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -1,0 +1,159 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their personal details' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their personal details' do
+    given_i_am_signed_in
+    and_the_international_candidates_flag_is_active
+    and_i_visit_the_site
+
+    when_i_click_on_personal_details
+    and_i_fill_in_some_details_but_omit_some_required_details
+    and_i_submit_the_form
+    then_i_should_see_validation_errors
+    and_i_should_see_the_completed_fields
+
+    when_i_fill_in_the_rest_of_my_details
+    and_i_submit_the_form
+    then_i_see_the_nationalites_page
+
+    when_i_choose_that_i_am_british
+    and_i_submit_the_form
+    then_i_see_the_languages_page
+
+    when_i_choose_that_english_is_my_primary_language
+    and_i_submit_the_form
+    then_i_see_the_personal_details_review_page
+    and_i_can_check_my_answers
+
+    when_i_click_change_on_my_nationality
+    and_i_choose_that_i_am_irish
+    and_i_submit_the_form
+    then_i_see_the_personal_details_review_page
+    and_i_see_my_updated_nationality
+
+    when_i_click_change_on_my_nationality
+    and_i_choose_other
+    and_i_select_i_am_german
+    and_i_submit_the_form
+    then_i_see_the_personal_details_review_page
+    and_i_see_i_am_german
+
+    when_i_mark_the_section_as_completed
+    and_i_submit_my_details
+    then_i_should_see_my_application_form
+    and_that_the_section_is_completed
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_international_candidates_flag_is_active
+    FeatureFlag.activate('international_personal_details')
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_personal_details
+    click_link t('page_titles.personal_details')
+  end
+
+  def then_i_see_the_languages_page
+    expect(page).to have_current_path candidate_interface_languages_path
+  end
+
+  def and_i_fill_in_some_details_but_omit_some_required_details
+    @scope = 'application_form.personal_details'
+    fill_in t('first_name.label', scope: @scope), with: 'Lando'
+    fill_in t('last_name.label', scope: @scope), with: 'Calrissian'
+    fill_in 'Month', with: '11'
+  end
+
+  def then_i_should_see_validation_errors
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/personal_details_form.attributes.date_of_birth.invalid')
+  end
+
+  def and_i_should_see_the_completed_fields
+    expect(find_field(t('first_name.label', scope: @scope)).value).to eq('Lando')
+    expect(find_field(t('last_name.label', scope: @scope)).value).to eq('Calrissian')
+    expect(find_field('Month').value).to eq('11')
+  end
+
+  def when_i_fill_in_the_rest_of_my_details
+    fill_in 'Day', with: '6'
+    fill_in 'Month', with: '4'
+    fill_in 'Year', with: '1937'
+  end
+
+  def and_i_submit_the_form
+    click_button t('application_form.personal_details.complete_form_button')
+  end
+
+  def then_i_see_the_nationalites_page
+    expect(page).to have_current_path candidate_interface_nationalities_path
+  end
+
+  def when_i_choose_that_i_am_british
+    choose 'British'
+  end
+
+  def then_i_see_the_personal_details_review_page
+    expect(page).to have_current_path candidate_interface_personal_details_show_path
+  end
+
+  def when_i_choose_that_english_is_my_primary_language
+    choose 'Yes'
+    fill_in t('english_main_language.yes_label', scope: @scope), with: "I'm great at Galactic Basic so English is a piece of cake", match: :prefer_exact
+  end
+
+  def and_i_can_check_my_answers
+    expect(page).to have_content 'Name'
+    expect(page).to have_content 'Lando Calrissian'
+    expect(page).to have_content 'British'
+    expect(page).to have_content "I'm great at Galactic Basic so English is a piece of cake"
+  end
+
+  def when_i_click_change_on_my_nationality
+    all('.govuk-summary-list__actions')[2].click_link 'Change'
+  end
+
+  def and_i_choose_that_i_am_irish
+    choose 'Irish'
+  end
+
+  def and_i_see_my_updated_nationality
+    expect(page).to have_content 'Irish'
+  end
+
+  def and_i_choose_other
+    choose 'Other'
+  end
+
+  def and_i_select_i_am_german
+    select 'German'
+  end
+
+  def and_i_see_i_am_german
+    expect(page).to have_content 'German'
+  end
+
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def and_i_submit_my_details
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_my_application_form
+    expect(page).to have_content(t('page_titles.personal_details'))
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#personal-details-badge-id', text: 'Completed')
+  end
+end


### PR DESCRIPTION
## Context

The nationalities page in the personal details section has changed. It is a set of radio buttons. 
The candidate can choose between:
1. British
2. Irish
3. Other (they get an input using nationalities.js)
4. Multiple - text area 

## Changes proposed in this pull request

- Implement the above radio buttons when the international_candidates_personal_details flag is on
- Get the nationalities controller and form working for the flag being on/off

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/42515961/86567796-d423b980-bf63-11ea-8e00-a0d220cfd30c.png) |![image](https://user-images.githubusercontent.com/42515961/86567658-9d4da380-bf63-11ea-973b-fe3baff6db79.png) |

## Guidance to review

I think 'first nationality' should probably just be refactored to 'nationality'. Thoughts?  

Design history - https://bat-design-history.netlify.app/apply-for-teacher-training/international-candidates/#residency-and-visa-status

Prototype - https://apply-beta-prototype.herokuapp.com/application/12345/personal-details/review

## Link to Trello card

https://trello.com/c/AsOuRv9u/1760-dev-%F0%9F%8C%90-international-residency-visa-status

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
