### PR TITLE
Prefer "ratifies" to "accredits" in Support

### DIFF
--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -23,6 +23,6 @@
 <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accredited_provider))) %>
 
 <% if @provider.accredited_courses.any? %>
-  <h2 class='govuk-heading-l'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
+  <h2 class='govuk-heading-l'>Ratifies <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
   <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses)) %>
 <% end %>


### PR DESCRIPTION
We didn't update this screen when we decided to use "ratify" to describe this relationship

## Changes proposed in this pull request

**Before**

![Screenshot 2020-08-03 at 10 04 09](https://user-images.githubusercontent.com/642279/89165620-bb152500-d570-11ea-9fe4-baa6d04c38a8.png)

**After**

![Screenshot 2020-08-03 at 10 04 01](https://user-images.githubusercontent.com/642279/89165615-b7819e00-d570-11ea-8e22-2c74c93e7bdf.png)

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
