### PR TITLE
Bug fix on referees controller to flow back to app if choice is deleted

### DIFF
--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class RefereesController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted, except: %i[confirm_cancel cancel]
     before_action :set_referee, only: %i[edit update confirm_destroy destroy confirm_cancel cancel]
+    before_action :redirect_to_dashboard_if_referee_destroyed, only: %i[confirm_destroy destroy]
     before_action :set_referees, only: %i[type update_type new create index review]
     before_action :set_nth_referee, only: %i[type new]
 
@@ -134,11 +135,15 @@ module CandidateInterface
 
   private
 
+    def redirect_to_dashboard_if_referee_destroyed
+      redirect_to candidate_interface_application_form_path unless @referee
+    end
+
     def set_referee
       @referee = current_candidate.current_application
                                     .application_references
                                     .includes(:application_form)
-                                    .find(params[:id])
+                                    .find_by(id: params[:id])
     end
 
     def set_referee_id


### PR DESCRIPTION
## Context

This is a bug fix to an error message that is received when navigating 'Back' via the browser. This specifically from the referee review screen, after a referee choice has just been deleted. Navigating backwards flows back to the 'confirm delete' view which is unable to render given that the db record no longer exists.

## Changes proposed in this pull request

I have altered the controller so that navigating back, after a deletion, from the referee review screen takes you to the application dashboard. This involve an alteration of an existing private method called by a before action and the addition of another.

## Guidance to review

It's worth going to the review app to replicate the behaviour as well as checking the code.

## Link to Trello card

https://trello.com/c/JJsVnJ0m/1588-back-button-after-deleting-a-reference-causes-a-server-error

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
