### PR TITLE
Add NARIC reference number page to the international GCSE flow

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -13,12 +13,14 @@ module CandidateInterface
     def gcse_qualification_rows
       if application_qualification.missing_qualification?
         [missing_qualification_row]
-      elsif FeatureFlag.active?('international_gcses')
+      elsif FeatureFlag.active?('international_gcses') && @application_qualification.qualification_type == 'non_uk'
         [
           qualification_row,
+          country_row,
+          naric_row,
+          comparable_uk_qualification,
           award_year_row,
           grade_row,
-          country_row,
         ]
       else
         [
@@ -89,6 +91,24 @@ module CandidateInterface
         value: COUNTRIES[application_qualification.institution_country],
         action: 'Change the country that you studied in',
         change_path: candidate_interface_gcse_details_edit_institution_country_path(subject: subject),
+      }
+    end
+
+    def naric_row
+      {
+        key: 'NARIC reference number',
+        value: application_qualification.naric_reference,
+        action: 'Change the NARIC reference number',
+        change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
+      }
+    end
+
+    def comparable_uk_qualification
+      {
+        key: 'Comparable UK qualification',
+        value: application_qualification.comparable_uk_qualification,
+        action: 'Change the comparable uk qualification',
+        change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }
     end
   end

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -97,7 +97,7 @@ module CandidateInterface
     def naric_row
       {
         key: 'NARIC reference number',
-        value: application_qualification.naric_reference,
+        value: application_qualification.naric_reference || 'Not provided',
         action: 'Change the NARIC reference number',
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }
@@ -106,7 +106,7 @@ module CandidateInterface
     def comparable_uk_qualification
       {
         key: 'Comparable UK qualification',
-        value: application_qualification.comparable_uk_qualification,
+        value: application_qualification.comparable_uk_qualification || 'Not provided',
         action: 'Change the comparable uk qualification',
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -45,7 +45,7 @@ module CandidateInterface
         current_application.qualification_in_subject(:gcse, subject_param),
       )
       if @details_form.qualification.grade.nil?
-        candidate_interface_gcse_details_edit_grade_path
+        candidate_interface_gcse_details_edit_naric_reference_path
       else
         candidate_interface_gcse_review_path
       end

--- a/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
@@ -45,7 +45,6 @@ module CandidateInterface
     end
 
     def naric_reference_params
-      binding.pry
       params.require(:candidate_interface_naric_reference_form)
         .permit(:naric_reference_choice, :naric_reference, :comparable_uk_qualification,
         )

--- a/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
@@ -11,7 +11,6 @@ module CandidateInterface
 
       @naric_reference_form.set_attributes(naric_reference_params)
 
-
       if @naric_reference_form.save(@current_qualification)
         update_gcse_completed(false)
 
@@ -46,8 +45,7 @@ module CandidateInterface
 
     def naric_reference_params
       params.require(:candidate_interface_naric_reference_form)
-        .permit(:naric_reference_choice, :naric_reference, :comparable_uk_qualification,
-        )
+        .permit(:naric_reference_choice, :naric_reference, :comparable_uk_qualification)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
@@ -1,0 +1,39 @@
+module CandidateInterface
+  class Gcse::NaricReferenceController < Gcse::DetailsController
+    before_action :redirect_to_dashboard_if_submitted, :set_subject, :render_404_if_flag_is_inactive
+
+    def edit
+      @naric_reference_form = NaricReferenceForm.new
+    end
+
+  private
+
+    def render_404_if_flag_is_inactive
+      render_404 and return unless FeatureFlag.active?('international_gcses')
+    end
+    #
+    # def find_or_build_qualification_form
+    #   @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
+    #
+    #   if @current_qualification
+    #     GcseInstitutionCountryForm.build_from_qualification(@current_qualification)
+    #   else
+    #     GcseInstitutionCountryForm.new(
+    #       subject: subject_param,
+    #       level: ApplicationQualification.levels[:gcse],
+    #     )
+    #   end
+    # end
+
+    # def next_gcse_path
+    #   @details_form = GcseQualificationDetailsForm.build_from_qualification(
+    #     current_application.qualification_in_subject(:gcse, subject_param),
+    #   )
+    #   if @details_form.qualification.grade.nil?
+    #     candidate_interface_gcse_details_edit_naric_reference_path
+    #   else
+    #     candidate_interface_gcse_review_path
+    #   end
+    # end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
@@ -3,7 +3,23 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted, :set_subject, :render_404_if_flag_is_inactive
 
     def edit
