### PR TITLE
Provider user invitation wizard - part 2 - Saving new users

### DIFF
--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -62,8 +62,8 @@ module ProviderInterface
       service = SaveAndInviteProviderUser.new(
         form: @wizard,
         save_service: ProviderInterface::SaveProviderUserService.new(@wizard),
-        invite_service: InviteProviderUser.new(provider_user: nil),
-        new_user: false,
+        invite_service: InviteProviderUser.new(provider_user: @wizard.email_address),
+        new_user: @wizard.new_user?,
       )
       render :check and return unless service.call
 

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -59,7 +59,14 @@ module ProviderInterface
 
     def commit
       @wizard = ProviderUserInvitationWizard.new(session)
-      # wizard.save!
+      service = SaveAndInviteProviderUser.new(
+        form: @wizard,
+        save_service: ProviderInterface::SaveProviderUserService.new(@wizard),
+        invite_service: InviteProviderUser.new(provider_user: nil),
+        new_user: false,
+      )
+      render :check and return unless service.call
+
       @wizard.clear_state!
 
       flash[:success] = 'User successfully invited'

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -83,10 +83,6 @@ module ProviderInterface
       end
     end
 
-    def save!
-      SaveProviderUserService.new(self).call
-    end
-
     def save_state!
       @state_store[STATE_STORE_KEY] = state
     end

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -95,6 +95,10 @@ module ProviderInterface
       @state_store.delete(STATE_STORE_KEY)
     end
 
+    def new_user?
+      email_address.present? && ProviderUser.find_by(email_address: email_address).nil?
+    end
+
   private
 
     def state

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -162,7 +162,21 @@ module ProviderInterface
         first_name: wizard.first_name,
         last_name: wizard.last_name,
       )
+      create_provider_permissions(user)
       user
+    end
+
+    def create_provider_permissions(user)
+      wizard.provider_permissions.each do |provider_id, permission|
+        provider_permission = ProviderPermissions.new(
+          provider_id: provider_id,
+          provider_user_id: user.id,
+        )
+        permission['permissions'].each do |permission_name|
+          provider_permission.send("#{permission_name}=".to_sym, true)
+        end
+        provider_permission.save!
+      end
     end
   end
 end

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -84,7 +84,7 @@ module ProviderInterface
     end
 
     def save!
-      raise NotImplementedError, 'Persistence not implemented yet'
+      SaveNewProviderUserService.new(self).call
     end
 
     def save_state!
@@ -127,6 +127,42 @@ module ProviderInterface
 
     def any_provider_needs_permissions_setup
       next_provider_needing_permissions_setup.present?
+    end
+  end
+
+  class SaveNewProviderUserService
+    attr_accessor :wizard
+
+    def initialize(wizard)
+      self.wizard = wizard
+    end
+
+    def call
+      if email_exists?
+        update_user
+      else
+        create_user
+      end
+    end
+
+  private
+
+    def email_exists?
+      # TODO:
+      false
+    end
+
+    def update_user
+      # TODO:
+    end
+
+    def create_user
+      user = ProviderUser.create(
+        email_address: wizard.email_address,
+        first_name: wizard.first_name,
+        last_name: wizard.last_name,
+      )
+      user
     end
   end
 end

--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -10,6 +10,7 @@ class InviteProviderUser
   end
 
   def call!
+    lookup_provider_user
     invite_user_to_dfe_sign_in
 
     send_welcome_email
@@ -39,6 +40,12 @@ private
 
   def send_welcome_email
     ProviderMailer.account_created(@provider_user).deliver_later
+  end
+
+  def lookup_provider_user
+    if @provider_user.is_a?(String)
+      @provider_user = ProviderUser.find_by!(email_address: @provider_user)
+    end
   end
 end
 

--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -67,9 +67,6 @@ module ProviderInterface
         end
         provider_permission.save!
       end
-
-      deleted_permissions = user.provider_permissions.select { |permission| wizard.provider_permissions[permission.provider_id.to_s].blank? }
-      deleted_permissions.each(&:destroy)
     end
   end
 end

