### PR TITLE
use sslmod=require for database connection

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,3 +22,4 @@ test:
 
 production:
   <<: *default
+  sslmode: require


### PR DESCRIPTION
https://www.postgresql.org/docs/9.1/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS

## Context

## Changes proposed in this pull request
We have ssl enforced on the server, use the require mode on client as well.
use `sslmode=require`

## Guidance to review


## Link to Trello card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
