### PR TITLE
Fix 'Withdraw offer' link visibility

### DIFF
--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -3,7 +3,7 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
-<% if FeatureFlag.active?('provider_change_response') %>
+<% if FeatureFlag.active?('provider_change_response') && provider_can_respond %>
 <p class="govuk-body govuk-!-margin-bottom-0 app-!-print-display-none">
   <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
 </p>

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -4,11 +4,12 @@ module ProviderInterface
       include ViewHelper
       include StatusBoxComponents::CourseRows
 
-      attr_reader :application_choice
+      attr_reader :application_choice, :provider_can_respond
       attr_reader :available_providers, :available_courses, :available_study_modes, :available_course_options
 
       def initialize(application_choice:, options: {})
         @application_choice = application_choice
+        @provider_can_respond = options[:provider_can_respond]
         @available_providers = options[:available_providers]
         @available_courses = options[:available_courses]
         @available_study_modes = options[:available_study_modes]

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -38,6 +38,8 @@ module ProviderInterface
                             else
                               {}
                             end
+
+      @status_box_options[:provider_can_respond] = @provider_can_respond
     end
 
     def notes


### PR DESCRIPTION
## Context

The 'Withdraw offer' link is always visible, even if the user lacks permission to `make_decisions`. Following the link doesn't work, but we should really be hiding it.

## Changes proposed in this pull request

Hide this link if the user lacks permission to use it.

## Guidance to review

Small change, easy to review.

## Link to Trello card

https://trello.com/c/Zfj9ZyLP

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
