### PR TITLE
Hide Languages section of Personal Details when EFL is active

### DIFF
--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -21,9 +21,13 @@ module CandidateInterface
     end
 
     def rows
-      CandidateInterface::PersonalDetailsReviewPresenter
-        .new(personal_details_form: @personal_details_form, nationalities_form: @nationalities_form, languages_form: @languages_form, right_to_work_form: @right_to_work_or_study_form)
-        .rows
+      CandidateInterface::PersonalDetailsReviewPresenter.new(
+        personal_details_form: @personal_details_form,
+        nationalities_form: @nationalities_form,
+        languages_form: @languages_form,
+        application_form: @application_form,
+        right_to_work_form: @right_to_work_or_study_form,
+      ).rows
     end
 
     def show_missing_banner?

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -17,10 +17,13 @@ module CandidateInterface
 
         if @nationalities_form.save(current_application)
           current_application.update!(personal_details_completed: false)
+
           if FeatureFlag.active?('international_personal_details') && british_or_irish?
             redirect_to candidate_interface_personal_details_show_path
           elsif FeatureFlag.active?('international_personal_details')
             redirect_to candidate_interface_right_to_work_or_study_path
+          elsif LanguagesSectionPolicy.hide?(current_application)
+            redirect_to candidate_interface_personal_details_show_path
           else
             redirect_to candidate_interface_languages_path
           end

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -8,12 +8,8 @@ module CandidateInterface
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
-        @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
-        @personal_details_review = PersonalDetailsReviewPresenter.new(
-          personal_details_form: @personal_details_form,
-          nationalities_form: @nationalities_form,
-          languages_form: @languages_form,
-          right_to_work_form: @right_to_work_or_study_form,
+        @personal_details_review = PersonalDetailsReviewComponent.new(
+          application_form: current_application,
         )
       end
 
@@ -33,7 +29,7 @@ module CandidateInterface
           redirect_to candidate_interface_application_form_path
         elsif @personal_details_form.valid? &&
             @nationalities_form.valid? &&
-            @languages_form.valid?
+            (hiding_languages_section? || @languages_form.valid?)
 
           current_application.update!(application_form_params)
 
@@ -48,6 +44,10 @@ module CandidateInterface
       def application_form_params
         params.require(:application_form).permit(:personal_details_completed)
           .transform_values(&:strip)
+      end
+
+      def hiding_languages_section?
+        LanguagesSectionPolicy.hide?(current_application)
       end
     end
   end

--- a/app/services/languages_section_policy.rb
+++ b/app/services/languages_section_policy.rb
@@ -1,0 +1,9 @@
+class LanguagesSectionPolicy
+  def self.hide?(application_form)
+    FeatureFlag.active?(:efl_section) &&
+      (
+        application_form.application_choices.any?(&:unsubmitted?) ||
+        application_form.english_main_language.nil?
+      )
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We're adding an 'English as a foreign language' section to the
application form, visible to any candidate with a nationality other than
British and Irish. This has a lot of overlap with the existing Languages
page of the Personal Details section, so we should hide it if the EFL
feature is active.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
- Add an object which checks if we should hide the Languages page. This
  checks if the EFL feature is active, and if one of the following is
  true:
  * The application_form is unsubmitted
  * The application_form#english_main_language field is nil (ie - it's
    never been completed)
- Use this object to:
  * Skip the Languages page when filling in Personal Details
  * Hide the corresponding Review rows.
  * Allow the section to be marked complete even if the Languages data
    is missing.
## Guidance to review

- Enable efl_section feature flag
- Via support, go to an application that's unsubmitted
- Step through Personal Details, noting that it doesn't require you to complete the Languages page.

### Questions:

- Does this approach make sense? Is there a simpler alternative?
- Could we just rework the existing questions so that we don't necessarily need to hide that part of the form? Information about other languages the candidate speaks is one thing that the new EFL section doesn't cover, so we may want to preserve this somehow.
- What are the implications for the API? Is there anything that needs updating? 
- Do we need a migration strategy in place to eventually remove the DB fields related to this page? Is this something we'd even want to do?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/9fk7yluU

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
