### PR TITLE
Reintroduce Languages to international_personal_details flow

### DIFF
--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -17,9 +17,7 @@ module CandidateInterface
 
         if @nationalities_form.save(current_application)
           current_application.update!(personal_details_completed: false)
-          if FeatureFlag.active?('international_personal_details') && british_or_irish?
-            redirect_to candidate_interface_personal_details_show_path
-          elsif FeatureFlag.active?('international_personal_details')
+          if FeatureFlag.active?('international_personal_details') && !british_or_irish?
             redirect_to candidate_interface_right_to_work_or_study_path
           else
             redirect_to candidate_interface_languages_path
@@ -40,12 +38,10 @@ module CandidateInterface
 
         if @nationalities_form.save(current_application)
           current_application.update!(personal_details_completed: false)
-          if FeatureFlag.active?('international_personal_details') && british_or_irish?
-            redirect_to candidate_interface_personal_details_show_path
-          elsif FeatureFlag.active?('international_personal_details')
-            redirect_to candidate_interface_right_to_work_or_study_path
+          if FeatureFlag.active?('international_personal_details') && !british_or_irish?
+            redirect_to candidate_interface_edit_right_to_work_or_study_path
           else
-            redirect_to candidate_interface_languages_path
+            redirect_to candidate_interface_personal_details_show_path
           end
         else
           track_validation_error(@nationalities_form)

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -26,17 +26,15 @@ module CandidateInterface
         if FeatureFlag.active?('international_personal_details') &&
             @personal_details_form.valid? &&
             @nationalities_form.valid? &&
-            @right_to_work_or_study_form.valid?
-
+            @right_to_work_or_study_form.valid? &&
+            @languages_form.valid?
           current_application.update!(application_form_params)
-
           redirect_to candidate_interface_application_form_path
         elsif @personal_details_form.valid? &&
             @nationalities_form.valid? &&
             @languages_form.valid?
 
           current_application.update!(application_form_params)
-
           redirect_to candidate_interface_application_form_path
         else
           render :show

--- a/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
         @right_to_work_or_study_form = RightToWorkOrStudyForm.new(right_to_work_params)
 
         if @right_to_work_or_study_form.save(current_application)
-          redirect_to candidate_interface_personal_details_show_path
+          redirect_to candidate_interface_languages_path
         else
           track_validation_error(@right_to_work_or_study_form)
           render :new

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -228,6 +228,11 @@ module CandidateInterface
       incomplete_qualifications.blank?
     end
 
+    def display_efl_link?
+      @application_form.nationalities.present? &&
+        !@application_form.english_speaking_nationality?
+    end
+
   private
 
     def show_review_volunteering?

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -11,24 +11,20 @@ module CandidateInterface
     end
 
     def rows
+      assembled_rows = [
+        name_row,
+        date_of_birth_row,
+        nationality_row,
+      ]
+
       if FeatureFlag.active?('international_personal_details')
-        [
-          name_row,
-          date_of_birth_row,
-          nationality_row,
-          right_to_work_row,
-        ]
-        .compact
-      else
-        [
-          name_row,
-          date_of_birth_row,
-          nationality_row,
-          english_main_language_row,
-          language_details_row,
-        ]
-          .compact
+        assembled_rows << right_to_work_row
       end
+
+      assembled_rows << english_main_language_row
+      assembled_rows << language_details_row
+
+      assembled_rows.compact
     end
 
   private

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -147,7 +147,7 @@
         ) %>
       </li>
       <% if FeatureFlag.active? :efl_section %>
