### PR TITLE
Refactor ChooseEflReviewComponent and MissingApplicationFormError

### DIFF
--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       before_action :check_for_english_proficiency
 
       def show
-        @component_instance = derive_component_instance(english_proficiency)
+        @component_instance = ChooseEflReviewComponent.call(english_proficiency)
       end
 
       def complete
@@ -21,20 +21,6 @@ module CandidateInterface
       def check_for_english_proficiency
         if english_proficiency.blank?
           redirect_to candidate_interface_english_foreign_language_root_path
-        end
-      end
-
-      def derive_component_instance(english_proficiency)
-        if !english_proficiency.has_qualification?
-          return NoEflQualificationReviewComponent.new(english_proficiency)
-        end
-
-        qualification = english_proficiency.efl_qualification
-        case english_proficiency.efl_qualification_type
-        when 'IeltsQualification'
-          IeltsReviewComponent.new(qualification)
-        when 'ToeflQualification'
-          ToeflReviewComponent.new(qualification)
         end
       end
 

--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   module EnglishForeignLanguage
-    class MissingApplicationFormError < StandardError; end
-
     class IeltsForm
       include ActiveModel::Model
       include ValidationUtils

--- a/app/forms/candidate_interface/english_foreign_language/missing_application_form_error.rb
+++ b/app/forms/candidate_interface/english_foreign_language/missing_application_form_error.rb
@@ -1,0 +1,5 @@
+module CandidateInterface
+  module EnglishForeignLanguage
+    class MissingApplicationFormError < StandardError; end
+  end
+end

--- a/app/forms/candidate_interface/english_foreign_language/start_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/start_form.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   module EnglishForeignLanguage
     class StartForm
-      class MissingApplicationFormError < StandardError; end
       include ActiveModel::Model
       include Rails.application.routes.url_helpers
 

--- a/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   module EnglishForeignLanguage
-    class MissingApplicationFormError < StandardError; end
-
     class ToeflForm
       include ActiveModel::Model
       include ValidationUtils

--- a/app/services/candidate_interface/choose_efl_review_component.rb
+++ b/app/services/candidate_interface/choose_efl_review_component.rb
@@ -1,0 +1,27 @@
+module CandidateInterface
+  class ChooseEflReviewComponent
+    def self.call(english_proficiency)
+      new(english_proficiency).call
+    end
+
+    attr_reader :english_proficiency
+
+    def initialize(english_proficiency)
+      @english_proficiency = english_proficiency
+    end
+
+    def call
+      if !english_proficiency.has_qualification?
+        return NoEflQualificationReviewComponent.new(english_proficiency)
+      end
+
+      qualification = english_proficiency.efl_qualification
+      case english_proficiency.efl_qualification_type
+      when 'IeltsQualification'
+        IeltsReviewComponent.new(qualification)
+      when 'ToeflQualification'
+        ToeflReviewComponent.new(qualification)
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/english_foreign_language/start_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/start_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::StartForm, type: :mod
 
     it 'raises an error if no application_form present' do
       expect { valid_form.save }.to raise_error(
-        CandidateInterface::EnglishForeignLanguage::StartForm::MissingApplicationFormError,
+        CandidateInterface::EnglishForeignLanguage::MissingApplicationFormError,
       )
     end
 

--- a/spec/services/candidate_interface/choose_efl_review_component_spec.rb
+++ b/spec/services/candidate_interface/choose_efl_review_component_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ChooseEflReviewComponent do
+  describe '.call' do
+    context 'when english_proficiency has an IELTS qualification' do
+      let(:english_proficiency) { build(:english_proficiency, :with_ielts_qualification) }
+
+      it 'returns an instance of IeltsReviewComponent' do
+        component = described_class.call(english_proficiency)
+
+        expect(component).to be_instance_of(IeltsReviewComponent)
+        expect(component.ielts_qualification).to eq english_proficiency.efl_qualification
+      end
+    end
+
+    context 'when english_proficiency has a TOEFL qualification' do
+      let(:english_proficiency) { build(:english_proficiency, :with_toefl_qualification) }
+
+      it 'returns an instance of ToeflReviewComponent' do
+        component = described_class.call(english_proficiency)
+
+        expect(component).to be_instance_of(ToeflReviewComponent)
+        expect(component.toefl_qualification).to eq english_proficiency.efl_qualification
+      end
+    end
+
+    context 'when english_proficiency does not have a qualification' do
+      let(:english_proficiency) { build(:english_proficiency, :no_qualification) }
+
+      it 'returns an instance of NoEflQualificationReviewComponent' do
+        component = described_class.call(english_proficiency)
+
+        expect(component).to be_instance_of(NoEflQualificationReviewComponent)
+        expect(component.english_proficiency).to eq english_proficiency
+      end
+    end
+  end
+end


### PR DESCRIPTION
In EnglishForeignLanguage::ReviewController, we have a method that
selects an appropriate view component based on the characteristics of an
EnglishProficiency record that's passed in.

Move this logic into a service object so that the controller is simpler
and the code easily unit-tested.

Also, refactor class declarations for `CandidateInterface::EnglishForeignLanguage::MissingApplicationFormError`.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/9fk7yluU

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
