### PR TITLE
Bug fix alteration of flow and addition of view so that candidate can give one referee at a time

### DIFF
--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -3,7 +3,7 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
-<% if FeatureFlag.active?('provider_change_response') %>
+<% if FeatureFlag.active?('provider_change_response') && provider_can_respond %>
 <p class="govuk-body govuk-!-margin-bottom-0 app-!-print-display-none">
   <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
 </p>

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -4,11 +4,12 @@ module ProviderInterface
       include ViewHelper
       include StatusBoxComponents::CourseRows
 
-      attr_reader :application_choice
+      attr_reader :application_choice, :provider_can_respond
       attr_reader :available_providers, :available_courses, :available_study_modes, :available_course_options
 
       def initialize(application_choice:, options: {})
         @application_choice = application_choice
+        @provider_can_respond = options[:provider_can_respond]
         @available_providers = options[:available_providers]
         @available_courses = options[:available_courses]
         @available_study_modes = options[:available_study_modes]

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -79,7 +79,7 @@ module CandidateInterface
       return render :add_another_referee unless @add_another_referee.valid?
 
       if @add_another_referee.add_another_referee?
-        redirect_to candidate_interface_additional_referee_type_path
+        redirect_to candidate_interface_additional_referee_type_path(second: true)
       else
         redirect_to candidate_interface_application_form_path
       end

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -70,6 +70,13 @@ module CandidateInterface
       @references = not_requested_references
     end
 
+    def add_another_referee
+
+    end
+
+    def add_another_referee_decision
+    end
+
     def request_references
       references_to_confirm = not_requested_references.includes(:application_form).to_a
 
@@ -79,7 +86,15 @@ module CandidateInterface
 
       flash[:success] = I18n.t!('additional_referees.feedback_flash', count: references_to_confirm.size)
 
-      redirect_to candidate_interface_application_form_path
+      if FeatureFlag.active?(:separate_additional_referees)
+        if reference_status.still_more_references_needed?
+          redirect_to candidate_interface_add_another_referee_path
+        else
+          redirect_to candidate_interface_application_form_path
+        end
+      else
+        redirect_to candidate_interface_application_form_path
+      end
     end
 
     def edit

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -54,7 +54,9 @@ module CandidateInterface
 
       reference.referee_type = params[:type]
 
-      if reference.save
+      if FeatureFlag.active?(:separate_additional_referees) && reference.save
+        redirect_to candidate_interface_confirm_additional_referees_path
+      elsif reference.save
         redirect_to_confirm_or_show_another_reference_form
       else
         track_validation_error(reference)
@@ -86,7 +88,9 @@ module CandidateInterface
     end
 
     def update
-      if current_reference.update(referee_params)
+      if FeatureFlag.active?(:separate_additional_referees) && current_reference.update(referee_params)
+        redirect_to candidate_interface_confirm_additional_referees_path
+      elsif current_reference.update(referee_params)
         redirect_to_confirm_or_show_another_reference_form
       else
         track_validation_error(current_reference)

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -71,10 +71,18 @@ module CandidateInterface
     end
 
     def add_another_referee
-
+      @add_another_referee = AddAnotherRefereeForm.new
     end
 
     def add_another_referee_decision
+      @add_another_referee = AddAnotherRefereeForm.new(add_another_referee_params)
+      return render :add_another_referee unless @add_another_referee.valid?
+
+      if @add_another_referee.add_another_referee?
+        redirect_to candidate_interface_additional_referee_type_path
+      else
+        redirect_to candidate_interface_application_form_path
+      end
     end
 
     def request_references
@@ -140,6 +148,10 @@ module CandidateInterface
         :email_address,
         :relationship,
       ).transform_values(&:strip)
+    end
+
+    def add_another_referee_params
+      params.fetch(:candidate_interface_add_another_referee_form, {}).permit(:add_another_referee)
     end
 
     def redirect_to_dashboard_if_no_references_needed

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -38,6 +38,8 @@ module ProviderInterface
                             else
                               {}
                             end
+
+      @status_box_options[:provider_can_respond] = @provider_can_respond
     end
 
     def notes

