### PR TITLE
Add provider-provider permissions to the edit page

### DIFF
--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -26,13 +26,14 @@
                           label: { text: 'Manage users' },
                           hint_text: 'Invite or delete users and set their permissions' %>
 
+    <%= f.govuk_check_box :make_decisions, true, multiple: false,
+                          label: { text: 'Make decisions' },
+                          hint_text: 'Make offers, amend offers and reject applications' %>
+
     <%= f.govuk_check_box :view_safeguarding_information, true, multiple: false,
                           label: { text: 'View safeguarding information' },
                           hint_text: 'View sensitive material about the candidate' %>
 
-    <%= f.govuk_check_box :make_decisions, true, multiple: false,
-                          label: { text: 'Make decisions' },
-                          hint_text: 'Make offers, amend offers and reject applications' %>
   <% end %>
   <%= f.govuk_submit 'Save' %>
 <% end %>

--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -29,11 +29,51 @@
     <%= f.govuk_check_box :make_decisions, true, multiple: false,
                           label: { text: 'Make decisions' },
                           hint_text: 'Make offers, amend offers and reject applications' %>
+    <% if training_providers_that_can('make_decisions').any? %>
+      <div class="govuk-!-margin-left-9">
+        <p class="govuk-body govuk-!-margin-bottom-1">Applies to courses run by:</p>
+        <ul class="govuk-list">
+          <% training_providers_that_can('make_decisions').each do |provider| %>
+            <li><%= render CheckIcon.new %> <%= provider.name %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <% if ratifying_providers_that_can('make_decisions').any? %>
+      <div class="govuk-!-margin-left-9">
+        <p class="govuk-body govuk-!-margin-bottom-1">Applies to courses ratified by:</p>
+        <ul class="govuk-list">
+          <% ratifying_providers_that_can('make_decisions').each do |provider| %>
+            <li><%= render CheckIcon.new %> <%= provider.name %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
     <%= f.govuk_check_box :view_safeguarding_information, true, multiple: false,
                           label: { text: 'View safeguarding information' },
                           hint_text: 'View sensitive material about the candidate' %>
-
+    <% if training_providers_that_can('view_safeguarding_information').any? %>
+      <div class="govuk-!-margin-left-8">
+        <p class="govuk-body govuk-!-margin-bottom-1">Applies to courses run by:</p>
+        <ul class="govuk-list">
+          <% training_providers_that_can('view_safeguarding_information').each do |provider| %>
+            <li><%= render CheckIcon.new %> <%= provider.name %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <% if ratifying_providers_that_can('view_safeguarding_information').any? %>
+      <div class="govuk-!-margin-left-9">
+        <p class="govuk-body govuk-!-margin-bottom-1">Applies to courses ratified by:</p>
+        <ul class="govuk-list">
+          <% ratifying_providers_that_can('view_safeguarding_information').each do |provider| %>
+            <li><%= render CheckIcon.new %> <%= provider.name %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
   <% end %>
+
   <%= f.govuk_submit 'Save' %>
 <% end %>

--- a/app/components/provider_interface/edit_provider_user_permissions_component.rb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.rb
@@ -7,5 +7,27 @@ module ProviderInterface
     def initialize(form:)
       @permissions_form = form
     end
+
+    def training_providers_that_can(permission)
+      permissions_as_ratifying_provider.map do |permission_relationship|
+        permission_relationship.training_provider if permission_relationship.send("training_provider_can_#{permission}?")
+      end
+    end
+
+    def ratifying_providers_that_can(permission)
+      permissions_as_training_provider.map do |permission_relationship|
+        permission_relationship.ratifying_provider if permission_relationship.send("ratifying_provider_can_#{permission}?")
+      end
+    end
+
+  private
+
+    def permissions_as_ratifying_provider
+      @permissions_as_ratifying_provider ||= ProviderRelationshipPermissions.where(ratifying_provider_id: permissions_form.provider.id)
+    end
+
+    def permissions_as_training_provider
+      @permissions_as_training_provider ||= ProviderRelationshipPermissions.where(training_provider_id: permissions_form.provider.id)
+    end
   end
 end


### PR DESCRIPTION
## Changes proposed in this pull request

| Before | After |
| ------------- | ------------- |
|<img width="413" alt="Screenshot 2020-07-23 at 09 56 08" src="https://user-images.githubusercontent.com/38078064/88268757-d9eefe00-ccca-11ea-8872-e8d0bd566e64.png">| <img width="413" alt="Screenshot 2020-07-23 at 09 59 08" src="https://user-images.githubusercontent.com/38078064/88269030-3ce09500-cccb-11ea-8aff-9bdd853660b9.png">|

## Guidance to review

- visit User edit page

## Link to Trello card

https://trello.com/c/ygSVGvI5/2481-add-provider-provider-permissions-to-edit-view

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
