### PR TITLE
Restrict 'confirm conditions' to provider users with `make_decisions`

### DIFF
--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -2,4 +2,6 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
+<% if provider_can_respond %>
 <%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0  app-!-print-display-none' %>
+<% end %>

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.rb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.rb
@@ -4,10 +4,11 @@ module ProviderInterface
       include ViewHelper
       include StatusBoxComponents::CourseRows
 
-      attr_reader :application_choice
+      attr_reader :application_choice, :provider_can_respond
 
       def initialize(application_choice:, options: {})
         @application_choice = application_choice
+        @provider_can_respond = options[:provider_can_respond]
         @options = options
       end
 

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -28,7 +28,7 @@ module ProviderInterface
 
     def show
       auth = ProviderAuthorisation.new(actor: current_provider_user)
-      @provider_can_respond = auth.can_make_offer?(
+      @provider_can_respond = auth.can_make_decisions?(
         application_choice: @application_choice,
         course_option_id: @application_choice.offered_option.id,
       )

--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ConditionsController < ProviderInterfaceController
     before_action :set_application_choice
+    before_action :requires_make_decisions_permission
 
     def edit
       @conditions_form = ConfirmConditionsForm.new

--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -22,10 +22,18 @@ module ProviderInterface
       redirect_to action: :edit unless @conditions_form.valid?
 
       if @conditions_form.conditions_met?
-        ConfirmOfferConditions.new(application_choice: @application_choice).save || raise('ConfirmOfferConditions failure')
+        ConfirmOfferConditions.new(
+          actor: current_provider_user,
+          application_choice: @application_choice,
+        ).save || raise('ConfirmOfferConditions failure')
+
         flash[:success] = 'Conditions successfully marked as met'
       else
-        ConditionsNotMet.new(application_choice: @application_choice).save || raise('ConditionsNotMet failure')
+        ConditionsNotMet.new(
+          actor: current_provider_user,
+          application_choice: @application_choice,
+        ).save || raise('ConditionsNotMet failure')
+
         flash[:success] = 'Conditions successfully marked as not met'
       end
 

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -71,11 +71,15 @@ module ProviderInterface
     end
 
     def new_reject
-      @reject_application = RejectApplication.new(application_choice: @application_choice)
+      @reject_application = RejectApplication.new(
+        actor: current_provider_user,
+        application_choice: @application_choice,
+      )
     end
 
     def confirm_reject
       @reject_application = RejectApplication.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
         rejection_reason: params.dig(:reject_application, :rejection_reason),
       )
@@ -84,6 +88,7 @@ module ProviderInterface
 
     def create_reject
       @reject_application = RejectApplication.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
         rejection_reason: params.dig(:reject_application, :rejection_reason),
       )
@@ -99,12 +104,14 @@ module ProviderInterface
 
     def new_withdraw_offer
       @withdraw_offer = WithdrawOffer.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
       )
     end
 
     def confirm_withdraw_offer
       @withdraw_offer = WithdrawOffer.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
         offer_withdrawal_reason: params.dig(:withdraw_offer, :offer_withdrawal_reason),
       )
@@ -115,6 +122,7 @@ module ProviderInterface
 
     def withdraw_offer
       @withdraw_offer = WithdrawOffer.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
         offer_withdrawal_reason: params.dig(:withdraw_offer, :offer_withdrawal_reason),
       )

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -83,9 +83,7 @@ module ProviderInterface
     end
 
     def requires_make_decisions_permission
