### PR TITLE
Add international GCSE grade page

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -19,14 +19,14 @@ module CandidateInterface
           country_row,
           naric_row,
           comparable_uk_qualification,
-          award_year_row,
           grade_row,
+          award_year_row,
         ]
       else
         [
           qualification_row,
-          award_year_row,
           grade_row,
+          award_year_row,
         ]
       end
     end

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -18,7 +18,7 @@ module CandidateInterface
           qualification_row,
           country_row,
           naric_row,
-          comparable_uk_qualification,
+          comparable_uk_qualification_row,
           grade_row,
           award_year_row,
         ]
@@ -63,7 +63,7 @@ module CandidateInterface
     def grade_row
       {
         key: 'Grade',
-        value: application_qualification.grade ? application_qualification.grade.upcase : t('gcse_summary.not_specified'),
+        value: application_qualification.grade || t('gcse_summary.not_specified'),
         action: "grade for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: candidate_interface_gcse_details_edit_grade_path(subject: subject),
       }
@@ -103,7 +103,7 @@ module CandidateInterface
       }
     end
 
-    def comparable_uk_qualification
+    def comparable_uk_qualification_row
       {
         key: 'Comparable UK qualification',
         value: application_qualification.comparable_uk_qualification || 'Not provided',

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def details_params
-      params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year])
+      params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year other_grade])
     end
 
     def details_form

--- a/app/controllers/candidate_interface/gcse/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_controller.rb
@@ -7,6 +7,7 @@ module CandidateInterface
       @qualification_type = details_form.qualification.qualification_type
 
       details_form.grade = details_params[:grade]
+      details_form.other_grade = details_params[:other_grade]
 
       @application_qualification = details_form.save_grade
 

--- a/app/forms/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_details_form.rb
@@ -107,7 +107,9 @@ module CandidateInterface
       when 'other'
         other_grade
       when 'not_applicable'
-        'n/a'
+        'N/A'
+      when 'unknown'
+        'Unknown'
       else
         grade
       end

--- a/app/forms/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_details_form.rb
@@ -3,19 +3,29 @@ module CandidateInterface
     include ActiveModel::Model
     include ValidationUtils
 
-    attr_accessor :grade, :award_year, :qualification
+    attr_accessor :grade, :award_year, :qualification, :other_grade
     validates :grade, presence: true, on: :grade
+    validates :other_grade, presence: true, if: :grade_is_other?
     validates :award_year, presence: true, on: :award_year
-    validates :grade, length: { maximum: 6 }, on: :grade
+    validates :grade, length: { maximum: 6 }, on: :grade, unless: :international_gcses_flag_active?
     validate :award_year_is_a_valid_date, if: :award_year, on: :award_year
     validate :validate_grade_format, unless: :new_record?, on: :grade
 
     def self.build_from_qualification(qualification)
-      new(
-        grade: qualification.grade,
-        award_year: qualification.award_year,
-        qualification: qualification,
-      )
+      if FeatureFlag.active?('international_gcses') && qualification.qualification_type == 'non_uk'
+        new(
+          grade: qualification.set_grade,
+          other_grade: qualification.set_other_grade,
+          award_year: qualification.award_year,
+          qualification: qualification,
+        )
+      else
+        new(
+          grade: qualification.grade,
+          award_year: qualification.award_year,
+          qualification: qualification,
+        )
+      end
     end
 
     def save_grade
@@ -23,13 +33,12 @@ module CandidateInterface
         log_validation_errors(:grade)
         return false
       end
-
-      qualification.update(grade: grade, award_year: award_year)
+      qualification.update(grade: set_grade, award_year: award_year)
     end
 
     def save_year
       if valid?(:award_year)
-        qualification.update(grade: grade, award_year: award_year)
+        qualification.update(grade: set_grade, award_year: award_year)
         return true
       end
 
@@ -56,7 +65,7 @@ module CandidateInterface
     end
 
     def validate_grade_format
-      return if qualification.qualification_type.nil? || qualification.qualification_type == 'other_uk'
+      return if qualification.qualification_type.nil? || qualification.qualification_type == 'other_uk' || qualification.qualification_type == 'non_uk'
 
       qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
 
@@ -87,6 +96,25 @@ module CandidateInterface
       }
 
       Rails.logger.info("Validation error: #{error_message.inspect}")
