### PR TITLE
Implement the new two-level header for Manage

### DIFF
--- a/app/components/provider_interface/header_component.html.erb
+++ b/app/components/provider_interface/header_component.html.erb
@@ -1,36 +1,38 @@
 <header class="govuk-header <%= classes %>" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-header__logo provider-header__logo">
-      <%= link_to service_url, class: 'govuk-header__link govuk-header__link--homepage' do %>
-        <span class="govuk-header__logotype">
-          <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
+  <div class="govuk-header__container">
+    <div class="govuk-width-container">
+      <div class="govuk-header__logo provider-header__logo">
+        <%= link_to service_url, class: 'govuk-header__link govuk-header__link--homepage' do %>
+          <span class="govuk-header__logotype">
+            <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
+              <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+              <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+            </svg>
+            <span class="govuk-header__logotype-text">
+              GOV.UK
+            </span>
           </span>
-        </span>
-        <span class="govuk-header__product-name">
-          <%= product_name %>
-        </span>
-      <% end %>
-    </div>
-    <div class="govuk-header__content provider-header__content">
-      <% if navigation_items.any? %>
-         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
-          <% navigation_items.each do |nav_item| %>
-            <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
-              <% if nav_item.href %>
-                <%= link_to nav_item.text, nav_item.href, class: 'govuk-header__link' %>
-              <% else %>
-                <strong><%= nav_item.text %></strong>
+          <span class="govuk-header__product-name">
+            <%= product_name %>
+          </span>
+        <% end %>
+      </div>
+      <div class="govuk-header__content provider-header__content">
+        <% if navigation_items.any? %>
+          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
+            <% navigation_items.each do |nav_item| %>
+              <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
+                <% if nav_item.href %>
+                  <%= link_to nav_item.text, nav_item.href, class: 'govuk-header__link' %>
+                <% else %>
+                  <strong><%= nav_item.text %></strong>
+                <% end %>
               <% end %>
-            <% end %>
-          </li>
-        </ul>
-      <% end %>
+            </li>
+          </ul>
+        <% end %>
+      </div>
     </div>
   </div>
 </header>

--- a/app/components/provider_interface/header_component.html.erb
+++ b/app/components/provider_interface/header_component.html.erb
@@ -36,3 +36,22 @@
     </div>
   </div>
 </header>
+<div class="moj-primary-navigation">
+  <div class="moj-primary-navigation__container">
+    <div class="moj-primary-navigation__nav">
+      <nav class="moj-primary-navigation" aria-label="Primary navigation">
+        <ul class="moj-primary-navigation__list">
+          <% @sub_navigation_items.each do |nav_item| %>
+            <li class="moj-primary-navigation__item">
+              <a class="moj-primary-navigation__link"
+                <%= nav_item.active ? 'aria-current="page"' : '' %>
+                 href="<%= nav_item.href %>">
+                 <%= nav_item.text %>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/components/provider_interface/header_component.rb
+++ b/app/components/provider_interface/header_component.rb
@@ -2,10 +2,11 @@ class ProviderInterface::HeaderComponent < ViewComponent::Base
   attr_reader :navigation_items, :service_url, :product_name, :classes
   include ViewHelper
 
-  def initialize(navigation_items:, product_name:, service_url:, classes: '')
-    @navigation_items = navigation_items
-    @product_name     = product_name
-    @service_url      = service_url
-    @classes          = classes
+  def initialize(navigation_items:, sub_navigation_items:, product_name:, service_url:, classes: '')
+    @navigation_items     = navigation_items
+    @sub_navigation_items = sub_navigation_items
+    @product_name         = product_name
+    @service_url          = service_url
+    @classes              = classes
   end
 end

--- a/app/frontend/styles/_environments.scss
+++ b/app/frontend/styles/_environments.scss
@@ -1,55 +1,24 @@
+$app-colour-production: govuk-colour("blue");
 $app-colour-qa: govuk-colour("orange");
 $app-colour-sandbox: govuk-colour("purple");
 $app-colour-review: govuk-colour("purple");
 $app-colour-staging: govuk-colour("red");
 $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 
-.app-header--production .govuk-header__container {
-  // default blue styling
+@mixin environment-colour($environment, $colour) {
+  .app-header--#{$environment} .govuk-header__container {
+    border-bottom-color: $colour;
+  }
+
+  .app-environment-tag--#{$environment} {
+    background-color: $colour;
+  }
 }
 
