### PR TITLE
Update design for provider users in Support

### DIFF
--- a/app/components/check_icon.html.erb
+++ b/app/components/check_icon.html.erb
@@ -1,0 +1,3 @@
+<svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+   <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+</svg>

--- a/app/components/check_icon.rb
+++ b/app/components/check_icon.rb
@@ -1,0 +1,2 @@
+class CheckIcon < ViewComponent::Base
+end

--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -1,0 +1,19 @@
+<ul class='govuk-list'>
+  <li><%= render CheckIcon.new %> View applications</li>
+
+  <% if @permission_model.manage_users? %>
+    <li><%= render CheckIcon.new %> Manage users</li>
+  <% end %>
+
+  <% if @permission_model.manage_organisations? %>
+    <li><%= render CheckIcon.new %> Manage organisations</li>
+  <% end %>
+
+  <% if @permission_model.view_safeguarding_information? %>
+    <li><%= render CheckIcon.new %> View safeguarding information</li>
+  <% end %>
+
+  <% if @permission_model.make_decisions? %>
+    <li><%= render CheckIcon.new %> Make decisions</li>
+  <% end %>
+</ul>

--- a/app/components/permissions_list.rb
+++ b/app/components/permissions_list.rb
@@ -1,0 +1,5 @@
+class PermissionsList < ViewComponent::Base
+  def initialize(permission_model)
+    @permission_model = permission_model
+  end
+end

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -2,6 +2,7 @@ class SummaryListComponent < ViewComponent::Base
   validates :rows, presence: true
 
   def initialize(rows:)
+    rows = transform_hash(rows) if rows.is_a?(Hash)
     @rows = rows
   end
 
@@ -12,4 +13,13 @@ class SummaryListComponent < ViewComponent::Base
 private
 
   attr_reader :rows
+
+  def transform_hash(row_hash)
+    row_hash.map do |key, value|
+      {
+        key: key,
+        value: value,
+      }
+    end
+  end
 end

--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -2,9 +2,8 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Email address</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and email address</th>
         <th scope="col" class="govuk-table__header">Providers</th>
-        <th scope="col" class="govuk-table__header">DfE Sign-in UID</th>
         <th scope="col" class="govuk-table__header">Last signed in at</th>
       </tr>
     </thead>
@@ -12,9 +11,18 @@
     <tbody class="govuk-table__body">
       <% table_rows.each do |row| %>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= row[:email_address] %></td>
-          <td class="govuk-table__cell"><%= row[:links_to_providers].html_safe %></td>
-          <td class="govuk-table__cell"><%= row[:dfe_sign_in_uid] %></td>
+          <td class="govuk-table__cell">
+            <%= govuk_link_to(row[:provider_user].full_name, edit_support_interface_provider_user_path(row[:provider_user])) %><br/>
+            <span style='word-break: break-all;'><%= row[:provider_user].email_address %></span>
+          </td>
+          <td class="govuk-table__cell">
+            <% row[:provider_user].provider_permissions.each do |permission| %>
+              <div class='govuk-!-margin-bottom-2'>
+                <h3 class='govuk-heading-s'><%= permission.provider.name_and_code %></h3>
+                <%= render PermissionsList.new(permission) %>
+              </div>
+            <% end %>
+          </td>
           <% if row[:last_signed_in_at] %>
             <td class="govuk-table__cell"><%= row[:last_signed_in_at] %></td>
           <% else %>
@@ -23,7 +31,7 @@
             <% else %>
               <td class="govuk-table__cell"><em>Never signed in</em></td>
             <% end %>
-          <%end %>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/components/support_interface/provider_users_table_component.rb
+++ b/app/components/support_interface/provider_users_table_component.rb
@@ -9,9 +9,7 @@ module SupportInterface
     def table_rows
       provider_users.map do |provider_user|
         {
-          email_address: govuk_link_to(provider_user.email_address, edit_support_interface_provider_user_path(provider_user)),
-          links_to_providers: links_to_providers(provider_user),
-          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          provider_user: provider_user,
           created_at: provider_user.created_at,
           last_signed_in_at: last_signed_in_at(provider_user),
         }
@@ -20,14 +18,6 @@ module SupportInterface
 
     def last_signed_in_at(provider_user)
       provider_user.last_signed_in_at&.to_s(:govuk_date_and_time)
