### PR TITLE
Minor refactor for provider user invitation wizard

### DIFF
--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -138,36 +138,10 @@ module ProviderInterface
 
     def setup_permission_form
       @provider = Provider.find(params[:provider_id])
-      permission_struct = Struct.new(:slug, :name, :hint)
-      available_permissions = [
-        permission_struct.new(
-          'manage_organisations',
-          'Manage organisations',
-          'Change permissions between organisations',
-        ),
-        permission_struct.new(
-          'manage_users',
-          'Manage users',
-          'Invite or delete users and set their permissions',
-        ),
-        permission_struct.new(
-          'make_decisions',
-          'Make decisions',
-          'Make offers, amend offers and reject applications',
-        ),
-        permission_struct.new(
-          'view_safeguarding_information',
-          'Access safeguarding information',
-          'View sensitive material about the candidate',
-        ),
-      ]
 
-      permissions_form_struct = Struct.new(:id, :provider_id, :permissions, :available_permissions)
-      @permissions_form = permissions_form_struct.new(
-        @provider.id,
-        @provider.id,
-        @wizard.permissions_for_provider(@provider.id),
-        available_permissions,
+      @permissions_form = ProviderInterface::ProviderUserInvitationWizard::PermissionsForm.new(
+        provider_id: @provider.id,
+        permissions: @wizard.permissions_for_provider(@provider.id),
       )
     end
   end

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -13,6 +13,38 @@ module ProviderInterface
     validates :email_address, email: true, on: :details
     validates :providers, presence: true, on: :providers
 
+    PermissionOption = Struct.new(:slug, :name, :hint)
+    AVAILABLE_PERMISSIONS = [
+      PermissionOption.new(
+        'manage_organisations',
+        'Manage organisations',
+        'Change permissions between organisations',
+      ),
+      PermissionOption.new(
+        'manage_users',
+        'Manage users',
+        'Invite or delete users and set their permissions',
+      ),
+      PermissionOption.new(
+        'make_decisions',
+        'Make decisions',
+        'Make offers, amend offers and reject applications',
+      ),
+      PermissionOption.new(
+        'view_safeguarding_information',
+        'Access safeguarding information',
+        'View sensitive material about the candidate',
+      ),
+    ].freeze
+
+    class PermissionsForm
+      include ActiveModel::Model
+
+      attr_accessor :provider_id, :permissions
+
+      alias_method :id, :provider_id
+    end
+
     def initialize(state_store, attrs = {})
       @state_store = state_store
 

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -13,7 +13,7 @@
         <%= pf.hidden_field :provider_id %>
         <%= pf.govuk_collection_check_boxes(
           :permissions,
-          @permissions_form.available_permissions,
+          ProviderInterface::ProviderUserInvitationWizard::AVAILABLE_PERMISSIONS,
           :slug,
           :name,
           :hint,


### PR DESCRIPTION
## Context

When we merged work from other branches there was a fairly lengthy 'setup' method for creating the form model for the permissions form of the provider invitation wizard. This PR attempts to address that.

## Changes proposed in this pull request

- Move available providers list into `ProviderInvitationWizard::AVAILABLE_PROVIDERS`
- Move struct responsible for the list of provider permissions into `ProviderInvitationWizard::ProviderPermissionsForm` - it's quite specific to the data structure backing the wizard so making it a class within the wizard class made sense at the time.

## Guidance to review

- Does this simplify the code?

## Link to Trello card

Follow up to https://trello.com/c/BcoX8Mt9/2431-implement-the-provider-user-invitation-wizard

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
