### PR TITLE
Provider user invitation wizard - part 1

### DIFF
--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -42,7 +42,7 @@ module ProviderInterface
       @wizard = ProviderUserInvitationWizard.new(session, current_step: 'permissions', current_provider_id: params[:provider_id])
       @wizard.save_state!
 
-      @permissions_form = ProviderPermissionsForm.new(@wizard.permissions_for(params[:provider_id]))
+      @permissions_form = ProviderUserPermissionsForm.new(@wizard.permissions_for(params[:provider_id]))
     end
 
     def update_permissions

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -78,7 +78,7 @@ module ProviderInterface
 
     def wizard_params
       params.require(:provider_interface_provider_user_invitation_wizard)
-        .permit(:change_answer, :first_name, providers: [], provider_permissions: {})
+        .permit(:change_answer, :first_name, :last_name, :email_address, :first_name, providers: [], provider_permissions: {})
     end
 
   private

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -9,7 +9,7 @@ module ProviderInterface
     end
 
     def update_details
-      @wizard = ProviderUserInvitationWizard.new(session, wizard_params)
+      @wizard = ProviderUserInvitationWizard.new(session, details_params)
 
       if @wizard.valid_for_current_step?
         @wizard.save_state!
@@ -27,7 +27,7 @@ module ProviderInterface
     end
 
     def update_providers
-      @wizard = ProviderUserInvitationWizard.new(session, wizard_params)
+      @wizard = ProviderUserInvitationWizard.new(session, providers_params)
       @available_providers = current_provider_user.providers
 
       if @wizard.valid_for_current_step?
@@ -46,7 +46,7 @@ module ProviderInterface
     end
 
     def update_permissions
-      @wizard = ProviderUserInvitationWizard.new(session, wizard_params)
+      @wizard = ProviderUserInvitationWizard.new(session, permissions_params)
       @wizard.save_state!
 
       redirect_to next_redirect(@wizard)
@@ -66,6 +66,8 @@ module ProviderInterface
       redirect_to provider_interface_provider_users_path
     end
 
+  private
+
     def next_redirect(wizard)
       step, provider_id = wizard.next_step
 
@@ -76,12 +78,20 @@ module ProviderInterface
       }.fetch(step)
     end
 
-    def wizard_params
+    def details_params
       params.require(:provider_interface_provider_user_invitation_wizard)
-        .permit(:change_answer, :first_name, :last_name, :email_address, :first_name, providers: [], provider_permissions: {})
+        .permit(:first_name, :last_name, :email_address)
     end
 
-  private
+    def providers_params
+      params.require(:provider_interface_provider_user_invitation_wizard)
+        .permit(providers: [])
+    end
+
+    def permissions_params
+      params.require(:provider_interface_provider_user_invitation_wizard)
+        .permit(provider_permissions: {})
+    end
 
     def require_feature_flag
       render_404 unless FeatureFlag.active?(:providers_can_manage_users_and_permissions)

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -1,5 +1,8 @@
 module ProviderInterface
   class ProviderUsersInvitationsController < ProviderInterfaceController
+    before_action :require_feature_flag
+    before_action :redirect_unless_permitted_to_manage_users
+
     def edit_details
       @wizard = ProviderUserInvitationWizard.new(session, current_step: 'details')
       @wizard.save_state!
@@ -76,6 +79,17 @@ module ProviderInterface
     def wizard_params
       params.require(:provider_interface_provider_user_invitation_wizard)
         .permit(:change_answer, :first_name, providers: [], provider_permissions: {})
+    end
+
+  private
+
+    def require_feature_flag
+      render_404 unless FeatureFlag.active?(:providers_can_manage_users_and_permissions)
+    end
+
+    def redirect_unless_permitted_to_manage_users
+      can_manage_users = ProviderPermissions.exists?(provider_user: current_provider_user, manage_users: true)
+      render_404 unless can_manage_users
     end
   end
 end

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -1,26 +1,5 @@
 module ProviderInterface
   class ProviderUsersInvitationsController < ProviderInterfaceController
-    class ProviderPermissionsForm
-      include ActiveModel::Model
-
-      Permission = Struct.new(:slug, :name)
-
-      attr_accessor :provider_id, :permissions
-
-      def available_permissions
-        [
-          Permission.new('manage_users', 'Manage users'),
-          Permission.new('make_decisions', 'Make decisions'),
-        ]
-      end
-
-      def provider
-        Provider.find(provider_id)
-      end
-
-      alias_method :id, :provider_id
-    end
-
     def edit_details
       @wizard = ProviderUserInvitationWizard.new(session, current_step: 'details')
       @wizard.save_state!
@@ -97,102 +76,6 @@ module ProviderInterface
     def wizard_params
       params.require(:provider_interface_provider_user_invitation_wizard)
         .permit(:change_answer, :first_name, providers: [], provider_permissions: {})