-    end
-
-    def links_to_providers(provider_user)
-      links = provider_user.providers.map do |p|
-        govuk_link_to(p.name, support_interface_provider_path(p))
-      end
-
-      links.join(', ')
     end
 
   private

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -35,10 +35,8 @@ module SupportInterface
       provider_user = ProviderUser.find(params[:id])
 
       @form = ProviderUserForm.new(
-        provider_user_params.merge(
-          provider_user: provider_user,
-          provider_permissions: provider_permissions_params,
-        ),
+        provider_user: provider_user,
+        provider_permissions: provider_permissions_params,
       )
 
       service = SaveProviderUser.new(

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Provider', tag: 'h2' } do %>
+<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Providers and permissions', tag: 'h2' } do %>
   <div class="app-checkboxes-scroll" %>
     <% f.object.forms_for_possible_permissions.each do |permission_form| %>
       <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>

--- a/app/views/support_interface/provider_users/audits.html.erb
+++ b/app/views/support_interface/provider_users/audits.html.erb
@@ -1,3 +1,5 @@
+<% content_for :browser_title, "Audit trail for provider user #{@provider_user.full_name}" %>
+
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
@@ -13,6 +15,10 @@
     </ol>
   </div>
 
+  <h1 class='govuk-heading-xl'>
+    Provider user <%= @provider_user.full_name %> - Audit Trail
+  </h1>
+
   <%= render SubNavigationComponent.new(items: [
     { name: 'Details', url: edit_support_interface_provider_user_path(@provider_user) },
     { name: 'Audit trail', url: support_interface_provider_user_audits_path(@provider_user), current: true },
@@ -20,10 +26,6 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <h1 class='govuk-heading-xl'>
-    <%= @provider_user.email_address %>
-  </h1>
-
   <div class="govuk-grid-column-two-thirds">
     <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider_user) %>
   </div>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -39,14 +39,6 @@
         'Last sign in at' => @form.provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet',
       }) %>
 
-      <% if @form.provider_user.dfe_sign_in_uid.present? %>
-        <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
-      <% else %>
-        <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' }, disabled: true, hint_text: 'The email address is not editable until the user has signed in for the first time. This is to ensure it continues to match the email on their DfE Sign-in invitation' %>
-      <% end %>
-      <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
-      <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
-
       <%= render 'provider_options', f: f %>
 
       <%= f.govuk_submit 'Update user' %>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -1,3 +1,5 @@
+  <% content_for :browser_title, "Edit provider user #{@form.provider_user.full_name}" %>
+
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
@@ -13,6 +15,10 @@
     </ol>
   </div>
 
+  <h1 class='govuk-heading-xl'>
+    Provider user <%= @form.provider_user.full_name %> - Edit
+  </h1>
+
   <%= render SubNavigationComponent.new(items: [
     { name: 'Details', url: support_interface_provider_user_path(@form.provider_user), current: true },
     { name: 'Audit trail', url: support_interface_provider_user_audits_path(@form.provider_user) },
@@ -24,9 +30,14 @@
     <%= form_with model: @form, url: support_interface_provider_user_path(@form.provider_user) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class='govuk-heading-xl'>
-        Edit provider user
-      </h1>
+      <%= render SummaryListComponent.new(rows: {
+        'First name' => @form.provider_user.first_name,
+        'Last name' => @form.provider_user.last_name,
+        'Email address' => @form.provider_user.email_address,
+        'DfE Signin UID' => @form.provider_user.dfe_sign_in_uid,
+        'Account created at' => @form.provider_user.created_at.to_s(:govuk_date_and_time),
+        'Last sign in at' => @form.provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet',
+      }) %>
 
       <% if @form.provider_user.dfe_sign_in_uid.present? %>
         <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -34,7 +34,7 @@
         'First name' => @form.provider_user.first_name,
         'Last name' => @form.provider_user.last_name,
         'Email address' => @form.provider_user.email_address,
-        'DfE Signin UID' => @form.provider_user.dfe_sign_in_uid,
+        'DfE Sign-in UID' => @form.provider_user.dfe_sign_in_uid,
         'Account created at' => @form.provider_user.created_at.to_s(:govuk_date_and_time),
         'Last sign in at' => @form.provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet',
       }) %>

