### PR TITLE
Implement new checkbox structure for managing provider level permissions

### DIFF
--- a/app/components/provider_relationship_permissions_list.html.erb
+++ b/app/components/provider_relationship_permissions_list.html.erb
@@ -1,12 +1,12 @@
 <p class="govuk-!-margin-bottom-1 govuk-body">The following organisation(s) can make decisions:</p>
-<ul class="govuk-list">
+<ul class="govuk-list make-decisions">
   <% providers_that_can('make_decisions').each do |provider| %>
     <li><%= render CheckIcon.new %> <%= provider.name %> </li>
   <% end %>
 </ul>
 
 <p class="govuk-!-margin-bottom-1 govuk-body">The following organisation(s) can see safeguarding information:</p>
-<ul class="govuk-list">
+<ul class="govuk-list view-safeguarding-information">
   <% providers_that_can('view_safeguarding_information').each do |provider| %>
     <li><%= render CheckIcon.new %> <%= provider.name %> </li>
   <% end %>

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -1,0 +1,61 @@
+module ProviderInterface
+  class ProviderRelationshipPermissionsController < ProviderInterfaceController
+    before_action :render_404_unless_permissions_found
+    before_action :render_403_unless_access_permitted
+
+    def edit
+      initialize_form
+    end
+
+    def update
+      initialize_form
+
+      if @form.update!(provider_relationship_permissions_form_params)
+        flash[:success] = 'Permissions successfully changed'
+        redirect_to provider_interface_organisation_path(provider_relationship_permissions.training_provider)
+      else
+        flash[:warning] = 'Unable to save permissions, please try again. If problems persist please contact support.'
+        render :edit
+      end
+    end
+
+  private
+
+    def initialize_form
+      @form = ProviderRelationshipPermissionsForm.new(permissions: provider_relationship_permissions)
+    end
+
+    def provider_relationship_permissions
+      @provider_relationship_permissions ||= ProviderRelationshipPermissions.find_by(provider_relationship_params)
+    end
+
+    def provider_relationship_params
+      params.permit(:ratifying_provider_id, :training_provider_id).to_h
+    end
+
+    def provider_relationship_permissions_form_params
+      return {} unless params.key?(:provider_interface_provider_relationship_permissions_form)
+
+      params
+        .require(:provider_interface_provider_relationship_permissions_form)
+        .require(:permissions)
+        .permit(*ProviderRelationshipPermissions.permissions_fields)
+        .to_h
+    end
+
+    def provider_relationship_permissions_params
+      provider_relationship_permissions_form_params.fetch(:permissions, {})
+    end
+
+    def render_404_unless_permissions_found
+      render_404 if provider_relationship_permissions.blank?
+    end
+
+    def render_403_unless_access_permitted
+      training_provider = provider_relationship_permissions.training_provider
+
+      render_403 unless ProviderAuthorisation.new(actor: current_provider_user)
+        .can_manage_organisation?(provider: training_provider)
+    end
+  end
+end

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   class ProviderRelationshipPermissionsController < ProviderInterfaceController
     before_action :render_404_unless_permissions_found
     before_action :render_403_unless_access_permitted
+    attr_reader :permissions_model
 
     def edit
       @form = ProviderRelationshipPermissionsForm.new(permissions_model: permissions_model)
@@ -21,13 +22,6 @@ module ProviderInterface
 
   private
 
-    def permissions_model
-      ProviderRelationshipPermissions.find_by(
-        ratifying_provider_id: params[:ratifying_provider_id],
-        training_provider_id: params[:training_provider_id],
-      )
-    end
-
     def permissions_params
       return {} unless params.key?(:provider_interface_provider_relationship_permissions_form)
 
@@ -36,7 +30,9 @@ module ProviderInterface
     end
 
     def render_404_unless_permissions_found
-      render_404 if permissions_model.blank?
+      @permissions_model ||= ProviderRelationshipPermissions.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render_404
     end
 
     def render_403_unless_access_permitted

