### PR TITLE
Add provider-specific edit user permissions flow to provider_interface

### DIFF
--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -1,0 +1,38 @@
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+  <h1 class="govuk-fieldset__heading">
+    <span class="govuk-caption-xl"><%= permissions_form.provider_user.full_name %></span>
+    Change permissions: <%= permissions_form.provider.name %>
+  </h1>
+</legend>
+
+<span class="govuk-hint">
+  The user will still be able to view all applications made to courses at this organisation.
+</span>
+
+<%= form_with model: permissions_form,
+              method: :patch,
+              url: provider_interface_provider_user_update_permissions_path(
+                provider_id: permissions_form.provider.id,
+                provider_user_id: permissions_form.provider_user.id,
+              ) do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.hidden_field :provider_id %>
+  <%= f.govuk_check_boxes_fieldset :permissions do %>
+    <%= f.govuk_check_box :manage_organisations, true, multiple: false,
+                          label: { text: 'Manage organisation' },
+                          hint_text: 'Change permissions between organisations' %>
+
+    <%= f.govuk_check_box :manage_users, true, multiple: false,
+                          label: { text: 'Manage users' },
+                          hint_text: 'Invite or delete users and set their permissions' %>
+
+    <%= f.govuk_check_box :view_safeguarding_information, true, multiple: false,
+                          label: { text: 'View safeguarding information' },
+                          hint_text: 'View sensitive material about the candidate' %>
+
+    <%= f.govuk_check_box :make_decisions, true, multiple: false,
+                          label: { text: 'Make decisions' },
+                          hint_text: 'Make offers, amend offers and reject applications' %>
+  <% end %>
+  <%= f.govuk_submit 'Save' %>
+<% end %>

--- a/app/components/provider_interface/edit_provider_user_permissions_component.rb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.rb
@@ -1,0 +1,11 @@
+module ProviderInterface
+  class EditProviderUserPermissionsComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :permissions_form
+
+    def initialize(form:)
+      @permissions_form = form
+    end
+  end
+end

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -26,7 +26,7 @@ module ProviderInterface
         {
           key: "Permissions: #{permission.provider.name}",
           value: render(PermissionsList.new(permission)),
-          change_path: provider_interface_provider_user_edit_providers_path(@provider_user),
+          change_path: provider_interface_provider_user_edit_permissions_path(@provider_user, provider_id: permission.provider.id),
           action: 'Change',
         }
       end

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -27,7 +27,7 @@ module ProviderInterface
           key: "Permissions: #{permission.provider.name}",
           value: render(PermissionsList.new(permission)),
           change_path: provider_interface_provider_user_edit_permissions_path(@provider_user, provider_id: permission.provider.id),
-          action: 'Change',
+          action: "Change permissions for #{permission.provider.name}",
         }
       end
     end

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -143,7 +143,7 @@ module ProviderInterface
     end
 
     def assert_current_user_can_manage_users_for(provider)
-      access_denied_for_provider(provider) unless current_user_can_manage_users_for?(provider)
+      access_denied_for_provider(provider) unless current_provider_user.authorisation.can_manage_users_for?(provider)
     end
 
     def current_user_can_manage_users_for?(provider)

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -43,6 +43,9 @@ module ProviderInterface
       @wizard = ProviderUserInvitationWizard.new(session, current_step: 'permissions', current_provider_id: @provider.id)
       @wizard.save_state!
 
+      # This is gnarly but meant to mirror the related wizard data structure
+      # Best refactored as part of an invitation wizard PR
+      # --
       permission_struct = Struct.new(:slug, :name)
       @permissions = [
         permission_struct.new('manage_users', 'Manage users'),
@@ -55,6 +58,7 @@ module ProviderInterface
         @provider.id,
         @permissions,
       )
+      # --
     end
 
     def update_permissions

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -39,10 +39,22 @@ module ProviderInterface
     end
 
     def edit_permissions
-      @wizard = ProviderUserInvitationWizard.new(session, current_step: 'permissions', current_provider_id: params[:provider_id])
+      @provider = Provider.find(params[:provider_id])
+      @wizard = ProviderUserInvitationWizard.new(session, current_step: 'permissions', current_provider_id: @provider.id)
       @wizard.save_state!
 
