### PR TITLE
SPIKE: Set up ProviderUser permissions with a session-backed wizard

### DIFF
--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -1,0 +1,181 @@
+module ProviderInterface
+  class ProviderUsersInvitationsController < ProviderInterfaceController
+    WIZARD_STATE_SESSION_KEY = :provider_user_invitation_wizard
+
+    class ProviderPermissionsForm
+      include ActiveModel::Model
+
+      Permission = Struct.new(:slug, :name)
+
+      attr_accessor :provider_id, :permissions
+
+      def available_permissions
+        [
+          Permission.new('manage_users', 'Manage users'),
+          Permission.new('make_decisions', 'Make decisions'),
+        ]
+      end
+
+      def provider
+        Provider.find(provider_id)
+      end
+
+      alias_method :id, :provider_id
+    end
+
+    def wizard_state
+      { _state: session[WIZARD_STATE_SESSION_KEY].presence || {} }
+    end
+
+    def save_wizard_state!
+      session[WIZARD_STATE_SESSION_KEY] = @wizard.state
+    end
+
+    def clear_wizard_state!
+      session.delete(WIZARD_STATE_SESSION_KEY)
+    end
+
+    def edit_details
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'details', returning_to_answered_question: params[:change]))
+      save_wizard_state!
+    end
+
+    def update_details
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(wizard_params))
+
+      if @wizard.valid_for_current_step?
+        save_wizard_state!
+        redirect_to next_redirect(@wizard)
+      else
+        render :edit_details
+      end
+    end
+
+    def edit_providers
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'providers', returning_to_answered_question: params[:change]))
+      save_wizard_state!
+
+      @available_providers = current_provider_user.providers
+    end
+
+    def update_providers
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(wizard_params))
+      @available_providers = current_provider_user.providers
+
+      if @wizard.valid_for_current_step?
+        save_wizard_state!
+        redirect_to next_redirect(@wizard)
+      else
+        render :edit_providers
+      end
+    end
+
+    def edit_permissions
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'permissions', returning_to_answered_question: params[:change]))
+      save_wizard_state!
+
+      @permissions_form = ProviderPermissionsForm.new(@wizard.permissions_for(params[:provider_id]))
+    end
+
+    def update_permissions
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(wizard_params))
+      save_wizard_state!
+
+      redirect_to next_redirect(@wizard)
+    end
+
+    def check
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'check'))
+    end
+
+    def commit
+      @wizard = ProviderUserInvitationWizard.new(wizard_state)
+
+      clear_wizard_state!
+
+      flash[:success] = 'User successfully invited'
+      redirect_to provider_interface_provider_users_path
+    end
+
+    def next_redirect(wizard)
+      if wizard.returning_to_answered_question
+        if wizard.has_permissions_to_set?
+          { action: :edit_permissions, provider_id: wizard.next_provider_requiring_permissions_setup }
+       else # carry on back to the check answers page
+          { action: :check }
+        end
+      elsif wizard.current_step == 'details'
+        { action: :edit_providers }
+      elsif wizard.current_step == 'providers' && wizard.has_permissions_to_set?
+        { action: :edit_permissions, provider_id: wizard.next_provider_requiring_permissions_setup }
+      elsif wizard.current_step == 'permissions' && wizard.has_permissions_to_set?
+        { action: :edit_permissions, provider_id: wizard.next_provider_requiring_permissions_setup }
+      else
+        { action: :check }
+      end
+    end
+
+    def wizard_params
+      params.require(:provider_interface_provider_user_invitation_wizard)
+        .permit(:change_answer, :first_name, providers: [], provider_permissions: {})
+    end
+  end
+
+  class ProviderUserInvitationWizard
+    include ActiveModel::Model
+
+    attr_accessor :current_step, :first_name, :returning_to_answered_question
+    attr_writer :providers, :provider_permissions, :_state
+
+    validates :first_name, presence: true, on: :details
+    validates :providers, presence: true, on: :providers
+
+    def initialize(attrs)
+      state = attrs[:_state].presence || '{}'
+      attrs_incl_state = JSON.parse(state).deep_merge(attrs)
+      super(attrs_incl_state)
+    end
+
+    def valid_for_current_step?
+      valid?(current_step.to_sym)
+    end
+
+    def save!
+      raise '💾'
+    end
+
+    def state
+      as_json(except: %w[_state change_answer errors validation_context]).to_json
+    end
+
+    def providers
+      if @providers
+        @providers.reject(&:blank?).map(&:to_i)
+      else
+        []
+      end
+    end
+
+    def provider_permissions
+      @provider_permissions || {}
+    end
+
+    def applicable_provider_permissions
+      @provider_permissions.select do |id, _details|
+        providers.include?(id.to_i)
+      end
+    end
+
+    def permissions_for(provider_id)
+      provider_permissions[provider_id].presence || { provider_id: provider_id, permissions: [] }
+    end
+
+    def next_provider_requiring_permissions_setup
+      providers.find { |p| provider_permissions.keys.exclude?(p.to_s) }
+    end
+
+    def has_permissions_to_set?
+      next_provider_requiring_permissions_setup.present?
+    end
+  end
+end