--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -6,7 +6,7 @@ module ProviderInterface
       self.wizard = wizard
     end
 
-    def call
+    def call!
       if email_exists?
         update_user
       else
@@ -46,7 +46,7 @@ module ProviderInterface
           provider_id: provider_id,
           provider_user_id: user.id,
         )
-        permission['permissions'].each do |permission_name|
+        permission['permissions'].reject(&:blank?).each do |permission_name|
           provider_permission.send("#{permission_name}=".to_sym, true)
         end
         provider_permission.save!

--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -1,0 +1,75 @@
+module ProviderInterface
+  class SaveProviderUserService
+    attr_accessor :wizard
+
+    def initialize(wizard)
+      self.wizard = wizard
+    end
+
+    def call
+      if email_exists?
+        update_user
+      else
+        create_user
+      end
+    end
+
+  private
+
+    def email_exists?
+      ProviderUser.find_by(email_address: wizard.email_address).present?
+    end
+
+    def update_user
+      existing_user = ProviderUser.find_by(email_address: wizard.email_address)
+      existing_user.update(
+        email_address: wizard.email_address,
+        first_name: wizard.first_name,
+        last_name: wizard.last_name,
+      )
+      update_provider_permissions(existing_user)
+    end
+
+    def create_user
+      user = ProviderUser.create(
+        email_address: wizard.email_address,
+        first_name: wizard.first_name,
+        last_name: wizard.last_name,
+      )
+      create_provider_permissions(user)
+      user
+    end
+
+    def create_provider_permissions(user)
+      wizard.provider_permissions.each do |provider_id, permission|
+        provider_permission = ProviderPermissions.new(
+          provider_id: provider_id,
+          provider_user_id: user.id,
+        )
+        permission['permissions'].each do |permission_name|
+          provider_permission.send("#{permission_name}=".to_sym, true)
+        end
+        provider_permission.save!
+      end
+    end
+
+    def update_provider_permissions(user)
+      wizard.provider_permissions.each do |provider_id, permission|
+        provider_permission = ProviderPermissions.find_or_initialize_by(
+          provider_id: provider_id,
+          provider_user_id: user.id,
+        )
+        %w[manage_users make_decisions].each do |permission_type|
+          provider_permission.send(
+            "#{permission_type}=",
+            permission['permissions'].include?(permission_type),
+          )
+        end
+        provider_permission.save!
+      end
+
+      deleted_permissions = user.provider_permissions.select { |permission| wizard.provider_permissions[permission.provider_id.to_s].blank? }
+      deleted_permissions.each(&:destroy)
+    end
+  end
+end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -159,6 +159,40 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
     end
 
     it 'invokes a service to persist the current state for an existing user' do
+      providers = create_list(:provider, 2)
+      existing_user = create(
+        :provider_user,
+        email_address: 'ed@example.com',
+        first_name: 'Edward',
+        last_name: 'Yewcater',
+      )
+      existing_user.provider_permissions.create(
+        provider_id: providers[0],
+        manage_users: false,
+        make_decisions: true,
+      )
+      state_store = state_store_for({
+        first_name: 'Ed',
+        last_name: 'Yewcater',
+        email_address: 'ed@example.com',
+        providers: providers.map { |provider| provider.id.to_s },
+        provider_permissions: {
+          providers[0].id.to_s => { provider_id: providers[0].id.to_s, 'permissions': %w[manage_users] },
+          providers[1].id.to_s => { provider_id: providers[1].id.to_s, permissions: %w[make_decisions] },
+        },
+        checking_answers: false,
+      })
+      wizard = described_class.new(state_store, {})
+      expect { wizard.save! }.not_to(change { ProviderUser.count })
+      existing_user.reload
+      expect(existing_user.provider_permissions.count).to eq 2
+
+      first_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == providers[0].id }
+      second_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == providers[1].id }
+      expect(first_permission.manage_users).to be true
+      expect(first_permission.make_decisions).to be false
+      expect(second_permission.manage_users).to be false
+      expect(second_permission.make_decisions).to be true
     end
   end
 end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -159,16 +159,21 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
     end
 
     it 'invokes a service to persist the current state for an existing user' do