-    end
-  end
-
-  class ProviderUserInvitationWizard
-    include ActiveModel::Model
-    STATE_STORE_KEY = :provider_user_invitation_wizard
-
-    attr_accessor :current_step, :first_name, :checking_answers
-    attr_writer :providers, :provider_permissions, :state_store
-
-    validates :first_name, presence: true, on: :details
-    validates :providers, presence: true, on: :providers
-
-    def initialize(state_store, attrs = {})
-      @state_store = state_store
-
-      super(JSON.parse(last_saved_state).deep_merge(attrs))
-
-      @checking_answers = true if current_step == 'check'
-    end
-
-    def providers
-      if @providers
-        @providers.reject(&:blank?).map(&:to_i)
-      else
-        []
-      end
-    end
-
-    def provider_permissions
-      @provider_permissions || {}
-    end
-
-    def applicable_provider_permissions
-      @provider_permissions.select do |id, _details|
-        providers.include?(id.to_i)
-      end
-    end
-
-    def permissions_for(provider_id)
-      provider_permissions[provider_id].presence || { provider_id: provider_id, permissions: [] }
-    end
-
-    def valid_for_current_step?
-      valid?(current_step.to_sym)
-    end
-
-    # returns [step, *params] for the next step.
-    #
-    # this way the wizard is responsible for its own routing
-    # but it doesn't need to know about HTTP, so we can test it
-    # in isolation
-    def next_step
-      if checking_answers
-        if any_provider_needs_permissions_setup
-          [:permissions, next_provider_needing_permissions_setup]
-        else
-          [:check]
-        end
-      elsif current_step == 'details'
-        [:providers]
-      elsif %w[providers permissions].include?(current_step) && any_provider_needs_permissions_setup
-        [:permissions, next_provider_needing_permissions_setup]
-      else
-        [:check]
-      end
-    end
-
-    def save!
-      raise '💾'
-    end
-
-    def save_state!
-      @state_store[STATE_STORE_KEY] = state
-    end
-
-    def clear_state!
-      @state_store.delete(STATE_STORE_KEY)
-    end
-
-  private
-
-    def state
-      as_json(except: %w[state_store errors validation_context]).to_json
-    end
-
-    def last_saved_state
-      @state_store[STATE_STORE_KEY].presence || '{}'
-    end
-
-    def next_provider_needing_permissions_setup
-      providers.find { |p| provider_permissions.keys.exclude?(p.to_s) }
-    end
-
-    def any_provider_needs_permissions_setup
-      next_provider_needing_permissions_setup.present?
     end
   end
 end

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -1,0 +1,181 @@
+module ProviderInterface
+  class ProviderUsersInvitationsController < ProviderInterfaceController
+    WIZARD_STATE_SESSION_KEY = :provider_user_invitation_wizard
+
+    class ProviderPermissionsForm
+      include ActiveModel::Model
+
+      Permission = Struct.new(:slug, :name)
+
+      attr_accessor :provider_id, :permissions
+
+      def available_permissions
+        [
+          Permission.new('manage_users', 'Manage users'),
+          Permission.new('make_decisions', 'Make decisions'),
+        ]
+      end
+
+      def provider
+        Provider.find(provider_id)
+      end
+
+      alias_method :id, :provider_id
+    end
+
+    def wizard_state
+      { _state: session[WIZARD_STATE_SESSION_KEY].presence || {} }
+    end
+
+    def save_wizard_state!
+      session[WIZARD_STATE_SESSION_KEY] = @wizard.state
+    end
+
+    def clear_wizard_state!
+      session.delete(WIZARD_STATE_SESSION_KEY)
+    end
+
+    def edit_details
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'details', returning_to_answered_question: params[:change]))
+      save_wizard_state!
+    end
+
+    def update_details
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(wizard_params))
+
+      if @wizard.valid_for_current_step?
+        save_wizard_state!
+        redirect_to next_redirect(@wizard)
+      else
+        render :edit_details
+      end
+    end
+
+    def edit_providers
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'providers', returning_to_answered_question: params[:change]))
+      save_wizard_state!
+
+      @available_providers = current_provider_user.providers
+    end
+
+    def update_providers
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(wizard_params))
+      @available_providers = current_provider_user.providers
+
+      if @wizard.valid_for_current_step?
+        save_wizard_state!
+        redirect_to next_redirect(@wizard)
+      else
+        render :edit_providers
+      end
+    end
+
+    def edit_permissions
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'permissions', returning_to_answered_question: params[:change]))
+      save_wizard_state!
+
+      @permissions_form = ProviderPermissionsForm.new(@wizard.permissions_for(params[:provider_id]))
+    end
+
+    def update_permissions
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(wizard_params))
+      save_wizard_state!
+
+      redirect_to next_redirect(@wizard)
+    end
+
+    def check
+      @wizard = ProviderUserInvitationWizard.new(wizard_state.merge(current_step: 'check'))
+    end
+
+    def commit
+      @wizard = ProviderUserInvitationWizard.new(wizard_state)
+
+      clear_wizard_state!
+
+      flash[:success] = 'User successfully invited'
+      redirect_to provider_interface_provider_users_path
+    end
+
+    def next_redirect(wizard)
+      if wizard.returning_to_answered_question
+        if wizard.has_permissions_to_set?
+          { action: :edit_permissions, provider_id: wizard.next_provider_requiring_permissions_setup }
+       else # carry on back to the check answers page
+          { action: :check }
+        end
+      elsif wizard.current_step == 'details'
+        { action: :edit_providers }
+      elsif wizard.current_step == 'providers' && wizard.has_permissions_to_set?
+        { action: :edit_permissions, provider_id: wizard.next_provider_requiring_permissions_setup }
+      elsif wizard.current_step == 'permissions' && wizard.has_permissions_to_set?
+        { action: :edit_permissions, provider_id: wizard.next_provider_requiring_permissions_setup }
+      else
+        { action: :check }
+      end
+    end
+
+    def wizard_params
+      params.require(:provider_interface_provider_user_invitation_wizard)
+        .permit(:change_answer, :first_name, providers: [], provider_permissions: {})
+    end
+  end
+
+  class ProviderUserInvitationWizard
+    include ActiveModel::Model
+
+    attr_accessor :current_step, :first_name, :returning_to_answered_question
+    attr_writer :providers, :provider_permissions, :_state
+
+    validates :first_name, presence: true, on: :details
+    validates :providers, presence: true, on: :providers
+
+    def initialize(attrs)
+      state = attrs[:_state].presence || '{}'
+      attrs_incl_state = JSON.parse(state).deep_merge(attrs)
+      super(attrs_incl_state)
+    end
+
+    def valid_for_current_step?
+      valid?(current_step.to_sym)
+    end
+
+    def save!
+      raise '💾'
+    end
+
+    def state
+      as_json(except: %w[_state change_answer errors validation_context]).to_json
+    end
+
+    def providers
+      if @providers
+        @providers.reject(&:blank?).map(&:to_i)
+      else
+        []
+      end
+    end
+
+    def provider_permissions
+      @provider_permissions || {}
+    end
+
+    def applicable_provider_permissions
+      @provider_permissions.select do |id, _details|
+        providers.include?(id.to_i)
+      end
+    end
+
+    def permissions_for(provider_id)
+      provider_permissions[provider_id].presence || { provider_id: provider_id, permissions: [] }
+    end
+
+    def next_provider_requiring_permissions_setup
+      providers.find { |p| provider_permissions.keys.exclude?(p.to_s) }
+    end
+
+    def has_permissions_to_set?
+      next_provider_requiring_permissions_setup.present?
+    end
+  end
+end

