### PR TITLE
International degrees part 1 - modifications to degree type form

### DIFF
--- a/app/controllers/candidate_interface/degrees/type_controller.rb
+++ b/app/controllers/candidate_interface/degrees/type_controller.rb
@@ -54,7 +54,7 @@ module CandidateInterface
       def degree_type_params
         params
           .require(:candidate_interface_degree_type_form)
-          .permit(:type_description)
+          .permit(:uk_degree, :type_description, :international_type_description)
       end
 
       def create_params

--- a/app/forms/candidate_interface/degree_type_form.rb
+++ b/app/forms/candidate_interface/degree_type_form.rb
@@ -3,8 +3,10 @@ module CandidateInterface
     include ActiveModel::Model
 
     attr_accessor :type_description
+    attr_accessor :uk_degree
     attr_accessor :application_form, :degree
 
+    validates :uk_degree, presence: true, if: -> { FeatureFlag.active?(:international_degrees) }
     validates :type_description, presence: true
     validates :type_description, length: { maximum: 255 }
 
@@ -13,6 +15,7 @@ module CandidateInterface
       return false unless application_form_present?
 
       self.degree = application_form.application_qualifications.degree.create!(
+        international: international?,
         qualification_type: type_description,
         qualification_type_hesa_code: hesa_code,
       )
@@ -23,12 +26,14 @@ module CandidateInterface
       return false unless degree_present?
 
       degree.update!(
+        international: international?,
         qualification_type: type_description,
         qualification_type_hesa_code: hesa_code,
       )
     end
 
     def fill_form_values
+      self.uk_degree = !degree.international?
       self.type_description = degree.qualification_type
       self
     end
@@ -55,6 +60,10 @@ module CandidateInterface
         errors.add(:degree, 'is missing')
         false
       end