-      providers = create_list(:provider, 2)
+      providers = create_list(:provider, 3)
       existing_user = create(
         :provider_user,
         email_address: 'ed@example.com',
         first_name: 'Edward',
         last_name: 'Yewcater',
       )
-      existing_user.provider_permissions.create(
-        provider_id: providers[0],
+      existing_user.provider_permissions.create!(
+        provider: providers[0],
         manage_users: false,
+        make_decisions: true,
+      )
+      existing_user.provider_permissions.create!(
+        provider: providers[2],
+        manage_users: true,
         make_decisions: true,
       )
       state_store = state_store_for({

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -143,4 +143,25 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
       expect { wizard.save! }.to change { ProviderUser.count }.by(1)
     end
   end
+
+  describe '#new_user?' do
+    it 'returns false if there is no email_address set' do
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, {})
+      expect(wizard.new_user?).to be false
+    end
+
+    it 'returns false if a user with the given email_address exists' do
+      provider_user = create :provider_user
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, email_address: provider_user.email_address)
+      expect(wizard.new_user?).to be false
+    end
+
+    it 'returns true if a user with the given email_address does not exist' do
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, email_address: 'not.a.user@example.com')
+      expect(wizard.new_user?).to be true
+    end
+  end
 end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -130,38 +130,4 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
       end
     end
   end
-
-  describe 'save!' do
-    it 'invokes a service to persist a new ProviderUser for a new user' do
-      create_list(:provider, 2)
-      state_store = state_store_for({
-        first_name: 'Ed',
-        last_name: 'Yewcater',
-        email_address: 'ed@example.com',
-      })
-      wizard = described_class.new(state_store, {})
-      expect { wizard.save! }.to change { ProviderUser.count }.by(1)
-    end
-  end
-
-  describe '#new_user?' do
-    it 'returns false if there is no email_address set' do
-      state_store = state_store_for({})
-      wizard = described_class.new(state_store, {})
-      expect(wizard.new_user?).to be false
-    end
-
-    it 'returns false if a user with the given email_address exists' do
-      provider_user = create :provider_user
-      state_store = state_store_for({})
-      wizard = described_class.new(state_store, email_address: provider_user.email_address)
-      expect(wizard.new_user?).to be false
-    end
-
-    it 'returns true if a user with the given email_address does not exist' do
-      state_store = state_store_for({})
-      wizard = described_class.new(state_store, email_address: 'not.a.user@example.com')
-      expect(wizard.new_user?).to be true
-    end
-  end
 end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -133,71 +133,14 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
 
   describe 'save!' do
     it 'invokes a service to persist a new ProviderUser for a new user' do
-      providers = create_list(:provider, 2)
+      create_list(:provider, 2)
       state_store = state_store_for({
         first_name: 'Ed',
         last_name: 'Yewcater',
         email_address: 'ed@example.com',
-        providers: providers.map { |provider| provider.id.to_s },
-        provider_permissions: {
-          providers[0].id.to_s => { provider_id: providers[0].id.to_s, 'permissions': %w[manage_users] },
-          providers[1].id.to_s => { provider_id: providers[1].id.to_s, permissions: %w[make_decisions] },
-        },
-        checking_answers: false,
       })
       wizard = described_class.new(state_store, {})
       expect { wizard.save! }.to change { ProviderUser.count }.by(1)
