### PR TITLE
Add EFL review components

### DIFF
--- a/app/components/ielts_review_component.html.erb
+++ b/app/components/ielts_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(SummaryCardComponent.new(rows: ielts_rows)) %>

--- a/app/components/ielts_review_component.rb
+++ b/app/components/ielts_review_component.rb
@@ -1,0 +1,42 @@
+class IeltsReviewComponent < ViewComponent::Base
+  attr_reader :ielts_qualification
+
+  def initialize(ielts_qualification)
+    @ielts_qualification = ielts_qualification
+  end
+
+  def ielts_rows
+    [
+      {
+        key: 'Do you have an English as a foreign language qualification?',
+        value: 'Yes',
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'Type of qualification',
+        value: 'IELTS',
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'Test report form (TRF) number',
+        value: ielts_qualification.trf_number,
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'Year awarded',
+        value: ielts_qualification.award_year,
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'Overall band score',
+        value: ielts_qualification.band_score,
+        action: 'Change',
+        change_path: '',
+      },
+    ]
+  end
+end

--- a/app/components/toefl_review_component.html.erb
+++ b/app/components/toefl_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(SummaryCardComponent.new(rows: toefl_rows)) %>

--- a/app/components/toefl_review_component.rb
+++ b/app/components/toefl_review_component.rb
@@ -1,0 +1,42 @@
+class ToeflReviewComponent < ViewComponent::Base
+  attr_reader :toefl_qualification
+
+  def initialize(toefl_qualification)
+    @toefl_qualification = toefl_qualification
+  end
+
+  def toefl_rows
+    [
+      {
+        key: 'Do you have an English as a foreign language qualification?',
+        value: 'Yes',
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'Type of qualification',
+        value: 'TOEFL',
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'TOEFL registration number',
+        value: toefl_qualification.registration_number,
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'Year awarded',
+        value: toefl_qualification.award_year,
+        action: 'Change',
+        change_path: '',
+      },
+      {
+        key: 'Total score',
+        value: toefl_qualification.total_score,
+        action: 'Change',
+        change_path: '',
+      },
+    ]
+  end
+end

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -4,14 +4,22 @@ module CandidateInterface
       before_action :check_for_english_language_proficiency
 
       def show
-        @english_language_proficiency = current_application.english_language_proficiency
-        @component_instance = derive_component_instance(@english_language_proficiency)
+        @component_instance = derive_component_instance(english_language_proficiency)
+      end
+
+      def complete
+        current_application.update!(completion_params)
+        redirect_to candidate_interface_application_form_path
       end
 
     private
 
+      def english_language_proficiency
+        current_application.english_language_proficiency
+      end
+
       def check_for_english_language_proficiency
-        if current_application.english_language_proficiency.blank?
+        if english_language_proficiency.blank?
           redirect_to candidate_interface_english_foreign_language_root_path
         end
       end
@@ -26,6 +34,12 @@ module CandidateInterface
         when 'ToeflQualification'
           ToeflReviewComponent.new(qualification)
         end
+      end
+
+      def completion_params
+        params
+          .require(:application_form)
+          .permit(:efl_completed)
       end
     end
   end

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -17,9 +17,14 @@ module CandidateInterface
       end
 
       def derive_component_instance(english_language_proficiency)
-        case english_language_proficiency.efl_qualification_type
+        qualification = english_language_proficiency.efl_qualification
+        type = english_language_proficiency.efl_qualification_type
+
+        case type
         when 'IeltsQualification'
-          IeltsReviewComponent.new(english_language_proficiency.efl_qualification)
+          IeltsReviewComponent.new(qualification)
+        when 'ToeflQualification'
+          ToeflReviewComponent.new(qualification)
         end
       end
     end

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -1,8 +1,26 @@
 module CandidateInterface
   module EnglishForeignLanguage
     class ReviewController < CandidateInterfaceController
+      before_action :check_for_english_language_proficiency
+
       def show
         @english_language_proficiency = current_application.english_language_proficiency
