### PR TITLE
Add job to send matching data to UCAS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,5 @@ GOVUK_NOTIFY_CALLBACK_API_KEY=
 DSI_API_URL=https://test-api.signin.education.gov.uk
 DSI_API_SECRET=xxxxxxxxxxxx-xxxxx-xxxxxxxx-xxxxxxxx
 SANDBOX=false
+UCAS_USERNAME=abcdef
+UCAS_PASSWORD=123123

--- a/.env.test
+++ b/.env.test
@@ -5,3 +5,5 @@ STATE_CHANGE_SLACK_URL=https://example.com/slack-webhook
 GOVUK_NOTIFY_CALLBACK_API_KEY=test
 DSI_API_URL=https://test-api.signin.education.gov.uk
 DSI_API_SECRET=some-secret
+UCAS_USERNAME=abcdef
+UCAS_PASSWORD=123123

--- a/app/services/ucas_matching/ucas_api.rb
+++ b/app/services/ucas_matching/ucas_api.rb
@@ -1,0 +1,32 @@
+module UCASMatching
+  class UCASAPI
+    def self.auth_string
+      "Bearer #{access_token}"
+    end
+
+    def self.access_token
+      # https://transfer.ucasenvironments.com/swagger/ui/index#/Authentication/Auth_GetToken
+      response = HTTP
+        .post(
+          "#{base_url}/token",
+          form: {
+            grant_type: 'password',
+            username: ENV.fetch('UCAS_USERNAME'),
+            password: ENV.fetch('UCAS_PASSWORD'),
+          },
+        )
+
+      if response.status.success?
+        JSON.parse(response.body).fetch('access_token')
+      else
+        raise ApiError, "HTTP #{response.status} when fetching access token: '#{response}'"
+      end
+    end
+
+    def self.base_url
+      'https://transfer.ucasenvironments.com/api/v1'
+    end
+  end
+
+  class ApiError < StandardError; end
+end

--- a/app/services/ucas_matching/upload_matching_data.rb
+++ b/app/services/ucas_matching/upload_matching_data.rb
@@ -1,0 +1,51 @@
+require 'csv'
+
+module UCASMatching
+  class UploadMatchingData
+    include Sidekiq::Worker
+
+    # The `dfe_apply_itt_applications` folder in Movit. This will probably
+    # change for the production version.
+    UPLOAD_FOLDER = 685520099
+
+    def perform
+      unless ENV['UCAS_USERNAME']
+        Rails.logger.info 'UCAS credentials aren\'t configured, assuming that this this is a test environment. Not uploading data.'
+        return
+      end
+
+      filename = "/tmp/dfe_apply_itt_applications_#{DateTime.now}.csv"
+
+      File.open(filename, 'w') do |f|
+        f.write(csv_as_string)
+      end
+
+      # https://transfer.ucasenvironments.com/swagger/ui/index#/Folders/POSTapi%2Fv1%2Ffolders%2F%7BId%7D%2Fmove-1.0
+      response = HTTP
+        .auth(UCASAPI.auth_string)
+        .post(
+          "#{UCASAPI.base_url}/folders/#{UPLOAD_FOLDER}/files",
+          form: { file: HTTP::FormData::File.new(filename) },
+        )
+
+      unless response.status.success?
+        raise ApiError, "HTTP #{response.status} when uploading to Movit: '#{response}'"
+      end
+    end
+
+  private
+
+    def csv_as_string
+      applications = MatchingDataExport.new.applications
+      header_row = MatchingDataExport.csv_header(applications)
+
+      CSV.generate do |rows|
+        rows << header_row
+
+        applications.each do |application|
+          rows << application.values
+        end
+      end
+    end
+  end
+end

--- a/azure/pipelines/build.yml
+++ b/azure/pipelines/build.yml
@@ -303,7 +303,7 @@ stages:
       displayName: 'Integration Tests'
       jobId: 'integration_tests'
       jobAttempt: $(System.JobAttempt)
