### PR TITLE
Don't assume TimeLimitConfig(:rule).first.limit is the correct limit

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -142,6 +142,7 @@ class CandidateMailer < ApplicationMailer
   def chase_candidate_decision(application_form)
     @application_choices = application_form.application_choices.select(&:offer?)
     @dbd_date = @application_choices.first.decline_by_default_at.to_s(:govuk_date).strip
+    @days_until_chaser = TimeLimitCalculator.new(rule: :chase_candidate_before_dbd, effective_date: @application_choices.first.sent_to_provider_at).call.fetch(:days)
 
     subject_pluralisation = @application_choices.count > 1 ? 'plural' : 'singular'
 

--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>
 # Respond by <%= @dbd_date %>
 <% else %>
 If you don’t reply within <%= @dbd_days %> working days, your applications will be withdrawn.
-# Respond within <%= TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit %> working days
+# Respond within <%= @days_until_chaser %> working days
 <% end %>
 
 <% if @application_choices.count > 1 %>

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_submitted.subject'),
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
-      'RBD time limit' => "to make an offer within #{TimeLimitConfig.limits_for(:reject_by_default).first.limit} working days",
+      'RBD time limit' => "to make an offer within #{TimeLimitCalculator.new(rule: :reject_by_default, effective_date: Time.zone.today).call.fetch(:days)} working days",
       'magic link to authenticate' => 'http://localhost:3000/candidate/authenticate?token=raw_token&u=encrypted_id',
     )
 
@@ -104,7 +104,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a mail with subject and content', :chase_candidate_decision,
         I18n.t!('chase_candidate_decision_email.subject_singular'),
         'heading' => 'Dear Bob',
-        'days left to respond' => "#{TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit} working days",
+        'days left to respond' => "#{TimeLimitCalculator.new(rule: :chase_candidate_before_dbd, effective_date: Time.zone.today).call.fetch(:days)} working days",
         'dbd date' => 10.business_days.from_now.to_s(:govuk_date).strip,
         'course name and code' => 'Applied Science (Psychology)',
         'provider name' => 'Brighthurst Technical College'

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -367,7 +367,8 @@ private
   def application_choice_with_offer
     FactoryBot.build_stubbed(:application_choice, :with_offer,
                              course_option: course_option,
-                             decline_by_default_at: Time.zone.now)
+                             decline_by_default_at: Time.zone.now,
+                             sent_to_provider_at: 1.day.ago)
   end
 
   def application_choice_awaiting_references

--- a/spec/queries/get_application_forms_for_decline_by_default_reminder_spec.rb
+++ b/spec/queries/get_application_forms_for_decline_by_default_reminder_spec.rb
@@ -1,14 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe GetApplicationFormsForDeclineByDefaultReminder do
-  let(:current_time) { Time.zone.local(2019, 6, 1, 12, 0, 0) }
-  let(:time_limit_before_dbd) { TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit }
-
-  around do |example|
-    Timecop.freeze(current_time) do
-      example.run
-    end
-  end
+  let(:chase_date) { TimeLimitCalculator.new(rule: :chase_candidate_before_dbd, effective_date: Time.zone.now).call.fetch(:time_in_future) }
 
   def create_application(status:, decline_by_default_at:, application_form: create(:application_form))
     create(
@@ -19,28 +12,28 @@ RSpec.describe GetApplicationFormsForDeclineByDefaultReminder do
     )
   end
 
-  it 'returns application forms that has less than the defined limit till DBD date' do
+  it 'returns an application where the DBD date is nearer than the chase_date' do
     application_form = create_application(
       status: 'offer',
-      decline_by_default_at: time_limit_before_dbd.business_days.from_now,
+      decline_by_default_at: chase_date - 1,
     ).application_form
 
     expect(described_class.call).to include application_form
   end
 
-  it 'does not return application forms that has not exceeeded the DBD date' do
+  it 'does not return an application where the DBD date is beyond the chase date' do
     create_application(
       status: 'offer',
-      decline_by_default_at: (time_limit_before_dbd + 1).business_days.from_now,
+      decline_by_default_at: chase_date + 1,
     )
 
     expect(described_class.call).to be_empty
   end
 
-  it 'does not return an application forms that has been chased already' do
+  it 'does not return an application where the DBD date is nearer than the chase date if the chaser has already been sent' do
     application_form = create_application(
       status: 'offer',
-      decline_by_default_at: time_limit_before_dbd.business_days.from_now,
+      decline_by_default_at: chase_date - 1,
     ).application_form
 
     ChaserSent.create!(chased: application_form, chaser_type: :candidate_decision_request)

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Decline by default' do
 
   def when_i_have_an_offer_waiting_for_my_decision
     @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter')
-    @application_choice = create(:application_choice, status: :offer, application_form: @application_form, decline_by_default_at: Time.zone.now + 10.days)
+    @application_choice = create(:application_choice, status: :offer, application_form: @application_form, sent_to_provider_at: Time.zone.now, decline_by_default_at: Time.zone.now + 10.days)
 
     @provider_user = create(:provider_user, providers: [@application_choice.provider])
   end


### PR DESCRIPTION
Should fix the build (see https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=93068&view=ms.vss-test-web.build-test-results-tab&runId=1334394&resultId=100162&paneView=debug).

There can be multiple time limits per rule (eg summer deadlines changing) so taking the first limit is not always the right thing to do.

`TimeLimitCalculator` knows how to choose the right date, so always go through that.

There are still a couple of system specs using `TimeLimitConfig(:rule).first.limit` directly but they need more surgery.

## Link to Trello card

https://trello.com/c/UZg93KLf/1731-we-use-timelimitconfig-directly-in-mailers-which-can-cause-problems-over-the-summer-when-time-limits-change?menu=filter&filter=label:Dev

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