+        @component_instance = derive_component_instance(@english_language_proficiency)
+      end
+
+    private
+
+      def check_for_english_language_proficiency
+        if current_application.english_language_proficiency.blank?
+          redirect_to candidate_interface_english_foreign_language_root_path
+        end
+      end
+
+      def derive_component_instance(english_language_proficiency)
+        case english_language_proficiency.efl_qualification_type
+        when 'IeltsQualification'
+          IeltsReviewComponent.new(english_language_proficiency.efl_qualification)
+        end
       end
     end
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -140,7 +140,11 @@ module CandidateInterface
     end
 
     def english_as_a_foreign_language_path
-      Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_root_path
+      if @application_form.english_language_proficiency.present?
+        Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_review_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_english_foreign_language_root_path
+      end
     end
 
     def volunteering_path

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -153,7 +153,7 @@
               TaskListItemComponent.new(
                 text: 'English as a foreign language',
                 completed: @application_form_presenter.english_as_a_foreign_language_completed?,
-                path: @application_form_presenter.english_as_a_foreign_language_path, show_incomplete: false
+                path: @application_form_presenter.english_as_a_foreign_language_path
               )
             ) %>
           </li>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -40,22 +40,58 @@
     </h2>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.personal_details'), completed: @application_form_presenter.personal_details_completed?, path: @application_form_presenter.personal_details_completed? ? candidate_interface_personal_details_show_path : candidate_interface_personal_details_new_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.personal_details'),
+            completed: @application_form_presenter.personal_details_completed?,
+            path: @application_form_presenter.personal_details_completed? ? candidate_interface_personal_details_show_path : candidate_interface_personal_details_new_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.contact_details'), completed: @application_form_presenter.contact_details_completed?, path: @application_form_presenter.contact_details_completed? ? candidate_interface_contact_details_review_path : candidate_interface_contact_details_edit_base_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.contact_details'),
+            completed: @application_form_presenter.contact_details_completed?,
+            path: @application_form_presenter.contact_details_completed? ? candidate_interface_contact_details_review_path : candidate_interface_contact_details_edit_base_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.work_history'), completed: @application_form_presenter.work_experience_completed?, path: @application_form_presenter.work_experience_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.work_history'),
+            completed: @application_form_presenter.work_experience_completed?,
+            path: @application_form_presenter.work_experience_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.volunteering.short'), completed: @application_form_presenter.volunteering_completed?, path: @application_form_presenter.volunteering_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.volunteering.short'),
+            completed: @application_form_presenter.volunteering_completed?,
+            path: @application_form_presenter.volunteering_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.training_with_a_disability'),
+            completed: @application_form_presenter.training_with_a_disability_completed?,
+            path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.suitability_to_work_with_children'), completed: @application_form_presenter.safeguarding_completed?, path: @application_form_presenter.safeguarding_completed? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.suitability_to_work_with_children'),
+            completed: @application_form_presenter.safeguarding_completed?,
+            path: @application_form_presenter.safeguarding_completed? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path
+          )
+        ) %>
       </li>
     </ul>
 
@@ -64,26 +100,62 @@
     </h2>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.degree'), completed: @application_form_presenter.degrees_completed?, path: @application_form_presenter.degrees_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.degree'),
+            completed: @application_form_presenter.degrees_completed?,
+            path: @application_form_presenter.degrees_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: 'Maths GCSE or equivalent', completed: @application_form_presenter.maths_gcse_completed?, path: @application_form_presenter.maths_gcse_completed? ? candidate_interface_gcse_review_path(subject: :maths) : candidate_interface_gcse_details_edit_type_path(subject: :maths))) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: 'Maths GCSE or equivalent',
+            completed: @application_form_presenter.maths_gcse_completed?,
+            path: @application_form_presenter.maths_gcse_completed? ? candidate_interface_gcse_review_path(subject: :maths) : candidate_interface_gcse_details_edit_type_path(subject: :maths)
+          )
+        ) %>
       </li>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: 'English GCSE or equivalent', completed: @application_form_presenter.english_gcse_completed?, path: @application_form_presenter.english_gcse_completed? ? candidate_interface_gcse_review_path(subject: :english) : candidate_interface_gcse_details_edit_type_path(subject: :english))) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: 'English GCSE or equivalent',
