### PR TITLE
Add non-uk qualifications to the GCSE type page

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -72,6 +72,7 @@ module CandidateInterface
     def gcse_qualification_types
       t('application_form.gcse.qualification_types').merge(
         other_uk: application_qualification.other_uk_qualification_type,
+        non_uk: application_qualification.non_uk_qualification_type,
       )
     end
   end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -60,7 +60,7 @@ module CandidateInterface
 
     def qualification_params
       params.require(:candidate_interface_gcse_qualification_type_form)
-        .permit(:qualification_type, :other_uk_qualification_type, :missing_explanation)
+        .permit(:qualification_type, :other_uk_qualification_type, :missing_explanation, :non_uk_qualification_type)
         .transform_values(&:strip)
     end
   end

--- a/app/forms/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_type_form.rb
@@ -1,17 +1,18 @@
 module CandidateInterface
   class GcseQualificationTypeForm
     OTHER_UK_QUALIFICATION_TYPE = 'other_uk'.freeze
-
+    NON_UK_QUALIFICATION_TYPE = 'non_uk'.freeze
     include ActiveModel::Model
 
     attr_accessor :subject, :level, :qualification_type, :other_uk_qualification_type,
-                  :missing_explanation, :qualification_id
+                  :missing_explanation, :qualification_id, :non_uk_qualification_type
 
     validates :subject, :level, :qualification_type, presence: true
 
     validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == OTHER_UK_QUALIFICATION_TYPE }
+    validates :non_uk_qualification_type, presence: true, if: -> { qualification_type == NON_UK_QUALIFICATION_TYPE }
     validates :qualification_type, length: { maximum: 255 }
-    validates :other_uk_qualification_type, length: { maximum: 255 }
+    validates :other_uk_qualification_type, :non_uk_qualification_type, length: { maximum: 255 }
 
     validates :missing_explanation, word_count: { maximum: 200 }
 
@@ -21,6 +22,7 @@ module CandidateInterface
       return false unless valid?
 
       reset_other_uk_qualification_type
+      reset_non_uk_qualification_type
 
       if new_record?
         application_form.application_qualifications.create(
@@ -28,6 +30,7 @@ module CandidateInterface
           subject: subject,
           qualification_type: qualification_type,
           other_uk_qualification_type: other_uk_qualification_type,
+          non_uk_qualification_type: non_uk_qualification_type,
           missing_explanation: missing_explanation,
         )
       else
@@ -38,6 +41,7 @@ module CandidateInterface
           subject: subject,
           qualification_type: qualification_type,
           other_uk_qualification_type: other_uk_qualification_type,
+          non_uk_qualification_type: non_uk_qualification_type,
           missing_explanation: missing_explanation,
         )
       end
@@ -46,6 +50,7 @@ module CandidateInterface
     def set_attributes(params)
       @qualification_type = params[:qualification_type]
       @other_uk_qualification_type = params[:other_uk_qualification_type]
+      @non_uk_qualification_type = params[:non_uk_qualification_type]
       @missing_explanation = params[:missing_explanation]
     end
 
@@ -59,6 +64,7 @@ module CandidateInterface
         subject: qualification.subject,
         qualification_type: qualification.qualification_type,
         other_uk_qualification_type: qualification.other_uk_qualification_type,
+        non_uk_qualification_type: qualification.non_uk_qualification_type,
         qualification_id: qualification.id,
         missing_explanation: qualification.missing_explanation,
       )
@@ -73,6 +79,12 @@ module CandidateInterface
     def reset_other_uk_qualification_type
       if qualification_type != OTHER_UK_QUALIFICATION_TYPE
         @other_uk_qualification_type = nil
