### PR TITLE
Update browser titles and ensure 'Error:' prefix is shown on error

### DIFF
--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "Account" %>
+<%= content_for :browser_title, "Account" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :browser_title, t('page_titles.application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/application_choices/emails.html.erb
+++ b/app/views/provider_interface/application_choices/emails.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Email log" %>
+<% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Email log" %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Applications' %>
+<% content_for :browser_title, 'Applications' %>
 
 <% if FeatureFlag.active?('covid_19') %>
   <div class="govuk-grid-row">

--- a/app/views/provider_interface/application_choices/new_note.html.erb
+++ b/app/views/provider_interface/application_choices/new_note.html.erb
@@ -1,5 +1,4 @@
-<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Add Note" %>
-
+<% content_for :browser_title, title_with_error_prefix("#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Add Note", @new_note_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(request.referer) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/application_choices/notes.html.erb
+++ b/app/views/provider_interface/application_choices/notes.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Notes" %>
+<% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Notes" %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code}" %>
+<% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code}" %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/provider_interface/application_choices/timeline.html.erb
+++ b/app/views/provider_interface/application_choices/timeline.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Timeline" %>
+<% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Timeline" %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/provider_interface/conditions/confirm_update.html.erb
+++ b/app/views/provider_interface/conditions/confirm_update.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Confirm conditions' %>
+<% content_for :browser_title, title_with_error_prefix('Confirm conditions', @conditions_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/conditions/edit.html.erb
+++ b/app/views/provider_interface/conditions/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Confirm conditions' %>
+<% content_for :browser_title, title_with_error_prefix('Confirm conditions', @conditions_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/content/rendered_markdown_template.html.erb
+++ b/app/views/provider_interface/content/rendered_markdown_template.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, t("page_titles.#{@page_name}") %>
+<%= content_for :browser_title, t("page_titles.#{@page_name}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.provider.confirm') %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.confirm'), @application_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_offer_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.application'), @reject_application.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_reject_path(@application_choice.id)) %>
 
 

--- a/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Withdraw offer' %>
+<% content_for :browser_title, title_with_error_prefix('Withdraw offer', @withdraw_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>

--- a/app/views/provider_interface/decisions/new_edit_response.html.erb
+++ b/app/views/provider_interface/decisions/new_edit_response.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, @edit_response.errors.any? ? 'Error: Change response' : 'Change response' %>
+<% content_for :browser_title, title_with_error_prefix('Change response', @edit_response.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
 <%= form_with model: @edit_response,

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Conditions of offer' %>
+<% content_for :browser_title, title_with_error_prefix('Conditions of offer', @application_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, @reject_application.errors.any? ? 'Error: Reject application' : 'Reject application' %>
+<% content_for :browser_title, title_with_error_prefix('Reject application', @reject_application.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Withdraw offer' %>
+<% content_for :browser_title, title_with_error_prefix('Withdraw offer', @withdraw_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.provider.respond') %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.respond'), @pick_response_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/permission_error.html.erb
+++ b/app/views/provider_interface/permission_error.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "Requires ‘#{@error.permission}’" %>
+<%= content_for :browser_title, "Requires ‘#{@error.permission}’" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, t('page_titles.data_sharing_agreement') %>
+<%= content_for :browser_title, t('page_titles.data_sharing_agreement') %>
 
 <% if @provider_agreement.persisted? %>
   <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-9">

--- a/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix('', @form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('', @form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/provider_users/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users/edit_permissions.html.erb
@@ -1,3 +1,4 @@
+<% content_for :browser_title, title_with_error_prefix("#{@form.provider_user.full_name}", @form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_provider_user_path(@form.provider_user)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -1,3 +1,4 @@
+<% content_for :browser_title, title_with_error_prefix("#{@form.provider_user.full_name}", @form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_provider_user_path(@form.provider_user)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Users' %>
+<% content_for :browser_title, 'Users' %>
 
 <h1 class="govuk-heading-xl">Users</h1>
 

--- a/app/views/provider_interface/provider_users_invitations/check.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
-<% content_for :title, 'Check permissions before you invite user' %>
+<% content_for :browser_title, title_with_error_prefix('Check permissions before you invite user', @wizard.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
-<% content_for :title, 'Basic details' %>
+<% content_for :browser_title, title_with_error_prefix('Basic details', @wizard.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
-<% content_for :title, 'Providers' %>
+<% content_for :browser_title, title_with_error_prefix('Providers', @wizard.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_providers.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content, govuk_back_link_to(previous_page, 'Back') %>
-<% content_for :title, 'Providers' %>
+<% content_for :browser_title, title_with_error_prefix('Providers', @wizard.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/provider_interface/sessions/authentication_fallback.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.sign_in') %>
+<% content_for :browser_title, t('page_titles.sign_in') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/sessions/check_your_email.html.erb
+++ b/app/views/provider_interface/sessions/check_your_email.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.check_your_email') %>
+<% content_for :browser_title, t('page_titles.check_your_email') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.sign_in') %>
+<% content_for :browser_title, t('page_titles.sign_in') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :browser_title, t('page_titles.application') %>
 
 <div class="app-masthead">
   <div class="govuk-width-container">

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -1,4 +1,4 @@
-  <% content_for :browser_title, "Edit provider user #{@form.provider_user.full_name}" %>
+<% content_for :browser_title, title_with_error_prefix("Edit provider user #{@form.provider_user.full_name}", @form.errors.any?) %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :browser_title, title_with_error_prefix('Add provider user', @form.errors.any?) %>
+
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">

--- a/app/views/support_interface/support_users/new.html.erb
+++ b/app/views/support_interface/support_users/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :browser_title, title_with_error_prefix('Add support user', @support_user.errors.any?) %>
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">


### PR DESCRIPTION
## Context
GOV.UK Design System recommends to reflect that there's been an error in the <title> by prefixing the existing title with "Error: ". That will make sure screen readers are alerted to there being an error as soon as possible.  

All views with `<%= f.govuk_error_summary %>` should be able to display `Error:` in the tittle on.

## Changes proposed in this pull request

Update content for title to check for errors and prefix as appropriate.

- <kbd><img width="464" alt="Screenshot 2020-07-29 at 17 46 16" src="https://user-images.githubusercontent.com/38078064/88949011-91b37b00-d28a-11ea-9938-9314b21d2293.png"></kbd>
- <kbd><img width="361" alt="Screenshot 2020-07-30 at 17 21 06" src="https://user-images.githubusercontent.com/38078064/88949039-9d06a680-d28a-11ea-981a-7c937336affa.png"></kbd>


## Guidance to review

Note: We decided to standardise on `:browser_title` everywhere but support.

## Link to Trello card

https://trello.com/c/GPafrj4C/2541-pages-with-an-error-summary-shown-should-have-error-prepended-in-the-page-title

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
