### PR TITLE
Hide Languages section of Personal Details when EFL is active

### DIFF
--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -21,9 +21,13 @@ module CandidateInterface
     end
 
     def rows
-      CandidateInterface::PersonalDetailsReviewPresenter
-        .new(personal_details_form: @personal_details_form, nationalities_form: @nationalities_form, languages_form: @languages_form, right_to_work_form: @right_to_work_or_study_form)
-        .rows
+      CandidateInterface::PersonalDetailsReviewPresenter.new(
+        personal_details_form: @personal_details_form,
+        nationalities_form: @nationalities_form,
+        languages_form: @languages_form,
+        application_form: @application_form,
+        right_to_work_form: @right_to_work_or_study_form,
+      ).rows
     end
 
     def show_missing_banner?

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -19,6 +19,8 @@ module CandidateInterface
           current_application.update!(personal_details_completed: false)
           if FeatureFlag.active?('international_personal_details') && !british_or_irish?
             redirect_to candidate_interface_right_to_work_or_study_path
+          elsif LanguagesSectionPolicy.hide?(current_application)
+            redirect_to candidate_interface_personal_details_show_path
           else
             redirect_to candidate_interface_languages_path
           end

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -8,12 +8,8 @@ module CandidateInterface
         @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @nationalities_form = NationalitiesForm.build_from_application(current_application)
         @languages_form = LanguagesForm.build_from_application(current_application)
-        @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(current_application)
-        @personal_details_review = PersonalDetailsReviewPresenter.new(
-          personal_details_form: @personal_details_form,
-          nationalities_form: @nationalities_form,
-          languages_form: @languages_form,
-          right_to_work_form: @right_to_work_or_study_form,
+        @personal_details_review = PersonalDetailsReviewComponent.new(
+          application_form: current_application,
         )
       end
 
@@ -32,7 +28,7 @@ module CandidateInterface
           redirect_to candidate_interface_application_form_path
         elsif @personal_details_form.valid? &&
             @nationalities_form.valid? &&
-            @languages_form.valid?
+            (hiding_languages_section? || @languages_form.valid?)
 
           current_application.update!(application_form_params)
           redirect_to candidate_interface_application_form_path
@@ -46,6 +42,10 @@ module CandidateInterface
       def application_form_params
         params.require(:application_form).permit(:personal_details_completed)
           .transform_values(&:strip)
+      end
+
+      def hiding_languages_section?
+        LanguagesSectionPolicy.hide?(current_application)
       end
     end
   end

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -2,11 +2,12 @@ module CandidateInterface
   class PersonalDetailsReviewPresenter
     include ActionView::Helpers::TagHelper
 
-    def initialize(personal_details_form:, nationalities_form:, languages_form:, right_to_work_form:, editable: true)
+    def initialize(personal_details_form:, nationalities_form:, languages_form:, right_to_work_form:, application_form:, editable: true)
       @personal_details_form = personal_details_form
       @nationalities_form = nationalities_form
       @languages_form = languages_form
       @right_to_work_or_study_form = right_to_work_form
+      @application_form = application_form
       @editable = editable
     end
 
@@ -21,8 +22,10 @@ module CandidateInterface
         assembled_rows << right_to_work_row
       end
 
-      assembled_rows << english_main_language_row
-      assembled_rows << language_details_row
+      unless LanguagesSectionPolicy.hide?(@application_form)
+        assembled_rows << english_main_language_row
+        assembled_rows << language_details_row
+      end
 
       assembled_rows.compact
     end
@@ -59,7 +62,7 @@ module CandidateInterface
     def english_main_language_row
       {
         key: I18n.t('application_form.personal_details.english_main_language.label'),
-        value: @languages_form.english_main_language.titleize,
+        value: @languages_form.english_main_language&.titleize,
         action: ('if English is your main language' if @editable),
         change_path: Rails.application.routes.url_helpers.candidate_interface_languages_path,
       }

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class PersonalDetailsReviewPresenter
     include ActionView::Helpers::TagHelper
+    include Rails.application.routes.url_helpers
 
     def initialize(personal_details_form:, nationalities_form:, languages_form:, right_to_work_form:, application_form:, editable: true)
       @personal_details_form = personal_details_form
@@ -37,7 +38,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.name.label'),
         value: @personal_details_form.name,
         action: ('name' if @editable),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path,
+        change_path: candidate_interface_personal_details_edit_path,
       }
     end
 
