### PR TITLE
Provider end of cycle comms page

### DIFF
--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -26,5 +26,9 @@ module ProviderInterface
     def covid_19_guidance
       render_content_page :covid_19_guidance
     end
+
+    def getting_ready_for_next_cycle
+      render_content_page :getting_ready_for_next_cycle
+    end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -18,7 +18,6 @@ class FeatureFlag
     [:dfe_sign_in_fallback, 'Use this when DfE Sign-in is down', 'Tijmen Brommet'],
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
-    [:summer_recruitment_banner, 'Displays an information banner related to RBD during the summer months', 'Michael Nacos'],
     [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to 2020 end-of-cycle with link to static page', 'Steve Hook'],
     [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
   ].freeze

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -19,6 +19,7 @@ class FeatureFlag
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
     [:summer_recruitment_banner, 'Displays an information banner related to RBD during the summer months', 'Michael Nacos'],
+    [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to 2020 end-of-cycle with link to static page', 'Steve Hook'],
     [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
   ].freeze
 

--- a/app/views/content/getting_ready_for_next_cycle.md
+++ b/app/views/content/getting_ready_for_next_cycle.md
@@ -49,9 +49,9 @@ Training providers will need to respond to all outstanding applications for the 
 
 ## Deferring offers
 
-The [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) team is working on a new feature allowing training providers to defer offers to the next cycle.
+The [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) team is working on a new feature allowing training providers to defer offers to the next cycle. We'll email you when the feature is ready to use.
 
-Deferrals can only be made at the request of the candidate.
+Please bear in mind that deferrals can only be made at the request of the candidate.
 
 You can:
 
@@ -61,9 +61,9 @@ You can:
 
 When the 2020 to 2021 cycle opens in mid-October, you’ll be guided through the process of checking and confirming deferred offers.
 
-### Changing the details of a deferred offer
+### Changing the details of a deferred offer when you check and confirm
 
-If you need to alter any details of a deferred offer – for example, the location, course or conditions – you should first explain and agree any changes with the candidate directly, via email or phone.
+You'll be able to change the details of a deferred offer when you check and confirm it at the start of the next cycle. If you need to alter any details – for example, the location, course or conditions – you should first explain and agree those changes with the candidate directly, via email or phone.
 
 You can then use [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) to send an amended offer to the candidate, who will also receive a formal notification.
 
@@ -79,7 +79,7 @@ By the end of November 2020, training providers will have access to and be able 
 
 * the previous cycle (2019 to 2020)
 * the current cycle (2020 to 2021)
-* the next cycle (for example, offers you defer to 2021 and to 2022)
+* the next cycle (for example, offers you defer until 2021 to 2022)
 
 Your notes and actions, including reasons for rejection, will be stored along with the application data so you can easily refer to them.
 

--- a/app/views/content/getting_ready_for_next_cycle.md
+++ b/app/views/content/getting_ready_for_next_cycle.md
@@ -1,0 +1,116 @@
+## 2020 dates for your diary
+
+### 1 July to 3 October
+Summer deadlines to respond to candidates: providers have 20 working days to respond before applications are automatically rejected.
+
+### 18 September
+The last date on which training providers will receive applications for the current cycle (2019 to 2020).
+
+### 3 October 2020
+Training providers must respond to all outstanding applications by 23.59pm on 3 October – all applications without a response will be rejected automatically.
+
+### Mid-October 2020
+The next training cycle (2020 to 2021) opens. We’ll inform you of the exact date nearer the time.
+
+## How we’re planning for a smooth transition
+
+The [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) and [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) teams are putting plans in place for a smooth transition from the current training cycle to the next.
+
+Training providers can be confident that:
+
+* all courses that were on [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) – and any new courses you create on [Publish teacher training](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) courses – will be available on Apply for the next cycle, unless you tell us otherwise
+* providers will be able to defer offers to candidates
+* application data will be stored and remain accessible in the next cycle
+* we’ll do all we can to help with data reporting
+
+
+We’ve covered these features in more detail below.
+
+For help and to give feedback at any time, contact us on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk).
+
+
+## Course rollover
+
+Our colleagues in [Publish teacher training courses](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) will, as usual, carry your courses over from this cycle to the next so they appear on [Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) in time for the opening of the 2020 to 2021 cycle in mid-October.
+
+(You should have an email from Publish with details about course rollover. Please get in touch with us on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk) if you have not received it.)
+
+All courses that were on Apply this cycle – and any new courses you create on [Publish teacher training courses](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) – will be available on Apply for the next cycle, unless you tell us otherwise.
+
+We’ll write to you again at the beginning of the next cycle to confirm your courses are going live on Apply for teaching training, so you’ll have the opportunity to make changes at this stage.
+
+
+## Closing the cycle
+
+DfE will close the current recruitment cycle on 3 October 2020. If your courses are full before that date, you are of course free to close your recruitment cycle earlier. You can do this by closing your courses on Find postgraduate teacher training using Publish teacher training courses.
+
+
+Training providers will need to respond to all outstanding applications by this date – any applications you have not responded to will be rejected automatically.
+
+
+## Deferring offers
+
+The Manage teacher training applications team is working on a new feature allowing training providers to defer offers to the next cycle.
+
+Deferrals must come at the request of the candidate.
+
+You can:
+* defer any offer that has been accepted by a candidate
+* defer at any point in the cycle
+* defer with conditions ‘pending’ or ‘met’
+
+When the 2020 to 2021 cycle opens in mid-October, you’ll be guided through the process of checking and confirming deferred offers.
+
+If you need to alter any details of the offer – for example, the location, course or conditions – you should explain and agree any changes with the candidate directly via email or phone.
+
+You can then use the service to send an amended offer to the candidate, who will also receive a formal notification.
+
+For the purposes of data reporting, deferred offers will not appear as rejected offers in the current cycle.  This will ensure you are able to submit accurate figures for rejections in each cycle.
+
+
+
+If you have to withdraw a deferred offer and cannot provide the candidate with an alternative, please contact us immediately on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk).
+
+
+## Storing and carrying over application data
+
+By the end of November 2020, training providers will have access to and be able to search application data relating to:
+
+
+* the previous cycle (2019 to 2020)
+* the current cycle (2020 to 2021)
+* the next cycle (for example, offers you defer to 2021 and to 2022)
+
+Your notes and actions, including reasons for rejection, will be stored along with the application data so you can easily refer to them.
+
+
+## Data reporting
+
+We understand that data reporting to both DTTP and HESA can be time-consuming.
+
+We’re now developing a feature allowing training providers to download their application data as a csv file. This should make this process easier – however we’ll continue to work on further improvements, and welcome all feedback.
+
+
+## Helping candidates apply again
+
+Where possible, candidates who were unsuccessful in the current cycle are strongly encouraged to apply again, through:
+
+
+* constructive feedback from training providers using the Manage teacher training service
+* supportive communications from the Apply for teacher training support team
+* allowing candidates to save and carry over their applications from the current cycle to the next
+
+
+## UCAS Teacher Training
+
+On UCAS, candidates will have slightly longer (until 6 September 2020) to submit applications to training providers before the cycle closes. We’ll let candidates know about this.
+
+More generally, UCAS will continue to run alongside Apply for teacher training for the 2020 to 2021 cycle.
+
+For the 2021 to 2022 cycle, Apply for teacher training will process all teacher training applications to all teacher training providers in England.
+
+Check [Using the Manage teacher training applications service](https://www.apply-for-teacher-training.education.gov.uk/provider/service-guidance) for more about the dual running of these 2 services.
+
+## Help and support
+
+Contact the support team at [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk).

--- a/app/views/content/getting_ready_for_next_cycle.md
+++ b/app/views/content/getting_ready_for_next_cycle.md
@@ -1,30 +1,30 @@
-## 2020 dates for your diary
+## Dates for your diary
 
-### 1 July to 3 October
+### 1 July to 3 October 2020
 Summer deadlines to respond to candidates: providers have 20 working days to respond before applications are automatically rejected.
 
-### 18 September
+### 18 September 2020
 The last date on which training providers will receive applications for the current cycle (2019 to 2020).
 
 ### 3 October 2020
-Training providers must respond to all outstanding applications by 23.59pm on 3 October – all applications without a response will be rejected automatically.
+Training providers must respond to all outstanding applications by 23.59pm on 3 October – any applications without a response will be rejected automatically.
 
 ### Mid-October 2020
 The next training cycle (2020 to 2021) opens. We’ll inform you of the exact date nearer the time.
 
 ## How we’re planning for a smooth transition
 
-The [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) and [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) teams are putting plans in place for a smooth transition from the current training cycle to the next.
+The [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) and [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) teams are putting plans in place for a smooth transition from this cycle to the next.
 
 Training providers can be confident that:
 
-* all courses that were on [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) – and any new courses you create on [Publish teacher training](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) courses – will be available on Apply for the next cycle, unless you tell us otherwise
-* providers will be able to defer offers to candidates
-* application data will be stored and remain accessible in the next cycle
-* we’ll do all we can to help with data reporting
+* all courses that are currently on [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) – and any new courses you publish – will be available for the next cycle, unless you tell us otherwise
+* you will be able to defer (and amend) offers to candidates
+* application data will be stored and remain accessible for the next cycle
+* we’ll do all we can to help with data reporting to the Higher Education Statistics Agency (HESA) and the Database of teacher trainees and providers (DTTP)
 
 
-We’ve covered these features in more detail below.
+We cover these features in more detail on this page.
 
 For help and to give feedback at any time, contact us on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk).
 
