### PR TITLE
Add provider permissions to the account page

### DIFF
--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -1,19 +1,19 @@
 <ul class="govuk-list" id="provider-<%= @permission_model.provider.id %>-enabled-permissions">
-  <li><%= render CheckIcon.new %> View applications</li>
+  <% if @permission_model.manage_organisations? %>
+    <li><%= render CheckIcon.new %> Manage organisations</li>
+  <% end %>
 
   <% if @permission_model.manage_users? %>
     <li><%= render CheckIcon.new %> Manage users</li>
   <% end %>
 
-  <% if @permission_model.manage_organisations? %>
-    <li><%= render CheckIcon.new %> Manage organisations</li>
+  <% if @permission_model.make_decisions? %>
+    <li><%= render CheckIcon.new %> Make decisions</li>
   <% end %>
 
   <% if @permission_model.view_safeguarding_information? %>
     <li><%= render CheckIcon.new %> View safeguarding information</li>
   <% end %>
 
-  <% if @permission_model.make_decisions? %>
-    <li><%= render CheckIcon.new %> Make decisions</li>
-  <% end %>
+  <li><%= render CheckIcon.new %> View applications</li>
 </ul>

--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -15,5 +15,7 @@
     <li><%= render CheckIcon.new %> View safeguarding information</li>
   <% end %>
 
-  <li><%= render CheckIcon.new %> View applications</li>
+  <% if @permission_model.view_applications_only? %>
+    <li>View applications only</li>
+  <% end %>
 </ul>

--- a/app/components/provider_interface/provider_account_component.html.erb
+++ b/app/components/provider_interface/provider_account_component.html.erb
@@ -1,3 +1,3 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
-<%= govuk_link_to 'Change your details in DfE Sign-in', dsi_profile_url %>
+<%= govuk_link_to 'Change your details or password in DfE Sign-in', dsi_profile_url %>

--- a/app/components/provider_interface/provider_account_component.rb
+++ b/app/components/provider_interface/provider_account_component.rb
@@ -14,7 +14,8 @@ module ProviderInterface
         { key: 'Last name', value: current_provider_user.last_name },
         { key: 'Email address', value: current_provider_user.email_address },
         organisations_row,
-      ]
+        permissions_rows,
+      ].flatten
     end
 
     def dsi_profile_url
@@ -34,6 +35,15 @@ module ProviderInterface
 
     def organisations
       current_provider_user.providers.map(&:name)
+    end
+
+    def permissions_rows
+      current_provider_user.provider_permissions.includes([:provider]).map do |permission|
+        {
+          key: "Permissions: #{permission.provider.name}",
+          value: render(PermissionsList.new(permission)),
+        }
+      end
     end
   end
 end

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -14,6 +14,7 @@ class ProviderPermissions < ActiveRecord::Base
   audited associated_with: :provider_user
 
   scope :manage_users, -> { where(manage_users: true) }
+  scope :manage_organisations, -> { where(manage_organisations: true) }
   scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
   scope :make_decisions, -> { where(make_decisions: true) }
 
@@ -31,5 +32,9 @@ class ProviderPermissions < ActiveRecord::Base
         provider_user_id: provider_user&.id,
       )
     end
+  end
+
+  def view_applications_only?
+    VALID_PERMISSIONS.map { |permission| send(permission) }.all?(false)
   end
 end

--- a/spec/components/permissions_list_component_spec.rb
+++ b/spec/components/permissions_list_component_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe PermissionsList do
+  it 'renders permissions' do
+    permission_model = create(:provider_permissions, manage_organisations: true)
+    result = render_inline(described_class.new(permission_model))
+
+    expect(result.css('li').text).to include('Manage organisations')
+    expect(result.css('li').text).not_to include('View applications only')
+  end
+
+  it 'renders View applications only' do
+    permission_model = create(:provider_permissions)
+    result = render_inline(described_class.new(permission_model))
+
+    expect(result.css('li').text).to include('View applications only')
+    expect(result.css('li').text).not_to include('Manage organisations')
+    expect(result.css('li').text).not_to include('Make manage users')
+    expect(result.css('li').text).not_to include('Make decistions')
+    expect(result.css('li').text).not_to include('View safeguarding information')
+  end
+end

