### PR TITLE
Relax check for next provider needing permissions setup

### DIFF
--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -163,10 +163,7 @@ module ProviderInterface
     end
 
     def next_provider_needing_permissions_setup
-      providers.find do |p|
-        provider_permissions.keys.exclude?(p.to_s) ||
-          provider_permissions[p.to_s]['permissions'].reject(&:blank?).blank?
-      end
+      providers.find { |p| provider_permissions.keys.exclude?(p.to_s) }
     end
 
     def any_provider_needs_permissions_setup?

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
       expect(wizard.next_step).to eq([:permissions, 456])
     end
 
+    it 'returns the review page from the first provider permissions page when permissions have been set and we are checking answers' do
+      state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [], 456 => [] } })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_id: '123')
+      wizard.checking_answers = true
+      expect(wizard.next_step).to eq([:check])
+    end
+
     it 'returns the review page from the last provider permissions page for a new user' do
       state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [], 456 => [] } })
       wizard = described_class.new(state_store, current_step: 'providers', current_provider_id: '456')


### PR DESCRIPTION
## Context

We do not validate that permissions should be non-empty so it doesn't make sense
to exclude empty permissions when calculating the next provider.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This commit attempts to rectify a bug where a user amending a set of permissions
in the wizard will be returned to the same permissions set unless they turn a permission
'on', this isn't a validation requirement so remove the check for empty permissions.
This allows them to return to the review step of the wizard.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Steps to replicate original bug:


- Start the invite user wizard flow
- Add a provider
- Assign permissions
- Go to "change" those permissions on the review step
- Remove the permissions and submit
   
you're stuck on the same permissions page


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yJUqNuQn/2531-its-possible-to-get-stuck-in-the-invite-provider-user-wizard

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