-      auth = ProviderAuthorisation.new(actor: current_provider_user)
-
-      if !auth.can_make_offer?(
+      if !current_provider_user.authorisation.can_make_offer?(
         application_choice: @application_choice,
         course_option_id: @application_choice.offered_option.id,
       )

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -83,7 +83,7 @@ module ProviderInterface
     end
 
     def requires_make_decisions_permission
-      if !current_provider_user.authorisation.can_make_offer?(
+      if !current_provider_user.authorisation.can_make_decisions?(
         application_choice: @application_choice,
         course_option_id: @application_choice.offered_option.id,
       )

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -68,6 +68,7 @@ module VendorAPI
 
     def confirm_enrolment
       decision = ConfirmEnrolment.new(
+        actor: @api_user,
         application_choice: application_choice,
       )
 

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -51,11 +51,13 @@ module VendorAPI
       decision =
         if application_choice.offer?
           WithdrawOffer.new(
+            actor: @api_user,
             application_choice: application_choice,
             offer_withdrawal_reason: params.dig(:data, :reason),
           )
         else
           RejectApplication.new(
+            actor: @api_user,
             application_choice: application_choice,
             rejection_reason: params.dig(:data, :reason),
           )

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -218,7 +218,7 @@ class TestApplications
   def reject_application(choice)
     as_provider_user(choice) do
       fast_forward(1..3)
-      RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
+      RejectApplication.new(actor: actor, application_choice: choice, rejection_reason: 'Some').save
       choice.update_columns(rejected_at: time)
     end
   end
@@ -226,7 +226,7 @@ class TestApplications
   def withdraw_offer(choice)
     as_provider_user(choice) do
       fast_forward(1..3)
-      WithdrawOffer.new(application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
+      WithdrawOffer.new(actor: actor, application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
       choice.update_columns(withdrawn_at: time)
     end
   end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -250,7 +250,7 @@ class TestApplications
   def confirm_enrollment(choice)
     as_provider_user(choice) do
       fast_forward(1..3)
-      ConfirmEnrolment.new(application_choice: choice).save
+      ConfirmEnrolment.new(actor: actor, application_choice: choice).save
       choice.update_columns(enrolled_at: time)
     end
   end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -234,7 +234,7 @@ class TestApplications
   def conditions_not_met(choice)
     as_provider_user(choice) do
       fast_forward(1..3)
-      ConditionsNotMet.new(application_choice: choice).save
+      ConditionsNotMet.new(actor: actor, application_choice: choice).save
       choice.update_columns(conditions_not_met_at: time)
     end
   end
@@ -242,7 +242,7 @@ class TestApplications
   def confirm_offer_conditions(choice)
     as_provider_user(choice) do
       fast_forward(1..3)
-      ConfirmOfferConditions.new(application_choice: choice).save
+      ConfirmOfferConditions.new(actor: actor, application_choice: choice).save
       choice.update_columns(recruited_at: time)
     end
   end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -15,7 +15,7 @@ class ChangeOffer
   end
 
   def save
-    @auth.assert_can_make_offer! application_choice: @application_choice, course_option_id: @course_option.id
+    @auth.assert_can_make_decisions! application_choice: @application_choice, course_option_id: @course_option.id
     if valid?
       attributes = {
         offered_course_option: @course_option,

--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -1,11 +1,14 @@
 class ConditionsNotMet
   include ActiveModel::Validations
 
-  def initialize(application_choice:)
+  def initialize(actor:, application_choice:)
+    @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
   end
 
   def save
+    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
+
     ApplicationStateChange.new(@application_choice).conditions_not_met!
     @application_choice.update!(conditions_not_met_at: Time.zone.now)
     CandidateMailer.conditions_not_met(@application_choice).deliver_later

--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -7,7 +7,7 @@ class ConditionsNotMet
   end
 
   def save
-    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
+    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
     ApplicationStateChange.new(@application_choice).conditions_not_met!
     @application_choice.update!(conditions_not_met_at: Time.zone.now)

--- a/app/services/confirm_enrolment.rb
+++ b/app/services/confirm_enrolment.rb
@@ -1,11 +1,14 @@
 class ConfirmEnrolment
   include ActiveModel::Validations
 
-  def initialize(application_choice:)
+  def initialize(actor:, application_choice:)
+    @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
   end
 
   def save
+    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
+
     ApplicationStateChange.new(@application_choice).confirm_enrolment!
     @application_choice.update!(enrolled_at: Time.zone.now)
   rescue Workflow::NoTransitionAllowed

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -7,7 +7,7 @@ class ConfirmOfferConditions
   end
 
   def save
-    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
+    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
     ApplicationStateChange.new(@application_choice).confirm_conditions_met!
     @application_choice.update!(recruited_at: Time.zone.now)

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -1,11 +1,14 @@
 class ConfirmOfferConditions
   include ActiveModel::Validations
 
-  def initialize(application_choice:)
+  def initialize(actor:, application_choice:)
+    @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
   end
 
   def save
+    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
+
     ApplicationStateChange.new(@application_choice).confirm_conditions_met!
     @application_choice.update!(recruited_at: Time.zone.now)
     CandidateMailer.conditions_met(@application_choice).deliver_later

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -34,7 +34,7 @@ class MakeAnOffer
   def save
     return unless valid?
 
-    @auth.assert_can_make_offer!(application_choice: application_choice, course_option_id: @course_option.id)
+    @auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: @course_option.id)
 
     ApplicationStateChange.new(application_choice).make_offer!
     application_choice.offered_course_option = course_option

--- a/app/services/make_decisions_authorisation.rb
+++ b/app/services/make_decisions_authorisation.rb
@@ -1,9 +1,9 @@
-class OfferAuthorisation
+class MakeDecisionsAuthorisation
   def initialize(actor:)
     @actor = actor
   end
 
-  def can_make_offer?(application_choice:, course_option_id:)
+  def can_make_decisions?(application_choice:, course_option_id:)
     return true if @actor.is_a?(SupportUser)
 
     course_option = CourseOption.find(course_option_id)

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -45,8 +45,8 @@ class ProviderAuthorisation
     providers_that_actor_can_manage_organisations_for.any?
   end
 
-  def can_make_offer?(application_choice:, course_option_id:)
-    OfferAuthorisation.new(actor: @actor).can_make_offer?(application_choice: application_choice, course_option_id: course_option_id)
+  def can_make_decisions?(application_choice:, course_option_id:)
+    MakeDecisionsAuthorisation.new(actor: @actor).can_make_decisions?(application_choice: application_choice, course_option_id: course_option_id)
   end
 
   def can_view_safeguarding_information?(course:)
@@ -68,10 +68,10 @@ class ProviderAuthorisation
     @actor.provider_permissions.exists?(provider: provider, manage_organisations: true)
   end
 
-  def assert_can_make_offer!(application_choice:, course_option_id:)
-    return if can_make_offer?(application_choice: application_choice, course_option_id: course_option_id)
+  def assert_can_make_decisions!(application_choice:, course_option_id:)
+    return if can_make_decisions?(application_choice: application_choice, course_option_id: course_option_id)
 
-    raise NotAuthorisedError, 'You are not allowed to make this offer'
+    raise NotAuthorisedError, 'You are not allowed to make decisions'
   end
 
   class NotAuthorisedError < StandardError; end

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -6,13 +6,16 @@ class RejectApplication
   validates_presence_of :rejection_reason
   validates_length_of :rejection_reason, maximum: 255
 
-  def initialize(application_choice:, rejection_reason: nil)
+  def initialize(actor:, application_choice:, rejection_reason: nil)
+    @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
     @rejection_reason = rejection_reason
   end
 
   def save
     return unless valid?
+
+    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).reject!

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -15,7 +15,7 @@ class RejectApplication
   def save
     return unless valid?
 
-    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
+    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).reject!

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -6,13 +6,16 @@ class WithdrawOffer
   validates_presence_of :offer_withdrawal_reason
   validates_length_of :offer_withdrawal_reason, maximum: 255
 
-  def initialize(application_choice:, offer_withdrawal_reason: nil)
+  def initialize(actor:, application_choice:, offer_withdrawal_reason: nil)
+    @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
     @offer_withdrawal_reason = offer_withdrawal_reason
   end
 
   def save
     return false unless valid?
+
+    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).reject!

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -15,7 +15,7 @@ class WithdrawOffer
   def save
     return false unless valid?
 
-    @auth.assert_can_make_offer!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
+    @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).reject!

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'You are not allowed to make this offer'
+      expect(error_response['message']).to match 'You are not allowed to make decisions'
     end
 
     it 'returns an error when specifying a course that is not open on Apply' do