+            completed: @application_form_presenter.english_gcse_completed?,
+            path: @application_form_presenter.english_gcse_completed? ? candidate_interface_gcse_review_path(subject: :english) : candidate_interface_gcse_details_edit_type_path(subject: :english)
+          )
+        ) %>
       </li>
       <% if @application_form.science_gcse_needed? %>
         <li class="app-task-list__item">
-          <%= render(TaskListItemComponent.new(text: 'Science GCSE or equivalent', completed: @application_form_presenter.science_gcse_completed?, path: @application_form_presenter.science_gcse_completed? ? candidate_interface_gcse_review_path(subject: :science) : candidate_interface_gcse_details_edit_type_path(subject: :science))) %>
+          <%= render(
+            TaskListItemComponent.new(
+              text: 'Science GCSE or equivalent',
+              completed: @application_form_presenter.science_gcse_completed?,
+              path: @application_form_presenter.science_gcse_completed? ? candidate_interface_gcse_review_path(subject: :science) : candidate_interface_gcse_details_edit_type_path(subject: :science)
+            )
+          ) %>
         </li>
       <% end %>
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.other_qualification'), completed: @application_form_presenter.other_qualifications_completed?, path: @application_form_presenter.other_qualification_path, show_incomplete: false)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.other_qualification'),
+            completed: @application_form_presenter.other_qualifications_completed?,
+            path: @application_form_presenter.other_qualification_path, show_incomplete: false
+          )
+        ) %>
       </li>
       <% if FeatureFlag.active? :efl_section %>
         <% unless @application_form.english_speaking_nationality? %>
           <li class="app-task-list__item">
-            <%= render(TaskListItemComponent.new(text: 'English as a foreign language', completed: @application_form_presenter.english_as_a_foreign_language_completed?, path: @application_form_presenter.english_as_a_foreign_language_path, show_incomplete: false)) %>
+            <%= render(
+              TaskListItemComponent.new(
+                text: 'English as a foreign language',
+                completed: @application_form_presenter.english_as_a_foreign_language_completed?,
+                path: @application_form_presenter.english_as_a_foreign_language_path, show_incomplete: false
+              )
+            ) %>
           </li>
         <% end %>
       <% end %>
@@ -94,20 +166,44 @@
     </h2>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item govuk-hint">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.becoming_a_teacher'), completed: @application_form_presenter.becoming_a_teacher_completed?, path: @application_form_presenter.becoming_a_teacher_completed? ? candidate_interface_becoming_a_teacher_show_path : candidate_interface_becoming_a_teacher_edit_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.becoming_a_teacher'),
+            completed: @application_form_presenter.becoming_a_teacher_completed?,
+            path: @application_form_presenter.becoming_a_teacher_completed? ? candidate_interface_becoming_a_teacher_show_path : candidate_interface_becoming_a_teacher_edit_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item govuk-hint">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.subject_knowledge'), completed: @application_form_presenter.subject_knowledge_completed?, path: @application_form_presenter.subject_knowledge_completed? ? candidate_interface_subject_knowledge_show_path : candidate_interface_subject_knowledge_edit_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.subject_knowledge'),
+            completed: @application_form_presenter.subject_knowledge_completed?,
+            path: @application_form_presenter.subject_knowledge_completed? ? candidate_interface_subject_knowledge_show_path : candidate_interface_subject_knowledge_edit_path
+          )
+        ) %>
       </li>
       <li class="app-task-list__item govuk-hint">
