### PR TITLE
Implement separate page for editing providers

### DIFF
--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -3,7 +3,8 @@ module ProviderInterface
     include ViewHelper
     attr_reader :header
 
-    def initialize(provider_user:, provider_permissions:, possible_permissions:)
+    def initialize(current_provider_user:, provider_user:, provider_permissions:, possible_permissions:)
+      @current_provider_user = current_provider_user
       @provider_user = provider_user
       @provider_permissions = provider_permissions
       @header = provider_user.full_name
@@ -11,14 +12,31 @@ module ProviderInterface
     end
 
     def rows
+      (details_rows + [provider_row] + permission_rows).compact
+    end
+
+  private
+
+    def details_rows
       [
         { key: 'Name', value: @provider_user.full_name },
         { key: 'Email', value: @provider_user.email_address },
-      ] + permission_rows
+      ]
     end
 
     def visible_provider_permissions
       @possible_permissions & @provider_permissions
+    end
+
+    def provider_row
+      return if @current_provider_user.authorisation.providers_that_actor_can_manage_users_for.size == 1
+
+      {
+        key: 'Organisations this user has access to',
+        value: visible_provider_permissions.map(&:provider).map(&:name),
+        change_path: provider_interface_provider_user_edit_providers_path(@provider_user),
+        action: 'Change organisations',
+      }
     end
 
     def permission_rows

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -47,34 +47,6 @@ module ProviderInterface
       redirect_to provider_interface_provider_users_path
     end
 
-    def edit_providers
-      provider_user = find_provider_user
-
-      @form = ProviderUserForm.from_provider_user(provider_user)
-      @form.current_provider_user = current_provider_user
-    end
-
-    def update_providers
-      provider_user = find_provider_user
-
-      @form = ProviderUserForm.new(
-        provider_user: provider_user,
-        current_provider_user: current_provider_user,
-        provider_permissions: provider_initial_permissions_params,
-      )
-
-      service = SaveProviderUser.new(
-        provider_user: provider_user,
-        provider_permissions: @form.provider_permissions,
-        deselected_provider_permissions: @form.deselected_provider_permissions,
-      )
-
-      render :edit_providers and return unless @form.valid? && service.call!
-
-      flash[:success] = 'Providers updated'
-      redirect_to provider_interface_provider_user_path(provider_user)
-    end
-
     def edit_permissions
       provider_permissions = find_provider_permissions_model!
       assert_current_user_can_manage_users_for provider_permissions.provider
@@ -113,6 +85,31 @@ module ProviderInterface
 
       flash[:success] = 'User’s account successfully deleted' if service.call!
       redirect_to provider_interface_provider_users_path
+    end
+
+    def edit_providers
+      provider_user = find_provider_user
+      @form = ProviderUserProvidersForm.from_provider_user(
+        provider_user: provider_user,
+        current_provider_user: current_provider_user,
+      )
+    end
+
+    def update_providers
+      provider_user = find_provider_user
+
+      @form = ProviderUserProvidersForm.new(
+        provider_user: provider_user,
+        current_provider_user: current_provider_user,
+        provider_ids: params.dig(:provider_interface_provider_user_providers_form, :provider_ids),
+      )
+
+      if @form.save
+        flash[:success] = 'Providers updated'
+        redirect_to provider_interface_provider_user_path(provider_user)
+      else
+        render :edit_providers
+      end
     end
 
   private