-        
+
   - template: templates/rspec-job.yml
     parameters:
       testCommand: 'unit-tests'
@@ -366,6 +366,8 @@ stages:
       govukNotifyCallbackAPIKey: $(govukNotifyCallbackAPIKey)
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      ucasUsername: '$(ucasUsername)'
+      ucasPassword: '$(ucasPassword)'
       sandbox: '$(sandbox)'
 
 
@@ -423,4 +425,6 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      ucasUsername: '$(ucasUsername)'
+      ucasPassword: '$(ucasPassword)'
       sandbox: '$(sandbox)'

--- a/azure/pipelines/release.yml
+++ b/azure/pipelines/release.yml
@@ -98,6 +98,8 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      ucasUsername: '$(ucasUsername)'
+      ucasPassword: '$(ucasPassword)'
       sandbox: '$(sandbox)'
 
 - stage: deploy_sandbox
@@ -155,6 +157,8 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      ucasUsername: '$(ucasUsername)'
+      ucasPassword: '$(ucasPassword)'
       sandbox: '$(sandbox)'
 
 
@@ -215,4 +219,6 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      ucasUsername: '$(ucasUsername)'
+      ucasPassword: '$(ucasPassword)'
       sandbox: '$(sandbox)'

--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -61,6 +61,8 @@ parameters:
   govukNotifyCallbackAPIKey:
   dsiApiUrl:
   dsiApiSecret:
+  ucasUsername:
+  ucasPassword:
 
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
@@ -247,6 +249,8 @@ jobs:
                 -logRetentionDays ${{parameters.logRetentionDays}}
                 -dsiApiUrl "${{parameters.dsiApiUrl}}"
                 -dsiApiSecret "${{parameters.dsiApiSecret}}"
+                -ucasUsername "${{parameters.ucasUsername}}"
+                -ucasPassword "${{parameters.ucasPassword}}"
                 -govukNotifyCallbackAPIKey "${{parameters.govukNotifyCallbackAPIKey}}"
                 -sandbox "${{parameters.sandbox}}"'
               deploymentOutputs: DeploymentOutput

--- a/azure/template.json
+++ b/azure/template.json
@@ -341,6 +341,18 @@
                 "description": "The DfE Sign-in API_SECRET for authenticating API requests"
             }
         },
