### PR TITLE
Test data - create study mode and locations to choose from for full choices

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -44,7 +44,6 @@ class TestApplications
         # Always use the first n courses, so that we can reliably generate
         # application choices to full courses without randomly affecting the
         # vacancy status of the entire set of available courses.
-
         fill_vacancies(courses_to_apply_to.first(states.size))
       else
         courses_to_apply_to.sample(states.count)
@@ -84,6 +83,10 @@ class TestApplications
           application_form: @application_form,
           created_at: time,
         )
+      end
+
+      application_choices.each do |choice|
+        create_alternative_locations_and_study_mode(choice) if course_full && choice.awaiting_references?
       end
 
       return if states.include? :unsubmitted
@@ -319,5 +322,26 @@ class TestApplications
       end
     end
     courses
+  end
+
+  def create_alternative_locations_and_study_mode(choice)
+    alternate_study_mode = choice.course_option.full_time? ? :part_time : :full_time
+    course_option = CourseOption.find_by(site: choice.site, course: choice.course, study_mode: alternate_study_mode)
+
+    if course_option
+      course_option.vacancies!
+    else
+      choice.course.full_time_or_part_time!
+      CourseOption.create!(course: choice.course,
+                           site: choice.course_option.site,
+                           study_mode: alternate_study_mode,
+                           vacancy_status: :vacancies)
+    end
+    3.times do
+      CourseOption.create!(course: choice.course,
+                           study_mode: choice.course_option.study_mode,
+                           site: FactoryBot.create(:site, provider: choice.provider),
+                           vacancy_status: :vacancies)
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently, when we generate our test applications, we do not create an additional study mode/locations for the user to select from on the course choice full page.

A need for this arose during a user research session on full course choices.


## Changes proposed in this pull request

Before 

![image](https://user-images.githubusercontent.com/42515961/88392917-bdc78b80-cdb4-11ea-8a88-c9c6696cfa76.png)

After 

![image](https://user-images.githubusercontent.com/42515961/88392961-d46de280-cdb4-11ea-9667-c07ab76ce0bf.png)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
