### PR TITLE
Deal with nil values when listing provider-provider permissions

### DIFF
--- a/app/components/permissions_list.rb
+++ b/app/components/permissions_list.rb
@@ -4,15 +4,15 @@ class PermissionsList < ViewComponent::Base
   end
 
   def training_providers_that_can(permission)
-    permissions_as_ratifying_provider.map do |permission_relationship|
+    permissions_as_ratifying_provider.map { |permission_relationship|
       permission_relationship.training_provider if permission_relationship.send("training_provider_can_#{permission}?")
-    end
+    }.compact
   end
 
   def ratifying_providers_that_can(permission)
-    permissions_as_training_provider.map do |permission_relationship|
+    permissions_as_training_provider.map { |permission_relationship|
       permission_relationship.ratifying_provider if permission_relationship.send("ratifying_provider_can_#{permission}?")
-    end
+    }.compact
   end
 
 private

--- a/app/components/provider_interface/edit_provider_user_permissions_component.rb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.rb
@@ -9,15 +9,15 @@ module ProviderInterface
     end
 
     def training_providers_that_can(permission)
-      permissions_as_ratifying_provider.map do |permission_relationship|
+      permissions_as_ratifying_provider.map { |permission_relationship|
         permission_relationship.training_provider if permission_relationship.send("training_provider_can_#{permission}?")
-      end
+      }.compact
     end
 
     def ratifying_providers_that_can(permission)
-      permissions_as_training_provider.map do |permission_relationship|
+      permissions_as_training_provider.map { |permission_relationship|
         permission_relationship.ratifying_provider if permission_relationship.send("ratifying_provider_can_#{permission}?")
-      end
+      }.compact
     end
 
   private


### PR DESCRIPTION
## Context

Minor fix for https://github.com/DFE-Digital/apply-for-teacher-training/pull/2567 I didn't review in time.

The component breaks because `map` can return nils.

## Changes proposed in this pull request

Use `.compact`.

## Guidance to review

Difficult to review, requires the setup of provider-provider relationships in a rails console.

## Link to Trello card

https://trello.com/c/ygSVGvI5/2481-add-provider-provider-permissions-to-edit-view

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