--- a/app/forms/provider_interface/provider_permissions_form.rb
+++ b/app/forms/provider_interface/provider_permissions_form.rb
@@ -1,0 +1,22 @@
+module ProviderInterface
+  class ProviderPermissionsForm
+    include ActiveModel::Model
+
+    Permission = Struct.new(:slug, :name)
+
+    attr_accessor :provider_id, :permissions
+
+    def available_permissions
+      [
+        Permission.new('manage_users', 'Manage users'),
+        Permission.new('make_decisions', 'Make decisions'),
+      ]
+    end
+
+    def provider
+      Provider.find(provider_id)
+    end
+
+    alias_method :id, :provider_id
+  end
+end

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -16,6 +16,8 @@ module ProviderInterface
       @state_store = state_store
 
       super(JSON.parse(last_saved_state).deep_merge(attrs))
+
+      self.checking_answers = false if current_step == 'check'
     end
 
     def providers
@@ -96,7 +98,7 @@ module ProviderInterface
   private
 
     def state
-      as_json(except: %w[state_store errors validation_context checking_answers current_step current_provider_id]).to_json
+      as_json(except: %w[state_store errors validation_context current_step current_provider_id]).to_json
     end
 
     def last_saved_state

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -16,8 +16,6 @@ module ProviderInterface
       @state_store = state_store
 
       super(JSON.parse(last_saved_state).deep_merge(attrs))
-
-      @checking_answers = true if current_step == 'check'
     end
 
     def providers

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -1,0 +1,97 @@
+module ProviderInterface
+  class ProviderUserInvitationWizard
+    include ActiveModel::Model
+    STATE_STORE_KEY = :provider_user_invitation_wizard
+
+    attr_accessor :current_step, :first_name, :checking_answers
+    attr_writer :providers, :provider_permissions, :state_store
+
+    validates :first_name, presence: true, on: :details
+    validates :providers, presence: true, on: :providers
+
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(JSON.parse(last_saved_state).deep_merge(attrs))
+
+      @checking_answers = true if current_step == 'check'
+    end
+
+    def providers
+      if @providers
+        @providers.reject(&:blank?).map(&:to_i)
+      else
+        []
+      end
+    end
+
+    def provider_permissions
+      @provider_permissions || {}
+    end
+
+    def applicable_provider_permissions
+      @provider_permissions.select do |id, _details|
+        providers.include?(id.to_i)
+      end
+    end
+
+    def permissions_for(provider_id)
+      provider_permissions[provider_id].presence || { provider_id: provider_id, permissions: [] }
+    end
+
+    def valid_for_current_step?
+      valid?(current_step.to_sym)
+    end
+
+    # returns [step, *params] for the next step.
+    #
+    # this way the wizard is responsible for its own routing
+    # but it doesn't need to know about HTTP, so we can test it
+    # in isolation
+    def next_step
+      if checking_answers
+        if any_provider_needs_permissions_setup
+          [:permissions, next_provider_needing_permissions_setup]
+        else
+          [:check]
+        end
+      elsif current_step == 'details'
+        [:providers]
+      elsif %w[providers permissions].include?(current_step) && any_provider_needs_permissions_setup
+        [:permissions, next_provider_needing_permissions_setup]
+      else
+        [:check]
+      end
+    end
+
+    def save!
+      raise '💾'
+    end
+
+    def save_state!
+      @state_store[STATE_STORE_KEY] = state
+    end
+
+    def clear_state!
+      @state_store.delete(STATE_STORE_KEY)
+    end
+
+  private
+
+    def state
+      as_json(except: %w[state_store errors validation_context]).to_json
+    end
+
+    def last_saved_state
+      @state_store[STATE_STORE_KEY].presence || '{}'
+    end
+
+    def next_provider_needing_permissions_setup
+      providers.find { |p| provider_permissions.keys.exclude?(p.to_s) }
+    end
+
+    def any_provider_needs_permissions_setup
+      next_provider_needing_permissions_setup.present?
+    end
+  end
+end

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -9,6 +9,7 @@ module ProviderInterface
     validates :first_name, presence: true, on: :details
     validates :last_name, presence: true, on: :details
     validates :email_address, presence: true, on: :details
