### PR TITLE
Fix link to chase_provider_decision email preview

### DIFF
--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -11,7 +11,7 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.application_rejected_by_default(provider_user, application_choice)
   end
 
-  def chase_provider_decision_after_twenty_working_days
+  def chase_provider_decision
     choice = application_choice
     choice.update(reject_by_default_at: 20.business_days.from_now)
     ProviderMailer.chase_provider_decision(provider_user, choice)


### PR DESCRIPTION
## Context

Link to chase_provider_decision didn't work

## Changes proposed in this pull request

Rename the method so it matches with ProviderMailer and template

## Guidance to review

- go to http://localhost:3000/support/when-emails-are-sent#awaiting_provider_decision
- click on "To provider: chase_provider_decision"

## Link to Trello card

https://trello.com/c/j5cI5cuF/2391-broken-link-to-email-preview-in-support

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