-      @naric_reference_form = NaricReferenceForm.new
+      @naric_reference_form = find_or_build_qualification_form
+    end
+
+    def update
+      @naric_reference_form = find_or_build_qualification_form
+
+      @naric_reference_form.set_attributes(naric_reference_params)
+
+
+      if @naric_reference_form.save(@current_qualification)
+        update_gcse_completed(false)
+
+        redirect_to next_gcse_path
+      else
+        track_validation_error(@naric_reference_form)
+        render :edit
+      end
     end
 
   private
@@ -11,29 +27,28 @@ module CandidateInterface
     def render_404_if_flag_is_inactive
       render_404 and return unless FeatureFlag.active?('international_gcses')
     end
-    #
-    # def find_or_build_qualification_form
-    #   @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
-    #
-    #   if @current_qualification
-    #     GcseInstitutionCountryForm.build_from_qualification(@current_qualification)
-    #   else
-    #     GcseInstitutionCountryForm.new(
-    #       subject: subject_param,
-    #       level: ApplicationQualification.levels[:gcse],
-    #     )
-    #   end
-    # end
 
-    # def next_gcse_path
-    #   @details_form = GcseQualificationDetailsForm.build_from_qualification(
-    #     current_application.qualification_in_subject(:gcse, subject_param),
-    #   )
-    #   if @details_form.qualification.grade.nil?
-    #     candidate_interface_gcse_details_edit_naric_reference_path
-    #   else
-    #     candidate_interface_gcse_review_path
-    #   end
-    # end
+    def find_or_build_qualification_form
+      @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
+      NaricReferenceForm.build_from_qualification(@current_qualification)
+    end
+
+    def next_gcse_path
+      @details_form = GcseQualificationDetailsForm.build_from_qualification(
+        current_application.qualification_in_subject(:gcse, subject_param),
+      )
+      if @details_form.qualification.grade.nil?
+        candidate_interface_gcse_details_edit_grade_path
+      else
+        candidate_interface_gcse_review_path
+      end
+    end
+
+    def naric_reference_params
+      binding.pry
+      params.require(:candidate_interface_naric_reference_form)
+        .permit(:naric_reference_choice, :naric_reference, :comparable_uk_qualification,
+        )
+    end
   end
 end

--- a/app/forms/candidate_interface/naric_reference_form.rb
+++ b/app/forms/candidate_interface/naric_reference_form.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  class NaricReferenceForm
+    include ActiveModel::Model
+
+    attr_accessor :naric_reference_choice, :naric_reference, :comparable_uk_qualification
+
+    validates :naric_reference_choice, presence: true
+
+    validates :naric_reference, :comparable_uk_qualification, presence: true, if: :chose_to_provide_naric_reference?
+
+    def chose_to_provide_naric_reference?
+      naric_reference_choice == 'Yes'
+    end
+  end
+end

--- a/app/forms/candidate_interface/naric_reference_form.rb
+++ b/app/forms/candidate_interface/naric_reference_form.rb
@@ -27,8 +27,8 @@ module CandidateInterface
 
     def set_attributes(params)
       @naric_reference_choice = params['naric_reference_choice']
-      @naric_reference = params['naric_reference']
-      @comparable_uk_qualification = params['comparable_uk_qualification']
+      @naric_reference = chose_to_provide_naric_reference? ? params['naric_reference'] : nil
+      @comparable_uk_qualification = chose_to_provide_naric_reference? ? params['comparable_uk_qualification'] : nil
     end
 
   private

