### PR TITLE
When inviting users, list only organisations the provider user can manage

### DIFF
--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -23,10 +23,7 @@ module ProviderInterface
       @wizard = wizard_for(current_step: 'providers')
       @wizard.save_state!
 
-      @available_providers = current_provider_user.provider_permissions
-                                                  .manage_users
-                                                  .includes(:provider)
-                                                  .map(&:provider)
+      @available_providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for
     end
 
     def update_providers

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -23,7 +23,10 @@ module ProviderInterface
       @wizard = wizard_for(current_step: 'providers')
       @wizard.save_state!
 
-      @available_providers = current_provider_user.providers
+      @available_providers = current_provider_user.provider_permissions
+                                                  .manage_users
+                                                  .includes(:provider)
+                                                  .map(&:provider)
     end
 
     def update_providers

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -14,8 +14,9 @@ class ProviderPermissions < ActiveRecord::Base
   audited associated_with: :provider_user
 
   scope :manage_organisations, -> { where(manage_organisations: true) }
-  scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
+  scope :manage_users, -> { where(manage_users: true) }
   scope :make_decisions, -> { where(make_decisions: true) }
+  scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
 
   def self.possible_permissions(current_provider_user:, provider_user:)
     providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for.order(:name)

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     when_i_fill_in_email_address_and_name
     and_i_press_continue
     then_i_see_the_select_organisations_form
+    and_select_organisations_only_lists_providers_i_can_manage
 
     when_i_select_one_provider
     and_i_press_continue
@@ -87,6 +88,8 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   end
 
   def and_i_can_manage_users_for_two_providers
+    @view_only_provider = create(:provider, :with_signed_agreement)
+    @provider_user.providers << @view_only_provider
     @provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
     @provider_user.provider_permissions.find_by(provider: @another_provider).update(manage_users: true)
   end
@@ -123,6 +126,10 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
 
   def then_i_see_the_select_organisations_form
     expect(page).to have_content('Select organisations this user will have access to')
+  end
+
+  def and_select_organisations_only_lists_providers_i_can_manage
+    expect(page).not_to have_content(@view_only_provider.name)
   end
 
   def when_i_select_one_provider


### PR DESCRIPTION
## Context

If a user is allowed to `manage_users` for Blackfriars, but not Keele, the user invitation wizard nevertheless lists both when adding the new user to providers.

![image](https://user-images.githubusercontent.com/107591/88790830-aad80100-d190-11ea-8e1d-44b85966ec5b.png)

## Changes proposed in this pull request

Fix this by restricting the list of providers to the list of organisations the current provider user can manage.

## Guidance to review

Is there a better way to write such queries?

## Link to Trello card

https://trello.com/c/6BAC6Bxt

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
