### PR TITLE
Fix for focus appearing on mousedown of checkbox labels

### DIFF
--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -1,5 +1,5 @@
 <div class="moj-filter-layout__filter app-filter">
-  <div class="moj-filter" tabindex="-1">
+  <div class="moj-filter">
     <div class="moj-filter__header">
       <div class="moj-filter__header-title">
         <h2 class="govuk-heading-m">Filter</h2>
@@ -36,7 +36,9 @@
         </div>
       <% end %>
 
-      <div class="moj-filter__options">
+      <!-- Div made focusable to 'catch' focus from checkboxes. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
+       -->
+      <div class="moj-filter__options" tabindex="-1">
         <form method="get">
           <%= hidden_field_tag :sort_by, page_state.sort_by %>
 

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -63,3 +63,17 @@
     margin-bottom: govuk-spacing(3);
   }
 }
+
+// Apply GOV.UK focus styles - only needed with js.
+.js-enabled .app-filter:focus {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}
+
+// Fix for focus issue - see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
+
+// We're catching the focus on a second element rather than having the filter component itself flash with focus when checkbox labels are clicked.
+.moj-filter__options:focus {
+  outline: none;
+}
+
+


### PR DESCRIPTION
## Context
Quick for [this issue](https://trello.com/c/GSHg4UkG/2552-focus-issue-on-filters-box-when-selecting-items-in-the-filters-box). Because the filter has `tabindex="-1"`, it briefly gets focus each mousedown on a checkbox label.

My fix involves having a _second_ focusable element inside the one we already have. That element has focus styles suppressed. When a user clicks on a checkbox label, it receives focus, but nothing visually changes. When they release their cursor, the checkboxes are focused as normal.

As that second element has `tabindex="-1"` users can't normally tab in to it. As our main filter has normal focus styles, it looks correct when the popover is opened.

## Before
![filter-a-list-focus-bug-before](https://user-images.githubusercontent.com/2204224/89197775-20ced480-d5a4-11ea-8168-2aa2960640d2.gif)

## After
![filter-a-list-focus-bug-after2](https://user-images.githubusercontent.com/2204224/89300651-710b6c80-d660-11ea-90f3-e94c02cf74a5.gif)


Note I've [raised an issue upstream](https://github.com/ministryofjustice/moj-design-system/issues/39) with the MOJ design system about the issue.

## Other changes

I fixed the incorrect focus styling on the filter component.