--- a/spec/components/provider_interface/provider_account_component_spec.rb
+++ b/spec/components/provider_interface/provider_account_component_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderAccountComponent do
-  let(:provider1) { build(:provider) }
-  let(:provider2) { build(:provider) }
-  let(:current_provider_user) { build(:provider_user, providers: [provider1, provider2]) }
+  let(:provider1) { create(:provider) }
+  let(:provider2) { create(:provider) }
+  let(:current_provider_user) { create(:provider_user, providers: [provider1, provider2]) }
 
   subject(:result) { render_inline(described_class.new(current_provider_user: current_provider_user)) }
 
@@ -31,5 +31,10 @@ RSpec.describe ProviderInterface::ProviderAccountComponent do
 
   it 'renders correct link to the DfE Sign-in profile page in non-qa environments' do
     expect(result.css('.govuk-link').attribute('href').value).to eq('https://profile.signin.education.gov.uk')
+  end
+
+  it 'renders permissions' do
+    expect(result.css('.govuk-summary-list__key').text).to include('Permissions: ')
+    expect(result.css('.govuk-summary-list__value').text).to include('View applications only')
   end
 end

--- a/spec/models/provider_permissions_spec.rb
+++ b/spec/models/provider_permissions_spec.rb
@@ -24,4 +24,18 @@ RSpec.describe ProviderPermissions do
       expect(expected_provider_names).to eq(%w[AAA ABB ABC])
     end
   end
+
+  describe '#view_applications_only?' do
+    let(:current_provider_user) { create(:provider_user, providers: [create(:provider)]) }
+
+    it 'returns true when there are not permissions' do
+      expect(current_provider_user.provider_permissions.first.view_applications_only?).to eq(true)
+    end
+
+    it 'returns false if there is at least one permission' do
+      current_provider_user.provider_permissions.update(make_decisions: true)
+
+      expect(current_provider_user.provider_permissions.first.view_applications_only?).to eq(false)
+    end
+  end
 end

--- a/spec/system/provider_interface/provider_views_account_page.rb
+++ b/spec/system/provider_interface/provider_views_account_page.rb
@@ -39,6 +39,6 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def and_i_see_a_link_to_dfe_signin_to_change_details
-    expect(page).to have_link('Change your details in DfE Sign-in', href: 'https://profile.signin.education.gov.uk')
+    expect(page).to have_link('Change your details or password in DfE Sign-in', href: 'https://profile.signin.education.gov.uk')
   end
 end

--- a/spec/system/provider_interface/provider_views_account_page.rb
+++ b/spec/system/provider_interface/provider_views_account_page.rb
@@ -10,6 +10,7 @@ RSpec.feature 'Managing provider user permissions' do
 
     when_i_click_on_the_account_link
     then_i_see_account_page_with_user_details
+    and_i_see_users_permissions
     and_i_see_a_link_to_dfe_signin_to_change_details
   end
 
@@ -31,11 +32,15 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def then_i_see_account_page_with_user_details
-    rows = find('div .govuk-summary-list').all('dd')
-    expect(rows[0].text).to eq(@user.first_name)
-    expect(rows[1].text).to eq(@user.last_name)
-    expect(rows[2].text).to eq(@user.email_address)
-    expect(rows[3].text).to include(@example_provider.name, @another_provider.name)
+    @rows = find('div .govuk-summary-list').all('dd')
+    expect(@rows[0].text).to eq(@user.first_name)
+    expect(@rows[1].text).to eq(@user.last_name)
+    expect(@rows[2].text).to eq(@user.email_address)
+    expect(@rows[3].text).to include(@example_provider.name, @another_provider.name)
+  end
+
+  def and_i_see_users_permissions
+    expect(@rows[4].text).to include('View applications only')
   end
 
   def and_i_see_a_link_to_dfe_signin_to_change_details


### PR DESCRIPTION
## Context

Users need to be able to view what permissions they have for their account

## Changes proposed in this pull request
Update DfE Sign-in link to mention password

-  Update DfE Sign-in link to mention password change
- Change order of permissions in PermissionsList component
- Show "View applications only" when user doesn't have other permissions
- Show user permissions on the provider account page

<kbd><img width="604" alt="Screenshot 2020-07-13 at 12 10 15" src="https://user-images.githubusercontent.com/38078064/87300460-c3e08100-c505-11ea-829f-7e005ffb3887.png"></kbd>


## Guidance to review

- visit http://localhost:3000/provider/account

## Link to Trello card

https://trello.com/c/V6p6TK33/2412-add-provider-permissions-to-account-page

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
