### PR TITLE
Add international contacts right to work page

### DIFF
--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -13,13 +13,16 @@ module CandidateInterface
       @languages_form = CandidateInterface::LanguagesForm.build_from_application(
         application_form,
       )
+      @right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.build_from_application(
+        application_form,
+      )
       @editable = editable
       @missing_error = missing_error
     end
 
     def rows
       CandidateInterface::PersonalDetailsReviewPresenter
-        .new(personal_details_form: @personal_details_form, nationalities_form: @nationalities_form, languages_form: @languages_form)
+        .new(personal_details_form: @personal_details_form, nationalities_form: @nationalities_form, languages_form: @languages_form, right_to_work_form: @right_to_work_form)
         .rows
     end
 

--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -13,7 +13,7 @@ module CandidateInterface
       @languages_form = CandidateInterface::LanguagesForm.build_from_application(
         application_form,
       )
-      @right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.build_from_application(
+      @right_to_work_or_study_form = CandidateInterface::RightToWorkOrStudyForm.build_from_application(
         application_form,
       )
       @editable = editable
@@ -22,7 +22,7 @@ module CandidateInterface
 
     def rows
       CandidateInterface::PersonalDetailsReviewPresenter
-        .new(personal_details_form: @personal_details_form, nationalities_form: @nationalities_form, languages_form: @languages_form, right_to_work_form: @right_to_work_form)
+        .new(personal_details_form: @personal_details_form, nationalities_form: @nationalities_form, languages_form: @languages_form, right_to_work_form: @right_to_work_or_study_form)
         .rows
     end
 

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -68,6 +68,11 @@ module CandidateInterface
           @nationalities_form.first_nationality != 'Irish' &&
           @nationalities_form.first_nationality != 'Multiple'
       end
+
+      def british_or_irish?
+        NationalitiesForm::UK_AND_IRISH_NATIONALITIES.include?(@nationalities_form.first_nationality) ||
+          NationalitiesForm::UK_AND_IRISH_NATIONALITIES.include?(@nationalities_form.other_nationality)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -17,9 +17,14 @@ module CandidateInterface
         @nationalities_form = NationalitiesForm.new(nationalities_params)
 
         if @nationalities_form.save(current_application)
+          if FeatureFlag.active?('international_personal_details') &&
+              (@nationalities_form.nationality == 'British' ||
+              @nationalities_form.nationality == 'Irish')
+            redirect_to candidate_interface_personal_details_show_path
+          else
+            redirect_to candidate_interface_languages_path
+          end
           current_application.update!(personal_details_completed: false)
-
-          redirect_to candidate_interface_languages_path
         else
           track_validation_error(@nationalities_form)
           render :new

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -23,7 +23,15 @@ module CandidateInterface
         @languages_form = LanguagesForm.build_from_application(current_application)
         @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
 
-        if @personal_details_form.valid? &&
+        if FeatureFlag.active?('international_personal_details') &&
+            @personal_details_form.valid? &&
+            @nationalities_form.valid? &&
+            @right_to_work_form.valid?
+
+          current_application.update!(application_form_params)
+
+          redirect_to candidate_interface_application_form_path
+        elsif @personal_details_form.valid? &&
             @nationalities_form.valid? &&
             @languages_form.valid?
 

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -8,10 +8,12 @@ module CandidateInterface
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
+        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
         @personal_details_review = PersonalDetailsReviewPresenter.new(
           personal_details_form: @personal_details_form,
           nationalities_form: @nationalities_form,
           languages_form: @languages_form,
+          right_to_work_form: @right_to_work_form,
         )
       end
 
@@ -19,6 +21,7 @@ module CandidateInterface
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
+        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
 
         if @personal_details_form.valid? &&
             @nationalities_form.valid? &&

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -8,12 +8,12 @@ module CandidateInterface
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
-        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
         @personal_details_review = PersonalDetailsReviewPresenter.new(
           personal_details_form: @personal_details_form,
           nationalities_form: @nationalities_form,
           languages_form: @languages_form,
-          right_to_work_form: @right_to_work_form,
+          right_to_work_form: @right_to_work_or_study_form,
         )
       end
 
@@ -21,12 +21,12 @@ module CandidateInterface
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
-        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
 
         if FeatureFlag.active?('international_personal_details') &&
             @personal_details_form.valid? &&
             @nationalities_form.valid? &&
-            @right_to_work_form.valid?
+            @right_to_work_or_study_form.valid?
 
           current_application.update!(application_form_params)
 

--- a/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
@@ -4,31 +4,31 @@ module CandidateInterface
       before_action :redirect_to_dashboard_if_submitted
 
       def new
-        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
       end
 
       def create
-        @right_to_work_form = RightToWorkOrStudyForm.new(right_to_work_params)
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.new(right_to_work_params)
 
-        if @right_to_work_form.save(current_application)
+        if @right_to_work_or_study_form.save(current_application)
           redirect_to candidate_interface_personal_details_show_path
         else
-          track_validation_error(@right_to_work_form)
+          track_validation_error(@right_to_work_or_study_form)
           render :new
         end
       end
 
       def edit
-        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
       end
 
       def update
-        @right_to_work_form = RightToWorkOrStudyForm.new(right_to_work_params)
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.new(right_to_work_params)
 
-        if @right_to_work_form.save(current_application)
+        if @right_to_work_or_study_form.save(current_application)
           redirect_to candidate_interface_personal_details_show_path
         else
-          track_validation_error(@right_to_work_form)
+          track_validation_error(@right_to_work_or_study_form)
           render :edit
         end
       end

--- a/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
@@ -1,0 +1,30 @@
+module CandidateInterface
+  module PersonalDetails
+    class RightToWorkOrStudyController < CandidateInterfaceController
+      before_action :redirect_to_dashboard_if_submitted
+
+      def new
+        @right_to_work_form = RightToWorkOrStudyForm.new
+      end
+
+      def create
+        @right_to_work_form = RightToWorkOrStudyForm.new(right_to_work_params)
+
+        if @right_to_work_form.save(current_application)
+          redirect_to candidate_interface_personal_details_show_path
+        else
+          track_validation_error(@right_to_work_form)
+          render :new
+        end
+      end
+
+    private
+
+      def right_to_work_params
+        params.require(:candidate_interface_right_to_work_or_study_form).permit(
+          :right_to_work_or_study, :right_to_work_or_study_details
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       before_action :redirect_to_dashboard_if_submitted
 
       def new
-        @right_to_work_form = RightToWorkOrStudyForm.new
+        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
       end
 
       def create
@@ -15,6 +15,21 @@ module CandidateInterface
         else
           track_validation_error(@right_to_work_form)
           render :new
+        end
+      end
+
+      def edit
+        @right_to_work_form = RightToWorkOrStudyForm.build_from_application(current_application)
+      end
+
+      def update
+        @right_to_work_form = RightToWorkOrStudyForm.new(right_to_work_params)
+
+        if @right_to_work_form.save(current_application)
+          redirect_to candidate_interface_personal_details_show_path
+        else
+          track_validation_error(@right_to_work_form)
+          render :edit
         end
       end
 

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -20,6 +20,8 @@ module CandidateInterface
               inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true },
               if: :international_flag_is_on?
 
+    UK_AND_IRISH_NATIONALITIES = ['British', 'Welsh', 'Scottish', 'Northern Irish', 'Irish', 'English']
+
     def self.build_from_application(application_form)
       new(
         first_nationality: application_form.first_nationality,

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -70,16 +70,6 @@ module CandidateInterface
       end
     end
 
-  private
-
-    def first_nationality_is_other?
-      first_nationality == 'other'
-    end
-
-    def multiple_nationalities_selected?
-      first_nationality == 'multiple'
-    end
-
     def international_flag_is_on?
       FeatureFlag.active?('international_personal_details')
     end

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -48,6 +48,10 @@ module CandidateInterface
       end
     end
 
+    def nationality
+      first_nationality_is_other? ? other_nationality : first_nationality
+    end
+
   private
 
     def first_nationality_is_other?
@@ -56,10 +60,6 @@ module CandidateInterface
 
     def multiple_nationalities_selected?
       first_nationality == 'Multiple'
-    end
-
-    def nationality
-      first_nationality_is_other? ? other_nationality : first_nationality
     end
 
     def populate_multiple_nationalties

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -20,7 +20,7 @@ module CandidateInterface
               inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true },
               if: :international_flag_is_on?
 
-    UK_AND_IRISH_NATIONALITIES = ['British', 'Welsh', 'Scottish', 'Northern Irish', 'Irish', 'English']
+    UK_AND_IRISH_NATIONALITIES = ['British', 'Welsh', 'Scottish', 'Northern Irish', 'Irish', 'English'].freeze
 
     def self.build_from_application(application_form)
       new(

--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class NationalitiesForm
     include ActiveModel::Model
-    include ValidationUtils
 
     attr_accessor :first_nationality, :second_nationality, :other_nationality, :multiple_nationalities
 
@@ -67,6 +66,16 @@ module CandidateInterface
       elsif second_nationality.present?
         "#{first_nationality} and #{second_nationality}"
       end
+    end
+
+  private
+
+    def first_nationality_is_other?
+      first_nationality == 'other'
+    end
+
+    def multiple_nationalities_selected?
+      first_nationality == 'multiple'
     end
 
     def international_flag_is_on?

--- a/app/forms/candidate_interface/right_to_work_or_study_form.rb
+++ b/app/forms/candidate_interface/right_to_work_or_study_form.rb
@@ -22,7 +22,7 @@ module CandidateInterface
 
       application_form.update(
         right_to_work_or_study: right_to_work_or_study,
-        right_to_work_or_study_details: right_to_work_or_study_details,
+        right_to_work_or_study_details: set_right_to_work_or_study_details,
       )
     end
 
@@ -30,6 +30,10 @@ module CandidateInterface
 
     def has_right_to_work_or_study?
       right_to_work_or_study == 'yes'
+    end
+
+    def set_right_to_work_or_study_details
+      has_right_to_work_or_study? ? right_to_work_or_study_details : nil
     end
   end
 end

--- a/app/forms/candidate_interface/right_to_work_or_study_form.rb
+++ b/app/forms/candidate_interface/right_to_work_or_study_form.rb
@@ -8,6 +8,8 @@ module CandidateInterface
 
     validates :right_to_work_or_study_details, presence: true, if: :has_right_to_work_or_study?
 
+    validates :right_to_work_or_study_details, word_count: { maximum: 200 }
+
     def self.build_from_application(application_form)
       new(
         right_to_work_or_study: application_form.right_to_work_or_study,

--- a/app/forms/candidate_interface/right_to_work_or_study_form.rb
+++ b/app/forms/candidate_interface/right_to_work_or_study_form.rb
@@ -1,0 +1,33 @@
+module CandidateInterface
+  class RightToWorkOrStudyForm
+    include ActiveModel::Model
+
+    attr_accessor :right_to_work_or_study, :right_to_work_or_study_details
+
+    validates :right_to_work_or_study, presence: true
+
+    validates :right_to_work_or_study_details, presence: true, if: :has_right_to_work_or_study?
+
+    def self.build_from_application(application_form)
+      new(
+        right_to_work_or_study: application_form.right_to_work_or_study,
+        right_to_work_or_study_details: application_form.right_to_work_or_study_details,
+      )
+    end
+
+    def save(application_form)
+      return false unless valid?
+
+      application_form.update(
+        right_to_work_or_study: right_to_work_or_study,
+        right_to_work_or_study_details: right_to_work_or_study_details,
+      )
+    end
+
+  private
+
+    def has_right_to_work_or_study?
+      right_to_work_or_study == 'yes'
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -41,6 +41,12 @@ class ApplicationForm < ApplicationRecord
     never_asked: 'never_asked',
   }
 
+  enum right_to_work_or_study: {
+    yes: 'yes',
+    no: 'no',
+    decide_later: 'decide_later',
+  }
+
   enum address_type: {
     uk: 'uk',
     international: 'international',

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -123,9 +123,9 @@ module CandidateInterface
 
     def formatted_right_to_work_or_study
       case @right_to_work_form.right_to_work_or_study
-      when 'Yes – I have the right to work or study in the UK'
+      when 'yes'
         'I have the right to work or study in the UK'
-      when 'Not yet – I will need to apply for permission to work or study in the UK'
+      when 'no'
         'I will need to apply for permission to work or study in the UK'
       else
         'I do not know'

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -96,10 +96,10 @@ module CandidateInterface
     end
 
     def right_to_work_row
-      if @nationalities_form.first_nationality != 'British' && @nationalities_form.first_nationality != 'Irish'
+      if NationalitiesForm::UK_AND_IRISH_NATIONALITIES.exclude?(@nationalities_form.first_nationality)
         {
           key: 'Residency status',
-          value: "#{formatted_right_to_work_or_study} <br> #{tag.p(@right_to_work_or_study_form.right_to_work_or_study_details)}".html_safe,
+          value: formatted_right_to_work_or_study,
           action: ('Right to work or study' if @editable),
           change_path: Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path,
         }
@@ -124,7 +124,7 @@ module CandidateInterface
     def formatted_right_to_work_or_study
       case @right_to_work_or_study_form.right_to_work_or_study
       when 'yes'
-        'I have the right to work or study in the UK'
+        "I have the right to work or study in the UK <br> #{tag.p(@right_to_work_or_study_form.right_to_work_or_study_details)}".html_safe
       when 'no'
         'I will need to apply for permission to work or study in the UK'
       else

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       @personal_details_form = personal_details_form
       @nationalities_form = nationalities_form
       @languages_form = languages_form
-      @right_to_work_form = right_to_work_form
+      @right_to_work_or_study_form = right_to_work_form
       @editable = editable
     end
 
@@ -99,7 +99,7 @@ module CandidateInterface
       if @nationalities_form.first_nationality != 'British' && @nationalities_form.first_nationality != 'Irish'
         {
           key: 'Residency status',
-          value: "#{formatted_right_to_work_or_study} <br> #{tag.p(@right_to_work_form.right_to_work_or_study_details)}".html_safe,
+          value: "#{formatted_right_to_work_or_study} <br> #{tag.p(@right_to_work_or_study_form.right_to_work_or_study_details)}".html_safe,
           action: ('Right to work or study' if @editable),
           change_path: Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path,
         }
@@ -122,7 +122,7 @@ module CandidateInterface
     end
 
     def formatted_right_to_work_or_study
-      case @right_to_work_form.right_to_work_or_study
+      case @right_to_work_or_study_form.right_to_work_or_study
       when 'yes'
         'I have the right to work or study in the UK'
       when 'no'

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -101,7 +101,7 @@ module CandidateInterface
           key: 'Residency status',
           value: "#{formatted_right_to_work_or_study} <br> #{tag.p(@right_to_work_form.right_to_work_or_study_details)}".html_safe,
           action: ('Right to work or study' if @editable),
-          change_path: Rails.application.routes.url_helpers.candidate_interface_right_to_work_or_study_path,
+          change_path: Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path,
         }
       end
     end
@@ -123,9 +123,9 @@ module CandidateInterface
 
     def formatted_right_to_work_or_study
       case @right_to_work_form.right_to_work_or_study
-      when 'yes'
+      when 'Yes – I have the right to work or study in the UK'
         'I have the right to work or study in the UK'
-      when 'no'
+      when 'Not yet – I will need to apply for permission to work or study in the UK'
         'I will need to apply for permission to work or study in the UK'
       else
         'I do not know'

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -1,9 +1,12 @@
 module CandidateInterface
   class PersonalDetailsReviewPresenter
-    def initialize(personal_details_form:, nationalities_form:, languages_form:, editable: true)
+    include ActionView::Helpers::TagHelper
+
+    def initialize(personal_details_form:, nationalities_form:, languages_form:, right_to_work_form:, editable: true)
       @personal_details_form = personal_details_form
       @nationalities_form = nationalities_form
       @languages_form = languages_form
+      @right_to_work_form = right_to_work_form
       @editable = editable
     end
 
@@ -13,6 +16,7 @@ module CandidateInterface
           name_row,
           date_of_birth_row,
           nationality_row,
+          right_to_work_row,
         ]
         .compact
       else
@@ -91,6 +95,17 @@ module CandidateInterface
       }
     end
 
