### PR TITLE
Fix bug when hiding Languages page

### DIFF
--- a/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
@@ -11,7 +11,11 @@ module CandidateInterface
         @right_to_work_or_study_form = RightToWorkOrStudyForm.new(right_to_work_params)
 
         if @right_to_work_or_study_form.save(current_application)
-          redirect_to candidate_interface_languages_path
+          if LanguagesSectionPolicy.hide?(current_application)
+            redirect_to candidate_interface_personal_details_show_path
+          else
+            redirect_to candidate_interface_languages_path
+          end
         else
           track_validation_error(@right_to_work_or_study_form)
           render :new

--- a/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Entering personal details' do
   scenario 'The languages page is hidden' do
     given_i_am_signed_in
     and_my_application_is_in_a_state_where_languages_should_not_be_visible
+    and_international_personal_details_is_active
     then_i_can_complete_personal_details_without_seeing_the_languages_page
     and_i_can_mark_the_section_complete
   end
@@ -23,9 +24,16 @@ RSpec.describe 'Entering personal details' do
     expect(current_candidate.current_application.english_main_language).to eq nil
   end
 
+  def and_international_personal_details_is_active
+    # This feature and efl_section will be enabled concurrently, so make sure
+    # we're testing under that scenario.
+    FeatureFlag.activate('international_personal_details')
+  end
+
   def then_i_can_complete_personal_details_without_seeing_the_languages_page
     click_link t('page_titles.personal_details')
 
+    # Basic details
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: scope), with: 'Lando'
     fill_in t('last_name.label', scope: scope), with: 'Calrissian'
@@ -33,16 +41,30 @@ RSpec.describe 'Entering personal details' do
     fill_in 'Month', with: '4'
     fill_in 'Year', with: '1937'
     click_button t('complete_form_button', scope: scope)
-    select('British', from: t('nationality.label', scope: scope))
-    find('details').click
-    within('details') do
-      select('American', from: t('second_nationality.label', scope: scope))
+
+    # Nationality
+    check 'British'
+    click_button t('complete_form_button', scope: scope)
+    expect(page).to have_current_path candidate_interface_personal_details_show_path
+
+    # Go back and change nationality
+    visit candidate_interface_nationalities_path
+    check 'Other'
+    within all('.govuk-form-group')[1] do
+      select 'Pakistani'
     end
     click_button t('complete_form_button', scope: scope)
 
+    # Right to work or study
+    expect(page).to have_content 'Do you have the right to work or study in the UK?'
+    choose 'I do not know'
+    click_button t('complete_form_button', scope: scope)
+
+    # Review
+    expect(page).to have_current_path candidate_interface_personal_details_show_path
     expect(page).to have_content 'Name'
     expect(page).to have_content 'Lando Calrissian'
-    expect(page).to have_content 'British and American'
+    expect(page).to have_content 'Pakistani'
   end
 
   def and_i_can_mark_the_section_complete


### PR DESCRIPTION
The Languages page in Personal Details should be hidden if
LanguagesSectionPolicy#hide? returns true. This doesn't happen currently
if the candidate selects a non-British nationality and has to complete
the Right to Work page.

Update the Right to Work controller to ensure we invoke
LanguagesSectionPolicy when deciding where to redirect after form
submission.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Oversight on my part, discovered while implementing some tangentially related functionality.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/9fk7yluU
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
