### PR TITLE
Centralise `can_manage_users?` permission

### DIFF
--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -109,8 +109,7 @@ module ProviderInterface
     end
 
     def redirect_unless_permitted_to_manage_users
-      can_manage_users = ProviderPermissions.exists?(provider_user: current_provider_user, manage_users: true)
-      render_404 unless can_manage_users
+      render_404 unless current_provider_user.authorisation.can_manage_users?
     end
 
     def find_provider_user

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class ProviderUsersController < ProviderInterfaceController
-    before_action :require_feature_flag
-    before_action :redirect_unless_permitted_to_manage_users
+    before_action :require_feature_flag!
+    before_action :require_manage_user_permission!
 
     def index
       users = ProviderUser.includes(:providers).visible_to(current_provider_user)
@@ -104,11 +104,11 @@ module ProviderInterface
             .to_h
     end
 
-    def require_feature_flag
+    def require_feature_flag!
       render_404 unless FeatureFlag.active?(:providers_can_manage_users_and_permissions)
     end
 
-    def redirect_unless_permitted_to_manage_users
+    def require_manage_user_permission!
       render_404 unless current_provider_user.authorisation.can_manage_users?
     end
 

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -109,7 +109,7 @@ module ProviderInterface
     end
 
     def require_manage_user_permission!
-      render_404 unless current_provider_user.authorisation.can_manage_users?
+      render_404 unless current_provider_user.authorisation.can_manage_users_for_at_least_one_provider?
     end
 
     def find_provider_user

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -111,8 +111,7 @@ module ProviderInterface
     end
 
     def redirect_unless_permitted_to_manage_users
-      can_manage_users = ProviderPermissions.exists?(provider_user: current_provider_user, manage_users: true)
-      render_404 unless can_manage_users
+      render_404 unless current_provider_user.authorisation.can_manage_users?
     end
   end
 end

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class ProviderUsersInvitationsController < ProviderInterfaceController
-    before_action :require_feature_flag
-    before_action :redirect_unless_permitted_to_manage_users
+    before_action :require_feature_flag!
+    before_action :require_manage_user_permission!
 
     def edit_details
       @wizard = ProviderUserInvitationWizard.new(session, current_step: 'details')
@@ -106,11 +106,11 @@ module ProviderInterface
         .permit(provider_permissions: {})
     end
 
-    def require_feature_flag
+    def require_feature_flag!
       render_404 unless FeatureFlag.active?(:providers_can_manage_users_and_permissions)
     end
 
-    def redirect_unless_permitted_to_manage_users
+    def require_manage_user_permission!
       render_404 unless current_provider_user.authorisation.can_manage_users?
     end
   end

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -111,7 +111,7 @@ module ProviderInterface
     end
 
     def require_manage_user_permission!
-      render_404 unless current_provider_user.authorisation.can_manage_users?
+      render_404 unless current_provider_user.authorisation.can_manage_users_for_at_least_one_provider?
     end
   end
 end

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -49,7 +49,7 @@ class NavigationItems
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 
-      if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.can_manage_users?
+      if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.authorisation.can_manage_users?
         items << NavigationItem.new('Users', provider_interface_provider_users_path, is_active(current_controller, 'provider_users'))
       end
 

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -49,7 +49,7 @@ class NavigationItems
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 
-      if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.authorisation.can_manage_users?
+      if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.authorisation.can_manage_users_for_at_least_one_provider?
         items << NavigationItem.new('Users', provider_interface_provider_users_path, is_active(current_controller, 'provider_users'))
       end
 

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -40,8 +40,8 @@ class ProviderUser < ActiveRecord::Base
     "#{first_name} #{last_name}" if first_name.present? && last_name.present?
   end
 
-  def can_manage_users?
-    provider_permissions.exists?(manage_users: true)
+  def authorisation
+    @authorisation ||= ProviderAuthorisation.new(actor: self)
   end
 
   def can_manage_organisations?

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -3,6 +3,13 @@ class ProviderAuthorisation
     @actor = actor
   end
 
