### PR TITLE
Add course_code to TAD export

### DIFF
--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -22,6 +22,7 @@ module SupportInterface
         provider_type: nil,
         urn: nil,
         lead_school: nil,
+        course_code: course.code,
         subject: course.name,
         applications: statuses.count,
         offers: 0,

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SupportInterface::TADProviderStatsExport do
       provider_one = create(:provider, code: 'ABC1', name: 'Tehanu')
       provider_two = create(:provider, code: 'DEF2', name: 'Anarres')
 
-      course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'History', provider: provider_one))
+      course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'History', provider: provider_one, code: 'XYZ'))
       course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'Biology', provider: provider_one))
       course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'Science book', provider: provider_two))
       course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'French I took', provider: provider_two))
@@ -56,6 +56,7 @@ RSpec.describe SupportInterface::TADProviderStatsExport do
       example_row = exported_rows.find { |r| r[:subject] == 'History' }
       expect(example_row[:provider]).to eq('Tehanu')
       expect(example_row[:provider_code]).to eq('ABC1')
+      expect(example_row[:course_code]).to eq('XYZ')
     end
   end
 end


### PR DESCRIPTION
## Context

This enables matching against other tables containing data we don't currently hold in Apply, eg program_type. This in turn will enable us to complete the TAD report in time for their 6th August deadline.

## Changes proposed in this pull request

Add the course code to the TAD export.

## Guidance to review

Could anything possibly go wrong?

## Link to Trello card

https://trello.com/c/n1M0E29s/2564-tad-data-request-acceptances-per-provider

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
