### PR TITLE
SCSS fix picked up by SCSS linter in another project

### DIFF
--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -46,7 +46,7 @@
 
 .app-banner__message {
   @include govuk-font($size: 19);
-  p { margin-top: 0 }
+  p { margin-top: 0; }
 }
 
 .app-banner__message *:last-child {


### PR DESCRIPTION
## Context

After **\<cough\>** borrowing the banner code for another project, our SCSS linter picked up a warning:

```
Run bundle exec scss-lint app/webpacker/styles
app/webpacker/styles/banner.scss:49:1 [W] TrailingSemicolon: Declaration should be terminated by a semicolon
```

## Changes proposed in this pull request

Terminate declaration by a semicolon.