@@ -46,7 +47,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.date_of_birth.label'),
         value: @personal_details_form.date_of_birth.to_s(:govuk_date),
         action: ('date of birth' if @editable),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path,
+        change_path: candidate_interface_personal_details_edit_path,
       }
     end
 
@@ -55,7 +56,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.nationality.label'),
         value: formatted_nationalities,
         action: ('nationality' if @editable),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path,
+        change_path: candidate_interface_edit_nationalities_path,
       }
     end
 
@@ -64,7 +65,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.english_main_language.label'),
         value: @languages_form.english_main_language&.titleize,
         action: ('if English is your main language' if @editable),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_languages_path,
+        change_path: candidate_interface_languages_path,
       }
     end
 
@@ -81,7 +82,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.other_language_details.label'),
         value: @languages_form.other_language_details,
         action: ('other languages' if @editable),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_languages_path,
+        change_path: candidate_interface_languages_path,
       }
     end
 
@@ -90,7 +91,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.english_language_details.label'),
         value: @languages_form.english_language_details,
         action: ('English language qualifications' if @editable),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_languages_path,
+        change_path: candidate_interface_languages_path,
       }
     end
 
@@ -100,7 +101,7 @@ module CandidateInterface
           key: 'Residency status',
           value: formatted_right_to_work_or_study,
           action: ('Right to work or study' if @editable),
-          change_path: Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path,
+          change_path: candidate_interface_edit_right_to_work_or_study_path,
         }
       end
     end

--- a/app/services/languages_section_policy.rb
+++ b/app/services/languages_section_policy.rb
@@ -1,0 +1,9 @@
+class LanguagesSectionPolicy
+  def self.hide?(application_form)
+    FeatureFlag.active?(:efl_section) &&
+      (
+        application_form.application_choices.any?(&:unsubmitted?) ||
+        application_form.english_main_language.nil?
+      )
+  end
+end

--- a/app/services/languages_section_policy.rb
+++ b/app/services/languages_section_policy.rb
@@ -1,9 +1,6 @@
 class LanguagesSectionPolicy
   def self.hide?(application_form)
     FeatureFlag.active?(:efl_section) &&
-      (
-        application_form.application_choices.any?(&:unsubmitted?) ||
-        application_form.english_main_language.nil?
-      )
+      application_form.english_main_language.nil?
   end
 end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -225,6 +225,23 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
     end
   end
 
+  context 'when the language rows should be hidden' do
+    before { allow(LanguagesSectionPolicy).to receive(:hide?).and_return true }
+
+    it 'does not show the language rows' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'Yes',
+        english_language_details: '',
+        other_language_details: 'Glossolalia',
+      )
+
+      row_data = rows(languages_form: languages_form)
+      keys = row_data.map { |row| row[:key] }
+      expect(keys).to match_array ['Name', 'Date of birth', 'Nationality']
+    end
+  end
+
   context 'when the international personal details flag is on and the candidate has selected they have the right to work' do
     before do
       FeatureFlag.activate('international_personal_details')

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -35,6 +35,8 @@ FactoryBot.define do
 end
 
 RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
+  include Rails.application.routes.url_helpers
+
   let(:default_personal_details_form) { build(:personal_details_form) }
   let(:default_nationalities_form) { build(:nationalities_form) }
   let(:default_languages_form) { build(:languages_form) }
@@ -69,8 +71,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(personal_details_form: personal_details_form)).to include(
-        row_for(:name, 'Max Caulfield', Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path),
-        row_for(:date_of_birth, '21 September 1995', Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path),
+        row_for(:name, 'Max Caulfield', candidate_interface_personal_details_edit_path),
+        row_for(:date_of_birth, '21 September 1995', candidate_interface_personal_details_edit_path),
       )
     end
   end
@@ -84,7 +86,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form)).to include(
-        row_for(:nationality, 'British', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
+        row_for(:nationality, 'British', candidate_interface_edit_nationalities_path),
       )
     end
 
@@ -96,7 +98,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form)).to include(
-        row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
+        row_for(:nationality, 'British and Spanish', candidate_interface_edit_nationalities_path),
       )
     end
 
