### PR TITLE
Don't show users providers whose relationships they can't manage

### DIFF
--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -19,11 +19,11 @@ module ProviderInterface
   private
 
     def manageable_providers
-      @_manageable_providers ||= Provider.with_permissions_visible_to(current_provider_user)
+      @_manageable_providers ||= current_provider_user.authorisation.providers_that_actor_can_manage_organisations_for
     end
 
     def render_403_unless_organisation_valid_for_user
-      render_403 unless Provider.with_permissions_visible_to(current_provider_user).include?(provider)
+      render_403 unless manageable_providers.include?(provider)
     end
 
     def provider

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -45,7 +45,8 @@ class NavigationItems
 
       items = []
 
-      if current_provider_user.can_manage_organisations? && Provider.with_permissions_visible_to(current_provider_user).exists?
+      if current_provider_user.can_manage_organisations? && \
+          current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -43,7 +43,11 @@ class Provider < ApplicationRecord
       )
       .pluck(:ratifying_provider_id, :training_provider_id).flatten
 
-    where(id: provider_ids).order(:name)
+    manageable_provider_ids = ProviderPermissions
+      .where(provider_id: provider_ids, provider_user: provider_user, manage_organisations: true)
+      .pluck(:provider_id)
+
+    where(id: manageable_provider_ids).order(:name)
   end
 
   def users_with_make_decisions

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -33,23 +33,6 @@ class Provider < ApplicationRecord
       .where(ProviderPermissions.table_name => { provider_user_id: provider_user.id, manage_users: true })
   end
 
-  def self.with_permissions_visible_to(provider_user)
-    provider_ids = ProviderRelationshipPermissions
-      .where(training_provider: provider_user.providers)
-      .or(
-        ProviderRelationshipPermissions.where(
-          ratifying_provider_id: provider_user.providers,
-        ),
-      )
-      .pluck(:ratifying_provider_id, :training_provider_id).flatten
-
-    manageable_provider_ids = ProviderPermissions
-      .where(provider_id: provider_ids, provider_user: provider_user, manage_organisations: true)
-      .pluck(:provider_id)
-
-    where(id: manageable_provider_ids).order(:name)
-  end
-
   def users_with_make_decisions
     provider_users.merge provider_permissions.make_decisions
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -12,42 +12,6 @@ RSpec.describe Provider, type: :model do
     end
   end
 
-  describe '.with_permissions_visible_to' do
-    it 'scopes results to providers the given user can manage permissions for and which have relationships to manage' do
-      a_provider = create(:provider)
-      training_provider = create(:provider)
-      ratifying_provider = create(:provider)
-
-      provider_user = create(:provider_user, providers: [training_provider, ratifying_provider, a_provider])
-
-      # The user will have manage_organisations for this provider but it has
-      # no relationships so it should not be returned
-      ProviderPermissions.find_by(
-        provider_user: provider_user,
-        provider: a_provider,
-      ).update!(
-        manage_organisations: true,
-      )
-
-      # there is a relationship to manage between these two providers...
-      create(:provider_relationship_permissions,
-             training_provider: training_provider,
-             ratifying_provider: ratifying_provider)
-
-      # ...and the user has manage_organisations permissions for only one of them.
-      ProviderPermissions.find_by(
-        provider_user: provider_user,
-        provider: training_provider,
-      ).update!(
-        manage_organisations: true,
-      )
-
-      expect(described_class.with_permissions_visible_to(provider_user)).to eq(
-        [training_provider],
-      )
-    end
-  end
-
   describe '#onboarded?' do
     it 'depends on the presence of a signed Data sharing agreement' do
       provider_with_dsa = create(:provider, :with_signed_agreement)

--- a/spec/requests/provider_interface/see_organisations_pages_spec.rb
+++ b/spec/requests/provider_interface/see_organisations_pages_spec.rb
@@ -16,17 +16,7 @@ RSpec.describe 'Organisations', type: :request do
       )
   end
 
-  context 'when the provider is not associated with the current user' do
-    describe 'GET show' do
-      it 'responds with 403' do
-        get provider_interface_organisation_path(create(:provider))
-
-        expect(response.status).to eq(403)
-      end
-    end
-  end
-
-  context 'when the provider is a ratifies courses for a provider associated with the current user' do
+  context 'when another provider ratifies courses for a provider associated with the current user' do
     describe 'GET show' do
       let(:ratifying_provider) { create(:provider, :with_signed_agreement) }
 
@@ -36,10 +26,18 @@ RSpec.describe 'Organisations', type: :request do
           ratifying_provider: ratifying_provider,
           training_provider: provider,
         )
+
+        provider.provider_permissions.update_all(manage_organisations: true)
       end
 
-      it 'responds successfully' do
+      it 'trying to view the ratifying provider gives 403' do
         get provider_interface_organisation_path(ratifying_provider)
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'trying to view the training provider gives 200' do
+        get provider_interface_organisation_path(provider)
 
         expect(response.status).to eq(200)
       end


### PR DESCRIPTION
## Context

Noticed while working on https://trello.com/c/N3Vdwg4X/2473-org-relationships-are-duplicated-on-the-organisationsshow-page, which will be fixed next.

This PR is about the "Organisations" section of Manage.

When you click on "Organisations", you see a list of providers.

This used to show all the providers you had access to who had relationships to manage AND all the providers on the other side of those relationships.

This PR reduces the contents of that list to providers

1. that have relationships to manage
2. that the current user has manage_organisations permission for

For example, in the old world, you might have manage_organisations permission for provider A, who ratifies courses at providers B, C and D. You would see providers A, B, C, and D in the list of organisations. Clicking on B, C or D would show you each one's relationship with A. Clicking on A would show you all A's relationships (i.e. the same relationships, grouped under A).

After this PR, only provider A will appear in the list. **No information is hidden, it's just less duplicated**.

While we're here, follow #2543 and #2553 in moving permissions-related stuff inside `ProviderAuthorisation`.

## Changes proposed in this pull request

**Before**

![Screenshot 2020-07-22 at 15 26 46](https://user-images.githubusercontent.com/642279/88188820-41a43b00-cc30-11ea-8f39-57b2b89dfd17.png)

**After**

![Screenshot 2020-07-22 at 15 26 18](https://user-images.githubusercontent.com/642279/88188467-ce022e00-cc2f-11ea-9eeb-38ddd258bd18.png)

## Guidance to review

Does this make sense?

There's a bit of fudge where `providers_that_actor_can_manage_organisations_for` doesn't technically return that, it returns the providers _with organisational relationships_ that the actor can manage organisations for. But I think this is probably right nonetheless.

## Link to Trello card

Towards https://trello.com/c/N3Vdwg4X/2473-org-relationships-are-duplicated-on-the-organisationsshow-page

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [Xx] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