+    end
+
+    def grade_is_other?
+      grade == 'other'
+    end
+
+    def set_grade
+      case grade
+      when 'other'
+        other_grade
+      when 'not_applicable'
+        'n/a'
+      else
+        grade
+      end
+    end
+
+    def international_gcses_flag_active?
+      FeatureFlag.active?('international_gcses')
     end
   end
 end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -68,4 +68,19 @@ class ApplicationQualification < ApplicationRecord
       'No'
     end
   end
+
+  def set_grade
+    case grade
+    when 'n/a'
+      'not_applicable'
+    when 'unknown'
+      'unknown'
+    else
+      'other'
+    end
+  end
+
+  def set_other_grade
+    grade if grade != 'n/a' && grade != 'unknown'
+  end
 end

--- a/app/views/candidate_interface/gcse/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <% if FeatureFlag.active?('international_gcses') %>
+      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :naric_details do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>

--- a/app/views/candidate_interface/gcse/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade/edit.html.erb
@@ -8,9 +8,19 @@
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
+      <% if FeatureFlag.active?('international_gcses') %>
+        <%= f.govuk_radio_buttons_fieldset :naric_details do %>
+          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
+          <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
+          <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
+            <%=  f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint_text: 'For example, ‘A’, ‘4.5’, ‘94%’', width: 10 %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
-      <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint_text: hint_for_gcse_edit_grade(@subject, @qualification_type), width: 10 %>
+        <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint_text: hint_for_gcse_edit_grade(@subject, @qualification_type), width: 10 %>
+      <% end %>
 
       <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -638,6 +638,8 @@ en:
               blank: Enter the year you gained your qualification
               invalid: Enter a real year
               in_future: Enter a year before %{date}
