### PR TITLE
Silence non-informative warnings in logs and console

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -20,7 +20,6 @@ class ApplicationQualification < ApplicationRecord
 
   scope :degrees, -> { where level: 'degree' }
   scope :gcses, -> { where level: 'gcse' }
-  scope :other, -> { where level: 'other' }
 
   enum level: {
     degree: 'degree',

--- a/config/initializers/rails_monkey_patches.rb
+++ b/config/initializers/rails_monkey_patches.rb
@@ -1,0 +1,24 @@
+module ActiveRecord::Enum
+  # Enums in Rails are also added as a negative. For example, a "cancelled" enum
+  # type will have a "not_cancelled" scope.
+  #
+  #   https://github.com/rails/rails/blob/1eade80dd69495cb98bcb03448a358107013dd61/activerecord/lib/active_record/enum.rb#L30-L36
+  #
+  # This works a bit weird with scopes that are already negative, like we have
+  # for ApplicationReference#not_requested_yet. If we were to add an enum called
+  # "requested_yet", both a scope "not_requested_yet" (positive) and
+  # "not_requested_yet" (negative of "requested_yet") would be generated.
+  #
+  # To prevent this Rails already raises an error if it actually occurs:
+  #
+  #   https://github.com/rails/rails/blob/1eade80dd69495cb98bcb03448a358107013dd61/activerecord/lib/active_record/enum.rb#L255-L265
+  #
+  # Rails also logs a warning, even if there's no actual conflict yet. This is a
+  # bit annoying because we're pretty sure what we're doing with the "not_requested_yet"
+  # enum. This monkey patch removes the warning log.
+  #
+  # https://github.com/rails/rails/blob/1eade80dd69495cb98bcb03448a358107013dd61/activerecord/lib/active_record/enum.rb#L255-L265
+  #
+  # There's a Rails issue from April 2020 that deals with this thing: https://github.com/rails/rails/issues/39065
+  def detect_negative_condition!(method_name); end
+end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,4 +1,5 @@
 Raven.configure do |config|
+  config.silence_ready = true
   config.current_environment = HostingEnvironment.environment_name
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.excluded_exceptions += [


### PR DESCRIPTION
## Context

The logs on production show this:

```
2020-06-22T08:47:14.175885062Z {"message":"Raven 2.13.0 ready to catch errors","@timestamp":"2020-06-22T09:47:11.215+01:00","@version":"1","severity":"INFO","host":"36d249bf43f1","domain":"staging.apply-for-teacher-training.education.gov.uk","hosting_environment":"staging","service":"web"}
2020-06-22T08:47:14.175944862Z {"message":"An enum element in ApplicationReference uses the prefix 'not_'. This will cause a conflict with auto generated negative scopes.","@timestamp":"2020-06-22T09:47:11.821+01:00","@version":"1","severity":"WARN","host":"36d249bf43f1","domain":"staging.apply-for-teacher-training.education.gov.uk","hosting_environment":"staging","service":"web"}
2020-06-22T08:47:14.175970162Z {"message":"An enum element in ApplicationReference uses the prefix 'not_'. This will cause a conflict with auto generated negative scopes.","@timestamp":"2020-06-22T09:47:11.823+01:00","@version":"1","severity":"WARN","host":"36d249bf43f1","domain":"staging.apply-for-teacher-training.education.gov.uk","hosting_environment":"staging","service":"web"}
2020-06-22T08:47:14.175975861Z {"message":"An enum element in Email uses the prefix 'not_'. This will cause a conflict with auto generated negative scopes.","@timestamp":"2020-06-22T09:47:13.412+01:00","@version":"1","severity":"WARN","host":"36d249bf43f1","domain":"staging.apply-for-teacher-training.education.gov.uk","hosting_environment":"staging","service":"web"}
2020-06-22T08:47:14.175981361Z {"message":"Creating scope :other. Overwriting existing method ApplicationQualification.other.","@timestamp":"2020-06-22T09:47:13.468+01:00","@version":"1","severity":"WARN","host":"36d249bf43f1","domain":"staging.apply-for-teacher-training.education.gov.uk","hosting_environment":"staging","service":"web"}
2020-06-22T08:47:14.175986661Z {"message":"An enum element in ApplicationForm uses the prefix 'not_'. This will cause a conflict with auto generated negative scopes.","@timestamp":"2020-06-22T09:47:13.486+01:00","@version":"1","severity":"WARN","host":"36d249bf43f1","domain":"staging.apply-for-teacher-training.education.gov.uk","hosting_environment":"staging","service":"web"}
```

These warnings are confusing and have made it harder to diagnose incidents on production.

## Changes proposed in this pull request

Fix the warnings!

## Guidance to review

See individual commits.

## Link to Trello card

https://trello.com/c/6fgw4kmq/307-bunch-of-warnings-in-logs-console

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
