### PR TITLE
Add autocomplete to Maths and English GCSE grades

### DIFF
--- a/app/controllers/candidate_interface/gcse/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_controller.rb
@@ -24,6 +24,11 @@ module CandidateInterface
 
   private
 
+    def autocomplete_grades?
+      @subject.in?(%w[maths english]) && @qualification_type == 'gcse'
+    end
+    helper_method :autocomplete_grades?
+
     def next_gcse_path
       if details_form.award_year.nil?
         candidate_interface_gcse_details_edit_year_path

--- a/app/forms/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_details_form.rb
@@ -11,6 +11,12 @@ module CandidateInterface
     validate :award_year_is_a_valid_date, if: :award_year, on: :award_year
     validate :validate_grade_format, unless: :new_record?, on: :grade
 
+    Grade = Struct.new(:value, :option)
+
+    def self.all_grade_drop_down_options
+      ALL_GCSE_GRADES.map { |g| Grade.new(g, g) }
+    end
+
     def self.build_from_qualification(qualification)
       if FeatureFlag.active?('international_gcses') && qualification.qualification_type == 'non_uk'
         new(

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -10,6 +10,7 @@ import initDegreeInstitutionAutocomplete from "./degree-institution-autocomplete
 import initDegreeInstitutionCountryAutocomplete from "./degree-institution-country-autocomplete";
 import initDegreeSubjectAutocomplete from "./degree-subject-autocomplete";
 import initDegreeTypeAutocomplete from "./degree-type-autocomplete";
+import initGcseGradeAutocomplete from "./gcse-grade-autocomplete";
 import initIeltsBandScoreAutocomplete from "./ielts-band-score-autocomplete";
 import initWarnOnUnsavedChanges from "./warn-on-unsaved-changes";
 import providerFilter from "./provider-filter";
@@ -27,6 +28,7 @@ initDegreeInstitutionAutocomplete();
 initDegreeInstitutionCountryAutocomplete();
 initDegreeSubjectAutocomplete();
 initDegreeTypeAutocomplete();
+initGcseGradeAutocomplete();
 initIeltsBandScoreAutocomplete();
 initWarnOnUnsavedChanges();
 providerFilter();

--- a/app/frontend/packs/gcse-grade-autocomplete.js
+++ b/app/frontend/packs/gcse-grade-autocomplete.js
@@ -1,0 +1,27 @@
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const initGcseGradeAutocomplete = () => {
+  try {
+    const ids = [
+      "candidate-interface-gcse-qualification-details-form-grade-field",
+      "candidate-interface-gcse-qualification-details-form-grade-field-error",
+    ];
+
+    ids.forEach(id => {
+      const gradeSelect = document.getElementById(id);
+      if (!gradeSelect) return;
+
+      accessibleAutocomplete.enhanceSelectElement({
+        defaultValue: '',
+        selectElement: gradeSelect,
+        showAllValues: true,
+        showNoOptionsFound: true,
+        confirmOnBlur: true,
+      });
+    });
+  } catch (err) {
+    console.error("Could not enhance GCSE grade input:", err);
+  }
+};
+
+export default initGcseGradeAutocomplete;

--- a/app/views/candidate_interface/gcse/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade/edit.html.erb
@@ -19,7 +19,20 @@
       <% else %>
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
-        <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint_text: hint_for_gcse_edit_grade(@subject, @qualification_type), width: 10 %>
+        <% if autocomplete_grades? %>
+          <div class="govuk-!-width-one-third">
+            <%= f.govuk_collection_select(
+              :grade,
+              CandidateInterface::GcseQualificationDetailsForm.all_grade_drop_down_options,
+              :value,
+              :option,
+              label: { text: 'Grade', size: 'm' },
+              hint_text: 'For example, ‘C’ or ‘4’',
+            ) %>
+          </div>
+        <% else %>
+          <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint_text: hint_for_gcse_edit_grade(@subject, @qualification_type), width: 10 %>
+        <% end %>
       <% end %>
 
       <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>

--- a/config/initializers/gcse_grades.rb
+++ b/config/initializers/gcse_grades.rb
@@ -1,0 +1,37 @@
+SINGLE_GCSE_GRADES = %w[9 8 7 6 5 4 3 2 1 A* A B C D E F G U].freeze
+DOUBLE_GCSE_GRADES = %w[
+  9-8
+  9-9
+  8-8
+  8-7
+  7-7
+  7-6
+  6-6
+  6-5
+  5-5
+  5-4
+  4-4
+  4-3
+  3-3
+  3-2
+  2-2
+  2-1
+  1-1
+  A*A
+  A*A*
+  AA
+  AB
+  BB
+  BC
+  CC
+  CD
+  DD
+  DE
+  EE
+  EF
+  FF
+  FG
+  GG
+  U
+].freeze
+ALL_GCSE_GRADES = (SINGLE_GCSE_GRADES + DOUBLE_GCSE_GRADES).uniq

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -217,7 +217,7 @@ en:
         label: Type of qualification
       qualification_types:
         gcse: GCSE
-        gce_o_level: GCE O Level
+        gce_o_level: O Level
         scottish_national_5: Scottish National 5
         other_uk: Other UK qualification
         non_uk: Non-UK qualification

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,7 +262,7 @@ en:
     attributes:
       application_qualification/qualification_type:
         gcse: GCSE
-        gce_o_level: GCE O Level
+        gce_o_level: O Level
         scottish_national_5: Scottish National 5
         other_uk: Other UK
         missing: I don’t have this qualification yet

--- a/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
       end
     end
 
-    context 'and a GCE O Level' do
+    context 'and an O Level' do
       it 'displays the guidance around triple GCSE science' do
         subject = 'science'
         qualification_type = 'gce_o_level'
@@ -126,7 +126,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
       end
     end
 
-    context 'and a GCE O Level' do
+    context 'and an O Level' do
       it 'displays the guidance around only having english literature and more than one english qualification' do
         subject = 'english'
         qualification_type = 'gce_o_level'

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -293,7 +293,7 @@ module CandidateHelper
   def candidate_fills_in_a_gcse
     choose('GCSE')
     click_button 'Save and continue'
-    fill_in 'Please specify your grade', with: 'B'
+    select 'B', from: 'Grade'
     click_button 'Save and continue'
     fill_in 'Enter year', with: '1990'
     click_button 'Save and continue'

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -128,7 +128,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_fill_in_the_grade
-    fill_in 'Please specify your grade', with: 'AA'
+    select 'AA', from: 'Grade'
   end
 
   def when_i_fill_in_the_year

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_select_gce_option
-    choose('GCE O Level')
+    choose('O Level')
   end
 
   def and_i_click_save_and_continue

--- a/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -119,7 +119,7 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     click_on 'Maths GCSE or equivalent'
     choose('GCSE')
     click_button 'Save and continue'
-    fill_in 'Please specify your grade', with: 'AA'
+    select 'AA', from: 'Grade'
     click_button 'Save and continue'
     fill_in 'Enter year', with: '1990'
     click_button 'Save and continue'


### PR DESCRIPTION
## Context
We're updating pre-degree qualifications to use structured data.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Add autocompleted grades to Maths and English GCSEs (but not Science - see commit for details)
- Rename GCE O Levels on the frontend
<!-- If there are UI changes, please include Before and After screenshots. -->

<img width="684" alt="Screenshot 2020-08-05 at 09 31 26" src="https://user-images.githubusercontent.com/519250/89390331-73240880-d6fe-11ea-89ff-3d52de264e82.png">


## Guidance to review
- In review app, Maths and English GCSE grade pages should have the autocomplete field. All other qualification types and science GCSE should have the existing free-form input.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/uUC4UwlK

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
