### PR TITLE
Add more logging for UCAS Sync

### DIFF
--- a/app/services/ucas_matching/matching_data_file.rb
+++ b/app/services/ucas_matching/matching_data_file.rb
@@ -10,9 +10,13 @@ module UCASMatching
       csv_filename = "#{filename_prefix}.csv"
       zip_filename = "#{filename_prefix}.zip"
 
+      Rails.logger.info 'Creating new export for UCAS'
+
       File.open(csv_filename, 'w') do |f|
         f.write(csv_as_string)
       end
+
+      Rails.logger.info "Finished creating export to #{csv_filename}. Archiving..."
 
       Archive::Zip.archive(
         zip_filename,
@@ -20,6 +24,8 @@ module UCASMatching
         encryption_codec: Archive::Zip::Codec::TraditionalEncryption,
         password: ENV.fetch('UCAS_ZIP_PASSWORD'),
       )
+
+      Rails.logger.info "Finished archiving export to #{zip_filename}"
 
       zip_filename
     end


### PR DESCRIPTION
## Context

This adds a few logging statements to inform us how the UCAS sync is doing. 

## Changes proposed in this pull request

Add logging statements.

## Guidance to review

Imagine the log statements being included on the new dashboard:

https://kibana.logit.io/app/kibana#/dashboard/6966e7e0-cb2d-11ea-8848-73aea0c4ba74

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