--- a/app/forms/provider_interface/provider_relationship_permissions_form.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_form.rb
@@ -1,0 +1,25 @@
+module ProviderInterface
+  class ProviderRelationshipPermissionsForm
+    include ActiveModel::Model
+
+    attr_accessor :permissions
+
+    def assign_permissions_attributes(attrs)
+      @permissions.assign_attributes(permissions_attributes(attrs))
+    end
+
+    def update!(attrs)
+      @permissions.update!(permissions_attributes(attrs))
+    end
+
+  private
+
+    def permissions_attributes(attrs)
+      {}.tap do |hash|
+        ProviderRelationshipPermissions.permissions_fields.each do |f|
+          hash[f] = attrs.fetch(f, false)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/provider_interface/provider_relationship_permissions_form.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_form.rb
@@ -2,23 +2,40 @@ module ProviderInterface
   class ProviderRelationshipPermissionsForm
     include ActiveModel::Model
 
-    attr_accessor :permissions
+    attr_accessor :permissions_model, :make_decisions, :view_safeguarding_information
+    delegate :errors, :training_provider, :ratifying_provider, to: :permissions_model
 
-    def assign_permissions_attributes(attrs)
-      @permissions.assign_attributes(permissions_attributes(attrs))
+    def initialize(attrs)
+      super(attrs)
+
+      @make_decisions ||= providers_currently_having_permission_to('make_decisions')
+      @view_safeguarding_information ||= providers_currently_having_permission_to('view_safeguarding_information')
     end
 
-    def update!(attrs)
-      @permissions.update!(permissions_attributes(attrs))
+    def save!
+      @permissions_model.assign_attributes(permissions_attributes_for_persistence)
+
+      if @permissions_model.valid?
+        @permissions_model.save!
+      end
     end
 
   private
 
-    def permissions_attributes(attrs)
-      {}.tap do |hash|
-        ProviderRelationshipPermissions.permissions_fields.each do |f|
-          hash[f] = attrs.fetch(f, false)
-        end
+    def permissions_attributes_for_persistence
+      %w[training ratifying].reduce({}) do |hash, role|
+        hash.merge({
+          "#{role}_provider_can_make_decisions" => @make_decisions.include?(role),
+          "#{role}_provider_can_view_safeguarding_information" => @view_safeguarding_information.include?(role),
+        })
+      end
+    end
+
+    def providers_currently_having_permission_to(permission)
+      %w[training ratifying].reduce([]) do |list, role|
+        list.push(role) if @permissions_model.send("#{role}_provider_can_#{permission}?")
+
+        list
       end
     end
   end

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -2,7 +2,7 @@ class ProviderRelationshipPermissions < ApplicationRecord
   belongs_to :ratifying_provider, class_name: 'Provider'
   belongs_to :training_provider, class_name: 'Provider'
 
-  PERMISSIONS = %w[make_decisions view_safeguarding_information].freeze
+  PERMISSIONS = %i[make_decisions view_safeguarding_information].freeze
 
   def training_provider_can_view_applications_only?
     PERMISSIONS.map { |permission| send("training_provider_can_#{permission}") }.all?(false)

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -19,7 +19,7 @@ private
   def at_least_one_active_permission_in_pair
     PERMISSIONS.each do |permission|
       if !send("training_provider_can_#{permission}") && !send("ratifying_provider_can_#{permission}")
-        errors.add(permission, "At least one organisation must have permission to #{permission.to_s.humanize.downcase}")
+        errors.add(permission, "Select which organisations can #{permission.to_s.humanize.downcase}")
       end
     end
   end

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -4,11 +4,23 @@ class ProviderRelationshipPermissions < ApplicationRecord
 
   PERMISSIONS = %i[make_decisions view_safeguarding_information].freeze
 
+  validate :at_least_one_active_permission_in_pair, if: -> { setup_at.present? }
+
   def training_provider_can_view_applications_only?
     PERMISSIONS.map { |permission| send("training_provider_can_#{permission}") }.all?(false)
   end
 
   def ratifying_provider_can_view_applications_only?
     PERMISSIONS.map { |permission| send("ratifying_provider_can_#{permission}") }.all?(false)
+  end
+
+private
+
+  def at_least_one_active_permission_in_pair
+    PERMISSIONS.each do |permission|
+      if !send("training_provider_can_#{permission}") && !send("ratifying_provider_can_#{permission}")
+        errors.add(permission, "At least one organisation must have permission to #{permission.to_s.humanize.downcase}")
+      end
+    end
   end
 end

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -22,10 +22,7 @@
       <%= render ProviderRelationshipPermissionsList.new(permissions) %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Change', provider_interface_edit_provider_relationship_permissions_path(