--- a/app/forms/candidate_interface/add_another_referee_form.rb
+++ b/app/forms/candidate_interface/add_another_referee_form.rb
@@ -1,0 +1,12 @@
+module CandidateInterface
+  class AddAnotherRefereeForm
+    include ActiveModel::Model
+
+    attr_accessor :add_another_referee
+    validates :add_another_referee, presence: true
+
+    def add_another_referee?
+      add_another_referee == 'yes'
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -38,8 +38,12 @@ class FeatureFlag
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],
     [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
     [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
+<<<<<<< HEAD
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],
     [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow']
+=======
+    [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow', 'George Holborn'],
+>>>>>>> Update to feature test to follow flow & tweak to redirect on controller
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -38,16 +38,8 @@ class FeatureFlag
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],
     [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
     [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
-<<<<<<< HEAD
-<<<<<<< HEAD
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],
-    [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow']
-=======
-    [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow', 'George Holborn'],
->>>>>>> Update to feature test to follow flow & tweak to redirect on controller
-=======
     [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow.', 'George Holborn'],
->>>>>>> Update app/services/feature_flag.rb
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -39,7 +39,7 @@ class FeatureFlag
     [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
     [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],
-
+    [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow']
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -39,11 +39,15 @@ class FeatureFlag
     [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
     [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
 <<<<<<< HEAD
+<<<<<<< HEAD
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],
     [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow']
 =======
     [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow', 'George Holborn'],
 >>>>>>> Update to feature test to follow flow & tweak to redirect on controller
+=======
+    [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow.', 'George Holborn'],
+>>>>>>> Update app/services/feature_flag.rb
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/additional_referees/add_another_referee.html.erb
+++ b/app/views/candidate_interface/additional_referees/add_another_referee.html.erb
@@ -1,0 +1,20 @@
+<% title = "Do you want to add a second referee now?" %>
+<% content_for :title, title_with_error_prefix(title, @add_another_referee.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+
+<%= form_with model: @add_another_referee, url: candidate_interface_add_another_referee_path, method: :post do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <%= f.govuk_radio_buttons_fieldset :add_another_referee do %>
+        <%= f.govuk_radio_button :add_another_referee, :yes, label: { text: 'Yes, I want to  add a second referee' }, link_errors: true %>
+        <%= f.govuk_radio_button :add_another_referee, :no, label: { text: 'No, I’ll add a second referee later' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -406,6 +406,10 @@ en:
           attributes:
             add_another_course:
               blank: Select if you want to add another course
+        candidate_interface/add_another_referee_form:
+          attributes:
+            add_another_referee:
+              blank: Select if you want to add another referee
         candidate_interface/eligibility_form:
           attributes:
             eligible_citizen:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,9 @@ Rails.application.routes.draw do
         get '/confirm' => 'additional_referees#confirm', as: :confirm_additional_referees
         post '/confirm' => 'additional_referees#request_references'
 
+        get '/add-another-referee' => 'additional_referees#add_another_referee', as: :add_another_referee
+        post '/add-another-referee' => 'additional_referees#add_another_referee_decision'
+
         get '/contact-support' => 'additional_referees#contact_support', as: :additional_referee_contact_support
       end
 

--- a/spec/forms/candidate_interface/add_another_referee_form_spec.rb
+++ b/spec/forms/candidate_interface/add_another_referee_form_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::AddAnotherRefereeForm, type: :model do
+  let(:form) { described_class.new(add_another_referee) }
+  let(:add_another_referee) do
+    { 'add_another_referee' => 'yes' }
+  end
+
+  it { is_expected.to validate_presence_of(:add_another_referee) }
+
+  describe '#add_another_referee?' do
+    context 'when the add_another_referee value is yes' do
+      it 'returns true' do
+        expect(form.add_another_referee?).to be_truthy
+      end
+    end
+
+    context 'when the add_another_referee value is no' do
+      let(:add_another_referee) do
+        { 'add_another_referee' => 'no' }
+      end
+
+      it 'returns false' do
+        expect(form.add_another_referee?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/add_another_referee_form_spec.rb
+++ b/spec/forms/candidate_interface/add_another_referee_form_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe CandidateInterface::AddAnotherRefereeForm, type: :model do
     end
 
     context 'when the add_another_referee value is no' do
-      let(:add_another_referee) { 'add_another_referee' => 'no' }
+      let(:add_another_referee) do
+        { 'add_another_referee' => 'no' }
+      end
 
       it 'returns false' do
         expect(form.add_another_referee?).to be_falsey

--- a/spec/forms/candidate_interface/add_another_referee_form_spec.rb
+++ b/spec/forms/candidate_interface/add_another_referee_form_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe CandidateInterface::AddAnotherRefereeForm, type: :model do
     end
 
     context 'when the add_another_referee value is no' do
-      let(:add_another_referee) do
-        { 'add_another_referee' => 'no' }
-      end
+      let(:add_another_referee) { 'add_another_referee' => 'no' }
 
       it 'returns false' do
         expect(form.add_another_referee?).to be_falsey

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_with_separate_additional_referees_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_with_separate_additional_referees_flag_on_spec.rb
@@ -1,0 +1,251 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate needs to provide 2 new referees' do
+  include CandidateHelper
+
+  scenario "Candidate provides a new referee because 2 didn't respond" do
+
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_submitted_my_application
+    and_both_of_my_referees_havent_responded_within_a_reasonable_timeframe
+    and_the_separate_additional_referees_flag_is_on
+
+    when_i_visit_the_application_dashboard
+    then_i_see_that_i_need_new_references
+
+    when_i_visit_the_start_page
+    then_i_see_the_interstitial_page_to_add_new_referees
+
+    when_i_click_to_add_a_new_referee
+    then_i_am_asked_to_specify_the_type_of_my_first_new_reference
+
+    when_i_click_continue
+    then_i_see_an_error_to_choose_the_type_of_my_first_reference
+
+    when_i_choose_school_based_as_reference_type
+    and_i_click_continue
+    then_i_am_asked_for_the_details_of_my_school_based_referee
+
+    when_i_fill_in_the_form
+    then_i_see_the_first_reference_review_page
+
+    when_i_click_continue
+    then_i_see_the_second_referee_choice_page
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_the_application_review_page
+
+    when_i_visit_the_second_referee_choice_page
+    and_i_choose_yes
+    and_i_click_continue
+    then_i_am_asked_to_specify_the_type_of_my_second_new_reference
+
+    when_i_choose_academic_as_reference_type
+    and_i_click_continue
+    then_i_am_asked_for_the_details_of_my_academic_referee
+
+    when_i_fill_in_the_second_form
+    then_i_see_the_reference_review_page
+
+    when_i_click_to_edit_the_referee_type
+    and_i_choose_character_as_reference_type
+    and_i_click_continue
+    then_i_can_see_the_updated_reference_type
+
+    when_i_click_to_edit_the_referee
+    and_i_edit_the_name
+    then_i_see_the_updated_name_on_the_confirm_page
+
+    when_i_click_to_confirm
+    then_the_new_referees_should_receive_emails
+    and_i_see_that_my_new_references_have_been_requested
+    and_i_should_not_be_asked_to_provide_another_reference
+
+    when_i_go_back_to_the_edit_page
+    then_i_see_a_404_page
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_submitted_my_application
+    @application_form = create(:completed_application_form, candidate: @candidate)
+  end
+
+  def and_both_of_my_referees_havent_responded_within_a_reasonable_timeframe
+    create(:reference, :requested, application_form: @application_form, requested_at: Time.zone.now - 30.days)
+    create(:reference, :requested, application_form: @application_form, requested_at: Time.zone.now - 30.days)
+  end
+
+  def and_the_separate_additional_referees_flag_is_on
+    FeatureFlag.activate('separate_additional_referees')
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_see_that_i_need_new_references
+    expect(page).to have_content 'You need to give details of 2 new referees'
+  end
+
+  def when_i_visit_the_start_page
+    visit candidate_interface_interstitial_path
+  end
+
+  def then_i_see_the_interstitial_page_to_add_new_referees
+    expect(page).to have_content 'You need to add 2 new referees'
+    @application_form.application_references.each do |referee|
+      expect(page).to have_content "#{referee.name} did not respond to our request"
+    end
+  end
+
+  def when_i_click_to_add_a_new_referee
+    click_on 'Add new referees'
+  end
+
+  def then_i_am_asked_to_specify_the_type_of_my_first_new_reference
+    expect(page).to have_content('Add your first new referee')
+    expect(page).to have_content('What kind of reference are you adding?')
+  end
+
+  def when_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_to_choose_the_type_of_my_first_reference
+    expect(page).to have_content('Choose the type of your reference')
+  end
+
+  def when_i_choose_school_based_as_reference_type
+    choose 'School-based'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_am_asked_for_the_details_of_my_school_based_referee
+    expect(page).to have_content('Details of your new school-based referee')
+  end
+
+  def when_i_fill_in_the_form
+    fill_in 'Full name', with: 'AO Reference'
+    fill_in 'Email address', with: 'betty@example.com'
+    fill_in 'What is your relationship to this referee and how long have you known them?', with: 'Just somebody I used to know'
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_first_reference_review_page
+    expect(page).to have_content 'AO Reference'
+    expect(page).to have_content 'betty@example.com'
+    expect(page).to have_content 'School-based'
+  end
+
+  def then_i_see_the_second_referee_choice_page
+    expect(page).to have_content 'Do you want to add a second referee now?'
+  end
+
+  def when_i_choose_no
+    choose 'No'
+  end
+
+  def then_i_see_the_application_review_page
+    expect(page).to have_content 'Application dashboard'
+  end
+
+  def when_i_visit_the_second_referee_choice_page
+    visit candidate_interface_additional_referees_choice_path
+  end
+
+  def and_i_choose_yes
+    choose 'Yes'
+  end
+
+  def then_i_am_asked_to_specify_the_type_of_my_second_new_reference
+    expect(page).to have_content('Add your second new referee')
+    expect(page).to have_content('What kind of reference are you adding?')
+  end
+
+  def when_i_choose_academic_as_reference_type
+    choose 'Academic'
+  end
+
+  def then_i_am_asked_for_the_details_of_my_academic_referee
+    expect(page).to have_content('Details of your new academic referee')
+  end
+
+  def when_i_fill_in_the_second_form
+    fill_in 'Full name', with: 'Second Reference'
+    fill_in 'Email address', with: 'boppie@example.com'
+    fill_in 'What is your relationship to this referee and how long have you known them?', with: 'Just somebody I used to know'
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_second_reference_review_page
+    expect(page).to have_content 'Second Reference'
+    expect(page).to have_content 'boppie@example.com'
+    expect(page).to have_content 'Academic'
+  end
+
+  def when_i_click_to_edit_the_referee_type
+    click_on 'Change reference type for AO Reference'
+  end
+
+  def and_i_choose_character_as_reference_type
+    choose 'Character'
+  end
+
+  def then_i_can_see_the_updated_reference_type
+    expect(page).to have_content 'Character'
+  end
+
+  def when_i_click_to_edit_the_referee
+    click_on 'Change name for AO Reference'
+  end
+
+  def and_i_edit_the_name
+    @edit_page_url = page.current_url
+    fill_in 'Full name', with: 'A.O. Reference'
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_updated_name_on_the_confirm_page
+    expect(page).to have_content 'A.O. Reference'
+    expect(page).to have_content 'betty@example.com'
+
+    expect(page).to have_content 'Second Reference'
+    expect(page).to have_content 'boppie@example.com'
+  end
+
+  def when_i_click_to_confirm
+    click_on 'Confirm new referees'
+  end
+
+  def then_the_new_referees_should_receive_emails
+    open_email('betty@example.com')
+    expect(current_email.subject).to have_content("Give #{@application_form.full_name} a reference for their teacher training application as soon as possible")
+
+    open_email('boppie@example.com')
+    expect(current_email.subject).to have_content("Give #{@application_form.full_name} a reference for their teacher training application as soon as possible")
+  end
+
+  def and_i_see_that_my_new_references_have_been_requested
+    expect(page).to have_content 'Thank you. We’ve asked each new referee for a reference'
+  end
+
+  def and_i_should_not_be_asked_to_provide_another_reference
+    expect(page).not_to have_content 'You need to give details of a new referee'
+  end
+
+  def when_i_go_back_to_the_edit_page
+    visit @edit_page_url
+  end
+
+  def then_i_see_a_404_page
+    expect(page).to have_content 'Page not found'
+  end
+end

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_with_separate_additional_referees_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_with_separate_additional_referees_flag_on_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   include CandidateHelper
 
   scenario "Candidate provides a new referee because 2 didn't respond" do
-
     given_i_am_signed_in_as_a_candidate
     and_i_have_submitted_my_application
     and_both_of_my_referees_havent_responded_within_a_reasonable_timeframe
@@ -29,7 +28,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
     when_i_fill_in_the_form
     then_i_see_the_first_reference_review_page
 
-    when_i_click_continue
+    when_i_click_confirm_new_referee
     then_i_see_the_second_referee_choice_page
 
     when_i_choose_no
@@ -46,7 +45,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
     then_i_am_asked_for_the_details_of_my_academic_referee
 
     when_i_fill_in_the_second_form
-    then_i_see_the_reference_review_page
+    then_i_see_the_second_reference_review_page
 
     when_i_click_to_edit_the_referee_type
     and_i_choose_character_as_reference_type
@@ -145,6 +144,10 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
     expect(page).to have_content 'School-based'
   end
 
+  def when_i_click_confirm_new_referee
+    click_button 'Confirm new referee'
+  end
+
   def then_i_see_the_second_referee_choice_page
     expect(page).to have_content 'Do you want to add a second referee now?'
   end
@@ -158,7 +161,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def when_i_visit_the_second_referee_choice_page
-    visit candidate_interface_additional_referees_choice_path
+    visit candidate_interface_add_another_referee_path
   end
 
   def and_i_choose_yes
@@ -192,7 +195,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def when_i_click_to_edit_the_referee_type
-    click_on 'Change reference type for AO Reference'
+    click_on 'Change reference type'
   end
 
   def and_i_choose_character_as_reference_type
@@ -204,7 +207,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def when_i_click_to_edit_the_referee
-    click_on 'Change name for AO Reference'
+    click_on 'Change name'
   end
 
   def and_i_edit_the_name
@@ -215,14 +218,11 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
 
   def then_i_see_the_updated_name_on_the_confirm_page
     expect(page).to have_content 'A.O. Reference'
-    expect(page).to have_content 'betty@example.com'
-
-    expect(page).to have_content 'Second Reference'
     expect(page).to have_content 'boppie@example.com'
   end
 
   def when_i_click_to_confirm
-    click_on 'Confirm new referees'
+    click_on 'Confirm new referee'
   end
 
   def then_the_new_referees_should_receive_emails
@@ -234,7 +234,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def and_i_see_that_my_new_references_have_been_requested
-    expect(page).to have_content 'Thank you. We’ve asked each new referee for a reference'
+    expect(page).to have_content 'Thank you. We’ve asked your new referee for a reference'
   end
 
   def and_i_should_not_be_asked_to_provide_another_reference


### PR DESCRIPTION
## Context

Post submission, Candidates are currently unable to submit referees independently of one another. This causes a potential issue if the candidate only has one referee to hand and wishes to request the other at a later date as currently they can only be confirmed and submitted in tandem.

## Changes proposed in this pull request

Split the confirmation flow to appear separately for each referee and introduce a new view to appear in between addition of referees to allow candidate to return to the application dashboard and add another referee later.

single referee confirmation screen:
![image](https://user-images.githubusercontent.com/62567622/89028267-eeaf3f80-d323-11ea-9170-08ba7b410784.png)

New Add another referee view:
![image](https://user-images.githubusercontent.com/62567622/89028003-69c42600-d323-11ea-8071-e03499e5c886.png)


## Guidance to review

Use the review app to check that the UI flow makes sense. 

Design doc here: https://docs.google.com/drawings/d/1mQxu3S7mR8IYxuREzfwOguWRc98e6gzqZZ1D-GF4UWE/edit

Review the code against best practices.

## Link to Trello card

https://trello.com/c/SWsfc89S/1811-bug-i-only-want-to-give-one-referee-at-a-time

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
