### PR TITLE
Add edit functionality international Other Qualifications

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -49,6 +49,15 @@ module CandidateInterface
       }
     end
 
+    def subject_row(qualification)
+      {
+        key: t('application_form.other_qualification.subject.label'),
+        value: qualification.subject,
+        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.subject.change_action')),
+        change_path: edit_other_qualification_path(qualification),
+      }
+    end
+
     def qualification_value(qualification)
       if FeatureFlag.active?('international_other_qualifications')
         if qualification.non_uk_qualification_type.present?

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -130,7 +130,11 @@ module CandidateInterface
     end
 
     def edit_other_qualification_path(qualification)
-      Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id)
+      if FeatureFlag.active?('international_other_qualifications')
+        Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_details_path(qualification.id)
+      else
+        Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id)
+      end
     end
 
     def edit_other_qualification_type_path(qualification)

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -58,15 +58,6 @@ module CandidateInterface
       end
     end
 
-    def subject_row(qualification)
-      {
-        key: t('application_form.other_qualification.subject.label'),
-        value: qualification.subject,
-        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.subject.change_action')),
-        change_path: edit_other_qualification_path(qualification),
-      }
-    end
-
     def qualification_value(qualification)
       if FeatureFlag.active?('international_other_qualifications')
         if qualification.non_uk_qualification_type.present?

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -41,12 +41,21 @@ module CandidateInterface
     attr_reader :application_form
 
     def qualification_row(qualification)
-      {
-        key: t('application_form.other_qualification.qualification.label'),
-        value: qualification_value(qualification),
-        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.qualification.change_action')),
-        change_path: edit_other_qualification_path(qualification),
-      }
+      if FeatureFlag.active?('international_other_qualifications')
+        {
+          key: t('application_form.other_qualification.qualification.label'),
+          value: qualification_value(qualification),
+          action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.qualification.change_action')),
+          change_path: edit_other_qualification_type_path(qualification),
+        }
+      else
+        {
+          key: t('application_form.other_qualification.qualification.label'),
+          value: qualification_value(qualification),
+          action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.qualification.change_action')),
+          change_path: edit_other_qualification_path(qualification),
+        }
+      end
     end
 
     def subject_row(qualification)
@@ -122,6 +131,10 @@ module CandidateInterface
 
     def edit_other_qualification_path(qualification)
       Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id)
+    end
+
+    def edit_other_qualification_type_path(qualification)
+      Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_type_path(qualification.id)
     end
 
     def generate_action(qualification:, attribute: '')

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     def new
       qualifications = OtherQualificationForm.build_all_from_application(current_application)
       @qualification = OtherQualificationForm.pre_fill_new_qualification(qualifications)
-      @type = @qualification.set_type(get_qualification.qualification_type)
+      @type = @qualification.set_type(current_application.application_qualifications.last)
     end
 
     def create
@@ -29,7 +29,7 @@ module CandidateInterface
         end
       else
         track_validation_error(@qualification)
-        @type = @qualification.set_type(get_qualification.qualification_type)
+        @type = @qualification.set_type(get_qualification)
 
         render :new
       end
@@ -37,7 +37,7 @@ module CandidateInterface
 
     def edit
       @qualification = OtherQualificationForm.build_from_qualification(current_application.application_qualifications.find(params[:id]))
-      @type = @qualification.set_type(get_qualification.qualification_type)
+      @type = @qualification.set_type(get_qualification)
     end
 
     def update
@@ -47,7 +47,7 @@ module CandidateInterface
         redirect_to candidate_interface_review_other_qualifications_path
       else
         track_validation_error(@qualification)
-        @type = @qualification.set_type(get_qualification.qualification_type)
+        @type = @qualification.set_type(get_qualification)
 
         render :edit
       end

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -43,7 +43,7 @@ module CandidateInterface
     def update
       @qualification = OtherQualificationForm.new(other_qualification_params)
 
-      if @qualification.save
+      if @qualification.update(current_application)
         redirect_to candidate_interface_review_other_qualifications_path
       else
         track_validation_error(@qualification)

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -35,6 +35,24 @@ module CandidateInterface
       end
     end
 