@@ -33,41 +33,41 @@ For help and to give feedback at any time, contact us on [becomingateacher@digit
 
 Our colleagues in [Publish teacher training courses](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) will, as usual, carry your courses over from this cycle to the next so they appear on [Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) in time for the opening of the 2020 to 2021 cycle in mid-October.
 
-(You should have an email from Publish with details about course rollover. Please get in touch with us on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk) if you have not received it.)
+(You should have an email from [Publish teacher training courses](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) with details about course rollover. Please get in touch with us on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk) if you have not received it.)
 
-All courses that were on Apply this cycle – and any new courses you create on [Publish teacher training courses](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) – will be available on Apply for the next cycle, unless you tell us otherwise.
+All courses that were on [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) this cycle – and any new courses you create on [Publish teacher training courses](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) – will be available on Apply for teacher training for the next cycle, unless you tell us otherwise.
 
-We’ll write to you again at the beginning of the next cycle to confirm your courses are going live on Apply for teaching training, so you’ll have the opportunity to make changes at this stage.
+We’ll write to you again at the beginning of the next cycle to confirm your courses are going live on [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate), so you’ll have the opportunity to make changes at this stage.
 
 
 ## Closing the cycle
 
-DfE will close the current recruitment cycle on 3 October 2020. If your courses are full before that date, you are of course free to close your recruitment cycle earlier. You can do this by closing your courses on Find postgraduate teacher training using Publish teacher training courses.
+The Department for Education (DfE) will close the current cycle on 3 October 2020. If your courses are full before that date, you are of course free to close your cycle earlier. Use [Publish teacher training courses](https://interactions.signin.education.gov.uk//cc4ac56f-35a9-4ec9-ae67-f0a1f5873db4/usernamepassword?clientid=bats2&redirect_uri=https://www.publish-teacher-training-courses.service.gov.uk/auth/dfe/callback) to close your courses.
 
-
-Training providers will need to respond to all outstanding applications by this date – any applications you have not responded to will be rejected automatically.
+Training providers will need to respond to all outstanding applications for the current cycle (2019 to 2020) by 3 October 2020. Any applications you have not responded to will be rejected automatically.
 
 
 ## Deferring offers
 
-The Manage teacher training applications team is working on a new feature allowing training providers to defer offers to the next cycle.
+The [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) team is working on a new feature allowing training providers to defer offers to the next cycle.
 
-Deferrals must come at the request of the candidate.
+Deferrals can only be made at the request of the candidate.
 
 You can:
+
 * defer any offer that has been accepted by a candidate
 * defer at any point in the cycle
 * defer with conditions ‘pending’ or ‘met’
 
 When the 2020 to 2021 cycle opens in mid-October, you’ll be guided through the process of checking and confirming deferred offers.
 
-If you need to alter any details of the offer – for example, the location, course or conditions – you should explain and agree any changes with the candidate directly via email or phone.
+### Changing the details of a deferred offer
 
-You can then use the service to send an amended offer to the candidate, who will also receive a formal notification.
+If you need to alter any details of a deferred offer – for example, the location, course or conditions – you should first explain and agree any changes with the candidate directly, via email or phone.
+
+You can then use [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) to send an amended offer to the candidate, who will also receive a formal notification.
 
 For the purposes of data reporting, deferred offers will not appear as rejected offers in the current cycle.  This will ensure you are able to submit accurate figures for rejections in each cycle.
-
-
 
 If you have to withdraw a deferred offer and cannot provide the candidate with an alternative, please contact us immediately on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk).
 
