### PR TITLE
Make the "Organisations" link in the header depend on the Org/Org feature flag

### DIFF
--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -45,8 +45,7 @@ class NavigationItems
 
       items = []
 
-      if current_provider_user.can_manage_organisations? && \
-          current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+      if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -45,7 +45,8 @@ class NavigationItems
 
       items = []
 
-      if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+      if FeatureFlag.active?('enforce_provider_to_provider_permissions') &&
+          current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
         items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
       end
 

--- a/spec/models/navigation_items_spec.rb
+++ b/spec/models/navigation_items_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe NavigationItems do
       before do
         provider_user.provider_permissions.find_by(provider: provider).update!(manage_organisations: true)
         create(:provider_relationship_permissions, training_provider: provider)
+        FeatureFlag.activate('enforce_provider_to_provider_permissions')
       end
 
       it 'includes a link to Organisations' do


### PR DESCRIPTION
## Context

We now have users in the DB with manage-orgs permission, and they'll see this link before it's ready

## Changes proposed in this pull request

Put it behind the feature flag with the rest of the manage-orgs permission

## Guidance to review

Is it good and gone?

## Link to Trello card

https://trello.com/c/k4LxRi4u/2383-%E2%9B%B5%EF%B8%8F-epic-ship-make-decisions-and-providers-managing-their-own-users-without-provider-provider-permissions

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