+    def right_to_work_row
+      if @nationalities_form.first_nationality != 'British' && @nationalities_form.first_nationality != 'Irish'
+        {
+          key: 'Residency status',
+          value: "#{formatted_right_to_work_or_study} <br> #{tag.p(@right_to_work_form.right_to_work_or_study_details)}".html_safe,
+          action: ('Right to work or study' if @editable),
+          change_path: Rails.application.routes.url_helpers.candidate_interface_right_to_work_or_study_path,
+        }
+      end
+    end
+
     def formatted_nationalities
       if @nationalities_form.multiple_nationalities.present?
         @nationalities_form.multiple_nationalities
@@ -103,6 +118,17 @@ module CandidateInterface
         ]
         .reject(&:blank?)
         .to_sentence
+      end
+    end
+
+    def formatted_right_to_work_or_study
+      case @right_to_work_form.right_to_work_or_study
+      when 'yes'
+        'I have the right to work or study in the UK'
+      when 'no'
+        'I will need to apply for permission to work or study in the UK'
+      else
+        'I do not know'
       end
     end
   end

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -8,14 +8,23 @@ module CandidateInterface
     end
 
     def rows
-      [
-        name_row,
-        date_of_birth_row,
-        nationality_row,
-        english_main_language_row,
-        language_details_row,
-      ]
+      if FeatureFlag.active?('international_personal_details')
+        [
+          name_row,
+          date_of_birth_row,
+          nationality_row,
+        ]
         .compact