@@ -88,7 +88,7 @@ Your notes and actions, including reasons for rejection, will be stored along wi
 
 We understand that data reporting to both DTTP and HESA can be time-consuming.
 
-We’re now developing a feature allowing training providers to download their application data as a csv file. This should make this process easier – however we’ll continue to work on further improvements, and welcome all feedback.
+We’re now developing a feature allowing training providers to download their application data as a csv file. This should make this process easier – however we’ll continue to work on further improvements and welcome all feedback.
 
 
 ## Helping candidates apply again
@@ -96,7 +96,7 @@ We’re now developing a feature allowing training providers to download their a
 Where possible, candidates who were unsuccessful in the current cycle are strongly encouraged to apply again, through:
 
 
-* constructive feedback from training providers using the Manage teacher training service
+* your constructive feedback, using the Manage teacher training applications service
 * supportive communications from the Apply for teacher training support team
 * allowing candidates to save and carry over their applications from the current cycle to the next
 
@@ -105,7 +105,7 @@ Where possible, candidates who were unsuccessful in the current cycle are strong
 
 On UCAS, candidates will have slightly longer (until 6 September 2020) to submit applications to training providers before the cycle closes. We’ll let candidates know about this.
 
-More generally, UCAS will continue to run alongside Apply for teacher training for the 2020 to 2021 cycle.
+More generally, UCAS will continue to run alongside [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) for the 2020 to 2021 cycle.
 
 For the 2021 to 2022 cycle, Apply for teacher training will process all teacher training applications to all teacher training providers in England.
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -31,6 +31,21 @@
   </div>
 <% end %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="app-banner">
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
+          <%= govuk_link_to(
+            'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition',
+            provider_interface_getting_ready_for_next_cycle_path
+          ) %>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <div class='moj-filter-layout'>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -31,20 +31,22 @@
   </div>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="app-banner">
