### PR TITLE
Use the new countries autocomplete where appropriate

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -79,7 +79,7 @@ module CandidateInterface
 
     def institution_value(qualification)
       if non_uk_qualification?(qualification) && qualification.institution_country.present?
-        "#{qualification.institution_name}, #{qualification.institution_country}"
+        "#{qualification.institution_name}, #{COUNTRIES[qualification.institution_country]}"
       else
         qualification.institution_name
       end

--- a/app/forms/candidate_interface/gcse_institution_country_form.rb
+++ b/app/forms/candidate_interface/gcse_institution_country_form.rb
@@ -7,11 +7,11 @@ module CandidateInterface
     validates :institution_country, presence: true
 
     validates :institution_country,
-              inclusion: { in: COUNTRY_NAMES }
+              inclusion: { in: COUNTRIES }
 
     def self.build_from_qualification(application_qualification)
       new(
-        institution_country: COUNTRIES[application_qualification.institution_country],
+        institution_country: application_qualification.institution_country,
       )
     end
 
@@ -19,7 +19,7 @@ module CandidateInterface
       return false unless valid?
 
       application_qualification.update!(
-        institution_country: COUNTRY_NAMES_TO_ISO_CODES[institution_country],
+        institution_country: institution_country,
       )
     end
   end

--- a/app/forms/candidate_interface/other_qualification_form.rb
+++ b/app/forms/candidate_interface/other_qualification_form.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
     validates :institution_country, presence: true, if: -> { qualification_type == 'non_uk' }
 
-    validates :institution_country, inclusion: { in: COUNTRY_NAMES }, if: -> { qualification_type == 'non_uk' }
+    validates :institution_country, inclusion: { in: COUNTRIES }, if: -> { qualification_type == 'non_uk' }
 
     validates :qualification_type, :subject, :institution_name, :grade, length: { maximum: 255 }
 
@@ -57,7 +57,7 @@ module CandidateInterface
           qualification_type: qualification.qualification_type,
           subject: qualification.subject,
           institution_name: qualification.institution_name,
-          institution_country: COUNTRIES[qualification.institution_country],
+          institution_country: qualification.institution_country,
           grade: qualification.grade,
           award_year: qualification.award_year,
           other_uk_qualification_type: qualification.other_uk_qualification_type,
@@ -89,7 +89,7 @@ module CandidateInterface
         qualification_type: qualification_type,
         subject: subject,
         institution_name: institution_name,
-        institution_country: COUNTRY_NAMES_TO_ISO_CODES[institution_country],
+        institution_country: institution_country,
         grade: grade,
         predicted_grade: false,
         award_year: award_year,
@@ -106,7 +106,7 @@ module CandidateInterface
         qualification_type: qualification_type,
         subject: subject,
         institution_name: institution_name,
-        institution_country: COUNTRY_NAMES_TO_ISO_CODES[institution_country],
+        institution_country: institution_country,
         grade: grade,
         predicted_grade: false,
         award_year: award_year,

