### PR TITLE
API docs dont display array length limits correctly

### DIFF
--- a/app/presenters/api_docs/api_schema.rb
+++ b/app/presenters/api_docs/api_schema.rb
@@ -52,7 +52,7 @@ module APIDocs
         if type == 'string' && attributes.max_length.present?
           desc << " (limited to #{attributes.max_length} characters)"
         elsif type == 'array' && attributes.max_items.present?
-          desc << " (limited to #{attributes.max_length} elements)"
+          desc << " (limited to #{attributes.max_items} elements)"
         end
 
         desc.join


### PR DESCRIPTION
## Context

The specified maximum number of elements for an array property is not being presented correctly in API docs.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Fixes lookup of Array `maxItems` property in schema presenter, this was attempting to present `maxLength`.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/OmNsQez2/2389-api-docs-dont-display-array-length-limits-correctly

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
