### PR TITLE
Add information about issues relating to multiple webpacker dev servers

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -22,3 +22,9 @@ check` before proceeding to debug using `bin/webpack`.
 **If assets work in dev but not in tests**, first confirm that you can compile
 by invoking `bin/webpack`. If all is well, there is a chance that
 `public/packs-test` contains stale output. Delete it and re-run the suite.
+
+**If you get `404`s on assets, but they compile ok or exist in `public/packs`**
+This can occur if webpacker is already running (likely from another project).
+Our webpacker uses the default port, which other services may also use. Try
+changing the port in `config/webpacker.yml` or quitting other webpacker dev
+servers.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -24,7 +24,7 @@ by invoking `bin/webpack`. If all is well, there is a chance that
 `public/packs-test` contains stale output. Delete it and re-run the suite.
 
 **If you get `404`s on assets, but they compile ok or exist in `public/packs`**
-This can occur if webpacker is already running (likely from another project).
+This can occur if a webpack-dev-server is already running (likely from another project).
 Our app is configured to look for webpack-dev-server on the default port, which other services may also use.
 changing the port in `config/webpacker.yml` or quitting other webpacker dev
 servers.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -25,6 +25,6 @@ by invoking `bin/webpack`. If all is well, there is a chance that
 
 **If you get `404`s on assets, but they compile ok or exist in `public/packs`**
 This can occur if webpacker is already running (likely from another project).
-Our webpacker uses the default port, which other services may also use. Try
+Our app is configured to look for webpack-dev-server on the default port, which other services may also use.
 changing the port in `config/webpacker.yml` or quitting other webpacker dev
 servers.


### PR DESCRIPTION
## Context
I had some issues with assets, that with @duncanjbrown's help we diagnosed as being caused by another webpacker dev server intercepting our requests (and our app sharing default port)

## Changes proposed in this pull request
Adds some guidance for this issue.

We _could_ consider changing from the default port (or making our port relate to the app port or something) - but at least we could describe the issue.

## Guidance to review
Does it make sense?
