### PR TITLE
mount local dev folder as container's working directory

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,9 @@
+# used to mount the local dev folder as the containers workdir for development
+version: "3.6"
+services:
+  web:
+    volumes:
+      - ${APP_ROOT_FOLDER:-.}:/app
+    environment:
+      - RAILS_ENV=development
+      - AUTHORISED_HOSTS=localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - .env
     command: /bin/sh -c "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
   clock:
-    image: apply-for-postgraduate-teacher-training
+    image: apply-for-teacher-training
     working_dir: /app
     depends_on:
       - db


### PR DESCRIPTION
## Context

Enable docker for local development, without having to rebuild.

## Changes proposed in this pull request

use `docker-compose.override.yml` to
mount local project folder to the container's `work_dir` local development

## Guidance to review

## Link to Trello card

https://trello.com/c/cAptq7vG/2494-check-docker-image-for-local-development

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)