### PR TITLE
Merge "provider_add_provider_users" and "provider_make_decisions_restriction" flags

### DIFF
--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class ProviderUsersController < ProviderInterfaceController
-    before_action :requires_provider_add_provider_users_feature_flag
+    before_action :require_feature_flag
     before_action :redirect_unless_permitted_to_manage_users
 
     def index
@@ -104,8 +104,8 @@ module ProviderInterface
             .to_h
     end
 
-    def requires_provider_add_provider_users_feature_flag
-      render_404 unless FeatureFlag.active?('provider_add_provider_users')
+    def require_feature_flag
+      render_404 unless FeatureFlag.active?(:providers_can_manage_users_and_permissions)
     end
 
     def redirect_unless_permitted_to_manage_users

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -45,7 +45,7 @@ class NavigationItems
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 
-      if FeatureFlag.active?('provider_add_provider_users') && current_provider_user.can_manage_users?
+      if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.can_manage_users?
         items << NavigationItem.new('Users', provider_interface_provider_users_path, is_active(current_controller, 'provider_users'))
       end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,10 +23,9 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:provider_add_provider_users, 'Allows provider users to invite other provider users', 'Steve Laing'],
+    [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
     [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],
     [:provider_view_safeguarding, 'Allows providers to see whether a candidate has declared safeguarding issues', 'Will McBrien'],
-    [:provider_make_decisions_restriction, 'Restricts ability to respond to users with make_decision permission', 'Michael Nacos'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],

--- a/app/services/offer_authorisation.rb
+++ b/app/services/offer_authorisation.rb
@@ -10,20 +10,20 @@ class OfferAuthorisation
     training_provider = course_option.provider
     ratifying_provider = course_option.course.accredited_provider
 
-    # enforce org-level 'make_decisions' restriction
-    return false if ratifying_provider &&
-      FeatureFlag.active?(:enforce_provider_to_provider_permissions) &&
-      FeatureFlag.active?(:providers_can_manage_users_and_permissions) &&
-      provider_relationship_permissions_for_actor(
-        training_provider: training_provider,
-        ratifying_provider: ratifying_provider,
-      ).none?(&:make_decisions)
+    if FeatureFlag.active?(:providers_can_manage_users_and_permissions)
+      # enforce user-level 'make_decisions' restriction
+      related_providers = [training_provider, ratifying_provider].compact
+      return false if !actor_has_permission_to_make_decisions?(providers: related_providers)
 
-    # enforce user-level 'make_decisions' restriction
-    related_providers = [training_provider, ratifying_provider].compact
-    return false if
-      FeatureFlag.active?(:providers_can_manage_users_and_permissions) &&
-        !actor_has_permission_to_make_decisions?(providers: related_providers)
+      if FeatureFlag.active?(:enforce_provider_to_provider_permissions)
+        # enforce org-level 'make_decisions' restriction
+        return false if ratifying_provider &&
+          provider_relationship_permissions_for_actor(
+            training_provider: training_provider,
+            ratifying_provider: ratifying_provider,
+          ).none?(&:make_decisions)
+      end
+    end
 
     # check (indirect) relationship between course_option and @actor
     if course_option_id != application_choice.course_option.id

--- a/app/services/offer_authorisation.rb
+++ b/app/services/offer_authorisation.rb
@@ -13,7 +13,7 @@ class OfferAuthorisation
     # enforce org-level 'make_decisions' restriction
     return false if ratifying_provider &&
       FeatureFlag.active?(:enforce_provider_to_provider_permissions) &&
-      FeatureFlag.active?('provider_make_decisions_restriction') &&
+      FeatureFlag.active?(:providers_can_manage_users_and_permissions) &&
       provider_relationship_permissions_for_actor(
         training_provider: training_provider,
         ratifying_provider: ratifying_provider,
@@ -22,7 +22,7 @@ class OfferAuthorisation
     # enforce user-level 'make_decisions' restriction
     related_providers = [training_provider, ratifying_provider].compact
     return false if
-      FeatureFlag.active?('provider_make_decisions_restriction') &&
+      FeatureFlag.active?(:providers_can_manage_users_and_permissions) &&
         !actor_has_permission_to_make_decisions?(providers: related_providers)
 
     # check (indirect) relationship between course_option and @actor

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -22,10 +22,8 @@
                     <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
                     <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
                                             label: { text: 'View safeguarding information' } %>
-                    <% if FeatureFlag.active?('provider_make_decisions_restriction') %>
                     <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
                                             label: { text: 'Make decisions' } %>
-                    <% end %>
                   <% end %>
                 <% end %>
               <% end %>

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -2,9 +2,7 @@
 
 <h1 class="govuk-heading-xl">Users</h1>
 
-<% if FeatureFlag.active?('provider_add_provider_users') -%>
-  <%= link_to 'Invite user', new_provider_interface_provider_user_path, class: 'govuk-button' %>
-<% end -%>
+<%= link_to 'Invite user', new_provider_interface_provider_user_path, class: 'govuk-button' %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -54,7 +54,7 @@
         <h2 class="govuk-heading-m">View applications</h2>
         <p class="govuk-body">See newly submitted applications at a glance.</p>
         <p class="govuk-body">Filter by status, training provider, ratifying body – and soon, reject by default date.</p>
-      <% if FeatureFlag.active?('provider_add_provider_users') %>
+      <% if FeatureFlag.active?(:providers_can_manage_users_and_permissions) %>
         <p class="govuk-body">Choose who in your organisation can make decisions and view sensitive info.</p>
       <% end %>
       </div>

--- a/spec/requests/provider_interface/managing_provider_users_spec.rb
+++ b/spec/requests/provider_interface/managing_provider_users_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'ProviderUserController actions' do
   let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
 
   before do
-    FeatureFlag.activate('provider_add_provider_users')
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
 
     allow(DfESignInUser).to receive(:load_from_session)
       .and_return(

--- a/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
   let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
 
   before do
-    FeatureFlag.activate('provider_add_provider_users')
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
 
     allow(DfESignInUser).to receive(:load_from_session)
       .and_return(

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe MakeAnOffer, sidekiq: true do
     end
 
     it 'raises error if actor does not have make_decisions permission' do
-      FeatureFlag.activate('provider_make_decisions_restriction')
+      FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
       unauthorised_user = create(:provider_user, :with_provider)
       course = create(:course, :open_on_apply, provider: unauthorised_user.providers.first)
       course_option = create(:course_option, course: course)

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe ProviderAuthorisation do
 
     context 'actor: provider user (org-level permissions)' do
       before do
-        FeatureFlag.activate('enforce_provider_to_provider_permissions')
-        FeatureFlag.activate('provider_make_decisions_restriction')
+        FeatureFlag.activate(:enforce_provider_to_provider_permissions)
+        FeatureFlag.activate(:providers_can_manage_users_and_permissions)
       end
 
       it 'training_provider without make_decisions' do
@@ -100,7 +100,7 @@ RSpec.describe ProviderAuthorisation do
     end
 
     context 'actor: provider user (user-level permissions)' do
-      before { FeatureFlag.activate('provider_make_decisions_restriction') }
+      before { FeatureFlag.activate(:providers_can_manage_users_and_permissions) }
 
       it 'training_provider_user without make_decisions' do
         training_provider_user.provider_permissions.update_all(make_decisions: false)
@@ -158,8 +158,8 @@ RSpec.describe ProviderAuthorisation do
 
     context 'actor: api user (org-level permissions)' do
       before do
-        FeatureFlag.activate('enforce_provider_to_provider_permissions')
-        FeatureFlag.activate('provider_make_decisions_restriction')
+        FeatureFlag.activate(:enforce_provider_to_provider_permissions)
+        FeatureFlag.activate(:providers_can_manage_users_and_permissions)
       end
 
       it 'is false for training_provider without make_decisions' do

--- a/spec/support/test_helpers/provider_user_permissions_helper.rb
+++ b/spec/support/test_helpers/provider_user_permissions_helper.rb
@@ -1,6 +1,6 @@
 module ProviderUserPermissionsHelper
   def permit_make_decisions!(dfe_sign_in_uid: 'DFE_SIGN_IN_UID', provider: nil)
-    FeatureFlag.activate 'provider_make_decisions_restriction'
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
 
     provider_user = ProviderUser.find_by_dfe_sign_in_uid dfe_sign_in_uid
     permissions = if provider
@@ -13,7 +13,7 @@ module ProviderUserPermissionsHelper
   end
 
   def deny_make_decisions!(dfe_sign_in_uid: 'DFE_SIGN_IN_UID', provider: nil)
-    FeatureFlag.activate 'provider_make_decisions_restriction'
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
 
     provider_user = ProviderUser.find_by_dfe_sign_in_uid dfe_sign_in_uid
     permissions = if provider

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -4,9 +4,9 @@ RSpec.feature 'Managing provider user permissions' do
   include DfESignInHelpers
 
   scenario 'Provider manages permissions for users' do
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_provider_add_provider_users_feature_is_enabled
-    and_the_make_decisions_restriction_feature_flag_is_active
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider
     and_i_sign_in_to_the_provider_interface
@@ -48,10 +48,6 @@ RSpec.feature 'Managing provider user permissions' do
   def and_i_can_manage_users_for_a_provider
     @managed_user = create(:provider_user, providers: [@provider])
     @managing_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
-  end
-
-  def and_the_provider_add_provider_users_feature_is_enabled
-    FeatureFlag.activate('provider_add_provider_users')
   end
 
   def when_i_click_on_the_users_link
@@ -118,10 +114,6 @@ RSpec.feature 'Managing provider user permissions' do
     within("#provider-#{@provider.id}-enabled-permissions") do
       expect(page).to have_content 'View safeguarding information'
     end
-  end
-
-  def and_the_make_decisions_restriction_feature_flag_is_active
-    FeatureFlag.activate('provider_make_decisions_restriction')
   end
 
   def and_i_add_permission_to_make_decisions_for_a_provider_user

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -5,8 +5,9 @@ RSpec.feature 'Provider invites a new provider user' do
   include DsiAPIHelper
 
   scenario 'Provider sends invite to user' do
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_provider_add_provider_users_feature_is_enabled
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider
     and_i_sign_in_to_the_provider_interface
@@ -41,10 +42,6 @@ RSpec.feature 'Provider invites a new provider user' do
 
   def and_i_can_manage_users_for_a_provider
     @provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
-  end
-
-  def and_the_provider_add_provider_users_feature_is_enabled
-    FeatureFlag.activate('provider_add_provider_users')
   end
 
   def and_i_click_invite_user

--- a/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
@@ -5,8 +5,9 @@ RSpec.feature 'Provider invites a new provider user' do
   include DsiAPIHelper
 
   scenario 'Provider use can see their individual users permissions' do
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_provider_add_provider_users_feature_is_enabled
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider
     and_i_sign_in_to_the_provider_interface
@@ -34,10 +35,6 @@ RSpec.feature 'Provider invites a new provider user' do
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
-  end
-
-  def and_the_provider_add_provider_users_feature_is_enabled
-    FeatureFlag.activate('provider_add_provider_users')
   end
 
   def and_i_can_manage_applications_for_two_providers

--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe 'Removing a provider user' do
   include DfESignInHelpers
 
   scenario 'removing a user from all providers' do
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_provider_add_provider_users_feature_is_enabled
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider
     and_a_provider_user_with_many_providers_exists
@@ -25,10 +26,6 @@ RSpec.describe 'Removing a provider user' do
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
-  end
-
-  def and_the_provider_add_provider_users_feature_is_enabled
-    FeatureFlag.activate('provider_add_provider_users')
   end
 
   def and_i_can_manage_applications_for_two_providers


### PR DESCRIPTION
## Context

We currently have 3 feature flags that interact with each other. The `provider_add_provider_users` flag allows providers to add other providers. `provider_make_decisions_restriction` allows the providers to then restrict some users from making decisions (the third `enforce_provider_to_provider_permissions` then extends this to provider-to-provider permissions, which we're not touching at the moment).

## Changes proposed in this pull request

This PR merges the 2 feature flags, because we're going to launch the features at the same time. It also makes it easier to understand the code. Additionally it makes some refactoring related to the flags.

## Guidance to review

Per commit.

## Link to Trello card

https://trello.com/c/sCTl8idK

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
