### PR TITLE
Prevent audit trail errors if provider_id cannot be found for permission updates

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -64,8 +64,12 @@ module SupportInterface
                             auditable_id: audit.auditable_id,
                             action: 'create',
                           )
-                          provider_id = creation_record&.audited_changes&.dig('provider_id')
-                          Provider.find_by(id: provider_id)&.name || 'a provider'
+
+                          if creation_record
+                            Provider.find_by(id: creation_record.audited_changes['provider_id']).name
+                          else
+                            'a provider'
+                          end
                         end
         "Permissions changed for #{provider_name}"
       when 'destroy'

--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -54,20 +54,20 @@ module SupportInterface
         provider = Provider.find(audit.audited_changes['provider_id'])
         "Access granted for #{provider.name}"
       when 'update'
-        # the original might have been destroyed, so get the creation record
-        # to discover which Provider is associated with this change
-        creation_record = Audited::Audit.find_by(
-          auditable_type: 'ProviderPermissions',
-          auditable_id: audit.auditable_id,
-          action: 'create',
-        )
-        provider = if creation_record
-                     Provider.find(creation_record.audited_changes['provider_id'])
-                   else
-                     Provider.find(audit.audited_changes['provider_id'])
-                   end
-
-        "Permissions changed for #{provider.name}"
+        # permissions record may not exist, user no longer associated with provider
+        provider = ProviderPermissions.find_by(id: audit.auditable_id)&.provider
+        provider_name = if provider
+                          provider.name
+                        else
+                          creation_record = Audited::Audit.find_by(
+                            auditable_type: 'ProviderPermissions',
+                            auditable_id: audit.auditable_id,
+                            action: 'create',
+                          )
+                          provider_id = creation_record&.audited_changes&.dig('provider_id')
+                          Provider.find_by(id: provider_id)&.name || 'a provider'
+                        end
+        "Permissions changed for #{provider_name}"
       when 'destroy'
         provider = Provider.find(audit.audited_changes['provider_id'])
         "Access revoked for #{provider.name}"

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -153,6 +153,23 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
       assert_includes rendered_component, 'Permissions changed for The School of Roke'
     end
 
+    it 'renders a label for "update" even when the provider can\'t be found', with_audited: true do
+      permissions = ProviderPermissions.create(
+        provider: provider,
+        provider_user: user,
+      )
+
+      permissions.manage_users = !permissions.manage_users
+      permissions.save
+
+      permissions.destroy # no provider available from permissions record
+      permissions.audits.find_by(action: 'create').destroy # no creation record to fall back to
+
+      render_inline(described_class.new(audit: permissions.audits.find_by(action: 'update')))
+
+      assert_includes rendered_component, 'Permissions changed for a provider'
+    end
+
     it 'provides a meaningful label for "destroy"', with_audited: true do
       permissions = ProviderPermissions.create(
         provider: provider,


### PR DESCRIPTION
## Context

It's not always possible to know the provider for which permissions were changed, if the provider user is no longer associated with this provider. This is because removing provider users from an organisation removes the `provider_users_providers` record on which the relevant `ProviderPermissions` model is based.

## Changes proposed in this pull request

This is a band aid fix so we can ship the feature. We should consider soft-deleting records from `provider_users_providers` table, which will preserve the relevant audit information.

## Guidance to review

Should be an easy review.

## Link to Trello card

Part of general preparation for https://trello.com/c/k4LxRi4u

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
