### PR TITLE
Support the single provider journey through the invite provider user wizard

### DIFF
--- a/app/components/provider_interface/provider_user_invitation_details_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_details_component.rb
@@ -8,12 +8,13 @@ module ProviderInterface
     end
 
     def rows
-      [
+      rows = [
         first_name_row,
         last_name_row,
         email_address_row,
-        providers_row,
-      ] + permission_rows
+      ]
+      rows << providers_row unless @wizard.single_provider
+      rows + permission_rows
     end
 
     def first_name_row
@@ -54,8 +55,10 @@ module ProviderInterface
 
     def permission_rows
       providers.map do |_id, provider|
+        key = 'Permissions'
+        key += ": #{provider.name}" unless @wizard.single_provider
         {
-          key: "Permissions: #{provider.name}",
+          key: key,
           value: render(
             ProviderInterface::ProviderUserInvitationPermissionsComponent.new(
               @wizard.provider_permissions[provider.id.to_s]['permissions'].reject(&:blank?),

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -4,7 +4,7 @@ module ProviderInterface
     before_action :require_manage_user_permission!
 
     def edit_details
-      @wizard = wizard_for(current_step: 'details')
+      @wizard = wizard_for(current_step: 'details', single_provider: current_provider_user.providers.size == 1)
       @wizard.save_state!
     end
 
@@ -115,7 +115,7 @@ module ProviderInterface
 
     def details_params
       params.require(:provider_interface_provider_user_invitation_wizard)
-        .permit(:first_name, :last_name, :email_address)
+        .permit(:first_name, :last_name, :email_address, :single_provider, providers: [])
     end
 
     def providers_params

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ActiveModel::Model
     STATE_STORE_KEY = :provider_user_invitation_wizard
 
-    attr_accessor :current_step, :current_provider_id, :first_name, :last_name, :checking_answers
+    attr_accessor :current_step, :current_provider_id, :first_name, :last_name, :checking_answers, :single_provider
     attr_reader :email_address
     attr_writer :providers, :provider_permissions, :state_store
 
@@ -96,7 +96,7 @@ module ProviderInterface
           [:check]
         end
       elsif current_step == 'details'
-        [:providers]
+        single_provider ? [:permissions, next_provider_id] : [:providers]
       elsif %w[providers permissions].include?(current_step) && next_provider_id.present?
         [:permissions, next_provider_id]
       else
@@ -112,7 +112,11 @@ module ProviderInterface
       elsif current_step == 'providers'
         [:details]
       elsif current_step == 'permissions'
-        previous_provider_id.present? ? [:permissions, previous_provider_id] : [:providers]
+        if previous_provider_id.present?
+          [:permissions, previous_provider_id]
+        else
+          single_provider ? [:details] : [:providers]
+        end
       elsif current_step == 'check'
         [:permissions, providers.last]
       else

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -13,10 +13,6 @@
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
 
-      <% if current_provider_user.providers.size == 1 %>
-        <%= f.hidden_field :providers, multiple: true, value: current_provider_user.providers.first.id %>
-      <% end %>
-
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -13,6 +13,10 @@
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
 
+      <% if current_provider_user.providers.size == 1 %>
+        <%= f.hidden_field :providers, multiple: true, value: current_provider_user.providers.first.id %>
+      <% end %>
+
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -8,13 +8,17 @@
 
       <%= f.fields_for "provider_permissions[]", @permissions_form do |pf| %>
         <%= pf.hidden_field :provider_id %>
+        <%
+          fieldset_legend_text = 'Select permissions'
+          fieldset_legend_text += ": #{@provider.name}" unless @wizard.single_provider
+        -%>
         <%= pf.govuk_collection_check_boxes(
           :permissions,
           ProviderInterface::ProviderUserInvitationWizard::AVAILABLE_PERMISSIONS,
           :slug,
           :name,
           :hint,
-          legend: { text: "Select permissions: #{@provider.name}", size: "xl" },
+          legend: { text: fieldset_legend_text, size: "xl" },
           caption: { text: "Invite user", size: "xl" },
         ) do %>
           <span id="permissions-hint" class="govuk-hint">

--- a/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ProviderInterface::ProviderUserInvitationDetailsComponent do
         @provider1.id.to_s => { 'provider_id' => @provider1.id, 'permissions' => %w[manage_users] },
         @provider2.id.to_s => { 'provider_id' => @provider2.id, 'permissions' => %w[make_decisions] },
       },
+      single_provider: nil,
     )
   end
 
@@ -45,5 +46,30 @@ RSpec.describe ProviderInterface::ProviderUserInvitationDetailsComponent do
     expect(result.css('.govuk-summary-list__key')[5].text).to include("Permissions: #{@provider2.name}")
     expect(result.css('.govuk-summary-list__value')[5].text).not_to include('Manage users')
     expect(result.css('.govuk-summary-list__value')[5].text).to include('Make decisions')
+  end
+
+  context 'when the wizard is for a single provider' do
+    let(:provider) { create(:provider) }
+    let(:wizard) do
+      instance_double(
+        ProviderInterface::ProviderUserInvitationWizard,
+        first_name: 'Ed',
+        last_name: 'Yewcator',
+        email_address: 'ed@example.com',
+        providers: [provider.id.to_s],
+        provider_permissions: {
+          provider.id.to_s => { 'provider_id' => provider.id, 'permissions' => %w[manage_users] },
+        },
+        single_provider: 'true',
+      )
+    end
+
+    it 'conditionally hides provider information' do
+      result = render_inline(described_class.new(wizard: wizard))
+
+      expect(result.css('.govuk-summary-list__key')[3].text).to include('Permissions')
+      expect(result.css('.govuk-summary-list__key')[3].text).not_to include("Permissions: #{provider.name}")
+      expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
+    end
   end
 end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -7,9 +7,15 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
 
   describe 'next_step' do
     it 'returns the providers page from the basic details page for a new user' do
-      state_store = state_store_for({})
+      state_store = state_store_for({ providers: [123, 456] })
       wizard = described_class.new(state_store, current_step: 'details')
       expect(wizard.next_step).to eq([:providers])
+    end
+
+    it 'returns the permissions page from the details page for a single provider' do
+      state_store = state_store_for({ providers: [123], single_provider: true })
+      wizard = described_class.new(state_store, current_step: 'details')
+      expect(wizard.next_step).to eq([:permissions, 123])
     end
 
     it 'returns the first provider permissions page from the providers page for a new user' do
@@ -55,6 +61,12 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
       state_store = state_store_for({ providers: [123, 456], provider_permissions: { 123 => [] } })
       wizard = described_class.new(state_store, current_step: 'permissions', current_provider_id: '123')
       expect(wizard.previous_step).to eq([:providers])
+    end
+
+    it 'returns the details page from the permissions page for a single provider' do
+      state_store = state_store_for({ providers: [123], provider_permissions: { 123 => [] }, single_provider: true })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_id: '123')
+      expect(wizard.previous_step).to eq([:details])
     end
 
     it 'returns the first provider permissions page from the last provider permissions page for a new user' do


### PR DESCRIPTION
## Context

The latest design has different conditional rendering logic for the scenario where an inviting user belongs to one provider organisation.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds conditional rendering logic for scenario where inviting user belongs to one provider organisation.

![image](https://user-images.githubusercontent.com/93511/88812474-a96a0100-d1af-11ea-9cd9-36f67eb06e5a.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/gH5jrsuu/2532-support-the-single-provider-journey-through-the-invite-provider-user-wizard
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
