### PR TITLE
Update GenerateTestApplications with full courses

### DIFF
--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -36,12 +36,7 @@ class GenerateTestApplications
       courses_to_apply_to: @courses_to_apply_to,
       states: states,
       apply_again: apply_again,
+      course_full: course_full,
     )
-
-    if course_full
-      application = ApplicationForm.last
-      choice = application.application_choices.first
-      choice.course.course_options.update_all(vacancy_status: 'no_vacancies')
-    end
   end
 end

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -13,6 +13,8 @@ class GenerateTestApplications
 
     create states: [:unsubmitted]
     create states: [:awaiting_references]
+    create states: [:unsubmitted], course_full: true
+    create states: [:awaiting_references], course_full: true
     create states: [:application_complete]
     create states: [:awaiting_provider_decision] * 3
     create states: [:offer] * 2
@@ -29,11 +31,17 @@ class GenerateTestApplications
     create states: [:awaiting_provider_decision], apply_again: true
   end
 
-  def create(states:, apply_again: false)
+  def create(states:, apply_again: false, course_full: false)
     @test_applications.create_application(
       courses_to_apply_to: @courses_to_apply_to,
       states: states,
       apply_again: apply_again,
     )
+
+    if course_full
+      application = ApplicationForm.last
+      choice = application.application_choices.first
+      choice.course.course_options.update_all(vacancy_status: 'no_vacancies')
+    end
   end
 end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe GenerateTestApplications do
     create(:course_option, course: create(:course, :open_on_apply))
   end
 
-  it 'generates 15 test candidates with applications in various states' do
+  it 'generates 18 test candidates with applications in various states' do
     GenerateTestApplications.new.perform
 
-    expect(Candidate.count).to be 16
+    expect(Candidate.count).to be 18
     expect(ApplicationChoice.pluck(:status)).to include(
+      'unsubmitted',
       'awaiting_provider_decision',
       'awaiting_references',
       'offer',
@@ -21,6 +22,10 @@ RSpec.describe GenerateTestApplications do
       'recruited',
       'enrolled',
     )
+    # there is at least one unsubmitted application to a full course
+    expect(ApplicationChoice.where(status: 'unsubmitted').any?(&:course_full?)).to eq true
+    # there is at least one awaiting_references application to a full course
+    expect(ApplicationChoice.where(status: 'awaiting_references').any?(&:course_full?)).to eq true
   end
 
   it 'does not notify Slack', sidekiq: true do


### PR DESCRIPTION

## Context

<!-- Why are you making this change? What might surprise someone about it? -->
To support user research by making it easier to test variants of the 'full courses' flow.

## Changes proposed in this pull request
Add code that ensures running #perform results in at least one:

- 'unsubmitted' application choice to a full course
- 'awaiting_references' application choice to a full course

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Navigate to `/support/applications/unavailable-choices`
- See the section titled `List of applications that are made to courses that no longer have vacancies`
- There should be at least one with status `Awaiting references` and at least one with status `Form started but unsubmitted`
- Sign in as either of these and navigate to course choices to see their respective 'course full' flows.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/x3SH17UD/1826-ur-courses-full

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