-      @permissions_form = ProviderUserPermissionsForm.new(@wizard.permissions_for(params[:provider_id]))
+      permission_struct = Struct.new(:slug, :name)
+      @permissions = [
+        permission_struct.new('manage_users', 'Manage users'),
+        permission_struct.new('make_decisions', 'Make decisions'),
+      ]
+
+      permissions_form_struct = Struct.new(:id, :provider_id, :permissions)
+      @permissions_form = permissions_form_struct.new(
+        @provider.id,
+        @provider.id,
+        @permissions,
+      )
     end
 
     def update_permissions

--- a/app/forms/provider_interface/provider_user_permissions_form.rb
+++ b/app/forms/provider_interface/provider_user_permissions_form.rb
@@ -2,21 +2,42 @@ module ProviderInterface
   class ProviderUserPermissionsForm
     include ActiveModel::Model
 
-    Permission = Struct.new(:slug, :name)
+    attr_accessor :model,
+                  :manage_organisations,
+                  :manage_users,
+                  :make_decisions,
+                  :view_safeguarding_information
 
-    attr_accessor :provider_id, :permissions
+    delegate :provider, to: :model
+    delegate :provider_user, to: :model
+    delegate :id, to: :provider, prefix: true
 
-    def available_permissions
-      [
-        Permission.new('manage_users', 'Manage users'),
-        Permission.new('make_decisions', 'Make decisions'),
-      ]
+    validates :model, presence: true
+
+    def self.from(permissions_model)
+      return unless permissions_model
+
+      new_form = new(model: permissions_model)
+      ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+        new_form.send("#{permission_name}=", permissions_model.send(permission_name))
+      end
+      new_form
     end
 
-    def provider
-      Provider.find(provider_id)
+    def update_from_params(hash)
+      ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+        send("#{permission_name}=", hash[permission_name] || false)
+      end
     end
 
-    alias_method :id, :provider_id
+    def save
+      if valid?
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+          @model.send("#{permission_name}=", send(permission_name))
+        end
+
+        @model.save
+      end
+    end
   end
 end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -10,6 +10,14 @@ class ProviderAuthorisation
     )
   end
 
+  def can_manage_users_for?(provider)
+    ProviderPermissions.exists?(
+      provider: provider,
+      provider_user: @actor,
+      manage_users: true,
+    )
+  end
+
   def can_make_offer?(application_choice:, course_option_id:)
     OfferAuthorisation.new(actor: @actor).can_make_offer?(application_choice: application_choice, course_option_id: course_option_id)
   end

--- a/app/views/provider_interface/provider_users/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users/edit_permissions.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::EditProviderUserPermissionsComponent.new(form: @form) %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -7,11 +7,11 @@
       <%= f.govuk_error_summary %>
 
       <span class="govuk-caption-xl">Invite user</span>
-      <h1 class="govuk-heading-xl">Set permissions for <%= @permissions_form.provider.name %></h1>
+      <h1 class="govuk-heading-xl">Set permissions for <%= @provider.name %></h1>
 
       <%= f.fields_for "provider_permissions[]", @permissions_form do |pf| %>
         <%= pf.hidden_field :provider_id %>
-        <%= pf.govuk_collection_check_boxes :permissions, @permissions_form.available_permissions, :slug, :name %>
+        <%= pf.govuk_collection_check_boxes :permissions, @permissions_form.permissions, :slug, :name %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -562,6 +562,9 @@ Rails.application.routes.draw do
       get 'edit-providers' => 'provider_users#edit_providers', as: :edit_providers
       patch 'update-providers' => 'provider_users#update_providers', as: :update_providers
 
+      get 'providers/:provider_id/permissions' => 'provider_users#edit_permissions', as: :edit_permissions
+      patch 'providers/:provider_id/permissions' => 'provider_users#update_permissions', as: :update_permissions
+
       get '/remove' => 'provider_users#confirm_remove', as: :confirm_remove_provider_user
       delete '/remove' => 'provider_users#remove', as: :remove_provider_user
     end

--- a/spec/components/previews/provider_interface/edit_provider_user_permissions_component_preview.rb
+++ b/spec/components/previews/provider_interface/edit_provider_user_permissions_component_preview.rb
@@ -1,0 +1,22 @@
+module ProviderInterface
+  class EditProviderUserPermissionsComponentPreview < ViewComponent::Preview
+    def peter_rovider_permissions
+      peter_rovider = ProviderUser.find_by_dfe_sign_in_uid('dev-provider')
+      model = ProviderPermissions.where(provider_user: peter_rovider).sample
+
+      render_component_for model: model
+    end
+
+  private
+
+    def render_component_for(model:)
+      if model.present?
+        form = ProviderInterface::ProviderUserPermissionsForm.from(model)
+
+        render ProviderInterface::EditProviderUserPermissionsComponent.new(form: form)
+      else
+        render template: 'support_interface/docs/missing_test_data'
+      end
+    end
+  end
+end

