### PR TITLE
Fix UX inconsistencies around ProviderUsers

### DIFF
--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -35,7 +35,7 @@
 
   <% if @permission_model.view_safeguarding_information? %>
     <li>
-      <%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">View safeguarding information</span>
+      <%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">Access safeguarding information</span>
       <% if training_providers_that_can('view_safeguarding_information').any? %>
         <div class="govuk-!-margin-left-5">
           Applies to courses run by:
@@ -60,6 +60,6 @@
   <% end %>
 
   <% if @permission_model.view_applications_only? %>
-    <li><span class="govuk-!-font-weight-bold">View applications only</span></li>
+    <li>The user can only view applications</li>
   <% end %>
 </ul>

--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -60,6 +60,10 @@
   <% end %>
 
   <% if @permission_model.view_applications_only? %>
-    <li>The user can only view applications</li>
+    <% if user_is_viewing_their_own_permissions %>
+      <li>You can only view applications</li>
+    <% else %>
+      <li>The user can only view applications</li>
+    <% end %>
   <% end %>
 </ul>

--- a/app/components/permissions_list.rb
+++ b/app/components/permissions_list.rb
@@ -1,6 +1,9 @@
 class PermissionsList < ViewComponent::Base
-  def initialize(permission_model)
+  attr_reader :user_is_viewing_their_own_permissions
+
+  def initialize(permission_model, user_is_viewing_their_own_permissions: false)
     @permission_model = permission_model
+    @user_is_viewing_their_own_permissions = user_is_viewing_their_own_permissions
   end
 
   def training_providers_that_can(permission)

--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -1,14 +1,3 @@
-<legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-  <h1 class="govuk-fieldset__heading">
-    <span class="govuk-caption-xl"><%= permissions_form.provider_user.full_name %></span>
-    Change permissions: <%= permissions_form.provider.name %>
-  </h1>
-</legend>
-
-<span class="govuk-hint">
-  The user will still be able to view all applications made to courses at this organisation.
-</span>
-
 <%= form_with model: permissions_form,
               method: :patch,
               url: provider_interface_provider_user_edit_permissions_path(
@@ -17,7 +6,15 @@
               ) do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.hidden_field :provider_id %>
-  <%= f.govuk_check_boxes_fieldset :permissions do %>
+  <%= f.govuk_check_boxes_fieldset :permissions, {
+          legend: { text: "Select permissions: #{permissions_form.provider.name}", size: "xl" },
+          caption: { text: "Invite user", size: "xl" },
+  } do %>
+
+    <span class="govuk-hint">
+      The user will still be able to view all applications made to courses at this organisation.
+    </span>
+
     <%= f.govuk_check_box :manage_organisations, true, multiple: false,
                           label: { text: 'Manage organisation' },
                           hint_text: 'Change permissions between organisations' %>

--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -51,7 +51,7 @@
     <% end %>
 
     <%= f.govuk_check_box :view_safeguarding_information, true, multiple: false,
-                          label: { text: 'View safeguarding information' },
+                          label: { text: 'Access safeguarding information' },
                           hint_text: 'View sensitive material about the candidate' %>
     <% if training_providers_that_can('view_safeguarding_information').any? %>
       <div class="govuk-!-margin-left-8">

--- a/app/components/provider_interface/provider_account_component.html.erb
+++ b/app/components/provider_interface/provider_account_component.html.erb
@@ -1,3 +1,5 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
-<%= govuk_link_to 'Change your details or password in DfE Sign-in', dsi_profile_url %>
+<p class="govuk-body">
+  <%= govuk_link_to 'Change your details or password in DfE Sign-in', dsi_profile_url %>
+</p>

--- a/app/components/provider_interface/provider_account_component.rb
+++ b/app/components/provider_interface/provider_account_component.rb
@@ -37,7 +37,7 @@ module ProviderInterface
       current_provider_user.provider_permissions.includes([:provider]).map do |permission|
         {
           key: "Permissions: #{permission.provider.name}",
-          value: render(PermissionsList.new(permission)),
+          value: render(PermissionsList.new(permission, user_is_viewing_their_own_permissions: true)),
         }
       end
     end

--- a/app/components/provider_interface/provider_account_component.rb
+++ b/app/components/provider_interface/provider_account_component.rb
@@ -29,12 +29,8 @@ module ProviderInterface
     def organisations_row
       {
         key: 'Organisations you have access to',
-        value: organisations,
+        value: render(UserDetailsOrganisationsList.new(current_provider_user.providers)),
       }
