### PR TITLE
Simplify changed_offer email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -198,12 +198,11 @@ class CandidateMailer < ApplicationMailer
 
   def changed_offer(application_choice)
     @application_choice = application_choice
-    @previous_offer = @application_choice.course_option
-    @new_offer = @application_choice.offered_course_option
+    @course_option = @application_choice.course_option
 
     email_for_candidate(
       @application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.changed_offer.subject', provider_name: @previous_offer.course.provider.name),
+      subject: I18n.t!('candidate_mailer.changed_offer.subject', provider_name: @course_option.course.provider.name),
     )
   end
 

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -1,16 +1,8 @@
 Dear <%= @application_form.first_name %>,
 
-<%= @previous_offer.course.provider.name %> has changed the details of your offer.
+<%= @course_option.course.provider.name %> has changed the details of your offer.
 
-# Previous offer
-
-<%= @previous_offer.course.name_and_code %> at <%= @previous_offer.site.name %>
-
-# New offer
-
-<%= @new_offer.course.name_and_code %> at <%= @new_offer.site.name %> with <%= @new_offer.course.provider.name %>
-
-Contact <%= @previous_offer.course.provider.name %> directly if you have any questions about this.
+Contact <%= @course_option.course.provider.name %> directly if you have any questions about this.
 
 You can sign in to Apply for teacher training to check the status of your application(s):
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -242,8 +242,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       :changed_offer,
       'Neverland University changed the details of your offer',
       'heading' => 'Dear Tingker Bell',
-      'previous offer' => 'Flying (F1Y) at Peter School',
-      'new offer' => 'Fighting (F1G) at Pan School with Neverland University',
     )
   end
 end


### PR DESCRIPTION
## Context

If the conditions of the offer are changed, the email can be a bit confusing:

```
Mallowpond University has changed the details of your offer.

Previous offer
Business (XVNK) at Main site

New offer
Business (XVNK) at Main site
```

## Changes proposed in this pull request

Instead, don't include details about the previous and new offer in the email.

## Guidance to review

Check the review app `/rails/mailers/candidate_mailer/changed_offer`.

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
