### PR TITLE
add timeout setting for rspec test runs

### DIFF
--- a/azure/pipelines/templates/run-rspec-test.yml
+++ b/azure/pipelines/templates/run-rspec-test.yml
@@ -33,6 +33,7 @@ steps:
         exit 1
       fi
     displayName: 'Execute ${{ parameters.testCommand }}'
+    timeoutInMinutes: 10
     env:
       testResultFile: ${{ parameters.testResultsFile }}
       dockerHubUsername: $(dockerHubUsername)


### PR DESCRIPTION
## Context

Default task timeout is 60 mins.

## Changes proposed in this pull request

Add a 10 mins timeout for rspec runs.

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
