### PR TITLE
Add breadcrumbs to provider user management screens

### DIFF
--- a/app/views/provider_interface/provider_users/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users/edit_permissions.html.erb
@@ -1,3 +1,5 @@
+<% content_for :before_content, govuk_back_link_to(provider_interface_provider_user_path(@form.provider_user)) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render ProviderInterface::EditProviderUserPermissionsComponent.new(form: @form) %>

--- a/app/views/provider_interface/provider_users/show.html.erb
+++ b/app/views/provider_interface/provider_users/show.html.erb
@@ -1,3 +1,16 @@
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', provider_interface_provider_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= @provider_user.full_name %>
+      </li>
+    </ol>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render ProviderInterface::ProviderUserDetailsComponent.new(

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -12,7 +12,8 @@ RSpec.feature 'Managing provider user permissions' do
     and_i_sign_in_to_the_provider_interface
 
     when_i_click_on_the_users_link
-    and_i_click_on_a_user
+    when_i_click_on_a_user
+    then_i_see_a_breadcrumb
     and_i_click_to_change_permissions
 
     then_i_see_user_permissions_for_this_provider
@@ -46,7 +47,7 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def and_i_can_manage_users_for_a_provider
-    @managed_user = create(:provider_user, providers: [@provider])
+    @managed_user = create(:provider_user, providers: [@provider], first_name: 'Sylvia', last_name: 'Mead')
     @managing_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
   end
 
@@ -54,7 +55,7 @@ RSpec.feature 'Managing provider user permissions' do
     click_on('Users')
   end
 
-  def and_i_click_on_a_user
+  def when_i_click_on_a_user
     click_on(@managed_user.full_name)
   end
 
@@ -64,6 +65,13 @@ RSpec.feature 'Managing provider user permissions' do
 
   def then_i_see_user_permissions_for_this_provider
     expect(page).to have_unchecked_field 'Manage users'
+  end
+
+  def then_i_see_a_breadcrumb
+    within '.govuk-breadcrumbs' do
+      expect(page).to have_link('Users')
+      expect(page).to have_content('Sylvia Mead')
+    end
   end
 
   def and_i_add_permission_to_manage_users_for_a_provider_user


### PR DESCRIPTION
## Context

We're missing breadcrumbs on the individual provider user page

## Changes proposed in this pull request

![Screenshot 2020-07-28 at 12 14 01](https://user-images.githubusercontent.com/642279/88659788-86672080-d0cd-11ea-9ac6-8e4e95c7c2f5.png)

![Screenshot 2020-07-28 at 12 24 38](https://user-images.githubusercontent.com/642279/88659790-8830e400-d0cd-11ea-9116-902681af926c.png)

## Link to Trello card

https://trello.com/c/k4LxRi4u/2383-%E2%9B%B5%EF%B8%8F-epic-ship-make-decisions-and-providers-managing-their-own-users-without-provider-provider-permissions

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
