### PR TITLE
Generate fake providers with courses in the sandbox

### DIFF
--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -24,5 +24,15 @@ module SupportInterface
         render_404
       end
     end
+
+    def create_fake_provider
+      @new_provider = GenerateFakeProvider.generate_provider(
+        {
+          name: Faker::Educator.unique.university,
+          code: Faker::Alphanumeric.unique.alphanumeric(number: 3).upcase,
+        },
+      )
+      @vendor_api_token = VendorAPIToken.create_with_random_token!(provider: @new_provider)
+    end
   end
 end

--- a/app/services/generate_fake_provider.rb
+++ b/app/services/generate_fake_provider.rb
@@ -1,0 +1,35 @@
+class GenerateFakeProvider
+  def self.generate_provider(provider)
+    raise 'You can\'t generate test data in production' if HostingEnvironment.production?
+
+    Provider.find_or_create_by(provider) do |new_provider|
+      generate_courses_for(new_provider)
+      generate_ratified_courses_for(new_provider) unless new_provider.code == 'TEST'
+    end
+  end
+
+  def self.generate_courses_for(training_provider)
+    10.times do
+      FactoryBot.create(
+        :course,
+        provider: training_provider,
+        code: Faker::Alphanumeric.alphanumeric(number: Course::CODE_LENGTH).upcase,
+      )
+    end
+  end
+
+  def self.generate_ratified_courses_for(ratifying_provider)
+    test_provider = Provider.default_scoped.find_or_create_by(name: 'Test Provider', code: 'TEST')
+
+    3.times do
+      FactoryBot.create(
+        :course,
+        provider: test_provider,
+        accredited_provider_id: ratifying_provider.id,
+        code: Faker::Alphanumeric.unique.alphanumeric(number: Course::CODE_LENGTH).upcase,
+      )
+    end
+  end
+
+  private_class_method :generate_ratified_courses_for, :generate_courses_for
+end

--- a/app/services/generate_vendor_providers.rb
+++ b/app/services/generate_vendor_providers.rb
@@ -16,7 +16,7 @@ class GenerateVendorProviders
     ]
 
     providers.each do |provider|
-      Provider.find_or_create_by(provider)
+      GenerateFakeProvider.generate_provider(provider)
     end
   end
 end

--- a/app/views/support_interface/tasks/create_fake_provider.html.erb
+++ b/app/views/support_interface/tasks/create_fake_provider.html.erb
@@ -1,0 +1,12 @@
+<% content_for :before_content, govuk_back_link_to(support_interface_tasks_path) %>
+<% content_for :title, 'New fake provider' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render SummaryListComponent.new(rows: [
+      { key: 'Provider name', value: @new_provider.name },
+      { key: 'Provider code', value: @new_provider.code },
+      { key: 'Vendor API token', value: @vendor_api_token },
+    ]) %>
+  </div>
+</div>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -32,4 +32,12 @@
     </div>
     <%= button_to 'Generate providers for vendors', support_interface_run_task_path('create_vendor_providers'), class: 'govuk-button' %>
   </div>
+
+  <div>
+    <h2 class='govuk-heading-m'>Fake provider for vendors</h2>
+    <div class='govuk-body'>
+      This will generate a fake provider with 10 courses and 3 ratified courses. You will be shown their name, code and vendor API token.
+    </div>
+    <%= button_to 'Generate a fake provider for a vendor', support_interface_tasks_create_fake_provider_path, class: 'govuk-button' %>
+  </div>
 <% end %>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -28,7 +28,7 @@
   <div>
     <h2 class='govuk-heading-m'>Vendor providers</h2>
     <div class='govuk-body'>
-      This will generate providers for providers to test with.
+      This will generate providers for providers to test with. It also generates 10 courses run by those providers and 3 courses ratified by them.
     </div>
     <%= button_to 'Generate providers for vendors', support_interface_run_task_path('create_vendor_providers'), class: 'govuk-button' %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -653,6 +653,7 @@ Rails.application.routes.draw do
     get '/performance/candidate-journey-tracking', to: 'performance#candidate_journey_tracking', as: :candidate_journey_tracking
 
     get '/tasks' => 'tasks#index', as: :tasks
+    post '/tasks/create-fake-provider' => 'tasks#create_fake_provider'
     post '/tasks/:task' => 'tasks#run', as: :run_task
 
     get '/validation-errors' => 'validation_errors#index', as: :validation_errors