@@ -112,7 +114,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form)).to include(
-        row_for(:nationality, 'British, French, German, and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
+        row_for(:nationality, 'British, French, German, and Spanish', candidate_interface_edit_nationalities_path),
       )
     end
   end
@@ -127,7 +129,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).to include(
-        row_for(:english_main_language, 'Yes', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:english_main_language, 'Yes', candidate_interface_languages_path),
       )
     end
 
@@ -140,7 +142,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).not_to include(
-        row_for(:other_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:other_language_details, '', candidate_interface_languages_path),
       )
     end
 
@@ -153,7 +155,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).not_to include(
-        row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:english_language_details, 'Broken? Oh man, are you cereal?', candidate_interface_languages_path),
       )
     end
 
@@ -166,7 +168,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).to include(
-        row_for(:other_language_details, 'I speak French', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:other_language_details, 'I speak French', candidate_interface_languages_path),
       )
     end
   end
@@ -181,7 +183,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).to include(
-        row_for(:english_main_language, 'No', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:english_main_language, 'No', candidate_interface_languages_path),
       )
     end
 
@@ -194,7 +196,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).not_to include(
-        row_for(:english_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:english_language_details, '', candidate_interface_languages_path),
       )
     end
 
@@ -207,7 +209,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).not_to include(
-        row_for(:other_language_details, 'Mi nombre es Max.', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:other_language_details, 'Mi nombre es Max.', candidate_interface_languages_path),
       )
     end
 
@@ -220,7 +222,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(languages_form: languages_form)).to include(
-        row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+        row_for(:english_language_details, 'Broken? Oh man, are you cereal?', candidate_interface_languages_path),
       )
     end
   end
@@ -259,7 +261,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).to include(
-        row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
+        row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", candidate_interface_edit_right_to_work_or_study_path),
       )
     end
   end
@@ -281,7 +283,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).not_to include(
-        row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
+        row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", candidate_interface_edit_right_to_work_or_study_path),
       )
     end
   end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -35,10 +35,27 @@ FactoryBot.define do
 end
 
 RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
-  let(:personal_details_form) { build(:personal_details_form) }
-  let(:nationalities_form) { build(:nationalities_form) }
-  let(:languages_form) { build(:languages_form) }
-  let(:right_to_work_form) { build(:right_to_work_form) }
+  let(:default_personal_details_form) { build(:personal_details_form) }
+  let(:default_nationalities_form) { build(:nationalities_form) }
+  let(:default_languages_form) { build(:languages_form) }
+  let(:default_right_to_work_form) { build(:right_to_work_form) }
+  let(:default_application_form) { build(:application_form) }
+
+  def rows(
+    personal_details_form: default_personal_details_form,
+    nationalities_form: default_nationalities_form,
+    languages_form: default_languages_form,
+    right_to_work_form: default_right_to_work_form,
+    application_form: default_application_form
+  )
+    CandidateInterface::PersonalDetailsReviewPresenter.new(
+      personal_details_form: personal_details_form,
+      nationalities_form: nationalities_form,
+      languages_form: languages_form,
+      right_to_work_form: right_to_work_form,
+      application_form: application_form,
+    ).rows
+  end
 
   context 'when personal details are editable' do
     it 'includes hashes for the name and date of birth' do
@@ -51,7 +68,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         year: 1995,
       )
 
-      expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+      expect(rows(personal_details_form: personal_details_form)).to include(
         row_for(:name, 'Max Caulfield', Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path),
         row_for(:date_of_birth, '21 September 1995', Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path),
       )
@@ -65,7 +82,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           second_nationality: nil,
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(nationalities_form: nationalities_form)).to include(
           row_for(:nationality, 'British', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
         )
       end
@@ -77,7 +94,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           second_nationality: 'Spanish',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(nationalities_form: nationalities_form)).to include(
           row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
         )
       end
