### PR TITLE
Improve readability of dashboard figures

### DIFF
--- a/app/components/support_interface/tile_component.html.erb
+++ b/app/components/support_interface/tile_component.html.erb
@@ -1,4 +1,4 @@
 <div class="app-card<%= colour == :default ? '' : " app-card--#{colour}" %>">
-  <span class="<%= count_class %>"><%= count %></span>
+  <span class="<%= count_class %>"><%= number_with_delimiter(count) %></span>
   <%= label %>
 </div>

--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -35,6 +35,6 @@
 }
 
 .app-card__secondary-count {
-  @include govuk-font($size: 48, $weight: bold);
+  @include govuk-font($size: 36, $weight: bold);
   display: block;
 }

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -66,7 +66,7 @@
         <% @statistics.candidate_status_counts.each do |row| %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= row['count'] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>
             <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
           </tr>
         <% end %>


### PR DESCRIPTION
- Prevent large numbers from encroaching on padding within reduced tiles
- Use delimiters to show 1000 as 1,000, etc

## Before
<img width="500" alt="Screen Shot 2020-08-04 at 14 56 20" src="https://user-images.githubusercontent.com/319055/89302614-f42dc200-d662-11ea-937a-e9cf2a33c5ff.png">

## After
<img width="503" alt="Screen Shot 2020-08-04 at 14 58 01" src="https://user-images.githubusercontent.com/319055/89302619-f55eef00-d662-11ea-9cd4-720e0faeeecd.png">


