### PR TITLE
Add breadcrumb for Apply again candidates in support

### DIFF
--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -10,8 +10,12 @@
       <li class="govuk-breadcrumbs__list-item">
         <%= link_to 'Applications', support_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
       </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to @application_form.candidate.email_address, support_interface_candidate_path(@application_form.candidate), class: 'govuk-breadcrumbs__link' %>
+      </li>
       <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <%= @application_form.candidate.email_address %>
+        <span class="govuk-visually-hidden">Support reference</span>
+        <%= @application_form.support_reference %>
       </li>
     </ol>
   </div>

--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -4,6 +4,19 @@
   <%= @candidate.email_address %>
 <% end %>
 
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Applications', support_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= @candidate.email_address %>
+      </li>
+    </ol>
+  </div>
+<% end %>
+
 <% unless HostingEnvironment.production? %>
   <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@candidate), class: 'govuk-button' %>
 <% end %>


### PR DESCRIPTION
## Context

This allows support users to more easily navigate between the multiple applications that an apply again candidate will have.

## Changes proposed in this pull request

Add a breadcrumb. :bread:

## Guidance to review

Does this make sense? If I don't get a quick approval on this and have time, I'll see if I can sneak in a refactoring to create a long overdue breadcrumbs component or [use the one from govuk-components](https://github.com/DFE-Digital/govuk-components/blob/master/app/components/govuk_component/breadcrumbs.rb).

### Before (no breadcrumbs)

![Screen Recording 2020-07-29 at 15 40 06](https://user-images.githubusercontent.com/1650875/88814753-6d846b00-d1b2-11ea-97a4-59098b7543fc.gif)

### After (delicious breadcrumbs)

![Screen Recording 2020-07-29 at 15 40 24](https://user-images.githubusercontent.com/1650875/88814769-72491f00-d1b2-11ea-8bdb-f84a7dd4bfe0.gif)


## Link to Trello card

https://trello.com/c/a3UuZeP9

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)