### PR TITLE
Present new EFL qualification data in Manage and on the API

### DIFF
--- a/app/forms/candidate_interface/languages_form.rb
+++ b/app/forms/candidate_interface/languages_form.rb
@@ -13,7 +13,9 @@ module CandidateInterface
 
     def self.build_from_application(application_form)
       new(
-        english_main_language: boolean_to_word(application_form[:english_main_language]),
+        english_main_language: boolean_to_word(
+          application_form.english_main_language(fetch_database_value: true),
+        ),
         english_language_details: application_form.english_language_details,
         other_language_details: application_form.other_language_details,
       )

--- a/app/forms/candidate_interface/languages_form.rb
+++ b/app/forms/candidate_interface/languages_form.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
     def self.build_from_application(application_form)
       new(
-        english_main_language: boolean_to_word(application_form.english_main_language),
+        english_main_language: boolean_to_word(application_form[:english_main_language]),
         english_language_details: application_form.english_language_details,
         other_language_details: application_form.other_language_details,
       )
@@ -30,8 +30,8 @@ module CandidateInterface
 
       application_form.update(
         english_main_language: english_main_language?,
-        english_language_details: english_main_language? ? '' : english_language_details,
-        other_language_details: english_main_language? ? other_language_details : '',
+        english_language_details: english_main_language? ? nil : english_language_details,
+        other_language_details: english_main_language? ? other_language_details : nil,
       )
     end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -201,6 +201,23 @@ class ApplicationForm < ApplicationRecord
     [first_nationality, second_nationality, third_nationality, fourth_nationality, fifth_nationality].reject(&:nil?)
   end
 
+  # Override method for english_main_language database field
+  def english_main_language
+    if self[:english_main_language].nil?
+      return true if english_speaking_nationality?
+      return true if english_proficiency&.qualification_not_needed?
+
+      false
+    else
+      self[:english_main_language]
+    end
+  end
+
+  # Override method for english_language_details database field
+  def english_language_details
+    self[:english_language_details].presence || english_proficiency&.formatted_qualification_description
+  end
+
 private
 
   def enough_references_have_been_provided?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -201,7 +201,15 @@ class ApplicationForm < ApplicationRecord
     [first_nationality, second_nationality, third_nationality, fourth_nationality, fifth_nationality].reject(&:nil?)
   end
 
-  # Override method for english_main_language database field
+  # The `english_main_language` and `english_language_details` database fields
+  # are deprecated. This arose from the 'Personal Details > Languages' page
+  # being replaced by an 'English as a Foreign Language' section. The fields
+  # are only editable on applications that already contain user-submitted
+  # values for them, and otherwise remain nil. Because we need to continue
+  # sending these values in the current version of the Vendor API, we override
+  # the default ORM methods. In both cases we use the contents of the legacy
+  # database field if present, otherwise we attempt to infer values from other
+  # parts of the application.
   def english_main_language(fetch_database_value: false)
     return self[:english_main_language] if fetch_database_value
 
@@ -215,7 +223,6 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
-  # Override method for english_language_details database field
   def english_language_details
     self[:english_language_details].presence || english_proficiency&.formatted_qualification_description
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -202,7 +202,9 @@ class ApplicationForm < ApplicationRecord
   end
 
   # Override method for english_main_language database field
-  def english_main_language
+  def english_main_language(fetch_database_value: false)
+    return self[:english_main_language] if fetch_database_value
+
     if self[:english_main_language].nil?
       return true if english_speaking_nationality?
       return true if english_proficiency&.qualification_not_needed?

--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -7,4 +7,10 @@ class EnglishProficiency < ApplicationRecord
     no_qualification: 'no_qualification',
     qualification_not_needed: 'qualification_not_needed',
   }
+
+  def formatted_qualification_description
+    return if efl_qualification.blank?
+
+    "Name: #{efl_qualification.name}, Grade: #{efl_qualification.grade}, Awarded: #{efl_qualification.award_year}"
+  end
 end

--- a/app/models/ielts_qualification.rb
+++ b/app/models/ielts_qualification.rb
@@ -26,4 +26,8 @@ class IeltsQualification < ApplicationRecord
   def name
     'IELTS'
   end
+
+  def grade
+    band_score
+  end
 end

--- a/app/models/toefl_qualification.rb
+++ b/app/models/toefl_qualification.rb
@@ -4,4 +4,8 @@ class ToeflQualification < ApplicationRecord
   def name
     'TOEFL'
   end
+
+  def grade
+    total_score
+  end
 end

--- a/app/services/languages_section_policy.rb
+++ b/app/services/languages_section_policy.rb
@@ -1,6 +1,6 @@
 class LanguagesSectionPolicy
   def self.hide?(application_form)
     FeatureFlag.active?(:efl_section) &&