-    end
-
-    def organisations
-      current_provider_user.providers.map(&:name)
     end
 
     def permissions_rows

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -30,11 +30,13 @@ module ProviderInterface
     end
 
     def provider_row
-      return if @current_provider_user.authorisation.providers_that_actor_can_manage_users_for.size == 1
+      manageable_providers = @current_provider_user.authorisation.providers_that_actor_can_manage_users_for
+      return if manageable_providers.size == 1
 
+      providers_to_show = @provider_user.providers & manageable_providers
       {
         key: 'Organisations this user has access to',
-        value: visible_provider_permissions.map(&:provider).map(&:name),
+        value: render(UserDetailsOrganisationsList.new(providers_to_show)),
         change_path: provider_interface_provider_user_edit_providers_path(@provider_user),
         action: 'organisations',
       }

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -46,7 +46,7 @@ module ProviderInterface
       visible_provider_permissions.map do |permission|
         {
           key: "Permissions: #{permission.provider.name}",
-          value: render(PermissionsList.new(permission)),
+          value: render(PermissionsList.new(permission, user_is_viewing_their_own_permissions: @current_provider_user == @provider_user)),
           change_path: provider_interface_provider_user_edit_permissions_path(@provider_user, provider_id: permission.provider.id),
           action: "permissions for #{permission.provider.name}",
         }

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -36,7 +36,7 @@ module ProviderInterface
         key: 'Organisations this user has access to',
         value: visible_provider_permissions.map(&:provider).map(&:name),
         change_path: provider_interface_provider_user_edit_providers_path(@provider_user),
-        action: 'Change organisations',
+        action: 'organisations',
       }
     end
 
@@ -46,7 +46,7 @@ module ProviderInterface
           key: "Permissions: #{permission.provider.name}",
           value: render(PermissionsList.new(permission)),
           change_path: provider_interface_provider_user_edit_permissions_path(@provider_user, provider_id: permission.provider.id),
-          action: "Change permissions for #{permission.provider.name}",
+          action: "permissions for #{permission.provider.name}",
         }
       end
     end

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -21,7 +21,7 @@ module ProviderInterface
       [
         { key: 'First name', value: @provider_user.first_name },
         { key: 'Last name', value: @provider_user.last_name },
-        { key: 'Email', value: @provider_user.email_address },
+        { key: 'Email address', value: @provider_user.email_address },
       ]
     end
 

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -19,7 +19,8 @@ module ProviderInterface
 
     def details_rows
       [
-        { key: 'Name', value: @provider_user.full_name },
+        { key: 'First name', value: @provider_user.first_name },
+        { key: 'Last name', value: @provider_user.last_name },
         { key: 'Email', value: @provider_user.email_address },
       ]
     end

--- a/app/components/provider_interface/provider_user_invitation_details_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_details_component.rb
@@ -46,7 +46,7 @@ module ProviderInterface
     def providers_row
       {
         key: 'Organisations this user will have access to',
-        value: provider_names_list,
+        value: render(UserDetailsOrganisationsList.new(providers.values)),
         change_path: provider_interface_update_invitation_providers_path(checking_answers: true),
         action: 'organisations this user will have access to',
       }

--- a/app/components/provider_interface/provider_user_invitation_details_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_details_component.rb
@@ -21,7 +21,7 @@ module ProviderInterface
         key: 'First name',
         value: @wizard.first_name,
         change_path: provider_interface_update_invitation_basic_details_path(checking_answers: true),
-        action: 'Change',
+        action: 'first name',
       }
     end
 
@@ -30,7 +30,7 @@ module ProviderInterface
         key: 'Last name',
         value: @wizard.last_name,
         change_path: provider_interface_update_invitation_basic_details_path(checking_answers: true),
-        action: 'Change',
+        action: 'last name',
       }
     end
 
@@ -39,7 +39,7 @@ module ProviderInterface
         key: 'Email address',
         value: @wizard.email_address,
         change_path: provider_interface_update_invitation_basic_details_path(checking_answers: true),
-        action: 'Change',
+        action: 'email address',
       }
     end
 
@@ -48,7 +48,7 @@ module ProviderInterface
         key: 'Organisations this user will have access to',
         value: provider_names_list,
         change_path: provider_interface_update_invitation_providers_path(checking_answers: true),
-        action: 'Change',
+        action: 'organisations this user will have access to',
       }
     end
 
@@ -65,7 +65,7 @@ module ProviderInterface
             checking_answers: true,
             provider_id: provider.id,
           ),
-          action: 'Change',
+          action: "permissions for #{provider.name}",
         }
       end
     end