-      new_provider_user = ProviderUser.last
-      expect(new_provider_user.provider_permissions.count).to eq 2
-
-      first_permission = new_provider_user.provider_permissions.find { |permission| permission.provider_id == providers[0].id }
-      second_permission = new_provider_user.provider_permissions.find { |permission| permission.provider_id == providers[1].id }
-      expect(first_permission.manage_users).to be true
-      expect(first_permission.make_decisions).to be false
-      expect(second_permission.manage_users).to be false
-      expect(second_permission.make_decisions).to be true
-    end
-
-    it 'invokes a service to persist the current state for an existing user' do
-      providers = create_list(:provider, 3)
-      existing_user = create(
-        :provider_user,
-        email_address: 'ed@example.com',
-        first_name: 'Edward',
-        last_name: 'Yewcater',
-      )
-      existing_user.provider_permissions.create!(
-        provider: providers[0],
-        manage_users: false,
-        make_decisions: true,
-      )
-      existing_user.provider_permissions.create!(
-        provider: providers[2],
-        manage_users: true,
-        make_decisions: true,
-      )
-      state_store = state_store_for({
-        first_name: 'Ed',
-        last_name: 'Yewcater',
-        email_address: 'ed@example.com',
-        providers: providers.map { |provider| provider.id.to_s },
-        provider_permissions: {
-          providers[0].id.to_s => { provider_id: providers[0].id.to_s, 'permissions': %w[manage_users] },
-          providers[1].id.to_s => { provider_id: providers[1].id.to_s, permissions: %w[make_decisions] },
-        },
-        checking_answers: false,
-      })
-      wizard = described_class.new(state_store, {})
-      expect { wizard.save! }.not_to(change { ProviderUser.count })
-      existing_user.reload
-      expect(existing_user.provider_permissions.count).to eq 2
-
-      first_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == providers[0].id }
-      second_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == providers[1].id }
-      expect(first_permission.manage_users).to be true
-      expect(first_permission.make_decisions).to be false
-      expect(second_permission.manage_users).to be false
-      expect(second_permission.make_decisions).to be true
     end
   end
 end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
     context 'with missing name and email fields' do
       it 'first, last name and email address are required' do
         state_store = state_store_for({})
-        wizard = described_class.new(state_store, {})
+        wizard = described_class.new(state_store, current_step: 'check')
 
         wizard.valid?(:details)
 
@@ -128,6 +128,24 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
 
         expect(wizard.errors[:email_address]).to be_empty
       end
+    end
+  end
+
+  describe 'save!' do
+    it 'invokes a service to persist the current state as a new or existing user' do
+      state_store = state_store_for({
+        first_name: 'Ed',
+        last_name: 'Yewcater',
+        email_address: 'ed@example.com',
+        providers: %w[1 3],
+        provider_permissions: {
+          '1': { provider_id: '1', 'permissions': %w[manage_users] },
+          '3': { provider_id: '3', permissions: %w[make_decisions] },
+        },
+        checking_answers: false,
+      })
+      wizard = described_class.new(state_store, {})
+      expect { wizard.save! }.to change { ProviderUser.count }.by(1)
     end
   end
 end

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe InviteProviderUser, sidekiq: true do
     end
   end
 
+  describe '#call! if API response is successful given a ProviderUser#email_address' do
+    before do
+      set_dsi_api_response(success: true)
+      InviteProviderUser.new(provider_user: provider_user.email_address).call!
+    end
+
+    it 'queues an email' do
+      expect(ProviderMailer.deliveries.count).to be 1
+    end
+  end
+
   describe '#call! if API response is not successful' do
     before do
       set_dsi_api_response(success: false)

--- a/spec/services/provider_interface/save_provider_user_service_spec.rb
+++ b/spec/services/provider_interface/save_provider_user_service_spec.rb
@@ -47,16 +47,18 @@ RSpec.describe ProviderInterface::SaveProviderUserService do
       manage_users: true,
       make_decisions: true,
     )
-    wizard = setup_wizard_double
     expect { described_class.new(wizard).call! }.not_to(change { ProviderUser.count })
     existing_user.reload
-    expect(existing_user.provider_permissions.count).to eq 2
+    expect(existing_user.provider_permissions.count).to eq 3
 
     first_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == @providers[0].id }
     second_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == @providers[1].id }
+    third_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == @providers[2].id }
     expect(first_permission.manage_users).to be true
     expect(first_permission.make_decisions).to be false
     expect(second_permission.manage_users).to be false
     expect(second_permission.make_decisions).to be true
+    expect(third_permission.make_decisions).to be true
+    expect(third_permission.manage_users).to be true
   end
 end

--- a/spec/services/provider_interface/save_provider_user_service_spec.rb
+++ b/spec/services/provider_interface/save_provider_user_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProviderInterface::SaveProviderUserService do
 
   it 'invokes a service to persist a new ProviderUser for a new user' do
     wizard = setup_wizard_double
