### PR TITLE
Update permissions display on organisations show page

### DIFF
--- a/app/components/provider_relationship_permissions_list.html.erb
+++ b/app/components/provider_relationship_permissions_list.html.erb
@@ -1,11 +1,22 @@
+<p class="govuk-!-margin-bottom-1 govuk-body">The following organisation(s) can make decisions:</p>
 <ul class="govuk-list">
-  <li>View applications <% @permission_model.view_applications_only? ? 'only' : nil %></li>
-
-  <% if @permission_model.make_decisions? %>
-    <li><%= render CheckIcon.new %> Make decisions</li>
-  <% end %>
-
-  <% if @permission_model.view_safeguarding_information? %>
-    <li><%= render CheckIcon.new %> View safeguarding information</li>
+  <% providers_that_can('make_decisions').each do |provider| %>
+    <li><%= render CheckIcon.new %> <%= provider.name %> </li>
   <% end %>
 </ul>
+
+<p class="govuk-!-margin-bottom-1 govuk-body">The following organisation(s) can see safeguarding information:</p>
+<ul class="govuk-list">
+  <% providers_that_can('view_safeguarding_information').each do |provider| %>
+    <li><%= render CheckIcon.new %> <%= provider.name %> </li>
+  <% end %>
+</ul>
+
+<% if show_view_applications_only_section? %>
+  <p class="govuk-!-margin-bottom-1 govuk-body">The following organisation(s) can only view applications:</p>
+  <ul class="govuk-list">
+    <% providers_that_can('view_applications_only').each do |provider| %>
+      <li><%= render CheckIcon.new %> <%= provider.name %> </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/provider_relationship_permissions_list.rb
+++ b/app/components/provider_relationship_permissions_list.rb
@@ -2,4 +2,18 @@ class ProviderRelationshipPermissionsList < ViewComponent::Base
   def initialize(permission_model)
     @permission_model = permission_model
   end
+
+  def providers_that_can(permission)
+    providers_that_can = %w[training_provider ratifying_provider].map do |provider_role|
+      if @permission_model.send("#{provider_role}_can_#{permission}?")
+        @permission_model.send(provider_role)
+      end
+    end
+
+    providers_that_can.compact
+  end
+
+  def show_view_applications_only_section?
+    providers_that_can(:view_applications_only).any?
+  end
 end

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -2,24 +2,13 @@ class ProviderRelationshipPermissions < ApplicationRecord
   belongs_to :ratifying_provider, class_name: 'Provider'
   belongs_to :training_provider, class_name: 'Provider'
 
-  # For ease of use in views, this struct acts like a ProviderPermissions model
-  PermissionsSet = Struct.new(:make_decisions?, :view_safeguarding_information?) do
-    def view_applications_only?
-      values.all?(&:!)
-    end
+  PERMISSIONS = %w[make_decisions view_safeguarding_information].freeze
+
+  def training_provider_can_view_applications_only?
+    PERMISSIONS.map { |permission| send("training_provider_can_#{permission}") }.all?(false)
   end
 
-  def ratifying_provider_permissions
-    PermissionsSet.new(
-      ratifying_provider_can_make_decisions,
-      ratifying_provider_can_view_safeguarding_information,
-    )
-  end
-
-  def training_provider_permissions
-    PermissionsSet.new(
-      training_provider_can_make_decisions,
-      training_provider_can_view_safeguarding_information,
-    )
+  def ratifying_provider_can_view_applications_only?
+    PERMISSIONS.map { |permission| send("ratifying_provider_can_#{permission}") }.all?(false)
   end
 end

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -11,25 +11,15 @@
         </div>
       </div>
 
-      <h2 class="govuk-heading-m">
-        For courses ratified by <%= permissions.ratifying_provider.name %> and run by <%= permissions.training_provider.name %>
-      </h2>
-      <p class="govuk-!-margin-bottom-1 govuk-body"><%= permissions.ratifying_provider.name %> can:</p>
-      <%= render ProviderRelationshipPermissionsList.new(permissions.ratifying_provider_permissions) %>
-
-      <p class="govuk-!-margin-bottom-1 govuk-body"><%= permissions.training_provider.name %> can:</p>
-      <%= render ProviderRelationshipPermissionsList.new(permissions.training_provider_permissions) %>
+      <%= render ProviderRelationshipPermissionsList.new(permissions) %>
     <% end %>
 
     <% @training_permissions.each do |permissions| %>
       <h2 class="govuk-heading-m">
         For courses run by <%= permissions.training_provider.name %> and ratified by <%= permissions.ratifying_provider.name %>
       </h2>
-      <p class="govuk-!-margin-bottom-1 govuk-body"><%= permissions.training_provider.name %> can:</p>
-      <%= render ProviderRelationshipPermissionsList.new(permissions.training_provider_permissions) %>
 