@@ -93,7 +110,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_nationality3: 'Spanish',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(nationalities_form: nationalities_form)).to include(
           row_for(:nationality, 'British, French, German, and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
         )
       end
@@ -108,7 +125,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(languages_form: languages_form)).to include(
           row_for(:english_main_language, 'Yes', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -121,7 +138,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
+        expect(rows(languages_form: languages_form)).not_to include(
           row_for(:other_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -134,7 +151,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: 'Broken? Oh man, are you cereal?',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
+        expect(rows(languages_form: languages_form)).not_to include(
           row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -147,7 +164,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: 'I speak French',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(languages_form: languages_form)).to include(
           row_for(:other_language_details, 'I speak French', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -162,7 +179,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(languages_form: languages_form)).to include(
           row_for(:english_main_language, 'No', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -175,7 +192,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
+        expect(rows(languages_form: languages_form)).not_to include(
           row_for(:english_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -188,7 +205,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
+        expect(rows(languages_form: languages_form)).not_to include(
           row_for(:other_language_details, 'Mi nombre es Max.', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -201,7 +218,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(languages_form: languages_form)).to include(
           row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
         )
       end
@@ -223,7 +240,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           right_to_work_or_study_details: 'I have the right.',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).to include(
+        expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).to include(
           row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
         )
       end
@@ -245,17 +262,11 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           right_to_work_or_study_details: 'I have the right.',
         )
 
-        expect(rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)).not_to include(
+        expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).not_to include(
           row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
         )
       end
     end
-  end
-
-  def rows(personal_details_form, nationalities_form, languages_form, right_to_work_form)
-    CandidateInterface::PersonalDetailsReviewPresenter
-      .new(personal_details_form: personal_details_form, nationalities_form: nationalities_form, languages_form: languages_form, right_to_work_form: right_to_work_form)
-      .rows
   end
 
   def row_for(key, value, path)

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
     ).rows
   end
 
-  context 'when personal details are editable' do
+  context 'when presenting personal details' do
     it 'includes hashes for the name and date of birth' do
       personal_details_form = build(
         :personal_details_form,
@@ -73,199 +73,199 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         row_for(:date_of_birth, '21 September 1995', Rails.application.routes.url_helpers.candidate_interface_personal_details_edit_path),
       )
     end
+  end
 
-    context 'when presenting nationality' do
-      it 'includes a hash for a single nationality' do
-        nationalities_form = build(
-          :nationalities_form,
-          first_nationality: 'British',
-          second_nationality: nil,
-        )
+  context 'when presenting nationality' do
+    it 'includes a hash for a single nationality' do
+      nationalities_form = build(
+        :nationalities_form,
+        first_nationality: 'British',
+        second_nationality: nil,
+      )
 
-        expect(rows(nationalities_form: nationalities_form)).to include(
-          row_for(:nationality, 'British', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
-        )
-      end
-
-      it 'includes a hash for dual nationalities' do
-        nationalities_form = build(
-          :nationalities_form,
-          first_nationality: 'British',
-          second_nationality: 'Spanish',
-        )
-
-        expect(rows(nationalities_form: nationalities_form)).to include(
-          row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
-        )
-      end
-
-      it 'includes a hash with up to 5 nationaltties when international_personal_details is on' do
-        FeatureFlag.activate('international_personal_details')
-        nationalities_form = build(
-          :nationalities_form,
-          british: 'British',
-          irish: nil,
-          other_nationality1: 'French',
-          other_nationality2: 'German',
-          other_nationality3: 'Spanish',
-        )
-
-        expect(rows(nationalities_form: nationalities_form)).to include(
-          row_for(:nationality, 'British, French, German, and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
-        )
-      end
+      expect(rows(nationalities_form: nationalities_form)).to include(
+        row_for(:nationality, 'British', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
+      )
     end
 
-    context 'when presenting English as the main language' do
-      it 'includes a hash with "Yes"' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'yes',
-          english_language_details: '',
-          other_language_details: '',
-        )
+    it 'includes a hash for dual nationalities' do
+      nationalities_form = build(
+        :nationalities_form,
+        first_nationality: 'British',
+        second_nationality: 'Spanish',
+      )
 
-        expect(rows(languages_form: languages_form)).to include(
-          row_for(:english_main_language, 'Yes', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
-
-      it 'excludes a hash for English language details if blank' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'yes',
-          english_language_details: '',
-          other_language_details: '',
-        )
-
-        expect(rows(languages_form: languages_form)).not_to include(
-          row_for(:other_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
-
-      it 'excludes a hash for other language details if given' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'yes',
-          english_language_details: '',
-          other_language_details: 'Broken? Oh man, are you cereal?',
-        )
-
-        expect(rows(languages_form: languages_form)).not_to include(
-          row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
-
-      it 'includes a hash for English language details if given' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'yes',
-          english_language_details: '',
-          other_language_details: 'I speak French',
-        )
-
-        expect(rows(languages_form: languages_form)).to include(
-          row_for(:other_language_details, 'I speak French', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
+      expect(rows(nationalities_form: nationalities_form)).to include(
+        row_for(:nationality, 'British and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
+      )
     end
 
-    context 'when presenting English not as the main language' do
-      it 'includes a hash with "No"' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'no',
-          english_language_details: '',
-          other_language_details: '',
-        )
+    it 'includes a hash with up to 5 nationalities when international_personal_details is on' do
+      FeatureFlag.activate('international_personal_details')
+      nationalities_form = build(
+        :nationalities_form,
+        british: 'British',
+        irish: nil,
+        other_nationality1: 'French',
+        other_nationality2: 'German',
+        other_nationality3: 'Spanish',
+      )
 
-        expect(rows(languages_form: languages_form)).to include(
-          row_for(:english_main_language, 'No', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
+      expect(rows(nationalities_form: nationalities_form)).to include(
+        row_for(:nationality, 'British, French, German, and Spanish', Rails.application.routes.url_helpers.candidate_interface_edit_nationalities_path),
+      )
+    end
+  end
 
-      it 'excludes a hash for other language details if blank' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'no',
-          english_language_details: '',
-          other_language_details: '',
-        )
+  context 'when presenting English as the main language' do
+    it 'includes a hash with "Yes"' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'yes',
+        english_language_details: '',
+        other_language_details: '',
+      )
 
-        expect(rows(languages_form: languages_form)).not_to include(
-          row_for(:english_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
-
-      it 'excludes a hash for English language details if given' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'no',
-          english_language_details: 'Mi nombre es Max.',
-          other_language_details: '',
-        )
-
-        expect(rows(languages_form: languages_form)).not_to include(
-          row_for(:other_language_details, 'Mi nombre es Max.', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
-
-      it 'includes a hash for other language details if given' do
-        languages_form = build(
-          :languages_form,
-          english_main_language: 'no',
-          english_language_details: 'Broken? Oh man, are you cereal?',
-          other_language_details: '',
-        )
-
-        expect(rows(languages_form: languages_form)).to include(
-          row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
-        )
-      end
+      expect(rows(languages_form: languages_form)).to include(
+        row_for(:english_main_language, 'Yes', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
     end
 
-    context 'when the international personal details flag is on and the candidate has selected they have the right to work' do
-      before do
-        FeatureFlag.activate('international_personal_details')
-      end
+    it 'excludes a hash for English language details if blank' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'yes',
+        english_language_details: '',
+        other_language_details: '',
+      )
 
-      it 'renders the right to work row' do
-        nationalities_form = build(
-          :nationalities_form,
-          first_nationality: 'German',
-        )
-        right_to_work_form = build(
-          :right_to_work_form,
-          right_to_work_or_study: 'yes',
-          right_to_work_or_study_details: 'I have the right.',
-        )
-
-        expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).to include(
-          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
-        )
-      end
+      expect(rows(languages_form: languages_form)).not_to include(
+        row_for(:other_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
     end
 
-    context 'when the international personal details flag is on and the candidate is British or Irish' do
-      before do
-        FeatureFlag.activate('international_personal_details')
-      end
+    it 'excludes a hash for other language details if given' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'yes',
+        english_language_details: '',
+        other_language_details: 'Broken? Oh man, are you cereal?',
+      )
 
-      it 'renders the right to work row' do
-        nationalities_form = build(
-          :nationalities_form,
-          first_nationality: 'British',
-        )
-        right_to_work_form = build(
-          :right_to_work_form,
-          right_to_work_or_study: 'yes',
-          right_to_work_or_study_details: 'I have the right.',
-        )
+      expect(rows(languages_form: languages_form)).not_to include(
+        row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
+    end
 
-        expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).not_to include(
-          row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
-        )
-      end
+    it 'includes a hash for English language details if given' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'yes',
+        english_language_details: '',
+        other_language_details: 'I speak French',
+      )
+
+      expect(rows(languages_form: languages_form)).to include(
+        row_for(:other_language_details, 'I speak French', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
+    end
+  end
+
+  context 'when presenting English not as the main language' do
+    it 'includes a hash with "No"' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'no',
+        english_language_details: '',
+        other_language_details: '',
+      )
+
+      expect(rows(languages_form: languages_form)).to include(
+        row_for(:english_main_language, 'No', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
+    end
+
+    it 'excludes a hash for other language details if blank' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'no',
+        english_language_details: '',
+        other_language_details: '',
+      )
+
+      expect(rows(languages_form: languages_form)).not_to include(
+        row_for(:english_language_details, '', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
+    end
+
+    it 'excludes a hash for English language details if given' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'no',
+        english_language_details: 'Mi nombre es Max.',
+        other_language_details: '',
+      )
+
+      expect(rows(languages_form: languages_form)).not_to include(
+        row_for(:other_language_details, 'Mi nombre es Max.', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
+    end
+
+    it 'includes a hash for other language details if given' do
+      languages_form = build(
+        :languages_form,
+        english_main_language: 'no',
+        english_language_details: 'Broken? Oh man, are you cereal?',
+        other_language_details: '',
+      )
+
+      expect(rows(languages_form: languages_form)).to include(
+        row_for(:english_language_details, 'Broken? Oh man, are you cereal?', Rails.application.routes.url_helpers.candidate_interface_languages_path),
+      )
+    end
+  end
+
+  context 'when the international personal details flag is on and the candidate has selected they have the right to work' do
+    before do
+      FeatureFlag.activate('international_personal_details')
+    end
+
+    it 'renders the right to work row' do
+      nationalities_form = build(
+        :nationalities_form,
+        first_nationality: 'German',
+      )
+      right_to_work_form = build(
+        :right_to_work_form,
+        right_to_work_or_study: 'yes',
+        right_to_work_or_study_details: 'I have the right.',
+      )
+
+      expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).to include(
+        row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
+      )
+    end
+  end
+
+  context 'when the international personal details flag is on and the candidate is British or Irish' do
+    before do
+      FeatureFlag.activate('international_personal_details')
+    end
+
+    it 'renders the right to work row' do
+      nationalities_form = build(
+        :nationalities_form,
+        first_nationality: 'British',
+      )
+      right_to_work_form = build(
+        :right_to_work_form,
+        right_to_work_or_study: 'yes',
+        right_to_work_or_study_details: 'I have the right.',
+      )
+
+      expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).not_to include(
+        row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", Rails.application.routes.url_helpers.candidate_interface_edit_right_to_work_or_study_path),
+      )
     end
   end
 

--- a/spec/services/languages_section_policy_spec.rb
+++ b/spec/services/languages_section_policy_spec.rb
@@ -5,14 +5,6 @@ RSpec.describe LanguagesSectionPolicy do
     context 'when efl_section feature flag is active' do
       before { FeatureFlag.activate :efl_section }
 
-      context 'and application is unsubmitted' do
-        let(:application_form) { application_form_that_is_unsubmitted }
-
-        it 'returns true' do
-          expect(described_class.hide?(application_form)).to eq true
-        end
-      end
-
       context 'and english_main_language has not been filled' do
         let(:application_form) { application_form_where_english_main_language_is_nil }
 
@@ -21,9 +13,8 @@ RSpec.describe LanguagesSectionPolicy do
         end
       end
 
-      context 'application is submitted and english_main_language has been filled' do
-        let(:application_choice) { build(:application_choice, :awaiting_references) }
-        let(:application_form) { build(:completed_application_form, english_main_language: true, application_choices: [application_choice]) }
+      context 'and english_main_language has been filled' do
+        let(:application_form) { build(:application_form, english_main_language: true) }
 
         it 'returns false' do
           expect(described_class.hide?(application_form)).to eq false
@@ -35,20 +26,11 @@ RSpec.describe LanguagesSectionPolicy do
       before { FeatureFlag.deactivate :efl_section }
 
       # An application state which would return true if the flag were active
-      let(:application_form) { application_form_that_is_unsubmitted }
+      let(:application_form) { application_form_where_english_main_language_is_nil }
 
       it 'returns false' do
         expect(described_class.hide?(application_form)).to eq false
       end
-    end
-
-    def application_form_that_is_unsubmitted
-      application_choice = build(:application_choice, :unsubmitted)
-      build(
-        :completed_application_form,
-        english_main_language: true,
-        application_choices: [application_choice],
-      )
     end
 
     def application_form_where_english_main_language_is_nil

--- a/spec/services/languages_section_policy_spec.rb
+++ b/spec/services/languages_section_policy_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe LanguagesSectionPolicy do
+  describe '#hide?' do
+    context 'when efl_section feature flag is active' do
+      before { FeatureFlag.activate :efl_section }
+
+      context 'and application is unsubmitted' do
+        let(:application_form) { application_form_that_is_unsubmitted }
+
+        it 'returns true' do
+          expect(described_class.hide?(application_form)).to eq true
+        end
+      end
+
+      context 'and english_main_language has not been filled' do
+        let(:application_form) { application_form_where_english_main_language_is_nil }
+
+        it 'returns true' do
+          expect(described_class.hide?(application_form)).to eq true
+        end
+      end
+
+      context 'application is submitted and english_main_language has been filled' do
+        let(:application_choice) { build(:application_choice, :awaiting_references) }
+        let(:application_form) { build(:completed_application_form, english_main_language: true, application_choices: [application_choice]) }
+
+        it 'returns false' do
+          expect(described_class.hide?(application_form)).to eq false
+        end
+      end
+    end
+
+    context 'when efl_section feature flag is inactive' do
+      before { FeatureFlag.deactivate :efl_section }
+
+      # An application state which would return true if the flag were active
+      let(:application_form) { application_form_that_is_unsubmitted }
+
+      it 'returns false' do
+        expect(described_class.hide?(application_form)).to eq false
+      end
+    end
+
+    def application_form_that_is_unsubmitted
+      application_choice = build(:application_choice, :unsubmitted)
+      build(
+        :completed_application_form,
+        english_main_language: true,
+        application_choices: [application_choice],
+      )
+    end
+
+    def application_form_where_english_main_language_is_nil
+      application_choice = build(:application_choice, :awaiting_references)
+      build(
+        :completed_application_form,
+        english_main_language: nil,
+        application_choices: [application_choice],
+      )
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Entering personal details' do
+  include CandidateHelper
+
+  scenario 'The languages page is hidden' do
+    given_i_am_signed_in
+    and_my_application_is_in_a_state_where_languages_should_not_be_visible
+    then_i_can_complete_personal_details_without_seeing_the_languages_page
+    and_i_can_mark_the_section_complete
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+    visit candidate_interface_application_form_path
+  end
+
+  def and_my_application_is_in_a_state_where_languages_should_not_be_visible
+    # This is the expected state for Personal Details -> Languages to be
+    # hidden. See LanguagesSectionPolicy and its corresponding spec for more
+    # detail.
+    FeatureFlag.activate(:efl_section)
+    expect(current_candidate.current_application.english_main_language).to eq nil
+  end
+
+  def then_i_can_complete_personal_details_without_seeing_the_languages_page
+    click_link t('page_titles.personal_details')
+
+    scope = 'application_form.personal_details'
+    fill_in t('first_name.label', scope: scope), with: 'Lando'
+    fill_in t('last_name.label', scope: scope), with: 'Calrissian'
+    fill_in 'Day', with: '6'
+    fill_in 'Month', with: '4'
+    fill_in 'Year', with: '1937'
+    click_button t('complete_form_button', scope: scope)
+    select('British', from: t('nationality.label', scope: scope))
+    find('details').click
+    within('details') do
+      select('American', from: t('second_nationality.label', scope: scope))
+    end
+    click_button t('complete_form_button', scope: scope)
+
+    expect(page).to have_content 'Name'
+    expect(page).to have_content 'Lando Calrissian'
+    expect(page).to have_content 'British and American'
+  end
+
+  def and_i_can_mark_the_section_complete
+    check t('application_form.completed_checkbox')
+    click_button 'Continue'
+
+    expect(page).to have_css('#personal-details-badge-id', text: 'Completed')
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->


We're adding an 'English as a foreign language' section to the
application form, visible to any candidate with a nationality other than
British and Irish. This has a lot of overlap with the existing Languages
page of the Personal Details section, so we should hide it if the EFL
feature is active.
## Changes proposed in this pull request

- Add a policy object to handle the checks for whether or not we should hide the Languages page, and use it where required.
- Rework all affected tests.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Take particular note of the last two commits, which illustrate a refinement/simplification of the `LanguagesSectionPolicy` boolean check. 
- Does the boolean check make sense? Are there any edge cases this behaviour doesn't account for?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/9fk7yluU
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
