### PR TITLE
Add JavaScript to the personal details nationalities page

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -12,6 +12,7 @@ import initDegreeTypeAutocomplete from "./degree-type-autocomplete";
 import initIeltsBandScoreAutocomplete from "./ielts-band-score-autocomplete";
 import initWarnOnUnsavedChanges from "./warn-on-unsaved-changes";
 import providerFilter from "./provider-filter";
+import nationalitiesComponent from "./nationalities-component";
 
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import "../styles/application.scss";
@@ -28,3 +29,4 @@ initDegreeTypeAutocomplete();
 initIeltsBandScoreAutocomplete();
 initWarnOnUnsavedChanges();
 providerFilter();
+nationalitiesComponent();

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -1,6 +1,5 @@
 const nationalitiesComponent = () => {
-
-  const pageHasErrors = document.querySelector('.govuk-error-summary');
+  const pageHasErrors = document.querySelector(".govuk-error-summary");
   if (pageHasErrors) return;
 
   const secondSelect = document.getElementById(
@@ -18,27 +17,19 @@ const nationalitiesComponent = () => {
     "[for=candidate-interface-nationalities-form-other-nationality3-field]"
   );
 
-  let addNationalityButton = null
+  let addNationalityButton = null;
 
-  addRemoveLink(
-    secondSelect.id
-  );
+  addRemoveLink(secondSelect.id);
 
-  addRemoveLink(
-    thirdSelect.id
-  );
+  addRemoveLink(thirdSelect.id);
 
   addAddNationalityButton(
     "#candidate-interface-nationalities-form-other-other-conditional"
   );
 
-  hideSection(
-    secondSelect.id
-  );
+  hideSection(secondSelect.id);
 
-  hideSection(
-    thirdSelect.id
-  );
+  hideSection(thirdSelect.id);
 
   function addRemoveLink(selector) {
     const labelEl = document.querySelector(`[for=${selector}]`);
@@ -51,7 +42,7 @@ const nationalitiesComponent = () => {
     removeLink.href = "#";
     labelEl.appendChild(removeLink);
 
-    addNthNationalityHiddenSpan(removeLink, selector)
+    addNthNationalityHiddenSpan(removeLink, selector);
 
     removeLink.addEventListener("click", function () {
       handleRemoveLinkClick(labelEl, selector);
@@ -60,13 +51,12 @@ const nationalitiesComponent = () => {
 
   function addNthNationalityHiddenSpan(removeLink, selector) {
     const nthNationalitySpan = document.createElement("span");
-    nthNationalitySpan.classList.add("govuk-visually-hidden")
+    nthNationalitySpan.classList.add("govuk-visually-hidden");
 
     if (selector == secondSelect.id) {
-      nthNationalitySpan.innerHTML = 'Second nationality';
-    }
-    else {
-      nthNationalitySpan.innerHTML = 'Third nationality';
+      nthNationalitySpan.innerHTML = "Second nationality";
+    } else {
+      nthNationalitySpan.innerHTML = "Third nationality";
     }
 
     removeLink.appendChild(nthNationalitySpan);
@@ -77,7 +67,10 @@ const nationalitiesComponent = () => {
     addNationalityButton = document.createElement("button");
     addNationalityButton.innerHTML = "Add another nationality";
     addNationalityButton.id = "add-nationality-button";
-    addNationalityButton.classList.add("govuk-button", "govuk-button--secondary");
+    addNationalityButton.classList.add(
+      "govuk-button",
+      "govuk-button--secondary"
+    );
     parent.appendChild(addNationalityButton);
 
     if (secondSelect.value && thirdSelect.value) {
@@ -111,8 +104,7 @@ const nationalitiesComponent = () => {
       thirdFormLabel.parentElement.style.display === "none"
     ) {
       secondFormLabel.parentElement.style.display = "";
-    }
-    else if (secondFormLabel.parentElement.style.display === "none") {
+    } else if (secondFormLabel.parentElement.style.display === "none") {
       secondFormLabel.parentElement.style.display = "";
       addNationalityButton.style.display = "none";
     } else {

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -1,0 +1,116 @@
+const nationalitiesComponent = () => {
+  if (
+    document.querySelector(
+      "[for=candidate-interface-nationalities-form-other-nationality2-field-error]"
+    ) ||
+    document.querySelector(
+      "[for=candidate-interface-nationalities-form-other-nationality3-field-error]"
+    )
+  ) {
+    return;
+  }
+
+  addRemoveLink(
+    "candidate-interface-nationalities-form-other-nationality2-field"
+  );
+
+  addRemoveLink(
+    "candidate-interface-nationalities-form-other-nationality3-field"
+  );
+
+  addAddNationalityButton(
+    "#candidate-interface-nationalities-form-other-other-conditional"
+  );
+
+  hideSection(
+    "candidate-interface-nationalities-form-other-nationality2-field"
+  );
+
+  hideSection(
+    "candidate-interface-nationalities-form-other-nationality3-field"
+  );
+
+  function addRemoveLink(selector) {
+    const labelEl = document.querySelector(`[for=${selector}]`);
+    const removeLink = document.createElement("a");
+    removeLink.innerHTML = "Remove";
+    removeLink.classList.add("govuk-link", "remove-link");
+
+    // This has to be a link and not a button as the govuk-link class requires an
+    // href to apply  it's styling
+    removeLink.href = "#";
+    labelEl.appendChild(removeLink);
+
+    removeLink.addEventListener("click", function () {
+      addRemoveLinkEvent(labelEl, selector);
+    });
+  }
+
+  function addAddNationalityButton(parentSelector) {
+    const parent = document.querySelector(parentSelector);
+    const nationalityButton = document.createElement("button");
+    nationalityButton.innerHTML = "Add another nationality";
+    nationalityButton.id = "add-nationality-button";
+    nationalityButton.classList.add("govuk-button", "govuk-button--secondary");
+    parent.appendChild(nationalityButton);
+
+    const secondSelect = document.querySelector(
+      "[id=candidate-interface-nationalities-form-other-nationality2-field]"
+    );
+    const thirdSelect = document.querySelector(
+      "[id=candidate-interface-nationalities-form-other-nationality3-field]"
+    );
+
+    if (secondSelect.value && thirdSelect.value) {
+      nationalityButton.style.display = "none";
+    }
+
+    nationalityButton.addEventListener("click", function () {
+      event.preventDefault();
+      addNationalityEvent(nationalityButton);
+    });
+  }
+
+  function hideSection(selector) {
+    const select = document.getElementById(selector);
+    const labelEl = document.querySelector(`[for=${selector}]`);
+
+    if (select.value === "") {
+      labelEl.parentElement.style.display = "none";
+    }
+  }
+
+  function addRemoveLinkEvent(labelEl, selector) {
+    const addNationalityButton = document.getElementById(
+      "add-nationality-button"
+    );
+
+    addNationalityButton.style.display = "block";
+    labelEl.parentElement.style.display = "none";
+    document.getElementById(selector).value = "";
+  }
+
+  function addNationalityEvent(nationalityButton) {
+    const secondFormLabel = document.querySelector(
+      "[for=candidate-interface-nationalities-form-other-nationality2-field]"
+    );
+    const thirdFormLabel = document.querySelector(
+      "[for=candidate-interface-nationalities-form-other-nationality3-field]"
+    );
+
+    if (secondFormLabel.parentElement.style.display === "none") {
+      secondFormLabel.parentElement.style.display = "block";
+    } else {
+      thirdFormLabel.parentElement.style.display = "block";
+    }
+
+    if (
+      secondFormLabel.parentElement.style.display === "block" &&
+      thirdFormLabel.parentElement.style.display === "block"
+    ) {
+      nationalityButton.style.display = "none";
+    }
+  }
+};
+
+export default nationalitiesComponent;

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -2,11 +2,11 @@ const nationalitiesComponent = () => {
   const pageHasErrors = document.querySelector(".govuk-error-summary");
   if (pageHasErrors) return;
 
-  const secondSelect = document.getElementById(
+  const secondSelectEl = document.getElementById(
     "candidate-interface-nationalities-form-other-nationality2-field"
   );
 
-  const thirdSelect = document.getElementById(
+  const thirdSelectEl = document.getElementById(
     "candidate-interface-nationalities-form-other-nationality3-field"
   );
 
@@ -19,19 +19,19 @@ const nationalitiesComponent = () => {
 
   let addNationalityButton = null;
 
-  addRemoveLink(secondFormLabel, secondSelect);
+  addRemoveLink(secondFormLabel, secondSelectEl);
 
-  addRemoveLink(thirdFormLabel, thirdSelect);
+  addRemoveLink(thirdFormLabel, thirdSelectEl);
 
   addAddNationalityButton(
     "#candidate-interface-nationalities-form-other-other-conditional"
   );
 
-  hideSection(secondSelect, secondFormLabel);
+  hideSection(secondSelectEl, secondFormLabel);
 
-  hideSection(thirdSelect, thirdFormLabel);
+  hideSection(thirdSelectEl, thirdFormLabel);
 
-  function addRemoveLink(labelEl, select) {
+  function addRemoveLink(labelEl, selectEl) {
     const removeLink = document.createElement("a");
     removeLink.innerHTML = "Remove";
     removeLink.classList.add("govuk-link", "app-nationality-remove-link");
@@ -49,7 +49,7 @@ const nationalitiesComponent = () => {
     }
 
     removeLink.addEventListener("click", function () {
-      handleRemoveLinkClick(labelEl, select);
+      handleRemoveLinkClick(labelEl, selectEl);
     });
   }
 
@@ -71,7 +71,7 @@ const nationalitiesComponent = () => {
     );
     parent.appendChild(addNationalityButton);
 
-    if (secondSelect.value && thirdSelect.value) {
+    if (secondSelectEl.value && thirdSelectEl.value) {
       addNationalityButton.style.display = "none";
     }
 
@@ -81,16 +81,16 @@ const nationalitiesComponent = () => {
     });
   }
 
-  function hideSection(select, labelEl) {
-    if (select.value === "") {
+  function hideSection(selectEl, labelEl) {
+    if (selectEl.value === "") {
       labelEl.parentElement.style.display = "none";
     }
   }
 
-  function handleRemoveLinkClick(labelEl, select) {
+  function handleRemoveLinkClick(labelEl, selectEl) {
     addNationalityButton.style.display = "";
     labelEl.parentElement.style.display = "none";
-    select.value = "";
+    selectEl.value = "";
   }
 
   function handleAddNationalityClick() {

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -51,9 +51,25 @@ const nationalitiesComponent = () => {
     removeLink.href = "#";
     labelEl.appendChild(removeLink);
 
+    addNthNationalityHiddenSpan(removeLink, selector)
+
     removeLink.addEventListener("click", function () {
       handleRemoveLinkClick(labelEl, selector);
     });
+  }
+
+  function addNthNationalityHiddenSpan(removeLink, selector) {
+    const nthNationalitySpan = document.createElement("span");
+    nthNationalitySpan.classList.add("govuk-visually-hidden")
+
+    if (selector == secondSelect.id) {
+      nthNationalitySpan.innerHTML = 'Second nationality';
+    }
+    else {
+      nthNationalitySpan.innerHTML = 'Third nationality';
+    }
+
+    removeLink.appendChild(nthNationalitySpan);
   }
 
   function addAddNationalityButton(parentSelector) {

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -85,12 +85,13 @@ const nationalitiesComponent = () => {
       "add-nationality-button"
     );
 
-    addNationalityButton.style.display = "block";
+    addNationalityButton.style.display = "";
     labelEl.parentElement.style.display = "none";
     document.getElementById(selector).value = "";
   }
 
   function addNationalityEvent(nationalityButton) {
+
     const secondFormLabel = document.querySelector(
       "[for=candidate-interface-nationalities-form-other-nationality2-field]"
     );
@@ -98,15 +99,16 @@ const nationalitiesComponent = () => {
       "[for=candidate-interface-nationalities-form-other-nationality3-field]"
     );
 
+
     if (secondFormLabel.parentElement.style.display === "none") {
-      secondFormLabel.parentElement.style.display = "block";
+      secondFormLabel.parentElement.style.display = "";
     } else {
-      thirdFormLabel.parentElement.style.display = "block";
+      thirdFormLabel.parentElement.style.display = "";
     }
 
     if (
-      secondFormLabel.parentElement.style.display === "block" &&
-      thirdFormLabel.parentElement.style.display === "block"
+      secondFormLabel.parentElement.style.display === "" &&
+      thirdFormLabel.parentElement.style.display === ""
     ) {
       nationalityButton.style.display = "none";
     }

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -19,20 +19,19 @@ const nationalitiesComponent = () => {
 
   let addNationalityButton = null;
 
-  addRemoveLink(secondSelect.id);
+  addRemoveLink(secondFormLabel, secondSelect);
 
-  addRemoveLink(thirdSelect.id);
+  addRemoveLink(thirdFormLabel, thirdSelect);
 
   addAddNationalityButton(
     "#candidate-interface-nationalities-form-other-other-conditional"
   );
 
-  hideSection(secondSelect.id);
+  hideSection(secondSelect, secondFormLabel);
 
-  hideSection(thirdSelect.id);
+  hideSection(thirdSelect, thirdFormLabel);
 
-  function addRemoveLink(selector) {
-    const labelEl = document.querySelector(`[for=${selector}]`);
+  function addRemoveLink(labelEl, select) {
     const removeLink = document.createElement("a");
     removeLink.innerHTML = "Remove";
     removeLink.classList.add("govuk-link", "app-nationality-remove-link");
@@ -42,23 +41,22 @@ const nationalitiesComponent = () => {
     removeLink.href = "#";
     labelEl.appendChild(removeLink);
 
-    addNthNationalityHiddenSpan(removeLink, selector);
+    if (labelEl == secondFormLabel) {
+      addNthNationalityHiddenSpan(removeLink, 'Second');
+    } else {
+      addNthNationalityHiddenSpan(removeLink, 'Third');
+
+    }
 
     removeLink.addEventListener("click", function () {
-      handleRemoveLinkClick(labelEl, selector);
+      handleRemoveLinkClick(labelEl, select);
     });
   }
 
-  function addNthNationalityHiddenSpan(removeLink, selector) {
+  function addNthNationalityHiddenSpan(removeLink, nthNationality) {
     const nthNationalitySpan = document.createElement("span");
     nthNationalitySpan.classList.add("govuk-visually-hidden");
-
-    if (selector == secondSelect.id) {
-      nthNationalitySpan.innerHTML = "Second nationality";
-    } else {
-      nthNationalitySpan.innerHTML = "Third nationality";
-    }
-
+    nthNationalitySpan.innerHTML = `${nthNationality} nationality`;
     removeLink.appendChild(nthNationalitySpan);
   }
 
@@ -83,19 +81,16 @@ const nationalitiesComponent = () => {
     });
   }
 
-  function hideSection(selector) {
-    const select = document.getElementById(selector);
-    const labelEl = document.querySelector(`[for=${selector}]`);
-
+  function hideSection(select, labelEl) {
     if (select.value === "") {
       labelEl.parentElement.style.display = "none";
     }
   }
 
-  function handleRemoveLinkClick(labelEl, selector) {
+  function handleRemoveLinkClick(labelEl, select) {
     addNationalityButton.style.display = "";
     labelEl.parentElement.style.display = "none";
-    document.getElementById(selector).value = "";
+    select.value = "";
   }
 
   function handleAddNationalityClick() {

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -18,6 +18,8 @@ const nationalitiesComponent = () => {
     "[for=candidate-interface-nationalities-form-other-nationality3-field]"
   );
 
+  let addNationalityButton = null
+
   addRemoveLink(
     secondSelect.id
   );
@@ -56,19 +58,19 @@ const nationalitiesComponent = () => {
 
   function addAddNationalityButton(parentSelector) {
     const parent = document.querySelector(parentSelector);
-    const nationalityButton = document.createElement("button");
-    nationalityButton.innerHTML = "Add another nationality";
-    nationalityButton.id = "add-nationality-button";
-    nationalityButton.classList.add("govuk-button", "govuk-button--secondary");
-    parent.appendChild(nationalityButton);
+    addNationalityButton = document.createElement("button");
+    addNationalityButton.innerHTML = "Add another nationality";
+    addNationalityButton.id = "add-nationality-button";
+    addNationalityButton.classList.add("govuk-button", "govuk-button--secondary");
+    parent.appendChild(addNationalityButton);
 
     if (secondSelect.value && thirdSelect.value) {
-      nationalityButton.style.display = "none";
+      addNationalityButton.style.display = "none";
     }
 
-    nationalityButton.addEventListener("click", function () {
+    addNationalityButton.addEventListener("click", function () {
       event.preventDefault();
-      handleAddNationalityClick(nationalityButton);
+      handleAddNationalityClick();
     });
   }
 
@@ -82,17 +84,12 @@ const nationalitiesComponent = () => {
   }
 
   function handleRemoveLinkClick(labelEl, selector) {
-    const addNationalityButton = document.getElementById(
-      "add-nationality-button"
-    );
-
     addNationalityButton.style.display = "";
     labelEl.parentElement.style.display = "none";
     document.getElementById(selector).value = "";
   }
 
-  function handleAddNationalityClick(nationalityButton) {
-
+  function handleAddNationalityClick() {
     if (
       secondFormLabel.parentElement.style.display === "none" &&
       thirdFormLabel.parentElement.style.display === "none"
@@ -101,10 +98,10 @@ const nationalitiesComponent = () => {
     }
     else if (secondFormLabel.parentElement.style.display === "none") {
       secondFormLabel.parentElement.style.display = "";
-      nationalityButton.style.display = "none";
+      addNationalityButton.style.display = "none";
     } else {
       thirdFormLabel.parentElement.style.display = "";
-      nationalityButton.style.display = "none";
+      addNationalityButton.style.display = "none";
     }
   }
 };

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -1,21 +1,29 @@
 const nationalitiesComponent = () => {
-  if (
-    document.querySelector(
-      "[for=candidate-interface-nationalities-form-other-nationality2-field-error]"
-    ) ||
-    document.querySelector(
-      "[for=candidate-interface-nationalities-form-other-nationality3-field-error]"
-    )
-  ) {
-    return;
-  }
 
-  addRemoveLink(
+  const pageHasErrors = document.querySelector('.govuk-error-summary');
+  if (pageHasErrors) return;
+
+  const secondSelect = document.getElementById(
     "candidate-interface-nationalities-form-other-nationality2-field"
   );
 
-  addRemoveLink(
+  const thirdSelect = document.getElementById(
     "candidate-interface-nationalities-form-other-nationality3-field"
+  );
+
+  const secondFormLabel = document.querySelector(
+    "[for=candidate-interface-nationalities-form-other-nationality2-field]"
+  );
+  const thirdFormLabel = document.querySelector(
+    "[for=candidate-interface-nationalities-form-other-nationality3-field]"
+  );
+
+  addRemoveLink(
+    secondSelect.id
+  );
+
+  addRemoveLink(
+    thirdSelect.id
   );
 
   addAddNationalityButton(
@@ -23,18 +31,18 @@ const nationalitiesComponent = () => {
   );
 
   hideSection(
-    "candidate-interface-nationalities-form-other-nationality2-field"
+    secondSelect.id
   );
 
   hideSection(
-    "candidate-interface-nationalities-form-other-nationality3-field"
+    thirdSelect.id
   );
 
   function addRemoveLink(selector) {
     const labelEl = document.querySelector(`[for=${selector}]`);
     const removeLink = document.createElement("a");
     removeLink.innerHTML = "Remove";
-    removeLink.classList.add("govuk-link", "remove-link");
+    removeLink.classList.add("govuk-link", "app-nationality-remove-link");
 
     // This has to be a link and not a button as the govuk-link class requires an
     // href to apply  it's styling
@@ -42,7 +50,7 @@ const nationalitiesComponent = () => {
     labelEl.appendChild(removeLink);
 
     removeLink.addEventListener("click", function () {
-      addRemoveLinkEvent(labelEl, selector);
+      handleRemoveLinkClick(labelEl, selector);
     });
   }
 
@@ -54,20 +62,13 @@ const nationalitiesComponent = () => {
     nationalityButton.classList.add("govuk-button", "govuk-button--secondary");
     parent.appendChild(nationalityButton);
 
-    const secondSelect = document.querySelector(
-      "[id=candidate-interface-nationalities-form-other-nationality2-field]"
-    );
-    const thirdSelect = document.querySelector(
-      "[id=candidate-interface-nationalities-form-other-nationality3-field]"
-    );
-
     if (secondSelect.value && thirdSelect.value) {
       nationalityButton.style.display = "none";
     }
 
     nationalityButton.addEventListener("click", function () {
       event.preventDefault();
-      addNationalityEvent(nationalityButton);
+      handleAddNationalityClick(nationalityButton);
     });
   }
 
@@ -80,7 +81,7 @@ const nationalitiesComponent = () => {
     }
   }
 
-  function addRemoveLinkEvent(labelEl, selector) {
+  function handleRemoveLinkClick(labelEl, selector) {
     const addNationalityButton = document.getElementById(
       "add-nationality-button"
     );
@@ -90,26 +91,19 @@ const nationalitiesComponent = () => {
     document.getElementById(selector).value = "";
   }
 
-  function addNationalityEvent(nationalityButton) {
-
-    const secondFormLabel = document.querySelector(
-      "[for=candidate-interface-nationalities-form-other-nationality2-field]"
-    );
-    const thirdFormLabel = document.querySelector(
-      "[for=candidate-interface-nationalities-form-other-nationality3-field]"
-    );
-
-
-    if (secondFormLabel.parentElement.style.display === "none") {
-      secondFormLabel.parentElement.style.display = "";
-    } else {
-      thirdFormLabel.parentElement.style.display = "";
-    }
+  function handleAddNationalityClick(nationalityButton) {
 
     if (
-      secondFormLabel.parentElement.style.display === "" &&
-      thirdFormLabel.parentElement.style.display === ""
+      secondFormLabel.parentElement.style.display === "none" &&
+      thirdFormLabel.parentElement.style.display === "none"
     ) {
+      secondFormLabel.parentElement.style.display = "";
+    }
+    else if (secondFormLabel.parentElement.style.display === "none") {
+      secondFormLabel.parentElement.style.display = "";
+      nationalityButton.style.display = "none";
+    } else {
+      thirdFormLabel.parentElement.style.display = "";
       nationalityButton.style.display = "none";
     }
   }

--- a/app/frontend/styles/_nationalities-component.scss
+++ b/app/frontend/styles/_nationalities-component.scss
@@ -1,3 +1,3 @@
-.remove-link {
+.app-nationality-remove-link {
   float: right;
 }

--- a/app/frontend/styles/_nationalities-component.scss
+++ b/app/frontend/styles/_nationalities-component.scss
@@ -1,3 +1,7 @@
 .app-nationality-remove-link {
   float: right;
 }
+
+.app-nationality-add-margin-to-last-select .govuk-form-group:last-of-type {
+  margin-bottom: 30px;
+}

--- a/app/frontend/styles/_nationalities-component.scss
+++ b/app/frontend/styles/_nationalities-component.scss
@@ -1,0 +1,3 @@
+.remove-link {
+  float: right;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -62,6 +62,8 @@ $govuk-breakpoints: (
 @import "_application-tabs";
 @import "_review_warning";
 @import "_provider_header";
+@import "_nationalities-component";
+
 
 // Support
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -18,7 +18,7 @@
 
   <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
 
-    <details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>
+    <details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>>
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
         Add another nationality

--- a/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @nationalities_form, url: candidate_interface_edit_nationalities_path do |f| %>
+    <%= form_with model: @nationalities_form, url: candidate_interface_edit_nationalities_path, class: 'app-nationality-add-margin-to-last-select' do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/nationalities/new.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @nationalities_form, url: candidate_interface_nationalities_path do |f| %>
+    <%= form_with model: @nationalities_form, url: candidate_interface_nationalities_path, class: 'app-nationality-add-margin-to-last-select' do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>


### PR DESCRIPTION
## Context

Candidates need to be able to input multiple nationalities. Paul built the design using some JS.

This should do a few things. 

It should have an add nationalities button. When clicked this should display an additional select for candidates to pick an additional nationality. This button should not display once all 3 selects are visible.

It should have a remove link on the second and third select. When clicked it should hide the select and clear its value.

If multiple nationalities are present, when a user goes to edit their nationality they should pre-populate.

If an error occurs, use the non-js solution.

## Changes proposed in this pull request

- Build the JS functionality. for the nationalities page

![image](https://user-images.githubusercontent.com/42515961/89163506-94a1ba80-d56d-11ea-9939-59ca82105142.png)


## Guidance to review

Screenshots of the designs are on the Trello ticket.

Probably easiest to just manually test it and see if you can break it.

## Link to Trello card

https://trello.com/c/AsOuRv9u/1760-dev-%F0%9F%8C%90-international-residency-visa-status

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