-      application_form[:english_main_language].nil?
+      application_form.english_main_language(fetch_database_value: true).nil?
   end
 end

--- a/app/services/languages_section_policy.rb
+++ b/app/services/languages_section_policy.rb
@@ -1,6 +1,6 @@
 class LanguagesSectionPolicy
   def self.hide?(application_form)
     FeatureFlag.active?(:efl_section) &&
-      application_form.english_main_language.nil?
+      application_form[:english_main_language].nil?
   end
 end

--- a/spec/forms/candidate_interface/languages_form_spec.rb
+++ b/spec/forms/candidate_interface/languages_form_spec.rb
@@ -1,30 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::LanguagesForm, type: :model do
-  let(:data) do
-    {
-      english_main_language: true,
-      english_language_details: '',
-      other_language_details: Faker::Lorem.paragraph_by_chars(number: 200),
-    }
-  end
-
-  let(:form_data) do
-    {
-      english_main_language: data[:english_main_language] ? 'yes' : 'no',
-      english_language_details: data[:english_language_details],
-      other_language_details: data[:other_language_details],
-    }
-  end
-
   describe '.build_from_application' do
     it 'creates an object based on the provided ApplicationForm' do
-      application_form = ApplicationForm.new(data)
+      application_form = ApplicationForm.new(
+        english_main_language: true,
+        english_language_details: nil,
+        other_language_details: 'I speak French',
+      )
       languages_form = CandidateInterface::LanguagesForm.build_from_application(
         application_form,
       )
 
-      expect(languages_form).to have_attributes(form_data)
+      expect(languages_form).to have_attributes(
+        english_main_language: 'yes',
+        english_language_details: nil,
+        other_language_details: 'I speak French',
+      )
     end
 
     it "initialises english_main_language to nil when it's nil in the application form" do
@@ -44,34 +36,34 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
       expect(languages_form.save(ApplicationForm.new)).to eq(false)
     end
 
-    it 'updates the provided ApplicationForm if valid' do
-      application_form = FactoryBot.create(:application_form)
-      languages_form = CandidateInterface::LanguagesForm.new(form_data)
-
-      expect(languages_form.save(application_form)).to eq(true)
-      expect(application_form).to have_attributes(data)
-    end
-
     it 'saves the English language details only if English is not the main language' do
+      form_data = {
+        english_main_language: 'no',
+        english_language_details: 'I have English qualifications',
+        other_language_details: 'I also speak French',
+      }
       application_form = FactoryBot.create(:application_form)
-      data[:english_main_language] = false
       languages_form = CandidateInterface::LanguagesForm.new(form_data)
 
       languages_form.save(application_form)
 
-      expect(application_form.english_language_details).to eq(form_data[:english_language_details])
-      expect(application_form.other_language_details).to eq('')
+      expect(application_form.english_language_details).to eq 'I have English qualifications'
+      expect(application_form.other_language_details).to eq nil
     end
 
     it 'saves the other language details only if English is the main language' do
+      form_data = {
+        english_main_language: 'yes',
+        english_language_details: 'I have English qualifications',
+        other_language_details: 'I also speak French',
+      }
       application_form = FactoryBot.create(:application_form)
-      data[:other_language_details] = Faker::Lorem.paragraph_by_chars(number: 200)
       languages_form = CandidateInterface::LanguagesForm.new(form_data)
 
       languages_form.save(application_form)
 
-      expect(application_form.other_language_details).to eq(form_data[:other_language_details])
-      expect(application_form.english_language_details).to eq('')
+      expect(application_form.other_language_details).to eq 'I also speak French'
+      expect(application_form.english_language_details).to eq nil
     end
   end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -283,4 +283,47 @@ RSpec.describe ApplicationForm do
       expect(application_form.nationalities).to match_array ['British', 'Irish', 'Welsh', 'Northern Irish']
     end
   end
