### PR TITLE
International degrees part 3 - Review component and changes to grades form

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -99,7 +99,7 @@ module CandidateInterface
 
       {
         key: t('application_form.degree.comparable_uk_degree.review_label'),
-        value: t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}", default: ''),
+        value: degree.comparable_uk_degree.present? ? t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}", default: '') : '',
         action: generate_action(degree: degree, attribute: t('application_form.degree.comparable_uk_degree.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree.id),
       }

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -63,10 +63,22 @@ module CandidateInterface
     def institution_row(degree)
       {
         key: t('application_form.degree.institution_name.review_label'),
-        value: degree.institution_name,
+        value: institution_value(degree),
         action: generate_action(degree: degree, attribute: t('application_form.degree.institution_name.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_institution_path(degree.id),
       }
+    end
+
+    def institution_value(degree)
+      if international?(degree) && degree.institution_country.present?
+        "#{degree.institution_name}, #{COUNTRIES[degree.institution_country]}"
+      else
+        degree.institution_name
+      end
+    end
+
+    def international?(degree)
+      degree.international? && FeatureFlag.active?(:international_degrees)
     end
 
     def start_year_row(degree)

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -16,10 +16,12 @@ module CandidateInterface
         degree_type_row(degree),
         subject_row(degree),
         institution_row(degree),
+        naric_reference_row(degree),
+        comparable_uk_degree_row(degree),
         start_year_row(degree),
         award_year_row(degree),
         grade_row(degree),
-      ]
+      ].compact
     end
 
     def show_missing_banner?
@@ -79,6 +81,28 @@ module CandidateInterface
 
     def international?(degree)
       degree.international? && FeatureFlag.active?(:international_degrees)
+    end
+
+    def naric_reference_row(degree)
+      return nil unless international?(degree)
+
+      {
+        key: t('application_form.degree.naric_reference.review_label'),
+        value: degree.naric_reference,
+        action: generate_action(degree: degree, attribute: t('application_form.degree.naric_reference.change_action')),
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree.id),
+      }
+    end
+
+    def comparable_uk_degree_row(degree)
+      return nil unless international?(degree)
+
+      {
+        key: t('application_form.degree.comparable_uk_degree.review_label'),
+        value: t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}", default: ''),
+        action: generate_action(degree: degree, attribute: t('application_form.degree.comparable_uk_degree.change_action')),
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree.id),
+      }
     end
 
     def start_year_row(degree)

--- a/app/controllers/candidate_interface/degrees/grade_controller.rb
+++ b/app/controllers/candidate_interface/degrees/grade_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
       before_action :redirect_to_dashboard_if_submitted
       before_action :set_main_grades
       before_action :set_other_grades
+      before_action :set_international_main_grades
 
       def new
         @degree_grade_form = DegreeGradeForm.new(degree: degree)
@@ -45,6 +46,10 @@ module CandidateInterface
         @main_grades = Hesa::Grade.grouping_for(
           degree_type_code: degree.qualification_type_hesa_code,
         ).map(&:description)
+      end
+
+      def set_international_main_grades
+        @international_main_grades = DegreeGradeForm::INTERNATIONAL_OPTIONS
       end
 
       def set_other_grades

--- a/app/forms/candidate_interface/degree_grade_form.rb
+++ b/app/forms/candidate_interface/degree_grade_form.rb
@@ -4,6 +4,8 @@ module CandidateInterface
 
     attr_accessor :grade, :other_grade, :predicted_grade, :degree
 
+    delegate :international?, to: :degree, allow_nil: true
+
     validates :grade, presence: true
     validates :other_grade, presence: true, if: :other_grade?
     validates :predicted_grade, presence: true, if: :predicted_grade?
@@ -28,6 +30,11 @@ module CandidateInterface
 
       self
     end
+
+    INTERNATIONAL_OPTIONS = [
+      'Not applicable',
+      'Unknown',
+    ].freeze
 
   private
 

--- a/app/frontend/packs/degree-institution-country-autocomplete.js
+++ b/app/frontend/packs/degree-institution-country-autocomplete.js
@@ -21,7 +21,6 @@ const initDegreeInstitutionCountryAutocomplete = () => {
         showAllValues: true,
         confirmOnBlur: false
       });