+      else
+        [
+          name_row,
+          date_of_birth_row,
+          nationality_row,
+          english_main_language_row,
+          language_details_row,
+        ]
+          .compact
+      end
     end
 
   private

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -1,0 +1,22 @@
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'xl', text: t('page_titles.right_to_work'), tag: 'h2' } do %>
+  <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' } do %>
+    <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint_text: 'For example, you have settled status or a permanent residence card' %>
+  <% end %>
+
+  <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
+    <div class="govuk-body">
+      Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+    </div>
+  <% end %>
+  <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
+    <div class="govuk-body">
+      Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+    </div>
+  <% end %>
+<% end %>
+
+<%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_or_study_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_show_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @right_to_work_form, url: candidate_interface_edit_right_to_work_or_study_path do |f| %>
+    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_edit_right_to_work_or_study_path do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_nationalities_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_show_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @right_to_work_form, url: candidate_interface_right_to_work_or_study_path do |f| %>
+    <%= form_with model: @right_to_work_form, url: candidate_interface_edit_right_to_work_or_study_path do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/new.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/new.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_nationalities_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @right_to_work_form, url: candidate_interface_right_to_work_or_study_path do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'xl', text: t('page_titles.right_to_work'), tag: 'h2' } do %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' } do %>
+          <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint_text: 'For example, you have settled status or a permanent residence card' %>
+        <% end %>
+
+        <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
+          <div class="govuk-body">
+            Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+          </div>
+        <% end %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
+          <div class="govuk-body">
+            Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Save and continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/new.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/new.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_or_study_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_nationalities_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @right_to_work_form, url: candidate_interface_right_to_work_or_study_path do |f| %>
+    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_right_to_work_or_study_path do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -50,6 +50,9 @@ en:
       other_language_details:
         label: Other languages spoken
         change_action: other languages
