### PR TITLE
Check feature flag when validating EFL completion

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -194,7 +194,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def efl_section_required?
-    nationalities.present? && !english_speaking_nationality?
+    nationalities.present? && !english_speaking_nationality? && FeatureFlag.active?(:efl_section)
   end
 
   def build_nationalties_hash


### PR DESCRIPTION
Only check for completion of the EFL section if the feature flag is
enabled, otherwise we prevent submission of applications where a
non-British or non-Irish nationality has been chosen.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