-      select.name = "";
     });
   } catch (err) {
     console.error("Could not enhance degree institution country select:", err);

--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -1,26 +1,59 @@
-<%= f.govuk_radio_buttons_fieldset :grade, legend: { tag: 'span' } do %>
+<% if FeatureFlag.active?(:international_degrees) && @degree_grade_form.international? %>
 
-  <% @main_grades.each do |grade| %>
-    <%= f.govuk_radio_button :grade, grade, label: { text: grade } %>
-  <% end %>
+  <%= f.govuk_radio_buttons_fieldset :grade, legend: { tag: 'span' } do %>
 
-  <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
-    <%= f.govuk_text_field :other_grade, label: { text: t('application_form.degree.grade.other.conditional.label') }, width: 10 %>
-    <% if FeatureFlag.active? :hesa_degree_data %>
-      <%= tag.div(id: 'degree-grade-autocomplete', class: 'govuk-form-group', data: { source: @other_grades }) %>
+    <% @international_main_grades.each do |grade| %>
+      <%= f.govuk_radio_button :grade, grade, label: { text: grade } %>
+    <% end %>
+
+    <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
+      <%= f.govuk_text_field(
+        :other_grade,
+        label: { text: t('application_form.degree.grade.other.conditional.label') },
+        hint_text: t('application_form.degree.grade.other.conditional.international_hint_text'),
+        width: 10,
+      ) %>
+    <% end %>
+
+    <%= f.govuk_radio_divider %>
+
+    <%= f.govuk_radio_button :grade, 'predicted', label: { text: t('application_form.degree.grade.predicted.label') } do %>
+      <%= f.govuk_text_field(
+        :predicted_grade,
+        label: { text: t('application_form.degree.grade.predicted.conditional.label') },
+        hint_text: t('application_form.degree.grade.predicted.conditional.hint_text'),
+        width: 10
+      ) %>
     <% end %>
   <% end %>
 
-  <%= f.govuk_radio_divider %>
+<% else %>
 
-  <%= f.govuk_radio_button :grade, 'predicted', label: { text: t('application_form.degree.grade.predicted.label') } do %>
-    <%= f.govuk_text_field(
-      :predicted_grade,
-      label: { text: t('application_form.degree.grade.predicted.conditional.label') },
-      hint_text: t('application_form.degree.grade.predicted.conditional.hint_text'),
-      width: 10
-    ) %>
+  <%= f.govuk_radio_buttons_fieldset :grade, legend: { tag: 'span' } do %>
+
+    <% @main_grades.each do |grade| %>
+      <%= f.govuk_radio_button :grade, grade, label: { text: grade } %>
+    <% end %>
+
+    <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
+      <%= f.govuk_text_field :other_grade, label: { text: t('application_form.degree.grade.other.conditional.label') }, width: 10 %>
+      <% if FeatureFlag.active? :hesa_degree_data %>
+        <%= tag.div(id: 'degree-grade-autocomplete', class: 'govuk-form-group', data: { source: @other_grades }) %>
+      <% end %>
+    <% end %>
+
+    <%= f.govuk_radio_divider %>
+
+    <%= f.govuk_radio_button :grade, 'predicted', label: { text: t('application_form.degree.grade.predicted.label') } do %>
+      <%= f.govuk_text_field(
+        :predicted_grade,
+        label: { text: t('application_form.degree.grade.predicted.conditional.label') },
+        hint_text: t('application_form.degree.grade.predicted.conditional.hint_text'),
+        width: 10
+      ) %>
+    <% end %>
   <% end %>
+
 <% end %>
 
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
@@ -17,7 +17,6 @@
     label: { text: t('application_form.degree.institution_country.label') }
   ) %>
 
-
 <% else %>
 
   <%= f.govuk_text_field(

--- a/app/views/candidate_interface/degrees/naric_statement/edit.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @degree_naric_statement_form,
-      url: candidate_interface_degree_naric_statement_path(@degree_naric_statement_form.degree),
+      url: candidate_interface_edit_degree_naric_statement_path(@degree_naric_statement_form.degree),
       method: :patch
     ) do |f| %>
       <h1 class="govuk-heading-xl">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -170,6 +170,7 @@ en:
           label: Other
           conditional:
             label: Enter your degree grade
+            international_hint_text: For example, ‘A’, ‘4.5’, ‘94%’, ‘Distinction’
         predicted:
           label: I am still studying for my degree
           conditional:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -197,12 +197,12 @@ en:
         label: UK NARIC reference number
         hint_text: For example ‘4000228363’
         review_label: UK NARIC reference number
-        change_action: naric_statement
+        change_action: NARIC statement
       comparable_uk_degree:
         label: Select the comparable UK degree
         hint_text: As shown on your statement
         review_label: Comparable UK degree