+    validates :email_address, email: true, on: :details
     validates :providers, presence: true, on: :providers
 
     def initialize(state_store, attrs = {})

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -109,8 +109,7 @@ module ProviderInterface
       if current_provider_id.blank?
         providers.first
       else
-        index = providers.index(current_provider_id.to_i)
-        index.present? && index < (providers.size - 1) ? providers[index + 1] : nil
+        providers.drop_while { |provider_id| provider_id != current_provider_id.to_i }[1]
       end
     end
 
@@ -118,8 +117,7 @@ module ProviderInterface
       if current_provider_id.blank?
         providers.last
       else
-        index = providers.index(current_provider_id.to_i)
-        index&.positive? ? providers[index - 1] : nil
+        providers.reverse.drop_while { |provider_id| provider_id != current_provider_id.to_i }[1]
       end
     end
 

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -115,8 +115,8 @@ module ProviderInterface
 
     def previous_provider_id_with_permissions
       if current_provider_id.present?
-        index = provider_permissions.keys.find(current_provider_id)
-        index.positive? ? provider_permissions.keys[index - 1] : nil
+        index = provider_permissions.keys.index(current_provider_id)
+        index&.positive? ? provider_permissions.keys[index - 1] : nil
       else
         provider_permissions.keys.last
       end

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -3,10 +3,12 @@ module ProviderInterface
     include ActiveModel::Model
     STATE_STORE_KEY = :provider_user_invitation_wizard
 
-    attr_accessor :current_step, :first_name, :checking_answers
+    attr_accessor :current_step, :first_name, :last_name, :email_address, :checking_answers
     attr_writer :providers, :provider_permissions, :state_store
 
     validates :first_name, presence: true, on: :details
+    validates :last_name, presence: true, on: :details
+    validates :email_address, presence: true, on: :details
     validates :providers, presence: true, on: :providers
 
     def initialize(state_store, attrs = {})

--- a/app/forms/provider_interface/provider_user_permissions_form.rb
+++ b/app/forms/provider_interface/provider_user_permissions_form.rb
@@ -1,5 +1,5 @@
 module ProviderInterface
-  class ProviderPermissionsForm
+  class ProviderUserPermissionsForm
     include ActiveModel::Model
 
     Permission = Struct.new(:slug, :name)

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -4,7 +4,7 @@
 
 <%= link_to(
   'Invite user',
-  provider_interface_edit_invitation_basic_details_path,
+  new_provider_interface_provider_user_path,
   class: 'govuk-button',
 ) %>
 

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -2,7 +2,11 @@
 
 <h1 class="govuk-heading-xl">Users</h1>
 
-<%= link_to 'Invite user', new_provider_interface_provider_user_path, class: 'govuk-button' %>
+<%= link_to(
+  'Invite user',
+  provider_interface_edit_invitation_basic_details_path,
+  class: 'govuk-button',
+) %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/provider_interface/provider_users_invitations/check.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/check.html.erb
@@ -1,0 +1,20 @@
+name <%= @wizard.first_name %><br />
+
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_basic_details_path(change: true) %>
+
+<br />
+
+providers <%= @wizard.providers.map { |p| Provider.find(p).name } %><br />
+
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_providers_path(change: true) %>
+
+<br />
+
+permissions
+<% @wizard.applicable_provider_permissions.map do |p, details| %>
+  <%= "#{Provider.find(p).name}, perms: #{details['permissions'].reject(&:blank?).join(',')}" %>
+  <%= govuk_link_to 'Change', provider_interface_edit_invitation_provider_permissions_path(change: true, provider_id: p) %>
+<% end %>
+
+
+<%= button_to 'Invite user', provider_interface_commit_invitation_path, class: 'govuk-button' %>

--- a/app/views/provider_interface/provider_users_invitations/check.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/check.html.erb
@@ -1,19 +1,19 @@
 name <%= @wizard.first_name %><br />
 
-<%= govuk_link_to 'Change', provider_interface_edit_invitation_basic_details_path(change: true) %>
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_basic_details_path %>
 
 <br />
 
 providers <%= @wizard.providers.map { |p| Provider.find(p).name } %><br />
 
-<%= govuk_link_to 'Change', provider_interface_edit_invitation_providers_path(change: true) %>
+<%= govuk_link_to 'Change', provider_interface_edit_invitation_providers_path %>
 
 <br />
 
 permissions
 <% @wizard.applicable_provider_permissions.map do |p, details| %>
   <%= "#{Provider.find(p).name}, perms: #{details['permissions'].reject(&:blank?).join(',')}" %>
-  <%= govuk_link_to 'Change', provider_interface_edit_invitation_provider_permissions_path(change: true, provider_id: p) %>
+  <%= govuk_link_to 'Change', provider_interface_edit_invitation_provider_permissions_path(provider_id: p) %>
 <% end %>
 
 