+            other_grade:
+              blank: Enter your grade
         candidate_interface/gcse_qualification_type_form:
           attributes:
             qualification_type:

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
 
       expect(result.text).to match(/Qualification\s+#{@qualification.non_uk_qualification_type}/)
       expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
-      expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
+      expect(result.text).to match(/Grade\s+#{@qualification.grade}/)
       expect(result.text).to match(/Country\s+#{COUNTRIES[@qualification.institution_country]}/)
     end
 
@@ -68,7 +68,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
 
       expect(result.text).to match(/Qualification\s+GCSE/)
       expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
-      expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
+      expect(result.text).to match(/Grade\s+#{@qualification.grade}/)
       expect(result.text).not_to match(/Country\s+#{@qualification.institution_country}/)
     end
   end

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -49,27 +49,6 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.text).to match(/NARIC reference number\s+Not provided/)
       expect(result.text).to match(/Comparable UK qualification\s+Not provided/)
     end
-
-    it 'displays "Not provided" for naric_reference and comparable_uk_qualification when nil' do
-      application_form = build :application_form
-      @qualification = application_qualification = build(
-        :application_qualification,
-        application_form: application_form,
-        qualification_type: 'non_uk',
-        non_uk_qualification_type: 'High school diploma',
-        level: 'gcse',
-        grade: 'c',
-        institution_country: 'United States',
-        naric_reference: nil,
-        comparable_uk_qualification: nil,
-      )
-      result = render_inline(
-        described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
-      )
-
-      expect(result.text).to match(/NARIC reference number\s+Not provided/)
-      expect(result.text).to match(/Comparable UK qualification\s+Not provided/)
-    end
   end
 
   context 'with the international_gcses flag off' do

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -49,6 +49,27 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.text).to match(/NARIC reference number\s+Not provided/)
       expect(result.text).to match(/Comparable UK qualification\s+Not provided/)
     end
+
+    it 'displays "Not provided" for naric_reference and comparable_uk_qualification when nil' do
+      application_form = build :application_form
+      @qualification = application_qualification = build(
+        :application_qualification,
+        application_form: application_form,
+        qualification_type: 'non_uk',
+        non_uk_qualification_type: 'High school diploma',
+        level: 'gcse',
+        grade: 'c',
+        institution_country: 'United States',
+        naric_reference: nil,
+        comparable_uk_qualification: nil,
+      )
+      result = render_inline(
+        described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
+      )
+
+      expect(result.text).to match(/NARIC reference number\s+Not provided/)
+      expect(result.text).to match(/Comparable UK qualification\s+Not provided/)
+    end
   end
 
   context 'with the international_gcses flag off' do

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -41,11 +41,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
 
       expect(institution_country_form.save(application_qualification)).to eq(true)
-<<<<<<< HEAD
       expect(application_qualification.institution_country).to eq COUNTRY_NAMES_TO_ISO_CODES[form_data[:institution_country]]
-=======
-      expect(application_qualification.institution_country).to eq REVERSE_COUNTRIES_HASH[form_data[:institution_country]]
->>>>>>> Rework to store ISO nationality codes
     end
   end
 end

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -41,7 +41,11 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
 
       expect(institution_country_form.save(application_qualification)).to eq(true)
+<<<<<<< HEAD
       expect(application_qualification.institution_country).to eq COUNTRY_NAMES_TO_ISO_CODES[form_data[:institution_country]]
+=======
+      expect(application_qualification.institution_country).to eq REVERSE_COUNTRIES_HASH[form_data[:institution_country]]
+>>>>>>> Rework to store ISO nationality codes
     end
   end
 end

--- a/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
         end
       end
 
-      context 'with the international_gcses feature flag on, the qualification_type in non_uk and grade is not_applicable' do
+      context 'with the international_gcses feature flag on, the qualification_type is non_uk and grade is not_applicable' do
         it 'sets grade to not_applicable and other grade to nil' do
           FeatureFlag.activate('international_gcses')
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'n/a')

--- a/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
     it { is_expected.to validate_presence_of(:award_year).on(:award_year) }
     it { is_expected.to validate_length_of(:grade).is_at_most(6).on(:grade) }
 
+    context 'when grade is "other"' do
+      let(:form) { subject }
+
+      before { allow(form).to receive(:grade_is_other?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:other_grade) }
+    end
+
     context 'when qualification type is GCSE' do
       let(:form) { CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification) }
       let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gcse', level: 'gcse') }
@@ -119,6 +127,20 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
 
         expect(qualification.grade).to eq('AB')
       end
+
+      it 'sets grade to other_grade if candidate selected "other"' do
+        application_form = create(:application_form)
+        qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
+        details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
+
+        details_form.grade = 'other'
+        details_form.other_grade = 'D'
+
+        details_form.save_grade
+        qualification.reload
+
+        expect(qualification.grade).to eq('D')
+      end
     end
 
     describe '#save_year' do
@@ -147,6 +169,57 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
         qualification.reload
 
         expect(qualification.award_year).to eq('1990')
+      end
+    end
+
+    describe '.build_from_qualification' do
+      context 'with the international_gcses feature flag off' do
+        let(:data) do
+          {
+            grade: 'D',
+            award_year: '2012',
+          }
+        end
+
+        it 'creates an object based on the provided ApplicationForm' do
+          qualification = ApplicationQualification.new(data)
+          gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form).to have_attributes(data)
+        end
+      end
+
+      context 'with the international_gcses feature flag on, the qualification_type in non_uk and grade is not_applicable' do
+        it 'sets grade to not_applicable and other grade to nil' do
+          FeatureFlag.activate('international_gcses')
+          qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'n/a')
+          gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form.grade).to eq 'not_applicable'
+          expect(gcse_details_form.other_grade).to eq nil
+        end
+      end
+
+      context 'with the international_gcses feature flag on and grade is unknown' do
+        it 'sets grade to not_applicable and other grade to nil' do
+          FeatureFlag.activate('international_gcses')
+          qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'unknown')
+          gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form.grade).to eq 'unknown'
+          expect(gcse_details_form.other_grade).to eq nil
+        end
+      end
+
+      context 'with the international_gcses feature flag on and grade is another value' do
+        it 'sets grade to other and other grade to grades value' do
+          FeatureFlag.activate('international_gcses')
+          qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'D')
+          gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form.grade).to eq 'other'
+          expect(gcse_details_form.other_grade).to eq 'D'
+        end
       end
     end
   end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -122,4 +122,38 @@ RSpec.describe ApplicationQualification, type: :model do
       expect(qualification.naric_reference_choice).to eq(nil)
     end
   end
