### PR TITLE
Centralise query to figure out providers that the user has `manage_users` permissions for

### DIFF
--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -13,22 +13,16 @@ class ProviderPermissions < ActiveRecord::Base
 
   audited associated_with: :provider_user
 
-  scope :manage_users, -> { where(manage_users: true) }
   scope :manage_organisations, -> { where(manage_organisations: true) }
   scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
   scope :make_decisions, -> { where(make_decisions: true) }
 
   def self.possible_permissions(current_provider_user:, provider_user:)
-    provider_ids = current_provider_user
-      .provider_permissions
-      .manage_users
-      .includes(:provider)
-      .order('providers.name')
-      .pluck(:provider_id)
+    providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for.order(:name)
 
-    provider_ids.map do |id|
+    providers.map do |provider|
       find_or_initialize_by(
-        provider_id: id,
+        provider_id: provider.id,
         provider_user_id: provider_user&.id,
       )
     end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -11,10 +11,10 @@ class ProviderUser < ActiveRecord::Base
   has_associated_audits
 
   scope :visible_to, lambda { |provider_user|
-    providers_that_user_can_manage = provider_user.provider_permissions.manage_users.select(:provider_id)
+    providers_that_actor_can_manage_users_for = provider_user.authorisation.providers_that_actor_can_manage_users_for.select(:id)
 
     users_that_user_can_see = ProviderPermissions.where(
-      provider_id: providers_that_user_can_manage,
+      provider_id: providers_that_actor_can_manage_users_for,
     ).select(:provider_user_id)
 
     where(id: users_that_user_can_see)

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -3,6 +3,12 @@ class ProviderAuthorisation
     @actor = actor
   end
 
+  def providers_that_actor_can_manage_users_for
+    Provider.where(
+      id: @actor.provider_permissions.where(manage_users: true).select(:provider_id),
+    )
+  end
+
   def can_manage_users_for_at_least_one_provider?
     ProviderPermissions.exists?(
       provider_user: @actor,

--- a/app/services/remove_provider_user.rb
+++ b/app/services/remove_provider_user.rb
@@ -9,7 +9,7 @@ class RemoveProviderUser
   # Removes associations to providers common to the managing user
   # and the user we're editing/removing.
   def call!
-    managed_providers = current_provider_user.provider_permissions.manage_users.includes(:provider).map(&:provider)
+    managed_providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for
     shared_providers = managed_providers & user_to_remove.providers
     user_to_remove.providers -= shared_providers
     user_to_remove.save!

--- a/spec/services/save_provider_user_spec.rb
+++ b/spec/services/save_provider_user_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SaveProviderUser do
     it 'adds permissions flags for the saved user' do
       result = service.call!
 
-      expect(result.provider_permissions.manage_users.map(&:provider)).to eq([another_provider])
+      expect(result.authorisation.providers_that_actor_can_manage_users_for).to eq([another_provider])
     end
   end
 end


### PR DESCRIPTION
## Context

Refactor to tidy up how we deal with permissions. Similar to https://github.com/DFE-Digital/apply-for-teacher-training/pull/2543/files.

## Changes proposed in this pull request

This query exists in some form in 3 places. This centralises it into the `ProviderAuthorisation` class, because that's the place that should know about permission-related things.

Also removes the `manage_users` scope because I think it's clearer to read `provider_permissions.where(manage_users: true)` instead of `provider_permissions.manage_users`.

## Guidance to review

A better name would be nice!

## Link to Trello card

https://trello.com/c/k4LxRi4u

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
