### PR TITLE
Update to New References Needed component new contextual banner message

### DIFF
--- a/app/components/candidate_interface/new_references_needed_component.html.erb
+++ b/app/components/candidate_interface/new_references_needed_component.html.erb
@@ -1,7 +1,9 @@
 <div class="app-banner app-banner--info" aria-labelledby="info-message">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m" id="info-message">
-      <% if reference_status.number_of_references_that_currently_need_replacing == 1 %>
+      <% if reference_status.not_requested_yet?.present? %>
+        One or more of your references have not been confirmed. <%= govuk_link_to 'Please do so to ensure they are contacted.', candidate_interface_confirm_additional_referees_path %>
+      <% elsif reference_status.number_of_references_that_currently_need_replacing == 1 %>
         You need to <%= govuk_link_to 'give details of a new referee', candidate_interface_additional_referee_type_path %>
       <% else %>
         You need to <%= govuk_link_to 'give details of 2 new referees', candidate_interface_additional_referee_type_path %>

--- a/app/components/candidate_interface/new_references_needed_component.html.erb
+++ b/app/components/candidate_interface/new_references_needed_component.html.erb
@@ -1,8 +1,10 @@
 <div class="app-banner app-banner--info" aria-labelledby="info-message">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m" id="info-message">
-      <% if reference_status.not_requested_yet?.present? %>
-        One or more of your references have not been confirmed. <%= govuk_link_to 'Please do so to ensure they are contacted.', candidate_interface_confirm_additional_referees_path %>
+      <% if reference_status.not_requested_yet?.count == 1 %>
+        You have not confirmed your referee yet. <%= govuk_link_to 'Confirm your referee', candidate_interface_confirm_additional_referees_path %> so that they can be contacted.
+      <% elsif reference_status.not_requested_yet?.count > 1 %>
+        You have not confirmed your referees yet. <%= govuk_link_to 'Confirm your referees', candidate_interface_confirm_additional_referees_path %> so that they can be contacted.
       <% elsif reference_status.number_of_references_that_currently_need_replacing == 1 %>
         You need to <%= govuk_link_to 'give details of a new referee', candidate_interface_additional_referee_type_path %>
       <% else %>

--- a/app/components/candidate_interface/new_references_needed_component.html.erb
+++ b/app/components/candidate_interface/new_references_needed_component.html.erb
@@ -2,9 +2,11 @@
   <div class="app-banner__message">
     <h2 class="govuk-heading-m" id="info-message">
       <% if reference_status.not_requested_yet?.count == 1 %>
-        You have not confirmed your referee yet. <%= govuk_link_to 'Confirm your referee', candidate_interface_confirm_additional_referees_path %> so that they can be contacted.
+        <p>You have not confirmed your referee yet.</p>
+        <p><%= govuk_link_to 'Confirm your referee so that they can be contacted', candidate_interface_confirm_additional_referees_path %></p>
       <% elsif reference_status.not_requested_yet?.count > 1 %>
-        You have not confirmed your referees yet. <%= govuk_link_to 'Confirm your referees', candidate_interface_confirm_additional_referees_path %> so that they can be contacted.
+        <p>You have not confirmed your referees yet.</p>
+        <p><%= govuk_link_to 'Confirm your referees so that they can be contacted', candidate_interface_confirm_additional_referees_path %></p>
       <% elsif reference_status.number_of_references_that_currently_need_replacing == 1 %>
         You need to <%= govuk_link_to 'give details of a new referee', candidate_interface_additional_referee_type_path %>
       <% else %>

--- a/app/components/candidate_interface/new_references_needed_component.html.erb
+++ b/app/components/candidate_interface/new_references_needed_component.html.erb
@@ -1,12 +1,9 @@
 <div class="app-banner app-banner--info" aria-labelledby="info-message">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m" id="info-message">
