### PR TITLE
Swap to using smart quotes in error messages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -217,11 +217,11 @@ en:
         provider_interface/provider_user_form:
           attributes:
             email_address:
-              blank: Enter the user's email address
+              blank: Enter the user’s email address
             first_name:
-              blank: Enter the user's first name
+              blank: Enter the user’s first name
             last_name:
-              blank: Enter the user's last name
+              blank: Enter the user’s last name
             provider_permissions:
               blank: Please specify a provider
         change_offer:
@@ -249,11 +249,11 @@ en:
         provider_interface/provider_user_invitation_wizard:
           attributes:
             first_name:
-              blank: Enter the user's first name
+              blank: Enter the user’s first name
             last_name:
-              blank: Enter the user's last name
+              blank: Enter the user’s last name
             email_address:
-              blank: Enter the user's email address
+              blank: Enter the user’s email address
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer
               invalid: Enter an email address in the correct format, like name@example.com

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -119,9 +119,9 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   alias_method :when_i_press_continue, :and_i_press_continue
 
   def then_i_see_validation_errors_for_names_and_email_address
-    expect(page).to have_content('Enter the user\'s first name')
-    expect(page).to have_content('Enter the user\'s last name')
-    expect(page).to have_content('Enter the user\'s email address')
+    expect(page).to have_content('Enter the user’s first name')
+    expect(page).to have_content('Enter the user’s last name')
+    expect(page).to have_content('Enter the user’s email address')
   end
 
   def then_i_see_the_select_organisations_form


### PR DESCRIPTION
## Context
Smart quotes are better than dumb quotes!

## Changes proposed in this pull request
Changes to using smart quotes in two sets of error messages. I'm mostly doing this as a way of testing making a change and getting it through our pipeline. A nice byproduct is these messages look a little nicer.

Let me know if I should have touched anything else.

## After:
<img width="732" alt="Screenshot 2020-07-30 at 16 34 36" src="https://user-images.githubusercontent.com/2204224/88943067-ef43c980-d282-11ea-97e0-f8b0232afdc3.png">

## Before:
<img width="682" alt="Screenshot 2020-07-30 at 16 34 56" src="https://user-images.githubusercontent.com/2204224/88943057-ec48d900-d282-11ea-973d-3f230b375c8e.png">