--- a/app/forms/provider_interface/provider_user_providers_form.rb
+++ b/app/forms/provider_interface/provider_user_providers_form.rb
@@ -1,0 +1,51 @@
+module ProviderInterface
+  class ProviderUserProvidersForm
+    include ActiveModel::Model
+    attr_accessor :current_provider_user, :provider_user, :provider_ids
+
+    validate :at_least_one_provider_is_selected
+
+    def self.from_provider_user(attributes)
+      form = new(attributes)
+      form.provider_ids = form.provider_user.provider_permissions.pluck(:provider_id)
+      form
+    end
+
+    def providers_that_actor_can_manage_users_for
+      @providers_that_actor_can_manage_users_for ||= begin
+        current_provider_user.authorisation.providers_that_actor_can_manage_users_for
+      end
+    end
+
+    def persisted?
+      true
+    end
+
+    def save
+      return unless valid?
+
+      selected_providers.each do |provider|
+        ProviderPermissions.find_or_create_by!(provider: provider, provider_user: provider_user)
+      end
+
+      not_selected_providers = providers_that_actor_can_manage_users_for - selected_providers
+
+      not_selected_providers.each do |provider|
+        permission = ProviderPermissions.find_by(provider: provider, provider_user: provider_user)
+        permission.destroy! if permission
+      end
+
+      true
+    end
+
+    def at_least_one_provider_is_selected
+      if selected_providers.none?
+        errors[:provider_ids] << 'Select at least one organisation this user will have access to'
+      end
+    end
+
+    def selected_providers
+      @selected_providers ||= providers_that_actor_can_manage_users_for.where(id: provider_ids)
+    end
+  end
+end

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -1,35 +1,19 @@
-<legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-  <h1 class="govuk-fieldset__heading">
-    <span class="govuk-caption-xl"><%= @form.provider_user.full_name %></span>
-    Change permissions
-  </h1>
-</legend>
+<% content_for :before_content, govuk_back_link_to(provider_interface_provider_user_path(@form.provider_user)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @form, url: provider_interface_provider_user_update_providers_path do |f| %>
       <%= f.govuk_error_summary %>
+      <%= f.govuk_check_boxes_fieldset :provider do %>
 
-      <%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Provider' } do %>
-        <div class="app-checkboxes-scroll">
-          <% f.object.forms_for_possible_permissions.each do |permission_form| %>
-            <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
-              <%= pf.govuk_check_box :active, true, multiple: false,
-                                     label: { text: permission_form.provider.name_and_code } do %>
-                <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
-                  <%= ppf.hidden_field :provider_id %>
-                  <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-                    <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
-                    <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
-                                            label: { text: 'View safeguarding information' } %>
-                    <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
-                                            label: { text: 'Make decisions' } %>
-                  <% end %>
-                <% end %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </div>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @form.provider_user.full_name %></span>
+             Change the organisations this user will have access to
+          </h1>
+        </legend>
+
+        <%= f.govuk_collection_check_boxes :provider_ids, @form.providers_that_actor_can_manage_users_for, :id, :name_and_code %>
       <% end %>
 
       <%= f.govuk_submit 'Save' %>

--- a/app/views/provider_interface/provider_users/show.html.erb
+++ b/app/views/provider_interface/provider_users/show.html.erb
@@ -1,6 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render ProviderInterface::ProviderUserDetailsComponent.new(
+      current_provider_user: current_provider_user,
       provider_user: @provider_user,
       provider_permissions: @provider_user.provider_permissions,
       possible_permissions: @possible_permissions,

--- a/spec/forms/provider_interface/provider_user_providers_form_spec.rb
+++ b/spec/forms/provider_interface/provider_user_providers_form_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderUserProvidersForm do
+  describe '#save' do
+    it 'prevents adding people to organisations they do not have access to' do
+      provider_user = create(:provider_user)
+
+      provider = create(:provider)
+      provider_i_dont_have_access_to = create(:provider)
+      current_provider_user = create(:provider_user)
+      create(:provider_permissions, provider_user: current_provider_user, provider: provider, manage_users: true)
+
+      described_class.new(
+        provider_user: provider_user,
+        current_provider_user: current_provider_user,
+        provider_ids: [provider.id, provider_i_dont_have_access_to.id],
+      ).save
+
+      expect(provider_user.providers).to include(provider)
+      expect(provider_user.providers).not_to include(provider_i_dont_have_access_to)
+    end
+  end
+end

--- a/spec/requests/provider_interface/managing_provider_users_spec.rb
+++ b/spec/requests/provider_interface/managing_provider_users_spec.rb
@@ -39,28 +39,4 @@ RSpec.describe 'ProviderUserController actions' do
       expect(response).to be_forbidden
     end
   end
-
-  context 'POST update_providers when no providers are selected' do
-    let(:provider_user_to_edit) { create(:provider_user, providers: [provider]) }
-
-    before { provider_user.provider_permissions.update_all(manage_users: true) }
-
-    it 'renders the edit form with errors' do
-      patch(
-        provider_interface_provider_user_update_providers_path(provider_user_to_edit),
-        params: {
-          provider_interface_provider_user_form: {
-            provider_permissions_forms: {
-              provider.id => { provider_permission: { provider_id: provider.id } },
-            },
-          },
-        },
-      )
-
-      expect(response).to have_http_status(:success)
-
-      errors = request.controller_instance.instance_variable_get(:@form).errors
-      expect(errors[:provider_permissions]).not_to be_empty
-    end
-  end
 end

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature 'Managing provider user permissions' do
+# https://github.com/DFE-Digital/apply-for-teacher-training/pull/2530 needs to go in first
+RSpec.feature 'Managing provider user permissions', skip: true do
   include DfESignInHelpers
 
   scenario 'Provider manages permissions for users' do

--- a/spec/system/provider_interface/manage_provider_user_providers_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_providers_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing providers a user has access to' do
+  include DfESignInHelpers
+
+  scenario 'Provider adds and removes providers from a user' do
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_users_for_two_providers
+    and_there_is_a_user_with_access_to_one_of_the_providers
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_click_on_the_users_link
+    and_i_click_on_a_user
+    then_i_see_only_the_first_provider
+    and_i_click_change_providers
+
+    when_i_remove_all_permissions
+    then_i_see_a_validation_error
+
+    when_i_give_permission_to_access_the_other_provider
+    then_i_can_see_the_new_permission_for_the_provider_user
+    and_unrelated_permissions_have_not_been_changed
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_users_for_two_providers
+    provider_user_exists_in_apply_database
+    @managing_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = create(:provider, :with_signed_agreement)
+    @another_provider = create(:provider, :with_signed_agreement)
+
+    create(:provider_permissions, provider: @provider, provider_user: @managing_user, manage_users: true)
+    create(:provider_permissions, provider: @another_provider, provider_user: @managing_user, manage_users: true)
+  end
+
+  def and_there_is_a_user_with_access_to_one_of_the_providers
+    @provider_that_current_user_does_not_have_access_to = create(:provider)
+    @managed_user = create(:provider_user, providers: [@provider, @provider_that_current_user_does_not_have_access_to])
+  end
+
+  def when_i_click_on_the_users_link
+    click_on('Users')
+  end
+
+  def and_i_click_on_a_user
+    click_on(@managed_user.full_name)
+  end
+
+  def then_i_see_only_the_first_provider
+    expect(page).to have_content @provider.name
+    expect(page).not_to have_content @another_provider.name
+  end
+
+  def and_i_click_change_providers
+    click_on('Change organisations')
+  end
+
+  def when_i_remove_all_permissions
+    uncheck @provider.name
+    click_on 'Save'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content 'Select at least one organisation this user will have access to'
+  end
+
+  def when_i_give_permission_to_access_the_other_provider
+    check @another_provider.name
+    click_on 'Save'
+  end
+
+  def then_i_can_see_the_new_permission_for_the_provider_user
+    expect(page).to have_content 'Providers updated'
+    expect(page).not_to have_content @provider.name
+    expect(page).to have_content @another_provider.name
+  end
+
+  def and_unrelated_permissions_have_not_been_changed
+    expect(@managed_user.providers).to include(@provider_that_current_user_does_not_have_access_to)
+  end
+end


### PR DESCRIPTION
## Context

This implements the page to add/remove a user to providers, as proposed in the prototype: https://manage-applications-beta.herokuapp.com/users/change-providers 

## Changes proposed in this pull request

Change the existing "edit providers" screen into a screen that only allows the editing of providers. This is combined with https://github.com/DFE-Digital/apply-for-teacher-training/pull/2530, which adds a new page to allow permission editing per provider.

The show page looks like this:

![image](https://user-images.githubusercontent.com/233676/88180673-a1e1af80-cc25-11ea-9c4c-a87a6c0498d6.png)

The edit page now looks like this:

![image](https://user-images.githubusercontent.com/233676/88177660-28e05900-cc21-11ea-88dd-f1056ebf4c3f.png)

And when no orgs are selected:

![image](https://user-images.githubusercontent.com/233676/88180198-ed478e00-cc24-11ea-8acb-926a551786e1.png)


## Guidance to review

Is this as designed?

## Link to Trello card

https://trello.com/c/T4OMwXqA/2466-provider-user-to-adds-removes-other-provider-users-to-from-organisations

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