-        change_action: naric_statement
+        change_action: NARIC statement
         values:
           bachelor_ordinary_degree: 'Bachelor (Ordinary) degree'
           bachelor_honours_degree: 'Bachelor (Honours) degree'

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -159,6 +159,8 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
         subject: 'Woof',
         institution_name: 'University of Doge',
         institution_country: 'DE',
+        naric_reference: '0123456789',
+        comparable_uk_degree: 'bachelor_honours_degree',
         grade: 'erste Klasse',
         predicted_grade: false,
         start_year: '2005',
@@ -176,6 +178,23 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       expect(result.css('.govuk-summary-list__value')[2].text.strip).to eq('University of Doge, Germany')
       expect(result.css('.govuk-summary-list__actions a')[2].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_degree_institution_path(degree1),
+      )
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",
+      )
+    end
+
+    it 'renders component with correct values for NARIC statement' do
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.institution_name.review_label'))
+      expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('0123456789')
+      expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
+      )
+      expect(result.css('.govuk-summary-list__value')[4].text.strip).to eq('Bachelor (Honours) degree')
+      expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include(
         "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -151,6 +151,38 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
   end
 
+  context 'when degrees are editable and first degree is international' do
+    let(:degree1) do
+      build_stubbed(
+        :degree_qualification,
+        qualification_type: 'BA',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        institution_country: 'DE',
+        grade: 'erste Klasse',
+        predicted_grade: false,
+        start_year: '2005',
+        award_year: '2008',
+        international: true,
+      )
+    end
+
+    before { FeatureFlag.activate(:international_degrees) }
+
+    it 'renders component with correct values for an internationl institution' do
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.institution_name.review_label'))
+      expect(result.css('.govuk-summary-list__value')[2].text.strip).to eq('University of Doge, Germany')
+      expect(result.css('.govuk-summary-list__actions a')[2].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_degree_institution_path(degree1),
+      )
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",
+      )
+    end
+  end
+
   context 'when degrees are not editable' do
     it 'renders component without an edit link' do
       result = render_inline(described_class.new(application_form: application_form, editable: false))

--- a/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Entering their degrees' do
     and_i_fill_in_the_country
     and_i_click_on_save_and_continue
 
+    # Add NARIC statement
     then_i_can_see_the_naric_page
     when_i_click_on_save_and_continue
     then_i_see_validation_errors_for_naric_question
@@ -43,6 +44,23 @@ RSpec.feature 'Entering their degrees' do
     and_i_fill_in_naric_reference
     and_i_fill_in_comparable_uk_degree_type
     and_i_click_on_save_and_continue
+
+    # Add grade
+    then_i_can_see_the_degree_grade_page
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_degree_grade
+    when_i_check_other
+    and_i_enter_my_grade
+    and_i_click_on_save_and_continue
+
+    # Add years
+    then_i_can_see_the_start_and_graduation_year_page
+    when_i_click_on_save_and_continue
+    then_i_see_validation_errors_for_graduation_year
+    when_i_fill_in_the_start_and_graduation_year
+    and_i_click_on_save_and_continue
+
+    # TODO: Review page
   end
 
   def given_the_international_degrees_feature_flag_is_active
@@ -141,5 +159,36 @@ RSpec.feature 'Entering their degrees' do
 
   def and_i_fill_in_comparable_uk_degree_type
     choose 'Doctor of Philosophy degree'
+  end
+
+  def then_i_can_see_the_degree_grade_page
+    expect(page).to have_content('What grade is your degree?')
+  end
+
+  def then_i_see_validation_errors_for_degree_grade
+    expect(page).to have_content 'Enter your degree grade'
+  end
+
+  def when_i_check_other
+    choose 'Other'
+  end
+
+  def and_i_enter_my_grade
+    fill_in 'Enter your degree grade', with: '100'
+  end
+
+  def then_i_can_see_the_start_and_graduation_year_page
+    expect(page).to have_content('When did you study for your degree?')
+  end
+
+  def then_i_see_validation_errors_for_graduation_year
+    expect(page).to have_content 'Enter your graduation year'
+  end
+
+  def when_i_fill_in_the_start_and_graduation_year
+    year_with_trailing_space = '2006 '
+    year_with_preceding_space = ' 2009'
+    fill_in 'Year started course', with: year_with_trailing_space
+    fill_in 'Graduation year', with: year_with_preceding_space
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_degrees_spec.rb
@@ -60,7 +60,33 @@ RSpec.feature 'Entering their degrees' do
     when_i_fill_in_the_start_and_graduation_year
     and_i_click_on_save_and_continue
 