-      <p class="govuk-!-margin-bottom-1 govuk-body"><%= permissions.ratifying_provider.name %> can:</p>
-      <%= render ProviderRelationshipPermissionsList.new(permissions.ratifying_provider_permissions) %>
+      <%= render ProviderRelationshipPermissionsList.new(permissions) %>
 
       <p class="govuk-body">
         <%= govuk_link_to 'Change', provider_interface_edit_provider_relationship_permissions_path(

--- a/spec/components/provider_relationship_permissions_list_spec.rb
+++ b/spec/components/provider_relationship_permissions_list_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ProviderRelationshipPermissionsList do
+  let(:training_provider) { create(:provider) }
+  let(:ratifiying_provider) { create(:provider) }
+  let(:provider_relationship_permissions) do
+    create(:provider_relationship_permissions,
+           training_provider: training_provider,
+           ratifying_provider: ratifiying_provider,
+           training_provider_can_make_decisions: true,
+           training_provider_can_view_safeguarding_information: true)
+  end
+
+  it 'does not render view only organisations if both providers have at least one permission' do
+    provider_relationship_permissions =
+      create(:provider_relationship_permissions,
+             training_provider_can_make_decisions: true,
+             ratifying_provider_can_view_safeguarding_information: true)
+
+    result = render_inline(described_class.new(provider_relationship_permissions))
+    expect(result.css('.govuk-body').text).not_to include('The following organisation(s) can only view applications')
+  end
+
+  it 'renders organisations who can make decisions' do
+    result = render_inline(described_class.new(provider_relationship_permissions))
+
+    expect(result.css('.govuk-body').first.text).to include('The following organisation(s) can make decisions:')
+    expect(result.css('.govuk-list').first.text).to include(training_provider.name.to_s)
+    expect(result.css('.govuk-list').first.text).not_to include(ratifiying_provider.name.to_s)
+  end
+
+  it 'renders organisations who can view safeguarding information' do
+    result = render_inline(described_class.new(provider_relationship_permissions))
+
+    expect(result.css('.govuk-body')[1].text).to include('The following organisation(s) can see safeguarding information:')
+    expect(result.css('.govuk-list')[1].text).to include(training_provider.name.to_s)
+    expect(result.css('.govuk-list')[1].text).not_to include(ratifiying_provider.name.to_s)
+  end
+
+  it 'renders organisations who can only view applications' do
+    result = render_inline(described_class.new(provider_relationship_permissions))
+
+    expect(result.css('.govuk-body')[2].text).to include('The following organisation(s) can only view applications:')
+    expect(result.css('.govuk-list')[2].text).not_to include(training_provider.name.to_s)
+    expect(result.css('.govuk-list')[2].text).to include(ratifiying_provider.name.to_s)
+  end
+end

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -66,11 +66,11 @@ RSpec.feature 'See organisation permissions' do
 
   def then_i_can_see_permissions_for_the_ratifying_provider
     expect(page).to have_content("For courses ratified by #{@ratifying_provider.name} and run by #{@training_provider.name}")
-    expect(page).to have_content("#{@ratifying_provider.name} can:\nView applications View safeguarding information")
+    expect(page).to have_content("The following organisation(s) can see safeguarding information:\n#{@ratifying_provider.name}\nThe")
   end
 
   def and_i_can_see_permissions_for_the_training_provider
-    expect(page).to have_content("#{@training_provider.name} can:\nView applications")
+    expect(page).to have_content('The following organisation(s) can only view applications:')
   end
 
   def and_i_click_on_a_training_provider_organisation
@@ -79,7 +79,7 @@ RSpec.feature 'See organisation permissions' do
 
   def then_i_can_see_permissions_for_the_training_provider
     expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
-    expect(page).to have_content("#{@training_provider.name} can:\nView applications")
+    expect(page).to have_content("Provider\nThe following organisation(s) can only view applications:\n#{@training_provider.name}\nChange")
 
     expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(
       ratifying_provider_id: @ratifying_provider.id, training_provider_id: @training_provider.id,
@@ -87,6 +87,6 @@ RSpec.feature 'See organisation permissions' do
   end
 
   def and_i_can_see_permissions_for_the_ratifying_provider
-    expect(page).to have_content("#{@training_provider.name} can:\nView safeguarding information")
+    expect(page).to have_content("The following organisation(s) can see safeguarding information: \n#{@training_provider.name}")
   end
 end


### PR DESCRIPTION
## Context

Update permissions display on organisations show page so it's consistent with the prototype: https://manage-applications-beta.herokuapp.com/organisations/show
_Note: the black box should be blue_

## Changes proposed in this pull request
- courses as a ratifying provider

| Before  | After |
| ------------- | ------------- |
| <img width="335" alt="Screenshot 2020-07-20 at 13 42 35" src="https://user-images.githubusercontent.com/38078064/87938774-f9014c00-ca8e-11ea-9a2e-a60f6fae2322.png"> | <img width="338" alt="Screenshot 2020-07-20 at 12 23 13" src="https://user-images.githubusercontent.com/38078064/87938523-9f008680-ca8e-11ea-947b-cde7cb9618d1.png">  |

- courses as a training provider

| Before  | After |
| ------------- | ------------- |
| <img width="314" alt="Screenshot 2020-07-20 at 13 42 45" src="https://user-images.githubusercontent.com/38078064/87938884-1cc49200-ca8f-11ea-81ad-88f2e33a39f2.png"> | <img width="312" alt="Screenshot 2020-07-20 at 12 23 03" src="https://user-images.githubusercontent.com/38078064/87938899-24843680-ca8f-11ea-84c8-8135741c0573.png"> |


## Guidance to review

- create variations of ProviderRelationshipPermissions
- visit /organisations/:id

**Question**: what should I use in `app/components/provider_relationship_permissions_list.html.erb`?
1.  `[:training_provider, :ratifying_provider].each` with `send`
2. separate them like on lines 22-27 of this file
## Link to Trello card



## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
