### PR TITLE
Validation error summary page

### DIFF
--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -14,32 +14,7 @@ module SupportInterface
     end
 
     def summary
-      @validation_error_summary = ValidationErrorSummary.new.call
-    end
-
-    class ValidationErrorSummary
-      COUNT_QUERY =
-        'SELECT COUNT(*) AS incidents, COUNT(DISTINCT user_id) AS distinct_users
-        FROM validation_errors
-        WHERE created_at > $1'.freeze
-
-      def call
-        {
-          last_week: errors_since(1.week.ago),
-          last_month: errors_since(1.month.ago),
-          all_time: errors_since(Time.zone.local(2000, 1, 1)),
-        }
-      end
-
-    private
-
-      def errors_since(start_date)
-        ActiveRecord::Base.connection.exec_query(
-          COUNT_QUERY,
-          'SQL',
-          [[nil, start_date]],
-        ).first.with_indifferent_access
-      end
+      @validation_error_summary = ValidationErrorSummaryQuery.new.call
     end
 
     class ValidationErrorSearch

--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -14,7 +14,7 @@ module SupportInterface
     end
 
     def summary
-      @validation_error_summary = ValidationErrorSummaryQuery.new.call
+      @validation_error_summary = ::ValidationErrorSummaryQuery.new.call
     end
 
     class ValidationErrorSearch

--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -24,4 +24,20 @@ module SupportInterface
       end
     end
   end
+
+  # Per calendar month stats
+  # SELECT
+  #   EXTRACT(month FROM created_at) AS month,
+  #   EXTRACT(year FROM created_at) AS year,
+  #   COUNT(*) AS incidents,
+  #   COUNT(DISTINCT user_id) AS distinct_users
+  # FROM validation_errors
+  # GROUP BY month, year;
+  #
+  # Last week (etc.)
+  # SELECT
+  #   COUNT(*) AS incidents,
+  #   COUNT(DISTINCT user_id) AS distinct_users
+  # FROM validation_errors
+  # WHERE created_at > date_trunc('day', NOW() - interval '1 week');
 end

--- a/app/queries/validation_error_summary_query.rb
+++ b/app/queries/validation_error_summary_query.rb
@@ -5,25 +5,25 @@ class ValidationErrorSummaryQuery
         form_object,
         jsonb_object_keys(details) AS attribute,
         CASE
-          WHEN created_at > date_trunc('day', NOW() - interval '1 week') THEN
+          WHEN created_at > $1 THEN
             1
           ELSE
             0
         END AS incident_last_week,
         CASE
-          WHEN created_at > date_trunc('day', NOW() - interval '1 week') THEN
+          WHEN created_at > $1 THEN
             user_id
           ELSE
             NULL
         END AS user_id_last_week,
         CASE
-          WHEN created_at > date_trunc('day', NOW() - interval '1 month') THEN
+          WHEN created_at > $2 THEN
             1
           ELSE
             0
         END AS incident_last_month,
         CASE
-          WHEN created_at > date_trunc('day', NOW() - interval '1 month') THEN
+          WHEN created_at > $2 THEN
             user_id
           ELSE
             NULL
@@ -46,6 +46,10 @@ class ValidationErrorSummaryQuery
     ORDER BY incidents_all_time DESC".freeze
 
   def call
-    ActiveRecord::Base.connection.exec_query(COUNT_SQL).to_a
+    ActiveRecord::Base.connection.exec_query(
+      COUNT_SQL,
+      'SQL',
+      [[nil, 1.week.ago.beginning_of_day], [nil, 1.month.ago.beginning_of_day]],
+    ).to_a
   end
 end