+
+  describe '#set_grade' do
+    it 'sets grade to not_applicable and other grade to nil when grade is not_applicable' do
+      qualification = build_stubbed(:gcse_qualification, grade: 'n/a')
+      expect(qualification.set_grade).to eq 'not_applicable'
+    end
+
+    it 'sets grade to not_applicable and other grade to nil when grade is unknown' do
+      qualification = build_stubbed(:gcse_qualification, grade: 'unknown')
+      expect(qualification.set_grade).to eq 'unknown'
+    end
+
+    it 'sets grade to other and other grade to grades value when grade is another value' do
+      qualification = build_stubbed(:gcse_qualification, grade: 'D')
+      expect(qualification.set_grade).to eq 'other'
+    end
+  end
+
+  describe '#set_other_grade' do
+    it 'returns nil when grade is not_applicable' do
+      qualification = build_stubbed(:gcse_qualification, grade: 'n/a')
+      expect(qualification.set_other_grade).to eq nil
+    end
+
+    it 'returns nil when grade is unknown' do
+      qualification = build_stubbed(:gcse_qualification, grade: 'unknown')
+      expect(qualification.set_other_grade).to eq nil
+    end
+
+    it 'returns grade when grade is another value' do
+      qualification = build_stubbed(:gcse_qualification, grade: 'D')
+      expect(qualification.set_other_grade).to eq 'D'
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -160,11 +160,11 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_click_to_change_year
-    page.all('.govuk-summary-list__actions').to_a.second.click_link 'Change'
+    page.all('.govuk-summary-list__actions').to_a.third.click_link 'Change'
   end
 
   def when_i_click_to_change_grade
-    page.all('.govuk-summary-list__actions').to_a.third.click_link 'Change'
+    page.all('.govuk-summary-list__actions').to_a.second.click_link 'Change'
   end
 
   def when_i_enter_a_different_qualification_grade

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -41,7 +41,8 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     and_i_click_save_and_continue
     then_i_see_the_add_grade_page
 
-    when_i_fill_in_the_grade
+    when_i_choose_other
+    and_i_fill_in_my_grade
     and_i_click_save_and_continue
     then_i_see_add_year_page
 
@@ -140,6 +141,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def then_i_see_the_review_page_with_correct_details
+    save_and_open_page
     expect(page).to have_content 'Maths GCSE or equivalent'
     expect(page).to have_content 'High School Diploma'
     expect(page).to have_content 'PASS'
@@ -157,8 +159,12 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
     expect(page).to have_content t('gcse_edit_year.page_title', subject: 'maths')
   end
 
-  def when_i_fill_in_the_grade
-    fill_in 'Please specify your grade', with: 'Pass'
+  def when_i_choose_other
+    choose 'Other'
+  end
+
+  def and_i_fill_in_my_grade
+    fill_in 'Grade', with: 'Pass'
   end
 
   def when_i_fill_in_the_year

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -141,7 +141,6 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def then_i_see_the_review_page_with_correct_details
-    save_and_open_page
     expect(page).to have_content 'Maths GCSE or equivalent'
     expect(page).to have_content 'High School Diploma'
     expect(page).to have_content 'PASS'

--- a/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_international_gcse_spec.rb
@@ -143,7 +143,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   def then_i_see_the_review_page_with_correct_details
     expect(page).to have_content 'Maths GCSE or equivalent'
     expect(page).to have_content 'High School Diploma'
-    expect(page).to have_content 'PASS'
+    expect(page).to have_content 'Pass'
     expect(page).to have_content '1990'
     expect(page).to have_content 'United States'
     expect(page).to have_content '12345'


### PR DESCRIPTION
## Context

#2485 - Add non_uk qualifications to the qualification type page
#2499 - Add the institution country page 
#2509 - Adds a page for the candidate to input their naric reference and comparable UK qualification

This is the final PR in the international GCSE flow. It adds the grade view. This page only shows for non_uk qualifications.

## Changes proposed in this pull request

- Adds new grade view for non-uk qualifications


![image](https://user-images.githubusercontent.com/42515961/87690031-d5818d00-c780-11ea-8273-7070082ace74.png)

## Guidance to review

https://apply-beta-prototype.herokuapp.com/application/12345/gcse/maths/review

## Link to Trello card

https://trello.com/c/Sy4RX8lL/1763-dev-%F0%9F%8C%90-international-gcse-equivalents

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
