### PR TITLE
Content change - 'Reason for rejection' -> 'Feedback'

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -150,7 +150,7 @@ module CandidateInterface
 
     def rejection_reason_row(application_choice)
       {
-        key: 'Reason for rejection',
+        key: 'Feedback',
         value: application_choice.rejection_reason,
       }
     end

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -27,7 +27,7 @@ module CandidateInterface
 
     def rejection_reasons_row(application_choice)
       {
-        key: 'Reasons for rejection',
+        key: 'Feedback',
         value: application_choice.rejection_reason,
       }
     end

--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -33,7 +33,7 @@
   { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) },
 ] %>
 
-<% rows << { key: 'Reason for rejection', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>
+<% rows << { key: 'Feedback', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>
 <% rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at %>
 <% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at %>
 <% rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at %>

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Unsuccessful')
-      expect(result.css('.govuk-summary-list__key').text).to include('Reason for rejection')
+      expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
     end
   end

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
     expect(result.css('.govuk-summary-list__key').text).to include('Course')
     expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_and_code)
     expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
-    expect(result.css('.govuk-summary-list__key').text).to include('Reasons for rejection')
+    expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
     expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
   end
 end


### PR DESCRIPTION
## Context

This is part of the work for structured rejection reasons.

On the Course summary card we need to replace _Reason for rejection_ label with _Feedback_

## Changes proposed in this pull request

<img width="594" alt="image" src="https://user-images.githubusercontent.com/450843/86612713-749bcd00-bfa8-11ea-8ba6-892586db4745.png">

## Guidance to review

- Have I missed anything?

## Link to Trello card

https://trello.com/c/Omq1ZtBK/1766-dev-feedback-on-previously-unsuccessful-applications

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