-        <%= render(TaskListItemComponent.new(text: t('page_titles.interview_preferences'), completed: @application_form_presenter.interview_preferences_completed?, path: @application_form_presenter.interview_preferences_completed? ? candidate_interface_interview_preferences_show_path : candidate_interface_interview_preferences_edit_path)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: t('page_titles.interview_preferences'),
+            completed: @application_form_presenter.interview_preferences_completed?,
+            path: @application_form_presenter.interview_preferences_completed? ? candidate_interface_interview_preferences_show_path : candidate_interface_interview_preferences_edit_path
+          )
+        ) %>
       </li>
     </ul>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: 'Referees', completed: @application_form_presenter.all_referees_provided_by_candidate?, path: candidate_interface_referees_path, submitted: false)) %>
+        <%= render(
+          TaskListItemComponent.new(
+            text: 'Referees',
+            completed: @application_form_presenter.all_referees_provided_by_candidate?,
+            path: candidate_interface_referees_path, submitted: false
+          )
+        ) %>
       </li>
     </ul>
 

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -6,3 +6,12 @@
 </h1>
 
 <%= render(@component_instance) %>
+
+<%= form_with model: current_application, url: candidate_interface_english_foreign_language_complete_path do |f| %>
+  <div class='govuk-form-group'>
+    <%= f.hidden_field :efl_completed, value: false %>
+    <%= f.govuk_check_box :efl_completed, true, multiple: false, label: { text: t('application_form.degree.review.completed_checkbox') } %>
+  </div>
+
+  <%= f.govuk_submit t('application_form.degree.review.button') %>
+<% end %>

--- a/app/views/candidate_interface/english_foreign_language/review/show.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/review/show.html.erb
@@ -5,14 +5,4 @@
   <%= t('page_titles.efl.review') %>
 </h1>
 
-<% if @english_language_proficiency.efl_qualification_type == 'IeltsQualification' %>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.name %> </p>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.trf_number %></p>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.band_score %></p>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.award_year %></p>
-<% elsif @english_language_proficiency.efl_qualification_type == 'ToeflQualification' %>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.name %> </p>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.registration_number %></p>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.total_score %></p>
-  <p class='govuk-body'><%= @english_language_proficiency.efl_qualification.award_year %></p>
-<% end %>
+<%= render(@component_instance) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,6 +339,7 @@ Rails.application.routes.draw do
         post '/toefl' => 'english_foreign_language/toefl#create'
 
         get '/review' => 'english_foreign_language/review#show', as: :english_foreign_language_review
+        patch '/review' => 'english_foreign_language/review#complete', as: :english_foreign_language_complete
       end
 
       scope '/referees' do

--- a/spec/components/ielts_review_component_spec.rb
+++ b/spec/components/ielts_review_component_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe IeltsReviewComponent, type: :component do
+  it 'renders a review summary for an IELTS qualification' do
+    ielts_qualification = build(
+      :ielts_qualification,
+      trf_number: '111111',
+      award_year: '2001',
+      band_score: '8',
+    )
+    result = render_inline(described_class.new(ielts_qualification))
+
+    [
+      { position: 0, title: 'Do you have an English as a foreign language qualification?', value: 'Yes' },
+      { position: 1, title: 'Type of qualification', value: 'IELTS' },
+      { position: 2, title: 'Test report form (TRF) number', value: '111111' },
+      { position: 3, title: 'Year awarded', value: '2001' },
+      { position: 4, title: 'Overall band score', value: '8' },
+    ].each do |row|
+      expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
+      expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:value])
+    end
+  end
+end