--- a/app/queries/validation_error_summary_query.rb
+++ b/app/queries/validation_error_summary_query.rb
@@ -1,0 +1,30 @@
+class ValidationErrorSummaryQuery
+  COUNT_SQL =
+    'SELECT COUNT(*) AS incidents, COUNT(DISTINCT user_id) AS distinct_users
+    FROM validation_errors'.freeze
+  COUNT_WITH_START_TIME_SQL =
+    "#{COUNT_SQL}
+    WHERE created_at > $1".freeze
+
+  def call
+    {
+      last_week: errors_since(1.week.ago),
+      last_month: errors_since(1.month.ago),
+      all_time: all_errors,
+    }
+  end
+
+private
+
+  def all_errors
+    ActiveRecord::Base.connection.exec_query(COUNT_SQL).first.symbolize_keys
+  end
+
+  def errors_since(start_date)
+    ActiveRecord::Base.connection.exec_query(
+      COUNT_WITH_START_TIME_SQL,
+      'SQL',
+      [[nil, start_date]],
+    ).first.symbolize_keys
+  end
+end

--- a/app/queries/validation_error_summary_query.rb
+++ b/app/queries/validation_error_summary_query.rb
@@ -1,30 +1,51 @@
 class ValidationErrorSummaryQuery
   COUNT_SQL =
-    'SELECT COUNT(*) AS incidents, COUNT(DISTINCT user_id) AS distinct_users
-    FROM validation_errors'.freeze
-  COUNT_WITH_START_TIME_SQL =
-    "#{COUNT_SQL}
-    WHERE created_at > $1".freeze
+    "WITH validation_error_counts AS (
+      SELECT
+        form_object,
+        jsonb_object_keys(details) AS attribute,
+        CASE
+          WHEN created_at > date_trunc('day', NOW() - interval '1 week') THEN
+            1
+          ELSE
+            0
+        END AS incident_last_week,
+        CASE
+          WHEN created_at > date_trunc('day', NOW() - interval '1 week') THEN
+            user_id
+          ELSE
+            NULL
+        END AS user_id_last_week,
+        CASE
+          WHEN created_at > date_trunc('day', NOW() - interval '1 month') THEN
+            1
+          ELSE
+            0
+        END AS incident_last_month,
+        CASE
+          WHEN created_at > date_trunc('day', NOW() - interval '1 month') THEN
+            user_id
+          ELSE
+            NULL
+        END AS user_id_last_month,
+        1 AS incident,
+        user_id AS user_id
+      FROM validation_errors
+    )
+    SELECT
+      form_object,
+      attribute,
+      SUM(incident_last_week) AS incidents_last_week,
+      COUNT(DISTINCT user_id_last_week) AS unique_users_last_week,
+      SUM(incident_last_month) AS incidents_last_month,
+      COUNT(DISTINCT user_id_last_month) AS unique_users_last_month,
+      SUM(incident) AS incidents_all_time,
+      COUNT(DISTINCT user_id) AS unique_users_all_time
+    FROM validation_error_counts
+    GROUP BY form_object, attribute
+    ORDER BY incidents_all_time DESC".freeze
 
   def call
-    {
-      last_week: errors_since(1.week.ago),
-      last_month: errors_since(1.month.ago),
-      all_time: all_errors,
-    }
-  end
-
-private
-
-  def all_errors
-    ActiveRecord::Base.connection.exec_query(COUNT_SQL).first.symbolize_keys
-  end
-
-  def errors_since(start_date)
-    ActiveRecord::Base.connection.exec_query(
-      COUNT_WITH_START_TIME_SQL,
-      'SQL',
-      [[nil, start_date]],
-    ).first.symbolize_keys
+    ActiveRecord::Base.connection.exec_query(COUNT_SQL).to_a
   end
 end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -7,6 +7,7 @@
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
   <li><%= govuk_link_to 'Applications with unavailable choices', support_interface_unavailable_choices_path %></li>
   <li><%= govuk_link_to 'Validation errors', support_interface_validation_errors_path %></li>
+  <li><%= govuk_link_to 'Validation error summary', support_interface_validation_error_summary_path %></li>
 </ul>
 
 <h2 class='govuk-heading-l'>Downloads for analysis</h2>

--- a/app/views/support_interface/validation_errors/summary.html.erb
+++ b/app/views/support_interface/validation_errors/summary.html.erb
@@ -24,10 +24,16 @@
   <% @validation_error_summary.each do |row| %>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