--- a/app/components/provider_interface/provider_user_invitation_permissions_component.html.erb
+++ b/app/components/provider_interface/provider_user_invitation_permissions_component.html.erb
@@ -1,6 +1,6 @@
 <% if permissions.any? %>
   <% permissions.each do |permission| %>
-    <p class="govuk-!-font-weight-bold govuk-body"><%= render CheckIcon.new %> <%= permission.humanize %></p>
+    <p class="govuk-!-font-weight-bold govuk-body"><%= render CheckIcon.new %> <%= permission %></p>
   <% end %>
 <% else %>
   <p class="govuk-body">The user will only be able to view applications</p>

--- a/app/components/provider_interface/provider_user_invitation_permissions_component.html.erb
+++ b/app/components/provider_interface/provider_user_invitation_permissions_component.html.erb
@@ -1,3 +1,7 @@
-<% permissions.each do |permission| %>
-  <p class="govuk-!-font-weight-bold govuk-body"><%= render CheckIcon.new %> <%= permission.humanize %></p>
+<% if permissions.any? %>
+  <% permissions.each do |permission| %>
+    <p class="govuk-!-font-weight-bold govuk-body"><%= render CheckIcon.new %> <%= permission.humanize %></p>
+  <% end %>
+<% else %>
+  <p class="govuk-body">The user will only be able to view applications</p>
 <% end %>

--- a/app/components/provider_interface/provider_user_invitation_permissions_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_permissions_component.rb
@@ -1,10 +1,20 @@
 module ProviderInterface
   class ProviderUserInvitationPermissionsComponent < ViewComponent::Base
     include ViewHelper
-    attr_reader :permissions
+
+    HUMAN_READABLE_PERMISSIONS = {
+      'view_safeguarding_information' => 'Access safeguarding information',
+      'manage_organisations' => 'Manage organisations',
+      'manage_users' => 'Manage users',
+      'make_decisions' => 'Make decisions',
+    }.freeze
 
     def initialize(permissions)
       @permissions = permissions
+    end
+
+    def permissions
+      @permissions.map { |p| HUMAN_READABLE_PERMISSIONS.fetch(p.to_s) }
     end
   end
 end

--- a/app/components/provider_interface/user_details_organisations_list.html.erb
+++ b/app/components/provider_interface/user_details_organisations_list.html.erb
@@ -1,0 +1,5 @@
+<ul class="govuk-list">
+  <% @organisations.each do |o| %>
+    <li><%= o.name %></li>
+  <% end %>
+</ul>

--- a/app/components/provider_interface/user_details_organisations_list.rb
+++ b/app/components/provider_interface/user_details_organisations_list.rb
@@ -1,0 +1,9 @@
+module ProviderInterface
+  class UserDetailsOrganisationsList < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(organisations)
+      @organisations = organisations
+    end
+  end
+end

--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -19,7 +19,7 @@
             <% row[:provider_user].provider_permissions.each do |permission| %>
               <div class='govuk-!-margin-bottom-2'>
                 <h3 class='govuk-heading-s'><%= permission.provider.name_and_code %></h3>
-                <%= render PermissionsList.new(permission) %>
+                <%= render PermissionsList.new(permission, user_is_viewing_their_own_permissions: false) %>
               </div>
             <% end %>
           </td>

--- a/app/forms/provider_interface/provider_user_providers_form.rb
+++ b/app/forms/provider_interface/provider_user_providers_form.rb
@@ -40,7 +40,7 @@ module ProviderInterface
 
     def at_least_one_provider_is_selected
       if selected_providers.none?
-        errors[:provider_ids] << 'Select at least one organisation this user will have access to'
+        errors[:provider_ids] << 'Select which organisations this user will have access to'
       end
     end
 

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -13,7 +13,7 @@
           </h1>
         </legend>
 
-        <%= f.govuk_collection_check_boxes :provider_ids, @form.providers_that_actor_can_manage_users_for, :id, :name_and_code %>
+        <%= f.govuk_collection_check_boxes :provider_ids, @form.providers_that_actor_can_manage_users_for, :id, :name %>
       <% end %>
 
       <%= f.govuk_submit 'Save' %>

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -9,7 +9,7 @@
       <span class="govuk-caption-xl">Invite user</span>
       <h1 class="govuk-heading-xl">Basic details</h1>
 
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
+      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' } %>
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
 

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -6,9 +6,6 @@
     <%= form_with model: @wizard, url: provider_interface_update_invitation_provider_permissions_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-xl">Invite user</span>
