### PR TITLE
Properly remove provider users

### DIFF
--- a/spec/services/remove_provider_user_spec.rb
+++ b/spec/services/remove_provider_user_spec.rb
@@ -19,14 +19,5 @@ RSpec.describe RemoveProviderUser do
 
       expect(user_to_remove.reload.providers).to eq([non_visible_provider])
     end
-
-    context 'when save! fails' do
-      it 'raises an error' do
-        error = StandardError.new('Ops!')
-        allow(user_to_remove).to receive(:save!).and_raise(error)
-
-        expect { service.call! }.to raise_error(error)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Context

@mnacos noticed that the audit log wasn't being updated when a user is deleted from the provider UI. It turns out that `users.providers =` does not update the audit log (added in https://github.com/DFE-Digital/apply-for-teacher-training/pull/2012, cc @steventux).

## Changes proposed in this pull request

This PR changes the way we "delete" a user so that we remove individual permissions, which updates the log. For extra info we also add an audited comment.

## Guidance to review

![image](https://user-images.githubusercontent.com/233676/88787512-e0c6b680-d18b-11ea-81d9-9acab6532ada.png)


## Link to Trello card

https://trello.com/c/GvQ0UIli/2339-removing-a-user-from-a-provider-doesnt-always-update-the-audit-log

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