-        <%= row['form_object'].to_s %>
+        <%= govuk_link_to(
+          row['form_object'].to_s.demodulize.underscore.humanize,
+          support_interface_validation_error_search_path(form_object: row['form_object'].to_s),
+        ) %>
       </td>
       <td class="govuk-table__cell">
-        <%= row['attribute'].to_s.humanize %>
+        <%= govuk_link_to(
+          row['attribute'].to_s.humanize,
+          support_interface_validation_error_search_path(form_object: row['form_object'], attribute: row['attribute']),
+        ) %>
       </td>
       <td class="govuk-table__cell">
         <%= row['incidents_all_time'] %>

--- a/app/views/support_interface/validation_errors/summary.html.erb
+++ b/app/views/support_interface/validation_errors/summary.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, 'Validation error summary' %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-half"></th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Error count</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Unique users</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @validation_error_summary.each do |label, counts| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <%= label.to_s.humanize %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= counts[:incidents] %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= counts[:distinct_users] %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/validation_errors/summary.html.erb
+++ b/app/views/support_interface/validation_errors/summary.html.erb
@@ -3,22 +3,49 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-half"></th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter"></th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter"></th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter" colspan="2">All time</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter" colspan="2">Last month</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter" colspan="2">Last week</th>
+    </tr>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter"></th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter"></th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Error count</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Unique users</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Error count</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Unique users</th>
       <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Error count</th>
       <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Unique users</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <% @validation_error_summary.each do |label, counts| %>
+  <% @validation_error_summary.each do |row| %>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
-        <%= label.to_s.humanize %>
+        <%= row['form_object'].to_s %>
       </td>
       <td class="govuk-table__cell">
-        <%= counts[:incidents] %>
+        <%= row['attribute'].to_s.humanize %>
       </td>
       <td class="govuk-table__cell">
-        <%= counts[:distinct_users] %>
+        <%= row['incidents_all_time'] %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= row['unique_users_all_time'] %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= row['incidents_last_month'] %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= row['unique_users_last_month'] %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= row['incidents_last_week'] %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= row['unique_users_last_week'] %>
       </td>
     </tr>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -632,6 +632,7 @@ Rails.application.routes.draw do
 
     get '/validation-errors' => 'validation_errors#index', as: :validation_errors
     get '/validation-errors/search' => 'validation_errors#search', as: :validation_error_search
+    get '/validation-errors/summary' => 'validation_errors#summary', as: :validation_error_summary
 
     scope '/users' do
       get '/' => 'users#index', as: :users

--- a/spec/queries/validation_error_summary_query_spec.rb
+++ b/spec/queries/validation_error_summary_query_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ValidationErrorSummaryQuery do
+  describe '#call' do
+    it 'returns an empty result' do
+      expect(described_class.new.call).to eq({
+        last_week: { distinct_users: 0, incidents: 0 },
+        last_month: { distinct_users: 0, incidents: 0 },
+        all_time: { distinct_users: 0, incidents: 0 },
+      })
+    end
+
+    it 'returns data for each time period' do
+      create :validation_error, created_at: 2.days.ago
+      create :validation_error, created_at: 10.days.ago
+      old_error = create :validation_error, created_at: 60.days.ago
+      create :validation_error, created_at: 60.days.ago, user: old_error.user
+
+      expect(described_class.new.call).to eq({
+        last_week: { distinct_users: 1, incidents: 1 },
+        last_month: { distinct_users: 2, incidents: 2 },
+        all_time: { distinct_users: 3, incidents: 4 },
+      })
+    end
+  end
+end

--- a/spec/queries/validation_error_summary_query_spec.rb
+++ b/spec/queries/validation_error_summary_query_spec.rb
@@ -3,11 +3,7 @@ require 'rails_helper'
 RSpec.describe ValidationErrorSummaryQuery do
   describe '#call' do
     it 'returns an empty result' do
-      expect(described_class.new.call).to eq({
-        last_week: { distinct_users: 0, incidents: 0 },
-        last_month: { distinct_users: 0, incidents: 0 },
-        all_time: { distinct_users: 0, incidents: 0 },
-      })
+      expect(described_class.new.call).to eq([])
     end
 
     it 'returns data for each time period' do
