### PR TITLE
do not mount /public assets local folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ shell: ## Open a shell on the app container
 
 .PHONY: serve
 serve: ## Run the service
-	docker-compose up --build
+	docker-compose up -V --build
 
 .PHONY: ci.lint-ruby
 ci.lint-ruby: ## Run Rubocop with results formatted for CI

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,13 @@ services:
   web:
     volumes:
       - ${APP_ROOT_FOLDER:-.}:/app
+      # do not mount these below local files/folders into the container
+      - /app/public
     environment:
       - RAILS_ENV=development
       - AUTHORISED_HOSTS=localhost
+# disable clock and worker when running locally
+  clock:
+    entrypoint: ["/bin/true"]
+  worker:
+    entrypoint: ["/bin/true"]


### PR DESCRIPTION
## Context

when running docker-compose for local development, 
`/public` folder might not contain the compiled packs folder

also not run the clock and worker services for local development

## Changes proposed in this pull request


## Guidance to review

## Link to Trello card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