--- a/app/views/provider_interface/provider_users_invitations/check.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/check.html.erb
@@ -1,0 +1,20 @@
+name <%= @wizard.first_name %><br />
+
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_basic_details_path(change: true) %>
+
+<br />
+
+providers <%= @wizard.providers.map { |p| Provider.find(p).name } %><br />
+
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_providers_path(change: true) %>
+
+<br />
+
+permissions
+<% @wizard.applicable_provider_permissions.map do |p, details| %>
+  <%= "#{Provider.find(p).name}, perms: #{details['permissions'].reject(&:blank?).join(',')}" %>
+  <%= govuk_link_to 'Change', provider_interface_edit_invitation_provider_permissions_path(change: true, provider_id: p) %>
+<% end %>
+
+
+<%= button_to 'Invite user', provider_interface_commit_invitation_path, class: 'govuk-button' %>

--- a/app/views/provider_interface/provider_users_invitations/check.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/check.html.erb
@@ -1,19 +1,19 @@
 name <%= @wizard.first_name %><br />
 
-<%= govuk_link_to 'Change', provider_interface_edit_invitation_basic_details_path(change: true) %>
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_basic_details_path %>
 
 <br />
 
 providers <%= @wizard.providers.map { |p| Provider.find(p).name } %><br />
 
-<%= govuk_link_to 'Change', provider_interface_edit_invitation_providers_path(change: true) %>
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_providers_path %>
 
 <br />
 
 permissions
 <% @wizard.applicable_provider_permissions.map do |p, details| %>
   <%= "#{Provider.find(p).name}, perms: #{details['permissions'].reject(&:blank?).join(',')}" %>
-  <%= govuk_link_to 'Change', provider_interface_edit_invitation_provider_permissions_path(change: true, provider_id: p) %>
+  <%= govuk_link_to 'Change', provider_interface_edit_invitation_provider_permissions_path(provider_id: p) %>
 <% end %>
 
 

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, 'Basic details' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_update_invitation_basic_details_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Basic details</h1>
+
+      <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, 'Providers' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_update_invitation_provider_permissions_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Set permissions for <%= @permissions_form.provider.name %></h1>
+
+      <%= f.fields_for "provider_permissions[]", @permissions_form do |pf| %>
+        <%= pf.hidden_field :provider_id %>
+        <%= pf.govuk_collection_check_boxes :permissions, @permissions_form.available_permissions, :slug, :name %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, 'Providers' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_update_invitation_providers_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Select organisations this user will have access to</h1>
+
+      <%= f.govuk_collection_check_boxes :providers,
+            @available_providers,
+            :id,
+            :name %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -529,6 +529,15 @@ Rails.application.routes.draw do
       delete '/remove' => 'provider_users#remove', as: :remove_provider_user
     end
 
+    get 'users/new' => 'provider_users_invitations#edit_details', as: :edit_invitation_basic_details
+    post 'users/new' => 'provider_users_invitations#update_details', as: :update_invitation_basic_details
+    get 'users/new/providers' => 'provider_users_invitations#edit_providers', as: :edit_invitation_providers
+    post 'users/new/providers' => 'provider_users_invitations#update_providers', as: :update_invitation_providers
+    get 'users/new/providers/:provider_id/permissions' => 'provider_users_invitations#edit_permissions', as: :edit_invitation_provider_permissions
+    post 'users/new/providers/:provider_id/permissions' => 'provider_users_invitations#update_permissions', as: :update_invitation_provider_permissions
+    get 'users/new/check' => 'provider_users_invitations#check', as: :check_invitation
+    post 'users/new/commit' => 'provider_users_invitations#commit', as: :commit_invitation
+
     resources :organisations, only: %i[index show], path: 'organisations'
 
     get '/provider-relationship-permissions/setup' => 'provider_relationship_permissions#setup',


### PR DESCRIPTION
## Context

We don't have any session-backed wizards in the app. This is what one might look like.

The need here is for a wizard which:

- can add and remove pages according to what is selected at different points in the process
- has "change" links that preserve the existing state of the form
- does not persist anything intermediate to the database. We don't want users hanging around in a half-invited state where we have to go and clean them up with cron

The prototype flow is here:

https://manage-applications-beta.herokuapp.com/users/new

You can try out the flow in this PR by navigating to `provider/users/new` locally or on the review app.

## Questions

- ⚠️ There may well be a security issue here where in the final POST, a user could assign permissions to a provider they don't have access to. `ProviderUserInvitationWizard#save!` could handle that.
- ~Not sure how best to test this as the controller is closely coupled with the Wizard. Probably a longish system spec?~ The wizard could be mostly tested in isolation following the below changes
- ~I'm not totally convinced the balance of responsibilites between controller and wizard, esp with respect to saving, is right. Only the controller can see the session, obviously, but maybe the wizard should be responsible for saving itself?~ the wizard can't know when to save itself (it's different for `update` actions) but moving the implementation of saving into the wizard feels better than the controller knowing about it. It also means we don't need to pass in the state-to-be-saved
- ~in the same way, the controller propbably knows too much about routing logic — it might be nicer for next_redirect to get a symbol from the wizard and dispatch accordingly. this would make the wizard more testable in isolation.~ did this — it's better!
- ~@adamsilver would like to lose the query param `?change=true` when we head back from the check answers page — we could perhaps set it pre-emptively in the session as soon as we get to that page, which might simplify the controller too. Maybe the wizard should know it's in the "checking" state?~ done this, and it's simpler: once we hit the check-answers page once we're in checking-answers mode from then on. No need for query param.

## Link to Trello card

https://trello.com/c/lTQDSi7i/2401-spike-a-wizard-for-the-provider-adding-a-provider-user-flow