### PR TITLE
Hide header navigation links from provider interface during onboarding

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -63,14 +63,15 @@ module ProviderInterface
 
     def redirect_if_setup_required
       return unless current_provider_user
+
+      # setup object is needed for hiding header links during provider setup
+      @provider_setup = ProviderSetup.new(provider_user: current_provider_user)
       return if performing_provider_organisation_setup?
 
-      provider_setup = ProviderSetup.new(provider_user: current_provider_user)
-
-      if provider_setup.next_agreement_pending
+      if @provider_setup.next_agreement_pending
         redirect_to provider_interface_new_data_sharing_agreement_path
       elsif FeatureFlag.active?('enforce_provider_to_provider_permissions') &&
-          provider_setup.next_relationship_pending
+          @provider_setup.next_relationship_pending
         # redirect_to provider_interface_provider_relationship_permissions_setup_path
         # TODO: Implement this
       end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -36,25 +36,32 @@ class NavigationItems
       end
     end
 
-    def for_provider_primary_nav(current_controller)
-      [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]
+    def for_provider_primary_nav(current_controller, performing_setup = false)
+      if performing_setup
+        []
+      else
+        [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]
+      end
     end
 
-    def for_provider_account_nav(current_provider_user, current_controller)
+    def for_provider_account_nav(current_provider_user, current_controller, performing_setup = false)
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
       items = []
 
-      if FeatureFlag.active?('enforce_provider_to_provider_permissions') &&
-          current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
-        items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
+      unless performing_setup
+        if FeatureFlag.active?('enforce_provider_to_provider_permissions') &&
+            current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+          items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
+        end
+
+        if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.authorisation.can_manage_users_for_at_least_one_provider?
+          items << NavigationItem.new('Users', provider_interface_provider_users_path, is_active(current_controller, 'provider_users'))
+        end
+
+        items << NavigationItem.new('Account', provider_interface_account_path, is_active(current_controller, 'account'))
       end
 
-      if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.authorisation.can_manage_users_for_at_least_one_provider?
-        items << NavigationItem.new('Users', provider_interface_provider_users_path, is_active(current_controller, 'provider_users'))
-      end
-
-      items << NavigationItem.new('Account', provider_interface_account_path, is_active(current_controller, 'account'))
       items << NavigationItem.new('Sign out', provider_interface_sign_out_path, false)
     end
 

--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -3,6 +3,10 @@ class ProviderSetup
     @provider_user = provider_user
   end
 
+  def pending?
+    next_agreement_pending || next_relationship_pending
+  end
+
   def next_agreement_pending
     providers = @provider_user.providers
     pending_dsa_providers = providers.where.not(

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,7 +15,7 @@
   <%= render(ProviderInterface::HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  product_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_provider_account_nav(current_provider_user, controller))) %>
+                                 navigation_items: NavigationItems.for_provider_account_nav(current_provider_user, controller, @provider_setup&.pending?))) %>
 
                                <% if controller.controller_name == 'start_page' %>
                                  <%= render PhaseBanner.new(no_border: true) %>
@@ -24,7 +24,7 @@
                                <% else %>
                                  <%= render PhaseBanner.new(no_border: true) %>
                                  <%= render(ProviderInterface::PrimaryNavigation.new(
-                                   navigation_items: NavigationItems.for_provider_primary_nav(controller))) %>
+                                   navigation_items: NavigationItems.for_provider_primary_nav(controller, @provider_setup&.pending?))) %>
                                <% end %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Accept data sharing agreement' do
     given_i_am_an_authorised_provider_user
     and_no_data_sharing_agreement_for_my_provider_has_been_accepted
     and_i_am_presented_with_a_data_sharing_agreement
+    and_i_cannot_navigate_to_pages_i_do_not_have_access_to
     when_i_agree_to_the_data_sharing_agreement
     then_i_can_navigate_to_the_provider_interface
   end
@@ -30,9 +31,9 @@ RSpec.feature 'Accept data sharing agreement' do
   end
 
   def given_i_am_an_authorised_provider_user
+    provider_user_exists_in_apply_database
     provider_exists_in_dfe_sign_in
     provider_signs_in_using_dfe_sign_in
-    provider_user_exists_in_apply_database
   end
 
   def and_no_data_sharing_agreement_for_my_provider_has_been_accepted
@@ -73,5 +74,13 @@ RSpec.feature 'Accept data sharing agreement' do
 
   def then_i_can_navigate_to_the_provider_interface
     expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def and_i_cannot_navigate_to_pages_i_do_not_have_access_to
+    expect(page).to have_link 'Sign out'
+    expect(page).not_to have_link 'Organisations'
+    expect(page).not_to have_link 'Users'
+    expect(page).not_to have_link 'Account'
+    expect(page).not_to have_link 'Applications'
   end
 end


### PR DESCRIPTION
## Context

There are links in the header during onboarding. These won't work because users will be redirected back to the onboarding screens.

![image](https://user-images.githubusercontent.com/107591/88935506-bbb07180-d279-11ea-8170-dd63b3f854d2.png)

## Changes proposed in this pull request

Hide the specified links from the header if the provider user is `performing_setup`. I've added a `@provider_setup.pending?` method which is used to set an optional boolean `performing_setup` as an extra argument to `NavigationItem.for_provider_*_nav` methods. We currently only show 'Applications' in the sub-header, but it should be easy to add the other links when they are ready.

## Guidance to review

Is this approach reasonable? `NavigationItems` code does not have access to `@provider_setup`, set in the controller, hence the need for the new argument. 

I've also moved `NavigationItems` to `app/helpers`, as it's not a model.

## Link to Trello card

https://trello.com/c/ejHRNikf

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
