### PR TITLE
Fix year validation in WorkExperienceForm

### DIFF
--- a/app/helpers/date_validation_helper.rb
+++ b/app/helpers/date_validation_helper.rb
@@ -22,11 +22,15 @@ module DateValidationHelper
   end
 
   def end_date_valid
-    errors.add(:end_date, :invalid) unless end_date.is_a?(Date)
+    errors.add(:end_date, :invalid) unless
+      end_date.is_a?(Date) &&
+        end_date.year.positive?
   end
 
   def start_date_valid
-    errors.add(:start_date, :invalid) unless start_date.is_a?(Date)
+    errors.add(:start_date, :invalid) unless
+      start_date.is_a?(Date) &&
+        start_date.year.positive?
   end
 
   def start_date_before_end_date

--- a/spec/forms/candidate_interface/work_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/work_experience_form_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
 
     include_examples 'validation for a start date', 'work_experience_form'
     include_examples 'validation for an end date that can be blank', 'work_experience_form'
+
+    it 'does not accept negative integers in the year field' do
+      form_data[:start_date_year] = -1999
+      form_data[:end_date_year] = -1999
+      work_experience = CandidateInterface::WorkExperienceForm.new(form_data)
+
+      expect(work_experience).not_to be_valid
+      errors = work_experience.errors.messages
+      expect(errors[:start_date].pop).to eq 'Enter a start date in the correct format'
+      expect(errors[:end_date].pop).to eq 'Enter an end date in the correct format'
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION


## Context
"Within the work history section of the application form, when entering the dates (start date/end date) of my former employment, I can include negative integers"
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Update date validations so we don't allow negative integers in the year field.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/CraXIRmz
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