--- a/app/views/provider_interface/provider_users_invitations/check.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/check.html.erb
@@ -1,20 +1,17 @@
-name <%= @wizard.first_name %><br />
+<% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
+<% content_for :title, 'Check permissions before you invite user' %>
 
-<%= govuk_link_to 'Change', provider_interface_edit_invitation_basic_details_path %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_commit_invitation_path do |f| %>
+      <%= f.govuk_error_summary %>
 
-<br />
+      <span class="govuk-caption-xl">Invite user</span>
+      <h1 class="govuk-heading-xl">Check permissions before you invite user</h1>
 
-providers <%= @wizard.providers.map { |p| Provider.find(p).name } %><br />
+      Details here
 
-<%= govuk_link_to 'Change', provider_interface_edit_invitation_providers_path %>
-
-<br />
-
-permissions
-<% @wizard.applicable_provider_permissions.map do |p, details| %>
-  <%= "#{Provider.find(p).name}, perms: #{details['permissions'].reject(&:blank?).join(',')}" %>
-  <%= govuk_link_to 'Change', provider_interface_edit_invitation_provider_permissions_path(provider_id: p) %>
-<% end %>
-
-
-<%= button_to 'Invite user', provider_interface_commit_invitation_path, class: 'govuk-button' %>
+      <%= f.govuk_submit 'Invite user' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -5,11 +5,22 @@
     <%= form_with model: @wizard, url: provider_interface_update_invitation_basic_details_path do |f| %>
       <%= f.govuk_error_summary %>
 
+      <span class="govuk-caption-xl">Invite user</span>
       <h1 class="govuk-heading-xl">Basic details</h1>
 
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          Anyone you invite to your organisation will be able to view all applications to courses you
+          look after. They'll be able to make decisions about applications and view sensitive information,
+          if you give them permission.
+        </strong>
+      </div>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, 'Basic details' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_update_invitation_basic_details_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Basic details</h1>
+
+      <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -1,3 +1,4 @@
+<% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
 <% content_for :title, 'Basic details' %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -8,6 +8,8 @@
       <h1 class="govuk-heading-xl">Basic details</h1>
 
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -1,3 +1,4 @@
+<% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
 <% content_for :title, 'Providers' %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, 'Providers' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_update_invitation_provider_permissions_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Set permissions for <%= @permissions_form.provider.name %></h1>
+
+      <%= f.fields_for "provider_permissions[]", @permissions_form do |pf| %>
+        <%= pf.hidden_field :provider_id %>
+        <%= pf.govuk_collection_check_boxes :permissions, @permissions_form.available_permissions, :slug, :name %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -5,6 +5,7 @@
     <%= form_with model: @wizard, url: provider_interface_update_invitation_provider_permissions_path do |f| %>
       <%= f.govuk_error_summary %>
 
+      <span class="govuk-caption-xl">Invite user</span>
       <h1 class="govuk-heading-xl">Set permissions for <%= @permissions_form.provider.name %></h1>
 
       <%= f.fields_for "provider_permissions[]", @permissions_form do |pf| %>

--- a/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
@@ -1,3 +1,4 @@
+<% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
 <% content_for :title, 'Providers' %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
@@ -5,6 +5,7 @@
     <%= form_with model: @wizard, url: provider_interface_update_invitation_providers_path do |f| %>
       <%= f.govuk_error_summary %>
 
+      <span class="govuk-caption-xl">Invite user</span>
       <h1 class="govuk-heading-xl">Select organisations this user will have access to</h1>
 
       <%= f.govuk_collection_check_boxes :providers,

--- a/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, 'Providers' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @wizard, url: provider_interface_update_invitation_providers_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Select organisations this user will have access to</h1>
+
+      <%= f.govuk_collection_check_boxes :providers,
+            @available_providers,
+            :id,
+            :name %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,6 +242,17 @@ en:
               too_long: |
                 The explanation for why you're rejecting the application must be
                 %{count} characters or fewer
+        provider_interface/provider_user_invitation_wizard:
+          attributes:
+            first_name:
+              blank: Enter the user's first name
+            last_name:
+              blank: Enter the user's last name
+            email_address:
+              blank: Enter the user's email address
+              taken: Email address is already in use
+              too_long: Email address must be %{count} characters or fewer
+              invalid: Enter an email address in the correct format, like name@example.com
   activerecord:
     attributes:
       application_qualification/qualification_type:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -551,6 +551,15 @@ Rails.application.routes.draw do
       delete '/remove' => 'provider_users#remove', as: :remove_provider_user
     end
 
+    get 'users/new' => 'provider_users_invitations#edit_details', as: :edit_invitation_basic_details
+    post 'users/new' => 'provider_users_invitations#update_details', as: :update_invitation_basic_details
+    get 'users/new/providers' => 'provider_users_invitations#edit_providers', as: :edit_invitation_providers
+    post 'users/new/providers' => 'provider_users_invitations#update_providers', as: :update_invitation_providers
+    get 'users/new/providers/:provider_id/permissions' => 'provider_users_invitations#edit_permissions', as: :edit_invitation_provider_permissions
+    post 'users/new/providers/:provider_id/permissions' => 'provider_users_invitations#update_permissions', as: :update_invitation_provider_permissions
+    get 'users/new/check' => 'provider_users_invitations#check', as: :check_invitation
+    post 'users/new/commit' => 'provider_users_invitations#commit', as: :commit_invitation
+
     resources :organisations, only: %i[index show], path: 'organisations'
 
     get '/provider-relationship-permissions/setup' => 'provider_relationship_permissions#setup',

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -1,11 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
-  let(:form_params) do
-    {}
+  let(:form_params) { {} }
+  let(:initial_state) { {} }
+  let(:state_store) do
+    {
+      described_class::STATE_STORE_KEY => initial_state.to_json,
+    }
   end
 