--- a/spec/services/conditions_not_met_spec.rb
+++ b/spec/services/conditions_not_met_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe ConditionsNotMet do
 
     Timecop.freeze do
       expect {
-        ConditionsNotMet.new(application_choice: application_choice).save
+        ConditionsNotMet.new(
+          actor: create(:support_user),
+          application_choice: application_choice,
+        ).save
       }.to change { application_choice.conditions_not_met_at }.to(Time.zone.now)
     end
   end

--- a/spec/services/conditions_not_met_spec.rb
+++ b/spec/services/conditions_not_met_spec.rb
@@ -1,6 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe ConditionsNotMet do
+  it 'raises an error if the user is not authorised' do
+    application_choice = create(:application_choice, status: :pending_conditions)
+    provider_user = create(:provider_user)
+    provider_user.providers << application_choice.offered_course.provider
+
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
+    service = ConditionsNotMet.new(
+      actor: provider_user,
+      application_choice: application_choice,
+    )
+
+    expect { service.save }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+
+    expect(application_choice.reload.status).to eq 'pending_conditions'
+  end
+
   it 'sets the conditions_not_met_at date for the application_choice' do
     application_choice = create(:application_choice, status: :pending_conditions)
 

--- a/spec/services/confirm_enrolment_spec.rb
+++ b/spec/services/confirm_enrolment_spec.rb
@@ -1,12 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe ConfirmEnrolment do
+  it 'raises an error if the user is not authorised' do
+    application_choice = create(:application_choice, status: :recruited)
+    provider_user = create(:provider_user)
+    provider_user.providers << application_choice.offered_course.provider
+
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
+    service = ConfirmEnrolment.new(
+      actor: provider_user,
+      application_choice: application_choice,
+    )
+
+    expect { service.save }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+
+    expect(application_choice.reload.status).to eq 'recruited'
+  end
+
   it 'sets the enrolled_at date for the application_choice' do
     application_choice = create(:application_choice, status: :recruited)
 
     Timecop.freeze do
       expect {
-        ConfirmEnrolment.new(application_choice: application_choice).save
+        ConfirmEnrolment.new(
+          actor: create(:support_user),
+          application_choice: application_choice,
+        ).save
       }.to change { application_choice.enrolled_at }.to(Time.zone.now)
     end
   end