--- a/app/forms/candidate_interface/naric_reference_form.rb
+++ b/app/forms/candidate_interface/naric_reference_form.rb
@@ -8,10 +8,6 @@ module CandidateInterface
 
     validates :naric_reference, :comparable_uk_qualification, presence: true, if: :chose_to_provide_naric_reference?
 
-    def chose_to_provide_naric_reference?
-      naric_reference_choice == 'Yes'
-    end
-
     def self.build_from_qualification(qualification)
       new(
         naric_reference: qualification.naric_reference,
@@ -27,6 +23,18 @@ module CandidateInterface
         naric_reference: naric_reference,
         comparable_uk_qualification: comparable_uk_qualification,
       )
+    end
+
+  private
+
+    def chose_to_provide_naric_reference?
+      naric_reference_choice == 'Yes'
+    end
+
+    def set_attributes(params)
+      @naric_reference_choice = params['naric_reference_choice']
+      @naric_reference = params['naric_reference']
+      @comparable_uk_qualification = params['comparable_uk_qualification']
     end
   end
 end

--- a/app/forms/candidate_interface/naric_reference_form.rb
+++ b/app/forms/candidate_interface/naric_reference_form.rb
@@ -11,5 +11,22 @@ module CandidateInterface
     def chose_to_provide_naric_reference?
       naric_reference_choice == 'Yes'
     end
+
+    def self.build_from_qualification(qualification)
+      new(
+        naric_reference: qualification.naric_reference,
+        naric_reference_choice: qualification.naric_reference_choice,
+        comparable_uk_qualification: qualification.comparable_uk_qualification,
+      )
+    end
+
+    def save(qualification)
+      return false unless valid?
+
+      qualification.update!(
+        naric_reference: naric_reference,
+        comparable_uk_qualification: comparable_uk_qualification,
+      )
+    end
   end
 end

--- a/app/forms/candidate_interface/naric_reference_form.rb
+++ b/app/forms/candidate_interface/naric_reference_form.rb
@@ -25,16 +25,16 @@ module CandidateInterface
       )
     end
 
-  private
-
-    def chose_to_provide_naric_reference?
-      naric_reference_choice == 'Yes'
-    end
-
     def set_attributes(params)
       @naric_reference_choice = params['naric_reference_choice']
       @naric_reference = params['naric_reference']
       @comparable_uk_qualification = params['comparable_uk_qualification']
+    end
+
+  private
+
+    def chose_to_provide_naric_reference?
+      naric_reference_choice == 'Yes'
     end
   end
 end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -60,4 +60,15 @@ class ApplicationQualification < ApplicationRecord
       send(field_name).blank?
     end
   end
+
+  def naric_reference_choice
+    case naric_reference
+    when 'Not entered'
+      'No'
+    when nil
+      nil
+    else
+      'Yes'
+    end
+  end
 end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -62,13 +62,10 @@ class ApplicationQualification < ApplicationRecord
   end
 
   def naric_reference_choice
-    case naric_reference
-    when 'Not entered'
-      'No'
-    when nil
-      nil
-    else
+    if naric_reference.present?
       'Yes'