-          training_provider_id: permissions.training_provider.id,
-          ratifying_provider_id: permissions.ratifying_provider.id,
-        ) if current_provider_user.can_manage_organisations? %>
+        <%= govuk_link_to 'Change', provider_interface_edit_provider_relationship_permissions_path(permissions) if current_provider_user.can_manage_organisations? %>
       </p>
     <% end %>
   </div>

--- a/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
@@ -1,0 +1,58 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl">Change permissions</span>
+    <h1 class="govuk-heading-xl">
+      For courses run by <%= @form.permissions.training_provider.name %> and ratified by
+      <%= @form.permissions.ratifying_provider.name %>
+    </h1>
+    <div class="app-banner">
+      <div class="app-banner__message">
+        <p>All users at your organisation and ratifying organisation(s) will be able to view applications to these courses. You don’t need to set permissions for this.</p>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              More about permissions
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <h2 class="govuk-heading-m">Permission to make decisions</h2>
+            <p>You can allow this organisation to make offers, amend offers and reject applications.</p>
+
+            <h2 class="govuk-heading-m">Permission to see safeguarding information</h2>
+            <p>You can give this organisation access to information disclosed in:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>the ‘criminal convictions and professional misconduct’ section of the application, which may include highly sensitive material about the candidate</li>
+              <li>the ‘equality and diversity’ section of the application form</li>
+            </ul>
+          </div>
+        </details>
+      </div>
+    </div>
+
+    <%= form_with(
+      model: @form,
+      url: provider_interface_update_provider_relationship_permissions_path,
+      method: :patch
+    ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
+        <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">
+          <%= f.govuk_check_boxes_fieldset :permissions, legend: { text: t("provider_relationship_permissions.form.fieldset.#{permission_name}") } do %>
+            <%= f.fields_for :permissions, @form.permissions do |p| %>
+              <%= p.govuk_check_box "training_provider_can_#{permission_name}", true, multiple: false,
+                                    label: { text: @form.permissions.training_provider.name } %>
+
+              <%= p.govuk_check_box "ratifying_provider_can_#{permission_name}", true, multiple: false,
+                                    label: { text: @form.permissions.ratifying_provider.name } %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <button class="govuk-button" data-module="govuk-button">
+        Save permissions
+      </button>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
@@ -2,8 +2,8 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">Change permissions</span>
     <h1 class="govuk-heading-xl">
-      For courses run by <%= @form.permissions.training_provider.name %> and ratified by
-      <%= @form.permissions.ratifying_provider.name %>
+      For courses run by <%= @form.training_provider.name %> and ratified by
+      <%= @form.ratifying_provider.name %>
     </h1>
     <div class="app-banner">
       <div class="app-banner__message">
@@ -38,14 +38,13 @@
 
       <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
         <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">
-          <%= f.govuk_check_boxes_fieldset :permissions, legend: { text: t("provider_relationship_permissions.form.fieldset.#{permission_name}") } do %>
-            <%= f.fields_for :permissions, @form.permissions do |p| %>
-              <%= p.govuk_check_box "training_provider_can_#{permission_name}", true, multiple: false,
-                                    label: { text: @form.permissions.training_provider.name } %>
+          <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: t("provider_relationship_permissions.form.fieldset.#{permission_name}") } do %>
+            <%= hidden_field_tag "#{f.object_name}[#{permission_name}][]", '' %>
+            <%= f.govuk_check_box permission_name, 'training', link_errors: true,
+                                  label: { text: @form.training_provider.name } %>
 
-              <%= p.govuk_check_box "ratifying_provider_can_#{permission_name}", true, multiple: false,
-                                    label: { text: @form.permissions.ratifying_provider.name } %>
-            <% end %>
+            <%= f.govuk_check_box permission_name, 'ratifying',
+                                  label: { text: @form.ratifying_provider.name } %>
           <% end %>
         </div>
       <% end %>

