### PR TITLE
arm templates to create event hubs & logic app

### DIFF
--- a/azure/eventhubs-logic-app.json
+++ b/azure/eventhubs-logic-app.json
@@ -1,0 +1,143 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "logic_app_name": {
+            "defaultValue": "[concat(resourceGroup().name, '-la-eventhubs-logstash')]",
+            "type": "string"
+        },
+        "eventhub_connection_name": {
+            "defaultValue": "[concat(resourceGroup().name, '-eventhub-connection')]",
+            "type": "string"
+        },
+        "eventhub_name": {
+            "defaultValue": "",
+            "type": "string"
+        },
+        "logit_apikey":{
+            "defaultValue": "",
+            "type": "string"
+        },
+        "logit_api":{
+            "defaultValue": "https://api.logit.io/v2",
+            "type": "string"
+        },
+        "resourceTags":{
+            "defaultValue": {},
+            "type": "object"
+        },
+        "deploymentUrlBaseLocal":{
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2017-05-10",
+            "name": "event-hubs",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(parameters('deploymentUrlBaseLocal'),'eventhubs.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('resourceTags')]"
+                    },
+                    "eventhubs":{
+                        "value": ["[parameters('eventhub_name')]"]
+                    }
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[parameters('eventhub_connection_name')]",
+            "location": "[resourceGroup().location]",
+            "tags": "[parameters('resourceTags')]",
+            "properties": {
+                "displayName": "[parameters('eventhub_connection_name')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat(subscription().id,'/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/eventhubs')]"
+                }
+            },
+            "dependsOn": ["event-hubs"]
+        },
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2017-07-01",
+            "name": "[parameters('logic_app_name')]",
+            "location": "[resourceGroup().location]",
+            "tags": "[parameters('resourceTags')]",
+            "dependsOn": ["[resourceId('Microsoft.Web/connections', parameters('eventhub_connection_name'))]"],
+            "properties": {
+                "state": "Enabled",
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "$connections": {
+                            "defaultValue": {},
+                            "type": "Object"
+                        }
+                    },
+                    "triggers": {
+                        "When_events_are_available_in_Event_Hub": {
+                            "recurrence": {
+                                "frequency": "Minute",
+                                "interval": 5
+                            },
+                            "splitOn": "@triggerBody()",
+                            "type": "ApiConnection",
+                            "inputs": {
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['eventhubs']['connectionId']"
+                                    }
+                                },
+                                "method": "get",
+                                "path": "[concat('/@{encodeURIComponent(''', parameters('eventhub_name'), ''')}/events/batch/head')]",
+                                "queries": {
+                                    "consumerGroupName": "$Default",
+                                    "contentType": "application/json",
+                                    "maximumEventsCount": 50
+                                }
+                            }
+                        }
+                    },
+                    "actions": {
+                        "HTTP": {
+                            "runAfter": {},
+                            "type": "Http",
+                            "inputs": {
+                                "body": "@triggerBody()?['ContentData']",
+                                "headers": {
+                                    "ApiKey": "[parameters('logit_apikey')]",
+                                    "Content-Type": "application/json",
+                                    "LogType": "postgres"
+                                },
+                                "method": "POST",
+                                "uri": "[parameters('logit_api')]"
+                            }
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {
+                    "$connections": {
+                        "value": {
+                            "eventhubs": {
+                                "id": "[concat(subscription().id,'/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/eventhubs')]",
+                                "connectionId": "[resourceId('Microsoft.Web/connections', parameters('eventhub_connection_name'))]",
+                                "connectionName": "[parameters('eventhub_connection_name')]"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/azure/eventhubs-logic-app.json
+++ b/azure/eventhubs-logic-app.json
@@ -59,6 +59,9 @@
             "tags": "[parameters('resourceTags')]",
             "properties": {
                 "displayName": "[parameters('eventhub_connection_name')]",
+                "parameterValues": {
+                    "connectionString": "[ reference('event-hubs').outputs.connectionStrings.value[0] ]"
+                },
                 "customParameterValues": {},
                 "api": {
                     "id": "[concat(subscription().id,'/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/eventhubs')]"

--- a/azure/eventhubs.json
+++ b/azure/eventhubs.json
@@ -137,5 +137,14 @@
                 ]
             }
         }
-    ]
+    ],
+    "outputs": {
+        "connectionStrings": {
+            "type": "array",
+            "copy": {
+                "count": "[length(parameters('eventhubs'))]",
+                "input":  "[listKeys(resourceId('Microsoft.EventHub/namespaces/eventhubs/authorizationRules', parameters('eventhubs_namespace'), parameters('eventhubs')[copyIndex()], parameters('eventhubs')[copyIndex()]), '2017-04-01').primaryConnectionString]"
+            }
+        }
+    }
 }

--- a/azure/eventhubs.json
+++ b/azure/eventhubs.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "eventhubs_namespace": {
+            "defaultValue": "[concat(resourceGroup().name, '-eventhubs')]",
+            "type": "string"
+        },
+        "eventhubs": {
+            "defaultValue": [],
+            "type": "array"
+        },
+        "resourceTags":{
+            "defaultValue": {},
+            "type": "object"
+        }
+    },
+    "variables": {
+        "copy":[{
+             "name": "consumerGroups",
+             "count": "[length(parameters('eventhubs'))]",
+             "input": {
+                 "consumerGroupName": "[concat(parameters('eventhubs')[copyIndex('consumerGroups')], '/$Default')]",
+                 "eventHubsName": "[parameters('eventhubs')[copyIndex('consumerGroups')]]"
+             }
+        }]
+    },
+    "resources": [
+        {
+            "type": "Microsoft.EventHub/namespaces",
+            "apiVersion": "2018-01-01-preview",
+            "name": "[parameters('eventhubs_namespace')]",
+            "location": "[resourceGroup().location]",
+            "tags": "[parameters('resourceTags')]",            
+            "sku": {
+                "name": "Standard",
+                "tier": "Standard",
+                "capacity": 1
+            },
+            "properties": {
+                "zoneRedundant": false,
+                "isAutoInflateEnabled": false,
+                "maximumThroughputUnits": 0,
+                "kafkaEnabled": true
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/AuthorizationRules",
+            "apiVersion": "2017-04-01",
+            "name": "[concat(parameters('eventhubs_namespace'), '/RootManageSharedAccessKey')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('eventhubs_namespace'))]"
+            ],
+            "properties": {
+                "rights": [
+                    "Listen",
+                    "Manage",
+                    "Send"
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/networkRuleSets",
+            "apiVersion": "2018-01-01-preview",
+            "name": "[concat(parameters('eventhubs_namespace'), '/default')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('eventhubs_namespace'))]"
+            ],
+            "properties": {
+                "defaultAction": "Deny",
+                "virtualNetworkRules": [],
+                "ipRules": []
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/eventhubs",
+            "apiVersion": "2017-04-01",
+            "tags": "[parameters('resourceTags')]",            
+            "copy":{
+                "name": "eventhubsCopy",
+                "batchSize" : 1,
+                "mode": "serial",
+                "count" : "[length(parameters('eventhubs'))]"
+            },
+            "name": "[concat(parameters('eventhubs_namespace'), '/', parameters('eventhubs')[copyIndex('eventhubsCopy')])]",
+            "condition": "[greater(length(parameters('eventhubs')),0)]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('eventhubs_namespace'))]"
+            ],
+            "properties": {
+                "messageRetentionInDays": 1,
+                "partitionCount": 1,
+                "status": "Active"
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
+            "apiVersion": "2017-04-01",
+            "copy":{
+                "name": "consumerGroupsCopy",
+                "batchSize" : 1,
+                "mode": "serial",
+                "count" : "[length(variables('consumerGroups'))]"
+            },
+            "name": "[concat(parameters('eventhubs_namespace'), '/', variables('consumerGroups')[copyIndex('consumerGroupsCopy')].consumerGroupName)]",
+            "location": "[resourceGroup().location]",
+            "condition": "[greater(length(parameters('eventhubs')),0)]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('eventhubs_namespace'), variables('consumerGroups')[copyIndex('consumerGroupsCopy')].eventHubsName)]",
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('eventhubs_namespace'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules",
+            "apiVersion": "2017-04-01",
+            "copy":{
+                "name": "eventhubsCopy",
+                "batchSize" : 1,
+                "mode": "serial",
+                "count" : "[length(parameters('eventhubs'))]"
+            },
+            "name": "[concat(parameters('eventhubs_namespace'), '/', parameters('eventhubs')[copyIndex('eventhubsCopy')], '/',parameters('eventhubs')[copyIndex('eventhubsCopy')])]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('eventhubs_namespace'), parameters('eventhubs')[copyIndex('eventhubsCopy')])]",
+                "[resourceId('Microsoft.EventHub/namespaces', parameters('eventhubs_namespace'))]"
+            ],
+            "properties": {
+                "rights": [
+                    "Manage",
+                    "Listen",
+                    "Send"
+                ]
+            }
+        }
+    ]
+}

--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -228,6 +228,7 @@ jobs:
                 -logstashHost "${{parameters.logstashHost}}"
                 -logstashPort "${{parameters.logstashPort}}"
                 -logstashSsl "${{parameters.logstashSsl}}"
+                -logitApikey "$(logitApikey)"
                 -findBaseUrl "${{parameters.findBaseUrl}}"
                 -redisCacheName "$(redisCacheName)"
                 -containerInstanceNamePrefix "$(containerInstanceNamePrefix)"

--- a/azure/template.json
+++ b/azure/template.json
@@ -264,6 +264,10 @@
                 "description": "Set this to 'true' to use SSL when shipping logs."
             }
         },