+    elsif naric_reference.nil? && grade.present?
+      'No'
     end
   end
 end

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, title_with_error_prefix(t("gcse_edit_naric_reference.page_title", subject: @subject.capitalize), @naric_reference_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @naric_reference_form, url: candidate_interface_gcse_details_update_naric_reference_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -6,6 +6,21 @@
     <%= form_with model: @naric_reference_form, url: candidate_interface_gcse_details_update_naric_reference_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.gcse_naric_reference') %>
+      </h1>
+
+      <p class='govuk-body'>This shows how your qualifications compare to UK qualifications. Not all providers ask for a NARIC statement of comparability.</p>
+
+      <%= f.govuk_radio_buttons_fieldset :naric_details do %>
+        <%= f.govuk_radio_button :naric_reference_choice, 'Yes', label: { text: 'Yes' } do %>
+          <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number' }, hint_text: 'For example ‘4000228363’' %>
+        <% end %>
+        <%= f.govuk_radio_button :naric_reference_choice, 'No', label: { text: 'No' } do %>
+          <p class='govuk-body'> Ask your training provider if they need a NARIC statement of comparability. Register with <%= govuk_link_to 'Get Into Teaching', 'https://register.getintoteaching.education.gov.uk/register' %> for help if you need to get one.</p>
+        <% end %>
+      <% end %>
+
       <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -14,7 +14,13 @@
 
       <%= f.govuk_radio_buttons_fieldset :naric_details do %>
         <%= f.govuk_radio_button :naric_reference_choice, 'Yes', label: { text: 'Yes' } do %>
-          <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number' }, hint_text: 'For example ‘4000228363’' %>
+          <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint_text: 'For example ‘4000228363’', width: 20 %>
+          <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: 'Select the comparable UK qualification', size: 's'}, hint_text: 'As shown on your statement' do %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, 'GCSE (grades A*-C / 9-4)', label: { text: 'GCSE (grades A*-C / 9-4)' } %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, 'Between GCSE and GCE AS level', label: { text: 'Between GCSE and GCE AS level' } %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, 'GCE Advanced Subsidiary (AS) level', label: { text: 'GCE Advanced Subsidiary (AS) level' } %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, 'GCE Advanced (A) level', label: { text: 'GCE Advanced (A) level' } %>
+          <% end %>
         <% end %>
         <%= f.govuk_radio_button :naric_reference_choice, 'No', label: { text: 'No' } do %>
           <p class='govuk-body'> Ask your training provider if they need a NARIC statement of comparability. Register with <%= govuk_link_to 'Get Into Teaching', 'https://register.getintoteaching.education.gov.uk/register' %> for help if you need to get one.</p>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -655,6 +655,14 @@ en:
             institution_country:
               blank: Enter the country you studied in
               inclusion: Select the country you studied in from the list
+        candidate_interface/naric_reference_form:
+          attributes:
+            naric_reference_choice:
+              blank: Select if you have a NARIC statement of comparability
+            naric_reference:
+              blank: Enter your NARIC reference number
+            comparable_uk_qualification:
+              blank: Choose a comparable UK qualification
         candidate_interface/volunteering_experience_form:
           attributes:
             experience:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
     confirm_replacement_course_choice: Your updated course choice
     remove_course_choice: Remove your course choice
     withdraw_application: Are you sure you want to withdraw your application?
+    gcse_naric_reference: Do you have a NARIC statement of comparability for your maths qualification?
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -33,7 +33,7 @@ en:
   gcse_edit_institution_country:
     page_title: In which country did you study for your %{subject} qualification?
   gcse_edit_naric_reference:
-    Do you have a NARIC statement of comparability for your %{subject} qualification?
+    page_title: Do you have a NARIC statement of comparability for your %{subject} qualification?
   gcse_summary:
     page_titles:
       maths: Maths GCSE or equivalent

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -32,6 +32,8 @@ en:
     page_title: When was your %{subject} qualification awarded?
   gcse_edit_institution_country:
     page_title: In which country did you study for your %{subject} qualification?
+  gcse_edit_naric_reference:
+    Do you have a NARIC statement of comparability for your %{subject} qualification?
   gcse_summary:
     page_titles:
       maths: Maths GCSE or equivalent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,9 @@ Rails.application.routes.draw do
         get '/country' => 'gcse/institution_country#edit', as: :gcse_details_edit_institution_country
         post '/country' => 'gcse/institution_country#update', as: :gcse_details_update_institution_country
 
+        get '/naric-reference' => 'gcse/naric_reference#edit', as: :gcse_details_edit_naric_reference
+        post '/naric-reference' => 'gcse/naric_reference#update', as: :gcse_details_update_naric_reference
+
         get '/grade' => 'gcse/grade#edit', as: :gcse_details_edit_grade
         patch '/grade' => 'gcse/grade#update', as: :gcse_details_update_grade
 

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
   context 'with the international_gcses flag on' do
