### PR TITLE
Show organisation level permission changes in support console

### DIFF
--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -9,9 +9,28 @@ module SupportInterface
     end
 
     def audits
-      audited_thing.own_and_associated_audits.includes(:user).order('id desc')
+      audits = if audited_thing.is_a? Provider
+                 audits_for_provider
+               else
+                 standard_audits
+               end
+
+      audits.includes(:user).order('id desc')
     end
 
     attr_reader :audited_thing
+
+  private
+
+    def audits_for_provider
+      standard_audits.or(Audited::Audit.where(
+                           auditable_type: 'ProviderRelationshipPermissions',
+                           auditable_id: ProviderRelationshipPermissions.where(ratifying_provider_id: audited_thing.id),
+                         ))
+    end
+
+    def standard_audits
+      audited_thing.own_and_associated_audits.unscope(:order)
+    end
   end
 end

--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -13,6 +13,8 @@ module SupportInterface
         "Comment on #{audit.auditable_type.titlecase}"
       elsif audit.auditable_type == 'ProviderPermissions'
         label_for_provider_permission_change(audit)
+      elsif audit.auditable_type == 'ProviderRelationshipPermissions'
+        label_for_provider_relationship_permission_change(audit)
       else
         "#{audit.action.capitalize} #{audit.auditable_type.titlecase} ##{audit.auditable_id}"
       end
@@ -71,6 +73,18 @@ module SupportInterface
       when 'destroy'
         provider = Provider.find(audit.audited_changes['provider_id'])
         "Access revoked for #{provider.name}"
+      end
+    end
+
+    def label_for_provider_relationship_permission_change(audit)
+      training_provider = audit.auditable.training_provider
+      ratifying_provider = audit.auditable.ratifying_provider
+
+      case audit.action
+      when 'create'
+        "Permission relationship between training provider #{training_provider.name} and ratifying provider #{ratifying_provider.name} created"
+      when 'update'
+        "Permission relationship between training provider #{training_provider.name} and ratifying provider #{ratifying_provider.name} changed"
       end
     end
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -27,6 +27,7 @@ class Provider < ApplicationRecord
   }
 
   audited
+  has_associated_audits
 
   def self.with_users_manageable_by(provider_user)
     joins(:provider_permissions)

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -5,6 +5,7 @@ class ProviderRelationshipPermissions < ApplicationRecord
   PERMISSIONS = %i[make_decisions view_safeguarding_information].freeze
 
   validate :at_least_one_active_permission_in_pair, if: -> { setup_at.present? }
+  audited associated_with: :training_provider
 
   def training_provider_can_view_applications_only?
     PERMISSIONS.map { |permission| send("training_provider_can_#{permission}") }.all?(false)

--- a/spec/components/support_interface/audit_trail_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_component_spec.rb
@@ -66,15 +66,15 @@ RSpec.describe SupportInterface::AuditTrailComponent, with_audited: true do
   end
 
   it 'renders an update provider relationship permissions records for a ratifying provider' do
-    ratifying_provider = create(:provider)
+    ratifying_provider = create(:provider, name: 'B')
     provider_relationship_permissions =
       create(:provider_relationship_permissions,
-             training_provider: create(:provider),
+             training_provider: create(:provider, name: 'A'),
              ratifying_provider: ratifying_provider)
     provider_relationship_permissions.update!(ratifying_provider_can_make_decisions: true)
 
     render_result = render_inline(described_class.new(audited_thing: ratifying_provider))
 
-    expect(render_result.text).to include('Update Provider Relationship Permissions')
+    expect(render_result.text).to include('Permission relationship between training provider A and ratifying provider B changed')
   end
 end

--- a/spec/components/support_interface/audit_trail_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_component_spec.rb
@@ -64,4 +64,17 @@ RSpec.describe SupportInterface::AuditTrailComponent, with_audited: true do
     expect(render_result.text).to include('Update Application Form')
     expect(render_result.text).to include('(Unknown User)')
   end
+
+  it 'renders an update provider relationship permissions records for a ratifying provider' do
+    ratifying_provider = create(:provider)
+    provider_relationship_permissions =
+      create(:provider_relationship_permissions,
+             training_provider: create(:provider),
+             ratifying_provider: ratifying_provider)
+    provider_relationship_permissions.update!(ratifying_provider_can_make_decisions: true)
+
+    render_result = render_inline(described_class.new(audited_thing: ratifying_provider))
+
+    expect(render_result.text).to include('Update Provider Relationship Permissions')
+  end
 end

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -166,4 +166,38 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
       assert_includes rendered_component, 'Access revoked for The School of Roke'
     end
   end
+
+  context 'the audited item is a ProviderRelationshipPermissions record' do
+    let!(:training_provider) { create(:provider, name: 'A') }
+    let!(:ratifying_provider) { create(:provider, name: 'B') }
+
+    it 'provides a meaningful label for "create"', with_audited: true do
+      permissions = ProviderRelationshipPermissions.create(
+        training_provider_id: training_provider.id,
+        ratifying_provider_id: ratifying_provider.id,
+        training_provider_can_make_decisions: true,
+        ratifying_provider_can_view_safeguarding_information: true,
+      )
+      render_inline(described_class.new(audit: permissions.audits.last))
+
+      assert_includes rendered_component, 'Permission relationship between training provider A and ratifying provider B created'
+    end
+
+    it 'provides a meaningful label for "update"', with_audited: true do
+      permissions = ProviderRelationshipPermissions.create(
+        training_provider_id: training_provider.id,
+        ratifying_provider_id: ratifying_provider.id,
+        training_provider_can_make_decisions: true,
+        ratifying_provider_can_view_safeguarding_information: true,
+      )
+
+      permissions.update!(
+        training_provider_can_make_decisions: false,
+        ratifying_provider_can_make_decisions: true,
+      )
+      render_inline(described_class.new(audit: permissions.audits.last))
+
+      assert_includes rendered_component, 'Permission relationship between training provider A and ratifying provider B changed'
+    end
+  end
 end


### PR DESCRIPTION
## Context

We don't currently audit changes to organisation permissions.
History tab for providers in the support console should include organisation permission changes. 

## Changes proposed in this pull request
Changes to ProviderRelationshipPermissions are visible in History tab for both providers.

<img width="1184" alt="Screenshot 2020-07-27 at 12 10 24" src="https://user-images.githubusercontent.com/38078064/88539157-a385eb80-d008-11ea-86fb-52dd83d70d70.png">

_See commits for more details on implementation, which is a bit messy so any comments on how to make it pretty are welcome._ 

## Guidance to review
- make changes to ProviderRelationshipPermissions
- visit http://localhost:5000/support/providers/:id/history

## Link to Trello card

https://trello.com/c/8QFALaUS/2338-show-organisation-level-permission-changes-in-support-console

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
