### PR TITLE
Remove "provider_view_safeguarding" feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,7 +25,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
     [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],
-    [:provider_view_safeguarding, 'Allows providers to see whether a candidate has declared safeguarding issues', 'Will McBrien'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -53,11 +53,9 @@
 
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
-    <% if FeatureFlag.active?('provider_view_safeguarding') %>
-      <% if ProviderAuthorisation.new(actor: current_provider_user).can_view_safeguarding_information?(course: @application_choice.course) %>
-        <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
-        <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
-      <% end %>
+    <% if ProviderAuthorisation.new(actor: current_provider_user).can_view_safeguarding_information?(course: @application_choice.course) %>
+      <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
+      <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
     <% end %>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Interview</h2>

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
   scenario 'Provider manages permissions for their organisation' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_provider_permissions_feature_is_enabled
-    and_the_safeguarding_declaration_feature_flag_is_active
     and_i_sign_in_to_the_provider_interface
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
@@ -43,10 +42,6 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
 
   def and_the_provider_permissions_feature_is_enabled
     FeatureFlag.activate('enforce_provider_to_provider_permissions')
-  end
-
-  def and_the_safeguarding_declaration_feature_flag_is_active
-    FeatureFlag.activate('provider_view_safeguarding')
   end
 
   def and_i_can_manage_organisations_for_a_provider

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   scenario 'the application data is visible' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_safeguarding_declaration_feature_flag_is_active
     and_the_enforce_provider_to_provider_permissions_feature_flag_is_active
     and_my_organisation_has_received_an_application
     and_i_am_permitted_to_see_applications_for_my_provider
@@ -46,10 +45,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def then_i_should_see_the_safeguarding_declaration_section
     expect(page).to have_content('Criminal convictions and professional misconduct')
     expect(page).to have_content('The candidate has shared information related to safeguarding. Please contact them directly for more details.')
-  end
-
-  def and_the_safeguarding_declaration_feature_flag_is_active
-    FeatureFlag.activate('provider_view_safeguarding')
   end
 
   def and_the_enforce_provider_to_provider_permissions_feature_flag_is_active


### PR DESCRIPTION
This flag has been turned on since at least May 15th. Removing the flag now makes the permissions code easier to manage.