+        "logitApikey":{
+            "defaultValue": "",
+            "type": "string"
+        },
         "findBaseUrl": {
             "type": "string",
             "metadata": {
@@ -1077,6 +1081,32 @@
                 "postgresql-server",
 		"app-service-and-containers"
             ]
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "event-hubs-logit-logic-app",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBaseLocal'),'eventhubs-logic-app.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
+                    "eventhub_name":{
+                        "value": "logstash"
+                    },
+                    "logit_apikey":{
+                        "value": "[parameters('logitApikey')]"
+                    },
+                    "deploymentUrlBaseLocal":{
+                        "value": "[variables('deploymentUrlBaseLocal')]"
+                    }
+                }
+            }
         }
     ],
     "outputs": {


### PR DESCRIPTION
postgres diagnostic setting to send logs to event hubs which is sent to
logit using a logic app.

## Context
postgres logs are only available in the Azure portal, make it accessible from logit.
## Changes proposed in this pull request

Configure postgres to stream logs to event hubs and use a logic app to post the logs to logit API.

Sample logs in kibana -> https://kibana.logit.io/goto/2400fff0cf6487210f53801a72ac7141

## Guidance to review
The two ARM template files `eventhubs.json` and `event-hubs-logic-app.json` will be moded to the [BAT ARM template repository](https://github.com/DFE-Digital/bat-platform-building-blocks/pull/51).

I have also configured the below logstash filters in logit.
I will refine this once we start seeing more logs/patterns.
```
if [type] == "postgres" { 
      json {
        source => "message"
      }
      split {
        field => "[records]"
        remove_field => "message"
      }
      date {
        match => [ "[records][time]", "ISO8601" ]
        target => "@timestamp"
      }
      mutate {
        rename => { "[records][properties][message]" => "[message]" }
        rename => { "[records][LogicalServerName]" => "[records][databaseServer]" }
        remove_field => [ "[records][resourceId]" ]
        remove_field => [ "[records][SubscriptionId]" ]
      }
    }
```

## Link to Trello card
https://trello.com/c/Fq1F1UFN/2448-send-postgres-error-logs-logit-in-production-staging-and-sandbox

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
