### PR TITLE
Fix referee replacement double render error

### DIFF
--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
         @reference_type_form = Reference::RefereeTypeForm.build_from_reference(current_referee(@id))
       else
-        redirect_to_confirm_if_no_more_reference_needed
+        return if redirect_to_confirm_if_no_more_reference_needed
 
         @reference_type_form = Reference::RefereeTypeForm.new
       end
@@ -39,7 +39,7 @@ module CandidateInterface
     end
 
     def new
-      redirect_to_confirm_if_no_more_reference_needed
+      return if redirect_to_confirm_if_no_more_reference_needed
 
       @reference = current_candidate.current_application.application_references.build(referee_type: params[:type])
       @page_title = "Details of your new #{@reference.referee_type.downcase.dasherize} referee"
@@ -48,7 +48,8 @@ module CandidateInterface
     def show; end
 
     def create
-      redirect_to_confirm_if_no_more_reference_needed
+      return if redirect_to_confirm_if_no_more_reference_needed
+
       reference = current_application.application_references.build(referee_params.merge(replacement: true))
 
       reference.referee_type = params[:type]


### PR DESCRIPTION
## Context

We had a Sentry error come in from a user that triggered a double render error in the AdditionalRefereesController: https://sentry.io/organizations/dfe-bat/issues/1790159249/?project=1765973

This is because we call the `redirect_to_confirm_if_no_more_reference_needed` method, and return from its context, but don't return in the caller method.

This can lead to a `redirect_to` being run, with a follow-up `render` call later down.

## Changes proposed in this pull request

A solution is to `return if` the method returns something truthy.  The method returns nil or the value of `redirect_to`, which works well enough.

## Guidance to review

Because this occurs on a double submit, I've only tested it manually; how could we test it programatically? Request spec?

### Before

![Screen Recording 2020-07-24 at 14 25 24](https://user-images.githubusercontent.com/1650875/88408416-6da7f380-cdcb-11ea-9aba-99783c0dcf46.gif)

### After

![Screen Recording 2020-07-24 at 16 26 07](https://user-images.githubusercontent.com/1650875/88408487-8912fe80-cdcb-11ea-9967-8ddfa585d57b.gif)

## Link to Trello card

https://trello.com/c/JdKw5s7w/1861-fix-double-submit-error-when-submitting-referees

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)