### PR TITLE
English as a Foreign Language UI improvements

### DIFF
--- a/app/controllers/candidate_interface/english_foreign_language/efl_root_concern.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/efl_root_concern.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  module EnglishForeignLanguage
+    module EflRootConcern
+      def redirect_to_efl_root
+        redirect_to candidate_interface_english_foreign_language_root_path
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module EnglishForeignLanguage
     class IeltsController < CandidateInterfaceController
+      include EflRootConcern
+
       def new
         render_404 unless FeatureFlag.active?(:efl_section)
 
@@ -18,7 +20,9 @@ module CandidateInterface
       end
 
       def edit
-        ielts = current_application.english_proficiency.efl_qualification
+        ielts = IeltsQualification.where(id: current_application.english_proficiency&.efl_qualification_id).first
+        redirect_to_efl_root and return unless ielts
+
         @ielts_form = EnglishForeignLanguage::IeltsForm.new.fill(ielts: ielts)
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module EnglishForeignLanguage
     class OtherEflQualificationController < CandidateInterfaceController
+      include EflRootConcern
+
       def new
         render_404 unless FeatureFlag.active?(:efl_section)
 
@@ -18,7 +20,9 @@ module CandidateInterface
       end
 
       def edit
-        other_qualification = current_application.english_proficiency.efl_qualification
+        other_qualification = OtherEflQualification.where(id: current_application.english_proficiency&.efl_qualification_id).first
+        redirect_to_efl_root and return unless other_qualification
+
         @other_qualification_form = EnglishForeignLanguage::OtherEflQualificationForm.new.fill(qualification: other_qualification)
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module EnglishForeignLanguage
     class ReviewController < CandidateInterfaceController
+      include EflRootConcern
+
       before_action :check_for_english_proficiency
 
       def show
@@ -20,7 +22,7 @@ module CandidateInterface
 
       def check_for_english_proficiency
         if english_proficiency.blank?
-          redirect_to candidate_interface_english_foreign_language_root_path
+          redirect_to_efl_root
         end
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module EnglishForeignLanguage
     class ToeflController < CandidateInterfaceController
+      include EflRootConcern
+
       def new
         render_404 unless FeatureFlag.active?(:efl_section)
 
@@ -18,7 +20,9 @@ module CandidateInterface
       end
 
       def edit
-        toefl = current_application.english_proficiency.efl_qualification
+        toefl = ToeflQualification.where(id: current_application.english_proficiency&.efl_qualification_id).first
+        redirect_to_efl_root and return unless toefl
+
         @toefl_form = EnglishForeignLanguage::ToeflForm.new.fill(toefl: toefl)
       end
 

--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -4,12 +4,18 @@ module CandidateInterface
       include ActiveModel::Model
       include ValidationUtils
 
+      BandScore = Struct.new(:value, :option)
+
       attr_accessor :trf_number, :band_score, :award_year, :application_form
 
       validates :trf_number, presence: true, length: { maximum: 255 }
       validates :band_score, presence: true, length: { maximum: 255 }
       validates :award_year, presence: true
       validate :award_year_is_a_valid_year
+
+      def self.band_score_drop_down_options
+        IeltsQualification::VALID_SCORES.map { |s| BandScore.new(s, s) }
+      end
 
       def save
         return false unless valid?

--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -6,8 +6,8 @@ module CandidateInterface
 
       attr_accessor :trf_number, :band_score, :award_year, :application_form
 
-      validates :trf_number, presence: true
-      validates :band_score, presence: true
+      validates :trf_number, presence: true, length: { maximum: 255 }
+      validates :band_score, presence: true, length: { maximum: 255 }
       validates :award_year, presence: true
       validate :award_year_is_a_valid_year
 

--- a/app/forms/candidate_interface/english_foreign_language/other_efl_qualification_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/other_efl_qualification_form.rb
@@ -6,8 +6,8 @@ module CandidateInterface
 
       attr_accessor :name, :grade, :award_year, :application_form
 
-      validates :name, presence: true
-      validates :grade, presence: true
+      validates :name, presence: true, length: { maximum: 255 }
+      validates :grade, presence: true, length: { maximum: 255 }
       validates :award_year, presence: true
       validate :award_year_is_a_valid_year
 

--- a/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
@@ -6,8 +6,8 @@ module CandidateInterface
 
       attr_accessor :registration_number, :total_score, :award_year, :application_form
 
