### PR TITLE
Update the display of safeguarding information

### DIFF
--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,1 +1,13 @@
 <p class="govuk-body"><%= message %></p>
+<% if current_user_has_permission_to_view_safeguarding_information? %>
+  <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        View information disclosed by the candidate
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <%= details %>
+    </div>
+  </details>
+<% end %>

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -21,6 +21,10 @@ module ProviderInterface
         .can_view_safeguarding_information?(course: application_choice.course)
     end
 
+    def details
+      application_choice.application_form.safeguarding_issues
+    end
+
   private
 
     def status

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -2,13 +2,37 @@ module ProviderInterface
   class SafeguardingDeclarationComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :message
+    attr_reader :application_choice, :current_provider_user
 
-    def initialize(application_form:)
-      @message = SafeguardingStatus.new(
-        status: application_form.safeguarding_issues_status,
+    def initialize(application_choice:, current_provider_user:)
+      @application_choice = application_choice
+      @current_provider_user = current_provider_user
+    end
+
+    def message
+      SafeguardingStatus.new(
+        status: status,
         i18n_key: 'provider_interface.safeguarding_declaration_component',
       ).message
+    end
+
+    def current_user_has_permission_to_view_safeguarding_information?
+      current_provider_user.authorisation
+        .can_view_safeguarding_information?(course: application_choice.course)
+    end
+
+  private
+
+    def status
+      if safeguarding_issues_declared? && !current_user_has_permission_to_view_safeguarding_information?
+        'has_safeguarding_issues_to_declare_no_permissions'
+      else
+        application_choice.application_form.safeguarding_issues_status
+      end
+    end
+
+    def safeguarding_issues_declared?
+      application_choice.application_form.has_safeguarding_issues_to_declare?
     end
   end
 end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -40,10 +40,9 @@
 
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
-    <% if ProviderAuthorisation.new(actor: current_provider_user).can_view_safeguarding_information?(course: @application_choice.course) %>
-      <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
-      <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
-    <% end %>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
+    <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user)%>
+
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Interview</h2>
 

--- a/config/locales/safeguarding.yml
+++ b/config/locales/safeguarding.yml
@@ -1,10 +1,11 @@
 en:
   provider_interface:
     safeguarding_declaration_component:
-      has_safeguarding_issues_to_declare: 'The candidate has shared information related to safeguarding. Please contact them directly for more details.'
+      has_safeguarding_issues_to_declare: 'The candidate has disclosed sensitive material related to safeguarding.'
       not_answered_yet: 'Not answered yet.'
       never_asked: 'Never asked.'
       no_safeguarding_issues_to_declare: 'No information shared.'