-        <% unless @application_form.english_speaking_nationality? %>
+        <% if @application_form_presenter.display_efl_link? %>
           <li class="app-task-list__item">
             <%= render(
               TaskListItemComponent.new(

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -207,38 +207,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       end
     end
 
-    context 'when the international personal details feature flag is on' do
-      before do
-        FeatureFlag.activate('international_personal_details')
-      end
-
-      it 'does not render english language details row' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'no',
-          english_language_details: 'Broken? Oh man, are you cereal?',
-          other_language_details: 'Anything',
-        )
-
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
-          row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
-
-      it 'does not render other language details row' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'no',
-          english_language_details: 'Broken? Oh man, are you cereal?',
-          other_language_details: 'Anything',
-        )
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
-          row_for(:other_language_details, 'Anything', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
-    end
-
-    context 'when the when the international personal details flag is on and the candidate has selected they have the right to work' do
+    context 'when the international personal details flag is on and the candidate has selected they have the right to work' do
       before do
         FeatureFlag.activate('international_personal_details')
       end
@@ -260,7 +229,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       end
     end
 
-    context 'when the when the international personal details flag is the candidate is British or Irish' do
+    context 'when the international personal details flag is on and the candidate is British or Irish' do
       before do
         FeatureFlag.activate('international_personal_details')
       end

--- a/spec/support/test_helpers/efl_helper.rb
+++ b/spec/support/test_helpers/efl_helper.rb
@@ -3,22 +3,24 @@ module EFLHelper
     FeatureFlag.activate(:efl_section)
   end
 
-  def and_i_declare_a_non_english_speaking_nationality
+  def when_i_declare_a_non_english_nationality
+    current_candidate.current_application.update(
+      first_nationality: 'Hong Konger',
+      second_nationality: 'Pakistani',
+    )
     visit candidate_interface_application_form_path
-    click_link 'Personal details'
-    candidate_fills_in_personal_details
-    click_link 'Personal details'
-    click_link 'Change nationality'
-    select 'Hong Konger', from: 'Nationality'
-    select 'Pakistani', from: 'Second nationality'
-    click_button 'Save and continue'
-    click_button 'Save and continue'
-    check t('application_form.completed_checkbox')
-    click_button 'Continue'
+  end
+
+  def when_i_click_on_the_efl_section_link
+    click_link efl_link_text
+  end
+
+  def and_i_declare_a_non_english_speaking_nationality
+    when_i_declare_a_non_english_nationality
   end
 
   def and_i_click_on_the_efl_section_link
-    click_link efl_link_text
+    when_i_click_on_the_efl_section_link
   end
 
   def efl_link_text

--- a/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'View EFL form' do
   include CandidateHelper
+  include EFLHelper
 
   scenario 'Candidate navigates to EFL form' do
     given_i_am_signed_in
@@ -19,43 +20,17 @@ RSpec.feature 'View EFL form' do
     create_and_sign_in_candidate
   end
 
-  def and_the_efl_feature_flag_is_active
-    FeatureFlag.activate(:efl_section)
-  end
-
   def then_i_cannot_see_the_efl_section_link
+    visit candidate_interface_application_form_path
     expect(page).not_to have_link efl_link_text
   end
 
-  def when_i_declare_a_non_english_nationality
-    visit candidate_interface_application_form_path
-    click_link 'Personal details'
-    candidate_fills_in_personal_details
-    click_link 'Personal details'
-    click_link 'Change nationality'
-    select 'Hong Konger', from: 'Nationality'
-    select 'Pakistani', from: 'Second nationality'
-    click_button 'Save and continue'
-    click_button 'Save and continue'
-    check t('application_form.completed_checkbox')
-    click_button 'Continue'
-  end
-
   def then_i_can_see_the_efl_section_link
+    visit candidate_interface_application_form_path
     expect(page).to have_link efl_link_text
-  end
-
-  def when_i_click_on_the_efl_section_link
-    click_link efl_link_text
   end
 
   def then_i_see_the_efl_form
     expect(page).to have_content 'Do you have an English as a foreign language qualification?'
-  end
-
-private
-
-  def efl_link_text
-    'English as a foreign language'
   end
 end

--- a/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_personal_details_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Entering their personal details' do
     and_the_international_candidates_flag_is_active
     and_i_visit_the_site
 
+    # Entering details
     when_i_click_on_personal_details
     and_i_fill_in_some_details_but_omit_some_required_details
     and_i_submit_the_form
@@ -20,13 +21,19 @@ RSpec.feature 'Entering their personal details' do
 
     when_i_check_that_i_am_british
     and_i_submit_the_form
+    then_i_see_the_languages_page
+
+    when_i_choose_that_english_is_my_primary_language
+    and_i_submit_the_form
     then_i_see_the_personal_details_review_page
     and_i_can_check_my_answers
 
+    # Editing
     when_i_click_change_on_my_nationality
     and_i_uncheck_that_i_am_british
     and_i_check_that_i_am_irish
     and_i_submit_the_form
+
     then_i_see_the_personal_details_review_page
     and_i_see_my_updated_nationality
 
@@ -115,6 +122,19 @@ RSpec.feature 'Entering their personal details' do
     check 'British'
   end
 
+  def then_i_see_the_languages_page
+    expect(page).to have_current_path candidate_interface_languages_path
+  end
+
+  def when_i_choose_that_english_is_my_primary_language
+    choose 'Yes'
+    fill_in(
+      t('english_main_language.yes_label', scope: @scope),
+      with: "I'm great at Galactic Basic so English is a piece of cake",
+      match: :prefer_exact,
+    )
+  end
+
   def then_i_see_the_personal_details_review_page
     expect(page).to have_current_path candidate_interface_personal_details_show_path
   end
@@ -177,7 +197,9 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def then_i_see_the_right_to_work_or_study_page
-    expect(page).to have_current_path candidate_interface_right_to_work_or_study_path
+    within 'main h2' do
+      expect(page).to have_content 'Do you have the right to work or study in the UK?'
+    end
   end
 
   def and_i_choose_yes


### PR DESCRIPTION


## Context

<!-- Why are you making this change? What might surprise someone about it? -->
The `international_personal_details` feature flag currently ensures
that the Languages page of the Personal Details section is hidden. We
want responsibility for hiding Languages to be handled by the
`efl_section` feature instead.

Reasons:

- EFL is intended as the direct replacement for the Languages page,
  whereas `international_personal_details` is only tangentially related.
- Some pre-requisite work is required on the Vendor API before EFL goes
  live and Languages is hidden from candidates.  Decoupling
  `international_personal_details` from Languages means it can go live
  without waiting for that pre-requisite work.

## Changes proposed in this pull request


Rework the path helpers and feature flag checks to slot Languages in as
the last step of the Personal Details flow, whether or not `international_personal_details` is active.

Changes to make the `efl_section` flag hide Languages instead will appear in a separate PR.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/AsOuRv9u
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