-    expect { described_class.new(wizard).call }.to change { ProviderUser.count }.by(1)
+    expect { described_class.new(wizard).call! }.to change { ProviderUser.count }.by(1)
     new_provider_user = ProviderUser.last
     expect(new_provider_user.provider_permissions.count).to eq 2
 
@@ -48,7 +48,7 @@ RSpec.describe ProviderInterface::SaveProviderUserService do
       make_decisions: true,
     )
     wizard = setup_wizard_double
-    expect { described_class.new(wizard).call }.not_to(change { ProviderUser.count })
+    expect { described_class.new(wizard).call! }.not_to(change { ProviderUser.count })
     existing_user.reload
     expect(existing_user.provider_permissions.count).to eq 2
 

--- a/spec/services/provider_interface/save_provider_user_service_spec.rb
+++ b/spec/services/provider_interface/save_provider_user_service_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SaveProviderUserService do
+  def setup_wizard_double
+    @providers = create_list(:provider, 3)
+    instance_double(
+      ProviderInterface::ProviderUserInvitationWizard,
+      first_name: 'Ed',
+      last_name: 'Yewcater',
+      email_address: 'ed@example.com',
+      provider_permissions: {
+        @providers[0].id.to_s => { 'provider_id' => @providers[0].id.to_s, 'permissions' => %w[manage_users] },
+        @providers[1].id.to_s => { 'provider_id' => @providers[1].id.to_s, 'permissions' => %w[make_decisions] },
+      },
+    )
+  end
+
+  it 'invokes a service to persist a new ProviderUser for a new user' do
+    wizard = setup_wizard_double
+    expect { described_class.new(wizard).call }.to change { ProviderUser.count }.by(1)
+    new_provider_user = ProviderUser.last
+    expect(new_provider_user.provider_permissions.count).to eq 2
+
+    first_permission = new_provider_user.provider_permissions.find { |permission| permission.provider_id == @providers[0].id }
+    second_permission = new_provider_user.provider_permissions.find { |permission| permission.provider_id == @providers[1].id }
+    expect(first_permission.manage_users).to be true
+    expect(first_permission.make_decisions).to be false
+    expect(second_permission.manage_users).to be false
+    expect(second_permission.make_decisions).to be true
+  end
+
+  it 'invokes a service to persist the current state for an existing user' do
+    wizard = setup_wizard_double
+    existing_user = create(
+      :provider_user,
+      email_address: 'ed@example.com',
+      first_name: 'Edward',
+      last_name: 'Yewcater',
+    )
+    existing_user.provider_permissions.create!(
+      provider: @providers[0],
+      manage_users: false,
+      make_decisions: true,
+    )
+    existing_user.provider_permissions.create!(
+      provider: @providers[2],
+      manage_users: true,
+      make_decisions: true,
+    )
+    wizard = setup_wizard_double
+    expect { described_class.new(wizard).call }.not_to(change { ProviderUser.count })
+    existing_user.reload
+    expect(existing_user.provider_permissions.count).to eq 2
+
+    first_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == @providers[0].id }
+    second_permission = existing_user.provider_permissions.find { |permission| permission.provider_id == @providers[1].id }
+    expect(first_permission.manage_users).to be true
+    expect(first_permission.make_decisions).to be false
+    expect(second_permission.manage_users).to be false
+    expect(second_permission.make_decisions).to be true
+  end
+end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     @another_provider = Provider.find_by(code: 'DEF')
   end
 
-  def and_i_can_manage_users_for_two_provider
+  def and_i_can_manage_users_for_two_providers
     @provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
     @provider_user.provider_permissions.find_by(provider: @another_provider).update(manage_users: true)
   end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -46,6 +46,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
     when_i_commit_changes
     then_i_see_the_new_user_on_the_index_page
+    and_new_user_gets_an_invitation_email
   end
 
   def when_i_try_to_visit_the_users_page
@@ -131,11 +132,17 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   end
 
   def when_i_commit_changes
