### PR TITLE
Allow 4 nested groups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,10 @@ Bundler/OrderedGems:
 Metrics/BlockLength:
   Enabled: false
 
+RSpec/NestedGroups:
+  Enabled: true
+  Max: 4
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe 'rejection emails' do
-    # rubocop:disable RSpec/NestedGroups
     def setup_application
       provider = build_stubbed(:provider, name: 'Falconholt Technical College')
       course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
@@ -211,7 +210,6 @@ RSpec.describe CandidateMailer, type: :mailer do
         )
       end
     end
-    # rubocop:enable RSpec/NestedGroups
   end
 
   describe '.changed_offer' do

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -209,7 +209,6 @@ RSpec.describe ProviderAuthorisation do
         .can_view_safeguarding_information?(course: course)
     end
 
-    # rubocop:disable RSpec/NestedGroups
     context 'when a user is permitted to view safeguarding info for a training provider' do
       let(:provider_user) { create(:provider_user, providers: [training_provider]) }
 
@@ -277,7 +276,6 @@ RSpec.describe ProviderAuthorisation do
         it { is_expected.to be false }
       end
     end
-    # rubocop:enable RSpec/NestedGroups
 
     context 'when a user is not permitted to view safeguarding info' do
       let(:provider_user) { create(:provider_user, providers: [training_provider]) }


### PR DESCRIPTION
## Context

As discussed in the apply_tech channel. Bump the number of allowed nested groups up to 4.
