### PR TITLE
Fix character limit rendering for API fields

### DIFF
--- a/app/presenters/api_docs/api_schema.rb
+++ b/app/presenters/api_docs/api_schema.rb
@@ -57,6 +57,7 @@ module APIDocs
           desc << " (limited to #{attributes.max_length} characters)"
         elsif type == 'array' && attributes.max_items.present?
           desc << " (limited to #{attributes.max_items} elements)"
+          desc << " of strings (limited to #{attributes.items.max_length} characters)" if limited_string_within_array
         end
 
         desc.join
@@ -80,6 +81,12 @@ module APIDocs
         return if location.match?('/properties')
 
         location.gsub(/#\/components\/schemas\//, '')
+      end
+
+    private
+
+      def limited_string_within_array
+        attributes.items.type == 'string' && attributes.items.max_length
       end
     end
   end


### PR DESCRIPTION
## Context

`maxLength` property of string with an array was not showing.

## Changes proposed in this pull request

Display the character limit for items within an array in the API docs. This affected:
- Offer - conditions
- MakeOffer - conditions

<img width="490" alt="Screenshot 2020-08-04 at 09 27 11" src="https://user-images.githubusercontent.com/38078064/89273113-0560d980-d637-11ea-886c-258e93f8a029.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/keAy5Kxp/2512-fix-character-limit-rendering-for-api-fields

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
