### PR TITLE
Fix calculation of RBD days remaining in ApplicationCardComponent

### DIFF
--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -41,7 +41,7 @@ module ProviderInterface
     end
 
     def days_to_respond
-      @days_to_respond ||= (application_choice.reject_by_default_at.to_date - Date.current).to_i
+      @days_to_respond ||= ((application_choice.reject_by_default_at - Time.zone.now) / 1.day).floor
     end
   end
 end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -132,6 +132,10 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
   end
 
   describe '#contextual_date' do
+    around do |example|
+      Timecop.freeze(Time.zone.local(2020, 7, 31, 12, 30, 0)) { example.run }
+    end
+
     let(:reject_by_default_at) { Time.zone.parse('2020-06-02T09:05:00+01:00') }
     let(:updated_at) { Time.zone.parse('2020-06-02T09:05:00+01:00') }
     let(:status) { 'awaiting_provider_decision' }
@@ -173,6 +177,16 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     end
 
     context 'when reject_by_default_at is less than a day away' do
+      let(:reject_by_default_at) { 1.hour.from_now }
+
+      it { is_expected.to eq('Less than 1 day to respond') }
+    end
+
+    context 'when reject_by_default_at is less than a day away and on the next date' do
+      around do |example|
+        Timecop.freeze(Time.zone.local(2020, 7, 31, 23, 30, 0)) { example.run }
+      end
+
       let(:reject_by_default_at) { 1.hour.from_now }
 
       it { is_expected.to eq('Less than 1 day to respond') }

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -4,6 +4,10 @@ RSpec.feature 'Providers should be able to sort applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 8, 3, 10, 30, 12)) { example.run }
+  end
+
   scenario 'by sort options' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
@@ -42,7 +46,7 @@ RSpec.feature 'Providers should be able to sort applications' do
       :awaiting_provider_decision,
       course_option: course_option_one,
       application_form: create(:application_form, first_name: 'Jim', last_name: 'James'),
-      reject_by_default_at: 1.day.from_now,
+      reject_by_default_at: 1.day.from_now.end_of_day,
       updated_at: 1.day.ago,
     )
 
@@ -51,7 +55,7 @@ RSpec.feature 'Providers should be able to sort applications' do
       :awaiting_provider_decision,
       course_option: course_option_two,
       application_form: create(:application_form, first_name: 'Adam', last_name: 'Jones'),
-      reject_by_default_at: 5.days.from_now,
+      reject_by_default_at: 5.days.from_now.end_of_day,
       updated_at: 2.days.ago,
     )
 
@@ -60,7 +64,7 @@ RSpec.feature 'Providers should be able to sort applications' do
       :awaiting_provider_decision,
       course_option: course_option_two,
       application_form: create(:application_form, first_name: 'Tom', last_name: 'Jones'),
-      reject_by_default_at: 10.days.from_now,
+      reject_by_default_at: 10.days.from_now.end_of_day,
       updated_at: 2.days.ago,
     )
 
@@ -69,7 +73,7 @@ RSpec.feature 'Providers should be able to sort applications' do
       :awaiting_provider_decision,
       course_option: course_option_three,
       application_form: create(:application_form, first_name: 'Bill', last_name: 'Bones'),
-      reject_by_default_at: 1.day.ago,
+      reject_by_default_at: 1.day.ago.end_of_day,
       updated_at: 3.days.ago,
     )
   end


### PR DESCRIPTION
## Context

Found this when trying to fix a time dependent spec.

`ApplicationCardComponent#days_to_respond` was calculating the number of days remaining based on the date difference so could lead to a lower value than I think is intended, e.g. if it's 23:59 and the RBD is 0:01 the following day we probably don't want to say that you have '1 day remaining'. You would normally get the correct result in real life because RBD dates are always at the end of the day but in tests that don't follow this rule the results are dependent on the time the test ran. (e.g. there were test failures when run between 23:00 and 0:00.)

## Changes proposed in this pull request

Fix the implementation of `ApplicationCardComponent#days_to_respond`

## Guidance to review

Is this the correct way to interpret `ApplicationCardComponent#days_to_respond`?

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