-      <h1 class="govuk-heading-xl">Set permissions for <%= @provider.name %></h1>
-
       <%= f.fields_for "provider_permissions[]", @permissions_form do |pf| %>
         <%= pf.hidden_field :provider_id %>
         <%= pf.govuk_collection_check_boxes(
@@ -17,7 +14,13 @@
           :slug,
           :name,
           :hint,
-        ) %>
+          legend: { text: "Select permissions: #{@provider.name}", size: "xl" },
+          caption: { text: "Invite user", size: "xl" },
+        ) do %>
+          <span id="permissions-hint" class="govuk-hint">
+            The user will be able to view all applications made to courses at these organisations. You don't need to set permissions for this.
+          </span>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
@@ -6,13 +6,12 @@
     <%= form_with model: @wizard, url: provider_interface_update_invitation_providers_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-xl">Invite user</span>
-      <h1 class="govuk-heading-xl">Select organisations this user will have access to</h1>
-
       <%= f.govuk_collection_check_boxes :providers,
             @available_providers,
             :id,
-            :name %>
+            :name,
+            legend: { text: 'Select organisations this user will have access to', size: "xl" },
+            caption: { text: 'Invite user', size: "xl" } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -11,7 +11,7 @@
               <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
                                       label: { text: 'Manage organisations' } %>
               <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
-                                      label: { text: 'View safeguarding information' } %>
+                                      label: { text: 'Access safeguarding information' } %>
               <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
                                       label: { text: 'Make decisions' } %>
             <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,9 +258,7 @@ en:
               too_long: Email address must be %{count} characters or fewer
               invalid: Enter an email address in the correct format, like name@example.com
             providers:
-              blank: Select one or more providers
-            provider_permissions:
-              blank: Select one or more permissions
+              blank: Select which organisations this user will have access to
   activerecord:
     attributes:
       application_qualification/qualification_type:

--- a/spec/components/permissions_list_component_spec.rb
+++ b/spec/components/permissions_list_component_spec.rb
@@ -13,15 +13,34 @@ RSpec.describe PermissionsList do
 
   it 'renders permissions' do
     permission_model = create(:provider_permissions, manage_organisations: true)
-    result = render_inline(described_class.new(permission_model))
+    result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: false))
 
     expect(result.css('li').text).to include('Manage organisations')
     expect(result.css('li').text).not_to include('The user can only view applications')
   end
 
+  describe 'rendering View applications only' do
+    it 'shows an appropriate message when the user is viewing another user’s permissions' do
+      permission_model = create(:provider_permissions)
+      result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: false))
+
+      expect(result.css('li').text).to include('The user can only view applications')
+      expect(result.css('li').text).not_to include('Manage organisations')
+      expect(result.css('li').text).not_to include('Make manage users')
+      expect(result.css('li').text).not_to include('Make decistions')
+      expect(result.css('li').text).not_to include('View safeguarding information')
+    end
+
+    it 'shows an appropriate message when the user is viewing their own permissions' do
+      permission_model = create(:provider_permissions)
+      result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: true))
+      expect(result.css('li').text).to include('You can only view applications')
+    end
+  end
+
   it 'renders View applications only' do
     permission_model = create(:provider_permissions)
-    result = render_inline(described_class.new(permission_model))
+    result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: false))
 
     expect(result.css('li').text).to include('The user can only view applications')
     expect(result.css('li').text).not_to include('Manage organisations')
@@ -35,7 +54,7 @@ RSpec.describe PermissionsList do
                               provider: training_provider,
                               make_decisions: true)
     provider_relationship_permissions
-    result = render_inline(described_class.new(permission_model))
+    result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: false))
 
     expect(result.text).to include('Applies to courses ratified by:')
     expect(result.css('li').text).to include(ratifying_provider.name.to_s)
@@ -46,7 +65,7 @@ RSpec.describe PermissionsList do
                               provider: ratifying_provider,
                               make_decisions: true)
     provider_relationship_permissions
-    result = render_inline(described_class.new(permission_model))
+    result = render_inline(described_class.new(permission_model, user_is_viewing_their_own_permissions: false))
 
     expect(result.text).to include('Applies to courses run by:')
     expect(result.css('li').text).to include(training_provider.name.to_s)

--- a/spec/components/permissions_list_component_spec.rb
+++ b/spec/components/permissions_list_component_spec.rb
@@ -16,18 +16,18 @@ RSpec.describe PermissionsList do
     result = render_inline(described_class.new(permission_model))
 
     expect(result.css('li').text).to include('Manage organisations')