-      <% if reference_status.not_requested_yet?.count == 1 %>
-        <p>You have not confirmed your referee yet.</p>
-        <p><%= govuk_link_to 'Confirm your referee so that they can be contacted', candidate_interface_confirm_additional_referees_path %></p>
-      <% elsif reference_status.not_requested_yet?.count > 1 %>
-        <p>You have not confirmed your referees yet.</p>
-        <p><%= govuk_link_to 'Confirm your referees so that they can be contacted', candidate_interface_confirm_additional_referees_path %></p>
+      <% if reference_status.not_requested_yet?.present?%>
+        <p>You have not confirmed your <%= pluralize_referee %> yet.</p>
+        <p><%= govuk_link_to 'Confirm your ' + pluralize_referee + ' so that they can be contacted', candidate_interface_confirm_additional_referees_path %></p>
       <% elsif reference_status.number_of_references_that_currently_need_replacing == 1 %>
         You need to <%= govuk_link_to 'give details of a new referee', candidate_interface_additional_referee_type_path %>
       <% else %>

--- a/app/components/candidate_interface/new_references_needed_component.rb
+++ b/app/components/candidate_interface/new_references_needed_component.rb
@@ -12,6 +12,10 @@ module CandidateInterface
       reference_status.still_more_references_needed?
     end
 
+    def pluralize_referee
+      'referee'.pluralize(reference_status.not_requested_yet?.count)
+    end
+
   private
 
     def reference_status

--- a/app/services/reference_status.rb
+++ b/app/services/reference_status.rb
@@ -30,6 +30,10 @@ class ReferenceStatus
     refused + bounced + ignored + cancelled
   end
 
+  def not_requested_yet?
+    application_references.select(&:not_requested_yet?)
+  end
+
 private
 
   def replacement_references

--- a/spec/services/reference_status_spec.rb
+++ b/spec/services/reference_status_spec.rb
@@ -158,12 +158,12 @@ RSpec.describe ReferenceStatus do
   describe '#references not requested yet?' do
     it 'returns true if references not yet requested' do
       application_form = create(:application_form)
-      create(:reference, :not_requested_yet, application_form: application_form)
-      create(:reference, :not_requested_yet, application_form: application_form)
+      reference1 = create(:reference, :not_requested_yet, application_form: application_form)
+      reference2 = create(:reference, :feedback_provided, application_form: application_form)
 
       status = ReferenceStatus.new(application_form.reload)
 
-      expect(status.not_requested_yet?.present?).to be(true)
+      expect(status.not_requested_yet?).to match_array([reference1])
     end
   end
 end

--- a/spec/services/reference_status_spec.rb
+++ b/spec/services/reference_status_spec.rb
@@ -154,4 +154,16 @@ RSpec.describe ReferenceStatus do
       expect(status.needs_a_replacement_reference?).to be(true)
     end
   end
+
+  describe '#references not requested yet?' do
+    it 'returns true if references not yet requested' do
+      application_form = create(:application_form)
+      create(:reference, :not_requested_yet, application_form: application_form)
+      create(:reference, :not_requested_yet, application_form: application_form)
+
+      status = ReferenceStatus.new(application_form.reload)
+
+      expect(status.not_requested_yet?.present?).to be(true)
+    end
+  end
 end

--- a/spec/services/reference_status_spec.rb
+++ b/spec/services/reference_status_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe ReferenceStatus do
     it 'returns true if references not yet requested' do
       application_form = create(:application_form)
       reference1 = create(:reference, :not_requested_yet, application_form: application_form)
-      reference2 = create(:reference, :feedback_provided, application_form: application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
 
       status = ReferenceStatus.new(application_form.reload)
 


### PR DESCRIPTION
## Context

Change is being made to fix bug that occurs on the banner message of the dashboard. If a new referee is added and not confirmed the banner message currently shows a message asking to add referee details.

## Changes proposed in this pull request

Alteration to the component view and service to generate a new method that can be called on the reference status to check if it exists and if so to display a corresponding banner message with a link to the confirmation screen.

![image](https://user-images.githubusercontent.com/62567622/88562255-5d408480-d028-11ea-9d24-d9d7a89e28e0.png)


## Guidance to review

Use the review app to test functionality by adding referees to an already submitted application then and returning to the dashboard before confirming. Then confirm the references and check that the message correctly changes.

## Link to Trello card

https://trello.com/c/tdUbl6Of/1882-add-logic-to-add-referee-new-banner-for-the-notrequestedyet-state

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
