### PR TITLE
Back bugs

### DIFF
--- a/app/views/candidate_interface/degrees/type/edit.html.erb
+++ b/app/views/candidate_interface/degrees/type/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_degree_type'), @degree_type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -3,7 +3,7 @@
                                                  @nationalities_form.errors.any? ||
                                                  @languages_form.errors.any?) %>
 
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_edit_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <h1 class="govuk-heading-xl">
   <%= t('page_titles.personal_details') %>

--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children'), @safeguarding.errors.any?)%>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.suitability_to_work_with_children') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <h1 class="govuk-heading-xl">
   <%= t('page_titles.suitability_to_work_with_children') %>


### PR DESCRIPTION
## Context

* Fix back link on personal details review page so that it links back to the main application page, and uses the correct text (‘Back to application’, not ‘Back’)
* Fix back link text on safeguarding review page (‘Back to application’, not ‘Back’)
* Ensure back link text on safeguarding edit page matches that of other edit pages (‘Back to application’, not ‘Back’).
* Ensure back link when editing a degree goes to the review degrees page, not application page.

These are low hanging bugs with back links that I’ve found. Found a lot of other behaviour that needs correcting, but will card those items up separately.