+    end
+
+    def international?
+      FeatureFlag.active?(:international_degrees) && uk_degree == 'no'
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -36,6 +36,7 @@ class FeatureFlag
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],
+    [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -1,9 +1,35 @@
-<%= f.govuk_text_field(
-  :type_description,
-  label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
-  hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
-) %>
-<% if FeatureFlag.active? :hesa_degree_data %>
-  <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
+<% if FeatureFlag.active? :international_degrees %>
+
+  <%= f.govuk_radio_buttons_fieldset :uk_degree, legend: { tag: 'span' } do %>
+    <%= f.govuk_radio_button :uk_degree, 'yes', label: { text: t('application_form.degree.uk_degree.label') } do %>
+      <%= f.govuk_text_field(
+        :type_description,
+        label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
+        hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
+      ) %>
+      <% if FeatureFlag.active? :hesa_degree_data %>
+        <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
+      <% end %>
+    <% end %>
+    <%= f.govuk_radio_button :uk_degree, 'no', label: { text: t('application_form.degree.non_uk_degree.label') } do %>
+      <%= f.govuk_text_field(
+        :international_type_description,
+        label: { text: t('application_form.degree.international_qualification_type.label'), size: 'm' },
+        hint_text: t('application_form.degree.international_qualification_type.hint_text')
+      ) %>
+    <% end %>
+  <% end %>
+
+<% else %>
+
+  <%= f.govuk_text_field(
+    :type_description,
+    label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
+    hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
+  ) %>
+  <% if FeatureFlag.active? :hesa_degree_data %>
+    <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
+  <% end %>
+
 <% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -132,6 +132,10 @@ en:
         button: Save and continue
       qualification:
         change_action: qualification
+      uk_degree:
+        label: UK degree
+      non_uk_degree:
+        label: Non-UK degree
       qualification_type:
         label: Type of degree
         review_label: Degree type
@@ -139,6 +143,10 @@ en:
           undergraduate: For example, BA, BSc or other
           another: For example, Masters, PhD, or other
           all: For example, BA, BSc, Masters, PhD, or other
+      international_qualification_type:
+        label: Type of qualification
+        review_label: Degree type
+        hint_text: For example, Bachelor degree, Bachelor of Arts, Diplôme, Licenciatura
       subject:
         label: What subject is your degree?
         review_label: Subject
@@ -468,9 +476,14 @@ en:
               too_many_words: Explanation for why you’ve been out of the workplace must be %{count} words or fewer
         candidate_interface/degree_type_form:
           attributes:
+            uk_degree:
+              blank: Select if this is a UK degree or not
             type_description:
               blank: Enter your degree type
               too_long: Type of degree must be %{count} characters or fewer
+            international_type_description:
+              blank: Enter your qualification type
+              too_long: Type of qualification must be %{count} characters or fewer
         candidate_interface/degree_subject_form:
           attributes:
             subject:

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -114,5 +114,53 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
         expect(form.errors.full_messages).to eq ['Degree is missing']
       end
     end
+
+    context 'when UK degree is selected and international_degrees feature flag is active' do
+      let(:degree) do
+        create(
+          :degree_qualification,
+          application_form: create(:application_form),
+          qualification_type: 'BSc',
+        )
+      end
+
+      let(:form) do
+        described_class.new(degree: degree, type_description: 'Doctor of Rap Battles', uk_degree: 'yes')
+      end
+
+      before { FeatureFlag.activate(:international_degrees) }
+
+      it 'updates the qualification_type and sets international to false' do
+        form.update
+
+        expect(degree.qualification_type).to eq 'Doctor of Rap Battles'
+        expect(degree.qualification_type_hesa_code).to eq nil
+        expect(degree.international).to be false
+      end
+    end
+
+    context 'when non-UK degree is selected and international_degrees feature flag is active' do
+      let(:degree) do
+        create(
+          :degree_qualification,
+          application_form: create(:application_form),
+          qualification_type: 'BSc',
+        )
+      end
+
+      let(:form) do
+        described_class.new(degree: degree, type_description: 'Doctor of Rap Battles', uk_degree: 'no')
+      end
+
+      before { FeatureFlag.activate(:international_degrees) }
+
+      it 'updates the qualification_type and sets international to false' do
+        form.update
+
+        expect(degree.qualification_type).to eq 'Doctor of Rap Battles'
+        expect(degree.qualification_type_hesa_code).to eq nil
+        expect(degree.international).to be true
+      end
+    end
   end
 end

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
       end
 
       let(:form) do
-        described_class.new(degree: degree, type_description: 'Doctor of Rap Battles', uk_degree: 'no')
+        described_class.new(degree: degree, international_type_description: 'Doctor of Rap Battles', uk_degree: 'no')
       end
 
       before { FeatureFlag.activate(:international_degrees) }

--- a/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
@@ -1,0 +1,330 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their degrees' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their degrees' do
+    given_the_international_degrees_feature_flag_is_active
+    given_i_am_signed_in
+    and_i_visit_the_site
+    when_i_click_on_degree
+    then_i_see_the_undergraduate_degree_form
+
+    # Add degree type after specifying Non-UK degree
+    when_i_check_non_uk_degree
+    and_i_fill_in_the_degree_type
+    and_i_click_on_save_and_continue
+
+    # Add subject
+    then_i_can_see_the_degree_subject_page
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_degree_subject
+    when_i_fill_in_the_degree_subject
+    and_i_click_on_save_and_continue
+
+    # Add institution
+    then_i_can_see_the_degree_institution_page
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_degree_institution_and_country
+    when_i_fill_in_the_degree_institution
+    and_i_fill_in_the_country
+    and_i_click_on_save_and_continue
+
+    # Add NARIC information
+    then_i_can_see_the_naric_page
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_naric_question
+    when_i_check_yes_for_naric_statement
+    and_i_fill_in_naric_reference
+    and_i_fill_in_comparable_uk_degree_type
+    and_i_click_on_save_and_continue
+
+    # Add grade
+    then_i_can_see_the_degree_grade_page
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_degree_grade
+    when_i_check_other
+    and_i_enter_my_grade
+    and_i_click_on_save_and_continue
+
+    # Add years
+    then_i_can_see_the_start_and_graduation_year_page
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_graduation_year
+    when_i_fill_in_the_start_and_graduation_year
+    and_i_click_on_save_and_continue
+
+    # Review
+    then_i_can_check_my_undergraduate_degree
+
+    # Edit details
+    when_i_click_to_change_my_undergraduate_degree_type
+    then_i_see_my_undergraduate_degree_type_filled_in
+    when_i_change_my_undergraduate_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_type
+
+    when_i_click_to_change_my_undergraduate_degree_year
+    then_i_see_my_undergraduate_degree_year_filled_in
+    when_i_change_my_undergraduate_degree_year
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_year
+
+    when_i_click_to_change_my_undergraduate_degree_subject
+    then_i_see_my_undergraduate_degree_subject_filled_in
+    when_i_change_my_undergraduate_degree_subject
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_subject
+
+    when_i_click_to_change_my_undergraduate_degree_institution
+    then_i_see_my_undergraduate_degree_institution_filled_in
+    when_i_change_my_undergraduate_degree_institution_and_country
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_institution
+
+    when_i_click_to_change_my_naric_details
+    then_i_see_my_original_naric_details_filled_in
+    when_i_change_my_reference_number_and_comparable_uk_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_naric_details
+
+    when_i_click_to_change_my_undergraduate_degree_grade
+    then_i_see_my_undergraduate_degree_grade_filled_in
+    when_i_change_my_undergraduate_degree_grade
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_grade
+
+    # Mark section as complete
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_should_see_the_form
+    and_that_the_section_is_completed
+
+    when_i_click_on_degree
+    then_i_can_check_my_answers
+  end
+
+  def given_the_international_degrees_feature_flag_is_active
+    FeatureFlag.activate :international_degrees
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_degree
+    click_link 'Degree'
+  end
+
+  def then_i_see_the_undergraduate_degree_form
+    expect(page).to have_content 'Add undergraduate degree'
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('application_form.degree.base.button')
+  end
+
+  def when_i_click_on_save_and_continue
+    click_button t('application_form.degree.base.button')
+  end
+
+  def when_i_check_non_uk_degree
+    pending 'not implemented'
+  end
+
+  def then_i_see_validation_errors_for_degree_type
+    expect(page).to have_content 'Enter your degree type'
+  end
+
+  def and_i_fill_in_the_degree_type
+    pending 'not implemented'
+  end
+
+  def then_i_can_see_the_degree_subject_page
+    expect(page).to have_content 'What subject is your degree?'
+  end
+
+  def then_i_see_validation_errors_for_degree_subject
+    expect(page).to have_content 'Enter your degree subject'
+  end
+
+  def when_i_fill_in_the_degree_subject
+    fill_in 'What subject is your degree?', with: 'Computer Science'
+  end
+
+  def then_i_can_see_the_degree_institution_page
+    expect(page).to have_content 'What institution did you study at?'
+  end
+
+  def then_i_see_validation_errors_for_degree_institution_and_country
+    expect(page).to have_content 'Enter the institution where you studied'
+    pending 'not implemented'
+  end
+
+  def when_i_fill_in_the_degree_institution
+    fill_in 'What institution did you study at?', with: 'MIT'
+  end
+
+  def and_i_fill_in_the_country
+    pending 'not implemented yet'
+  end
+
+  def then_i_can_see_the_naric_page
+    pending 'not implemented yet'
+  end
+
+  def then_i_see_validation_errors_for_naric_question
+    pending 'not implemented yet'
+  end
+
+  def when_i_check_yes_for_naric_statement
+    pending 'not implemented yet'
+  end
+
+  def and_i_fill_in_naric_reference
+    pending 'not implemented yet'
+  end
+
+  def and_i_fill_in_comparable_uk_degree_type
+    pending 'not implemented yet'
+  end
+
+  def then_i_can_see_the_degree_grade_page
+    expect(page).to have_content('What grade is your degree?')
+  end
+
+  def then_i_see_validation_errors_for_degree_grade
+    expect(page).to have_content 'Enter your degree grade'
+  end
+
+  def when_i_check_other
+    pending 'not implemented yet'
+  end
+
+  def and_i_enter_my_grade
+    pending 'not implemented yet'
+  end
+
+  def then_i_can_see_the_start_and_graduation_year_page
+    expect(page).to have_content('When did you study for your degree?')
+  end
+
+  def then_i_see_validation_errors_for_graduation_year
+    expect(page).to have_content 'Enter your graduation year'
+  end
+
+  def when_i_fill_in_the_start_and_graduation_year
+    year_with_trailing_space = '2006 '
+    year_with_preceding_space = ' 2009'
+    fill_in 'Year started course', with: year_with_trailing_space
+    fill_in 'Graduation year', with: year_with_preceding_space
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_degrees_review_path
+    expect(page).to have_content 'Computer Science'
+  end
+
+  def and_i_click_on_continue
+    click_button t('application_form.degree.review.button')
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_type
+    page.all('.govuk-summary-list__actions').to_a.first.click_link 'Change qualification'
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_year
+    page.all('.govuk-summary-list__actions').to_a.fourth.click_link 'Change year'
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_grade
+    page.all('.govuk-summary-list__actions').to_a[5].click_link 'Change grade'
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_subject
+    page.all('.govuk-summary-list__actions').to_a.second.click_link 'Change subject'
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_institution
+    page.all('.govuk-summary-list__actions').to_a.third.click_link 'Change institution'
+  end
+
+  def then_i_see_my_undergraduate_degree_type_filled_in
+    expect(page).to have_selector("input[value='BSc']")
+  end
+
+  def then_i_see_my_undergraduate_degree_year_filled_in
+    expect(page).to have_selector("input[name='candidate_interface_degree_year_form[start_year]'][value='2006']")
+    expect(page).to have_selector("input[name='candidate_interface_degree_year_form[award_year]'][value='2009']")
+  end
+
+  def then_i_see_my_undergraduate_degree_subject_filled_in
+    expect(page).to have_selector("input[value='Computer Science']")
+  end
+
+  def then_i_see_my_undergraduate_degree_institution_filled_in
+    expect(page).to have_selector("input[value='MIT']")
+  end
+
+  def then_i_see_my_undergraduate_degree_grade_filled_in
+    expect(page).to have_selector("input[value='First class honours']")
+  end
+
+  def when_i_change_my_undergraduate_degree_type
+    fill_in 'Type of degree', with: 'BA'
+  end
+
+  def when_i_change_my_undergraduate_degree_year
+    fill_in 'Year started course', with: '2008'
+    fill_in 'Graduation year', with: '2011'
+  end
+
+  def when_i_change_my_undergraduate_degree_subject
+    fill_in 'What subject is your degree?', with: 'Computer Science and AI'
+  end
+
+  def when_i_change_my_undergraduate_degree_grade
+    choose 'Lower second-class honours'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_type
+    expect(page).to have_content 'BA'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_year
+    expect(page).to have_content '2008'
+    expect(page).to have_content '2011'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_subject
+    expect(page).to have_content 'Computer Science and AI'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_institution
+    expect(page).to have_content 'Computer Science and AI'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_grade
+    expect(page).to have_content 'Lower second-class honours'
+  end
+
+  def when_i_mark_this_section_as_completed
+    check t('application_form.degree.review.completed_checkbox')
+  end
+
+  def then_i_should_see_the_form
+    expect(page).to have_content(t('page_titles.application_form'))
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#degree-badge-id', text: 'Completed')
+  end
+
+  def then_i_can_check_my_answers
+    then_i_can_check_my_revised_undergraduate_degree_type
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Entering their degrees' do
   include CandidateHelper
 
-  scenario 'Candidate submits their degrees' do
+  scenario 'Candidate submits their international degree' do
     given_the_international_degrees_feature_flag_is_active
     given_i_am_signed_in
     and_i_visit_the_site
@@ -11,97 +11,13 @@ RSpec.feature 'Entering their degrees' do
     then_i_see_the_undergraduate_degree_form
 
     # Add degree type after specifying Non-UK degree
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_uk_degree
     when_i_check_non_uk_degree
-    and_i_fill_in_the_degree_type
     and_i_click_on_save_and_continue
-
-    # Add subject
-    then_i_can_see_the_degree_subject_page
-    when_i_click_on_save_and_continue
-    then_i_see_validation_errors_for_degree_subject
-    when_i_fill_in_the_degree_subject
+    then_i_see_validation_errors_for_qualification_type
+    and_i_fill_in_the_qualification_type
     and_i_click_on_save_and_continue
-
-    # Add institution
-    then_i_can_see_the_degree_institution_page
-    when_i_click_on_save_and_continue
-    then_i_see_validation_errors_for_degree_institution_and_country
-    when_i_fill_in_the_degree_institution
-    and_i_fill_in_the_country
-    and_i_click_on_save_and_continue
-
-    # Add NARIC information
-    then_i_can_see_the_naric_page
-    when_i_click_on_save_and_continue
-    then_i_see_validation_errors_for_naric_question
-    when_i_check_yes_for_naric_statement
-    and_i_fill_in_naric_reference
-    and_i_fill_in_comparable_uk_degree_type
-    and_i_click_on_save_and_continue
-
-    # Add grade
-    then_i_can_see_the_degree_grade_page
-    when_i_click_on_save_and_continue
-    then_i_see_validation_errors_for_degree_grade
-    when_i_check_other
-    and_i_enter_my_grade
-    and_i_click_on_save_and_continue
-
-    # Add years
-    then_i_can_see_the_start_and_graduation_year_page
-    when_i_click_on_save_and_continue
-    then_i_see_validation_errors_for_graduation_year
-    when_i_fill_in_the_start_and_graduation_year
-    and_i_click_on_save_and_continue
-
-    # Review
-    then_i_can_check_my_undergraduate_degree
-
-    # Edit details
-    when_i_click_to_change_my_undergraduate_degree_type
-    then_i_see_my_undergraduate_degree_type_filled_in
-    when_i_change_my_undergraduate_degree_type
-    and_i_click_on_save_and_continue
-    then_i_can_check_my_revised_undergraduate_degree_type
-
-    when_i_click_to_change_my_undergraduate_degree_year
-    then_i_see_my_undergraduate_degree_year_filled_in
-    when_i_change_my_undergraduate_degree_year
-    and_i_click_on_save_and_continue
-    then_i_can_check_my_revised_undergraduate_degree_year
-
-    when_i_click_to_change_my_undergraduate_degree_subject
-    then_i_see_my_undergraduate_degree_subject_filled_in
-    when_i_change_my_undergraduate_degree_subject
-    and_i_click_on_save_and_continue
-    then_i_can_check_my_revised_undergraduate_degree_subject
-
-    when_i_click_to_change_my_undergraduate_degree_institution
-    then_i_see_my_undergraduate_degree_institution_filled_in
-    when_i_change_my_undergraduate_degree_institution_and_country
-    and_i_click_on_save_and_continue
-    then_i_can_check_my_revised_undergraduate_degree_institution
-
-    when_i_click_to_change_my_naric_details
-    then_i_see_my_original_naric_details_filled_in
-    when_i_change_my_reference_number_and_comparable_uk_degree_type
-    and_i_click_on_save_and_continue
-    then_i_can_check_my_revised_naric_details
-
-    when_i_click_to_change_my_undergraduate_degree_grade
-    then_i_see_my_undergraduate_degree_grade_filled_in
-    when_i_change_my_undergraduate_degree_grade
-    and_i_click_on_save_and_continue
-    then_i_can_check_my_revised_undergraduate_degree_grade
-
-    # Mark section as complete
-    when_i_mark_this_section_as_completed
-    and_i_click_on_continue
-    then_i_should_see_the_form
-    and_that_the_section_is_completed
-
-    when_i_click_on_degree
-    then_i_can_check_my_answers
   end
 
   def given_the_international_degrees_feature_flag_is_active
@@ -124,207 +40,27 @@ RSpec.feature 'Entering their degrees' do
     expect(page).to have_content 'Add undergraduate degree'
   end
 
-  def and_i_click_on_save_and_continue
-    click_button t('application_form.degree.base.button')
-  end
-
   def when_i_click_on_save_and_continue
     click_button t('application_form.degree.base.button')
   end
 
+  def and_i_click_on_save_and_continue
+    when_i_click_on_save_and_continue
+  end
+
   def when_i_check_non_uk_degree
-    pending 'not implemented'
+    choose 'Non-UK degree'
   end
 
-  def then_i_see_validation_errors_for_degree_type
-    expect(page).to have_content 'Enter your degree type'
+  def then_i_see_validation_errors_for_uk_degree
+    expect(page).to have_content 'Select if this is a UK degree or not'
   end
 
-  def and_i_fill_in_the_degree_type
-    pending 'not implemented'
+  def then_i_see_validation_errors_for_qualification_type
+    expect(page).to have_content 'Enter your qualification type'
   end
 
-  def then_i_can_see_the_degree_subject_page
-    expect(page).to have_content 'What subject is your degree?'
-  end
-
-  def then_i_see_validation_errors_for_degree_subject
-    expect(page).to have_content 'Enter your degree subject'
-  end
-
-  def when_i_fill_in_the_degree_subject
-    fill_in 'What subject is your degree?', with: 'Computer Science'
-  end
-
-  def then_i_can_see_the_degree_institution_page
-    expect(page).to have_content 'What institution did you study at?'
-  end
-
-  def then_i_see_validation_errors_for_degree_institution_and_country
-    expect(page).to have_content 'Enter the institution where you studied'
-    pending 'not implemented'
-  end
-
-  def when_i_fill_in_the_degree_institution
-    fill_in 'What institution did you study at?', with: 'MIT'
-  end
-
-  def and_i_fill_in_the_country
-    pending 'not implemented yet'
-  end
-
-  def then_i_can_see_the_naric_page
-    pending 'not implemented yet'
-  end
-
-  def then_i_see_validation_errors_for_naric_question
-    pending 'not implemented yet'
-  end
-
-  def when_i_check_yes_for_naric_statement
-    pending 'not implemented yet'
-  end
-
-  def and_i_fill_in_naric_reference
-    pending 'not implemented yet'
-  end
-
-  def and_i_fill_in_comparable_uk_degree_type
-    pending 'not implemented yet'
-  end
-
-  def then_i_can_see_the_degree_grade_page
-    expect(page).to have_content('What grade is your degree?')
-  end
-
-  def then_i_see_validation_errors_for_degree_grade
-    expect(page).to have_content 'Enter your degree grade'
-  end
-
-  def when_i_check_other
-    pending 'not implemented yet'
-  end
-
-  def and_i_enter_my_grade
-    pending 'not implemented yet'
-  end
-
-  def then_i_can_see_the_start_and_graduation_year_page
-    expect(page).to have_content('When did you study for your degree?')
-  end
-
-  def then_i_see_validation_errors_for_graduation_year
-    expect(page).to have_content 'Enter your graduation year'
-  end
-
-  def when_i_fill_in_the_start_and_graduation_year
-    year_with_trailing_space = '2006 '
-    year_with_preceding_space = ' 2009'
-    fill_in 'Year started course', with: year_with_trailing_space
-    fill_in 'Graduation year', with: year_with_preceding_space
-  end
-
-  def then_i_can_check_my_undergraduate_degree
-    expect(page).to have_current_path candidate_interface_degrees_review_path
-    expect(page).to have_content 'Computer Science'
-  end
-
-  def and_i_click_on_continue
-    click_button t('application_form.degree.review.button')
-  end
-
-  def when_i_click_to_change_my_undergraduate_degree_type
-    page.all('.govuk-summary-list__actions').to_a.first.click_link 'Change qualification'
-  end
-
-  def when_i_click_to_change_my_undergraduate_degree_year
-    page.all('.govuk-summary-list__actions').to_a.fourth.click_link 'Change year'
-  end
-
-  def when_i_click_to_change_my_undergraduate_degree_grade
-    page.all('.govuk-summary-list__actions').to_a[5].click_link 'Change grade'
-  end
-
-  def when_i_click_to_change_my_undergraduate_degree_subject
-    page.all('.govuk-summary-list__actions').to_a.second.click_link 'Change subject'
-  end
-
-  def when_i_click_to_change_my_undergraduate_degree_institution
-    page.all('.govuk-summary-list__actions').to_a.third.click_link 'Change institution'
-  end
-
-  def then_i_see_my_undergraduate_degree_type_filled_in
-    expect(page).to have_selector("input[value='BSc']")
-  end
-
-  def then_i_see_my_undergraduate_degree_year_filled_in
-    expect(page).to have_selector("input[name='candidate_interface_degree_year_form[start_year]'][value='2006']")
-    expect(page).to have_selector("input[name='candidate_interface_degree_year_form[award_year]'][value='2009']")
-  end
-
-  def then_i_see_my_undergraduate_degree_subject_filled_in
-    expect(page).to have_selector("input[value='Computer Science']")
-  end
-
-  def then_i_see_my_undergraduate_degree_institution_filled_in
-    expect(page).to have_selector("input[value='MIT']")
-  end
-
-  def then_i_see_my_undergraduate_degree_grade_filled_in
-    expect(page).to have_selector("input[value='First class honours']")
-  end
-
-  def when_i_change_my_undergraduate_degree_type
-    fill_in 'Type of degree', with: 'BA'
-  end
-
-  def when_i_change_my_undergraduate_degree_year
-    fill_in 'Year started course', with: '2008'
-    fill_in 'Graduation year', with: '2011'
-  end
-
-  def when_i_change_my_undergraduate_degree_subject
-    fill_in 'What subject is your degree?', with: 'Computer Science and AI'
-  end
-
-  def when_i_change_my_undergraduate_degree_grade
-    choose 'Lower second-class honours'
-  end
-
-  def then_i_can_check_my_revised_undergraduate_degree_type
-    expect(page).to have_content 'BA'
-  end
-
-  def then_i_can_check_my_revised_undergraduate_degree_year
-    expect(page).to have_content '2008'
-    expect(page).to have_content '2011'
-  end
-
-  def then_i_can_check_my_revised_undergraduate_degree_subject
-    expect(page).to have_content 'Computer Science and AI'
-  end
-
-  def then_i_can_check_my_revised_undergraduate_degree_institution
-    expect(page).to have_content 'Computer Science and AI'
-  end
-
-  def then_i_can_check_my_revised_undergraduate_degree_grade
-    expect(page).to have_content 'Lower second-class honours'
-  end
-
-  def when_i_mark_this_section_as_completed
-    check t('application_form.degree.review.completed_checkbox')
-  end
-
-  def then_i_should_see_the_form
-    expect(page).to have_content(t('page_titles.application_form'))
-  end
-
-  def and_that_the_section_is_completed
-    expect(page).to have_css('#degree-badge-id', text: 'Completed')
-  end
-
-  def then_i_can_check_my_answers
-    then_i_can_check_my_revised_undergraduate_degree_type
+  def and_i_fill_in_the_qualification_type
+    fill_in 'Type of qualification', with: 'Bachelors degree'
   end
 end


### PR DESCRIPTION
## Context

International candidates need to be able to give details of any degree(s) awarded by institutions based outside the UK. This PR implements the first part of the new flow for international degrees behind a feature flag.

## Changes proposed in this pull request

- [x] `international_degrees` feature flag
- [x] Updates to `DegreeTypeForm` to switch behaviour based on value of `international` attribute
- [x] Updates to template to switch to the new form when feature flag is active.
- [x] Initial system spec that tests the first form in the international degree flow.

<img width="636" alt="image" src="https://user-images.githubusercontent.com/450843/87143071-6d710980-c29d-11ea-9d44-ab64fcd084dd.png">


## Guidance to review

- Is the feature flag watertight? The feature is far from complete so the system must behave as it does today unless the flag is set.

## Link to Trello card

https://trello.com/c/RafQrpaq/1762-dev-🌐-international-degrees

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
