### PR TITLE
Sort days_left_to_respond applications correctly under Timecop

### DIFF
--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -11,7 +11,7 @@ module ProviderInterface
         <<-ORDER_BY.strip_heredoc,
         (
           CASE
-            WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > NOW())) THEN 1
+            WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > '#{Time.zone.now.iso8601}')) THEN 1
             ELSE 0
           END
         ) DESC,

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -1,31 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::SortApplicationChoices do
+  describe '#call' do
+    it 'sorts the application choics by RBD date if the RBD date is in the future' do
+      Timecop.freeze(2020, 1, 1) do
+        choice_one = create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 2.days.from_now.end_of_day)
+        choice_two = create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 1.day.from_now.end_of_day)
+
+        expect(described_class.call(application_choices: ApplicationChoice.all, sort_by: 'days_left_to_respond')).to eq [choice_two, choice_one]
+      end
+    end
+
+    it 'sorts the application choices by last_changed if the RBD date is in the past' do
+      Timecop.freeze(2020, 1, 1) do
+        choice_one = create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 2.days.ago.end_of_day)
+        choice_two = create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 1.day.ago.end_of_day)
+
+        expect(described_class.call(application_choices: ApplicationChoice.all, sort_by: 'days_left_to_respond')).to eq [choice_one, choice_two]
+      end
+    end
+  end
+
   describe '#sort_order' do
     let(:sort_by) { nil }
 
     subject(:sort_order) { described_class.sort_order(sort_by) }
-
-    it { is_expected.to eq({ updated_at: :desc }) }
-
-    context 'when sort_by is RBD date' do
-      let(:sort_by) { 'days_left_to_respond' }
-
-      it 'returns reject_by_default_date and updated_at descending' do
-        expect(sort_order).to eq(
-          <<-ORDER_BY.strip_heredoc,
-          (
-            CASE
-              WHEN (status='awaiting_provider_decision' AND (DATE(reject_by_default_at) > NOW())) THEN 1
-              ELSE 0
-            END
-          ) DESC,
-          reject_by_default_at ASC,
-          application_choices.updated_at DESC
-          ORDER_BY
-        )
-      end
-    end
 
     context 'when sort param is last changed' do
       let(:sort_by) { 'last_changed' }


### PR DESCRIPTION
This spec started failing unexpectedly. We were using postgres's NOW() to decide how to sort these applications, and the spec set Timecop to create applications up to the 3rd of August. Today is the 4th of August!

## Context

Master was broken

## Changes proposed in this pull request

- don't use `NOW()` in the sorting SQL, interpolate the current time from Ruby instead
- make the specs for the application sorting more focus on the outcome of the sort order rather than the query itself

## Link to Trello card

N/A

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
