### PR TITLE
Add country to international GCSE flow 

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -13,6 +13,13 @@ module CandidateInterface
     def gcse_qualification_rows
       if application_qualification.missing_qualification?
         [missing_qualification_row]
+      elsif FeatureFlag.active?('international_gcses')
+        [
+          qualification_row,
+          award_year_row,
+          grade_row,
+          country_row,
+        ]
       else
         [
           qualification_row,
@@ -74,6 +81,15 @@ module CandidateInterface
         other_uk: application_qualification.other_uk_qualification_type,
         non_uk: application_qualification.non_uk_qualification_type,
       )
+    end
+
+    def country_row
+      {
+        key: 'Country',
+        value: application_qualification.institution_country,
+        action: 'Country that you studied in',
+        change_path: candidate_interface_gcse_details_edit_institution_country_path(subject: subject),
+      }
     end
   end
 end

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -86,8 +86,8 @@ module CandidateInterface
     def country_row
       {
         key: 'Country',
-        value: application_qualification.institution_country,
-        action: 'Country that you studied in',
+        value: COUNTRIES[application_qualification.institution_country],
+        action: 'Change the country that you studied in',
         change_path: candidate_interface_gcse_details_edit_institution_country_path(subject: subject),
       }
     end

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -7,18 +7,44 @@ module CandidateInterface
       @institution_country = find_or_build_qualification_form
     end
 
+    def update
+      @institution_country = find_or_build_qualification_form
+
+      @current_qualification = params['institution_country']
+
+      if @institution_country.save(@current_qualification)
+        update_gcse_completed(false)
+
+        redirect_to next_gcse_path
+      else
+        track_validation_error(@institution_country)
+        render :edit
+      end
+    end
+
   private
 
     def find_or_build_qualification_form
-      current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
+      @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
 
-      if current_qualification
-        GcseInstitutionCountryForm.build_from_qualification(current_qualification)
+      if @current_qualification
+        GcseInstitutionCountryForm.build_from_qualification(@current_qualification)
       else
         GcseInstitutionCountryForm.new(
           subject: subject_param,
           level: ApplicationQualification.levels[:gcse],
         )
+      end
+    end
+
+    def next_gcse_path
+      @details_form = GcseQualificationDetailsForm.build_from_qualification(
+        current_application.qualification_in_subject(:gcse, subject_param),
+      )
+      if @details_form.qualification.naric_reference.nil?
+        candidate_interface_gcse_details_edit_naric_reference_path
+      else
+        candidate_interface_gcse_review_path
       end
     end
   end

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -10,7 +10,7 @@ module CandidateInterface
     def update
       @institution_country = find_or_build_qualification_form
 
-      @current_qualification = params['institution_country']
+      @institution_country.institution_country = params.dig('candidate_interface_gcse_institution_country_form', 'institution_country')
 
       if @institution_country.save(@current_qualification)
         update_gcse_completed(false)
@@ -41,8 +41,8 @@ module CandidateInterface
       @details_form = GcseQualificationDetailsForm.build_from_qualification(
         current_application.qualification_in_subject(:gcse, subject_param),
       )
-      if @details_form.qualification.naric_reference.nil?
-        candidate_interface_gcse_details_edit_naric_reference_path
+      if @details_form.qualification.grade.nil?
+        candidate_interface_gcse_details_edit_grade_path
       else
         candidate_interface_gcse_review_path
       end

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -4,6 +4,22 @@ module CandidateInterface
     before_action :set_subject
 
     def edit
+      @institution_country = find_or_build_qualification_form
+    end
+
+  private
+
+    def find_or_build_qualification_form
+      current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
+
+      if current_qualification
+        GcseInstitutionCountryForm.build_from_qualification(current_qualification)
+      else
+        GcseInstitutionCountryForm.new(
+          subject: subject_param,
+          level: ApplicationQualification.levels[:gcse],
+        )
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class Gcse::InstitutionCountryController < Gcse::DetailsController
+    before_action :redirect_to_dashboard_if_submitted
+    before_action :set_subject
+
+    def edit
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class Gcse::InstitutionCountryController < Gcse::DetailsController
-    before_action :redirect_to_dashboard_if_submitted
-    before_action :set_subject
+    before_action :redirect_to_dashboard_if_submitted, :set_subject, :render_404_if_flag_is_inactive
 
     def edit
       @institution_country = find_or_build_qualification_form
