### PR TITLE
Update error handling when editing provider permissions

### DIFF
--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -15,7 +15,6 @@ module ProviderInterface
         flash[:success] = 'User’s permissions successfully updated'
         redirect_to provider_interface_organisation_path(permissions_model.training_provider)
       else
-        flash[:warning] = 'Unable to save permissions, please try again. If problems persist please contact support.'
         render :edit
       end
     end

--- a/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
@@ -1,10 +1,19 @@
+<% content_for :title, title_with_error_prefix('', @form.errors.any?) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+  <%= form_with(
+    model: @form,
+    url: provider_interface_update_provider_relationship_permissions_path,
+    method: :patch,
+  ) do |f| %>
+    <%= f.govuk_error_summary %>
     <span class="govuk-caption-xl">Change permissions</span>
     <h1 class="govuk-heading-xl">
       For courses run by <%= @form.training_provider.name %> and ratified by
       <%= @form.ratifying_provider.name %>
     </h1>
+
     <div class="app-banner">
       <div class="app-banner__message">
         <p>All users at your organisation and ratifying organisation(s) will be able to view applications to these courses. You don’t need to set permissions for this.</p>
@@ -28,13 +37,6 @@
         </details>
       </div>
     </div>
-
-    <%= form_with(
-      model: @form,
-      url: provider_interface_update_provider_relationship_permissions_path,
-      method: :patch
-    ) do |f| %>
-      <%= f.govuk_error_summary %>
 
       <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
         <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">


### PR DESCRIPTION
## Context



## Changes proposed in this pull request

- delete flash warning as the form builder is dealing with the errors
- move error summary above the heading and caption

| Before | After |
| --- | --- |
| <img width="511" alt="edit permissions" src="https://user-images.githubusercontent.com/38078064/88924725-8bfa6d00-d26b-11ea-9536-b2c2d741ee3c.png">| <img width="334" alt="Screenshot 2020-07-30 at 13 12 28" src="https://user-images.githubusercontent.com/38078064/88924571-5e152880-d26b-11ea-9758-16dde9b64647.png"> |

## Guidance to review

- visit http://localhost:5000/provider/provider-relationship-permissions/:id/edit
- try to submit blank form

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1596108182113000

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