+    set_dsi_api_response(success: true)
     click_button 'Invite user'
   end
 
   def then_i_see_the_new_user_on_the_index_page
     expect(page).to have_content('User successfully invited')
     expect(page).to have_content('Ed Ucator')
+  end
+
+  def and_new_user_gets_an_invitation_email
+    open_email('ed@example.com')
+    expect(current_email.subject).to have_content t('provider_account_created.email.subject')
   end
 end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     when_i_visit_the_invite_user_wizard
     then_i_see_a_404_page
 
-    and_i_can_manage_users_for_a_provider
+    and_i_can_manage_users_for_two_provider
     and_i_sign_in_again_to_the_provider_interface
 
     # when_i_click_on_the_users_link
@@ -42,7 +42,10 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     and_i_press_continue
     then_i_see_the_confirm_page
 
-    # TODO: TBC
+    # TODO: Assert the state of the confirm page
+
+    when_i_commit_changes
+    then_i_see_the_new_user_on_the_index_page
   end
 
   def when_i_try_to_visit_the_users_page
@@ -72,8 +75,9 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     @another_provider = Provider.find_by(code: 'DEF')
   end
 
-  def and_i_can_manage_users_for_a_provider
+  def and_i_can_manage_users_for_two_provider
     @provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
+    @provider_user.provider_permissions.find_by(provider: @another_provider).update(manage_users: true)
   end
 
   def and_i_sign_in_again_to_the_provider_interface
@@ -90,9 +94,9 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   end
 
   def when_i_fill_in_email_address_and_name
-    fill_in 'Email address', with: 'alice@example.com'
-    fill_in 'First name', with: 'Alice'
-    fill_in 'Last name', with: 'Alistair'
+    fill_in 'Email address', with: 'ed@example.com'
+    fill_in 'First name', with: 'Ed'
+    fill_in 'Last name', with: 'Ucator'
   end
 
   def and_i_press_continue
@@ -124,5 +128,14 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
   def then_i_see_the_confirm_page
     expect(page).to have_content('Check permissions before you invite user')
+  end
+
+  def when_i_commit_changes
+    click_button 'Invite user'
+  end
+
+  def then_i_see_the_new_user_on_the_index_page
+    expect(page).to have_content('User successfully invited')
+    expect(page).to have_content('Ed Ucator')
   end
 end

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     when_i_visit_the_invite_user_wizard
     then_i_see_a_404_page
 
-    and_i_can_manage_users_for_two_provider
+    and_i_can_manage_users_for_two_providers
     and_i_sign_in_again_to_the_provider_interface
 
     # when_i_click_on_the_users_link


### PR DESCRIPTION
## Context

This PR is the second part of the implementation of a new wizard based design for the provider interface invite new user flow. It follows on from PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/2523

This PR covers persistence of new and existing users to the database following input via the wizard. It doesn't cover the review page and change feature. It's behind a providers_can_manage_users_and_permissions feature flag and not yet linked to the users index page.

## Changes proposed in this pull request

- [x] Added a new `ProviderInterface#SaveProviderUserService` to implement the logic to either create or update a provider user based on state of the form model (`ProviderUserInvitationWizard `)
- [x] Removed the `ProviderUserInvitationWizard#save!` method - controller interacts directly with services to do persistence.
- [x] Integrate the new service with the existing `SaveAndInviteProviderUser` and `InviteProviderUser` services to implement the `ProviderUsersInvitationsController#commit` action.
- [x] Extend new system spec to assert that user is created in the database and that they get an invitation email.

## Guidance to review

- To some extent `ProviderInterface#SaveProviderUserService` is repeating work done by the existing `SaveProviderUser` service. I looked at reusing that but it seemed too tightly coupled to other parts to work with the new wizard.
- To get `SaveAndInviteProviderUser` and `InviteProviderUser` to work with the new service I had to extend `InviteProviderUser` to accept the `provider_user` as an email address as well as a model. This seemed like the easiest way to keep the various bits reasonably decoupled.

## Link to Trello card

https://trello.com/c/BcoX8Mt9/2431-implement-the-provider-user-invitation-wizard

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