--- a/config/locales/permissions.yml
+++ b/config/locales/permissions.yml
@@ -1,0 +1,6 @@
+en:
+  provider_relationship_permissions:
+    form:
+      fieldset:
+        make_decisions: Select which organisations can make decisions
+        view_safeguarding_information: Select which organisations can see safeguarding information

--- a/config/locales/permissions.yml
+++ b/config/locales/permissions.yml
@@ -2,5 +2,5 @@ en:
   provider_relationship_permissions:
     form:
       fieldset:
-        make_decisions: Select which organisations can make decisions
-        view_safeguarding_information: Select which organisations can see safeguarding information
+        make_decisions: Which organisations can make decisions?
+        view_safeguarding_information: Which organisations can see safeguarding information?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -574,13 +574,13 @@ Rails.application.routes.draw do
 
     get '/provider-relationship-permissions/setup' => 'provider_relationship_permissions#setup',
         as: :provider_relationship_permissions_setup
-    get '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id/success' => 'provider_relationship_permissions#success',
+    get '/provider-relationship-permissions/:id/success' => 'provider_relationship_permissions#success',
         as: :provider_relationship_permissions_success
-    get '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id/edit' => 'provider_relationship_permissions#edit',
+    get '/provider-relationship-permissions/:id/edit' => 'provider_relationship_permissions#edit',
         as: :edit_provider_relationship_permissions
-    patch '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id/confirm' => 'provider_relationship_permissions#confirm',
+    patch '/provider-relationship-permissions/:id/confirm' => 'provider_relationship_permissions#confirm',
           as: :confirm_provider_relationship_permissions
-    patch '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id' => 'provider_relationship_permissions#update',
+    patch '/provider-relationship-permissions/:id' => 'provider_relationship_permissions#update',
           as: :update_provider_relationship_permissions
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -326,6 +326,8 @@ FactoryBot.define do
   factory :provider_relationship_permissions do
     ratifying_provider { create(:provider) }
     training_provider { create(:provider) }
+    training_provider_can_make_decisions { true }
+    training_provider_can_view_safeguarding_information { true }
     setup_at { Time.zone.now }
   end
 

--- a/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderRelationshipPermissionsForm do
+  let(:permissions) { create(:provider_relationship_permissions) }
+
+  subject(:form) do
+    described_class.new(permissions: permissions)
+  end
+
+  describe '#assign_permissions_attributes' do
+    it 'assigns permissions attributes for accredited and training permissions' do
+      allow(permissions).to receive(:assign_attributes)
+
+      form.assign_permissions_attributes({ training_provider_can_view_safeguarding_information: 'true' })
+
+      expect(permissions).to have_received(:assign_attributes)
+        .with({
+          ratifying_provider_can_make_decisions: false,
+          training_provider_can_make_decisions: false,
+          ratifying_provider_can_view_safeguarding_information: false,
+          training_provider_can_view_safeguarding_information: 'true',
+        })
+    end
+  end
+
+  describe '#update!' do
+    let(:permissions_attrs) do
+      { ratifying_provider_can_make_decisions: 'true', training_provider_can_make_decisions: 'true' }
+    end
+
+    before do
+      allow(permissions).to receive(:update!).and_return(true)
+    end
+
+    it 'updates accredited and training provider permissions models' do
+      form.update!(permissions_attrs)
+
+      expect(permissions).to have_received(:update!)
+        .with({
+          ratifying_provider_can_make_decisions: 'true',
+          training_provider_can_make_decisions: 'true',
+          ratifying_provider_can_view_safeguarding_information: false,
+          training_provider_can_view_safeguarding_information: false,
+        })
+    end
+  end
+end

--- a/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
@@ -1,47 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderRelationshipPermissionsForm do
-  let(:permissions) { create(:provider_relationship_permissions) }
+  let(:permissions) { build_stubbed(:provider_relationship_permissions) }
+  let(:permissions_attrs) { {} }
 
   subject(:form) do
-    described_class.new(permissions: permissions)
+    described_class.new(permissions_attrs.merge(permissions_model: permissions))
   end
 