+      right_to_work:
+        label: Residency status
+        change_action: Right to work or study
       complete_form_button: Save and continue
     further_information:
       further_information:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -443,6 +443,11 @@ en:
               too_many_words: English language qualifications and other languages spoken must be %{count} words or fewer
             other_language_details:
               too_many_words: Other languages spoken must be %{count} words or fewer
+        candidate_interface/right_to_work_or_study_form:
+          attributes:
+            right_to_work_or_study_details:
+              blank: Please provide details of your right to work or study in the UK.
+              too_many_words: Other languages spoken must be %{count} words or fewer
         candidate_interface/becoming_a_teacher_form:
           attributes:
             becoming_a_teacher:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
     personal_details: Personal details
     nationalities: What is your nationality?
     languages: Languages
+    right_to_work: Do you have the right to work or study in the UK?
     review_application: Review your application
     data_sharing_agreement: Data sharing agreement
     accessibility: Accessibility statement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,8 @@ Rails.application.routes.draw do
         post '/languages' => 'personal_details/languages#update'
         get '/languages/edit' => 'personal_details/languages#edit', as: :edit_languages
         post '/languages/edit' => 'personal_details/languages#update'
+        get '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#new', as: :right_to_work_or_study
+        post '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#create'
         get '/review' => 'personal_details/review#show', as: :personal_details_show
         post '/review' => 'personal_details/review#complete', as: :personal_details_complete
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,8 @@ Rails.application.routes.draw do
         post '/languages/edit' => 'personal_details/languages#update'
         get '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#new', as: :right_to_work_or_study
         post '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#create'