-  subject(:wizard) { described_class.new(form_params) }
+  subject(:wizard) { described_class.new(state_store, form_params) }
+
+  describe 'initializer' do
+    let(:initial_state) do
+      {
+        first_name: 'Bob',
+        email_address: 'bob@example.com',
+      }
+    end
+
+    it 'deserializes state' do
+      expect(wizard.first_name).to eq 'Bob'
+      expect(wizard.last_name).to be_nil
+      expect(wizard.email_address).to eq 'bob@example.com'
+    end
+  end
+
+  describe '#save_state!' do
+    let(:initial_state) do
+      {
+        first_name: 'Bob',
+        email_address: 'bob@example.com',
+      }
+    end
+
+    it 'serializes state to state store' do
+      wizard.last_name = 'Roberts'
+      wizard.email_address = 'bob@roberts.com'
+      wizard.save_state!
+      expect(JSON.parse(state_store[described_class::STATE_STORE_KEY]).symbolize_keys).to eq({
+        first_name: 'Bob',
+        last_name: 'Roberts',
+        email_address: 'bob@roberts.com',
+      })
+    end
+  end
+
+  describe '#clear_state!' do
+    let(:initial_state) do
+      {
+        first_name: 'Bob',
+        email_address: 'bob@example.com',
+      }
+    end
+
+    it 'purges all state' do
+      wizard.last_name = 'Roberts'
+      wizard.clear_state!
+      expect(state_store[described_class::STATE_STORE_KEY]).to be_nil
+    end
+  end
 
   describe 'validations' do
     context 'with missing name and email fields' do

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -1,19 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
-  let(:form_params) { {} }
-  let(:initial_state) { {} }
-  let(:state_store) do
-    {
-      described_class::STATE_STORE_KEY => initial_state.to_json,
-    }
-  end
-
   def state_store_for(state)
     { described_class::STATE_STORE_KEY => state.to_json }
   end
-
-  subject(:wizard) { described_class.new(state_store, form_params) }
 
   describe 'next_step' do
     it 'returns the providers page from the basic details page for a new user' do
@@ -42,14 +32,11 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
   end
 
   describe 'initializer' do
-    let(:initial_state) do
-      {
-        first_name: 'Bob',
-        email_address: 'bob@example.com',
-      }
-    end
-
     it 'deserializes state' do
+      state_store = state_store_for(first_name: 'Bob', email_address: 'bob@example.com')
+
+      wizard = described_class.new(state_store, current_step: 'details')
+
       expect(wizard.first_name).to eq 'Bob'
       expect(wizard.last_name).to be_nil
       expect(wizard.email_address).to eq 'bob@example.com'
@@ -57,17 +44,14 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
   end
 
   describe '#save_state!' do
-    let(:initial_state) do
-      {
-        first_name: 'Bob',
-        email_address: 'bob@example.com',
-      }
-    end
-
     it 'serializes state to state store' do
+      state_store = state_store_for(first_name: 'Bob', email_address: 'bob@example.com')
+      wizard = described_class.new(state_store)
       wizard.last_name = 'Roberts'
       wizard.email_address = 'bob@roberts.com'
+
       wizard.save_state!
+
       expect(JSON.parse(state_store[described_class::STATE_STORE_KEY]).symbolize_keys).to eq({
         first_name: 'Bob',
         last_name: 'Roberts',
@@ -77,27 +61,23 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
   end
 
   describe '#clear_state!' do
-    let(:initial_state) do
-      {
-        first_name: 'Bob',
-        email_address: 'bob@example.com',
-      }
-    end
-
     it 'purges all state' do
+      state_store = state_store_for(first_name: 'Bob', email_address: 'bob@example.com')
+      wizard = described_class.new(state_store, current_step: 'details')
       wizard.last_name = 'Roberts'
+
       wizard.clear_state!
+
       expect(state_store[described_class::STATE_STORE_KEY]).to be_nil
     end
   end
 
   describe 'validations' do
     context 'with missing name and email fields' do
-      let(:form_params) do
-        {}
-      end
-
       it 'first, last name and email address are required' do
+        state_store = state_store_for({})
+        wizard = described_class.new(state_store, {})
+
         wizard.valid?(:details)
 
         expect(wizard.errors[:first_name]).not_to be_empty
@@ -107,13 +87,13 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
     end
 
     context 'with email address of an existing user' do
-      let(:email_address) { 'provider@example.com' }
-      let(:existing_user) { create(:provider_user, :with_provider, email_address: email_address) }
-
-      before { form_params[:email_address] = existing_user.email_address }
-
       it 'is valid' do
+        existing_user = create(:provider_user, :with_provider, email_address: 'provider@example.com')
+        state_store = state_store_for({})
+        wizard = described_class.new(state_store, email_address: existing_user.email_address)
+
         wizard.validate
+
         expect(wizard.errors[:email_address]).to be_empty
       end
     end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -20,14 +20,46 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
 
     it 'returns the second provider permissions page from the first provider permissions page for a new user' do
       state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [] } })
