### PR TITLE
remove assets:precompile command before running integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,6 @@ ci.unit-tests: ## Run the tests with results formatted for CI
 .PHONY: ci.integration-tests
 ci.integration-tests: ## Run the tests with results formatted for CI
 	docker-compose run web /bin/sh -c 'mkdir $(RSPEC_RESULTS_PATH) && \
-		apk add nodejs yarn && \
-		bundle exec rails assets:precompile && \
 		bundle exec --verbose rspec --pattern $(INTEGRATION_TEST_PATTERN) --failure-exit-code 0 --format RspecJunitFormatter --out $(RSPEC_RESULTS_PATH)/rspec-integration-tests-results.xml'
 	$(call copy_to_host,$(RSPEC_RESULTS_PATH))
 	$(call copy_to_host,$(COVERAGE_RESULT_PATH))


### PR DESCRIPTION
## Context


## Changes proposed in this pull request

remove install nodejs yarn and precompile commands before running test  commands.

Assets are already precompiled in the docker image.

## Guidance to review


## Link to Trello card


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
