### PR TITLE
Add provider-provider permissions to permissions list component

### DIFF
--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -8,11 +8,55 @@
   <% end %>
 
   <% if @permission_model.make_decisions? %>
-    <li><%= render CheckIcon.new %><span class="govuk-!-font-weight-bold">Make decisions</span></li>
+    <li>
+      <%= render CheckIcon.new %><span class="govuk-!-font-weight-bold">Make decisions</span>
+      <% if training_providers_that_can('make_decisions').any? %>
+        <div class="govuk-!-margin-left-5">
+          Applies to courses run by:
+          <ul class="govuk-list">
+            <% training_providers_that_can('make_decisions').each do |provider| %>
+              <li><%= render CheckIcon.new %> <%= provider.name %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+      <% if ratifying_providers_that_can('make_decisions').any? %>
+        <div class="govuk-!-margin-left-5">
+          Applies to courses ratified by:
+          <ul class="govuk-list">
+            <% ratifying_providers_that_can('make_decisions').each do |provider| %>
+              <li><%= render CheckIcon.new %> <%= provider.name %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </li>
   <% end %>
 
   <% if @permission_model.view_safeguarding_information? %>
-    <li><%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">View safeguarding information</span></li>
+    <li>
+      <%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">View safeguarding information</span>
+      <% if training_providers_that_can('view_safeguarding_information').any? %>
+        <div class="govuk-!-margin-left-5">
+          Applies to courses run by:
+          <ul class="govuk-list">
+            <% training_providers_that_can('view_safeguarding_information').each do |provider| %>
+              <li><%= render CheckIcon.new %> <%= provider.name %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+      <% if ratifying_providers_that_can('view_safeguarding_information').any? %>
+        <div class="govuk-!-margin-left-5">
+          Applies to courses ratified by:
+          <ul class="govuk-list">
+            <% ratifying_providers_that_can('view_safeguarding_information').each do |provider| %>
+              <li><%= render CheckIcon.new %> <%= provider.name %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </li>
   <% end %>
 
   <% if @permission_model.view_applications_only? %>

--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -1,21 +1,21 @@
 <ul class="govuk-list" id="provider-<%= @permission_model.provider.id %>-enabled-permissions">
   <% if @permission_model.manage_organisations? %>
-    <li><%= render CheckIcon.new %> Manage organisations</li>
+    <li><%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">Manage organisations</span></li>
   <% end %>
 
   <% if @permission_model.manage_users? %>
-    <li><%= render CheckIcon.new %> Manage users</li>
+    <li><%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">Manage users</span></li>
   <% end %>
 
   <% if @permission_model.make_decisions? %>
-    <li><%= render CheckIcon.new %> Make decisions</li>
+    <li><%= render CheckIcon.new %><span class="govuk-!-font-weight-bold">Make decisions</span></li>
   <% end %>
 
   <% if @permission_model.view_safeguarding_information? %>
-    <li><%= render CheckIcon.new %> View safeguarding information</li>
+    <li><%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">View safeguarding information</span></li>
   <% end %>
 
   <% if @permission_model.view_applications_only? %>
-    <li>View applications only</li>
+    <li><span class="govuk-!-font-weight-bold">View applications only</span></li>
   <% end %>
 </ul>

--- a/app/components/permissions_list.rb
+++ b/app/components/permissions_list.rb
@@ -2,4 +2,26 @@ class PermissionsList < ViewComponent::Base
   def initialize(permission_model)
     @permission_model = permission_model
   end
+
+  def training_providers_that_can(permission)
+    permissions_as_ratifying_provider.map do |permission_relationship|
+      permission_relationship.training_provider if permission_relationship.send("training_provider_can_#{permission}?")
+    end
+  end
+
+  def ratifying_providers_that_can(permission)
+    permissions_as_training_provider.map do |permission_relationship|
+      permission_relationship.ratifying_provider if permission_relationship.send("ratifying_provider_can_#{permission}?")
+    end
+  end
+
+private
+
+  def permissions_as_ratifying_provider
+    @permissions_as_ratifying_provider ||= ProviderRelationshipPermissions.where(ratifying_provider_id: @permission_model.provider.id)
+  end
+
+  def permissions_as_training_provider
+    @permissions_as_training_provider ||= ProviderRelationshipPermissions.where(training_provider_id: @permission_model.provider.id)
+  end
 end

--- a/spec/components/permissions_list_component_spec.rb
+++ b/spec/components/permissions_list_component_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe PermissionsList do
+  let(:ratifying_provider) { create(:provider) }
+  let(:training_provider) { create(:provider) }
+  let(:provider_relationship_permissions) do
+    create(:provider_relationship_permissions,
+           ratifying_provider: ratifying_provider,
+           training_provider: training_provider,
+           training_provider_can_make_decisions: true,
+           ratifying_provider_can_make_decisions: true)
+  end
+
   it 'renders permissions' do
     permission_model = create(:provider_permissions, manage_organisations: true)
     result = render_inline(described_class.new(permission_model))
@@ -18,5 +28,27 @@ RSpec.describe PermissionsList do
     expect(result.css('li').text).not_to include('Make manage users')
     expect(result.css('li').text).not_to include('Make decistions')
     expect(result.css('li').text).not_to include('View safeguarding information')
+  end
+
+  it 'renders ratifying providers who the permission also applies to' do
+    permission_model = create(:provider_permissions,
+                              provider: training_provider,
+                              make_decisions: true)
+    provider_relationship_permissions
+    result = render_inline(described_class.new(permission_model))
+
+    expect(result.text).to include('Applies to courses ratified by:')
+    expect(result.css('li').text).to include(ratifying_provider.name.to_s)
+  end
+
+  it 'renders training providers who the permission also applies to' do
+    permission_model = create(:provider_permissions,
+                              provider: ratifying_provider,
+                              make_decisions: true)
+    provider_relationship_permissions
+    result = render_inline(described_class.new(permission_model))
+
+    expect(result.text).to include('Applies to courses run by:')
+    expect(result.css('li').text).to include(training_provider.name.to_s)
   end
 end


### PR DESCRIPTION
## Context

The permissions on the provider account page and support user page also include provider/provider permissions, as seen on the prototype here: https://manage-applications-beta.herokuapp.com/account.

## Changes proposed in this pull request

Include provider-provider permissions in the permissions list component which is used on provider account page and on provider user page in support.

- Account page in Provider interface
<kbd><img width="437" alt="Screenshot 2020-07-22 at 12 16 02" src="https://user-images.githubusercontent.com/38078064/88179967-90e46e80-cc24-11ea-85e9-e4766cdd9992.png"></kbd>

- Provider users in Support interface
<kbd><img width="657" alt="Screenshot 2020-07-22 at 14 13 13" src="https://user-images.githubusercontent.com/38078064/88180747-c0e04180-cc25-11ea-8682-523ecfb62b58.png"></kbd>

## Guidance to review

- visit http://localhost:5000/provider/account
- visit http://localhost:5000/support/users/provider

## Link to Trello card

https://trello.com/c/XfqkmPRy/2460-add-provider-provider-permissions-to-the-individual-user-account-view-and-edit-screen

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