-    # TODO: Review page
+    # Review
+    then_i_can_check_my_undergraduate_degree
+
+    # Edit details
+    when_i_click_to_change_my_undergraduate_degree_type
+    then_i_see_my_undergraduate_degree_type_filled_in
+    when_i_change_my_undergraduate_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_type
+
+    when_i_click_to_change_my_undergraduate_degree_institution
+    then_i_see_my_undergraduate_degree_institution_filled_in
+    when_i_change_my_undergraduate_degree_institution_and_country
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_undergraduate_degree_institution
+
+    when_i_click_to_change_my_naric_details
+    then_i_see_my_original_naric_details_filled_in
+    when_i_change_my_reference_number_and_comparable_uk_degree_type
+    and_i_click_on_save_and_continue
+    then_i_can_check_my_revised_naric_details
+
+    # Mark section as complete
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_should_see_the_form
+    and_that_the_section_is_completed
   end
 
   def given_the_international_degrees_feature_flag_is_active
@@ -190,5 +216,78 @@ RSpec.feature 'Entering their degrees' do
     year_with_preceding_space = ' 2009'
     fill_in 'Year started course', with: year_with_trailing_space
     fill_in 'Graduation year', with: year_with_preceding_space
+  end
+
+  def then_i_can_check_my_undergraduate_degree
+    expect(page).to have_current_path candidate_interface_degrees_review_path
+    expect(page).to have_content 'Computer Science'
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_type
+    page.all('.govuk-summary-list__actions').to_a.first.click_link 'Change qualification'
+  end
+
+  def then_i_see_my_undergraduate_degree_type_filled_in
+    expect(page).to have_selector("input[value='Bachelors degree']")
+  end
+
+  def when_i_change_my_undergraduate_degree_type
+    fill_in 'Type of qualification', with: 'Bachelor of engineering degree'
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_type
+    expect(page).to have_content 'Bachelor of engineering degree'
+  end
+
+  def when_i_click_to_change_my_undergraduate_degree_institution
+    page.all('.govuk-summary-list__actions').to_a.third.click_link 'Change institution'
+  end
+
+  def then_i_see_my_undergraduate_degree_institution_filled_in
+    expect(page).to have_selector("input[value='University of Pune']")
+    expect(page).to have_selector("option[selected='selected'][value='IN']")
+  end
+
+  def when_i_change_my_undergraduate_degree_institution_and_country
+    fill_in 'Institution name', with: 'University of Bochum'
+    select('Germany', from: 'In which country is this institution based?')
+  end
+
+  def then_i_can_check_my_revised_undergraduate_degree_institution
+    expect(page).to have_content('University of Bochum, Germany')
+  end
+
+  def when_i_click_to_change_my_naric_details
+    page.all('.govuk-summary-list__actions').to_a.fourth.click_link 'Change NARIC statement'
+  end
+
+  def then_i_see_my_original_naric_details_filled_in
+    expect(page).to have_selector("input[value='0123456789']")
+  end
+
+  def when_i_change_my_reference_number_and_comparable_uk_degree_type
+    fill_in 'UK NARIC reference number', with: '9876543210'
+    choose 'Post Doctoral award'
+  end
+
+  def then_i_can_check_my_revised_naric_details
+    expect(page).to have_content '9876543210'
+    expect(page).to have_content 'Post Doctoral award'
+  end
+
+  def when_i_mark_this_section_as_completed
+    check t('application_form.degree.review.completed_checkbox')
+  end
+
+  def and_i_click_on_continue
+    click_button t('application_form.degree.review.button')
+  end
+
+  def then_i_should_see_the_form
+    expect(page).to have_content(t('page_titles.application_form'))
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#degree-badge-id', text: 'Completed')
   end
 end


### PR DESCRIPTION
## Context

International candidates need to be able to give details of any degree(s) awarded by institutions based outside the UK. This PR implements the third (and final) part of the new flow for international degrees behind an existing feature flag. Follows on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/2497

## Changes proposed in this pull request

- [x] Change the grades form to reflect options specified in design
- [x] Update system spec for grades form
- [x] Add international info to `DegreeReviewComponent`
- [x] Update system spec for review component
- [x] Rebase onto master after https://github.com/DFE-Digital/apply-for-teacher-training/pull/2497 is merged

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/450843/87406303-7244fe80-c5b8-11ea-9e0a-c43de0f9cc32.png">

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/450843/87406385-8a1c8280-c5b8-11ea-9841-18c8c99fcd23.png">


## Guidance to review

- Is the feature flag watertight?

## Link to Trello card

https://trello.com/c/RafQrpaq/1762-dev-🌐-international-degrees

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