-      <div class="app-banner__message">
-        <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
-          <%= govuk_link_to(
-            'Getting ready for the next cycle: important dates and our plans for a smooth transition',
-            provider_interface_getting_ready_for_next_cycle_path
-          ) %>
-        </h2>
+<% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="app-banner">
+        <div class="app-banner__message">
+          <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
+            <%= govuk_link_to(
+              'Getting ready for the next cycle: important dates and our plans for a smooth transition',
+              provider_interface_getting_ready_for_next_cycle_path
+            ) %>
+          </h2>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>
 
 <h1 class='govuk-heading-xl'>Applications</h1>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -17,20 +17,6 @@
   </div>
 <% end %>
 
-<% if FeatureFlag.active?('summer_recruitment_banner') %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="app-banner" aria-labelledby="summer-recruitment-message" data-module="govuk-error-summary" role="alert">
-        <div class="app-banner__message">
-          <h2 class="govuk-heading-m" id="summer-recruitment-message">
-            Summer deadlines for reject by default: providers have 20 working days to respond to applications received between 1 July 2020 and 3 October 2020
-          </h2>
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>
-
 <% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -37,7 +37,7 @@
       <div class="app-banner__message">
         <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
           <%= govuk_link_to(
-            'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition',
+            'Getting ready for the next cycle: important dates and our plans for a smooth transition',
             provider_interface_getting_ready_for_next_cycle_path
           ) %>
         </h2>
@@ -71,4 +71,3 @@
     <%= render(PaginatorComponent.new(scope: @application_choices)) %>
   </div>
 </div>
-

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -39,7 +39,8 @@
           <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
             <%= govuk_link_to(
               'Getting ready for the next cycle: important dates and our plans for a smooth transition',
-              provider_interface_getting_ready_for_next_cycle_path
+              provider_interface_getting_ready_for_next_cycle_path,
+              class: 'govuk-link--no-visited-state',
             ) %>
           </h2>
         </div>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -3,9 +3,9 @@
 <% if FeatureFlag.active?('covid_19') %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+      <div class="app-banner" aria-labelledby="covid-message" data-module="govuk-error-summary" role="alert">
         <div class="app-banner__message">
-          <h2 class="govuk-heading-m" id="success-message">
+          <h2 class="govuk-heading-m" id="covid-message">
             <%= link_to 'Coronavirus (COVID-19): check our guidance to see new deadlines for processing applications',
               provider_interface_covid_19_guidance_path,
               class: 'govuk-link'
