### PR TITLE
Fix international address label

### DIFF
--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -10,28 +10,24 @@
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <span class="govuk-caption-xl">
-            <%= t('page_titles.contact_details') %>
-          </span>
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.address') %>
-          </h1>
-        </legend>
-
-        <% if @contact_details_form.uk? %>
+      <% if @contact_details_form.uk? %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+            <h1 class="govuk-fieldset__heading">
+              <%= t('page_titles.address') %>
+            </h1>
+          </legend>
           <%= f.govuk_text_field :address_line1, label: { text: t('application_form.contact_details.address_line1.label') }, autocomplete: 'address-line1' %>
           <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
           <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
           <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
           <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
-        <% else %>
-          <%= f.govuk_text_area :international_address, label: { text: t('application_form.contact_details.international_address.label') }, autocomplete: 'address' %>
-        <% end %>
+        </fieldset>
+      <% else %>
+        <%= f.govuk_text_area :international_address, label: { text: t('page_titles.address'), size: 'xl' }, autocomplete: 'address' %>
+      <% end %>
 
-        <%= f.govuk_submit t('application_form.contact_details.address.button') %>
-      </fieldset>
+      <%= f.govuk_submit t('application_form.contact_details.address.button') %>
     <% end %>
   </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -89,9 +89,6 @@ en:
       country:
         label: Which country?
         default_option: Select a country
-      international_address:
-        label: Enter your address
-        button: Save and continue
       review:
         button: Continue
     work_history:

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -163,7 +163,7 @@ RSpec.feature 'Entering their contact details' do
   end
 
   def and_fill_in_an_international_address
-    fill_in t('application_form.contact_details.international_address.label'), with: '123 Chandni Chowk, Old Delhi'
+    fill_in t('page_titles.address'), with: '123 Chandni Chowk, Old Delhi'
   end
 
   def then_i_can_check_my_revised_address


### PR DESCRIPTION
## Context

As raised by @adamsilver, the original design for international address field included an unnecessary label, meaning the page title and label essentially said the same thing. This issue becomes more evident with validation, as the error message repeats the contents of the label. We’re also showing the section title as a heading caption, adding further verbosity.

## Changes proposed in this pull request

* Use page heading as label for international address
* Remove ‘Contact details’ heading caption
* Move submit button outside of fieldset

### International address: Before (without and with validation)

<img width="693" alt="Screenshot 2020-07-20 at 11 34 43" src="https://user-images.githubusercontent.com/813383/87929059-bb47f780-ca7d-11ea-938e-98c6ea17e361.png">
<img width="694" alt="Screenshot 2020-07-20 at 11 34 36" src="https://user-images.githubusercontent.com/813383/87929071-c3a03280-ca7d-11ea-95de-a0ede895be01.png">

### International address: After (without and with validation)

<img width="720" alt="Screenshot 2020-07-20 at 11 33 42" src="https://user-images.githubusercontent.com/813383/87929116-d3b81200-ca7d-11ea-9f64-e4039f0ad4cb.png">
<img width="694" alt="Screenshot 2020-07-20 at 11 33 47" src="https://user-images.githubusercontent.com/813383/87929124-d581d580-ca7d-11ea-8217-e57bc988fa32.png">

### Updates UK address by moving submit button outside of fieldset (before and after)

<img width="462" alt="Screenshot 2020-07-20 at 11 35 56" src="https://user-images.githubusercontent.com/813383/87929177-ecc0c300-ca7d-11ea-860c-4bf8b551a0ac.png">
<img width="372" alt="Screenshot 2020-07-20 at 11 36 20" src="https://user-images.githubusercontent.com/813383/87929210-f6e2c180-ca7d-11ea-875e-3aafdba1d851.png">