-      validates :registration_number, presence: true
-      validates :total_score, presence: true
+      validates :registration_number, presence: true, length: { maximum: 255 }
+      validates :total_score, presence: true, length: { maximum: 255 }
       validates :award_year, presence: true
       validate :award_year_is_a_valid_year
 

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -9,6 +9,7 @@ import initDegreeInstitutionAutocomplete from "./degree-institution-autocomplete
 import initDegreeInstitutionCountryAutocomplete from "./degree-institution-country-autocomplete";
 import initDegreeSubjectAutocomplete from "./degree-subject-autocomplete";
 import initDegreeTypeAutocomplete from "./degree-type-autocomplete";
+import initIeltsBandScoreAutocomplete from "./ielts-band-score-autocomplete";
 import initWarnOnUnsavedChanges from "./warn-on-unsaved-changes";
 import providerFilter from "./provider-filter";
 
@@ -24,5 +25,6 @@ initDegreeInstitutionAutocomplete();
 initDegreeInstitutionCountryAutocomplete();
 initDegreeSubjectAutocomplete();
 initDegreeTypeAutocomplete();
+initIeltsBandScoreAutocomplete();
 initWarnOnUnsavedChanges();
 providerFilter();

--- a/app/frontend/packs/ielts-band-score-autocomplete.js
+++ b/app/frontend/packs/ielts-band-score-autocomplete.js
@@ -1,0 +1,20 @@
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const initIeltsBandScoreAutocomplete = () => {
+  try {
+    const id = "#candidate-interface-english-foreign-language-ielts-form-band-score-field";
+    const bandScoreSelect = document.querySelector(id);
+
+    if (!bandScoreSelect) return;
+
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: bandScoreSelect,
+      showAllValues: true,
+      confirmOnBlur: false
+    });
+  } catch (err) {
+    console.error("Could not enhance courses select:", err);
+  }
+};
+
+export default initIeltsBandScoreAutocomplete;

--- a/app/frontend/packs/ielts-band-score-autocomplete.js
+++ b/app/frontend/packs/ielts-band-score-autocomplete.js
@@ -13,7 +13,7 @@ const initIeltsBandScoreAutocomplete = () => {
       confirmOnBlur: false
     });
   } catch (err) {
-    console.error("Could not enhance courses select:", err);
+    console.error("Could not enhance IELTS score select:", err);
   }
 };
 

--- a/app/models/ielts_qualification.rb
+++ b/app/models/ielts_qualification.rb
@@ -1,4 +1,26 @@
 class IeltsQualification < ApplicationRecord
+  VALID_SCORES = %w[
+    0.0
+    0.5
+    1.0
+    1.5
+    2.0
+    2.5
+    3.0
+    3.5
+    4.0
+    4.5
+    5.0
+    5.5
+    6.0
+    6.5
+    7.0
+    7.5
+    8.0
+    8.5
+    9.0
+  ].freeze
+
   has_one :english_proficiency, as: :efl_qualification
 
   def name

--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -3,11 +3,14 @@
   label: { text: 'Test report form (TRF) number', size: 'm' },
   hint_text: 'For example, 02GB0674SOOM599A') %>
 
-<%= f.govuk_text_field(
+<%= f.govuk_collection_select(
   :band_score,
+  CandidateInterface::EnglishForeignLanguage::IeltsForm.band_score_drop_down_options,
+  :value,
+  :option,
   label: { text: 'Overall band score', size: 'm' },
   hint_text: 'For example, 7.5',
-  width: 4) %>
+  ) %>
 
 <%= f.govuk_text_field(
   :award_year,

--- a/spec/system/candidate_interface/english_as_a_foreign_language/add_ielts_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/add_ielts_qualification_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Add IELTS qualification' do
 
   def when_i_provide_my_ielts_details
     fill_in 'Test report form (TRF) number', with: '123456'
-    fill_in 'Overall band score', with: '7.5'
+    select '7.5', from: 'Overall band score'
     fill_in 'Year qualification was awarded', with: '1999'
     click_button 'Save and continue'
   end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
A set of small improvements identified during the build of https://trello.com/c/9fk7yluU .

## Changes proposed in this pull request

- Add length limits to the EFL forms.
- Change IELTS band score from input field to drop down
- Make EFL controller navigation more robust

(see commits for more detail)

<!-- If there are UI changes, please include Before and After screenshots. -->
### IELTS band score change

![Uploading Screenshot_20200720_153112.png…]()

## Guidance to review
- Review app:
  - Switch on efl_section feature flag
  - As a candidate, select any nationality other than British and Irish.
  - Click through to the EFL section via the main application form screen.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/9fk7yluU
## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
