### PR TITLE
Add jest back in build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ FROM ${BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES} AS assets-precompile
 WORKDIR /app
 COPY . .
 
-RUN bundle exec rake assets:precompile && \
+RUN yarn jest && \
+    bundle exec rake assets:precompile && \
     apk del nodejs yarn && \
     rm -rf yarn.lock && \
     rm -rf tmp/* log/* node_modules /usr/local/share/.cache /tmp/*

--- a/azure/pipelines/build.yml
+++ b/azure/pipelines/build.yml
@@ -149,13 +149,13 @@ stages:
 
 
 - stage: test_release
-  displayName: 'Test & Publish Release'
+  displayName: 'Run Tests'
   dependsOn: build_release
   variables:
   - group: APPLY - ENV - QA
   jobs:
   - job: test_docker_image_batch_1
-    displayName: 'Test Docker Image - Rubocop & Brakeman'
+    displayName: 'Rubocop & Brakeman'
     condition: and(succeeded(), eq(variables['deployOnly'], false))
     pool:
       vmImage: 'Ubuntu-16.04'


### PR DESCRIPTION
## Context

`yarn jest` was not being run after GitHub actions had been removed.

## Changes proposed in this pull request

Add `yarn jest` into the build process.
This is not being executed as a separate task as it would require yarn & node dependencies which are removed as part of the final image.

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
