### PR TITLE
Remove duplicated org relationships on the organisations show page

### DIFF
--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -7,13 +7,12 @@ module ProviderInterface
     end
 
     def show
-      scope = ProviderRelationshipPermissions.includes(:training_provider, :ratifying_provider)
+      @training_permissions = ProviderRelationshipPermissions.where(training_provider_id: params[:id])
+        .or(ProviderRelationshipPermissions.where(training_provider_id: manageable_providers, ratifying_provider_id: params[:id]))
+        .includes(:training_provider)
 
-      permissions = scope.where(training_provider: manageable_providers)
-        .or(scope.where(ratifying_provider: manageable_providers))
-
-      @ratifying_permissions = permissions.select { |p| manageable_providers.include?(p.ratifying_provider) }
-      @training_permissions = permissions.select { |p| manageable_providers.include?(p.training_provider) }
+      @ratifying_permissions = ProviderRelationshipPermissions.where(ratifying_provider_id: params[:id])
+        .includes(:training_provider, :ratifying_provider)
     end
 
   private

--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -12,7 +12,7 @@ module ProviderInterface
         .includes(:training_provider)
 
       @ratifying_permissions = ProviderRelationshipPermissions.where(ratifying_provider_id: params[:id])
-        .includes(:training_provider, :ratifying_provider)
+        .includes(:training_provider, :ratifying_provider) - @training_permissions
     end
 
   private

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'See organisation permissions' do
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
     and_the_ratifying_provider_has_courses_run_by_another_provider
+    and_the_ratifying_provider_has_courses_run_by_unmanagable_provider
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_provider_organisations_page
@@ -69,6 +70,20 @@ RSpec.feature 'See organisation permissions' do
     )
   end
 
+  def and_the_ratifying_provider_has_courses_run_by_unmanagable_provider
+    @unmanageable_training_provider = create(:provider)
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @unmanageable_training_provider,
+      training_provider_can_make_decisions: false,
+      ratifying_provider_can_make_decisions: true,
+      ratifying_provider_can_view_safeguarding_information: true,
+      training_provider_can_view_safeguarding_information: false,
+      setup_at: Time.zone.now,
+    )
+  end
+
   def when_i_visit_the_provider_organisations_page
     click_on 'Organisations'
   end
@@ -84,12 +99,16 @@ RSpec.feature 'See organisation permissions' do
   end
 
   def then_i_can_see_permissions_for_the_ratifying_provider
-    expect(page).to have_content("For courses ratified by #{@ratifying_provider.name} and run by #{@training_provider.name}")
+    expect(page.text).to include("For courses ratified by #{@ratifying_provider.name} and run by #{@unmanageable_training_provider.name}")
     expect(page).to have_content("The following organisation(s) can see safeguarding information:\n#{@ratifying_provider.name}")
+    expect(page.text).to include("Contact #{@unmanageable_training_provider.name} to change permissions.")
   end
 
   def and_i_can_see_permissions_for_the_training_provider
+    expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name} ")
+    expect(page).not_to have_content("For courses ratified by #{@ratifying_provider.name} and run by #{@training_provider.name} ")
     expect(page).to have_content("#{@training_provider.name} can only view applications.")
+    expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(@permissions))
   end
 
   def and_i_click_on_a_training_provider_organisation

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'See organisation permissions' do
     and_the_provider_permissions_feature_is_enabled
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
+    and_the_ratifying_provider_has_courses_run_by_another_provider
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_provider_organisations_page
@@ -18,6 +19,7 @@ RSpec.feature 'See organisation permissions' do
 
     when_i_visit_the_provider_organisations_page
     and_i_click_on_a_training_provider_organisation
+    and_i_can_not_see_permissions_for_unassociated_providers
     then_i_can_see_permissions_for_the_training_provider
   end
 
@@ -35,7 +37,9 @@ RSpec.feature 'See organisation permissions' do
     @training_provider = Provider.find_by(code: 'ABC')
     @ratifying_provider = Provider.find_by(code: 'DEF')
     @unmanageable_provider = create(:provider, :with_signed_agreement)
+    @another_training_provider = create(:provider, :with_signed_agreement)
     @provider_user.providers << @unmanageable_provider
+    @provider_user.providers << @another_training_provider
     @provider_user.provider_permissions.update_all(manage_organisations: true)
   end
 
@@ -44,6 +48,19 @@ RSpec.feature 'See organisation permissions' do
       :provider_relationship_permissions,
       ratifying_provider: @ratifying_provider,
       training_provider: @training_provider,
+      training_provider_can_make_decisions: false,
+      ratifying_provider_can_make_decisions: true,
+      ratifying_provider_can_view_safeguarding_information: true,
+      training_provider_can_view_safeguarding_information: false,
+      setup_at: Time.zone.now,
+    )
+  end
+
+  def and_the_ratifying_provider_has_courses_run_by_another_provider
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @another_training_provider,
       training_provider_can_make_decisions: false,
       ratifying_provider_can_make_decisions: true,
       ratifying_provider_can_view_safeguarding_information: true,
@@ -84,6 +101,11 @@ RSpec.feature 'See organisation permissions' do
     expect(page).to have_content("#{@training_provider.name} can only view applications.")
 
     expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(@permissions))
+  end
+
+  def and_i_can_not_see_permissions_for_unassociated_providers
+    expect(page).not_to have_content("For courses run by #{@another_training_provider.name} and ratified by #{@ratifying_provider.name} ")
+    expect(page).not_to have_content("#{@another_training_provider.name} can only view applications.")
   end
 
   def and_i_can_see_permissions_for_the_ratifying_provider


### PR DESCRIPTION
## Context

If the user has access to both the ratifying and training providers we should
not be showing the relationship twice, in both directions. We keep the
relationship as a training provider since they are can make changes and the
removed duplicated entry.

## Changes proposed in this pull request

<img width="176" alt="Screenshot 2020-07-28 at 12 17 30" src="https://user-images.githubusercontent.com/38078064/88778753-caffc400-d180-11ea-8757-f451b3e57500.png">

## Guidance to review

- visit http://localhost:5000/provider/organisations/:id

## Link to Trello card

https://trello.com/c/N3Vdwg4X/2473-org-relationships-are-duplicated-on-the-organisationsshow-page

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