--- a/spec/services/confirm_offer_conditions_spec.rb
+++ b/spec/services/confirm_offer_conditions_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe ConfirmOfferConditions do
 
     Timecop.freeze do
       expect {
-        ConfirmOfferConditions.new(application_choice: application_choice).save
+        ConfirmOfferConditions.new(
+          actor: create(:support_user),
+          application_choice: application_choice,
+        ).save
       }.to change { application_choice.recruited_at }.to(Time.zone.now)
     end
   end

--- a/spec/services/confirm_offer_conditions_spec.rb
+++ b/spec/services/confirm_offer_conditions_spec.rb
@@ -1,6 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe ConfirmOfferConditions do
+  it 'raises an error if the user is not authorised' do
+    application_choice = create(:application_choice, status: :pending_conditions)
+    provider_user = create(:provider_user)
+    provider_user.providers << application_choice.offered_course.provider
+
+    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
+
+    service = ConfirmOfferConditions.new(
+      actor: provider_user,
+      application_choice: application_choice,
+    )
+
+    expect { service.save }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+
+    expect(application_choice.reload.status).to eq 'pending_conditions'
+  end
+
   it 'sets the recruited_at date for the application_choice' do
     application_choice = create(:application_choice, status: :pending_conditions)
 

--- a/spec/services/withdraw_offer_spec.rb
+++ b/spec/services/withdraw_offer_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe WithdrawOffer do
       application_choice = create(:application_choice, status: :offer)
 
       withdrawal_reason = 'We are so sorry...'
