### PR TITLE
Attempt to force DB rollback in mailer previews

### DIFF
--- a/app/controllers/apply_mailers_controller.rb
+++ b/app/controllers/apply_mailers_controller.rb
@@ -1,0 +1,8 @@
+module ApplyMailersController
+  def preview
+    ActiveRecord::Base.transaction do
+      super
+      raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.exceptions_app = self.routes
 
-    show_previews = Rails.env.development? || HostingEnvironment.qa? || HostingEnvironment.review?
+    show_previews = Rails.env.development? || Rails.env.test? || HostingEnvironment.qa? || HostingEnvironment.review?
 
     config.action_mailer.preview_path = Rails.root.join('spec/mailers/previews')
     config.action_mailer.show_previews = show_previews

--- a/config/initializers/mailer_previews.rb
+++ b/config/initializers/mailer_previews.rb
@@ -1,0 +1,3 @@
+ActiveSupport.on_load(:action_controller, run_once: true) do
+  Rails::MailersController.prepend(ApplyMailersController)
+end

--- a/spec/controllers/rails/mailers_controller_spec.rb
+++ b/spec/controllers/rails/mailers_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+# These tests are designed to verify that `ApplyMailersController` is rolling back DB changes
+RSpec.describe Rails::MailersController, type: :controller do
+  ActionMailer::Preview.all.each do |preview|
+    preview.emails.each do |email|
+      it "/rails/mailers/#{preview.preview_name}/#{email} does not pollute the database" do
+        expect { get(:preview, params: { path: "#{preview.preview_name}/#{email}" }) }.not_to(
+          change { ApplicationForm.count },
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We have a number of invalid 'test' applications on `qa` (e.g. awaiting provider decision without any references). These are the leftovers from invocations of mailer and component (?) previews. We need a way to avoid littering the database with temporary data such as this.

## Changes proposed in this pull request

- [x] Override `Rails::MailersController#preview` to wrap all preview invocations in a rolled back database transaction (just like RSpec tests).
- [x] Tests for the above.
- [x] Investigate component previews - I tested these manually and didn't see any issues with rogue applications created though it might be useful to guard against this in future.

## Guidance to review

- Wrapping mailer previews in a transaction is a bit more tricky than I expected. Maybe I'm missing something? There are a few solutions on StackOverflow but they didn't work. This is possibly because `mail-notify` already does so and I got into a muddle with the autoloader and `Rails::MailersController`. The way that worked was to mix in a module like `mail-notify` does.
- I tried a few different ways to test this. Testing the previews directly doesn't work because that doesn't invoke the transaction rollback. I tried system specs and request specs but ended up testing `Rails::MailersController` with a controller spec (again taking inspiration from `mail-notify`). However I had to enable mailer previews in `test` to get these to work because the routes for `Rails::MailersController` are not created otherwise.

## Link to Trello card

https://trello.com/c/qwF3Orpt/1788-dev-check-test-app-generator

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
