### PR TITLE
Speed up SupportInterface::ApplicationsExport

### DIFF
--- a/spec/services/support_interface/applications_export_spec.rb
+++ b/spec/services/support_interface/applications_export_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationsExport, with_audited: true do
   describe '#applications' do
-    it 'returns the correct last changed dates' do
+    it 'returns the correct last changed dates', with_audited: true do
       candidate = create(:candidate, created_at: '2020-01-01')
       application_form = create(
         :application_form,
@@ -15,8 +15,11 @@ RSpec.describe SupportInterface::ApplicationsExport, with_audited: true do
       create(:application_choice, :awaiting_provider_decision, application_form: application_form, updated_at: Time.zone.now - 1.year)
       create(:application_choice, :awaiting_provider_decision, application_form: application_form, updated_at: '2020-01-10')
 
-      Timecop.freeze(Time.zone.now + 1.day) do
+      time_to_freeze = (Time.zone.now + 1.day).beginning_of_hour # avoid microsecond weirdness on Azure
+
+      Timecop.freeze(time_to_freeze) do
         application_form.update! volunteering_experience: 'I have been a volunteer!'
+        create(:application_choice, :awaiting_provider_decision, application_form: application_form)
       end
 
       row = described_class.new.applications.first
@@ -26,9 +29,10 @@ RSpec.describe SupportInterface::ApplicationsExport, with_audited: true do
       expect(row[:submitted_form_at].to_s).to start_with('2020-01-03')
       expect(row[:support_reference]).to eql('PJ9825')
       expect(row[:process_state]).to be(:awaiting_provider_decisions)
-      expect(row[:form_updated_at]).to eql(application_form.updated_at)
+      expect(row[:form_updated_at]).to eql(time_to_freeze)
       expect(row[:subject_knowledge_last_updated_at]).to be_nil
-      expect(row[:volunteering_experience_last_updated_at]).to eql(application_form.updated_at)
+      expect(row[:volunteering_experience_last_updated_at]).to eql(time_to_freeze)
+      expect(row[:courses_last_updated_at]).to eql(time_to_freeze)
     end
   end
 end


### PR DESCRIPTION
This did a lot of queries and loaded a lot of AR objects into memory, and it stopped running on prod because it caused database timeouts (the threshold is 10 seconds).

Using pluck and storing more objects in RAM rather than fetching from the DB sacrifices a bit of readability for performance. Even though we retain more bits of data this still seems to be cheaper in memory terms.

Not 100% sure this will fix the problem on prod, but it ought to help.

Performance stats, using 2020 forms with 2594 application choices:

**Before**

_Benchmark_
real time, seconds: 20.882151999976486

_Memory profile_
Total allocated: 1062854626 bytes (7731962 objects)
Total retained:  858798 bytes (9154 objects)

**After**

_Benchmark_
real time, seconds: 6.385142999934033

_Memory profile_
Total allocated: 141258273 bytes (1403405 objects)
Total retained:  168 bytes (1 objects)


## Context

https://sentry.io/organizations/dfe-bat/issues/1689909459/?referrer=slack

## Guidance to review

Does the code still do the same thing?

## Link to Trello card

https://trello.com/c/A9JuYHfs/2436-speed-up-supportinterfaceapplicationsexport

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