--- a/spec/forms/provider_interface/provider_user_permissions_form_spec.rb
+++ b/spec/forms/provider_interface/provider_user_permissions_form_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderUserPermissionsForm do
+  let(:provider_permissions) { create(:provider_permissions) }
+
+  describe 'validations' do
+    it 'is valid when model is set' do
+      expect(described_class.new(model: provider_permissions)).to be_valid
+    end
+
+    it 'is invalid without a model' do
+      expect(described_class.new).to be_invalid
+    end
+  end
+
+  describe '#from' do
+    it 'generates a form object set to the model\'s permissions' do
+      provider_permissions.update(make_decisions: true)
+      form = described_class.from(provider_permissions)
+
+      expect(form.manage_organisations).to be_falsy
+      expect(form.manage_users).to be_falsy
+      expect(form.view_safeguarding_information).to be_falsy
+      expect(form.make_decisions).to be_truthy
+    end
+  end
+
+  describe '#update_from_params' do
+    it 'changes the form object permissions to match a hash' do
+      form = described_class.new(
+        manage_organisations: false,
+        manage_users: true,
+        view_safeguarding_information: false,
+        make_decisions: true,
+      )
+
+      form.update_from_params view_safeguarding_information: true, manage_users: false
+
+      expect(form.manage_organisations).to be_falsy
+      expect(form.manage_users).to be_falsy
+      expect(form.view_safeguarding_information).to be_truthy
+      expect(form.make_decisions).to be_falsy
+    end
+  end
+
+  describe '#save' do
+    it 'updates and associated model with current form permissions' do
+      provider_permissions.update(make_decisions: true)
+      form = described_class.from(provider_permissions)
+
+      form.view_safeguarding_information = true
+      form.make_decisions = false
+
+      form.save
+      expect(provider_permissions.view_safeguarding_information).to be_truthy
+      expect(provider_permissions.make_decisions).to be_falsy
+    end
+
+    it 'returns nil if there is no associated model' do
+      form = described_class.new
+      form.view_safeguarding_information = true
+      expect(form.save).to be_nil
+    end
+  end
+end

--- a/spec/requests/provider_interface/managing_provider_users_spec.rb
+++ b/spec/requests/provider_interface/managing_provider_users_spec.rb
@@ -22,21 +22,21 @@ RSpec.describe 'ProviderUserController actions' do
     it 'redirects GET requests to index' do
       get provider_interface_provider_users_path
 
-      expect(response).to be_not_found
+      expect(response).to be_forbidden
     end
 
     it 'redirects GET requests to show' do
       another_user = create(:provider_user, providers: [provider])
       get provider_interface_provider_user_path(another_user)
 
-      expect(response).to be_not_found
+      expect(response).to be_forbidden
     end
 
     it 'redirects GET requests to edit-providers' do
       another_user = create(:provider_user, providers: [provider])
       get provider_interface_provider_user_edit_providers_path(another_user)
 
-      expect(response).to be_not_found
+      expect(response).to be_forbidden
     end
   end
 

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -13,22 +13,22 @@ RSpec.feature 'Managing provider user permissions' do
 
     when_i_click_on_the_users_link
     and_i_click_on_a_user
-    and_i_click_change_providers_and_permissions
+    and_i_click_to_change_permissions
 
-    then_i_see_providers_and_permissions
+    then_i_see_user_permissions_for_this_provider
     and_i_add_permission_to_manage_users_for_a_provider_user
     then_i_can_see_the_manage_users_permission_for_the_provider_user
-    and_i_click_change_providers_and_permissions
+    and_i_click_to_change_permissions
 
     when_i_remove_manage_users_permissions_from_a_provider_user
     then_i_cant_see_the_manage_users_permission_for_the_provider_user
 
-    and_i_click_change_providers_and_permissions
+    and_i_click_to_change_permissions
 
     when_i_add_permission_to_view_safeguarding_for_a_provider_user
     then_i_can_see_the_view_safeguarding_permission_for_the_provider_user
 
-    and_i_click_change_providers_and_permissions
+    and_i_click_to_change_permissions
 
     and_i_add_permission_to_make_decisions_for_a_provider_user
     then_i_can_see_the_make_decisions_permission_for_the_provider_user
