### PR TITLE
Use the form builder's built-in legends and captions

### DIFF
--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -22,15 +22,14 @@
             legend: { text: 'Standard conditions', size: 'm', tag: 'h2' },
       ) %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
+      <%= f.govuk_fieldset legend: { text: 'Further conditions (optional)', size: 'm' } do %>
         <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
         <%= f.govuk_text_area :further_conditions0, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions0'), size: 's' }, rows: 3 %>
         <%= f.govuk_text_area :further_conditions1, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions1'), size: 's' }, rows: 3 %>
         <%= f.govuk_text_area :further_conditions2, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions2'), size: 's' }, rows: 3 %>
         <%= f.govuk_text_area :further_conditions3, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions3'), size: 's' }, rows: 3 %>
-      </fieldset>
+      <% end %>
 
       <%= f.govuk_submit 'Continue' %>
 

--- a/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
@@ -19,10 +19,9 @@
         { key: 'Preferred location', value: @application_choice.site.name },
       ]) %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Tell us why you’re withdrawing the offer</legend>
+      <%= f.govuk_fieldset legend: { text: 'Tell us why you’re withdrawing the offer', size: 'm' } do %>
         <%= f.govuk_text_area :offer_withdrawal_reason, rows: 5, label: { text: '' }, hint_text: 'We’ll forward your feedback to the candidate' %>
-      </fieldset>
+      <% end %>
 
       <%= f.govuk_submit 'Continue' %>
 

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -9,14 +9,9 @@
 
       <%= f.govuk_error_summary %>
 
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-        <h1 class="govuk-fieldset__heading">
-          <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-          Respond to application
-        </h1>
-      </legend>
-
-      <%= f.govuk_radio_buttons_fieldset :decision do %>
+      <%= f.govuk_radio_buttons_fieldset :decision,
+        legend: { text: 'Respond to application' , size: "xl" },
+        caption: { text: @application_choice.application_form.full_name, size: "xl" } do %>
 
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
         <% if FeatureFlag.active?('provider_change_response') -%>

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -4,14 +4,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @form, url: provider_interface_provider_user_edit_providers_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_check_boxes_fieldset :provider do %>
-
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @form.provider_user.full_name %></span>
-             Change the organisations this user will have access to
-          </h1>
-        </legend>
+      <%= f.govuk_check_boxes_fieldset :provider,
+        legend: { text: 'Change the organisations this user will have access to' , size: "xl" },
+        caption: { text: @form.provider_user.full_name, size: "xl" } do %>
 
         <%= f.govuk_collection_check_boxes :provider_ids, @form.providers_that_actor_can_manage_users_for, :id, :name %>
       <% end %>


### PR DESCRIPTION
This is now consistent across `ProviderInterface`. There are a couple more manual `<legend>`s in candidate and support, to follow

## Context

Using the standard formbuilder options means less markup for us to maintain and make mistakes on

## Changes proposed in this pull request

Behaviour should be exactly the same

## Guidance to review

Typos?

## Link to Trello card

Noticed during https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1596127192083400

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
