### PR TITLE
Revert "Bump pdfkit from 0.8.4.2 to 0.8.4.3.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)
-    pdfkit (0.8.4.3.1)
+    pdfkit (0.8.4.2)
     pg (1.2.3)
     protobuf-cucumber (3.10.8)
       activesupport (>= 3.2)


### PR DESCRIPTION
This upgrade seems to cause exceptions not to be properly raised from controllers. Instead the exception manifests as an exception in Rack.
https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1594136961212800

![image](https://user-images.githubusercontent.com/642279/86809809-2eac3b00-c074-11ea-99c4-5e41b9690959.png)
