### PR TITLE
Add a feature flag check to ProviderSetup#next_relationship_pending

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -70,8 +70,7 @@ module ProviderInterface
 
       if @provider_setup.next_agreement_pending
         redirect_to provider_interface_new_data_sharing_agreement_path
-      elsif FeatureFlag.active?('enforce_provider_to_provider_permissions') &&
-          @provider_setup.next_relationship_pending
+      elsif @provider_setup.next_relationship_pending
         # redirect_to provider_interface_provider_relationship_permissions_setup_path
         # TODO: Implement this
       end

--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -23,6 +23,8 @@ class ProviderSetup
   end
 
   def next_relationship_pending
+    return unless FeatureFlag.active?('enforce_provider_to_provider_permissions')
+
     permissions = ProviderRelationshipPermissions.find_by(
       setup_at: nil,
       training_provider: @provider_user.providers,

--- a/spec/services/provider_setup_spec.rb
+++ b/spec/services/provider_setup_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe ProviderSetup do
     end
 
     it 'returns a ProviderRelationshipPermissions record in need of setup' do
+      FeatureFlag.activate('enforce_provider_to_provider_permissions')
+
       create(
         :provider_relationship_permissions,
         training_provider: training_provider,
@@ -65,6 +67,8 @@ RSpec.describe ProviderSetup do
     end
 
     it 'provides all relationships pending setup for the user when called multiple times' do
+      FeatureFlag.activate('enforce_provider_to_provider_permissions')
+
       relationships = 3.times.map do
         create(
           :provider_relationship_permissions,


### PR DESCRIPTION
It was possible to get into a state where we weren't redirected to the setup page because the feature flag was off. However the header menu items were still hidden because `ProviderSetup` reported we still had a relationship to configure.

## Context

Noticed when working locally

## Changes proposed in this pull request

Check the flag in `ProviderSetup`, which controls both the controller and the menu. Previously only the controller checked the flag.

## Guidance to review

If the feature flag is turned off, the usual header menu items should appear on the /applications page.

## Link to Trello card

bugfix on https://trello.com/c/ejHRNikf/2509-remove-links-from-header-during-onboarding-process

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