--- a/spec/services/generate_fake_provider_spec.rb
+++ b/spec/services/generate_fake_provider_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe GenerateFakeProvider do
+  let(:provider_hash) { { name: 'Fake Provider', code: 'FAKE' } }
+
+  subject(:generate_provider_call) { described_class.generate_provider(provider_hash) }
+
+  describe '.generate_provider' do
+    it 'raises an error in production' do
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+        expect { generate_provider_call }.to raise_error(RuntimeError, 'You can\'t generate test data in production')
+      end
+    end
+
+    it 'generates a new provider and a test training provider for ratified courses' do
+      expect { generate_provider_call }
+        .to change { Provider.count }.by(2)
+    end
+
+    it 'generates courses run by the provider' do
+      generate_provider_call
+
+      expect(Provider.find_by(code: 'FAKE').courses.count).to eq(10)
+    end
+
+    it 'generates ratified courses' do
+      generate_provider_call
+
+      expect(Provider.find_by(code: 'FAKE').accredited_courses.count).to eq(3)
+    end
+  end
+end

--- a/spec/services/generate_vendor_providers_spec.rb
+++ b/spec/services/generate_vendor_providers_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe GenerateVendorProviders do
+  describe '#call' do
+    it 'raises an error in production' do
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+        expect { described_class.call }.to raise_error(RuntimeError, 'You can\'t generate test data in production')
+      end
+    end
+
+    it 'generates provider vendor data' do
+      expect { described_class.call }
+        .to change { Provider.count }.by(10)
+    end
+  end
+end

--- a/spec/services/generate_vendor_providers_spec.rb
+++ b/spec/services/generate_vendor_providers_spec.rb
@@ -10,7 +10,20 @@ RSpec.describe GenerateVendorProviders do
 
     it 'generates provider vendor data' do
       expect { described_class.call }
-        .to change { Provider.count }.by(10)
+        .to change { Provider.count }.by(11)
+        .and change { Course.count }.by(130)
+    end
+
+    it 'generates courses' do
+      described_class.call
+
+      expect(Provider.find_by(code: 'B35').courses.count).to eq(10)
+    end
+
+    it 'generates ratified courses' do
+      described_class.call
+
+      expect(Provider.find_by(code: 'B35').accredited_courses.count).to eq(3)
     end
   end
 end

--- a/spec/system/support_interface/tasks_spec.rb
+++ b/spec/system/support_interface/tasks_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature 'Tasks', sidekiq: false do
     when_i_visit_the_support_tasks_page
     and_i_click_on_generate_test_applications
     then_i_see_that_the_job_has_been_scheduled
+
+    and_when_i_click_on_generate_fake_provider
+    then_i_see_new_providers_details_and_api_token
+    and_i_am_able_to_connect_to_the_api_using_the_token
   end
 
   def given_i_am_a_support_user
@@ -25,5 +29,24 @@ RSpec.feature 'Tasks', sidekiq: false do
 
   def then_i_see_that_the_job_has_been_scheduled
     expect(page).to have_content 'Scheduled job to generate test applications'
+  end
+
+  def and_when_i_click_on_generate_fake_provider
+    click_button 'Generate a fake provider for a vendor'
+  end
+
+  def then_i_see_new_providers_details_and_api_token
+    expect(page).to have_content 'Provider name'
+    expect(page).to have_content 'Provider code'
+    expect(page).to have_content 'Vendor API token'
+  end
+
+  def and_i_am_able_to_connect_to_the_api_using_the_token
+    api_token = find('div .govuk-summary-list').all('dd')[2].text
+    page.driver.header 'Authorization', "Bearer #{api_token}"
+
+    visit '/api/v1/ping'
+
+    expect(page).to have_content('pong')
   end
 end


### PR DESCRIPTION
## Context

There are some providers, who need a "fake" provider to test features they can't test on the real one. In the case of UCB, they have many courses on Find, but only one is published. At some future date more of their courses might become available via Find and Apply. They therefore have an interest in testing cross-course features like making offers to different courses, but using the current data they only have a single course to work with so they can't.

It's also plausible that providers will need to test various relationships with accredited bodies.

Also some courses were getting full on Find so we need to add more courses for vendors to test with.

## Changes proposed in this pull request
- Add a new task to Support interface which generates a fake provider with 10 courses and 3 ratified courses as well as an API token
- Refactor GenerateVendorProviders to use the new service and therefore
  - create 10 courses
  - create a Test providers as a part of Generate vendor providers
  - create 3 courses as a ratifying provider for 10 providers with the Test provider running the training

<kbd><img width="676" alt="Screenshot 2020-07-14 at 19 46 19" src="https://user-images.githubusercontent.com/38078064/87466997-270a0a80-c60f-11ea-935f-9d30e6c67324.png"></kbd>
<kbd><img width="834" alt="Screenshot 2020-07-14 at 19 45 48" src="https://user-images.githubusercontent.com/38078064/87467006-2bcebe80-c60f-11ea-9b46-5ae7177103af.png"></kbd>


## Guidance to review

- click "Generate providers for vendors" http://localhost:3000/support/tasks 
- check in the console if the providers and courses were created

- click "Generate a fake provider for a vendor"

## Link to Trello card

https://trello.com/c/FID7u4VU/2385-generate-a-fake-provider-with-multiple-courses-in-sandbox

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