--- a/spec/components/support_interface/provider_users_table_component_spec.rb
+++ b/spec/components/support_interface/provider_users_table_component_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe SupportInterface::ProviderUsersTableComponent do
       [
         create(:provider_user,
                email_address: 'provider@example.com',
-               dfe_sign_in_uid: 'ABCDEF',
                last_signed_in_at: DateTime.new(2019, 12, 1, 10, 45, 0),
                providers: [create(:provider, name: 'The Provider')]),
       ]
@@ -20,7 +19,6 @@ RSpec.describe SupportInterface::ProviderUsersTableComponent do
 
     it 'renders all the fields' do
       expect(rendered_component).to include('provider@example.com')
-      expect(rendered_component).to include('ABCDEF')
       expect(rendered_component).to include('The Provider')
       expect(rendered_component).to include('1 December 2019 at 10:45am')
     end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_i_click_on_that_user
-    click_link 'harrison@example.com'
+    click_link 'Harrison Bergeron'
   end
 
   def when_i_add_them_to_another_organisation

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -33,16 +33,10 @@ RSpec.feature 'Managing provider users' do
     and_i_should_see_the_user_i_created
     and_the_user_should_be_sent_a_welcome_email
 
-    when_the_user_has_not_signed_in_yet
     and_i_click_on_that_user
-    then_their_email_should_not_be_editable
 
     when_i_add_them_to_another_organisation
     then_i_see_that_they_have_been_added_to_that_organisation
-
-    when_they_have_signed_in_at_least_once
-    and_i_reload_the_page
-    then_their_email_should_be_editable
     and_they_should_be_able_to_manage_users
     and_they_should_be_able_to_manage_organisations
     and_they_should_be_able_to_view_safeguarding_information
@@ -174,13 +168,6 @@ RSpec.feature 'Managing provider users' do
     expect(page).to have_checked_field('Another provider (DEF)')
   end
 
-  def when_the_user_has_not_signed_in_yet; end
-
-  def then_their_email_should_not_be_editable
-    expect(page).to have_field 'Email address', disabled: true
-    expect(page).to have_content 'The email address is not editable'
-  end
-
   def when_i_click_the_audit_trail_tab
     click_on 'Audit trail'
   end
@@ -188,19 +175,6 @@ RSpec.feature 'Managing provider users' do
   def then_i_should_see_the_audit_trail_for_that_user_record
     expect(page).to have_content 'Create Provider User'
     expect(page).to have_content 'email_address harrison@example.com'
-  end
-
-  def when_they_have_signed_in_at_least_once
-    @user = ProviderUser.find_by(email_address: 'harrison@example.com')
-    @user.update!(dfe_sign_in_uid: 'ABC123')
-  end
-
-  def and_i_reload_the_page
-    page.refresh
-  end
-
-  def then_their_email_should_be_editable
-    expect(page).to have_field 'Email address', disabled: false
   end
 
   def and_they_should_be_able_to_manage_users


### PR DESCRIPTION
## Context

We're going to be introducing more permissions for providers, but we haven't updated the provider user screens in a long time. 

## Changes proposed in this pull request

The provider list before:

![image](https://user-images.githubusercontent.com/233676/86927550-5e6a4a00-c12b-11ea-9f80-fd79037877ae.png)

After:

![image](https://user-images.githubusercontent.com/233676/86927468-4b577a00-c12b-11ea-989d-304606852357.png)

Things that have changed:

- Add the name of the provider user because that's useful to know
- Remove the DSI UID because it's only for 🤓 
- Add a list of permissions the user has. Controversy alert: I've added the implicit permission "View applications" as well, because otherwise the list would be empty, and I feel it's a permission. It's in a component that we might be able to reuse for the provider UI.

Provider user page before:

![image](https://user-images.githubusercontent.com/233676/86927843-bbfe9680-c12b-11ea-8ba8-6739f0d417cd.png)

And after:

![image](https://user-images.githubusercontent.com/233676/86929327-a12d2180-c12d-11ea-88a4-be48f7bb1a65.png)

Things that have changed:

- A list of things we know about the user in a summary list
- Remove the form fields - these attributes can only be edited in DfE Signin 
- Add provider name to the title

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/aIg23O4H/438-turn-on-providers-managing-provider-users-feature-flag

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
