### PR TITLE
Add the two-level header to Manage (v2)

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -17,17 +17,19 @@
       <%= link_to service_name, service_url, class: 'govuk-header__link govuk-header__link--service-name' %>
       <% if navigation_items.any? %>
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-!-print-display-none" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <ul id="navigation" class="govuk-header__navigation app-!-print-display-none" aria-label="Top Level Navigation">
-          <% navigation_items.each do |nav_item| %>
-            <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
-              <% if nav_item.href %>
-                <%= link_to nav_item.text, nav_item.href, class: 'govuk-header__link' %>
-              <% else %>
-                <strong><%= nav_item.text %></strong>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
+        <nav>
+          <ul id="navigation" class="govuk-header__navigation app-!-print-display-none" aria-label="Top Level Navigation">
+            <% navigation_items.each do |nav_item| %>
+              <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
+                <% if nav_item.href %>
+                  <%= link_to nav_item.text, nav_item.href, class: 'govuk-header__link' %>
+                <% else %>
+                  <strong><%= nav_item.text %></strong>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </nav>
       <% end %>
     </div>
   </div>

--- a/app/components/phase_banner.html.erb
+++ b/app/components/phase_banner.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-width-container">
-  <div class="govuk-phase-banner app-!-print-display-none">
+  <div class="govuk-phase-banner <%= @stacked ? 'app-phase-banner__stacked' : '' %> app-!-print-display-none">
     <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--<%= HostingEnvironment.environment_name %>">
       <%= HostingEnvironment.phase %>
     </strong>

--- a/app/components/phase_banner.html.erb
+++ b/app/components/phase_banner.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-width-container">
-  <div class="govuk-phase-banner <%= @stacked ? 'app-phase-banner__stacked' : '' %> app-!-print-display-none">
+  <div class="govuk-phase-banner <%= @no_border ? 'app-phase-banner__no-border' : '' %> app-!-print-display-none">
     <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--<%= HostingEnvironment.environment_name %>">
       <%= HostingEnvironment.phase %>
     </strong>

--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -1,2 +1,5 @@
 class PhaseBanner < ViewComponent::Base
+  def initialize(stacked: false)
+    @stacked = stacked
+  end
 end

--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -1,5 +1,5 @@
 class PhaseBanner < ViewComponent::Base
-  def initialize(stacked: false)
-    @stacked = stacked
+  def initialize(no_border: false)
+    @no_border = no_border
   end
 end

--- a/app/components/provider_interface/header_component.html.erb
+++ b/app/components/provider_interface/header_component.html.erb
@@ -18,18 +18,20 @@
     </div>
     <div class="govuk-header__content provider-header__content">
       <% if navigation_items.any? %>
-         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
-          <% navigation_items.each do |nav_item| %>
-            <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
-              <% if nav_item.href %>
-                <%= link_to nav_item.text, nav_item.href, class: 'govuk-header__link' %>
-              <% else %>
-                <strong><%= nav_item.text %></strong>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+        <nav>
+          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
+            <% navigation_items.each do |nav_item| %>
+              <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
+                <% if nav_item.href %>
+                  <%= link_to nav_item.text, nav_item.href, class: 'govuk-header__link' %>
+                <% else %>
+                  <strong><%= nav_item.text %></strong>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </nav>
       <% end %>
     </div>
   </div>

--- a/app/components/provider_interface/primary_navigation.html.erb
+++ b/app/components/provider_interface/primary_navigation.html.erb
@@ -1,0 +1,19 @@
+<div class="moj-primary-navigation">
+  <div class="moj-primary-navigation__container">
+    <div class="moj-primary-navigation__nav">
+      <nav class="moj-primary-navigation" aria-label="Primary navigation">
+        <ul class="moj-primary-navigation__list">
+          <% @navigation_items.each do |nav_item| %>
+            <li class="moj-primary-navigation__item">
+              <a class="moj-primary-navigation__link"
+                <%= nav_item.active ? 'aria-current=page' : '' %>
+                 href="<%= nav_item.href %>">
+                 <%= nav_item.text %>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/components/provider_interface/primary_navigation.rb
+++ b/app/components/provider_interface/primary_navigation.rb
@@ -1,0 +1,7 @@
+module ProviderInterface
+  class PrimaryNavigation < ViewComponent::Base
+    def initialize(navigation_items:)
+      @navigation_items = navigation_items
+    end
+  end
+end

