### PR TITLE
Fix several bugs related to IELTS band score

### DIFF
--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -9,12 +9,15 @@ module CandidateInterface
       attr_accessor :trf_number, :band_score, :award_year, :application_form
 
       validates :trf_number, presence: true, length: { maximum: 255 }
-      validates :band_score, presence: true, length: { maximum: 255 }
+      validates :band_score, presence: true
       validates :award_year, presence: true
       validate :award_year_is_a_valid_year
+      validate :band_score_is_a_valid_score
 
       def self.band_score_drop_down_options
-        IeltsQualification::VALID_SCORES.map { |s| BandScore.new(s, s) }
+        empty_option = [BandScore.new('', '')]
+        scores = IeltsQualification::VALID_SCORES.map { |s| BandScore.new(s, s) }
+        empty_option + scores
       end
 
       def save
@@ -46,6 +49,12 @@ module CandidateInterface
       def award_year_is_a_valid_year
         if !valid_year?(award_year)
           errors.add(:award_year, :invalid)
+        end
+      end
+
+      def band_score_is_a_valid_score
+        unless band_score.in? IeltsQualification::VALID_SCORES
+          errors.add(:band_score, :invalid)
         end
       end
 

--- a/app/frontend/packs/ielts-band-score-autocomplete.js
+++ b/app/frontend/packs/ielts-band-score-autocomplete.js
@@ -2,15 +2,23 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initIeltsBandScoreAutocomplete = () => {
   try {
-    const id = "#candidate-interface-english-foreign-language-ielts-form-band-score-field";
-    const bandScoreSelect = document.querySelector(id);
+    const ids = [
+      "#candidate-interface-english-foreign-language-ielts-form-band-score-field",
+      "#candidate-interface-english-foreign-language-ielts-form-band-score-field-error",
+    ]
 
-    if (!bandScoreSelect) return;
+    ids.forEach(id => {
+      const bandScoreSelect = document.querySelector(id);
 
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: bandScoreSelect,
-      showAllValues: true,
-      confirmOnBlur: false
+      if (!bandScoreSelect) return;
+
+      accessibleAutocomplete.enhanceSelectElement({
+        defaultValue: '',
+        selectElement: bandScoreSelect,
+        showAllValues: true,
+        showNoOptionsFound: true,
+        confirmOnBlur: false
+      });
     });
   } catch (err) {
     console.error("Could not enhance IELTS score select:", err);


### PR DESCRIPTION
- Update the autocomplete Javascript to correctly enhance the select box
  when the form field is in an error state.
- Add an empty select option so that the band score field is empty on a
  blank form. This allows all values to be visible when the candidate
  clicks on the enhanced select box.
- Add validation that checks the submitted value is in the list of
  possible band scores. Not ordinarily needed, but useful in cases where
  the form HTML has been modified by the client.
- Remove unnecessary length validation - no longer needed if we're
  validating that the submitted score is in the list of accepted values.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/9fk7yluU
## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
