### PR TITLE
Content email to confirm manage users permission has been assigned

### DIFF
--- a/app/views/provider_mailer/manage_user_added.text.erb
+++ b/app/views/provider_mailer/manage_user_added.text.erb
@@ -3,13 +3,13 @@ Dear <%= @provider_user.full_name || 'colleague' %>
 
 # Changes to your permissions settings on Manage teacher training applications
 
-As you requested, we have given <%= xxxx %> ‘Manage users’ permission. This allows them to:
+Your organisation has given you ‘Manage users’ permission. This allows you to:
 
 * set permissions for team members
 * invite new users
 * delete users
 
-They will be able to use their new permissions next time they sign in:
+You'll be able to use your new permissions next time you sign in:
 
 <%= provider_interface_sign_in_url %>
 

--- a/app/views/provider_mailer/manage_user_added.text.erb
+++ b/app/views/provider_mailer/manage_user_added.text.erb
@@ -1,0 +1,21 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+
+# Changes to your permissions settings on Manage teacher training applications
+
+As you requested, we have given <%= xxxx %> ‘Manage users’ permission. This allows them to:
+
+* set permissions for team members
+* invite new users
+* delete users
+
+They will be able to use their new permissions next time they sign in:
+
+<%= provider_interface_sign_in_url %>
+
+
+# Help and support
+
+To get help setting and amending permissions for your team members, email us at [becomingateacher@digital education.gov.uk](becomingateacher@digital education.gov.uk).
+
+For an overview of the service and answers to some common questions and concerns, see [Using Manage teacher training applications](<%= provider_interface_service_guidance_url %>).


### PR DESCRIPTION
Content email to confirm manage users permission has been assigned

## Context

We need to let provider users know they have been assigned manage users permission

## Changes proposed in this pull request

New email template

## Guidance to review

Currently this is being done manually by the support team when they get a completed Google form from existing training providers nominating team members for the manage users role.

Do we have plans to automate this? If so we can send out this email when the user has been given this permission.

## Link to Trello card

https://trello.com/c/F4i6l2CP/2165-help-notify-users-of-changes-to-access-controls-and-permissions

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