-.app-header--qa .govuk-header__container {
-  border-bottom-color: $app-colour-qa;
-}
-
-.app-header--staging .govuk-header__container {
-  border-bottom-color: $app-colour-staging;
-}
-
-.app-header--sandbox .govuk-header__container {
-  border-bottom-color: $app-colour-sandbox;
-}
-
-.app-header--review .govuk-header__container {
-  border-bottom-color: $app-colour-review;
-}
-
-.app-header--development .govuk-header__container,
-.app-header--unknown-environment .govuk-header__container {
-  border-bottom-color: $app-colour-development;
-}
-
-.app-environment-tag--production {
-  // default blue styling
-}
-
-.app-environment-tag--qa {
-  background-color: $app-colour-qa;
-}
-
-.app-environment-tag--staging {
-  background-color: $app-colour-staging;
-}
-
-.app-environment-tag--sandbox {
-  background-color: $app-colour-sandbox;
-}
-
-.app-environment-tag--review {
-  background-color: $app-colour-review;
-}
-
-.app-environment-tag--development,
-.app-environment-tag--unknown-environment {
-  background-color: $app-colour-development;
-}
+@include environment-colour("development", $app-colour-development);
+@include environment-colour("unknown-environment", $app-colour-development);
+@include environment-colour("qa", $app-colour-qa);
+@include environment-colour("staging", $app-colour-staging);
+@include environment-colour("sandbox", $app-colour-sandbox);
+@include environment-colour("review", $app-colour-review);
+@include environment-colour("production", $app-colour-production);

--- a/app/frontend/styles/_environments.scss
+++ b/app/frontend/styles/_environments.scss
@@ -6,8 +6,10 @@ $app-colour-staging: govuk-colour("red");
 $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 
 @mixin environment-colour($environment, $colour) {
-  .app-header--#{$environment} .govuk-header__container {
-    border-bottom-color: $colour;
+  .app-header--#{$environment} {
+    .govuk-header__container {
+      border-bottom-color: $colour;
+    }
   }
 
   .app-environment-tag--#{$environment} {

--- a/app/frontend/styles/_provider_header.scss
+++ b/app/frontend/styles/_provider_header.scss
@@ -1,3 +1,7 @@
+.provider-header {
+  border-bottom: 10px solid;
+}
+
 .provider-header__logo {
   @include govuk-media-query($from: tablet) {
     width: 60%;

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -45,10 +45,14 @@ $govuk-breakpoints: (
 @import "_work-history";
 @import "_timeline";
 @import "_notes";
-@import "~@ministryofjustice/frontend/moj/helpers/hidden";
+@import "~@ministryofjustice/frontend/moj/settings/measurements";
+@import "~@ministryofjustice/frontend/moj/objects/width-container";
+@import "~@ministryofjustice/frontend/moj/helpers/all";
+@import "~@ministryofjustice/frontend/moj/utilities/all";
 @import "~@ministryofjustice/frontend/moj/settings/assets";
 @import "~@ministryofjustice/frontend/moj/objects/filter-layout";
 @import "~@ministryofjustice/frontend/moj/components/filter/filter";
+@import "~@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
 @import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
 @import "~@ministryofjustice/frontend/moj/utilities/hidden";
 @import "_filter";

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -39,7 +39,7 @@ class NavigationItems
     def for_provider_interface(current_provider_user, current_controller)
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
-      items = [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]
+      items = []
 
       if current_provider_user.can_manage_organisations? && Provider.with_permissions_visible_to(current_provider_user).exists?
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
@@ -51,6 +51,12 @@ class NavigationItems
 
       items << NavigationItem.new('Account', provider_interface_account_path, is_active(current_controller, 'account'))
       items << NavigationItem.new('Sign out', provider_interface_sign_out_path, false)
+    end
+
+    def for_provider_interface_sub_nav(current_controller)
+      [
+        NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes])),
+      ]
     end
 
     def for_api_docs(current_controller)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,8 @@
   <%= render(ProviderInterface::HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  product_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user, controller))) %>
+                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user, controller),
+                                 sub_navigation_items: NavigationItems.for_provider_interface_sub_nav(controller))) %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,


### PR DESCRIPTION
## Context

The prototype has a two-level header which makes space for the new "Users" and "Organisations" items. We're about to add these so we need the new roomier design.

## Changes proposed in this pull request

- refactor the way we assign per-environment colours to the relevant UI elements because it's already repetitive and adding a third element (the full-width bar) will make it even more so
- add the necessary `moj-frontend` bits and put the markup in the provider header component
- move the `Applications` item into the new menu

## Guidance to review

Does the phase banner look a bit lost?

<img width="1232" alt="Screenshot 2020-07-16 at 17 33 56" src="https://user-images.githubusercontent.com/642279/87697866-9a845700-c78a-11ea-8e21-f68551c3eaa3.png">


## Link to Trello card

https://trello.com/c/OTojnjhu/2440-implement-the-new-two-level-header-for-manage

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