-  describe '#assign_permissions_attributes' do
-    it 'assigns permissions attributes for accredited and training permissions' do
-      allow(permissions).to receive(:assign_attributes)
-
-      form.assign_permissions_attributes({ training_provider_can_view_safeguarding_information: 'true' })
-
-      expect(permissions).to have_received(:assign_attributes)
-        .with({
-          ratifying_provider_can_make_decisions: false,
-          training_provider_can_make_decisions: false,
-          ratifying_provider_can_view_safeguarding_information: false,
-          training_provider_can_view_safeguarding_information: 'true',
-        })
-    end
-  end
-
-  describe '#update!' do
+  describe '#save!' do
     let(:permissions_attrs) do
-      { ratifying_provider_can_make_decisions: 'true', training_provider_can_make_decisions: 'true' }
+      { make_decisions: %w[ratifying training] }
     end
 
     before do
-      allow(permissions).to receive(:update!).and_return(true)
+      allow(permissions).to receive(:assign_attributes)
+      allow(permissions).to receive(:save!)
     end
 
     it 'updates accredited and training provider permissions models' do
-      form.update!(permissions_attrs)
+      form.save!
 
-      expect(permissions).to have_received(:update!)
+      expect(permissions).to have_received(:assign_attributes)
         .with({
-          ratifying_provider_can_make_decisions: 'true',
-          training_provider_can_make_decisions: 'true',
-          ratifying_provider_can_view_safeguarding_information: false,
-          training_provider_can_view_safeguarding_information: false,
+          'ratifying_provider_can_make_decisions' => true,
+          'training_provider_can_make_decisions' => true,
+          'ratifying_provider_can_view_safeguarding_information' => false,
+          'training_provider_can_view_safeguarding_information' => true,
         })
+
+      expect(permissions).to have_received(:save!)
     end
   end
 end

--- a/spec/models/provider_relationship_permissions_spec.rb
+++ b/spec/models/provider_relationship_permissions_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe ProviderRelationshipPermissions do
+end

--- a/spec/models/provider_relationship_permissions_spec.rb
+++ b/spec/models/provider_relationship_permissions_spec.rb
@@ -1,4 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe ProviderRelationshipPermissions do
+  describe 'validations' do
+    let(:setup_at) { Time.zone.now }
+
+    subject(:permissions) do
+      described_class.new(
+        ratifying_provider: build_stubbed(:provider),
+        training_provider: build_stubbed(:provider),
+        ratifying_provider_can_view_safeguarding_information: true,
+        setup_at: setup_at,
+      )
+    end
+
+    it 'ensures at least one permission in each pair is active' do
+      expect(permissions.valid?).to be false
+      expect(permissions.errors.keys).to eq(%i[make_decisions])
+    end
+
+    context 'when permissions have not been set up' do
+      let(:setup_at) { nil }
+
+      it 'skips validation' do
+        expect(permissions.valid?).to be true
+      end
+    end
+
+    context 'when at least one permission in each pair is active' do
+      it 'is a valid set of permissions' do
+        permissions.training_provider_can_make_decisions = true
+
+        expect(permissions.valid?).to be true
+      end
+    end
+  end
 end

--- a/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe 'ProviderRelationshipPermissions', type: :request do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  describe 'invalid provider relationship params' do
+    context 'GET edit' do
+      it 'responds with 404' do
+        get provider_interface_edit_provider_relationship_permissions_path(
+          ratifying_provider_id: 1,
+          training_provider_id: 1,
+        )
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'PATCH update' do
+      it 'responds with 404' do
+        patch provider_interface_update_provider_relationship_permissions_path(
+          ratifying_provider_id: 1,
+          training_provider_id: 1,
+        )
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe 'with a provider relationship not associated with the current user' do
+    let(:ratifying_provider) { create(:provider) }
+    let(:training_provider) { create(:provider) }
+
+    before do
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: training_provider,
+      )
+      provider_user.provider_permissions.update_all(manage_organisations: true)
+    end
+
+    context 'GET edit' do
+      it 'responds with 403 Forbidden' do
+        get provider_interface_edit_provider_relationship_permissions_path(
+          ratifying_provider_id: ratifying_provider.id,
+          training_provider_id: training_provider.id,
+        )
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    describe 'PATCH update' do
+      it 'responds with 403 Forbidden' do
+        patch provider_interface_update_provider_relationship_permissions_path(
+          ratifying_provider_id: ratifying_provider.id,
+          training_provider_id: training_provider.id,
+        )
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
@@ -18,13 +18,10 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
       )
   end
 