@@ -16,11 +12,18 @@ RSpec.describe ValidationErrorSummaryQuery do
       old_error = create :validation_error, created_at: 60.days.ago
       create :validation_error, created_at: 60.days.ago, user: old_error.user
 
-      expect(described_class.new.call).to eq({
-        last_week: { distinct_users: 1, incidents: 1 },
-        last_month: { distinct_users: 2, incidents: 2 },
-        all_time: { distinct_users: 3, incidents: 4 },
-      })
+      expect(described_class.new.call).to eq([
+        {
+          'attribute' => 'feedback',
+          'form_object' => 'RefereeInterface::ReferenceFeedbackForm',
+          'incidents_all_time' => 4,
+          'incidents_last_month' => 2,
+          'incidents_last_week' => 1,
+          'unique_users_all_time' => 3,
+          'unique_users_last_month' => 2,
+          'unique_users_last_week' => 1,
+        },
+      ])
     end
   end
 end

--- a/spec/system/support_interface/validation_errors_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_summary_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.feature 'Validation errors summary' do
+  include CandidateHelper
+  include DfESignInHelpers
+
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 4, 24, 12, 35, 46)) do
+      example.run
+    end
+  end
+
+  scenario 'Review validation error summary' do
+    given_i_am_a_candidate
+    and_the_track_validation_errors_feature_is_on
+    and_i_enter_invalid_contact_details
+
+    given_i_am_a_support_user
+
+    when_i_navigate_to_the_validation_errors_summary_page
+    then_i_should_see_numbers_for_the_past_week
+    and_i_should_see_numbers_for_the_past_month
+    and_i_should_see_numbers_for_all_time
+
+    when_i_click_on_a_row
+    then_i_should_see_the_search_page
+  end
+
+  def given_i_am_a_candidate
+    create_and_sign_in_candidate
+  end
+
+  def and_the_track_validation_errors_feature_is_on
+    FeatureFlag.activate('track_validation_errors')
+  end
+
+  def and_i_enter_invalid_contact_details
+    visit candidate_interface_application_form_path
+    click_link t('page_titles.contact_details')
+    fill_in t('application_form.contact_details.phone_number.label'), with: 'ABCDEF'
+    click_button t('application_form.contact_details.base.button')
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def when_i_navigate_to_the_validation_errors_summary_page
+    visit support_interface_path
+    click_link 'Performance'
+    click_link 'Validation errors summary'
+  end
+
+  def then_i_should_see_numbers_for_the_past_week
+    @validation_error = ValidationError.last
+    pending 'add assertion'
+  end
+
+  def and_i_should_see_numbers_for_the_past_month
+  end
+
+  def and_i_should_see_numbers_for_all_time
+  end
+
+  def when_i_click_on_a_row
+  end
+
+  def then_i_should_see_the_search_page
+  end
+end

--- a/spec/system/support_interface/validation_errors_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_summary_spec.rb
@@ -13,6 +13,9 @@ RSpec.feature 'Validation errors summary' do
 
     when_i_navigate_to_the_validation_errors_summary_page
     then_i_should_see_numbers_for_the_past_week_month_and_all_time
+
+    when_i_click_on_link_to_drilldown_contact_details_form_errors
+    then_i_should_see_errors_for_contact_details_form_only
   end
 
   def given_i_am_a_candidate
@@ -41,6 +44,16 @@ RSpec.feature 'Validation errors summary' do
   end
 
   def then_i_should_see_numbers_for_the_past_week_month_and_all_time
-    expect(find('table').all('tr')[2].text).to eq 'CandidateInterface::ContactDetailsForm Phone number 1 1 1 1 1 1'
+    expect(find('table').all('tr')[2].text).to eq 'Contact details form Phone number 1 1 1 1 1 1'
+  end
+
+  def when_i_click_on_link_to_drilldown_contact_details_form_errors
+    click_link 'Contact details form'
+  end
+
+  def then_i_should_see_errors_for_contact_details_form_only
+    expect(page).to have_current_path(
+      support_interface_validation_error_search_path(form_object: 'CandidateInterface::ContactDetailsForm'),
+    )
   end
 end

