### PR TITLE
Optional fields are correctly marked optional in the API docs

### DIFF
--- a/app/frontend/styles/_syntax-highlighting.scss
+++ b/app/frontend/styles/_syntax-highlighting.scss
@@ -22,8 +22,10 @@ $code-0F: #C92424; /* Deprecated, Opening/Closing Embedded Language Tags e.g. <?
 $code-insert-bg: #DEF8CA;
 $code-delete-bg: #FADDDD;
 
-.app-data-type {
+.app-api-metadata {
   color:  $govuk-secondary-text-colour;
+  margin: 0;
+  font-weight: normal;
 }
 
 .app-json-code-sample {

--- a/app/presenters/api_docs/api_schema.rb
+++ b/app/presenters/api_docs/api_schema.rb
@@ -44,6 +44,10 @@ module APIDocs
         name.in?(schema.required.to_a)
       end
 
+      def nullable?
+        attributes['nullable']
+      end
+
       def type_description
         desc = [type]
         desc << ', ISO 8601 date with time and timezone' if attributes.format == 'date-time'

--- a/app/views/api_docs/reference/_properties_list.html.erb
+++ b/app/views/api_docs/reference/_properties_list.html.erb
@@ -4,8 +4,9 @@
       <dt class="govuk-summary-list__key">
         <code><%= property.name %></code>
       </dt>
+
       <dd class="govuk-summary-list__value">
-        <div class="app-data-type">
+        <p class="app-api-metadata">
           <% if !property.object_schema_name %>
             <%= property.type_description %>
           <% elsif property.type == 'array' %>
@@ -13,7 +14,13 @@
           <% else %>
             <%= govuk_link_to property.object_schema_name, "##{property.object_schema_name.parameterize}-object" %> object
           <% end %>
-        </div>
+        </p>
+
+        <% if property.nullable? %>
+          <p class="app-api-metadata">
+            Optional
+          </p>
+        <% end %>
 
         <% if property.attributes.description %>
           <div class="app-styled-content govuk-!-margin-top-4">

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -95,6 +95,9 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - data
+                - meta
               properties:
                 data:
                   "$ref": "#/components/schemas/MakeOffer"
@@ -128,6 +131,8 @@ paths:
         content:
           application/json:
             schema:
+              required:
+                - meta
               type: object
               properties:
                 meta:
@@ -161,6 +166,8 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - meta
               properties:
                 meta:
                   "$ref": "#/components/schemas/MetaData"
@@ -193,6 +200,8 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - meta
               properties:
                 meta:
                   "$ref": "#/components/schemas/MetaData"
@@ -226,6 +235,9 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - meta
+                - data
               properties:
                 data:
                   "$ref": "#/components/schemas/Rejection"
@@ -449,7 +461,9 @@ components:
           - "$ref": "#/components/schemas/Rejection"
           nullable: true
         hesa_itt_data:
-          "$ref": "#/components/schemas/HESAITTData"
+          anyOf:
+          - "$ref": "#/components/schemas/HESAITTData"
+          nullable: true
         further_information:
           type: string
           maxLength: 10240
@@ -937,6 +951,7 @@ components:
           - '96'
         ethnicity:
           type: string
+          nullable: true
           description: The candidate’s ethnicity as [a 2-digit HESA code for Ethnicity](https://www.hesa.ac.uk/collection/c19053/e/ethnic)
           example: '10'
           enum:


### PR DESCRIPTION
## Context

A provider pointed out that the API docs don't tell them which fields they can expect to be populated in a given response.

We already specify whether request parameters are required or not, but don't do the same for fields in responses.

## Changes proposed in this pull request

- Use the `nullable` property to render the word "Optional" on fields which aren't guaranteed to be populated in API responses
- Add the `nullable` property to two fields which were missing it

## Link to Trello card

https://trello.com/c/DAdKeDdl/2508-optional-fields-are-correctly-marked-optional-in-the-api-docs

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