-  describe 'invalid provider relationship params' do
+  describe 'invalid provider relationship permissions param' do
     context 'GET edit' do
       it 'responds with 404' do
-        get provider_interface_edit_provider_relationship_permissions_path(
-          ratifying_provider_id: 1,
-          training_provider_id: 1,
-        )
+        get provider_interface_edit_provider_relationship_permissions_path(id: 666)
 
         expect(response.status).to eq(404)
       end
@@ -32,10 +29,7 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
 
     context 'PATCH update' do
       it 'responds with 404' do
-        patch provider_interface_update_provider_relationship_permissions_path(
-          ratifying_provider_id: 1,
-          training_provider_id: 1,
-        )
+        patch provider_interface_update_provider_relationship_permissions_path(id: 666)
 
         expect(response.status).to eq(404)
       end
@@ -46,21 +40,19 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
     let(:ratifying_provider) { create(:provider) }
     let(:training_provider) { create(:provider) }
 
-    before do
-      create(
+    let(:permissions) do
+      permissions = create(
         :provider_relationship_permissions,
         ratifying_provider: ratifying_provider,
         training_provider: training_provider,
       )
       provider_user.provider_permissions.update_all(manage_organisations: true)
+      permissions
     end
 
     context 'GET edit' do
       it 'responds with 403 Forbidden' do
-        get provider_interface_edit_provider_relationship_permissions_path(
-          ratifying_provider_id: ratifying_provider.id,
-          training_provider_id: training_provider.id,
-        )
+        get provider_interface_edit_provider_relationship_permissions_path(permissions)
 
         expect(response.status).to eq(403)
       end
@@ -68,10 +60,7 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
 
     describe 'PATCH update' do
       it 'responds with 403 Forbidden' do
-        patch provider_interface_update_provider_relationship_permissions_path(
-          ratifying_provider_id: ratifying_provider.id,
-          training_provider_id: training_provider.id,
-        )
+        patch provider_interface_update_provider_relationship_permissions_path(permissions)
 
         expect(response.status).to eq(403)
       end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -215,7 +215,6 @@ RSpec.describe ProviderAuthorisation do
           :provider_relationship_permissions,
           ratifying_provider: create(:provider),
           training_provider: training_provider,
-          training_provider_can_view_safeguarding_information: true,
         )
       end
 
@@ -226,7 +225,12 @@ RSpec.describe ProviderAuthorisation do
       end
 
       context 'the course training provider is not permitted, the course accredited provider is permitted' do
