### PR TITLE
Create 'open on apply' courses and course options for fake sandbox provider

### DIFF
--- a/app/services/generate_fake_provider.rb
+++ b/app/services/generate_fake_provider.rb
@@ -10,8 +10,10 @@ class GenerateFakeProvider
 
   def self.generate_courses_for(training_provider)
     10.times do
-      FactoryBot.create(
+      generate_course_options_for FactoryBot.create(
         :course,
+        :open_on_apply,
+        :with_both_study_modes,
         provider: training_provider,
         code: Faker::Alphanumeric.alphanumeric(number: Course::CODE_LENGTH).upcase,
       )
@@ -22,8 +24,10 @@ class GenerateFakeProvider
     test_provider = Provider.default_scoped.find_or_create_by(name: 'Test Provider', code: 'TEST')
 
     3.times do
-      FactoryBot.create(
+      generate_course_options_for FactoryBot.create(
         :course,
+        :open_on_apply,
+        :with_both_study_modes,
         provider: test_provider,
         accredited_provider_id: ratifying_provider.id,
         code: Faker::Alphanumeric.unique.alphanumeric(number: Course::CODE_LENGTH).upcase,
@@ -31,5 +35,13 @@ class GenerateFakeProvider
     end
   end
 
-  private_class_method :generate_ratified_courses_for, :generate_courses_for
+  def self.generate_course_options_for(course)
+    FactoryBot.create(:course_option, :full_time, course: course)
+    FactoryBot.create(:course_option, :part_time, course: course)
+    FactoryBot.create(:course_option, :no_vacancies, course: course)
+  end
+
+  private_class_method :generate_ratified_courses_for,
+                       :generate_courses_for,
+                       :generate_course_options_for
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -234,7 +234,7 @@ FactoryBot.define do
     provider
 
     code { Faker::Alphanumeric.unique.alphanumeric(number: 5).upcase }
-    name { Faker::Educator.unique.secondary_school }
+    name { "#{Faker::Educator.secondary_school} #{rand(100..999)}" }
     address_line1 { Faker::Address.street_address }
     address_line2 { Faker::Address.city }
     address_line3 { Faker::Address.county }

--- a/spec/services/generate_fake_provider_spec.rb
+++ b/spec/services/generate_fake_provider_spec.rb
@@ -17,16 +17,26 @@ RSpec.describe GenerateFakeProvider do
         .to change { Provider.count }.by(2)
     end
 
-    it 'generates courses run by the provider' do
-      generate_provider_call
+    describe 'courses and course options' do
+      let(:fake_provider) { Provider.find_by(code: 'FAKE') }
 
-      expect(Provider.find_by(code: 'FAKE').courses.count).to eq(10)
-    end
+      before { generate_provider_call }
 
-    it 'generates ratified courses' do
-      generate_provider_call
+      it 'generates 10 courses run by the fake provider, with associated options' do
+        courses = fake_provider.courses
 
-      expect(Provider.find_by(code: 'FAKE').accredited_courses.count).to eq(3)
+        expect(courses.count).to eq(10)
+        expect(courses).to all(be_open_on_apply)
+        expect(courses.map(&:course_options)).to all(be_present)
+      end
+
+      it 'generates 3 courses ratified by the fake provider, with associated options' do
+        accredited_courses = fake_provider.accredited_courses
+
+        expect(accredited_courses.count).to eq(3)
+        expect(accredited_courses).to all(be_open_on_apply)
+        expect(accredited_courses.map(&:course_options)).to all(be_present)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

When creating a fake provider via the Support console in sandbox, we create courses and set up ratifying relationships. However, clients cannot create applications because:
- Courses created for the fake provider are not marked 'exposed in find' and 'open on apply'
- Courses have no course options

## Changes proposed in this pull request

This PR addresses the two obstacles above.

## Guidance to review

This PR only changes the code generating the fake provider. Do we need any tasks modifying what is already in place on our sandbox server?

Also, I've appended an integer to FactoryBot-generated site names and removed `.unique`, because the increased number of generated sites started causing `Faker::UniqueGenerator::RetryLimitExceeded` errors.

## Link to Trello card

https://trello.com/c/Q4iXI38J

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