+        get '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#edit', as: :edit_right_to_work_or_study
+        post '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#update'
         get '/review' => 'personal_details/review#show', as: :personal_details_show
         post '/review' => 'personal_details/review#complete', as: :personal_details_complete
       end

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -28,29 +28,29 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
   describe '.nationality' do
     context 'when first nationality is british' do
       it 'returns British' do
-        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'british')
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'British')
         expect(nationalities.nationality).to eq 'British'
       end
     end
 
     context 'when firt nationality is irish' do
       it 'returns Irish' do
-        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'irish')
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'Irish')
         expect(nationalities.nationality).to eq 'Irish'
       end
     end
 
     context 'when first nationality is other' do
       it 'returns British' do
-        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'other', other_nationality: 'German')
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'Other', other_nationality: 'German')
         expect(nationalities.nationality).to eq 'German'
       end
     end
 
     context 'when first nationality is multiple' do
       it 'returns British' do
-        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'multiple', multiple_nationalities: 'German and Dutch')
-        expect(nationalities.nationality).to eq 'multiple'
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'Multiple', multiple_nationalities: 'German and Dutch')
+        expect(nationalities.nationality).to eq 'Multiple'
       end
     end
   end

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -25,6 +25,36 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
     end
   end
 
+  describe '.nationality' do
+    context 'when first nationality is british' do
+      it 'returns British' do
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'british')
+        expect(nationalities.nationality).to eq 'British'
+      end
+    end
+
+    context 'when firt nationality is irish' do
+      it 'returns Irish' do
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'irish')
+        expect(nationalities.nationality).to eq 'Irish'
+      end
+    end
+
+    context 'when first nationality is other' do
+      it 'returns British' do
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'other', other_nationality: 'German')
+        expect(nationalities.nationality).to eq 'German'
+      end
+    end
+
+    context 'when first nationality is multiple' do
+      it 'returns British' do
+        nationalities = CandidateInterface::NationalitiesForm.new(first_nationality: 'multiple', multiple_nationalities: 'German and Dutch')
+        expect(nationalities.nationality).to eq 'multiple'
+      end
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       nationalities = CandidateInterface::NationalitiesForm.new

--- a/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
+++ b/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RightToWorkOrStudyForm, type: :model do
+  describe '#validations' do
+    let(:form) { subject }
+
+    before do
+      allow(form).to receive(:has_right_to_work_or_study?).and_return(true)
+    end
+
+    it { is_expected.to validate_presence_of(:right_to_work_or_study) }
+    it { is_expected.to validate_presence_of(:right_to_work_or_study_details) }
+
+    describe '.build_from_application' do
+      let(:form_data) do
+        {
+          right_to_work_or_study: 'yes',
+          right_to_work_or_study_details: 'I come from the land down under.',
+        }
+      end
+
+      it 'creates an object based on the provided ApplicationForm' do
+        application_form = ApplicationForm.new(form_data)
+        right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.build_from_application(
+          application_form,
+        )
+        expect(right_to_work_form).to have_attributes(form_data)
+      end
+    end
+
+    describe '#save' do
+      let(:form_data) do
+        {
+          right_to_work_or_study: 'no',
+          right_to_work_or_study_details: '',
+        }
+      end
+
+      it 'returns false if not valid' do
+        right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.new
+
+        expect(right_to_work_form.save(ApplicationForm.new)).to eq(false)
+      end
+
+
+      it 'updates the provided ApplicationForm if valid' do
+        application_form = FactoryBot.create(:application_form)
+        right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.new(form_data)
+
+        expect(right_to_work_form.save(application_form)).to eq(true)
+        expect(application_form.right_to_work_or_study).to eq 'no'
+        expect(application_form.right_to_work_or_study_details).to eq ''
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
+++ b/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CandidateInterface::RightToWorkOrStudyForm, type: :model do
 
         expect(right_to_work_form.save(application_form)).to eq(true)
         expect(application_form.right_to_work_or_study).to eq 'no'
