### PR TITLE
Persist filter state across requests

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -6,6 +6,7 @@ module ProviderInterface
       @page_state = ProviderApplicationsPageState.new(
         params: params,
         provider_user: current_provider_user,
+        state_store: session,
       )
 
       application_choices = GetApplicationChoicesForProviders.call(

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -3,13 +3,11 @@ module ProviderInterface
     attr_accessor :available_filters, :filter_selections, :provider_user
     attr_reader :applied_filters
 
-    def initialize(params:, provider_user:)
-      @applied_filters = parse_params(params)
-      @provider_user = provider_user
-    end
 
-    def parse_params(params)
-      params.permit(:candidate_name, :sort_by, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
+    def initialize(params:, provider_user:, state_store:)
+      @provider_user = provider_user
+      @applied_filters = parse_params(params)
+      @state_store = state_store
     end
 
     def filters

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -1,10 +1,15 @@
 module ProviderInterface
   class ProviderApplicationsPageState
     attr_accessor :available_filters, :filter_selections, :provider_user
+    attr_reader :applied_filters
 
     def initialize(params:, provider_user:)
-      @params = params
+      @applied_filters = parse_params(params)
       @provider_user = provider_user
+    end
+
+    def parse_params(params)
+      params.permit(:candidate_name, :sort_by, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
     end
 
     def filters
@@ -15,12 +20,8 @@ module ProviderInterface
       applied_filters.values.any?
     end
 
-    def applied_filters
-      @params.permit(:candidate_name, :sort_by, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
-    end
-
     def sort_by
-      sort_options.map(&:last).flatten.include?(@params[:sort_by]) ? @params[:sort_by] : 'last_changed'
+      sort_options.map(&:last).flatten.include?(applied_filters[:sort_by]) ? applied_filters[:sort_by] : 'last_changed'
     end
 
     def sort_options

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
       params: applied_filters,
       provider_user: current_provider_user,
+      state_store: {},
     )
 
     result = render_inline described_class.new(page_state: page_state)
@@ -62,6 +63,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
       params: ActionController::Parameters.new({}),
       provider_user: current_provider_user,
+      state_store: {},
     )
     result = render_inline described_class.new(page_state: page_state)
 
@@ -81,6 +83,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
       params: applied_filters,
       provider_user: current_provider_user,
+      state_store: {},
     )
 
     result = render_inline described_class.new(page_state: page_state)
@@ -92,6 +95,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
       params: ActionController::Parameters.new({}),
       provider_user: current_provider_user,
+      state_store: {},
     )
 
     result = render_inline described_class.new(page_state: page_state)
@@ -103,6 +107,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
       params: ActionController::Parameters.new({ sort_by: 'last_changed' }),
       provider_user: current_provider_user,
+      state_store: {},
     )
 
     component = described_class.new(page_state: page_state)
@@ -115,6 +120,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     page_state = ProviderInterface::ProviderApplicationsPageState.new(
       params: ActionController::Parameters.new({ sort_by: 'last_changed' }),
       provider_user: current_provider_user,
+      state_store: {},
     )
 
     result = render_inline described_class.new(page_state: page_state)

--- a/spec/components/provider_interface/sort_order_component_spec.rb
+++ b/spec/components/provider_interface/sort_order_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProviderInterface::SortOrderComponent do
       })
     end
     let(:page_state) do
-      ProviderInterface::ProviderApplicationsPageState.new(params: params, provider_user: provider_user)
+      ProviderInterface::ProviderApplicationsPageState.new(params: params, provider_user: provider_user, state_store: {})
     end
 
     subject(:rendered_result) { render_inline(described_class.new(page_state: page_state)) }

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(
         params: ActionController::Parameters.new,
         provider_user: provider_user,
+        state_store: {},
       )
 
       expected_number_of_filters = 3
@@ -35,6 +36,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(
         params: ActionController::Parameters.new,
         provider_user: another_provider_user,
+        state_store: {},
       )
 
       expected_number_of_filters = 2