-    expect(result.css('li').text).not_to include('View applications only')
+    expect(result.css('li').text).not_to include('The user can only view applications')
   end
 
   it 'renders View applications only' do
     permission_model = create(:provider_permissions)
     result = render_inline(described_class.new(permission_model))
 
-    expect(result.css('li').text).to include('View applications only')
+    expect(result.css('li').text).to include('The user can only view applications')
     expect(result.css('li').text).not_to include('Manage organisations')
     expect(result.css('li').text).not_to include('Make manage users')
     expect(result.css('li').text).not_to include('Make decistions')
-    expect(result.css('li').text).not_to include('View safeguarding information')
+    expect(result.css('li').text).not_to include('Access safeguarding information')
   end
 
   it 'renders ratifying providers who the permission also applies to' do

--- a/spec/components/provider_interface/provider_account_component_spec.rb
+++ b/spec/components/provider_interface/provider_account_component_spec.rb
@@ -35,6 +35,6 @@ RSpec.describe ProviderInterface::ProviderAccountComponent do
 
   it 'renders permissions' do
     expect(result.css('.govuk-summary-list__key').text).to include('Permissions: ')
-    expect(result.css('.govuk-summary-list__value').text).to include('View applications only')
+    expect(result.css('.govuk-summary-list__value').text).to include('The user can only view applications')
   end
 end

--- a/spec/components/provider_interface/provider_account_component_spec.rb
+++ b/spec/components/provider_interface/provider_account_component_spec.rb
@@ -35,6 +35,6 @@ RSpec.describe ProviderInterface::ProviderAccountComponent do
 
   it 'renders permissions' do
     expect(result.css('.govuk-summary-list__key').text).to include('Permissions: ')
-    expect(result.css('.govuk-summary-list__value').text).to include('The user can only view applications')
+    expect(result.css('.govuk-summary-list__value').text).to include('You can only view applications')
   end
 end

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -100,14 +100,14 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def when_i_add_permission_to_view_safeguarding_for_a_provider_user
-    expect(page).not_to have_checked_field 'View safeguarding information'
-    check 'View safeguarding information'
+    expect(page).not_to have_checked_field 'Access safeguarding information'
+    check 'Access safeguarding information'
     click_on 'Save'
   end
 
   def then_i_can_see_the_view_safeguarding_permission_for_the_provider_user
     within("#provider-#{@provider.id}-enabled-permissions") do
-      expect(page).to have_content 'View safeguarding information'
+      expect(page).to have_content 'Access safeguarding information'
     end
   end
 

--- a/spec/system/provider_interface/manage_provider_user_providers_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_providers_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Managing providers a user has access to' do
   end
 
   def then_i_see_a_validation_error
-    expect(page).to have_content 'Select at least one organisation this user will have access to'
+    expect(page).to have_content 'Select which organisations this user will have access to'
   end
 
   def when_i_give_permission_to_access_the_other_provider

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   end
 
   def then_i_see_the_select_permissions_form_for_selected_provider
-    expect(page).to have_content('Set permissions for Another Provider')
+    expect(page).to have_content('Select permissions: Another Provider')
   end
 
   def when_i_select_make_decisions_permission
@@ -181,7 +181,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   end
 
   def then_i_can_see_the_permissions_form
-    expect(page).to have_content 'Set permissions for Another Provider'
+    expect(page).to have_content 'Select permissions: Another Provider'
   end
 
   def when_i_change_permissions

--- a/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Provider invites a new provider user' do
+RSpec.feature 'Providers can view managed users' do
   include DfESignInHelpers
   include DsiAPIHelper
 

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'Managing provider users' do
 
   def and_i_check_permission_to_view_safeguarding_information
     within(permissions_fields_id_for_provider(@provider)) do
-      check 'View safeguarding information'
+      check 'Access safeguarding information'
     end
   end
 
@@ -191,7 +191,7 @@ RSpec.feature 'Managing provider users' do
 
   def and_they_should_be_able_to_view_safeguarding_information
     within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_checked_field('View safeguarding information')
+      expect(page).to have_checked_field('Access safeguarding information')
     end
   end
 


### PR DESCRIPTION
## Context

These cropped up in a final design review.

## Changes proposed in this pull request

See commits. Note that this changeset introduces a possible _new_ bug — 🎉 — the "Account" page now shows "This user can only view applications" if you're in that state. A bit weird if you don't usually refer to yourself in the third person.

Fixing that is marginally more complicated than fixing all this, so I've preferred the latter & will add a backlog card.

## Link to Trello card

https://trello.com/c/6C0lcv6X/2533-manage-user-permissions-ux-discrepancies

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