-        expect(application_form.right_to_work_or_study_details).to eq ''
+        expect(application_form.right_to_work_or_study_details).to eq nil
       end
     end
   end

--- a/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
+++ b/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe CandidateInterface::RightToWorkOrStudyForm, type: :model do
         expect(right_to_work_form.save(ApplicationForm.new)).to eq(false)
       end
 
-
       it 'updates the provided ApplicationForm if valid' do
         application_form = FactoryBot.create(:application_form)
         right_to_work_form = CandidateInterface::RightToWorkOrStudyForm.new(form_data)

--- a/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
+++ b/spec/forms/candidate_interface/right_to_work_or_study_form_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe CandidateInterface::RightToWorkOrStudyForm, type: :model do
     it { is_expected.to validate_presence_of(:right_to_work_or_study) }
     it { is_expected.to validate_presence_of(:right_to_work_or_study_details) }
 
+    okay_text = Faker::Lorem.sentence(word_count: 200)
+    long_text = Faker::Lorem.sentence(word_count: 201)
+
+    it { is_expected.to allow_value(okay_text).for(:right_to_work_or_study_details) }
+    it { is_expected.not_to allow_value(long_text).for(:right_to_work_or_study_details) }
+
     describe '.build_from_application' do
       let(:form_data) do
         {

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
-          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_right_to_work_or_study_path),
+          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
         )
       end
     end
@@ -274,7 +274,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
-          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_right_to_work_or_study_path),
+          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
         )
       end
     end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -195,6 +195,37 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
       end
     end
+
+    context 'when the international personal details feature flag is on' do
+      before do
+        FeatureFlag.activate('international_personal_details')
+      end
+
+      it 'does not render english language details row' do
+        languages_form = build(
+          :languages_form,
+          english_main_language: 'no',
+          english_language_details: 'Broken? Oh man, are you cereal?',
+          other_language_details: 'Anything',
+        )
+
+        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+          row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        )
+      end
+
+      it 'does not render other language details row' do
+        languages_form = build(
+          :languages_form,
+          english_main_language: 'no',
+          english_language_details: 'Broken? Oh man, are you cereal?',
+          other_language_details: 'Anything',
+        )
+        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+          row_for(:other_language_details, 'Anything', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        )
+      end
+    end
   end
 
   def rows(personal_details_form, nationalities_form, languages_form)

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -27,10 +27,18 @@ FactoryBot.define do
   end
 end
 
+FactoryBot.define do
+  factory :right_to_work_form, class: 'CandidateInterface::RightToWorkOrStudyForm' do
+    right_to_work_or_study { 'yes' }
+    right_to_work_or_study_details { 'I have the right.' }
+  end
+end
+
 RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
   let(:personal_details_form) { build(:personal_details_form) }
   let(:nationalities_form) { build(:nationalities_form) }
   let(:languages_form) { build(:languages_form) }
+  let(:right_to_work_form) { build(:right_to_work_form) }
 
   context 'when personal details are editable' do
     it 'includes hashes for the name and date of birth' do
@@ -43,7 +51,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         year: 1995,
       )
 
-      expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+      expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
         row_for(:name, 'Max Caulfield', Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path),
         row_for(:date_of_birth, '21 September 1995', Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path),
       )
@@ -57,7 +65,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           second_nationality: nil,
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
           row_for(:nationality, 'British', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
         )
       end
@@ -69,7 +77,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           second_nationality: 'Spanish',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
           row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
         )
       end