--- a/app/frontend/styles/_phase-banner.scss
+++ b/app/frontend/styles/_phase-banner.scss
@@ -1,3 +1,3 @@
-.app-phase-banner__stacked {
+.app-phase-banner__no-border {
   border-bottom: 0;
 }

--- a/app/frontend/styles/_phase-banner.scss
+++ b/app/frontend/styles/_phase-banner.scss
@@ -1,0 +1,3 @@
+.app-phase-banner__stacked {
+  border-bottom: 0;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -46,10 +46,14 @@ $govuk-breakpoints: (
 @import "_work-history";
 @import "_timeline";
 @import "_notes";
-@import "~@ministryofjustice/frontend/moj/helpers/hidden";
+@import "~@ministryofjustice/frontend/moj/settings/measurements";
+@import "~@ministryofjustice/frontend/moj/objects/width-container";
+@import "~@ministryofjustice/frontend/moj/helpers/all";
+@import "~@ministryofjustice/frontend/moj/utilities/all";
 @import "~@ministryofjustice/frontend/moj/settings/assets";
 @import "~@ministryofjustice/frontend/moj/objects/filter-layout";
 @import "~@ministryofjustice/frontend/moj/components/filter/filter";
+@import "~@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
 @import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
 @import "~@ministryofjustice/frontend/moj/utilities/hidden";
 @import "_filter";

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -36,6 +36,7 @@ $govuk-breakpoints: (
 
 // Provider
 @import "~@ministryofjustice/frontend/moj/components/pagination/pagination";
+@import "_phase-banner";
 @import "_button";
 @import "_count";
 @import "_masthead";

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -36,10 +36,14 @@ class NavigationItems
       end
     end
 
-    def for_provider_interface(current_provider_user, current_controller)
+    def for_provider_primary_nav(current_controller)
+      [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]
+    end
+
+    def for_provider_account_nav(current_provider_user, current_controller)
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
-      items = [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]
+      items = []
 
       if current_provider_user.can_manage_organisations? && Provider.with_permissions_visible_to(current_provider_user).exists?
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
                                  product_name: service_name,
                                  service_url: service_link,
                                  navigation_items: NavigationItems.for_provider_interface(current_provider_user, controller))) %>
-                               <%= render PhaseBanner.new %>
+                               <%= render PhaseBanner.new(stacked: true) %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,8 +15,17 @@
   <%= render(ProviderInterface::HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  product_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user, controller))) %>
-                               <%= render PhaseBanner.new(stacked: true) %>
+                                 navigation_items: NavigationItems.for_provider_account_nav(current_provider_user, controller))) %>
+
+                               <% if controller.controller_name == 'start_page' %>
+                                 <%= render PhaseBanner.new(no_border: true) %>
+                               <% elsif controller.controller_name.in? %w[sessions content start_page provider_agreements] %>
+                                 <%= render PhaseBanner.new %>
+                               <% else %>
+                                 <%= render PhaseBanner.new(no_border: true) %>
+                                 <%= render(ProviderInterface::PrimaryNavigation.new(
+                                   navigation_items: NavigationItems.for_provider_primary_nav(controller))) %>
+                               <% end %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,

--- a/spec/models/navigation_items_spec.rb
+++ b/spec/models/navigation_items_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe NavigationItems do
-  describe '.for_provider_interface' do
+  describe '.for_provider_account_nav' do
     let(:provider) { create(:provider) }
     let(:provider_user) { create(:provider_user, providers: [provider]) }
     let(:controller) { ProviderInterface::ProviderInterfaceController }
 
-    subject(:navigation_items) { NavigationItems.for_provider_interface(provider_user, controller) }
+    subject(:navigation_items) { NavigationItems.for_provider_account_nav(provider_user, controller) }
 
     context 'when the user can manage organisations and there are no provider relationships to manage' do
       before { provider_user.provider_permissions.find_by(provider: provider).update!(manage_organisations: true) }

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'See applications' do
     and_i_sign_in_to_the_provider_interface
     then_i_should_see_the_applications_from_my_organisation
     and_i_should_not_see_a_covid19_information_banner
+    and_i_should_see_the_applications_menu_item_highlighted
 
     when_i_click_on_an_application
     then_i_should_be_on_the_application_view_page
@@ -66,6 +67,11 @@ RSpec.feature 'See applications' do
 
   def and_i_should_not_see_a_covid19_information_banner
     expect(page).not_to have_content 'coronavirus'
+  end
+
+  def and_i_should_see_the_applications_menu_item_highlighted
+    link = page.find_link('Applications', class: 'moj-primary-navigation__link')
+    expect(link['aria-current']).to eq('page')
   end
 
   def when_i_click_on_an_application


### PR DESCRIPTION
## Context

This PR implements the lower-level grey nav bar in the prototype.

## Changes proposed in this pull request

- Add `moj-frontend` bits
- Parameterize the `PhaseBanner` component so it can have its border removed when stacked on top of another element
- Refactor/add `NavigationItems#for_provider_account_nav` and `NavigationItems#for_primary_account_nav`
- touch it in a system spec

## Link to Trello card

https://trello.com/c/OTojnjhu/2440-implement-the-new-two-level-header-for-manage

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
