### PR TITLE
Don't try to upload data to UCAS if we don't have a username

### DIFF
--- a/app/services/ucas_matching/upload_matching_data.rb
+++ b/app/services/ucas_matching/upload_matching_data.rb
@@ -9,7 +9,7 @@ module UCASMatching
     UPLOAD_FOLDER = 685520099
 
     def perform
-      unless ENV['UCAS_USERNAME']
+      if ENV['UCAS_USERNAME'].blank?
         Rails.logger.info 'UCAS credentials aren\'t configured, assuming that this this is a test environment. Not uploading data.'
         return
       end


### PR DESCRIPTION
## Context

I forgot that Azure sets these environment variables to an empty string if the variable isn't set in the library. This now does the correct thing.

Fixes https://sentry.io/organizations/dfe-bat/issues/1774232835/?referrer=slack

## Changes proposed in this pull request

See commit.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