@@ -97,7 +105,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
           row_for(:english_main_language, 'Yes', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -110,7 +118,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
           row_for(:other_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -123,7 +131,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: 'Broken? Oh man, are you cereal?',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
           row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -136,7 +144,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: 'I speak French',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
           row_for(:other_language_details, 'I speak French', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -151,7 +159,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
           row_for(:english_main_language, 'No', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -164,7 +172,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
           row_for(:english_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -177,7 +185,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
           row_for(:other_language_details, 'Mi nombre es Max.', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -190,7 +198,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
           row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -209,7 +217,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: 'Anything',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
           row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -221,16 +229,60 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           english_language_details: 'Broken? Oh man, are you cereal?',
           other_language_details: 'Anything',
         )
-        expect(rows(personal_details_form, nationalities_form, languages_form)).not_to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
           row_for(:other_language_details, 'Anything', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        )
+      end
+    end
+
+    context 'when the when the international personal details flag is on and the candidate has selected they have the right to work' do
+      before do
+        FeatureFlag.activate('international_personal_details')
+      end
+
+      it 'renders the right to work row' do
+        nationalities_form = build(
+          :nationalities_form,
+          first_nationality: 'German',
+        )
+        right_to_work_form = build(
+          :right_to_work_form,
+          right_to_work_or_study: 'yes',
+          right_to_work_or_study_details: 'I have the right.',
+        )
+
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_right_to_work_or_study_path),
+        )
+      end
+    end
+
+    context 'when the when the international personal details flag is the candidate is British or Irish' do
+      before do
+        FeatureFlag.activate('international_personal_details')
+      end
+
+      it 'renders the right to work row' do
+        nationalities_form = build(
+          :nationalities_form,
+          first_nationality: 'British',
+        )
+        right_to_work_form = build(
+          :right_to_work_form,
+          right_to_work_or_study: 'yes',
+          right_to_work_or_study_details: 'I have the right.',
+        )
+
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
+          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_right_to_work_or_study_path),
         )
       end
     end
   end
 
-  def rows(personal_details_form, nationalities_form, languages_form)
+  def rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)
     CandidateInterface::PersonalDetailsReviewPresenter
-      .new(personal_details_form: personal_details_form, nationalities_form: nationalities_form, languages_form: languages_form)
+      .new(personal_details_form: personal_details_form, nationalities_form: nationalities_form, languages_form: languages_form, right_to_work_form: right_to_work_form)
       .rows
   end
 

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           multiple_nationalities: 'British and Spanish',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form)).to include(
+        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
           row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
         )
       end

--- a/spec/support/test_helpers/efl_helper.rb
+++ b/spec/support/test_helpers/efl_helper.rb
@@ -12,6 +12,8 @@ module EFLHelper
     select 'Hong Konger', from: 'Nationality'
     select 'Pakistani', from: 'Second nationality'
     click_button 'Save and continue'
+    click_button 'Save and continue'
+    check t('application_form.completed_checkbox')
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
@@ -36,6 +36,8 @@ RSpec.feature 'View EFL form' do
     select 'Hong Konger', from: 'Nationality'
     select 'Pakistani', from: 'Second nationality'
     click_button 'Save and continue'
+    click_button 'Save and continue'
+    check t('application_form.completed_checkbox')
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -42,14 +42,20 @@ RSpec.feature 'Entering their personal details' do
     and_i_submit_the_form
     then_i_see_the_right_to_work_or_study_page
 
-    when_i_choose_yes
+    when_i_choose_i_do_not_know
+    and_i_submit_the_form
+    then_i_see_the_personal_details_review_page
+    and_i_can_see_my_updated_details
+
+    when_i_click_change_on_my_right_to_work
+    and_i_choose_yes
     and_i_submit_the_form
     then_i_am_told_i_need_to_provide_details
 
     when_i_fill_in_my_right_to_work_details
     and_i_submit_the_form
     then_i_see_the_personal_details_review_page
-    and_i_can_see_my_updated_details
+    and_i_can_see_my_updated_right_to_work
 
     when_i_mark_the_section_as_completed
     and_i_submit_my_details
@@ -154,8 +160,12 @@ RSpec.feature 'Entering their personal details' do
     expect(page).to have_current_path candidate_interface_right_to_work_or_study_path
   end
 
-  def when_i_choose_yes
+  def and_i_choose_yes
     choose 'Yes'
+  end
+
+  def when_i_choose_i_do_not_know
+    choose "I do not know"
   end
 
   def then_i_am_told_i_need_to_provide_details
@@ -168,7 +178,16 @@ RSpec.feature 'Entering their personal details' do
 
   def and_i_can_see_my_updated_details
     expect(page).to have_content 'German'
+    expect(page).to have_content 'I do not know'
+  end
+
+  def when_i_click_change_on_my_right_to_work
+    all('.govuk-summary-list__actions')[3].click_link 'Change'
+  end
+
+  def and_i_can_see_my_updated_right_to_work
     expect(page).to have_content "Borders? I don't believe in no stinking borders."
+    expect(page).to have_content 'I have the right to work or study in the UK'
   end
 
   def when_i_mark_the_section_as_completed

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -165,7 +165,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def when_i_choose_i_do_not_know
-    choose "I do not know"
+    choose 'I do not know'
   end
 
   def then_i_am_told_i_need_to_provide_details

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -20,10 +20,6 @@ RSpec.feature 'Entering their personal details' do
 
     when_i_choose_that_i_am_british
     and_i_submit_the_form
