### PR TITLE
Only upload data to UCAS on weekdays

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -21,5 +21,9 @@ class Clock
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
-  every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') { UCASMatching::UploadMatchingData.perform_async }
+  every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
+    if Time.zone.today.weekday?
+      UCASMatching::UploadMatchingData.perform_async
+    end
+  end
 end


### PR DESCRIPTION
## Context

The UCAS training environment probably doesn't work on weekends (it only runs during office hours). To avoid needless errors this make the upload task run only on weekdays.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