-        before { provider_relationship_permissions.update!(ratifying_provider_can_view_safeguarding_information: true) }
+        before do
+          provider_relationship_permissions.update!(
+            ratifying_provider_can_view_safeguarding_information: true,
+            training_provider_can_view_safeguarding_information: false,
+          )
+        end
 
         it { is_expected.to be false }
       end

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider to provider relationship permissions' do
+  include DfESignInHelpers
+
+  scenario 'Provider manages permissions for their organisation' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_permissions_feature_is_enabled
+    and_the_safeguarding_declaration_feature_flag_is_active
+    and_i_sign_in_to_the_provider_interface
+    and_i_can_manage_organisations_for_a_provider
+    and_the_provider_has_courses_ratified_by_another_provider
+    and_i_am_permitted_to_view_safeguarding_information
+    and_the_provider_has_an_open_application
+
+    when_i_view_the_application
+    then_i_should_not_see_the_safeguarding_declaration_section
+
+    when_i_visit_the_edit_provider_relationship_permissions_page
+    and_i_allow_my_training_provider_to_view_safeguarding_information
+
+    then_i_can_see_the_permissions_were_successfully_changed
+    and_i_can_see_the_training_provider_has_permission_to_view_safeguarding
+
+    when_i_view_the_application
+    then_i_should_see_the_safeguarding_declaration_section
+
+    when_i_visit_the_edit_provider_relationship_permissions_page
+    and_i_allow_the_ratifying_provider_to_view_safeguarding_information
+    and_i_deny_my_training_provider_permission_to_view_safeguarding_information
+
+    then_i_can_see_the_permissions_were_successfully_changed
+    and_i_can_see_the_ratifying_provider_has_permission_to_view_safeguarding
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def and_the_provider_permissions_feature_is_enabled
+    FeatureFlag.activate('enforce_provider_to_provider_permissions')
+  end
+
+  def and_the_safeguarding_declaration_feature_flag_is_active
+    FeatureFlag.activate('provider_view_safeguarding')
+  end
+
+  def and_i_can_manage_organisations_for_a_provider
+    @provider_user = ProviderUser.last
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
+    @training_provider = Provider.find_by(code: 'ABC')
+    @ratifying_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_i_am_permitted_to_view_safeguarding_information
+    @provider_user.provider_permissions.update_all(view_safeguarding_information: true)
+  end
+
+  def and_the_provider_has_courses_ratified_by_another_provider
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @training_provider,
+      setup_at: Time.zone.now,
+    )
+  end
+
+  def and_the_provider_has_an_open_application
+    @application_choice = create(
+      :application_choice,
+      status: :application_complete,
+      course_option: create(
+        :course_option,
+        course: create(:course, accredited_provider_id: @ratifying_provider.id, provider_id: @training_provider.id),
+      ),
+      reject_by_default_at: 20.days.from_now,
+      application_form: create(:application_form),
+    )
+
+    ApplicationStateChange.new(@application_choice).send_to_provider!
+  end
+
+  def when_i_view_the_application
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def then_i_should_not_see_the_safeguarding_declaration_section
+    expect(page).not_to have_content('Criminal convictions and professional misconduct')
+  end
+
+  def when_i_visit_the_edit_provider_relationship_permissions_page
+    visit provider_interface_edit_provider_relationship_permissions_path(
+      ratifying_provider_id: @ratifying_provider.id,
+      training_provider_id: @training_provider.id,
+    )
+  end
+
+  def and_i_allow_my_training_provider_to_view_safeguarding_information
+    expect(page).to have_content('Select which organisations can see safeguarding information')
+
+    within('.view-safeguarding-information') do
+      check @training_provider.name
+    end
+
+    click_on 'Save permissions'
+  end
+
+  def then_i_can_see_the_permissions_were_successfully_changed
+    expect(page).to have_content('Permissions successfully changed')
+  end
+
+  def and_i_can_see_the_training_provider_has_permission_to_view_safeguarding
+    expect(page).to have_content('The following organisation(s) can see safeguarding information:')
+
+    within(find('.view-safeguarding-information', match: :first)) do
+      expect(page).to have_content @training_provider.name
+      expect(page).not_to have_content @ratifying_provider.name
+    end
+  end
+
+  def when_i_confirm_the_permissions
+    click_on 'Save permissions'
+  end
+
+  def then_i_should_see_the_safeguarding_declaration_section
+    expect(page).to have_content('Criminal convictions and professional misconduct')
+  end
+
+  def and_i_allow_the_ratifying_provider_to_view_safeguarding_information
+    within(find('.view-safeguarding-information', match: :first)) do
+      check @ratifying_provider.name
+    end
+  end
+
+  def and_i_deny_my_training_provider_permission_to_view_safeguarding_information
+    within(find('.view-safeguarding-information', match: :first)) do
+      uncheck @training_provider.name
+    end
+
+    click_on 'Save permissions'
+  end
+
+  def and_i_can_see_the_ratifying_provider_has_permission_to_view_safeguarding
+    within(find('.view-safeguarding-information', match: :first)) do
+      expect(page).not_to have_content @training_provider.name
+      expect(page).to have_content @ratifying_provider.name
+    end
+  end
+end

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
   end
 
   def and_the_provider_has_courses_ratified_by_another_provider