+        "ucasUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "The username for UCAS data exchange"
+            }
+        },
+        "ucasPassword": {
+            "type": "string",
+            "metadata": {
+                "description": "The password for UCAS data exchange"
+            }
+        },
         "stateChangeSlackUrl": {
             "type": "string",
             "metadata": {
@@ -717,6 +729,14 @@
                             {
                                 "name": "DSI_API_SECRET",
                                 "value": "[parameters('dsiApiSecret')]"
+                            },
+                            {
+                                "name": "UCAS_USERNAME",
+                                "value": "[parameters('ucasUsername')]"
+                            },
+                            {
+                                "name": "UCAS_PASSWORD",
+                                "value": "[parameters('ucasPassword')]"
                             },
                             {
                                 "name": "REDIS_URL",

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -20,4 +20,6 @@ class Clock
   every(1.hour, 'SendChaseEmailToProviders', at: '**:35') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
+
+  every(1.day, 'UCASMatching::UploadMatchingData', at: '03:23') { UCASMatching::UploadMatchingData.perform_async }
 end

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -24,4 +24,6 @@ services:
       - STATE_CHANGE_SLACK_URL
       - DSI_API_URL
       - DSI_API_SECRET
+      - UCAS_USERNAME
+      - UCAS_PASSWORD
       - SANDBOX

--- a/spec/lib/namespaces_spec.rb
+++ b/spec/lib/namespaces_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Namespace' do
-  namespaces = %w[CandidateInterface ProviderInterface SupportInterface APIDocs RefereeInterface VendorAPI]
+  namespaces = %w[CandidateInterface ProviderInterface SupportInterface APIDocs RefereeInterface VendorAPI UCASMatching]
 
   namespaces.each do |namespace|
     describe namespace.constantize do

--- a/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
+++ b/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.feature 'Uploading of matching data to UCAS', sidekiq: true do
+  scenario 'An eventually succesful upload to UCAS' do
+    given_there_is_an_application_in_the_system
+
+    given_the_access_token_can_not_be_acquired
+    when_the_daily_upload_runs
+    then_an_token_error_is_raised_so_sidekiq_tries_again
+
+    given_the_file_can_not_be_uploaded
+    when_the_daily_upload_runs
+    then_a_server_error_is_raised_so_sidekiq_tries_again
+
+    given_all_is_good_with_the_upload_system
+    when_the_daily_upload_runs
+    then_the_file_has_been_uploaded
+  end
+
+  def given_there_is_an_application_in_the_system
+    @application_choice = create(:submitted_application_choice)
+  end
+
+  def given_the_access_token_can_not_be_acquired
+    stub_request(:post, 'https://transfer.ucasenvironments.com/api/v1/token')
+      .to_return(
+        status: 401,
+        body: 'Something is wrong here!',
+      )
+  end
+
+  def when_the_daily_upload_runs
+    @latest_exception = nil
+    UCASMatching::UploadMatchingData.perform_async
+  rescue StandardError => e
+    @latest_exception = e
+  end
+
+  def then_an_token_error_is_raised_so_sidekiq_tries_again
+    expect(@latest_exception.message).to eql("HTTP 401 Unauthorized when fetching access token: 'Something is wrong here!'")
+  end
+
+  def given_the_file_can_not_be_uploaded
+    stub_request(:post, 'https://transfer.ucasenvironments.com/api/v1/token')
+      .to_return(
+        body: { access_token: '123456789' }.to_json,
+      )
+
+    @upload_request = stub_request(
+      :post,
+      'https://transfer.ucasenvironments.com/api/v1/folders/685520099/files',
+    ).with(headers: {
+      'Authorization' => 'Bearer 123456789',
+    }).to_return(
+      status: 500,
+      body: 'Brrr something has gone wrong',
+    )
+  end
+
+  def then_a_server_error_is_raised_so_sidekiq_tries_again
+    expect(@latest_exception.message).to eql("HTTP 500 Internal Server Error when uploading to Movit: 'Brrr something has gone wrong'")
+  end
+
+  def given_all_is_good_with_the_upload_system
+    stub_request(:post, 'https://transfer.ucasenvironments.com/api/v1/token')
+      .to_return(
+        body: { access_token: '123456789' }.to_json,
+      )
+
+    stub_request(
+      :post,
+      'https://transfer.ucasenvironments.com/api/v1/folders/685520099/files',
+    ).with(headers: {
+      'Authorization' => 'Bearer 123456789',
+    }).to_return(status: 200)
+  end
+
+  def then_the_file_has_been_uploaded
+    expect(@latest_exception).to be_nil
+
+    expect(WebMock).to have_requested(:post, 'https://transfer.ucasenvironments.com/api/v1/folders/685520099/files')
+      .with { |req| req.body.match?(@application_choice.application_form.first_name) }
+      .at_least_once
+  end
+end


### PR DESCRIPTION
##  Context

We're going to be sharing data with UCAS to find candidates who've applied to both services. 

## Changes proposed in this pull request

This is the first step in that process, it uploads the data every night to UCAS' Movit instance. It uses the Movit API, documented at https://transfer.ucasenvironments.com/swagger/ui.

Authentication works by fetching an access token using a username and password, configured in environment variables. Currently we have one email address that has to the folder we're uploading to - if you need access than you can look at the environment variables.

This uploads to a *test environment*. I'm not a 100% sure what will change between production and testing environments - definitely the username & password, likely the folder ID, perhaps the URL as well. We'll see once we have the production credentials. 

## Guidance to review

There's a follow up this to _download_ matched data from the servers. At that point we'll probably refactor this code a bit, because things will be shared (auth, folder IDs, etc).

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