+      has_safeguarding_issues_to_declare_no_permissions: 'The candidate has disclosed information related to safeguarding. Access is restricted to users with permissions to view sensitive material.'
   support_interface:
     safeguarding_issues_component:
       has_safeguarding_issues_to_declare: 'The candidate has shared information related to safeguarding.'

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
         result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
         expect(result.text).to include(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare'))
+        expect(result.css('.govuk-details__summary-text').text).to include('View information disclosed by the candidate')
+        expect(result.css('.govuk-details__text').text).to include('I have a criminal conviction.')
       end
     end
 
@@ -60,6 +62,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
         result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
         expect(result.text).to include(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare_no_permissions'))
+        expect(result.text).not_to include('View information disclosed by the candidate')
       end
     end
 
@@ -72,6 +75,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
         result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
         expect(result.text).to include(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare_no_permissions'))
+        expect(result.text).not_to include('View information disclosed by the candidate')
       end
     end
   end

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -10,10 +10,10 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
     and_i_am_permitted_to_view_safeguarding_information
-    and_the_provider_has_an_open_application
+    and_the_provider_has_an_open_application_with_safeguarding_issues_declared
 
     when_i_view_the_application
-    then_i_should_not_see_the_safeguarding_declaration_section
+    then_i_should_not_see_the_safeguarding_declaration_details
 
     when_i_visit_the_edit_provider_relationship_permissions_page
     and_i_allow_my_training_provider_to_view_safeguarding_information
@@ -66,7 +66,12 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
     )
   end
 
-  def and_the_provider_has_an_open_application
+  def and_the_provider_has_an_open_application_with_safeguarding_issues_declared
+    @application_form = create(
+      :application_form,
+      safeguarding_issues: 'I have a criminal conviction.',
+      safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
+    )
     @application_choice = create(
       :application_choice,
       status: :application_complete,
@@ -75,7 +80,7 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
         course: create(:course, accredited_provider_id: @ratifying_provider.id, provider_id: @training_provider.id),
       ),
       reject_by_default_at: 20.days.from_now,
-      application_form: create(:application_form),
+      application_form: @application_form,
     )
 
     ApplicationStateChange.new(@application_choice).send_to_provider!
@@ -85,8 +90,8 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
     visit provider_interface_application_choice_path(@application_choice)
   end
 
-  def then_i_should_not_see_the_safeguarding_declaration_section
-    expect(page).not_to have_content('Criminal convictions and professional misconduct')
+  def then_i_should_not_see_the_safeguarding_declaration_details
+    expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare_no_permissions'))
   end
 
   def when_i_visit_the_edit_provider_relationship_permissions_page

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
     then_i_should_see_the_candidates_degrees
     and_i_should_see_the_candidates_gcses
-    and_i_should_not_see_the_safeguarding_declaration_section
+    and_i_should_not_see_the_safeguarding_declaration_details
 
     when_i_am_permitted_to_see_safeguarding_information
     and_i_visit_that_application_in_the_provider_interface
@@ -37,14 +37,14 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_i_should_see_a_link_to_download_as_pdf
   end
 
-  def and_i_should_not_see_the_safeguarding_declaration_section
-    expect(page).not_to have_content('Criminal convictions and professional misconduct')
-    expect(page).not_to have_content('The candidate has shared information related to safeguarding. Please contact them directly for more details.')
+  def and_i_should_not_see_the_safeguarding_declaration_details
+    expect(page).to have_content('Criminal convictions and professional misconduct')
+    expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare_no_permissions'))
   end
 
   def then_i_should_see_the_safeguarding_declaration_section
     expect(page).to have_content('Criminal convictions and professional misconduct')
-    expect(page).to have_content('The candidate has shared information related to safeguarding. Please contact them directly for more details.')
+    expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare'))
   end
 
   def and_the_enforce_provider_to_provider_permissions_feature_flag_is_active


### PR DESCRIPTION
## Context

Since we released Access Controls [the design of displaying safeguarding information changed](https://bat-design-history.netlify.app/manage-teacher-training-applications/view-safeguarding-information/). Users with view safeguarding information permission should be shown the details.

## Changes proposed in this pull request

- always display 'Criminal convictions and professional misconduct' header
- update message copy
- show details to users with permissions (html stolen from candidate's interface)

| Without permissions | With permissions |
| ------------- | ------------- |
|<img width="339" alt="Screenshot 2020-08-03 at 12 51 07" src="https://user-images.githubusercontent.com/38078064/89193242-a0a57080-d59d-11ea-976b-5f6797ed2619.png">| <img width="348" alt="Screenshot 2020-08-03 at 12 47 32" src="https://user-images.githubusercontent.com/38078064/89193279-aac76f00-d59d-11ea-8591-9a14e6ab7a93.png"> |

## Guidance to review

- to declare safeguarding issues `ApplicationForm.find_by(support_reference: "XXXX").update!(safeguarding_issues_status: "has_safeguarding_issues_to_declare", safeguarding_issues: "I have a criminal conviction.")`
- test with different user and provider-provider permissions
- other states like "Not answered yet" also work

## Link to Trello card

https://trello.com/c/hfwlPpk7/2500-implement-new-design-for-safeguarding-information

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