-    create(
+    @permissions = create(
       :provider_relationship_permissions,
       ratifying_provider: @ratifying_provider,
       training_provider: @training_provider,
@@ -95,10 +95,7 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
   end
 
   def when_i_visit_the_edit_provider_relationship_permissions_page
-    visit provider_interface_edit_provider_relationship_permissions_path(
-      ratifying_provider_id: @ratifying_provider.id,
-      training_provider_id: @training_provider.id,
-    )
+    visit provider_interface_edit_provider_relationship_permissions_path(@permissions)
   end
 
   def and_i_allow_my_training_provider_to_view_safeguarding_information

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -153,6 +153,6 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
   end
 
   def then_i_can_see_a_validation_error_telling_me_to_assign_an_org_to_a_permission
-    expect(page).to have_content('At least one organisation must have permission to view safeguarding information')
+    expect(page).to have_content('Select which organisations can view safeguarding information')
   end
 end

--- a/spec/system/provider_interface/provider_cannot_respond_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_cannot_respond_to_application_spec.rb
@@ -77,6 +77,7 @@ RSpec.feature 'Provider cannot respond to application' do
   def and_my_organisation_is_not_permitted_to_make_decisions
     @provider_relationship.update(
       training_provider_can_make_decisions: false,
+      ratifying_provider_can_make_decisions: true,
     )
   end
 

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -44,6 +44,8 @@ RSpec.feature 'See organisation permissions' do
       :provider_relationship_permissions,
       ratifying_provider: @ratifying_provider,
       training_provider: @training_provider,
+      training_provider_can_make_decisions: false,
+      ratifying_provider_can_make_decisions: true,
       ratifying_provider_can_view_safeguarding_information: true,
       training_provider_can_view_safeguarding_information: false,
       setup_at: Time.zone.now,
@@ -66,7 +68,7 @@ RSpec.feature 'See organisation permissions' do
 
   def then_i_can_see_permissions_for_the_ratifying_provider
     expect(page).to have_content("For courses ratified by #{@ratifying_provider.name} and run by #{@training_provider.name}")
-    expect(page).to have_content("The following organisation(s) can see safeguarding information:\n#{@ratifying_provider.name}\nThe")
+    expect(page).to have_content("The following organisation(s) can see safeguarding information:\n#{@ratifying_provider.name}")
   end
 
   def and_i_can_see_permissions_for_the_training_provider
@@ -79,7 +81,7 @@ RSpec.feature 'See organisation permissions' do
 
   def then_i_can_see_permissions_for_the_training_provider
     expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
-    expect(page).to have_content("Provider\nThe following organisation(s) can only view applications:\n#{@training_provider.name}\nChange")
+    expect(page).to have_content("The following organisation(s) can only view applications:\n#{@training_provider.name}")
 
     expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(
       ratifying_provider_id: @ratifying_provider.id, training_provider_id: @training_provider.id,

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'See organisation permissions' do
   end
 
   def and_the_provider_has_courses_ratified_by_another_provider
-    create(
+    @permissions = create(
       :provider_relationship_permissions,
       ratifying_provider: @ratifying_provider,
       training_provider: @training_provider,
@@ -83,9 +83,7 @@ RSpec.feature 'See organisation permissions' do
     expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
     expect(page).to have_content("The following organisation(s) can only view applications:\n#{@training_provider.name}")
 
-    expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(
-      ratifying_provider_id: @ratifying_provider.id, training_provider_id: @training_provider.id,
-    ))
+    expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(@permissions))
   end
 
   def and_i_can_see_permissions_for_the_ratifying_provider


### PR DESCRIPTION
## Context

We've iterated the design for managing provider relationship permissions so that we group inputs by permission rather than provider.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Revives some of the provider relationship permissions UI temporarily removed in https://github.com/DFE-Digital/apply-for-teacher-training/pull/2520 but using the simpler single permissions model.

Reorganises the edit permissions form so that fields are grouped by permission.
<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/88079923-460c1d80-cb76-11ea-89f4-b54bcf8731ea.png)

#### Validating that at least one organisation has permission

![image](https://user-images.githubusercontent.com/93511/88188194-6815a680-cc2f-11ea-9651-13acd6ae8c05.png)


## Guidance to review

The bulk of the complexity in this PR is how we validate seemingly unrelated attributes on the `ProviderRelationshipPermissions` model as pairs of permissions. This makes for a slightly awkward params structure like:

```ruby
[
  { make_decisions: { training_provider_can_make_decisions: 'true', ratifying_provider_can_make_decisions: 'true' },
  { view_safeguarding_information: { ... },
}]
```
This allows us to highlight the correct fieldset in the form when no permissions have been selected.
The last few commits deal with validation so it might make sense to review as separate commits.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/g4jGI6XK/2457-implement-new-checkbox-structure-for-managing-provider-level-permissions

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