@@ -20,7 +20,7 @@
 <% if FeatureFlag.active?('summer_recruitment_banner') %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+      <div class="app-banner" aria-labelledby="summer-recruitment-message" data-module="govuk-error-summary" role="alert">
         <div class="app-banner__message">
           <h2 class="govuk-heading-m" id="summer-recruitment-message">
             Summer deadlines for reject by default: providers have 20 working days to respond to applications received between 1 July 2020 and 3 October 2020
@@ -34,7 +34,7 @@
 <% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <div class="app-banner">
+      <div class="app-banner" aria-labelledby="getting-ready-for-next-cycle-message">
         <div class="app-banner__message">
           <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
             <%= govuk_link_to(

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -54,7 +54,8 @@
         <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
           <%= govuk_link_to(
             'Getting ready for the next cycle: dates for your diary and our plans for a smooth transition',
-            provider_interface_getting_ready_for_next_cycle_path
+            provider_interface_getting_ready_for_next_cycle_path,
+            class: 'govuk-link--no-visited-state',
           ) %>
         </h2>
       </div>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -53,7 +53,7 @@
       <div class="app-banner__message">
         <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
           <%= govuk_link_to(
-            'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition',
+            'Getting ready for the next cycle: dates for your diary and our plans for a smooth transition',
             provider_interface_getting_ready_for_next_cycle_path
           ) %>
         </h2>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -48,6 +48,19 @@
 <% end %>
 
 <div class="govuk-width-container">
+  <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="summer-recruitment-message" >
+    <div class="app-banner__message">
+      <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
+        <%= govuk_link_to(
+          'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition',
+          provider_interface_getting_ready_for_next_cycle_path
+        ) %>
+      </h2>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-width-container">
   <section class="app-product-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -49,7 +49,7 @@
 
 <% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
   <div class="govuk-width-container">
-    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="summer-recruitment-message" >
+    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="getting-ready-for-next-cycle-message" >
       <div class="app-banner__message">
         <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
           <%= govuk_link_to(

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -47,18 +47,20 @@
   </div>
 <% end %>
 
-<div class="govuk-width-container">
-  <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="summer-recruitment-message" >
-    <div class="app-banner__message">
-      <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
-        <%= govuk_link_to(
-          'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition',
-          provider_interface_getting_ready_for_next_cycle_path
-        ) %>
-      </h2>
+<% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
+  <div class="govuk-width-container">
+    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="summer-recruitment-message" >
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m" id="getting-ready-for-next-cycle-message">
+          <%= govuk_link_to(
+            'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition',
+            provider_interface_getting_ready_for_next_cycle_path
+          ) %>
+        </h2>
+      </div>
     </div>
   </div>
-</div>
+<% end %>
 
 <div class="govuk-width-container">
   <section class="app-product-section">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -35,18 +35,6 @@
   </div>
 <% end %>
 
-<% if FeatureFlag.active?('summer_recruitment_banner') %>
-  <div class="govuk-width-container">
-    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="summer-recruitment-message" >
-      <div class="app-banner__message">
-        <h2 class="govuk-heading-m" id="summer-recruitment-message">
-          Summer deadlines for reject by default: providers have 20 working days to respond to applications received between 1 July 2020 and 3 October 2020
-        </h2>
-      </div>
-    </div>
-  </div>
-<% end %>
-
 <% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
   <div class="govuk-width-container">
     <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="getting-ready-for-next-cycle-message" >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     privacy_policy: How we look after your personal data
     terms_candidate: Terms of use
     service_guidance_provider: 'Using the Manage teacher training applications service: guidance for teacher training providers'
-    getting_ready_for_next_cycle: 'Getting ready for the next training cycle (2020 to 2021)'
+    getting_ready_for_next_cycle: 'Getting ready for the next cycle (2020 to 2021)'
     cookies_candidate: Cookies
     cookies_provider: Cookies
     contact_details: Contact details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     privacy_policy: How we look after your personal data
     terms_candidate: Terms of use
     service_guidance_provider: 'Using the Manage teacher training applications service: guidance for teacher training providers'
+    getting_ready_for_next_cycle: 'Getting ready for the next training cycle (2020 to 2021)'
     cookies_candidate: Cookies
     cookies_provider: Cookies
     contact_details: Contact details

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -521,6 +521,7 @@ Rails.application.routes.draw do
     get '/cookies', to: 'content#cookies_provider', as: :cookies
     get '/service-guidance', to: 'content#service_guidance_provider', as: :service_guidance
     get '/covid-19-guidance', to: 'content#covid_19_guidance', as: :covid_19_guidance
+    get '/getting-ready-for-next-cycle', to: 'content#getting_ready_for_next_cycle', as: :getting_ready_for_next_cycle
 
     get '/data-sharing-agreements/new', to: 'provider_agreements#new_data_sharing_agreement', as: :new_data_sharing_agreement
     post '/data-sharing-agreements', to: 'provider_agreements#create_data_sharing_agreement', as: :create_data_sharing_agreement

--- a/spec/system/provider_interface/providers_can_view_end_of_cycle_comms_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_end_of_cycle_comms_spec.rb
@@ -26,11 +26,11 @@ RSpec.feature 'Provider can view end-of-cycle comms' do
   end
 
   def then_i_see_a_link_to_the_end_of_cycle_comms_page
-    expect(page).to have_link 'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition'
+    expect(page).to have_link 'Getting ready for the next cycle: dates for your diary and our plans for a smooth transition'
   end
 
   def when_i_click_the_link_to_the_end_of_cycle_comms_page
-    click_link 'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition'
+    click_link 'Getting ready for the next cycle: dates for your diary and our plans for a smooth transition'
   end
 
   def then_i_see_the_end_of_cycle_comms_page
@@ -42,6 +42,6 @@ RSpec.feature 'Provider can view end-of-cycle comms' do
   end
 
   def then_i_dont_see_a_link_to_the_end_of_cycle_comms_page
-    expect(page).not_to have_link 'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition'
+    expect(page).not_to have_link 'Getting ready for the next cycle: dates for your diary and our plans for a smooth transition'
   end
 end

--- a/spec/system/provider_interface/providers_can_view_end_of_cycle_comms_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_end_of_cycle_comms_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider can view end-of-cycle comms' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'Provider can view end-of-cycle comms when feature flag is on' do
+    when_feature_flag_is_on
+    and_i_visit_the_provider_start_page
+    then_i_see_a_link_to_the_end_of_cycle_comms_page
+
+    when_i_click_the_link_to_the_end_of_cycle_comms_page
+    then_i_see_the_end_of_cycle_comms_page
+
+    when_feature_flag_is_off
+    and_i_visit_the_provider_start_page
+    then_i_dont_see_a_link_to_the_end_of_cycle_comms_page
+  end
+
+  def when_feature_flag_is_on
+    FeatureFlag.activate(:getting_ready_for_next_cycle_banner)
+  end
+
+  def and_i_visit_the_provider_start_page
+    visit provider_interface_path
+  end
+
+  def then_i_see_a_link_to_the_end_of_cycle_comms_page
+    expect(page).to have_link 'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition'
+  end
+
+  def when_i_click_the_link_to_the_end_of_cycle_comms_page
+    click_link 'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition'
+  end
+
+  def then_i_see_the_end_of_cycle_comms_page
+    expect(page).to have_content 'Getting ready for the next cycle (2020 to 2021)'
+  end
+
+  def when_feature_flag_is_off
+    FeatureFlag.deactivate(:getting_ready_for_next_cycle_banner)
+  end
+
+  def then_i_dont_see_a_link_to_the_end_of_cycle_comms_page
+    expect(page).not_to have_link 'Getting ready for the next training cycle: dates for your diary and our plans for a smooth transition'
+  end
+end


### PR DESCRIPTION
## Context

This PR adds a page of static content with information for providers about the end-of-cycle.

## Changes proposed in this pull request

- [x] `getting_ready_for_next_cycle_banner` feature flag to toggle the links to the new page.
- [x] Add link to Applications page (this needs a proper design review)
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/450843/88399940-81e5f380-cdbf-11ea-862d-174b997cb761.png">

- [x] Add link to Microsite
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/450843/88538646-9fa59980-d007-11ea-848d-aad140fde570.png">

- [x] Add static content page.
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/450843/88400015-9aeea480-cdbf-11ea-8459-a936f4f02b30.png">

## Guidance to review

- Has the content been converted to markdown correctly?
- What should the link on the applications page really look like?
- Should the banner/link on the applications page and microsite be feature flagged? Assuming yes after discussing with @laurahermionetennant92 so that it can be toggled just like the other informational banners.

## Link to Trello card

https://trello.com/c/t8uI2rDr/2489-implement-provider-end-of-cycle-comms-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