@@ -58,28 +58,22 @@ RSpec.feature 'Managing provider user permissions' do
     click_on(@managed_user.full_name)
   end
 
-  def and_i_click_change_providers_and_permissions
+  def and_i_click_to_change_permissions
     click_on('Change')
   end
 
-  def then_i_see_providers_and_permissions
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_unchecked_field 'Manage users'
-    end
+  def then_i_see_user_permissions_for_this_provider
+    expect(page).to have_unchecked_field 'Manage users'
   end
 
   def and_i_add_permission_to_manage_users_for_a_provider_user
     expect(page).not_to have_checked_field 'Manage users'
-
-    within(permissions_fields_id_for_provider(@provider)) do
-      check 'Manage users'
-    end
-
+    check 'Manage users'
     click_on 'Save'
   end
 
   def then_i_can_see_the_manage_users_permission_for_the_provider_user
-    expect(page).to have_content 'Providers updated'
+    expect(page).to have_content 'Permissions updated'
 
     within("#provider-#{@provider.id}-enabled-permissions") do
       expect(page).to have_content 'Manage users'
@@ -87,26 +81,19 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def when_i_remove_manage_users_permissions_from_a_provider_user
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_checked_field 'Manage users'
-      uncheck 'Manage users'
-    end
-
+    expect(page).to have_checked_field 'Manage users'
+    uncheck 'Manage users'
     click_on 'Save'
   end
 
   def then_i_cant_see_the_manage_users_permission_for_the_provider_user
-    expect(page).to have_content 'Providers updated'
+    expect(page).to have_content 'Permissions updated'
     expect(page).not_to have_content 'Manage users'
   end
 
   def when_i_add_permission_to_view_safeguarding_for_a_provider_user
     expect(page).not_to have_checked_field 'View safeguarding information'
-
-    within(permissions_fields_id_for_provider(@provider)) do
-      check 'View safeguarding information'
-    end
-
+    check 'View safeguarding information'
     click_on 'Save'
   end
 
@@ -118,11 +105,7 @@ RSpec.feature 'Managing provider user permissions' do
 
   def and_i_add_permission_to_make_decisions_for_a_provider_user
     expect(page).not_to have_checked_field 'Make decisions'
-
-    within(permissions_fields_id_for_provider(@provider)) do
-      check 'Make decisions'
-    end
-
+    check 'Make decisions'
     click_on 'Save'
   end
 
@@ -130,9 +113,5 @@ RSpec.feature 'Managing provider user permissions' do
     within("#provider-#{@provider.id}-enabled-permissions") do
       expect(page).to have_content 'Make decisions'
     end
-  end
-
-  def permissions_fields_id_for_provider(provider)
-    "#provider-interface-provider-user-form-provider-permissions-forms-#{provider.id}-active-true-conditional"
   end
 end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     and_i_sign_in_to_the_provider_interface
 
     when_i_try_to_visit_the_users_page
-    then_i_see_a_404_page
+    then_i_see_a_403_page
     when_i_visit_the_invite_user_wizard
     then_i_see_a_404_page
 
@@ -51,6 +51,10 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
   def when_i_try_to_visit_the_users_page
     visit provider_interface_provider_users_path
+  end
+
+  def then_i_see_a_403_page
+    expect(page).to have_content('Access denied')
   end
 
   def then_i_see_a_404_page


### PR DESCRIPTION
## Context

A previous PR, https://github.com/DFE-Digital/apply-for-teacher-training/pull/2488, introduced provider-specific permissions 'Change' links within the provider_interface. This PR implements the provider-specific user permissions page these links are intended to point to.

## Changes proposed in this pull request

Add two new routes for editing per-provider permissions for a user:

```
GET /provider/provider-users/2/providers/5/permissions
PATCH /provider/provider-users/2/providers/5/permissions
```

Add `edit_permissions` and `update_permissions` actions to `provider_interface/provider_users_controller.rb`.

Add an `edit_permissions.html.erb` view displaying checkboxes. The checkboxes are generated by a component.

Add a new form `ProviderInterface::ProviderPermissionsForm`, responsible for basic validations and persisting permission changes.

## Guidance to review

![image](https://user-images.githubusercontent.com/107591/87920481-30f99680-ca71-11ea-85a3-a0a28726b555.png)

## Link to Trello card

https://trello.com/c/GU90aVjA

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