-    it 'displays award year, qualification type, grade and institution country' do
+    it 'displays award year, qualification type, grade, institution country, naric reference and comparable UK qualification' do
       FeatureFlag.activate('international_gcses')
       application_form = build :application_form
       @qualification = application_qualification = build(
         :application_qualification,
         application_form: application_form,
-        qualification_type: 'GCSE',
+        qualification_type: 'non_uk',
+        non_uk_qualification_type: 'High school diploma',
         level: 'gcse',
         grade: 'c',
         institution_country: 'US',
@@ -19,7 +20,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
       )
 
-      expect(result.text).to match(/Qualification\s+GCSE/)
+      expect(result.text).to match(/Qualification\s+#{@qualification.non_uk_qualification_type}/)
       expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
       expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
       expect(result.text).to match(/Country\s+#{COUNTRIES[@qualification.institution_country]}/)
@@ -35,7 +36,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         qualification_type: 'GCSE',
         level: 'gcse',
         grade: 'c',
-        institution_country: 'United States',
+        institution_country: 'US',
       )
       result = render_inline(
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
   context 'with the international_gcses flag on' do
-    it 'displays award year, qualification type, grade, institution country, naric reference and comparable UK qualification' do
+    before do
       FeatureFlag.activate('international_gcses')
+    end
+
+    it 'renders a non-uk GCSE equivalent qualification' do
       application_form = build :application_form
       @qualification = application_qualification = build(
         :application_qualification,
@@ -24,6 +27,27 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
       expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
       expect(result.text).to match(/Country\s+#{COUNTRIES[@qualification.institution_country]}/)
+    end
+
+    it 'displays "Not provided" for naric_reference and comparable_uk_qualification when nil' do
+      application_form = build :application_form
+      @qualification = application_qualification = build(
+        :application_qualification,
+        application_form: application_form,
+        qualification_type: 'non_uk',
+        non_uk_qualification_type: 'High school diploma',
+        level: 'gcse',
+        grade: 'c',
+        institution_country: 'United States',
+        naric_reference: nil,
+        comparable_uk_qualification: nil,
+      )
+      result = render_inline(
+        described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
+      )
+
+      expect(result.text).to match(/NARIC reference number\s+Not provided/)
+      expect(result.text).to match(/Comparable UK qualification\s+Not provided/)
     end
   end
 

--- a/spec/forms/candidate_interface/naric_reference_form_spec.rb
+++ b/spec/forms/candidate_interface/naric_reference_form_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::NaricReferenceForm do
+  describe 'validations' do
+    let(:form) { subject }
+
+    let(:qualification_data) do
+      {
+        naric_reference: '12345',
+        comparable_uk_qualification: 'GCSE (grades A*-C / 9-4)',
+      }
+    end
+
+    it { is_expected.to validate_presence_of(:naric_reference_choice) }
+
+    context 'validates naric_reference if they have chosen that they have one' do
+      before { allow(form).to receive(:chose_to_provide_naric_reference?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:naric_reference) }
+    end
+
+    context 'validates comparable_uk_qualification if they have chosen to provide a naric reference' do
+      before { allow(form).to receive(:chose_to_provide_naric_reference?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:comparable_uk_qualification) }
+    end
+
+    describe '#build_from_qualification' do
+      it 'creates an object based on the provided ApplicationQualification' do
+        qualification = ApplicationQualification.new(qualification_data)
+        naric_reference_form = CandidateInterface::NaricReferenceForm.build_from_qualification(
+          qualification,
+        )
+
+        expect(naric_reference_form.naric_reference_choice).to eq 'Yes'
+        expect(naric_reference_form.naric_reference).to eq qualification.naric_reference
+        expect(naric_reference_form.comparable_uk_qualification).to eq qualification.comparable_uk_qualification
+      end
+    end
+
+    describe '#save' do
+      it 'returns false if not valid' do
+        naric_reference_form = CandidateInterface::NaricReferenceForm.new
+
+        expect(naric_reference_form.save(ApplicationQualification.new)).to eq(false)
+      end
+
+      it 'updates the provided ApplicationQualification if valid' do
+        qualification = create(:application_form)
+        naric_reference_form = CandidateInterface::NaricReferenceForm.new(qualification_data)
+
+        expect(naric_reference_form.save(qualification)).to eq(true)
+        expect(qualification.naric_reference).to eq qualification_data['naric_reference']
+        expect(qualification.comparable_uk_qualification).to eq qualification_data['comparable_uk_qualification']
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/naric_reference_form_spec.rb
+++ b/spec/forms/candidate_interface/naric_reference_form_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe CandidateInterface::NaricReferenceForm do
     end
 
     describe '#save' do
+      let(:form_data) do
+        {
+          naric_reference: '12345',
+          comparable_uk_qualification: 'GCSE (grades A*-C / 9-4)',
+          naric_reference_choice: 'Yes',
+        }
+      end
+
       it 'returns false if not valid' do
         naric_reference_form = CandidateInterface::NaricReferenceForm.new
 
@@ -46,12 +54,12 @@ RSpec.describe CandidateInterface::NaricReferenceForm do
       end
 
       it 'updates the provided ApplicationQualification if valid' do
-        qualification = create(:application_form)
-        naric_reference_form = CandidateInterface::NaricReferenceForm.new(qualification_data)
+        qualification = create(:gcse_qualification)
+        naric_reference_form = CandidateInterface::NaricReferenceForm.new(form_data)
 
         expect(naric_reference_form.save(qualification)).to eq(true)
-        expect(qualification.naric_reference).to eq qualification_data['naric_reference']
-        expect(qualification.comparable_uk_qualification).to eq qualification_data['comparable_uk_qualification']
+        expect(qualification.naric_reference).to eq form_data[:naric_reference]
+        expect(qualification.comparable_uk_qualification).to eq form_data[:comparable_uk_qualification]
       end
     end
   end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe ApplicationQualification, type: :model do
   end
 
   describe '#naric_reference_choice' do
-    it 'returns No when naric reference = Not entered' do
-      qualification = build_stubbed(:application_qualification, naric_reference: 'Not entered')
+    it 'returns No when naric reference is nil and grade is present' do
+      qualification = build_stubbed(:application_qualification, naric_reference: nil, grade: 'c')
       expect(qualification.naric_reference_choice).to eq('No')
     end
 
@@ -118,7 +118,7 @@ RSpec.describe ApplicationQualification, type: :model do
     end
 
     it 'returns nil when field not submitted' do
-      qualification = build_stubbed(:application_qualification, naric_reference: nil)
+      qualification = build_stubbed(:application_qualification, naric_reference: nil, grade: nil)
       expect(qualification.naric_reference_choice).to eq(nil)
     end
   end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -105,4 +105,21 @@ RSpec.describe ApplicationQualification, type: :model do
       end
     end
   end
+
+  describe '#naric_reference_choice' do
+    it 'returns No when naric reference = Not entered' do
+      qualification = build_stubbed(:application_qualification, naric_reference: 'Not entered')
+      expect(qualification.naric_reference_choice).to eq('No')
+    end
+
+    it 'returns Yes when reference number provided' do
+      qualification = build_stubbed(:application_qualification, naric_reference: '12345')
+      expect(qualification.naric_reference_choice).to eq('Yes')
+    end
+
+    it 'returns nil when field not submitted' do
+      qualification = build_stubbed(:application_qualification, naric_reference: nil)
+      expect(qualification.naric_reference_choice).to eq(nil)
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -115,7 +115,11 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   def when_i_do_not_input_my_naric_reference_or_choose_an_equivalency; end
 
   def then_i_see_the_do_you_have_a_naric_reference_error
-    expect(page).to have_content 'Enter if you have a NARIC statement of comparability'
+    expect(page).to have_content 'Select if you have a NARIC statement of comparability'
+  end
+
+  def when_i_choose_yes
+    choose 'Yes'
   end
 
   def then_i_see_the_naric_reference_blank_error
@@ -127,9 +131,8 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def when_i_fill_in_my_naric_reference_and_choose_an_equivalency
-    choose 'Yes'
-    fill_in :naric_reference, with: '12345'
-    choose
+    fill_in 'candidate-interface-naric-reference-form-naric-reference-field-error', with: '12345'
+    choose 'GCSE (grades A*-C / 9-4)'
   end
 
   def then_i_see_the_add_grade_page

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def then_i_see_the_add_naric_reference_page
-    expect(page).to have_current_path candidate_interface_gcse_details_edit_naric_reference_path
+    expect(page).to have_current_path candidate_interface_gcse_details_edit_naric_reference_path('maths')
   end
 
   def when_i_do_not_input_my_naric_reference_or_choose_an_equivalency; end

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -26,6 +26,19 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
 
     when_i_fill_in_a_valid_country
     and_i_click_save_and_continue
+    then_i_see_the_add_naric_reference_page
+
+    when_i_do_not_input_my_naric_reference_or_choose_an_equivalency
+    and_i_click_save_and_continue
+    then_i_see_the_do_you_have_a_naric_reference_error
+
+    when_i_choose_yes
+    and_i_click_save_and_continue
+    then_i_see_the_naric_reference_blank_error
+    and_i_see_the_choose_a_equivalency_option_error
+
+    when_i_fill_in_my_naric_reference_and_choose_an_equivalency
+    and_i_click_save_and_continue
     then_i_see_the_add_grade_page
 
     when_i_fill_in_the_grade
@@ -95,16 +108,42 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     select 'United States'
   end
 
+  def then_i_see_the_add_naric_reference_page
+    expect(page).to have_current_path candidate_interface_gcse_details_edit_naric_reference_path
+  end
+
+  def when_i_do_not_input_my_naric_reference_or_choose_an_equivalency; end
+
+  def then_i_see_the_do_you_have_a_naric_reference_error
+    expect(page).to have_content 'Enter if you have a NARIC statement of comparability'
+  end
+
+  def then_i_see_the_naric_reference_blank_error
+    expect(page).to have_content 'Enter your NARIC reference number'
+  end
+
+  def and_i_see_the_choose_a_equivalency_option_error
+    expect(page).to have_content 'Choose a comparable UK qualification'
+  end
+
+  def when_i_fill_in_my_naric_reference_and_choose_an_equivalency
+    choose 'Yes'
+    fill_in :naric_reference, with: '12345'
+    choose
+  end
+
   def then_i_see_the_add_grade_page
     expect(page).to have_current_path candidate_interface_gcse_details_edit_grade_path('maths')
   end
 
   def then_i_see_the_review_page_with_correct_details
     expect(page).to have_content 'Maths GCSE or equivalent'
-
     expect(page).to have_content 'High School Diploma'
     expect(page).to have_content 'PASS'
     expect(page).to have_content '1990'
+    expect(page).to have_content 'United States'
+    expect(page).to have_content '12345'
+    expect(page).to have_content 'GCSE (grades A*-C / 9-4)'
   end
 
   def then_i_see_add_grade_page
@@ -121,18 +160,6 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
 
   def when_i_fill_in_the_year
     fill_in 'Enter year', with: '1990'
-  end
-
-  def then_i_see_the_non_uk_qualification_option_selected
-    expect(find_field('Non-UK qualification')).to be_checked
-  end
-
-  def then_i_see_the_gcse_grade_entered
-    expect(page).to have_selector("input[value='Pass']")
-  end
-
-  def then_i_see_the_gcse_year_entered
-    expect(page).to have_selector("input[value='1990']")
   end
 
   def when_i_mark_the_section_as_completed


### PR DESCRIPTION
## Context

Previous PRs are:
 
#2485 - Add non_uk to qualification the qualification type page
#2499 - Add the institution country page 

Candidates need to able to provide the NARIC reference number and the comparable UK qualification
for their GCSE equivalency.

## Changes proposed in this pull request

- Add the naric reference page which allows a user to provide their NARIC reference number and the comparable uk equivalent

![image](https://user-images.githubusercontent.com/42515961/87546524-99c3c600-c6a1-11ea-8a04-e1ce8ceb89b9.png)

## Guidance to review

There will be one more PR which will allow you to change the grade page.

## Link to Trello card

https://trello.com/c/Sy4RX8lL/1763-dev-%F0%9F%8C%90-international-gcse-equivalents

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
