### PR TITLE
Correct error message ordering on Provider User wizard details page

### DIFF
--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -8,10 +8,10 @@ module ProviderInterface
     attr_writer :providers, :provider_permissions, :state_store
 
     with_options(on: :details) do
+      validates :email_address, presence: true
+      validates :email_address, email_address: true
       validates :first_name, presence: true
       validates :last_name, presence: true
-      validates :email_address, presence: true
-      validates :email_address, email: true
     end
 
     with_options(on: :providers) do

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -7,11 +7,16 @@ module ProviderInterface
     attr_reader :email_address
     attr_writer :providers, :provider_permissions, :state_store
 
-    validates :first_name, presence: true, on: :details
-    validates :last_name, presence: true, on: :details
-    validates :email_address, presence: true, on: :details
-    validates :email_address, email: true, on: :details
-    validates :providers, presence: true, on: :providers
+    with_options(on: :details) do
+      validates :first_name, presence: true
+      validates :last_name, presence: true
+      validates :email_address, presence: true
+      validates :email_address, email: true
+    end
+
+    with_options(on: :providers) do
+      validates :providers, presence: true
+    end
 
     PermissionOption = Struct.new(:slug, :name, :hint)
     AVAILABLE_PERMISSIONS = [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,7 +256,6 @@ en:
               blank: Enter the user’s email address
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer
-              invalid: Enter an email address in the correct format, like name@example.com
             providers:
               blank: Select which organisations this user will have access to
   activerecord:


### PR DESCRIPTION
## Context

The errors were wrong and out of order with the fields.

## Changes proposed in this pull request

- correct the ordering
- use the `email_address` validator which gives the correct error message for an invalid email

The validator depends on a translation in the candidate namespace, but it does the right thing.

Tech debt card to clean up email validation: https://trello.com/c/X99crwm4/352-standardise-email-validation

**Before**

![Screenshot 2020-08-03 at 09 31 28](https://user-images.githubusercontent.com/642279/89162570-30cac200-d56c-11ea-80af-ad8a60c45d1e.png)

**After**

![Screenshot 2020-08-03 at 09 31 12](https://user-images.githubusercontent.com/642279/89162563-2e686800-d56c-11ea-8a17-ff99583026a5.png)


## Guidance to review

Try from the front end

## Link to Trello card

https://trello.com/c/A8aKK1eW/2546-correct-error-messages-ordering-on-provider-user-wizard-details-page

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