@@ -23,6 +22,10 @@ module CandidateInterface
     end
 
   private
+
+    def render_404_if_flag_is_inactive
+      render_404 and return unless FeatureFlag.active?('international_gcses')
+    end
 
     def find_or_build_qualification_form
       @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -47,11 +47,13 @@ module CandidateInterface
     end
 
     def next_gcse_path
-      details_form = GcseQualificationDetailsForm.build_from_qualification(
+      @details_form = GcseQualificationDetailsForm.build_from_qualification(
         current_application.qualification_in_subject(:gcse, subject_param),
       )
 
-      if !@application_qualification.missing_qualification? && details_form.grade.nil?
+      if new_non_uk_qualification?
+        candidate_interface_gcse_details_edit_institution_country_path
+      elsif !@application_qualification.missing_qualification? && @details_form.grade.nil?
         candidate_interface_gcse_details_edit_grade_path
       else
         candidate_interface_gcse_review_path
@@ -62,6 +64,12 @@ module CandidateInterface
       params.require(:candidate_interface_gcse_qualification_type_form)
         .permit(:qualification_type, :other_uk_qualification_type, :missing_explanation, :non_uk_qualification_type)
         .transform_values(&:strip)
+    end
+
+    def new_non_uk_qualification?
+      FeatureFlag.active?('international_gcses') &&
+        @application_qualification.qualification_type == 'non_uk' &&
+        @details_form.qualification.institution_country.nil?
     end
   end
 end

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -4,6 +4,8 @@ module CandidateInterface
 
     attr_accessor :institution_country
 
+    validates :institution_country, presence: true
+
     validates :institution_country,
               inclusion: { in: COUNTRIES_BY_NAME }
 

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -1,0 +1,24 @@
+module CandidateInterface
+  class GcseInstitutionCountryForm
+    include ActiveModel::Model
+
+    attr_accessor :institution_country
+
+    validates :institution_country,
+              inclusion: { in: COUNTRIES_BY_NAME }
+
+    def self.build_from_qualification(application_qualification)
+      new(
+        institution_country: application_qualification.institution_country,
+      )
+    end
+
+    def save(application_qualification)
+      return false unless valid?
+
+      application_qualification.update!(
+        institution_country: institution_country,
+      )
+    end
+  end
+end

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
     def self.build_from_qualification(application_qualification)
       new(
-        institution_country: application_qualification.institution_country,
+        institution_country: COUNTRIES[application_qualification.institution_country],
       )
     end
 
@@ -19,7 +19,7 @@ module CandidateInterface
       return false unless valid?
 
       application_qualification.update!(
-        institution_country: institution_country,
+        institution_country: REVERSE_COUNTRIES_HASH[institution_country],
       )
     end
   end

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     validates :institution_country, presence: true
 
     validates :institution_country,
-              inclusion: { in: COUNTRIES_BY_NAME }
+              inclusion: { in: COUNTRY_NAMES }
 
     def self.build_from_qualification(application_qualification)
       new(
@@ -19,7 +19,7 @@ module CandidateInterface
       return false unless valid?
 
       application_qualification.update!(
-        institution_country: REVERSE_COUNTRIES_HASH[institution_country],
+        institution_country: COUNTRY_NAMES_TO_ISO_CODES[institution_country],
       )
     end
   end

--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -9,6 +9,8 @@ const initNationalityAutocomplete = () => {
       "#candidate-interface-nationalities-form-second-nationality-field-error",
       "#candidate-interface-contact-details-form-country-field",
       "#candidate-interface-contact-details-form-country-field-error",
+      "#candidate-interface-gcse-institution-country-form-institution-country-field",
+      "#candidate-interface-gcse-institution-country-form-institution-country-field-error",
     ].forEach(id => {
       const nationalitySelect = document.querySelector(id);
 

--- a/app/helpers/select_options_helper.rb
+++ b/app/helpers/select_options_helper.rb
@@ -11,6 +11,12 @@ module SelectOptionsHelper
     ] + COUNTRIES.except('GB').map { |iso3166, country| OpenStruct.new(id: iso3166, name: country) }
   end
 
+  def select_institution_country_options
+    [
+      OpenStruct.new(id: '', name: t('application_form.contact_details.country.default_option')),
+    ] + COUNTRIES.except('GB').map { |_, country| OpenStruct.new(id: country, name: country) }
+  end
+
   def select_course_options(courses)
     [
       OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_course_form.attributes.course_id.blank')),

--- a/app/views/candidate_interface/gcse/institution_country/edit.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/edit.html.erb
@@ -6,8 +6,7 @@
     <%= form_with model: @institution_country, url: candidate_interface_gcse_details_update_institution_country_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>
-
+      <%= f.govuk_collection_select :institution_country, select_institution_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>
       <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/institution_country/edit.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/edit.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, title_with_error_prefix(t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), @institution_country.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @institution_country, url: candidate_interface_gcse_details_update_institution_country_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>
+
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -200,3 +200,4 @@ COUNTRIES = {
 }.freeze
 
 COUNTRIES_BY_NAME = COUNTRIES.map(&:second)
+REVERSE_COUNTRIES_HASH = COUNTRIES.map(&:reverse).to_h

--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -198,3 +198,5 @@ COUNTRIES = {
   'ZM' => 'Zambia',
   'ZW' => 'Zimbabwe',
 }.freeze
+
+COUNTRIES_BY_NAME = COUNTRIES.map(&:second)

--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -199,5 +199,5 @@ COUNTRIES = {
   'ZW' => 'Zimbabwe',
 }.freeze
 
-COUNTRIES_BY_NAME = COUNTRIES.map(&:second)
-REVERSE_COUNTRIES_HASH = COUNTRIES.map(&:reverse).to_h
+COUNTRY_NAMES = COUNTRIES.map(&:second)
+COUNTRY_NAMES_TO_ISO_CODES = COUNTRIES.map(&:reverse).to_h

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -650,6 +650,11 @@ en:
             missing_explanation:
               blank: Give us some details
               too_many_words: Details must be %{count} words or fewer
+        candidate_interface/gcse_institution_country_form:
+          attributes:
+            institution_country:
+              blank: Enter the country you studied in
+              inclusion: Select the country you studied in from the list
         candidate_interface/volunteering_experience_form:
           attributes:
             experience:

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -30,6 +30,8 @@ en:
         scottish_national_5: For example, ‘C’ or ‘4’
   gcse_edit_year:
     page_title: When was your %{subject} qualification awarded?
+  gcse_edit_institution_country:
+    page_title: In which country did you study for your %{subject} qualification?
   gcse_summary:
     page_titles:
       maths: Maths GCSE or equivalent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,9 @@ Rails.application.routes.draw do
         get '/' => 'gcse/type#edit', as: :gcse_details_edit_type
         post '/' => 'gcse/type#update', as: :gcse_details_update_type
 
+        get '/country' => 'gcse/institution_country#edit', as: :gcse_details_edit_institution_country
+        post '/country' => 'gcse/institution_country#update', as: :gcse_details_update_institution_country
+
         get '/grade' => 'gcse/grade#edit', as: :gcse_details_edit_grade
         patch '/grade' => 'gcse/grade#update', as: :gcse_details_update_grade
 

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         qualification_type: 'GCSE',
         level: 'gcse',
         grade: 'c',
-        institution_country: 'United States',
+        institution_country: 'US',
+        naric_reference: '12345',
+        comparable_uk_qualification: 'Between GCSE and GCE AS level',
       )
       result = render_inline(
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
@@ -20,7 +22,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.text).to match(/Qualification\s+GCSE/)
       expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
       expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
-      expect(result.text).to match(/Country\s+#{@qualification.institution_country}/)
+      expect(result.text).to match(/Country\s+#{COUNTRIES[@qualification.institution_country]}/)
     end
   end
 

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -1,21 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
-  it 'displays award year, qualification type and grade' do
-    application_form = build :application_form
-    @qualification = application_qualification = build(
-      :application_qualification,
-      application_form: application_form,
-      qualification_type: 'GCSE',
-      level: 'gcse',
-      grade: 'c',
-    )
-    result = render_inline(
-      described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
-    )
+  context 'with the international_gcses flag on' do
+    it 'displays award year, qualification type, grade and institution country' do
+      FeatureFlag.activate('international_gcses')
+      application_form = build :application_form
+      @qualification = application_qualification = build(
+        :application_qualification,
+        application_form: application_form,
+        qualification_type: 'GCSE',
+        level: 'gcse',
+        grade: 'c',
+        institution_country: 'United States',
+      )
+      result = render_inline(
+        described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
+      )
 
-    expect(result.text).to match(/Qualification\s+GCSE/)
-    expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
-    expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
+      expect(result.text).to match(/Qualification\s+GCSE/)
+      expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
+      expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
+      expect(result.text).to match(/Country\s+#{@qualification.institution_country}/)
+    end
+  end
+
+  context 'with the international_gcses flag off' do
+    it 'displays award year, qualification type and grade' do
+      application_form = build :application_form
+      @qualification = application_qualification = build(
+        :application_qualification,
+        application_form: application_form,
+        qualification_type: 'GCSE',
+        level: 'gcse',
+        grade: 'c',
+        institution_country: 'United States',
+      )
+      result = render_inline(
+        described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
+      )
+
+      expect(result.text).to match(/Qualification\s+GCSE/)
+      expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
+      expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
+      expect(result.text).not_to match(/Country\s+#{@qualification.institution_country}/)
+    end
   end
 end

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
   let(:form_data) { { institution_country: COUNTRIES_BY_NAME.sample } }
 
   describe 'validations' do
+    it { is_expected.to validate_presence_of(:institution_country) }
+
     it 'validates nationalities against the COUNTRIES_BY_NAME list' do
       invalid_nationality = CandidateInterface::GcseInstitutionCountryForm.new(
         institution_country: 'Tralfamadorian',

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
+  let(:form_data) { { institution_country: COUNTRIES_BY_NAME.sample } }
+
+  describe 'validations' do
+    it 'validates nationalities against the COUNTRIES_BY_NAME list' do
+      invalid_nationality = CandidateInterface::GcseInstitutionCountryForm.new(
+        institution_country: 'Tralfamadorian',
+      )
+      valid_nationality = CandidateInterface::GcseInstitutionCountryForm.new(
+        institution_country: COUNTRIES_BY_NAME.sample,
+      )
+      valid_nationality.validate
+      invalid_nationality.validate
+      expect(valid_nationality.errors.keys).not_to include :institution_country
+      expect(invalid_nationality.errors.keys).to include :institution_country
+    end
+  end
+
+  describe '#build_from_qualification' do
+    it 'sets the institution_country attribute on the form the to qualifications institution_country' do
+      application_qualification = create(:application_qualification)
+      institution_country_form = CandidateInterface::GcseInstitutionCountryForm.build_from_qualification(application_qualification)
+
+      expect(institution_country_form.institution_country).to eq application_qualification.institution_country
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new
+
+      expect(institution_country_form.save(ApplicationQualification.new)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm if valid' do
+      application_qualification = create(:application_qualification)
+      institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
+
+      expect(institution_country_form.save(application_qualification)).to eq(true)
+      expect(application_qualification.institution_country).to eq form_data[:institution_country]
+    end
+  end
+end

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
-  let(:form_data) { { institution_country: COUNTRIES_BY_NAME.sample } }
+  let(:form_data) { { institution_country: COUNTRY_NAMES.sample } }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:institution_country) }
 
-    it 'validates nationalities against the COUNTRIES_BY_NAME list' do
+    it 'validates nationalities against the COUNTRY_NAMES list' do
       invalid_nationality = CandidateInterface::GcseInstitutionCountryForm.new(
         institution_country: 'Tralfamadorian',
       )
       valid_nationality = CandidateInterface::GcseInstitutionCountryForm.new(
-        institution_country: COUNTRIES_BY_NAME.sample,
+        institution_country: COUNTRY_NAMES.sample,
       )
       valid_nationality.validate
       invalid_nationality.validate
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
 
       expect(institution_country_form.save(application_qualification)).to eq(true)
-      expect(application_qualification.institution_country).to eq REVERSE_COUNTRIES_HASH[form_data[:institution_country]]
+      expect(application_qualification.institution_country).to eq COUNTRY_NAMES_TO_ISO_CODES[form_data[:institution_country]]
     end
   end
 end

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       application_qualification = create(:application_qualification)
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.build_from_qualification(application_qualification)
 
-      expect(institution_country_form.institution_country).to eq application_qualification.institution_country
+      expect(institution_country_form.institution_country).to eq COUNTRIES[application_qualification.institution_country]
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
 
       expect(institution_country_form.save(application_qualification)).to eq(true)
-      expect(application_qualification.institution_country).to eq form_data[:institution_country]
+      expect(application_qualification.institution_country).to eq REVERSE_COUNTRIES_HASH[form_data[:institution_country]]
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -18,6 +18,18 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     when_i_select_non_uk_qualification
     and_i_fill_in_my_qualification_type
     and_i_click_save_and_continue
+    then_i_see_the_add_institution_country_page
+
+    when_i_do_not_select_a_country
+    and_i_click_save_and_continue
+    then_i_see_the_country_blank_error
+
+    when_i_fill_in_a_non_existent_country
+    and_i_click_save_and_continue
+    then_i_see_the_select_a_valid_country_error
+
+    when_i_fill_in_a_valid_country
+    and_i_click_save_and_continue
     then_i_see_the_add_grade_page
 
     when_i_fill_in_the_grade
@@ -71,6 +83,28 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
 
   def when_i_visit_the_candidate_application_page
     visit '/candidate/application'
+  end
+
+  def then_i_see_the_add_institution_country_page
+    expect(page).to have_current_path candidate_interface_gcse_details_edit_institution_country_path('maths')
+  end
+
+  def when_i_do_not_select_a_country; end
+
+  def then_i_see_the_country_blank_error
+    expect(page).to have_content 'Enter the country you studied in'
+  end
+
+  def when_i_fill_in_a_non_existent_country
+    fill_in :institution_country, with: 'Caprica City'
+  end
+
+  def then_i_see_the_select_a_valid_country_error
+    expect(page).to have_content 'Select the country you studied in from the list'
+  end
+
+  def when_i_fill_in_a_valid_country
+    fill_in :institution_country, with: 'United States'
   end
 
   def then_i_see_the_add_grade_page

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -24,10 +24,6 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     and_i_click_save_and_continue
     then_i_see_the_country_blank_error
 
-    when_i_fill_in_a_non_existent_country
-    and_i_click_save_and_continue
-    then_i_see_the_select_a_valid_country_error
-
     when_i_fill_in_a_valid_country
     and_i_click_save_and_continue
     then_i_see_the_add_grade_page
@@ -95,16 +91,8 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     expect(page).to have_content 'Enter the country you studied in'
   end
 
-  def when_i_fill_in_a_non_existent_country
-    fill_in :institution_country, with: 'Caprica City'
-  end
-
-  def then_i_see_the_select_a_valid_country_error
-    expect(page).to have_content 'Select the country you studied in from the list'
-  end
-
   def when_i_fill_in_a_valid_country
-    fill_in :institution_country, with: 'United States'
+    select 'United States'
   end
 
   def then_i_see_the_add_grade_page


### PR DESCRIPTION
## Context

When an international candidate is inputting their GCSE equivalency they need to be able to input which country they studied in.

## Changes proposed in this pull request

- Add the institution country page 

![image](https://user-images.githubusercontent.com/42515961/87401808-8dad0b00-c5b2-11ea-898e-e737be04c1f0.png)

## Guidance to review

I'm not the institution_country should be saved as a country code? If so this will need to be tweaked.

## Link to Trello card

https://trello.com/c/Sy4RX8lL/1763-dev-%F0%9F%8C%90-international-gcse-equivalents

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
