### PR TITLE
Zip the file we're sending to UCAS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,6 @@ DSI_API_SECRET=xxxxxxxxxxxx-xxxxx-xxxxxxxx-xxxxxxxx
 SANDBOX=false
 UCAS_USERNAME=abcdef
 UCAS_PASSWORD=123123
+UCAS_ZIP_PASSWORD=8712634
 UCAS_UPLOAD_BASEURL=https://transfer.ucasenvironments.com/api/v1
 UCAS_UPLOAD_FOLDER=folder

--- a/.env.test
+++ b/.env.test
@@ -7,5 +7,6 @@ DSI_API_URL=https://test-api.signin.education.gov.uk
 DSI_API_SECRET=some-secret
 UCAS_USERNAME=abcdef
 UCAS_PASSWORD=123123
+UCAS_ZIP_PASSWORD=98126312
 UCAS_UPLOAD_BASEURL=https://transfer.ucasenvironments.com/api/v1
 UCAS_UPLOAD_FOLDER=685520099

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -158,3 +158,7 @@ Layout/MultilineMethodArgumentLineBreaks:
 
 Layout/FirstMethodArgumentLineBreak:
   Enabled: false
+
+# 🤷‍♂️
+Style/AsciiComments:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'kaminari'
 gem ENV['WKHTMLTOPDF_GEM'] || 'wkhtmltopdf-binary'
 gem 'pdfkit'
 
+gem 'archive-zip'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
+    archive-zip (0.12.0)
+      io-like (~> 0.3.0)
     ast (2.4.1)
     attr_required (1.0.1)
     bcrypt (3.1.13)
@@ -185,6 +187,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.1)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -496,6 +499,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  archive-zip
   audited!
   brakeman
   bullet

--- a/app/services/ucas_matching/matching_data_file.rb
+++ b/app/services/ucas_matching/matching_data_file.rb
@@ -1,0 +1,42 @@
+require 'csv'
+# require 'archive/zip'
+
+module UCASMatching
+  class MatchingDataFile
+    # @returns filename
+    def create_file
+      timestamp = DateTime.now.strftime('%Y%m%d_%H%M%S_%z').gsub('+', '')
+      filename_prefix = "/tmp/dfe_apply_itt_applications_#{timestamp}-#{SecureRandom.hex}"
+      csv_filename = "#{filename_prefix}.csv"
+      zip_filename = "#{filename_prefix}.zip"
+
+      File.open(csv_filename, 'w') do |f|
+        f.write(csv_as_string)
+      end
+
+      Archive::Zip.archive(
+        zip_filename,
+        csv_filename,
+        encryption_codec: Archive::Zip::Codec::TraditionalEncryption,
+        password: ENV.fetch('UCAS_ZIP_PASSWORD'),
+      )
+
+      zip_filename
+    end
+
+  private
+
+    def csv_as_string
+      applications = MatchingDataExport.new.applications
+      header_row = MatchingDataExport.csv_header(applications)
+
+      CSV.generate do |rows|
+        rows << header_row
+
+        applications.each do |application|
+          rows << application.values
+        end
+      end
+    end
+  end
+end

--- a/azure/pipelines/build.yml
+++ b/azure/pipelines/build.yml
@@ -291,6 +291,7 @@ stages:
       dsiApiSecret: '$(dsiApiSecret)'
       ucasUsername: '$(ucasUsername)'
       ucasPassword: '$(ucasPassword)'
+      ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
 
 
@@ -348,4 +349,5 @@ stages:
       dsiApiSecret: '$(dsiApiSecret)'
       ucasUsername: '$(ucasUsername)'
       ucasPassword: '$(ucasPassword)'
+      ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'

--- a/azure/pipelines/release.yml
+++ b/azure/pipelines/release.yml
@@ -97,6 +97,7 @@ stages:
       dsiApiSecret: '$(dsiApiSecret)'
       ucasUsername: '$(ucasUsername)'
       ucasPassword: '$(ucasPassword)'
+      ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
 
 - stage: deploy_sandbox
@@ -153,6 +154,7 @@ stages:
       dsiApiSecret: '$(dsiApiSecret)'
       ucasUsername: '$(ucasUsername)'
       ucasPassword: '$(ucasPassword)'
+      ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
 
 
@@ -212,4 +214,5 @@ stages:
       dsiApiSecret: '$(dsiApiSecret)'
       ucasUsername: '$(ucasUsername)'
       ucasPassword: '$(ucasPassword)'
+      ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'

--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -60,6 +60,7 @@ parameters:
   dsiApiSecret:
   ucasUsername:
   ucasPassword:
+  ucasZipPassword:
 
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
@@ -243,6 +244,7 @@ jobs:
                 -dsiApiSecret "${{parameters.dsiApiSecret}}"
                 -ucasUsername "${{parameters.ucasUsername}}"
                 -ucasPassword "${{parameters.ucasPassword}}"