+    def edit
+      @qualification = OtherQualificationForm.build_from_qualification(current_application.application_qualifications.find(params[:id]))
+      @type = @qualification.set_type(get_qualification.qualification_type)
+    end
+
+    def update
+      @qualification = OtherQualificationForm.new(other_qualification_params)
+
+      if @qualification.save
+        redirect_to candidate_interface_review_other_qualifications_path
+      else
+        track_validation_error(@qualification)
+        @type = @qualification.set_type(get_qualification.qualification_type)
+
+        render :edit
+      end
+    end
+
   private
 
     def other_qualification_params

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -28,11 +28,7 @@ module CandidateInterface
     end
 
     def there_are_incomplete_qualifications?
-      attributes_that_should_be_completed = @application_form.application_qualifications.other.map do |qualification|
-        [qualification.qualification_type, qualification.subject, qualification.grade, qualification.institution_name]
-      end
-
-      attributes_that_should_be_completed.flatten.length != attributes_that_should_be_completed.flatten.compact.length
+      current_application.application_qualifications.other.select(&:incomplete_other_qualification?).present?
     end
 
     def section_marked_as_complete?

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -16,6 +16,21 @@ module CandidateInterface
       end
     end
 
+    def edit
+      @qualification_type = OtherQualificationTypeForm.build_from_qualification(ApplicationQualification.find(params[:id]))
+    end
+
+    def update
+      @qualification_type = OtherQualificationTypeForm.new(other_qualification_type_params)
+      @qualification = ApplicationQualification.find(params[:id])
+      if @qualification_type.update(@qualification)
+        redirect_to candidate_interface_review_other_qualifications_path
+      else
+        track_validation_error(@qualification_type)
+        render :edit
+      end
+    end
+
   private
 
     def other_qualification_type_params

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -23,7 +23,9 @@ module CandidateInterface
     def update
       @qualification_type = OtherQualificationTypeForm.new(other_qualification_type_params)
       @qualification = ApplicationQualification.find(params[:id])
-      if @qualification_type.update(@qualification)
+      if qualification_type_has_changed && @qualification_type.update(@qualification)
+        redirect_to candidate_interface_edit_other_qualification_details_path(@qualification.id)
+      elsif @qualification_type.update(@qualification)
         redirect_to candidate_interface_review_other_qualifications_path
       else
         track_validation_error(@qualification_type)
@@ -37,6 +39,10 @@ module CandidateInterface
       params.fetch(:candidate_interface_other_qualification_type_form, {}).permit(
         :qualification_type, :other_uk_qualification_type, :non_uk_qualification_type
       )
+    end
+
+    def qualification_type_has_changed
+      @qualification_type.qualification_type != @qualification.qualification_type
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_form.rb
+++ b/app/forms/candidate_interface/other_qualification_form.rb
@@ -75,10 +75,10 @@ module CandidateInterface
     def set_type(qualification)
       if qualification.qualification_type == 'non_uk'
         qualification.non_uk_qualification_type
-      elsif qualification.type == 'Other' && FeatureFlag.active?('international_other_qualifications')
+      elsif qualification.qualification_type == 'Other' && FeatureFlag.active?('international_other_qualifications')
         qualification.other_uk_qualification_type
       else
-        qualification.type
+        qualification.qualification_type
       end
     end
 

--- a/app/forms/candidate_interface/other_qualification_form.rb
+++ b/app/forms/candidate_interface/other_qualification_form.rb
@@ -72,13 +72,13 @@ module CandidateInterface
       end
     end
 
-    def set_type(type)
-      if type == 'non_uk'
-        non_uk_qualification_type
-      elsif type == 'Other' && FeatureFlag.active?('international_other_qualifications')
-        other_uk_qualification_type
+    def set_type(qualification)
+      if qualification.qualification_type == 'non_uk'
+        qualification.non_uk_qualification_type
+      elsif qualification.type == 'Other' && FeatureFlag.active?('international_other_qualifications')
+        qualification.other_uk_qualification_type
       else
-        type
+        qualification.type
       end
     end
 

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -29,8 +29,8 @@ module CandidateInterface
 
       qualification.update!(
         qualification_type: qualification_type,
-        other_uk_qualification_type: other_uk_qualification_type,
-        non_uk_qualification_type: non_uk_qualification_type,
+        other_uk_qualification_type: set_other_uk_qualification_type,
+        non_uk_qualification_type: set_non_uk_qualification_type,
       )
     end
 
@@ -40,6 +40,16 @@ module CandidateInterface
         other_uk_qualification_type: qualification.other_uk_qualification_type,
         non_uk_qualification_type: qualification.non_uk_qualification_type,
       )