-    then_i_see_the_languages_page
-
-    when_i_choose_that_english_is_my_primary_language
-    and_i_submit_the_form
     then_i_see_the_personal_details_review_page
     and_i_can_check_my_answers
 
@@ -117,11 +113,6 @@ RSpec.feature 'Entering their personal details' do
 
   def then_i_see_the_personal_details_review_page
     expect(page).to have_current_path candidate_interface_personal_details_show_path
-  end
-
-  def when_i_choose_that_english_is_my_primary_language
-    choose 'Yes'
-    fill_in t('english_main_language.yes_label', scope: @scope), with: "I'm great at Galactic Basic so English is a piece of cake", match: :prefer_exact
   end
 
   def and_i_can_check_my_answers

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature 'Entering their personal details' do
     when_i_click_change_on_my_nationality
     and_i_choose_other
     and_i_select_i_am_german
+    and_i_submit_the_form
     then_i_see_the_right_to_work_or_study_page
 
     when_i_choose_yes
@@ -119,7 +120,6 @@ RSpec.feature 'Entering their personal details' do
     expect(page).to have_content 'Name'
     expect(page).to have_content 'Lando Calrissian'
     expect(page).to have_content 'British'
-    expect(page).to have_content "I'm great at Galactic Basic so English is a piece of cake"
   end
 
   def when_i_click_change_on_my_nationality

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -73,10 +73,6 @@ RSpec.feature 'Entering their personal details' do
     click_link t('page_titles.personal_details')
   end
 
-  def then_i_see_the_languages_page
-    expect(page).to have_current_path candidate_interface_languages_path
-  end
-
   def and_i_fill_in_some_details_but_omit_some_required_details
     @scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: @scope), with: 'Lando'
@@ -155,7 +151,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def then_i_see_the_right_to_work_or_study_page
-    expect(page).to have_current_path candidate_interface_right_to_work_path
+    expect(page).to have_current_path candidate_interface_right_to_work_or_study_path
   end
 
   def when_i_choose_yes

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def then_i_am_told_i_need_to_provide_details
-    expect(page).to have_content "can't be blank"
+    expect(page).to have_content 'Please provide details of your right to work or study in the UK.'
   end
 
   def when_i_fill_in_my_right_to_work_details

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -35,10 +35,24 @@ RSpec.feature 'Entering their personal details' do
 
     when_i_click_change_on_my_nationality
     and_i_choose_other
-    and_i_select_i_am_german
+    and_select_i_am_british
     and_i_submit_the_form
     then_i_see_the_personal_details_review_page
-    and_i_see_i_am_german
+    and_i_see_i_am_british
+
+    when_i_click_change_on_my_nationality
+    and_i_choose_other
+    and_i_select_i_am_german
+    then_i_see_the_right_to_work_or_study_page
+
+    when_i_choose_yes
+    and_i_submit_the_form
+    then_i_am_told_i_need_to_provide_details
+
+    when_i_fill_in_my_right_to_work_details
+    and_i_submit_the_form
+    then_i_see_the_personal_details_review_page
+    and_i_can_see_my_updated_details
 
     when_i_mark_the_section_as_completed
     and_i_submit_my_details
@@ -133,12 +147,41 @@ RSpec.feature 'Entering their personal details' do
     choose 'Other'
   end
 
+  def and_select_i_am_british
+    select 'British'
+  end
+
+  def and_i_see_i_am_british
+    expect(page).to have_content 'British'
+  end
+
   def and_i_select_i_am_german
     select 'German'
   end
 
   def and_i_see_i_am_german
     expect(page).to have_content 'German'
+  end
+
+  def then_i_see_the_right_to_work_or_study_page
+    expect(page).to have_current_path candidate_interface_right_to_work_path
+  end
+
+  def when_i_choose_yes
+    choose 'Yes'
+  end
+
+  def then_i_am_told_i_need_to_provide_details
+    expect(page).to have_content "can't be blank"
+  end
+
+  def when_i_fill_in_my_right_to_work_details
+    fill_in :details, with: "Borders? I don't believe in no stinking borders."
+  end
+
+  def and_i_can_see_my_updated_details
+    expect(page).to have_content 'German'
+    expect(page).to have_content "Borders? I don't believe in no stinking borders."
   end
 
   def when_i_mark_the_section_as_completed


### PR DESCRIPTION
## Context

This PR covers adding the right to work or study page in the new international candidates personal details flow.

There have been 2 previous PRs. The first PR #2345 broke the personal details flow into 3 separate views.

The second PR #2446, adds the new nationalities page.

This page is only accessible with the Feature Flag on, and is only shown to non-UK and Irish Citizens. 

## Changes proposed in this pull request

- Added the right to work or study page
![image](https://user-images.githubusercontent.com/62567622/87029859-a5624900-c1d8-11ea-9148-f91b7711f432.png)

## Guidance to review

Test on the review app.

## Link to Trello card

https://trello.com/c/AsOuRv9u/1760-dev-%F0%9F%8C%90-international-residency-visa-status

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