-      wizard = described_class.new(state_store, current_step: 'providers')
+      wizard = described_class.new(state_store, current_step: 'providers', current_provider_id: '123')
       expect(wizard.next_step).to eq([:permissions, 456])
     end
 
     it 'returns the review page from the last provider permissions page for a new user' do
       state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [], 456 => [] } })
-      wizard = described_class.new(state_store, current_step: 'providers')
+      wizard = described_class.new(state_store, current_step: 'providers', current_provider_id: '456')
       expect(wizard.next_step).to eq([:check])
+    end
+  end
+
+  describe 'previous_step' do
+    it 'returns the providers page from the basic details page for a new user' do
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, current_step: 'details')
+      expect(wizard.previous_step).to eq([:index])
+    end
+
+    it 'returns the first provider permissions page from the providers page for a new user' do
+      state_store = state_store_for({ providers: [123, 456] })
+      wizard = described_class.new(state_store, current_step: 'providers')
+      expect(wizard.previous_step).to eq([:details])
+    end
+
+    it 'returns the providers page from the first provider permissions page for a new user' do
+      state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [] } })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_id: '123')
+      expect(wizard.previous_step).to eq([:providers])
+    end
+
+    it 'returns the first provider permissions page from the last provider permissions page for a new user' do
+      state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [], 456 => [] } })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_id: '456')
+      expect(wizard.previous_step).to eq([:permissions, 123])
+    end
+
+    it 'returns the last provider permissions page from the review page for a new user' do
+      state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [], 456 => [] } })
+      wizard = described_class.new(state_store, current_step: 'check')
+      expect(wizard.previous_step).to eq([:permissions, 456])
     end
   end
 

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
+  let(:form_params) do
+    {}
+  end
+
+  subject(:wizard) { described_class.new(form_params) }
+
+  describe 'validations' do
+    context 'with missing name and email fields' do
+      let(:form_params) do
+        {}
+      end
+
+      it 'first, last name and email address are required' do
+        wizard.valid?(:details)
+
+        expect(wizard.errors[:first_name]).not_to be_empty
+        expect(wizard.errors[:last_name]).not_to be_empty
+        expect(wizard.errors[:email_address]).not_to be_empty
+      end
+    end
+
+    context 'with email address of an existing user' do
+      let(:email_address) { 'provider@example.com' }
+      let(:existing_user) { create(:provider_user, :with_provider, email_address: email_address) }
+
+      before { form_params[:email_address] = existing_user.email_address }
+
+      it 'is valid' do
+        wizard.validate
+        expect(wizard.errors[:email_address]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider invites a new provider user using wizard interface' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'Provider sends invite to user' do
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_applications_for_two_providers
+    and_i_can_manage_users_for_a_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_click_on_the_users_link
+    and_i_click_invite_user
+    then_i_see_the_basic_details_form
+
+    when_i_fill_in_email_address_and_name
+    and_i_press_continue
+    then_i_see_the_select_organisations_form
+
+    when_i_select_one_provider
+    and_i_press_continue
+    then_i_see_the_select_permissions_form_for_selected_provider
+
+    # TODO: TBC
+  end
+
+  def when_i_click_on_the_users_link
+    click_on('Users')
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_i_can_manage_users_for_a_provider
+    @provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
+  end
+
+  def and_i_click_invite_user
+    click_on 'Invite user'
+  end
+
+  def then_i_see_the_basic_details_form
+    expect(page).to have_content('Basic details')
+  end
+
+  def when_i_fill_in_email_address_and_name
+    fill_in 'Email address', with: 'alice@example.com'
+    fill_in 'First name', with: 'Alice'
+    fill_in 'Last name', with: 'Alistair'
+  end
+
+  def and_i_press_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_select_organisations_form
+  end
+
+  def when_i_select_one_provider
+  end
+
+  def then_i_see_the_select_permissions_form_for_selected_provider
+  end
+end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -33,9 +33,13 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     and_i_press_continue
     then_i_see_the_select_organisations_form
 
-    # when_i_select_one_provider
-    # and_i_press_continue
-    # then_i_see_the_select_permissions_form_for_selected_provider
+    when_i_select_one_provider
+    and_i_press_continue
+    then_i_see_the_select_permissions_form_for_selected_provider
+
+    when_i_select_make_decisions_permission
+    and_i_press_continue
+    then_i_see_the_confirm_page
 
     # TODO: TBC
   end
@@ -105,9 +109,19 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     expect(page).to have_content('Select organisations this user will have access to')
   end
 
-  # def when_i_select_one_provider
-  # end
+  def when_i_select_one_provider
+    check 'Another Provider'
+  end
 
-  # def then_i_see_the_select_permissions_form_for_selected_provider
-  # end
+  def then_i_see_the_select_permissions_form_for_selected_provider
+    expect(page).to have_content('Set permissions for Another Provider')
+  end
+
+  def when_i_select_make_decisions_permission
+    check 'Make decisions'
+  end
+
+  def then_i_see_the_confirm_page
+    expect(page).to have_content('Check permissions before you invite user')
+  end
 end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -26,13 +26,16 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     and_i_click_invite_user
     then_i_see_the_basic_details_form
 
+    when_i_press_continue
+    then_i_see_validation_errors_for_names_and_email_address
+
     when_i_fill_in_email_address_and_name
     and_i_press_continue
     then_i_see_the_select_organisations_form
 
-    when_i_select_one_provider
-    and_i_press_continue
-    then_i_see_the_select_permissions_form_for_selected_provider
+    # when_i_select_one_provider
+    # and_i_press_continue
+    # then_i_see_the_select_permissions_form_for_selected_provider
 
     # TODO: TBC
   end
@@ -90,13 +93,21 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   def and_i_press_continue
     click_on 'Continue'
   end
+  alias_method :when_i_press_continue, :and_i_press_continue
+
+  def then_i_see_validation_errors_for_names_and_email_address
+    expect(page).to have_content('Enter the user\'s first name')
+    expect(page).to have_content('Enter the user\'s last name')
+    expect(page).to have_content('Enter the user\'s email address')
+  end
 
   def then_i_see_the_select_organisations_form
+    expect(page).to have_content('Select organisations this user will have access to')
   end
 
-  def when_i_select_one_provider
-  end
+  # def when_i_select_one_provider
+  # end
 
-  def then_i_see_the_select_permissions_form_for_selected_provider
-  end
+  # def then_i_see_the_select_permissions_form_for_selected_provider
+  # end
 end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -12,8 +12,15 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers
-    and_i_can_manage_users_for_a_provider
     and_i_sign_in_to_the_provider_interface
+
+    when_i_try_to_visit_the_users_page
+    then_i_see_a_404_page
+    when_i_try_to_visit_the_invite_user_wizard
+    then_i_see_a_404_page
+
+    and_i_can_manage_users_for_a_provider
+    and_i_sign_in_again_to_the_provider_interface
 
     when_i_click_on_the_users_link
     and_i_click_invite_user
@@ -28,6 +35,18 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     then_i_see_the_select_permissions_form_for_selected_provider
 
     # TODO: TBC
+  end
+
+  def when_i_try_to_visit_the_users_page
+    visit provider_interface_provider_users_path
+  end
+
+  def then_i_see_a_404_page
+    expect(page).to have_content('Page not found')
+  end
+
+  def when_i_try_to_visit_the_invite_user_wizard
+    visit provider_interface_edit_invitation_basic_details_path
   end
 
   def when_i_click_on_the_users_link
@@ -47,6 +66,11 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
   def and_i_can_manage_users_for_a_provider
     @provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
+  end
+
+  def and_i_sign_in_again_to_the_provider_interface
+    click_link('Sign out')
+    and_i_sign_in_to_the_provider_interface
   end
 
   def and_i_click_invite_user

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -7,6 +7,9 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   scenario 'Provider sends invite to user' do
     FeatureFlag.activate(:providers_can_manage_users_and_permissions)
 
+    # TODO: test what happens with the feature flag off
+    # TODO: test what happens without necessary permissions
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -16,14 +16,15 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
     when_i_try_to_visit_the_users_page
     then_i_see_a_404_page
-    when_i_try_to_visit_the_invite_user_wizard
+    when_i_visit_the_invite_user_wizard
     then_i_see_a_404_page
 
     and_i_can_manage_users_for_a_provider
     and_i_sign_in_again_to_the_provider_interface
 
-    when_i_click_on_the_users_link
-    and_i_click_invite_user
+    # when_i_click_on_the_users_link
+    # and_i_click_invite_user
+    when_i_visit_the_invite_user_wizard
     then_i_see_the_basic_details_form
 
     when_i_press_continue
@@ -52,7 +53,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     expect(page).to have_content('Page not found')
   end
 
-  def when_i_try_to_visit_the_invite_user_wizard
+  def when_i_visit_the_invite_user_wizard
     visit provider_interface_edit_invitation_basic_details_path
   end
 


### PR DESCRIPTION
## Context

This PR is the first part of the implementation of a new wizard based design for the provider interface invite new user flow. It follows on from the spike PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/2469.

This PR covers the forms needed to set basic details, select accessible providers and set their permissions. It doesn't cover the review page and change feature. It's behind a `providers_can_manage_users_and_permissions` feature flag and not yet linked to the users index page.

## Changes proposed in this pull request

- [x] Forms for the first 3 steps to match the design https://manage-applications-beta.herokuapp.com/users

<img width="538" alt="image" src="https://user-images.githubusercontent.com/450843/87768157-a10ae100-c813-11ea-960f-5248760be3c9.png">

<img width="538" alt="image" src="https://user-images.githubusercontent.com/450843/87768209-b4b64780-c813-11ea-8a7c-7b6f5c0c6e59.png">

<img width="538" alt="image" src="https://user-images.githubusercontent.com/450843/87768243-bf70dc80-c813-11ea-8a47-c325c7f9258f.png">

- [x] System spec that goes as far as a dummy review page
- [x] Navigation rules for the wizard (back as well as forward).
- [x] Specs for the wizard class.

## Guidance to review

- I've simplified the wizard `next_step` method a bit to avoid complicating it with the logic for making changes via the review page. e.g having the `checking_answers` attribute serialised to wizard state causes problems when the user deviates from the 'normal' path (e.g. by clicking a back button from the review page). In a follow up PR I think this will need a mechanism that's a bit more decoupled from the data for the new user.
- I've left the 'Invite user' button on the users index page pointing to the new implementation for now to keep this small (though I think the existing implementation is behind the same feature flag). So you'll need to navigate directly to `/provider/users/new` to test this -  it should 404 unless the `providers_can_manage_users_and_permissions` feature flag.

## Link to Trello card

https://trello.com/c/BcoX8Mt9/2431-implement-the-provider-user-invitation-wizard

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