+      end
+    end
+
+    def reset_non_uk_qualification_type
+      if qualification_type != NON_UK_QUALIFICATION_TYPE
+        @non_uk_qualification_type = nil
       end
     end
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -37,6 +37,7 @@ class FeatureFlag
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],
     [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
+    [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -14,9 +14,15 @@
         <% select_gcse_qualification_type_options.each_with_index do |option, i| %>
           <%= f.govuk_radio_divider if i == select_gcse_qualification_type_options.count - 1 %>
           <% if option.id == :other_uk %>
-
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
               <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' } %>
+            <% end %>
+
+          <% elsif option.id == :non_uk %>
+            <% if FeatureFlag.active?('international_gcses') %>
+              <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
+                <% f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' }, hint_text: t('application_form.gcse.other_uk.hint_text') %>
+              <% end %>
             <% end %>
 
           <% elsif option.id == :missing %>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -21,7 +21,7 @@
           <% elsif option.id == :non_uk %>
             <% if FeatureFlag.active?('international_gcses') %>
               <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
-                <% f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' }, hint_text: t('application_form.gcse.other_uk.hint_text') %>
+                <% f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint_text: t('application_form.gcse.non_uk.hint_text') %>
               <% end %>
             <% end %>
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -195,9 +195,11 @@ en:
         gce_o_level: GCE O Level
         scottish_national_5: Scottish National 5
         other_uk: Other UK qualification
+        non_uk: Non-UK qualification
         missing: I don’t have this qualification yet
       other_uk:
         label: Enter type of qualification
+        hint_text: For example, High School Diploma, Higher Secondary School Certificate, Baccalauréat Général, Título de Bachiller
       missing_explanation:
         label: If you are working towards this qualification, give us details (optional)
       grade:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -592,6 +592,8 @@ en:
             other_uk_qualification_type:
               blank: Enter the type of qualification
               too_long: Type of degree must be %{count} characters or fewer
+            non_uk_qualification_type:
+              blank: Enter the type of qualification
             missing_explanation:
               blank: Give us some details
               too_many_words: Details must be %{count} words or fewer

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -199,6 +199,8 @@ en:
         missing: I don’t have this qualification yet
       other_uk:
         label: Enter type of qualification
+      non_uk:
+        label: Enter type of qualification
         hint_text: For example, High School Diploma, Higher Secondary School Certificate, Baccalauréat Général, Título de Bachiller
       missing_explanation:
         label: If you are working towards this qualification, give us details (optional)

--- a/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -65,6 +65,38 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
       end
     end
 
+    context 'the type of qualification is non_uk ' do
+      it 'gets error if non_uk_qualification_type is empty' do
+        application_form = create(:application_form)
+        qualification = application_form.application_qualifications.create!(
+          level: 'gcse',
+          subject: 'maths',
+          qualification_type: 'non_uk',
+        )
+
+        form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+
+        expect(form.valid?).to eq false
+        expect(form.errors[:non_uk_qualification_type]).to include('Enter the type of qualification')
+      end
+
+      it 'saves when non_uk_qualification_type is present' do
+        application_form = create(:application_form)
+        qualification = application_form.application_qualifications.create!(
+          level: 'gcse',
+          subject: 'maths',
+          qualification_type: 'non_uk',
+          non_uk_qualification_type: 'High School Diploma',
+        )
+
+        form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+        form.save_base(application_form)
+
+        expect(application_form.application_qualifications.first.qualification_type).to eq 'non_uk'
+        expect(application_form.application_qualifications.first.non_uk_qualification_type).to eq 'High School Diploma'
+      end
+    end
+
     it 'update the existing qualification model' do
       application_form = create(:application_form)
       qualification = application_form.application_qualifications.create!(

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their maths Non UK GCSE equivalency details and then updates them' do
+    given_i_am_signed_in
+    and_the_international_gcses_flag_is_active
+
+    when_i_visit_the_candidate_application_page
+    and_i_click_on_the_maths_gcse_link
+    then_i_see_the_add_gcse_maths_page
+
+    when_i_do_not_select_any_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_the_qualification_type_error
+
+    when_i_select_non_uk_qualification
+    and_i_fill_in_my_qualification_type
+    and_i_click_save_and_continue
+    then_i_see_accrediting_country_page
+
+    when_i_fill_in_the_accrediting_country
+    and_i_click_save_and_continue
+
+    when_i_fill_in_the_grade
+    and_i_click_save_and_continue
+    then_i_see_add_year_page
+
+    when_i_fill_in_the_year
+    and_i_click_save_and_continue
+    then_i_see_the_review_page_with_correct_details
+
+    when_i_mark_the_section_as_completed
+    and_click_continue
+    then_i_see_the_maths_gcse_is_completed
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_international_gcses_flag_is_active
+    FeatureFlag.activate('international_gcses')
+  end
+
+  def given_i_am_not_signed_in; end
+
+  def and_i_click_on_the_maths_gcse_link
+    click_on 'Maths GCSE or equivalent'
+  end
+
+  def then_i_see_the_add_gcse_maths_page
+    expect(page).to have_content 'Add maths GCSE grade 4 (C) or above, or equivalent'
+  end
+
+  def then_i_see_the_qualification_type_error
+    expect(page).to have_content 'Enter the type of qualification'
+  end
+
+  def when_i_select_non_uk_qualification
+    choose('Non-UK qualification')
+  end
+
+  def and_i_fill_in_my_qualification_type
+    fill_in :other_non_uk_qualification, with: 'High School Diploma'
+  end
+
+  def then_i_see_accrediting_country_page
+    expect(page).to have_current_path candidate_interface_gcse_accrediting_country_path
+  end
+
+  def and_i_click_save_and_continue
+    click_button 'Save and continue'
+  end
+
+  def when_i_do_not_select_any_gcse_option; end
+
+  def when_i_visit_the_candidate_application_page
+    visit '/candidate/application'
+  end
+
+  def then_i_see_the_review_page_with_correct_details
+    expect(page).to have_content 'Maths GCSE or equivalent'
+
+    expect(page).to have_content 'High School Diploma'
+    expect(page).to have_content 'Pass'
+    expect(page).to have_content '1990'
+  end
+
+  def then_i_see_add_grade_page
+    expect(page).to have_content t('gcse_edit_grade.page_title', subject: 'maths')
+  end
+
+  def then_i_see_add_year_page
+    expect(page).to have_content t('gcse_edit_year.page_title', subject: 'maths')
+  end
+
+  def when_i_fill_in_the_grade
+    fill_in 'Please specify your grade', with: 'Pass'
+  end
+
+  def when_i_fill_in_the_year
+    fill_in 'Enter year', with: '1990'
+  end
+
+  def then_i_see_the_non_uk_qualification_option_selected
+    expect(find_field('Non-UK qualification')).to be_checked
+  end
+
+  def then_i_see_the_gcse_grade_entered
+    expect(page).to have_selector("input[value='Pass']")
+  end
+
+  def then_i_see_the_gcse_year_entered
+    expect(page).to have_selector("input[value='1990']")
+  end
+
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def then_i_see_the_maths_gcse_is_completed
+    expect(page).to have_css('#maths-gcse-or-equivalent-badge-id', text: 'Completed')
+  end
+
+  def and_click_continue
+    click_button t('application_form.continue')
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -18,10 +18,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     when_i_select_non_uk_qualification
     and_i_fill_in_my_qualification_type
     and_i_click_save_and_continue
-    then_i_see_accrediting_country_page
-
-    when_i_fill_in_the_accrediting_country
-    and_i_click_save_and_continue
+    then_i_see_the_add_grade_page
 
     when_i_fill_in_the_grade
     and_i_click_save_and_continue
@@ -63,11 +60,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def and_i_fill_in_my_qualification_type
-    fill_in :other_non_uk_qualification, with: 'High School Diploma'
-  end
-
-  def then_i_see_accrediting_country_page
-    expect(page).to have_current_path candidate_interface_gcse_accrediting_country_path
+    fill_in 'candidate-interface-gcse-qualification-type-form-non-uk-qualification-type-field', with: 'High School Diploma'
   end
 
   def and_i_click_save_and_continue
@@ -80,11 +73,15 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     visit '/candidate/application'
   end
 
+  def then_i_see_the_add_grade_page
+    expect(page).to have_current_path candidate_interface_gcse_details_edit_grade_path('maths')
+  end
+
   def then_i_see_the_review_page_with_correct_details
     expect(page).to have_content 'Maths GCSE or equivalent'
 
     expect(page).to have_content 'High School Diploma'
-    expect(page).to have_content 'Pass'
+    expect(page).to have_content 'PASS'
     expect(page).to have_content '1990'
   end
 


### PR DESCRIPTION
## Context

International candidates need to be able to input their GCSE equivalencies.

In an attempt to keep my PRs small, this just covers adding an additional radio button to the type page and makes sure the review page shows the correct values. 

The behaviour of non_uk_qualifcation_type is almost identically to other_uk_qualification_type. 

## Changes proposed in this pull request

- Add a radio button and text area for non-uk qualifications
- Update the GCSE qualification type from to use the new fields
- Update the review component to display the input qualification name

Type page

| Before  | After |
| ------------- | ------------- |
|![image](https://user-images.githubusercontent.com/42515961/87150861-c8f5c400-c2aa-11ea-8239-adcc1e2b9e70.png)| ![image](https://user-images.githubusercontent.com/42515961/87149471-348a6200-c2a8-11ea-9ef7-790549defb79.png)|

Review page

![image](https://user-images.githubusercontent.com/42515961/87151724-45d56d80-c2ac-11ea-9f6a-e93c60e9f27a.png)


## Guidance to review

I think it's fairly straight forward to review. Just literally clicking through and adding one and checking the behaviour is okay.

## Link to Trello card

https://trello.com/c/Sy4RX8lL/1763-dev-%F0%9F%8C%90-international-gcse-equivalents

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