+                -ucasZipPassword "${{parameters.ucasZipPassword}}"
                 -ucasUploadBaseurl "$(ucasUploadBaseurl)"
                 -ucasUploadFolder "$(ucasUploadFolder)"
                 -govukNotifyCallbackAPIKey "${{parameters.govukNotifyCallbackAPIKey}}"

--- a/azure/template.json
+++ b/azure/template.json
@@ -324,6 +324,12 @@
                 "description": "The password for UCAS data exchange"
             }
         },
+        "ucasZipPassword": {
+            "type": "string",
+            "metadata": {
+                "description": "The password for the zipfiles we exchange with UCAS"
+            }
+        },
         "ucasUploadBaseurl": {
             "type": "string",
             "metadata": {
@@ -692,6 +698,10 @@
                             {
                                 "name": "UCAS_UPLOAD_FOLDER",
                                 "value": "[parameters('ucasUploadFolder')]"
+                            },
+                            {
+                                "name": "UCAS_ZIP_PASSWORD",
+                                "value": "[parameters('ucasZipPassword')]"
                             },
                             {
                                 "name": "REDIS_URL",

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -26,6 +26,7 @@ services:
       - DSI_API_SECRET
       - UCAS_USERNAME
       - UCAS_PASSWORD
+      - UCAS_ZIP_PASSWORD
       - UCAS_UPLOAD_BASEURL
       - UCAS_UPLOAD_FOLDER
       - SANDBOX

--- a/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
+++ b/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
@@ -31,8 +31,8 @@ RSpec.feature 'Uploading of matching data to UCAS', sidekiq: true do
 
   def when_the_daily_upload_runs
     @latest_exception = nil
-    UCASMatching::UploadMatchingData.perform_async
-  rescue StandardError => e
+    UCASMatching::UploadMatchingData.new.perform
+  rescue UCASMatching::ApiError => e
     @latest_exception = e
   end
 
@@ -79,7 +79,6 @@ RSpec.feature 'Uploading of matching data to UCAS', sidekiq: true do
     expect(@latest_exception).to be_nil
 
     expect(WebMock).to have_requested(:post, 'https://transfer.ucasenvironments.com/api/v1/folders/685520099/files')
-      .with { |req| req.body.match?(@application_choice.application_form.first_name) }
       .at_least_once
   end
 end

--- a/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
+++ b/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
@@ -79,6 +79,36 @@ RSpec.feature 'Uploading of matching data to UCAS', sidekiq: true do
     expect(@latest_exception).to be_nil
 
     expect(WebMock).to have_requested(:post, 'https://transfer.ucasenvironments.com/api/v1/folders/685520099/files')
+      .with { |req|
+        tempfile = Rails.root.join('tmp', "#{SecureRandom.hex}.zip")
+
+        File.open(tempfile, 'wb') do |f|
+          # The `req.body` is a HTTP response that looks like this:
+          #
+          #   -----------------------d04a9b3742f0b3809dc6a392e2a91c02d22d1adf6a
+          #   Content-Disposition: form-data; name="file"; filename="dfe_apply_itt_applications_20200720_111327_0100-1acf8a7f568ad745f4d8d7dc08d0425c.zip"
+          #   Content-Type: application/octet-stream
+          #
+          #   P?Y?P??ȇkTdfe_apply_itt_applications_20200720_111327_0100-1acf8a7f568ad745f4d8d7dc08d0425c.csv]?[o?0
+          #
+          #   -----------------------d04a9b3742f0b3809dc6a392e2a91c02d22d1adf6a--
+          #
+          # Remove the first 4 and last 2 lines to get the actual zipfile.
+          f.write(req.body.lines[4..-2].join.chomp)
+        end
+
+        directory_to_extract_to = Rails.root.join('tmp', SecureRandom.hex)
+        Dir.mkdir(directory_to_extract_to)
+
+        Archive::Zip.extract(
+          tempfile.to_s,
+          directory_to_extract_to.to_s,
+          password: ENV.fetch('UCAS_ZIP_PASSWORD'),
+        )
+
+        csv = File.read(Dir.glob("#{directory_to_extract_to}/*.csv").first)
+        csv.match?(@application_choice.application_form.first_name)
+      }
       .at_least_once
   end
 end


### PR DESCRIPTION
## Context

UCAS would like to have the CSV we send them zipped and encrypted.

## Changes proposed in this pull request

This does that using the `archive_zip` gem. I also tried to use Rubyzip but the documentation scared me off (https://github.com/rubyzip/rubyzip#password-protection-experimental says the password thing is "experimental").

## Guidance to review

Run the export, test that you can extract the ZIP into a valid CSV.

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