+  def can_manage_users?
+    ProviderPermissions.exists?(
+      provider_user: @actor,
+      manage_users: true,
+    )
+  end
+
   def can_make_offer?(application_choice:, course_option_id:)
     OfferAuthorisation.new(actor: @actor).can_make_offer?(application_choice: application_choice, course_option_id: course_option_id)
   end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -3,7 +3,7 @@ class ProviderAuthorisation
     @actor = actor
   end
 
-  def can_manage_users?
+  def can_manage_users_for_at_least_one_provider?
     ProviderPermissions.exists?(
       provider_user: @actor,
       manage_users: true,

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -64,20 +64,6 @@ RSpec.describe ProviderUser, type: :model do
     end
   end
 
-  describe 'can_manage_users?' do
-    let(:provider_user) { create :provider_user, :with_provider }
-
-    it 'is false for users without the manage users permission' do
-      expect(provider_user.can_manage_users?).to be false
-    end
-
-    it 'is true for users with the manage users permission' do
-      provider_user.provider_permissions.first.update(manage_users: true)
-
-      expect(provider_user.can_manage_users?).to be true
-    end
-  end
-
   describe 'can_manage_organisations?' do
     let(:provider_user) { create :provider_user, :with_provider }
 

--- a/spec/queries/get_all_change_options_from_offered_option_spec.rb
+++ b/spec/queries/get_all_change_options_from_offered_option_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe GetAllChangeOptionsFromOfferedOption do
       course = course_option.course
       create(:course_option, :part_time, course: course)
 
-      expect(returned_hash[:available_study_modes]).to eq(%w[full_time part_time])
+      expect(returned_hash[:available_study_modes]).to match_array(%w[full_time part_time])
     end
 
     it 'includes all course options for current course (subject to study_mode)' do

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -13,18 +13,18 @@ RSpec.describe ProviderAuthorisation do
     end
   end
 
-  describe '#can_manage_users?' do
+  describe '#can_manage_users_for_at_least_one_provider?' do
     it 'is false for users without the manage users permission' do
       provider_user = create(:provider_user)
 
-      expect(described_class.new(actor: provider_user).can_manage_users?).to be false
+      expect(described_class.new(actor: provider_user).can_manage_users_for_at_least_one_provider?).to be false
     end
 
     it 'is true for users with the manage users permission for any organisation' do
       provider_user = create(:provider_user)
       create(:provider_permissions, provider_user: provider_user, manage_users: true)
 
-      expect(described_class.new(actor: provider_user).can_manage_users?).to be true
+      expect(described_class.new(actor: provider_user).can_manage_users_for_at_least_one_provider?).to be true
     end
   end
 

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe ProviderAuthorisation do
     end
   end
 
+  describe '#can_manage_users?' do
+    it 'is false for users without the manage users permission' do
+      provider_user = create(:provider_user)
+
+      expect(described_class.new(actor: provider_user).can_manage_users?).to be false
+    end
+
+    it 'is true for users with the manage users permission for any organisation' do
+      provider_user = create(:provider_user)
+      create(:provider_permissions, provider_user: provider_user, manage_users: true)
+
+      expect(described_class.new(actor: provider_user).can_manage_users?).to be true
+    end
+  end
+
   describe '#can_make_offer?' do
     let(:training_provider_user) { create(:provider_user, :with_provider, :with_make_decisions) }
     let(:training_provider) { training_provider_user.providers.first }


### PR DESCRIPTION
## Context

In our retro we discussed whether the `ProviderAuthorisation` class is now the source of truth for authorisation-related things. It isn't, but we thought it should be. This is a small refactor to start.

## Changes proposed in this pull request

We check if the user has "manage_users" permissions in 3 places. This PR centralises the usage into `ProviderAuthorisation`.

To make this easier, I've introduced a `ProviderUser#authorisation` shortcut to make it easier to query whether or not they have the correct permissions.

## Guidance to review

Does it make sense? Is `provider_user.authorisation` a good idea?

## Link to Trello card

https://trello.com/c/DqwdYmu1/335-we-dont-have-canviewapplication-in-provider-authorisation

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
