### PR TITLE
Only show Organisation nav item when there are organisations to manage

### DIFF
--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -41,7 +41,7 @@ class NavigationItems
 
       items = [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]
 
-      if current_provider_user.can_manage_organisations?
+      if current_provider_user.can_manage_organisations? && Provider.with_permissions_visible_to(current_provider_user).exists?
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 

--- a/spec/models/navigation_items_spec.rb
+++ b/spec/models/navigation_items_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe NavigationItems do
+  describe '.for_provider_interface' do
+    let(:provider) { create(:provider) }
+    let(:provider_user) { create(:provider_user, providers: [provider]) }
+    let(:controller) { ProviderInterface::ProviderInterfaceController }
+
+    subject(:navigation_items) { NavigationItems.for_provider_interface(provider_user, controller) }
+
+    context 'when the user can manage organisations and there are no provider relationships to manage' do
+      before { provider_user.provider_permissions.find_by(provider: provider).update!(manage_organisations: true) }
+
+      it 'does not include a link to Organisations' do
+        expect(navigation_items.map(&:text)).not_to include('Organisations')
+      end
+    end
+
+    context 'when the user can manage organisations and there are provider relationships to manage' do
+      before do
+        provider_user.provider_permissions.find_by(provider: provider).update!(manage_organisations: true)
+        create(:training_provider_permissions, training_provider: provider)
+      end
+
+      it 'includes a link to Organisations' do
+        expect(navigation_items.map(&:text)).to include('Organisations')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently the 'Organisations' navigation link is present when the user has the user-level permission to manage organisations.
This can link to an empty organisations index if there are no `ProviderRelationshipPermissions` associated with the current user's Providers.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This should only link to the organisations index if the user level permissions can manage organisations is present
and provider relationship permissions related to the current user's providers exist.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TZKXEZyt/2393-organisations-link-shows-in-the-header-even-when-the-current-user-has-no-organisations-to-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
