### PR TITLE
Remove full stop on "Edit your application" page

### DIFF
--- a/app/views/candidate_interface/application_form/edit_by_support.html.erb
+++ b/app/views/candidate_interface/application_form/edit_by_support.html.erb
@@ -10,7 +10,7 @@
     <p class="govuk-body">You have until <%= edit_by_date %> to edit your application. You can only make changes once.</p>
     <p class="govuk-body">Email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %> to make changes.</p>
     <h2 class="govuk-heading-m">Changing your referees</h2>
-    <p class="govuk-body"><%= govuk_link_to 'You can change your referees from your application dashboard.', candidate_interface_application_complete_path %></p>
+    <p class="govuk-body"><%= govuk_link_to 'You can change your referees from your application dashboard', candidate_interface_application_complete_path %></p>
     <h2 class="govuk-heading-m">Change your personal information</h2>
     <p class="govuk-body">Email us anytime at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %> to change your personal information.</p>
   </div>


### PR DESCRIPTION
https://trello.com/c/GF4aIq4X/1856-remove-full-stop-from-link-text-on-editing-your-application-page
