### PR TITLE
Highlight the current section of Manage in the header

### DIFF
--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -36,20 +36,20 @@ class NavigationItems
       end
     end
 
-    def for_provider_interface(current_provider_user)
+    def for_provider_interface(current_provider_user, current_controller)
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
-      items = [NavigationItem.new('Applications', provider_interface_applications_path, false)]
+      items = [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]
 
       if current_provider_user.can_manage_organisations?
-        items << NavigationItem.new('Organisations', provider_interface_organisations_path, false)
+        items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 
       if FeatureFlag.active?('provider_add_provider_users') && current_provider_user.can_manage_users?
-        items << NavigationItem.new('Users', provider_interface_provider_users_path, false)
+        items << NavigationItem.new('Users', provider_interface_provider_users_path, is_active(current_controller, 'provider_users'))
       end
 
-      items << NavigationItem.new('Account', provider_interface_account_path, false)
+      items << NavigationItem.new('Account', provider_interface_account_path, is_active(current_controller, 'account'))
       items << NavigationItem.new('Sign out', provider_interface_sign_out_path, false)
     end
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
   <%= render(ProviderInterface::HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  product_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user))) %>
+                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user, controller))) %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,


### PR DESCRIPTION
We didn’t set the active property on any of the header links, so none of them turned blue when visited. Check which controller we're on, as we do elsewhere.

I think there's a spec/refactor opportunity to analyse the controllers in each namespace and make sure they're all accounted for in the NavigationItems `active` criteria.

## Guidance to review

Are any controllers missing?

## Link to Trello card

https://trello.com/c/limNrbJv/2392-the-current-menu-item-in-the-header-isnt-highlighted

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
