### PR TITLE
Catch MessageVerifier::InvalidSignature errors in Encryptor

### DIFF
--- a/app/services/encryptor.rb
+++ b/app/services/encryptor.rb
@@ -7,7 +7,8 @@ class Encryptor
 
   def self.decrypt(text)
     ENCRYPTOR.decrypt_and_verify(text)
-  rescue ActiveSupport::MessageEncryptor::InvalidMessage
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage,
+         ActiveSupport::MessageVerifier::InvalidSignature
     false
   end
 end

--- a/spec/services/encryptor_spec.rb
+++ b/spec/services/encryptor_spec.rb
@@ -10,4 +10,14 @@ RSpec.describe Encryptor do
   it 'returns false given an invalid encrypted string' do
     expect(Encryptor.decrypt('invalid-input')).to be false
   end
+
+  it 'returns false when the encrypted string fails verification' do
+    encryptor_that_cannot_verify_the_message = double
+    allow(encryptor_that_cannot_verify_the_message).to receive(:decrypt_and_verify)
+      .and_raise(ActiveSupport::MessageVerifier::InvalidSignature.new)
+
+    stub_const('Encryptor::ENCRYPTOR', encryptor_that_cannot_verify_the_message)
+
+    expect(Encryptor.decrypt('any-old-thing')).to be false
+  end
 end


### PR DESCRIPTION
These errors are just as worthy as MessageEncryptor::InvalidMessage but we don't catch them. They happen in production, but not locally, bc locally Encryptor::ENCRYPTOR does not verify messages. Hence the stub in the test. (Don't know why not, but you could start digging here:
https://github.com/rails/rails/blob/bcfa51fba6ee529fbe357a183fd5bc8bebf13513/activesupport/lib/active_support/message_encryptor.rb#L216-L222).

## Context

https://sentry.io/organizations/dfe-bat/issues/1787494991/?referrer=slack

## Link to Trello card

No — ongoing sentry error

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