+
+  describe '#english_main_language' do
+    context 'database value is nil' do
+      let(:application_form) { build(:application_form, english_main_language: nil) }
+
+      it 'returns false by default' do
+        expect(application_form.english_main_language).to eq false
+      end
+
+      context 'when english_speaking_nationality? is true' do
+        it 'returns true' do
+          application_form.first_nationality = 'British'
+
+          expect(application_form.english_main_language).to eq true
+        end
+      end
+
+      context 'when the english_proficiency record declares that a qualification is not needed' do
+        it 'returns true' do
+          english_proficiency = build(:english_proficiency, :qualification_not_needed)
+          application_form.english_proficiency = english_proficiency
+
+          expect(application_form.english_main_language).to eq true
+        end
+      end
+    end
+
+    context 'database value is true' do
+      let(:application_form) { build(:application_form, english_main_language: true) }
+
+      it 'returns true' do
+        expect(application_form.english_main_language).to eq true
+      end
+    end
+
+    context 'database value is false' do
+      let(:application_form) { build(:application_form, english_main_language: false) }
+
+      it 'returns false' do
+        expect(application_form.english_main_language).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -285,6 +285,17 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#english_main_language' do
+    context 'when fetch_database_value is set to true' do
+      it 'returns whatever is in the database field' do
+        [nil, true, false].each do |db_value|
+          application_form = build(:application_form, english_main_language: db_value)
+          expect(
+            application_form.english_main_language(fetch_database_value: true),
+          ).to eq db_value
+        end
+      end
+    end
+
     context 'database value is nil' do
       let(:application_form) { build(:application_form, english_main_language: nil) }
 

--- a/spec/models/english_proficiency_spec.rb
+++ b/spec/models/english_proficiency_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe EnglishProficiency do
+  describe '#formatted_qualification_description' do
+    it 'returns nothing if no efl_qualification is present' do
+      english_proficiency = build(:english_proficiency)
+      expect(english_proficiency.formatted_qualification_description).to be_blank
+    end
+
+    it 'returns a formatted string description of various kinds of efl_qualification' do
+      english_proficiency = build(:english_proficiency)
+      expected_results = [
+        {
+          qualification: build(:ielts_qualification, band_score: '3.5', award_year: '1999'),
+          description: 'Name: IELTS, Grade: 3.5, Awarded: 1999',
+        },
+        {
+          qualification: build(:toefl_qualification, total_score: 30, award_year: '2000'),
+          description: 'Name: TOEFL, Grade: 30, Awarded: 2000',
+        },
+        {
+          qualification: build(:other_efl_qualification, name: 'Anglais for Dummies', grade: 'A+++', award_year: '2001'),
+          description: 'Name: Anglais for Dummies, Grade: A+++, Awarded: 2001',
+        },
+      ]
+
+      expected_results.each do |expected_result|
+        english_proficiency.efl_qualification = expected_result[:qualification]
+        expect(english_proficiency.formatted_qualification_description).to(
+          eq(expected_result[:description]),
+        )
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe 'Entering personal details' do
     # hidden. See LanguagesSectionPolicy and its corresponding spec for more
     # detail.
     FeatureFlag.activate(:efl_section)
-    expect(current_candidate.current_application[:english_main_language]).to eq nil
+    expect(
+      current_candidate.current_application.english_main_language(fetch_database_value: true),
+    ).to eq nil
   end
 
   def and_international_personal_details_is_active

--- a/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Entering personal details' do
     # hidden. See LanguagesSectionPolicy and its corresponding spec for more
     # detail.
     FeatureFlag.activate(:efl_section)
-    expect(current_candidate.current_application.english_main_language).to eq nil
+    expect(current_candidate.current_application[:english_main_language]).to eq nil
   end
 
   def and_international_personal_details_is_active

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature 'Vendor receives the application' do
           uk_residency_status: nil,
           english_main_language: true,
           other_languages: "I'm great at Galactic Basic so English is a piece of cake",
-          english_language_qualifications: '',
+          english_language_qualifications: nil,
           disability_disclosure: 'I have difficulty climbing stairs',
         },
         qualifications: {


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We've introduced an 'English as a foreign language' section to the
application. It appears if a candidate selects a nationality other than
British or Irish. Switching on the feature also hides the Languages
section of Personal Details if the candidate hasn't already filled this
in, as there is overlap between the two sets of questions and EFL is
intended as a replacement.

If the Languages section is hidden, the application can be submitted
with the following database fields containing null values:

- english_main_language
- english_language_details

Both are used in the Vendor API and in the Manage interface. To ensure
we continue to provide consistent data in these fields, we need to infer
values for them if they are blank.

## Changes proposed in this pull request

Override methods as follows:

- english_main_language
  * Return true if the candidate is British/Irish OR if they declare
    that they don't need an English qualification.
  * Return false otherwise.
- english_language_details
  * Return a formatted string description of the candidate's EFL
    qualification, if one has been provided.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Is the method overriding likely to confuse at all further down the road? Is there an approach that could be clearer?
- Suggested steps for testing in a review app:
  - Ensure `efl_section` feature flag is enabled.
  - Complete application as a new candidate, selecting a nationality other than British/Irish in the Personal Details section.
  - You shouldn't see the Languages page when completing Personal Details.
  - Complete the EFL section.
  - Submit the application.
  - View it via the Manage interface and the API.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/nlQgcKnR
## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