@@ -49,6 +51,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(
         params: ActionController::Parameters.new({ provider: [provider1.id] }),
         provider_user: another_provider_user,
+        state_store: {},
       )
 
       headings = page_state.filters.map { |filter| filter[:heading] }
@@ -77,7 +80,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'returns a has of permitted parameters' do
-      page_state = described_class.new(params: params, provider_user: provider_user)
+      page_state = described_class.new(params: params, provider_user: provider_user, state_store: {})
 
       expect(page_state.applied_filters).to be_a(Hash)
       expect(page_state.applied_filters.keys).to include('status')
@@ -95,12 +98,12 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     let(:empty_params) { ActionController::Parameters.new }
 
     it 'returns true if filers have been applied' do
-      page_state = described_class.new(params: params, provider_user: provider_user)
+      page_state = described_class.new(params: params, provider_user: provider_user, state_store: {})
       expect(page_state.filtered?).to be(true)
     end
 
     it 'returns false if filters have not been applied' do
-      page_state = described_class.new(params: empty_params, provider_user: provider_user)
+      page_state = described_class.new(params: empty_params, provider_user: provider_user, state_store: {})
       expect(page_state.filtered?).to be(false)
     end
   end
@@ -108,7 +111,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
   describe '#sort_options' do
     let(:params) { ActionController::Parameters.new }
 
-    subject(:sort_options) { described_class.new(params: params, provider_user: provider_user).sort_options }
+    subject(:sort_options) { described_class.new(params: params, provider_user: provider_user, state_store: {}).sort_options }
 
     it { is_expected.to eq([['Last changed', 'last_changed'], ['Days left to respond', 'days_left_to_respond']]) }
   end
@@ -116,7 +119,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
   describe '#sort_by' do
     let(:params) { ActionController::Parameters.new }
 
-    subject(:sort_by) { described_class.new(params: params, provider_user: provider_user).sort_by }
+    subject(:sort_by) { described_class.new(params: params, provider_user: provider_user, state_store: {}).sort_by }
 
     it { is_expected.to eq('last_changed') }
 

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -129,4 +129,35 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       it { is_expected.to eq('days_left_to_respond') }
     end
   end
+
+  it 'can load and persist its own state' do
+    state_store = {}
+
+    state_one = described_class.new(
+      params: ActionController::Parameters.new({ 'sort_by' => 'days_left_to_respond' }),
+      provider_user: provider_user,
+      state_store: state_store,
+    )
+
+    # The state is what we passed in
+    expect(state_one.applied_filters).to eq({ 'sort_by' => 'days_left_to_respond' })
+
+    state_two = described_class.new(
+      params: ActionController::Parameters.new, # empty params
+      provider_user: provider_user,
+      state_store: state_store,
+    )
+
+    # The state is kept from last time
+    expect(state_two.applied_filters).to eq({ 'sort_by' => 'days_left_to_respond' })
+
+    state_three = described_class.new(
+      params: ActionController::Parameters.new({ 'candidate_name' => 'Tom Thumb' }),
+      provider_user: provider_user,
+      state_store: state_store,
+    )
+
+    # Providing new params replaces the saved state
+    expect(state_three.applied_filters).to eq({ 'candidate_name' => 'Tom Thumb' })
+  end
 end


### PR DESCRIPTION
## Context

This is out of sync with the prototype

## Changes proposed in this pull request

- when visiting `/applications`, you can select filters, searches, ordering etc
- if you navigate away, and then click "Applications" in the header, your filters are preserved
- submitting new filters (or blank filters) will clear the saved state

This is achieved by having `ProviderApplicationsPageState` write its state into the session (handed down from the controller) whenever it changes. The above logic is used to decide whether to read the existing state, or update and rewrite that state.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/qPEBdMux/2411-ensure-that-users-filters-persist-across-sessions

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