--- a/app/frontend/packs/country-autocomplete.js
+++ b/app/frontend/packs/country-autocomplete.js
@@ -7,6 +7,10 @@ const initCountryAutocomplete = () => {
       "#candidate-interface-contact-details-form-country-field-error",
       "#candidate-interface-degree-institution-form-institution-country-field",
       "#candidate-interface-degree-institution-form-institution-country-field-error",
+      "#candidate-interface-gcse-institution-country-form-institution-country-field",
+      "#candidate-interface-gcse-institution-country-form-institution-country-field-error",
+      "#candidate-interface-other-qualification-form-institution-country-field",
+      "#candidate-interface-other-qualification-form-institution-country-field-error",
     ];
 
     inputIds.forEach(inputId => {

--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -13,10 +13,6 @@ const initNationalityAutocomplete = () => {
       "#candidate-interface-nationalities-form-other-nationality2-field-error",
       "#candidate-interface-nationalities-form-other-nationality3-field",
       "#candidate-interface-nationalities-form-other-nationality3-field-error",
-      "#candidate-interface-gcse-institution-country-form-institution-country-field",
-      "#candidate-interface-gcse-institution-country-form-institution-country-field-error",
-      "#candidate-interface-other-qualification-form-institution-country-field",
-      "#candidate-interface-other-qualification-form-institution-country-field-error",
     ].forEach(id => {
       const nationalitySelect = document.querySelector(id);
 

--- a/app/helpers/select_options_helper.rb
+++ b/app/helpers/select_options_helper.rb
@@ -11,12 +11,6 @@ module SelectOptionsHelper
     ] + COUNTRIES.except('GB').map { |iso3166, country| OpenStruct.new(id: iso3166, name: country) }
   end
 
-  def select_institution_country_options
-    [
-      OpenStruct.new(id: '', name: t('application_form.contact_details.country.default_option')),
-    ] + COUNTRIES.except('GB').map { |_, country| OpenStruct.new(id: country, name: country) }
-  end
-
   def select_course_options(courses)
     [
       OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_course_form.attributes.course_id.blank')),

--- a/app/views/candidate_interface/gcse/institution_country/edit.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @institution_country, url: candidate_interface_gcse_details_update_institution_country_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select :institution_country, select_institution_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>
+      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>
       <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -3,7 +3,7 @@
   <% if @qualification.non_uk_qualification_type.present? %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label') + ' (optional)', size: 'm' } %>
     <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
-    <%= f.govuk_collection_select :institution_country, select_institution_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
+    <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label') + ' (optional)', size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% else %>
@@ -19,7 +19,7 @@
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label') + ' (optional)', size: 'm' } %>
     <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
-    <%= f.govuk_collection_select :institution_country, select_institution_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
+    <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label') + ' (optional)', size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% elsif @qualification.qualification_type == 'Other' || @qualification.non_uk_qualification_type.present? %>

--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -198,6 +198,3 @@ COUNTRIES = {
   'ZM' => 'Zambia',
   'ZW' => 'Zimbabwe',
 }.freeze
-
-COUNTRY_NAMES = COUNTRIES.map(&:second)
-COUNTRY_NAMES_TO_ISO_CODES = COUNTRIES.map(&:reverse).to_h

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
-  let(:form_data) { { institution_country: COUNTRY_NAMES.sample } }
+  let(:form_data) { { institution_country: COUNTRIES.keys.sample } }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:institution_country) }
 
-    it 'validates nationalities against the COUNTRY_NAMES list' do
-      invalid_nationality = CandidateInterface::GcseInstitutionCountryForm.new(
-        institution_country: 'Tralfamadorian',
+    it 'validates nationalities against the COUNTRIES list' do
+      invalid_country = CandidateInterface::GcseInstitutionCountryForm.new(
+        institution_country: 'QQ',
       )
-      valid_nationality = CandidateInterface::GcseInstitutionCountryForm.new(
-        institution_country: COUNTRY_NAMES.sample,
+      valid_country = CandidateInterface::GcseInstitutionCountryForm.new(
+        institution_country: COUNTRIES.keys.sample,
       )
-      valid_nationality.validate
-      invalid_nationality.validate
-      expect(valid_nationality.errors.keys).not_to include :institution_country
-      expect(invalid_nationality.errors.keys).to include :institution_country
+      valid_country.validate
+      invalid_country.validate
+      expect(valid_country.errors.keys).not_to include :institution_country
+      expect(invalid_country.errors.keys).to include :institution_country
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       application_qualification = create(:application_qualification)
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.build_from_qualification(application_qualification)
 
-      expect(institution_country_form.institution_country).to eq COUNTRIES[application_qualification.institution_country]
+      expect(institution_country_form.institution_country).to eq application_qualification.institution_country
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
 
       expect(institution_country_form.save(application_qualification)).to eq(true)
-      expect(application_qualification.institution_country).to eq COUNTRY_NAMES_TO_ISO_CODES[form_data[:institution_country]]
+      expect(application_qualification.institution_country).to eq form_data[:institution_country]
     end
   end
 end

--- a/spec/forms/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_form_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     describe 'institution country' do
       context 'when it is a non-uk qualification' do
         it 'validates for presence and inclusion in the COUNTY_NAMES constant' do
-          valid_qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'non_uk', institution_country: 'Germany')
+          valid_qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'non_uk', institution_country: 'GB')
           blank_country_qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'non_uk')
-          inavlid_country_qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'non_uk', institution_country: 'Caprica City')
+          inavlid_country_qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'non_uk', institution_country: 'QQ')
 
           valid_qualification.validate
           blank_country_qualification.validate

--- a/spec/system/candidate_interface/international/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_enters_their_other_qualification_spec.rb
@@ -166,7 +166,7 @@ RSpec.feature 'Non-uk Other qualifications' do
   def then_i_see_my_qualification_filled_in
     expect(page).to have_selector("input[value='Believing in the Heart of the Cards']")
     expect(page).to have_selector("input[value='2015']")
-    expect(first('#candidate-interface-other-qualification-form-institution-country-field').value).to eq('Japan')
+    expect(first('#candidate-interface-other-qualification-form-institution-country-field').value).to eq('JP')
   end
 
   def when_i_change_my_qualification


### PR DESCRIPTION
## Context

In #2627 Steve added a new autocomplete component for countries. 

Some previous qualifications that ask for the institution country still use nationalities autocomplete.

## Changes proposed in this pull request

- Use the new countries autocomplete for international GCSE and Other qualifications


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