--- a/spec/system/support_interface/validation_errors_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_summary_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature 'Validation errors summary' do
     given_i_am_a_support_user
 
     when_i_navigate_to_the_validation_errors_summary_page
-    then_i_should_see_numbers_for_the_past_week
-    and_i_should_see_numbers_for_the_past_month
-    and_i_should_see_numbers_for_all_time
+    then_i_should_see_numbers_for_the_past_week_month_and_all_time
   end
 
   def given_i_am_a_candidate
@@ -42,15 +40,7 @@ RSpec.feature 'Validation errors summary' do
     click_link 'Validation error summary'
   end
 
-  def then_i_should_see_numbers_for_the_past_week
-    expect(find('table').all('tr')[1].text).to eq 'Last week 1 1'
-  end
-
-  def and_i_should_see_numbers_for_the_past_month
-    expect(find('table').all('tr')[2].text).to eq 'Last month 1 1'
-  end
-
-  def and_i_should_see_numbers_for_all_time
-    expect(find('table').all('tr')[3].text).to eq 'All time 1 1'
+  def then_i_should_see_numbers_for_the_past_week_month_and_all_time
+    expect(find('table').all('tr')[2].text).to eq 'CandidateInterface::ContactDetailsForm Phone number 1 1 1 1 1 1'
   end
 end

--- a/spec/system/support_interface/validation_errors_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_summary_spec.rb
@@ -4,12 +4,6 @@ RSpec.feature 'Validation errors summary' do
   include CandidateHelper
   include DfESignInHelpers
 
-  around do |example|
-    Timecop.freeze(Time.zone.local(2020, 4, 24, 12, 35, 46)) do
-      example.run
-    end
-  end
-
   scenario 'Review validation error summary' do
     given_i_am_a_candidate
     and_the_track_validation_errors_feature_is_on
@@ -21,9 +15,6 @@ RSpec.feature 'Validation errors summary' do
     then_i_should_see_numbers_for_the_past_week
     and_i_should_see_numbers_for_the_past_month
     and_i_should_see_numbers_for_all_time
-
-    when_i_click_on_a_row
-    then_i_should_see_the_search_page
   end
 
   def given_i_am_a_candidate
@@ -48,23 +39,18 @@ RSpec.feature 'Validation errors summary' do
   def when_i_navigate_to_the_validation_errors_summary_page
     visit support_interface_path
     click_link 'Performance'
-    click_link 'Validation errors summary'
+    click_link 'Validation error summary'
   end
 
   def then_i_should_see_numbers_for_the_past_week
-    @validation_error = ValidationError.last
-    pending 'add assertion'
+    expect(find('table').all('tr')[1].text).to eq 'Last week 1 1'
   end
 
   def and_i_should_see_numbers_for_the_past_month
+    expect(find('table').all('tr')[2].text).to eq 'Last month 1 1'
   end
 
   def and_i_should_see_numbers_for_all_time
-  end
-
-  def when_i_click_on_a_row
-  end
-
-  def then_i_should_see_the_search_page
+    expect(find('table').all('tr')[3].text).to eq 'All time 1 1'
   end
 end


### PR DESCRIPTION
## Context

We have built validation errors into the service and can now track these to a good level of detail. Tijmen has shown the value of this and where we can track user behavious. However to undertake analysis quickly effectively it would be helpful to have a summary table highlighting key areas for analysis focus.

## Changes proposed in this pull request

- [x] New support interface page that summarise the error totals broken down by error type (form and attribute) over the past week, month and all time:

<img width="871" alt="image" src="https://user-images.githubusercontent.com/450843/86584006-253fa780-bf7c-11ea-8dbd-13b5a0cd09b7.png">

- [x] System spec
- [x] Extract query logic into service class with specs
- [x] Links to search page (drill-down)

## Guidance to review

- Is there a better way to present this info?
- Are the tests sufficient?
- I tried implement as much of this as possible in a single database query rather than doing in-memory data manipulation in Ruby. Does the query make sense?

## Link to Trello card

https://trello.com/c/iI7lB1Cc/1711-dev-validation-error-summary

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