+    end
+
+  private
+
+    def set_other_uk_qualification_type
+      qualification_type == 'Other' ? other_uk_qualification_type : nil
+    end
+
+    def set_non_uk_qualification_type
+      qualification_type == 'non_uk' ? non_uk_qualification_type : nil
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -24,6 +24,16 @@ module CandidateInterface
       true
     end
 
+    def update(qualification)
+      return false unless valid?
+
+      qualification.update!(
+        qualification_type: qualification_type,
+        other_uk_qualification_type: other_uk_qualification_type,
+        non_uk_qualification_type: non_uk_qualification_type,
+      )
+    end
+
     def self.build_from_qualification(qualification)
       new(
         qualification_type: qualification.qualification_type,

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -16,8 +16,9 @@ class ApplicationQualification < ApplicationRecord
     award_year
   ].freeze
 
-  EXPECTED_OTHER_INTERNATIONAL_QUALIFICATION_DATA = %i[
+  EXPECTED_INTERNATIONAL_OTHER_QUALIFICATION_DATA = %i[
     qualification_type
+    non_uk_qualification_type
     institution_name
     institution_country
     award_year
@@ -63,9 +64,18 @@ class ApplicationQualification < ApplicationRecord
   def incomplete_other_qualification?
     return false unless other?
 
-    EXPECTED_OTHER_QUALIFICATION_DATA.any? do |field_name|
-      send(field_name).blank?
+    case qualification_type
+    when 'non_uk'
+      return true if EXPECTED_INTERNATIONAL_OTHER_QUALIFICATION_DATA.any? do |field_name|
+        send(field_name).blank?
+      end
+    else
+      return true if EXPECTED_OTHER_QUALIFICATION_DATA.any? do |field_name|
+        send(field_name).blank?
+      end
     end
+
+    false
   end
 
   def naric_reference_choice

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -16,6 +16,13 @@ class ApplicationQualification < ApplicationRecord
     award_year
   ].freeze
 
+  EXPECTED_OTHER_INTERNATIONAL_QUALIFICATION_DATA = %i[
+    qualification_type
+    institution_name
+    institution_country
+    award_year
+  ].freeze
+
   belongs_to :application_form, touch: true
 
   scope :degrees, -> { where level: 'degree' }

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -224,8 +224,7 @@ module CandidateInterface
     end
 
     def no_incomplete_qualifications?
-      incomplete_qualifications = @application_form.application_qualifications.other.select(&:incomplete_other_qualification?)
-      incomplete_qualifications.blank?
+      @application_form.application_qualifications.other.select(&:incomplete_other_qualification?).blank?
     end
 
     def display_efl_link?

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -1,16 +1,3 @@
-<%= f.govuk_error_summary %>
-
-<% if @type != 'Other' %>
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
-    Add <%= @type %> qualification
-  </h1>
-<% else %>
-  <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
-  </h1>
-<% end %>
-
 <% if @type == 'Other' %>
   <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: 'For example, BTEC, NVQ or non-UK other' %>
 <% end %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -1,0 +1,29 @@
+<%= f.govuk_error_summary %>
+
+<% if @type != 'Other' %>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+    Add <%= @type %> qualification
+  </h1>
+<% else %>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+  </h1>
+<% end %>
+
+<% if @type == 'Other' %>
+  <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: 'For example, BTEC, NVQ or non-UK other' %>
+<% end %>
+
+<% if @qualification.non_uk_qualification_type.present? %>
+  <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label') + ' (optional)', size: 'm' } %>
+  <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
+  <%= f.govuk_collection_select :institution_country, select_institution_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
+  <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label') + ' (optional)', size: 'm' }, width: 10 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
+<% else %>
+  <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
+  <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
+  <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
+  <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
+<% end %>

--- a/app/views/candidate_interface/other_qualifications/details/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/edit.html.erb
@@ -4,6 +4,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @qualification, url: candidate_interface_edit_other_qualification_details_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+        Edit <%= @type %> qualification
+      </h1>
 
       <%= render partial: 'form', locals: { f: f } %>
 

--- a/app/views/candidate_interface/other_qualifications/details/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.qualification_details'), @qualification.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification, url: candidate_interface_edit_other_qualification_details_path do |f| %>
+
+      <%= render partial: 'form', locals: { f: f } %>
+
+      <%= f.govuk_submit t('application_form.other_qualification.base.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -4,8 +4,25 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @qualification, url: candidate_interface_create_other_qualification_details_path do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <%= render partial: 'form', locals: { f: f } %>
+      <% if FeatureFlag.active?('international_other_qualifications') %>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+          Add <%= @type %> qualification
+        </h1>
+      <% elsif @type != 'Other' %>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+          Add <%= @type %> qualification
+        </h1>
+      <% else %>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+        </h1>
+      <% end %>
+
+      <%= render partial: 'form', locals: { f: f } %>
 
       <%= f.govuk_radio_buttons_fieldset :add_another_qualification, legend: { text: 'Do you want to add another qualification?', tag: 'span' } do %>
         <% if FeatureFlag.active?('international_other_qualifications') %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -4,35 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @qualification, url: candidate_interface_create_other_qualification_details_path do |f| %>
-      <%= f.govuk_error_summary %>
 
-      <% if @type != 'Other' %>
-        <h1 class="govuk-heading-xl">
-          <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
-          Add <%= @type %> qualification
-        </h1>
-      <% else %>
-        <h1 class="govuk-heading-xl">
-          <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
-        </h1>
-      <% end %>
-
-      <% if @type == 'Other' %>
-        <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: 'For example, BTEC, NVQ or non-UK other' %>
-      <% end %>
-
-      <% if @qualification.non_uk_qualification_type.present? %>
-        <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label') + ' (optional)', size: 'm' } %>
-        <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
-        <%= f.govuk_collection_select :institution_country, select_institution_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
-        <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label') + ' (optional)', size: 'm' }, width: 10 %>
-        <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
-      <% else %>
-        <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
-        <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
-        <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
-        <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
-      <% end %>
+    <%= render partial: 'form', locals: { f: f } %>
 
       <%= f.govuk_radio_buttons_fieldset :add_another_qualification, legend: { text: 'Do you want to add another qualification?', tag: 'span' } do %>
         <% if FeatureFlag.active?('international_other_qualifications') %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -1,0 +1,26 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.add_other_qualification') %>
+</h1>
+
+<%= render 'candidate_interface/other_qualifications/shared/instructions' %>
+
+<%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', tag: 'span' } do %>
+  <%= f.govuk_radio_button :qualification_type, 'GCSE', label: { text: 'GCSE' } %>
+  <%= f.govuk_radio_button :qualification_type, 'A level', label: { text: 'A level' } %>
+  <%= f.govuk_radio_button :qualification_type, 'AS level', label: { text: 'AS level' } %>
+
+  <% if FeatureFlag.active?('international_other_qualifications') %>
+    <%= f.govuk_radio_button :qualification_type, 'Other', label: { text: 'Other UK qualification' } do %>
+      <%= f.govuk_text_field :other_uk_qualification_type, label: { text: 'Qualification name' } %>
+    <% end %>
+    <%= f.govuk_radio_button :qualification_type, 'non_uk', label: { text: 'Non-UK qualification' } do %>
+      <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name' }, hint_text: 'For example, High school diploma, Higher Secondary School Certificate, Baccalauréat Général, Título de Bachiller' %>
+    <% end %>
+  <% else %>
+    <%= f.govuk_radio_button :qualification_type, 'Other', label: { text: 'Other' }  %>
+  <% end %>
+<% end %>
+
+<%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/other_qualifications/type/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_other_qualification'), @qualification_type.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @qualification_type, url: candidate_interface_create_other_qualification_type_path do |f| %>
+    <%= form_with model: @qualification_type, url: candidate_interface_edit_other_qualification_type_path do |f| %>
       <%= render partial: 'shared_form', locals: { f: f } %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -319,6 +319,9 @@ Rails.application.routes.draw do
         get '/' => 'other_qualifications/type#new', as: :new_other_qualification_type
         post '/' => 'other_qualifications/type#create', as: :create_other_qualification_type
 
+        get '/edit-type/:id' => 'other_qualifications/type#edit', as: :edit_other_qualification_type
+        post '/edit-type/:id' => 'other_qualifications/type#update'
+
         get '/new/:id' => 'other_qualifications/details#new', as: :new_other_qualification_details
         post '/new/:id' => 'other_qualifications/details#create', as: :create_other_qualification_details
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -325,6 +325,9 @@ Rails.application.routes.draw do
         get '/new/:id' => 'other_qualifications/details#new', as: :new_other_qualification_details
         post '/new/:id' => 'other_qualifications/details#create', as: :create_other_qualification_details
 
+        get '/edit-details/:id' => 'other_qualifications/details#edit', as: :edit_other_qualification_details
+        post '/edit-details/:id' => 'other_qualifications/details#update'
+
         get '/new' => 'other_qualifications/base#new', as: :new_other_qualification
         post '/new' => 'other_qualifications/base#create', as: :create_other_qualification
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -228,6 +228,26 @@ FactoryBot.define do
       qualification_type { %w[Diploma Doctorate NVQ Foundation].sample }
       grade { %w[pass merit distinction].sample }
     end
+
+    factory :other_uk_qualification do
+      level { 'other' }
+      qualification_type { 'Other' }
+      other_uk_qualification_type { Faker::Educator.subject }
+      subject { Faker::Educator.subject }
+      institution_name { Faker::Educator.university }
+      grade { %w[pass merit distinction].sample }
+      institution_country { 'GB' }
+    end
+
+    factory :non_uk_qualification do
+      level { 'other' }
+      qualification_type { 'non_uk' }
+      non_uk_qualification_type { Faker::Educator.subject }
+      subject { Faker::Educator.subject }
+      institution_name { Faker::Educator.university }
+      grade { %w[pass merit distinction].sample }
+      institution_country { Faker::Address.country_code }
+    end
   end
 
   factory :site do

--- a/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
     it 'returns false if not valid' do
       application_form = double
 
-      form = CandidateInterface::GcseQualificationTypeForm.new({})
-      expect(form.save_base(application_form)).to eq(false)
+      form = CandidateInterface::OtherQualificationTypeForm.new({})
+      expect(form.save(application_form)).to eq(false)
     end
 
     it 'creates a new other qualification if valid' do
@@ -71,6 +71,39 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
       expect(application_form.application_qualifications.last.level).to eq('other')
       expect(application_form.application_qualifications.last.qualification_type).to eq('non_uk')
       expect(application_form.application_qualifications.last.non_uk_qualification_type).to eq('Olympic Gold Medalist')
+    end
+  end
+
+  describe '#update' do
+    it 'returns false if not valid' do
+      qualification = double
+
+      form = CandidateInterface::OtherQualificationTypeForm.new({})
+      expect(form.update(qualification)).to eq(false)
+    end
+
+    it 'updates an other UK qualification if valid' do
+      qualification = create(:other_qualification)
+
+      form = CandidateInterface::OtherQualificationTypeForm.new(qualification_type: 'Other', other_uk_qualification_type: 'Wood Chopper')
+
+      form.update(qualification)
+
+      expect(qualification.level).to eq('other')
+      expect(qualification.qualification_type).to eq('Other')
+      expect(qualification.other_uk_qualification_type).to eq('Wood Chopper')
+    end
+
+    it 'updates a non_uk qualification if valid' do
+      qualification = create(:other_qualification)
+
+      form = CandidateInterface::OtherQualificationTypeForm.new(qualification_type: 'non_uk', non_uk_qualification_type: 'Olympic Gold Medalist')
+
+      form.update(qualification)
+
+      expect(qualification.level).to eq('other')
+      expect(qualification.qualification_type).to eq('non_uk')
+      expect(qualification.non_uk_qualification_type).to eq('Olympic Gold Medalist')
     end
   end
 

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -82,26 +82,53 @@ RSpec.describe ApplicationQualification, type: :model do
   end
 
   describe '#incomplete_other_qualification?' do
-    it 'returns false if not an other_qualification' do
-      qualification = build_stubbed(:gcse_qualification)
+    context 'when a non_uk qualification' do
+      it 'returns false if not an other_qualification' do
+        qualification = build_stubbed(:gcse_qualification)
 
-      expect(qualification.incomplete_other_qualification?).to eq false
+        expect(qualification.incomplete_other_qualification?).to eq false
+      end
+
+      it 'returns false if all expected information is present' do
+        qualification = build_stubbed(:non_uk_qualification, grade: nil, subject: nil)
+
+        expect(qualification.incomplete_other_qualification?).to eq false
+      end
+
+      it 'returns true if any expected information is missing' do
+        qualification = build_stubbed(:other_qualification)
+
+        ApplicationQualification::EXPECTED_OTHER_QUALIFICATION_DATA.each do |field|
+          qualification.send("#{field}=", nil)
+          expect(qualification.incomplete_other_qualification?).to eq true
+          qualification.send("#{field}=", '')
+          expect(qualification.incomplete_other_qualification?).to eq true
+        end
+      end
     end
 
-    it 'returns false if all expected information is present' do
-      qualification = build_stubbed(:other_qualification)
+    context 'for UK qualifications' do
+      it 'returns false if not an other_qualification' do
+        qualification = build_stubbed(:gcse_qualification)
 
-      expect(qualification.incomplete_other_qualification?).to eq false
-    end
+        expect(qualification.incomplete_other_qualification?).to eq false
+      end
 
-    it 'returns true if any expected information is missing' do
-      qualification = build_stubbed(:other_qualification)
+      it 'returns false if all expected information is present' do
+        qualification = build_stubbed(:other_qualification)
 
-      ApplicationQualification::EXPECTED_OTHER_QUALIFICATION_DATA.each do |field|
-        qualification.send("#{field}=", nil)
-        expect(qualification.incomplete_other_qualification?).to eq true
-        qualification.send("#{field}=", '')
-        expect(qualification.incomplete_other_qualification?).to eq true
+        expect(qualification.incomplete_other_qualification?).to eq false
+      end
+
+      it 'returns true if any expected information is missing' do
+        qualification = build_stubbed(:other_qualification)
+
+        ApplicationQualification::EXPECTED_OTHER_QUALIFICATION_DATA.each do |field|
+          qualification.send("#{field}=", nil)
+          expect(qualification.incomplete_other_qualification?).to eq true
+          qualification.send("#{field}=", '')
+          expect(qualification.incomplete_other_qualification?).to eq true
+        end
       end
     end
   end

--- a/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
@@ -44,6 +44,23 @@ RSpec.feature 'Non-uk Other qualifications' do
     and_click_save_and_continue
     then_i_can_check_my_revised_qualification
 
+    when_i_click_add_another_qualification
+    when_i_select_add_other_non_uk_qualification
+    and_i_fill_in_the_name_of_my_qualification
+    and_i_click_continue
+    then_i_see_the_other_qualifications_form
+
+    when_i_visit_the_review_page
+    and_i_mark_this_section_as_completed
+    and_i_click_continue
+    then_i_should_be_told_i_cannot_submit_incomplete_qualifications
+
+    when_i_click_to_change_my_second_qualification
+    and_i_fill_in_the_year_institution_and_country
+    and_leave_grade_and_subject_blank
+    and_click_save_and_continue
+    then_i_should_see_my_second_qualification
+
     when_i_mark_this_section_as_completed
     and_i_click_continue
     then_i_should_see_the_form
@@ -160,12 +177,43 @@ RSpec.feature 'Non-uk Other qualifications' do
     expect(page).to have_content 'Champion'
   end
 
-  def and_the_section_is_not_completed
-    expect(page).not_to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
+  def when_i_click_add_another_qualification
+    click_link 'Add another qualification'
   end
+
+  def when_i_visit_the_review_page
+    visit candidate_interface_review_other_qualifications_path
+  end
+
+  def when_i_click_to_change_my_second_qualification
+    within all('.app-summary-card__body')[1] do
+      all('.govuk-summary-list__actions')[1].click_link 'Change'
+    end
+  end
+
+  def and_i_fill_in_the_year_institution_and_country
+    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Clown College'
+    select 'United States'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
+  end
+
+  def then_i_should_see_my_second_qualification
+    expect(page).to have_content('Clown College, United States')
+    expect(page).to have_content('2015')
+  end
+
+  def and_leave_grade_and_subject_blank; end
 
   def when_i_mark_this_section_as_completed
     check t('application_form.other_qualification.review.completed_checkbox')
+  end
+
+  def and_i_mark_this_section_as_completed
+    when_i_mark_this_section_as_completed
+  end
+
+  def then_i_should_be_told_i_cannot_submit_incomplete_qualifications
+    expect(page).to have_content('You must fill in all your qualifications to complete this section')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
@@ -148,9 +148,8 @@ RSpec.feature 'Non-uk Other qualifications' do
 
   def then_i_see_my_qualification_filled_in
     expect(page).to have_selector("input[value='Believing in the Heart of the Cards']")
-    expect(page).to have_selector("input[value='Japan']")
-    expect(page).to have_selector("input[value='N/A']")
     expect(page).to have_selector("input[value='2015']")
+    expect(first('#candidate-interface-other-qualification-form-institution-country-field').value).to eq('Japan')
   end
 
   def when_i_change_my_qualification

--- a/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
@@ -30,6 +30,20 @@ RSpec.feature 'Non-uk Other qualifications' do
     then_i_see_the_other_qualification_review_page
     and_i_should_see_my_qualification
 
+    when_i_click_to_change_my_first_qualification_type
+    then_i_see_my_qualification_type_filled_in
+
+    when_i_change_my_qualification_type
+    and_click_save_and_continue
+    then_i_can_check_my_revised_qualification_type
+
+    when_i_click_to_change_my_first_qualification
+    then_i_see_my_qualification_filled_in
+
+    when_i_change_my_qualification
+    and_click_save_and_continue
+    then_i_can_check_my_revised_qualification
+
     when_i_mark_this_section_as_completed
     and_i_click_continue
     then_i_should_see_the_form
@@ -110,6 +124,45 @@ RSpec.feature 'Non-uk Other qualifications' do
     expect(page).to have_content('Believing in the Heart of the Cards')
     expect(page).to have_content('Yugi College, Japan')
     expect(page).to have_content('2015')
+  end
+
+  def when_i_click_to_change_my_first_qualification_type
+    first('.govuk-summary-list__actions').click_link 'Change'
+  end
+
+  def then_i_see_my_qualification_type_filled_in
+    expect(page).to have_selector("input[value='Master Rules']")
+  end
+
+  def when_i_change_my_qualification_type
+    fill_in t('application_form.other_qualification.non_uk.label'), with: 'Battle'
+  end
+
+  def then_i_can_check_my_revised_qualification_type
+    expect(page).to have_content 'Battle'
+  end
+
+  def when_i_click_to_change_my_first_qualification
+    all('.govuk-summary-list__actions')[1].click_link 'Change'
+  end
+
+  def then_i_see_my_qualification_filled_in
+    expect(page).to have_selector("input[value='Believing in the Heart of the Cards']")
+    expect(page).to have_selector("input[value='Japan']")
+    expect(page).to have_selector("input[value='N/A']")
+    expect(page).to have_selector("input[value='2015']")
+  end
+
+  def when_i_change_my_qualification
+    fill_in t('application_form.other_qualification.grade.label'), with: 'Champion'
+  end
+
+  def then_i_can_check_my_revised_qualification
+    expect(page).to have_content 'Champion'
+  end
+
+  def and_the_section_is_not_completed
+    expect(page).not_to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
   end
 
   def when_i_mark_this_section_as_completed

--- a/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/international_candidate_enters_their_other_qualification_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Non-uk Other qualifications' do
     then_i_see_my_qualification_type_filled_in
 
     when_i_change_my_qualification_type
-    and_click_save_and_continue
+    and_i_click_continue
     then_i_can_check_my_revised_qualification_type
 
     when_i_click_to_change_my_first_qualification
@@ -135,7 +135,7 @@ RSpec.feature 'Non-uk Other qualifications' do
   end
 
   def when_i_change_my_qualification_type
-    fill_in t('application_form.other_qualification.non_uk.label'), with: 'Battle'
+    fill_in 'candidate-interface-other-qualification-type-form-non-uk-qualification-type-field', with: 'Battle'
   end
 
   def then_i_can_check_my_revised_qualification_type


### PR DESCRIPTION
## Context

This is the follow-up PR for #2608 which added the create functionality for international qualifications 

This PR allows candidates to update the type and details of their qualification.

## Changes proposed in this pull request

- Add edit type page

- Add edit details page 

before 

![image](https://user-images.githubusercontent.com/42515961/88937983-b99be200-d27c-11ea-8652-140cae309e03.png)

after
Type page

![image](https://user-images.githubusercontent.com/42515961/88945037-61b5a900-d285-11ea-8ae3-06c432c3b594.png)


Details page
![image](https://user-images.githubusercontent.com/42515961/88944875-329f3780-d285-11ea-943c-b004b9b86b9a.png)

## Guidance to review

This will require further refactor went the feature flag gets removed. 

I've come up with the following list of things:

- Remove the other qual base controller
- Remove the views
- Refactor the Other Qual Form to have an application_form/qualification passed into the save and update methods. It currently calls ApplicationQualification.find(id) inside these methods :cry:
- Have a look at the factories

I'll create a tech debt card.

## Link to Trello card

https://trello.com/c/hcn07OYW/1764-dev-%F0%9F%8C%90-other-international-qualification

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