--- a/spec/components/toefl_review_component_spec.rb
+++ b/spec/components/toefl_review_component_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ToeflReviewComponent, type: :component do
+  it 'renders a review summary for a TOEFL qualification' do
+    toefl_qualification = build(
+      :toefl_qualification,
+      registration_number: '222222 22222',
+      award_year: '2001',
+      total_score: '80',
+    )
+    result = render_inline(described_class.new(toefl_qualification))
+
+    [
+      { position: 0, title: 'Do you have an English as a foreign language qualification?', value: 'Yes' },
+      { position: 1, title: 'Type of qualification', value: 'TOEFL' },
+      { position: 2, title: 'TOEFL registration number', value: '222222 22222' },
+      { position: 3, title: 'Year awarded', value: '2001' },
+      { position: 4, title: 'Total score', value: '80' },
+    ].each do |row|
+      expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
+      expect(result.css('.govuk-summary-list__value')[row[:position]].text).to include(row[:value])
+    end
+  end
+end

--- a/spec/system/candidate_interface/english_as_a_foreign_language/add_ielts_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/add_ielts_qualification_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature 'Add IELTS qualification' do
 
     and_i_select_the_options_for_ielts
     when_i_provide_my_ielts_details
-    then_i_have_completed_the_efl_section
+    then_i_can_review_my_qualification
+    and_i_can_complete_this_section
   end
 
   def given_i_am_signed_in
@@ -52,10 +53,20 @@ RSpec.feature 'Add IELTS qualification' do
     click_button 'Save and continue'
   end
 
-  def then_i_have_completed_the_efl_section
+  def then_i_can_review_my_qualification
     expect(page).to have_current_path candidate_interface_english_foreign_language_review_path
     expect(page).to have_content 'IELTS'
     expect(page).to have_content '123456'
+    expect(page).to have_content 'I have completed this section'
+  end
+
+  def and_i_can_complete_this_section
+    click_button 'Continue'
+    expect(page).to have_css('#english-as-a-foreign-language-badge-id', text: 'Incomplete')
+    click_link efl_link_text
+    check 'I have completed this section'
+    click_button 'Continue'
+    expect(page).to have_css('#english-as-a-foreign-language-badge-id', text: 'Completed')
   end
 
 private

--- a/spec/system/candidate_interface/english_as_a_foreign_language/add_toefl_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/add_toefl_qualification_spec.rb
@@ -11,7 +11,8 @@ RSpec.feature 'Add TOEFL qualification' do
 
     and_i_select_the_options_for_toefl
     when_i_provide_my_toefl_details
-    then_i_have_completed_the_efl_section
+    then_i_can_review_my_qualification
+    and_i_can_complete_this_section
   end
 
   def given_i_am_signed_in
@@ -52,10 +53,20 @@ RSpec.feature 'Add TOEFL qualification' do
     click_button 'Save and continue'
   end
 
-  def then_i_have_completed_the_efl_section
+  def then_i_can_review_my_qualification
     expect(page).to have_current_path candidate_interface_english_foreign_language_review_path
     expect(page).to have_content 'TOEFL'
     expect(page).to have_content '123456'
+    expect(page).to have_content 'I have completed this section'
+  end
+
+  def and_i_can_complete_this_section
+    click_button 'Continue'
+    expect(page).to have_css('#english-as-a-foreign-language-badge-id', text: 'Incomplete')
+    click_link efl_link_text
+    check 'I have completed this section'
+    click_button 'Continue'
+    expect(page).to have_css('#english-as-a-foreign-language-badge-id', text: 'Completed')
   end
 
 private


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
As an international candidate
I need to give details of any English language qualifications I have
So that I can demonstrate my proficiency of the English language
![Screenshot_20200714_121523](https://user-images.githubusercontent.com/519250/87419620-b7bef700-c5cb-11ea-87e4-b176da8ea756.png)

## Changes proposed in this pull request

Add review screens and the 'mark completed' flow for the IELTS and TOEFL qualifications.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Review app:
  - Switch on efl_section feature flag
  - As a candidate, select any nationality other than British and Irish.
  - Click through to the EFL section via the main application form screen.
- Only one option on some forms, further options to follow.
- The 'Change' actions on the Review screen are stubbed out, edit workflow to follow.
## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/9fk7yluU
## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
  - It does, however we won't be switching on the feature flag for this new section until its ready to use.
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