-      WithdrawOffer.new(application_choice: application_choice, offer_withdrawal_reason: withdrawal_reason).save
+      WithdrawOffer.new(
+        actor: create(:support_user),
+        application_choice: application_choice,
+        offer_withdrawal_reason: withdrawal_reason,
+      ).save
 
       expect(application_choice.reload.status).to eq 'offer_withdrawn'
     end
@@ -14,7 +18,12 @@ RSpec.describe WithdrawOffer do
     it 'does not change the state of the application_choice to "rejected" without a valid reason' do
       application_choice = create(:application_choice, status: :offer)
 
-      expect(WithdrawOffer.new(application_choice: application_choice).save).to be false
+      service = WithdrawOffer.new(
+        actor: create(:support_user),
+        application_choice: application_choice,
+      )
+
+      expect(service.save).to be false
 
       expect(application_choice.reload.status).to eq 'offer'
     end
@@ -24,7 +33,11 @@ RSpec.describe WithdrawOffer do
       allow(SetDeclineByDefault).to receive(:new).and_call_original
 
       withdrawal_reason = 'We are so sorry...'
-      WithdrawOffer.new(application_choice: application_choice, offer_withdrawal_reason: withdrawal_reason).save
+      WithdrawOffer.new(
+        actor: create(:support_user),
+        application_choice: application_choice,
+        offer_withdrawal_reason: withdrawal_reason,
+      ).save
 
       expect(SetDeclineByDefault).to have_received(:new).with(application_form: application_choice.application_form)
     end
@@ -34,7 +47,11 @@ RSpec.describe WithdrawOffer do
       allow(StateChangeNotifier).to receive(:call).and_return true
 
       withdrawal_reason = 'We are so sorry...'
-      WithdrawOffer.new(application_choice: application_choice, offer_withdrawal_reason: withdrawal_reason).save
+      WithdrawOffer.new(
+        actor: create(:support_user),
+        application_choice: application_choice,
+        offer_withdrawal_reason: withdrawal_reason,
+      ).save
 
       expect(StateChangeNotifier).to have_received(:call).with(:withdraw_offer, application_choice: application_choice)
     end

--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -70,7 +70,11 @@ RSpec.feature 'Receives rejection email' do
   end
 
   def and_a_provider_rejects_my_application
-    RejectApplication.new(application_choice: @application_choice, rejection_reason: 'No experience working with children.').save
+    RejectApplication.new(
+      actor: create(:support_user),
+      application_choice: @application_choice,
+      rejection_reason: 'No experience working with children.',
+    ).save
   end
 
   def then_i_receive_the_all_applications_rejected_email


### PR DESCRIPTION
## Context

The 'confirm conditions' (met/not met) flow has been unrestricted so far, subject to application visibility. Now that we have started restricting provider user actions based on their per-provider permissions, we have decided to change this and require `make_decisions` permission for any provider action which affects the application lifecycle.

## Changes proposed in this pull request

This PR hides the 'Confirm conditions' button in the provider interface when viewing 'accepted' offers and restricts access to the relevant screens. It also goes beyond the UI to enforce this restriction within the backend services, to prevent issues arising from changes to the UI.

Considering we have started using the `can_make_offer?` logic to authorise any decision-related provider action, this PR also renames all instances of `can_make_offer` to `can_make_decisions` for simplicity and consistency.

It also adds an `actor:` context to the `ConfirmEnrolment` service for completeness, even though this is not yet accessible via the UI (but may be triggered via the vendor API).

## Guidance to review

Should be straightforward for visible elements, such as the 'Confirm conditions' button and pages. Ideally, it shouldn't be possible to see any `NotAuthorised` errors from these services via the UI, because our policy is to hide the relevant navigation elements from unauthorised users.

## Link to Trello card

https://trello.com/c/Zfj9ZyLP

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
