### PR TITLE
Missing link classes

### DIFF
--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -41,7 +41,7 @@ module ProviderInterface
     def email_address_row
       {
         key: 'Email address',
-        value: mail_to(email_address),
+        value: mail_to(email_address, email_address, class: 'govuk-link'),
       }
     end
 

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -27,7 +27,7 @@ module HostingEnvironment
 
   def self.phase_banner_text
     if sandbox_mode?
-      return 'This is a <a href="/">test version of Apply</a> for providers and software vendors'.html_safe
+      return 'This is a <a href="/" class="govuk-link">test version of Apply</a> for providers and software vendors'.html_safe
     end
 
     case environment_name


### PR DESCRIPTION
Fixes two places where `govuk-link` was not given to links, meaning they use browser default colour. 

<img width="681" alt="Screenshot 2020-05-26 at 18 12 36" src="https://user-images.githubusercontent.com/813383/87565287-58d7ab80-c6b9-11ea-97e6-7ffd06517ae5.png">

<img width="520" alt="Screenshot 2020-07-15 at 16 30 04" src="https://user-images.githubusercontent.com/813383/87565300-5d03c900-c6b9-11ea-8d23-ad586b9864b0.png">
