### PR TITLE
Remove old feature flags

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,6 +1,6 @@
 <% @application_choices.each do |application_choice| %>
   <div id='course-choice-<%= application_choice.id %>' class='qa-application-choice-<%= application_choice.id %> <%= warning_container_css_class(application_choice) %>'>
-  <% if FeatureFlag.active?('unavailable_course_option_warnings') && @editable %>
+  <% if @editable %>
     <% if application_choice.course_not_available? %>
       <p class='app-review-warning__primary-message'><%= application_choice.course_not_available_error %>.</p>
       <p class='govuk-body'><%= application_choice.provider.name %> have decided not to run this course.</p>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -74,7 +74,7 @@ module CandidateInterface
     end
 
     def warning_container_css_class(application_choice)
-      return unless FeatureFlag.active?('unavailable_course_option_warnings') && @editable
+      return unless @editable
 
       if application_choice.course_option_availability_error?
         @application_choice_error ? 'app-review-warning app-review-warning--error' : 'app-review-warning'

--- a/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
+++ b/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
@@ -9,8 +9,7 @@ module CandidateInterface
     end
 
     def render?
-      FeatureFlag.active?('replace_full_or_withdrawn_application_choices') &&
-        @application_form.course_choices_that_need_replacing.any?
+      @application_form.course_choices_that_need_replacing.any?
     end
   end
 end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -17,8 +17,6 @@ module CandidateInterface
     end
 
     def track_validation_error(form)
-      return unless FeatureFlag.active?('track_validation_errors')
-
       ValidationError.create!(
         form_object: form.class.name,
         request_path: request.path,

--- a/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module CourseChoices
     module ReplaceChoices
       class BaseController < CandidateInterfaceController
-        before_action :render_404_if_flag_is_inactive, :redirect_to_dashboard_if_no_choices_need_replacing
+        before_action :redirect_to_dashboard_if_no_choices_need_replacing
 
         def pick_choice_to_replace
           if only_one_course_choice_needs_replacing?
@@ -30,10 +30,6 @@ module CandidateInterface
         end
 
       private
-
-        def render_404_if_flag_is_inactive
-          render_404 and return unless FeatureFlag.active?('replace_full_or_withdrawn_application_choices')
-        end
 
         def redirect_to_dashboard_if_no_choices_need_replacing
           redirect_to candidate_interface_application_complete_path if current_application.course_choices_that_need_replacing.blank?

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -18,13 +18,7 @@ module CandidateInterface
       @pluralized_provider_string = 'provider'.pluralize(provider_count)
     end
 
-    def start_apply_again
-      render_404 and return unless FeatureFlag.active?('apply_again')
-    end
-
     def apply_again
-      render_404 and return unless FeatureFlag.active?('apply_again')
-
       DuplicateApplication.new(current_application).duplicate
       flash[:success] = 'Your new application is ready for editing'
       redirect_to candidate_interface_before_you_start_path

--- a/app/forms/candidate_interface/degree_grade_form.rb
+++ b/app/forms/candidate_interface/degree_grade_form.rb
@@ -26,7 +26,7 @@ module CandidateInterface
     end
 
     def fill_form_values
-      FeatureFlag.active?(:hesa_degree_data) ? fill_hesa_form : fill_non_hesa_form
+      fill_hesa_form
 
       self
     end
@@ -50,18 +50,6 @@ module CandidateInterface
         else
           self.grade = hesa_grade.description
         end
-      else
-        self.grade = 'other'
-        self.other_grade = degree.grade
-      end
-    end
-
-    def fill_non_hesa_form
-      if degree.predicted_grade?
-        self.grade = 'predicted'
-        self.predicted_grade = degree.grade
-      elsif degree.grade.in? %w[first upper_second lower_second third]
-        self.grade = degree.grade
       else
         self.grade = 'other'
         self.other_grade = degree.grade

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -70,11 +70,7 @@ class CandidateMailer < ApplicationMailer
     @application_choice = application_choice
     @candidate_magic_link = candidate_magic_link(@application_choice.application_form.candidate)
 
-    template_name = if FeatureFlag.active?('apply_again')
-                      :application_rejected_all_rejected_apply_again
-                    else
-                      :application_rejected_all_rejected
-                    end
+    template_name = :application_rejected_all_rejected_apply_again
 
     email_for_candidate(
       application_choice.application_form,
@@ -156,10 +152,10 @@ class CandidateMailer < ApplicationMailer
     @declined_courses = application_form.application_choices.select(&:declined_by_default?)
     @declined_course_names = @declined_courses.map { |application_choice| "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}" }
 
-    if application_form.ended_without_success? && FeatureFlag.active?('apply_again') && application_form.application_choices.select(&:rejected?).present?
+    if application_form.ended_without_success? && application_form.application_choices.select(&:rejected?).present?
       template_name = :declined_by_default_with_rejections
       subject = I18n.t!('candidate_mailer.decline_by_default_last_course_choice.subject', count: @declined_courses.size)
-    elsif application_form.ended_without_success? && FeatureFlag.active?('apply_again')
+    elsif application_form.ended_without_success?
       template_name = :declined_by_default_without_rejections
       subject = I18n.t!('candidate_mailer.decline_by_default_last_course_choice.subject', count: @declined_courses.size)
     else

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -88,6 +88,6 @@ class ApplicationReference < ApplicationRecord
   end
 
   def editable?
-    !FeatureFlag.active?('apply_again') || feedback_status == 'not_requested_yet'
+    feedback_status == 'not_requested_yet'
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -92,12 +92,8 @@ module CandidateInterface
     end
 
     def ready_to_submit?
-      if FeatureFlag.active?('unavailable_course_option_warnings')
-        sections_with_completion.map(&:second).all? &&
-          application_choice_errors.empty?
-      else
-        sections_with_completion.map(&:second).all?
-      end
+      sections_with_completion.map(&:second).all? &&
+        application_choice_errors.empty?
     end
 
     def application_choices_added?

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -8,7 +8,7 @@ class DeclineOffer
     @application_choice.update!(declined_at: Time.zone.now)
     StateChangeNotifier.call(:offer_declined, application_choice: @application_choice)
 
-    if @application_choice.application_form.ended_without_success? && FeatureFlag.active?('apply_again')
+    if @application_choice.application_form.ended_without_success?
       CandidateMailer.decline_last_application_choice(@application_choice).deliver_later
     end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,7 +25,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
-    [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
     [:hesa_degree_data, 'Use structured HESA data to autocomplete certain parts of the add degree flow', 'Malcolm Baig'],

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,7 +28,6 @@ class FeatureFlag
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
-    [:unavailable_course_notifications, 'Candidates with applications waiting for references receive an email notification if their course choice is withdrawn has no vacancies', 'Steve Hook'],
     [:hesa_degree_data, 'Use structured HESA data to autocomplete certain parts of the add degree flow', 'Malcolm Baig'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,7 +28,6 @@ class FeatureFlag
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
-    [:replace_full_or_withdrawn_application_choices, 'Allows candidates to replace full or withdrawn application choices post-submission', 'David Gisbey'],
     [:unavailable_course_notifications, 'Candidates with applications waiting for references receive an email notification if their course choice is withdrawn has no vacancies', 'Steve Hook'],
     [:hesa_degree_data, 'Use structured HESA data to autocomplete certain parts of the add degree flow', 'Malcolm Baig'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,7 +25,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
-    [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,7 +25,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
-    [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
     [:hesa_degree_data, 'Use structured HESA data to autocomplete certain parts of the add degree flow', 'Malcolm Baig'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,7 +26,6 @@ class FeatureFlag
     [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
-    [:hesa_degree_data, 'Use structured HESA data to autocomplete certain parts of the add degree flow', 'Malcolm Baig'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -10,7 +10,7 @@ class WithdrawApplication
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
     end
 
-    if @application_choice.application_form.ended_without_success? && FeatureFlag.active?('apply_again')
+    if @application_choice.application_form.ended_without_success?
       CandidateMailer.withdraw_last_application_choice(@application_choice.application_form).deliver_later
     end
 

--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -37,9 +37,7 @@
 
     <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
       <%= f.govuk_text_field :other_grade, label: { text: t('application_form.degree.grade.other.conditional.label') }, width: 10 %>
-      <% if FeatureFlag.active? :hesa_degree_data %>
-        <%= tag.div(id: 'degree-grade-autocomplete', class: 'govuk-form-group', data: { source: @other_grades }) %>
-      <% end %>
+      <%= tag.div(id: 'degree-grade-autocomplete', class: 'govuk-form-group', data: { source: @other_grades }) %>
     <% end %>
 
     <%= f.govuk_radio_divider %>

--- a/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
@@ -23,9 +23,7 @@
     :institution_name,
     label: { text: t('application_form.degree.institution_name.label'), size: 'xl' }
   ) %>
-  <% if FeatureFlag.active? :hesa_degree_data %>
-    <%= tag.div(id: 'degree-institution-autocomplete', class: 'govuk-form-group', data: { source: @institutions }) %>
-  <% end %>
+  <%= tag.div(id: 'degree-institution-autocomplete', class: 'govuk-form-group', data: { source: @institutions }) %>
 
 <% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/subject/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/subject/_form_fields.html.erb
@@ -3,10 +3,8 @@
   label: { text: t('application_form.degree.subject.label'), size: 'xl' },
   hint_text: t('application_form.degree.subject.hint_text')
 ) %>
-<% if FeatureFlag.active? :hesa_degree_data %>
-  <% unless @degree_subject_form.international? %>
-    <%= tag.div(id: 'degree-subject-autocomplete', class: 'govuk-form-group', data: { source: @subjects }) %>
-  <% end %>
+<% unless @degree_subject_form.international? %>
+  <%= tag.div(id: 'degree-subject-autocomplete', class: 'govuk-form-group', data: { source: @subjects }) %>
 <% end %>
 
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -7,9 +7,7 @@
         label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
         hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
       ) %>
-      <% if FeatureFlag.active? :hesa_degree_data %>
-        <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
-      <% end %>
+      <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
     <% end %>
     <%= f.govuk_radio_button :uk_degree, 'no', label: { text: t('application_form.degree.non_uk_degree.label') } do %>
       <%= f.govuk_text_field(
@@ -27,9 +25,7 @@
     label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
     hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
   ) %>
-  <% if FeatureFlag.active? :hesa_degree_data %>
-    <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
-  <% end %>
+  <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
 
 <% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -10,7 +10,7 @@
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>
 <% end %>
 
-<% if FeatureFlag.active?('apply_again') && @application_form.ended_without_success? %>
+<% if @application_form.ended_without_success? %>
   <%= render CandidateInterface::ApplyAgainBannerComponent.new(application_form: @application_form) %>
 <% end %>
 

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -16,7 +16,7 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
-    <% if FeatureFlag.active?('apply_again') && @application_form.candidate_has_previously_applied? %>
+    <% if @application_form.candidate_has_previously_applied? %>
       <% if @application_form.previous_application_form.application_choices.rejected.any?  %>
         <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
       <% end %>
@@ -214,7 +214,7 @@
   <div class="govuk-grid-column-one-third">
     <%= render partial: '/candidate_interface/shared/need_help', locals: { support_reference: @application_form.support_reference } %>
 
-    <% if FeatureFlag.active?('apply_again') && @application_form.candidate_has_previously_applied? %>
+    <% if @application_form.candidate_has_previously_applied? %>
       <h2 class="govuk-heading-s">Previous applications</h2>
       <%= render(CandidateInterface::LinksToPreviousApplicationsComponent.new(application_form: @application_form)) %>
     <% end %>

--- a/app/views/candidate_mailer/course_unavailable_course_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_course_full.text.erb
@@ -6,27 +6,10 @@ There are no more places for <%= @application_choice.course_option.course.name_a
 
 The places filled up while we were waiting for your references, so the provider has not got your application.
 
-<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
-
 # Update course choice now
 
 Update your course choice:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
-
-<% else %>
-
-# Decide what you want to do and let us know as soon as possible
-
-Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
-
-You can:
-- choose a different course (go to https://www.find-postgraduate-teacher-training.service.gov.uk to find a course)
-- remove the course from your application
-- keep the course on your application
-
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
-
-<% end %>

--- a/app/views/candidate_mailer/course_unavailable_course_withdrawn.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_course_withdrawn.text.erb
@@ -6,27 +6,10 @@ Dear <%= @application_form.first_name %>,
 
 The provider removed the course while we were waiting for your references, so they have not got your application.
 
-<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
-
 # Update course choice now
 
 Update your course choice:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
-
-<% else %>
-
-# Decide what you want to do and let us know as soon as possible
-
-Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
-
-You can:
-- choose a different course (go to https://www.find-postgraduate-teacher-training.service.gov.uk to find a course)
-- remove the course from your application
-- keep the course on your application
-
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
-
-<% end %>

--- a/app/views/candidate_mailer/course_unavailable_location_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_location_full.text.erb
@@ -6,29 +6,10 @@ There are no more places at <%= @application_choice.course_option.site.name %> f
 
 The places filled up while we were waiting for your references, so the provider has not got your application.
 
-<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
-
 # Update your course choice now
 
 Find out about other options for <%= @application_choice.course_option.course.name_and_code %> and edit or replace the course choice:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
-
-<% else %>
-
-# Decide what you want to do and let us know as soon as possible
-
-Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
-
-You can:
-
-- choose a different course: https://www.find-postgraduate-teacher-training.service.gov.uk
-- choose a different option for this course: https://www.find-postgraduate-teacher-training.service.gov.uk
-- remove the course from your application
-- keep the course on your application
-
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
-
-<% end %>

--- a/app/views/candidate_mailer/course_unavailable_study_mode_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_study_mode_full.text.erb
@@ -6,29 +6,10 @@ There are no more <%= @application_choice.course_option.study_mode.humanize.down
 
 The places filled up while we were waiting for your references, so the provider has not got your application.
 
-<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
-
 # Update your course choice now
 
 Find out about other options for <%= @application_choice.course_option.course.name_and_code %> and edit or replace the course choice:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
-
-<% else %>
-
-# Decide what you want to do and let us know as soon as possible
-
-Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
-
-You can:
-
-- choose a different course: https://www.find-postgraduate-teacher-training.service.gov.uk
-- choose a different option for this course: https://www.find-postgraduate-teacher-training.service.gov.uk
-- remove the course from your application
-- keep the course on your application
-
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
-
-<% end %>

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -4,13 +4,11 @@ class SendCourseFullNotificationsWorker
   def perform
     GetApplicationChoicesWithNewlyUnavailableCourses.call.each do |application_choice|
       reason = ReasonCourseNotAvailable.new(application_choice).call
-      if FeatureFlag.active?(:unavailable_course_notifications)
-        ChaserSent.create!(
-          chased: application_choice,
-          chaser_type: :course_unavailable_notification,
-        )
-        CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
-      end
+      ChaserSent.create!(
+        chased: application_choice,
+        chaser_type: :course_unavailable_notification,
+      )
+      CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
       send_slack_message(application_choice, reason)
     end
   end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -139,10 +139,8 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'when course is unavailable and unavailable_course_option_warnings is active' do
+    context 'when course is unavailable' do
       it 'renders with the unavailable course text' do
-        FeatureFlag.activate('unavailable_course_option_warnings')
-
         application_form = create(:application_form)
         create(
           :submitted_application_choice,
@@ -215,10 +213,8 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'when course is unavailable and unavailable_course_option_warnings is active' do
+    context 'when course is unavailable' do
       it 'renders without the unavailable course text' do
-        FeatureFlag.activate('unavailable_course_option_warnings')
-
         application_form = create(:application_form)
         create(
           :submitted_application_choice,

--- a/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
+++ b/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
   describe '#render?' do
     let(:application_form) { create(:application_form) }
 
-    before { FeatureFlag.activate('replace_full_or_withdrawn_application_choices') }
-
     context 'when a course is only available on ucas and the candidate is awaiting their references' do
       it 'renders the component' do
         create(:course, withdrawn: false, open_on_apply: false)

--- a/spec/forms/candidate_interface/degree_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_grade_form_spec.rb
@@ -23,49 +23,7 @@ RSpec.describe CandidateInterface::DegreeGradeForm, type: :model do
     )
   end
 
-  describe '#fill_form_values (HESA feature flag off)' do
-    context 'when the database degree is marked as predicted' do
-      it 'sets the predicted grade attributes' do
-        degree = build_stubbed(:degree_qualification, grade: 'first', predicted_grade: true)
-        degree_form = described_class.new(degree: degree)
-
-        degree_form.fill_form_values
-
-        expect(degree_form.grade).to eq 'predicted'
-        expect(degree_form.predicted_grade).to eq 'first'
-      end
-    end
-
-    context 'when the database degree grade is one of the standard values' do
-      it 'sets the grade attribute to that value' do
-        degree = build_stubbed(:degree_qualification, grade: 'upper_second', predicted_grade: false)
-        degree_form = described_class.new(degree: degree)
-
-        degree_form.fill_form_values
-
-        expect(degree_form.grade).to eq 'upper_second'
-        expect(degree_form.predicted_grade).to be_blank
-        expect(degree_form.other_grade).to be_blank
-      end
-    end
-
-    context 'when the database degree is neither predicted nor a standard value' do
-      it 'sets the other grade attributes' do
-        degree = build_stubbed(:degree_qualification, grade: 'gold medal', predicted_grade: false)
-        degree_form = described_class.new(degree: degree)
-
-        degree_form.fill_form_values
-
-        expect(degree_form.grade).to eq 'other'
-        expect(degree_form.other_grade).to eq 'gold medal'
-        expect(degree_form.predicted_grade).to be_blank
-      end
-    end
-  end
-
-  describe '#fill_form_values (HESA feature flag on)' do
-    before { FeatureFlag.activate :hesa_degree_data }
-
+  describe '#fill_form_values' do
     context 'when the database degree is marked as predicted' do
       let(:degree) { build_stubbed(:degree_qualification, grade: 'first', predicted_grade: true) }
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -120,25 +120,12 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     describe '.application_rejected_all_rejected' do
-      context 'with the apply again feature flag on' do
-        FeatureFlag.activate('apply_again')
-        it_behaves_like(
-          'a mail with subject and content', :application_rejected_all_rejected,
-          I18n.t!('candidate_mailer.application_rejected.all_rejected.subject', provider_name: 'Falconholt Technical College'),
-          'heading' => 'Dear Tyrell',
-          'course name and code' => 'Forensic Science (E0FO)'
-        )
-      end
-
-      context 'with the apply again feature flag off' do
-        it_behaves_like(
-          'a mail with subject and content', :application_rejected_all_rejected,
-          I18n.t!('candidate_mailer.application_rejected.all_rejected.subject', provider_name: 'Falconholt Technical College'),
-          'heading' => 'Dear Tyrell',
-          'course name and code' => 'Forensic Science (E0FO)',
-          'providers rejection reason' => 'The application had little detail.'
-        )
-      end
+      it_behaves_like(
+        'a mail with subject and content', :application_rejected_all_rejected,
+        I18n.t!('candidate_mailer.application_rejected.all_rejected.subject', provider_name: 'Falconholt Technical College'),
+        'heading' => 'Dear Tyrell',
+        'course name and code' => 'Forensic Science (E0FO)'
+      )
     end
 
     describe '.application_rejected_awaiting_decisions' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -477,16 +477,6 @@ RSpec.describe CandidateMailer, type: :mailer do
         expect(email.subject).to eq 'There are no more places for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')
         expect(email.body).to include('There are no more places for Mathematics (M101) at Bilberry College')
-        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
-      end
-
-      it 'has the correct subject and content for new course flow' do
-        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
-        email = send_email
-
-        expect(email.subject).to eq 'There are no more places for Mathematics (M101) at Bilberry College: update your course choice now'
-        expect(email.body).to include('Dear Fred,')
-        expect(email.body).to include('There are no more places for Mathematics (M101) at Bilberry College')
         expect(email.body).to include('Update your course choice:')
       end
     end
@@ -502,17 +492,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
 
       it 'has the correct subject and content' do
-        email = send_email
-
-        expect(email.subject).to eq('Mathematics (M101) at Bilberry College is not running anymore: update your course choice now')
-        expect(email.body).to include('Dear Fred,')
-        expect(email.body).to include('Your course is not running anymore')
-        expect(email.body).to include('Bilberry College is not running Mathematics (M101) anymore.')
-        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
-      end
-
-      it 'has the correct subject and content for new course flow' do
-        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
         email = send_email
 
         expect(email.subject).to eq('Mathematics (M101) at Bilberry College is not running anymore: update your course choice now')
@@ -539,16 +518,6 @@ RSpec.describe CandidateMailer, type: :mailer do
         expect(email.subject).to eq 'There are no more places at your choice of location for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')
         expect(email.body).to include('There are no more places at West Wilford School for Mathematics (M101) at Bilberry College')
-        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
-      end
-
-      it 'has the correct subject and content for new course flow' do
-        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
-        email = send_email
-
-        expect(email.subject).to eq 'There are no more places at your choice of location for Mathematics (M101) at Bilberry College: update your course choice now'
-        expect(email.body).to include('Dear Fred,')
-        expect(email.body).to include('There are no more places at West Wilford School for Mathematics (M101) at Bilberry College')
         expect(email.body).to include('Find out about other options for Mathematics (M101) and edit or replace the course choice:')
       end
     end
@@ -564,16 +533,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
 
       it 'has the correct subject and content' do
-        email = send_email
-
-        expect(email.subject).to eq 'There are no more full time places for Mathematics (M101) at Bilberry College: update your course choice now'
-        expect(email.body).to include('Dear Fred,')
-        expect(email.body).to include('There are no more full time places for Mathematics (M101) at Bilberry College')
-        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
-      end
-
-      it 'has the correct subject and content for new course flow' do
-        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
         email = send_email
 
         expect(email.subject).to eq 'There are no more full time places for Mathematics (M101) at Bilberry College: update your course choice now'

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         FeatureFlag.activate('covid_19')
         @application_form = build_stubbed(
           :application_form,
+          candidate: @candidate,
           first_name: 'Fred',
           application_choices: [build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10)],
         )
@@ -140,8 +141,8 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like(
         'a mail with subject and content', :declined_by_default,
-        'Application withdrawn automatically',
-        'Reason' => 'because you didn’t respond in time.'
+        'You did not respond to your offer: next steps',
+        'Reason' => 'You did not respond in time so we declined your'
       )
     end
 
@@ -160,7 +161,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content',
         :declined_by_default,
-        'Application withdrawn automatically',
+        'You did not respond to your offer: next steps',
         'heading' => 'Dear Fred',
         'days left to respond' => '10 working days',
       )
@@ -179,142 +180,100 @@ RSpec.describe CandidateMailer, type: :mailer do
         )
       end
 
-      it_behaves_like 'a mail with subject and content', :declined_by_default, 'Applications withdrawn automatically', {}
+      it_behaves_like 'a mail with subject and content', :declined_by_default, 'You did not respond to your offers: next steps', {}
     end
-  end
 
-  context 'when the covid-19 feature flag is on and the apply again flag is on' do
-    before do
-      FeatureFlag.activate('covid_19')
-      FeatureFlag.activate('apply_again')
-      @application_form = build_stubbed(
-        :application_form,
-        candidate: @candidate,
-        application_choices: [build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10)],
+    context 'when a candidate has 1 offer that was declined by default and a rejection' do
+      before do
+        @application_form = build_stubbed(
+          :application_form,
+          first_name: 'Fred',
+          candidate: @candidate,
+          application_choices: [
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+            build_stubbed(:application_choice, status: 'rejected'),
+          ],
+        )
+      end
+
+      it_behaves_like(
+        'a mail with subject and content',
+        :declined_by_default,
+        'You did not respond to your offer: next steps',
+        'heading' => 'Dear Fred',
+        'DBD_days_they_had_to_respond' => '10 working days',
+        'still_interested' => 'If now’s the right time for you',
       )
     end
 
-    it_behaves_like(
-      'a mail with subject and content',
-      :declined_by_default,
-      'You did not respond to your offer: next steps',
-      'Reason' => 'You did not respond in time so we declined your',
-    )
-  end
+    context 'when a candidate has 2 offers that were declined by default and a rejection' do
+      before do
+        @application_form = build_stubbed(
+          :application_form,
+          first_name: 'Fred',
+          candidate: @candidate,
+          application_choices: [
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+            build_stubbed(:application_choice, status: 'rejected'),
+          ],
+        )
+      end
 
-  context 'when the covid-19 feature flag is off and the apply_again flag is on' do
-    before do
-      FeatureFlag.activate('apply_again')
-      @application_form = build_stubbed(
-        :application_form,
-        first_name: 'Fred',
-        candidate: @candidate,
-        application_choices: [build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10)],
+      it_behaves_like(
+        'a mail with subject and content',
+        :declined_by_default,
+        'You did not respond to your offers: next steps',
+        'heading' => 'Dear Fred',
+        'DBD_days_they_had_to_respond' => '10 working days',
+        'still_interested' => 'If now’s the right time for you',
       )
     end
 
-    it_behaves_like(
-      'a mail with subject and content',
-      :declined_by_default,
-      'You did not respond to your offer: next steps',
-      'Reason' => 'You did not respond within',
-    )
-  end
+    context 'when a candidate has 1 offer that was declined and it awaiting another decision' do
+      before do
+        @application_form = build_stubbed(
+          :application_form,
+          first_name: 'Fred',
+          candidate: @candidate,
+          application_choices: [
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+            build_stubbed(:application_choice, status: 'awaiting_provider_decision'),
+          ],
+        )
+      end
 
-  context 'when a candidate has 1 offer that was declined by default' do
-    before do
-      FeatureFlag.activate('apply_again')
-      @application_form = build_stubbed(
-        :application_form,
-        first_name: 'Fred',
-        candidate: @candidate,
-        application_choices: [
-          build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
-        ],
+      it_behaves_like(
+        'a mail with subject and content',
+        :declined_by_default,
+        'Application withdrawn automatically',
+        'heading' => 'Dear Fred',
+        'days left to respond' => '10 working days',
       )
     end
 
-    it_behaves_like(
-      'a mail with subject and content',
-      :declined_by_default,
-      'You did not respond to your offer: next steps',
-      'heading' => 'Dear Fred',
-      'DBD_days_they_had_to_respond' => '10 working days',
-      'still_interested' => 'You didn’t pursue your teacher training application',
-    )
-  end
+    context 'when a candidate has 2 offers that was declined and it awaiting another decision' do
+      before do
+        @application_form = build_stubbed(
+          :application_form,
+          first_name: 'Fred',
+          candidate: @candidate,
+          application_choices: [
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+            build_stubbed(:application_choice, status: 'awaiting_provider_decision'),
+          ],
+        )
+      end
 
-  context 'when a candidate has 2 offers that were declined by default' do
-    before do
-      FeatureFlag.activate('apply_again')
-      @application_form = build_stubbed(
-        :application_form,
-        first_name: 'Fred',
-        candidate: @candidate,
-        application_choices: [
-          build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
-          build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
-        ],
+      it_behaves_like(
+        'a mail with subject and content',
+        :declined_by_default,
+        'Applications withdrawn automatically',
+        'heading' => 'Dear Fred',
+        'days left to respond' => '10 working days',
       )
     end
-
-    it_behaves_like(
-      'a mail with subject and content',
-      :declined_by_default,
-      'You did not respond to your offers: next steps',
-      'heading' => 'Dear Fred',
-      'DBD_days_they_had_to_respond' => '10 working days',
-      'still_interested' => 'You didn’t pursue your teacher training application',
-    )
-  end
-
-  context 'when a candidate has 1 offer that was declined by default and a rejection' do
-    before do
-      FeatureFlag.activate('apply_again')
-      @application_form = build_stubbed(
-        :application_form,
-        first_name: 'Fred',
-        candidate: @candidate,
-        application_choices: [
-          build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
-          build_stubbed(:application_choice, status: 'rejected'),
-        ],
-      )
-    end
-
-    it_behaves_like(
-      'a mail with subject and content',
-      :declined_by_default,
-      'You did not respond to your offer: next steps',
-      'heading' => 'Dear Fred',
-      'DBD_days_they_had_to_respond' => '10 working days',
-      'still_interested' => 'If now’s the right time for you',
-    )
-  end
-
-  context 'when a candidate has 2 offers that were declined by default and a rejection' do
-    before do
-      FeatureFlag.activate('apply_again')
-      @application_form = build_stubbed(
-        :application_form,
-        first_name: 'Fred',
-        candidate: @candidate,
-        application_choices: [
-          build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
-          build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
-          build_stubbed(:application_choice, status: 'rejected'),
-        ],
-      )
-    end
-
-    it_behaves_like(
-      'a mail with subject and content',
-      :declined_by_default,
-      'You did not respond to your offers: next steps',
-      'heading' => 'Dear Fred',
-      'DBD_days_they_had_to_respond' => '10 working days',
-      'still_interested' => 'If now’s the right time for you',
-    )
   end
 
   describe '.withdraw_last_application_choice' do

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -141,25 +141,13 @@ RSpec.describe ApplicationReference, type: :model do
   end
 
   describe '#editable?' do
-    context 'when `apply_again` feature flag is on' do
-      before { FeatureFlag.activate('apply_again') }
-
-      it 'returns true for `not_requested_yet`' do
-        expect(described_class.new(feedback_status: :not_requested_yet).editable?).to be true
-      end
-
-      it 'returns false for all other statuses' do
-        ApplicationReference.feedback_statuses.keys.reject { |s| s == 'not_requested_yet' }.each do |status|
-          expect(described_class.new(feedback_status: status).editable?).to be false
-        end
-      end
+    it 'returns true for `not_requested_yet`' do
+      expect(described_class.new(feedback_status: :not_requested_yet).editable?).to be true
     end
 
-    context 'when `apply_again` feature flag is off' do
-      it 'returns true for all statuses' do
-        ApplicationReference.feedback_statuses.each_key do |status|
-          expect(described_class.new(feedback_status: status).editable?).to be true
-        end
+    it 'returns false for all other statuses' do
+      ApplicationReference.feedback_statuses.keys.reject { |s| s == 'not_requested_yet' }.each do |status|
+        expect(described_class.new(feedback_status: status).editable?).to be false
       end
     end
   end

--- a/spec/requests/candidate_interface/validation_error_tracking_spec.rb
+++ b/spec/requests/candidate_interface/validation_error_tracking_spec.rb
@@ -27,35 +27,15 @@ RSpec.describe 'Candidate interface - validation error tracking', type: :request
     }
   end
 
-  context 'when feature flag is NOT enabled' do
-    it 'does NOT create validation error when request is valid' do
-      expect {
-        post candidate_interface_contact_details_update_base_url(valid_attributes)
-      }.not_to(change { ValidationError.count })
-    end
-
-    it 'does NOT create validation error when request is invalid' do
-      expect {
-        post candidate_interface_contact_details_update_base_url(invalid_attributes)
-      }.not_to(change { ValidationError.count })
-    end
+  it 'does NOT create validation error when request is valid' do
+    expect {
+      post candidate_interface_contact_details_update_base_url(valid_attributes)
+    }.not_to(change { ValidationError.count })
   end
 
-  context 'when feature flag is enabled' do
-    before do
-      FeatureFlag.activate('track_validation_errors')
-    end
-
-    it 'does NOT create validation error when request is valid' do
-      expect {
-        post candidate_interface_contact_details_update_base_url(valid_attributes)
-      }.not_to(change { ValidationError.count })
-    end
-
-    it 'creates validation error when request is invalid' do
-      expect {
-        post candidate_interface_contact_details_update_base_url(invalid_attributes)
-      }.to(change { ValidationError.count }.by(1))
-    end
+  it 'creates validation error when request is invalid' do
+    expect {
+      post candidate_interface_contact_details_update_base_url(invalid_attributes)
+    }.to(change { ValidationError.count }.by(1))
   end
 end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe SubmitApplication do
     end
 
     context 'when application is in Apply Again' do
-      before { FeatureFlag.activate('apply_again') }
-
       it 'progresses to `awaiting_provider_decision` if all references are in' do
         original_application_form = create_application_form
 

--- a/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
   scenario 'Candidate submits why they want to be a teacher' do
     given_i_am_signed_in
     and_i_visit_the_site
-    and_the_track_validation_errors_feature_is_on
 
     when_i_click_on_becoming_a_teacher
     and_i_submit_the_form
@@ -33,10 +32,6 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_track_validation_errors_feature_is_on
-    FeatureFlag.activate('track_validation_errors')
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Candidate can see their rejection reasons on apply again' do
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
-    given_apply_again_is_active
-    and_i_am_signed_in
+    given_i_am_signed_in
     and_i_have_an_apply1_application_with_3_rejections
 
     when_i_visit_my_application_complete_page
@@ -14,11 +13,7 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
     then_i_can_see_my_previous_rejection_reasons
   end
 
-  def given_apply_again_is_active
-    FeatureFlag.activate('apply_again')
-  end
-
-  def and_i_am_signed_in
+  def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
   end

--- a/spec/system/candidate_interface/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_declines_offer_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate declines an offer' do
 
   scenario 'Candidate views an offer and declines' do
     given_i_am_signed_in
-    and_the_apply_again_flag_is_on
     and_i_have_multiple_offers
 
     when_i_visit_the_application_dashboard
@@ -27,10 +26,6 @@ RSpec.feature 'Candidate declines an offer' do
   def given_i_am_signed_in
     @candidate = create(:candidate)
     login_as(@candidate)
-  end
-
-  def and_the_apply_again_flag_is_on
-    FeatureFlag.activate('apply_again')
   end
 
   def and_i_have_multiple_offers

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature 'Entering their contact details' do
     given_i_am_signed_in
     and_the_international_addresses_flag_is_active
     and_i_visit_the_site
-    and_the_track_validation_errors_feature_is_on
 
     when_i_click_on_contact_details
     and_i_incorrectly_fill_in_my_phone_number
@@ -59,10 +58,6 @@ RSpec.feature 'Entering their contact details' do
 
   def and_i_visit_the_site
     visit candidate_interface_application_form_path
-  end
-
-  def and_the_track_validation_errors_feature_is_on
-    FeatureFlag.activate('track_validation_errors')
   end
 
   def when_i_click_on_contact_details

--- a/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature 'Entering their degrees' do
   include CandidateHelper
 
   scenario 'Candidate submits their degrees' do
-    given_the_hesa_data_feature_flag_is_active
     given_i_am_signed_in
     and_i_visit_the_site
     when_i_click_on_degree
@@ -108,10 +107,6 @@ RSpec.feature 'Entering their degrees' do
 
     when_i_click_on_degree
     then_i_can_check_my_answers
-  end
-
-  def given_the_hesa_data_feature_flag_is_active
-    FeatureFlag.activate :hesa_degree_data
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_removes_a_full_or_withdrawn_course_choice_post_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_removes_a_full_or_withdrawn_course_choice_post_submission_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe 'Both a candidates course choices have become full or been withdr
   include CourseOptionHelpers
 
   scenario 'when a candidate arrives at the dashboard they can follow the replace course flow' do
-    given_the_replace_full_or_withdrawn_application_choices_is_active?
-    and_apply_again_is_open
+    given_apply_again_is_open
     and_i_have_submitted_my_application
     and_both_of_my_application_choices_have_become_full
 
@@ -32,11 +31,7 @@ RSpec.describe 'Both a candidates course choices have become full or been withdr
     and_i_am_told_i_can_apply_again
   end
 
-  def given_the_replace_full_or_withdrawn_application_choices_is_active?
-    FeatureFlag.activate('replace_full_or_withdrawn_application_choices')
-  end
-
-  def and_apply_again_is_open
+  def given_apply_again_is_open
     FeatureFlag.activate('apply_again')
   end
 

--- a/spec/system/candidate_interface/candidate_removes_a_full_or_withdrawn_course_choice_post_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_removes_a_full_or_withdrawn_course_choice_post_submission_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe 'Both a candidates course choices have become full or been withdr
   include CourseOptionHelpers
 
   scenario 'when a candidate arrives at the dashboard they can follow the replace course flow' do
-    given_apply_again_is_open
-    and_i_have_submitted_my_application
+    given_i_have_submitted_my_application
     and_both_of_my_application_choices_have_become_full
 
     when_i_arrive_at_my_application_dashboard
@@ -31,11 +30,7 @@ RSpec.describe 'Both a candidates course choices have become full or been withdr
     and_i_am_told_i_can_apply_again
   end
 
-  def given_apply_again_is_open
-    FeatureFlag.activate('apply_again')
-  end
-
-  def and_i_have_submitted_my_application
+  def given_i_have_submitted_my_application
     candidate_completes_application_form
     candidate_submits_application
   end

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate applying again' do
 
   scenario 'Can replace a completed reference' do
     given_the_pilot_is_open
-    and_apply_again_feature_flag_is_active
     and_i_am_signed_in_as_a_candidate
 
     when_i_have_an_unsuccessful_application_with_references
@@ -37,10 +36,6 @@ RSpec.feature 'Candidate applying again' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_apply_again_feature_flag_is_active
-    FeatureFlag.activate('apply_again')
   end
 
   def and_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
 
   scenario 'sees warning messages for unavailable course options' do
     given_i_am_signed_in
-    and_the_unavailable_course_option_warnings_feature_is_active
     and_i_chose_course_options_that_have_since_become_unavailable
 
     when_i_visit_the_review_application_page
@@ -27,10 +26,6 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_unavailable_course_option_warnings_feature_is_active
-    FeatureFlag.activate('unavailable_course_option_warnings')
   end
 
   def and_i_chose_course_options_that_have_since_become_unavailable

--- a/spec/system/candidate_interface/candidate_signs_in_with_validation_errors_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_in_with_validation_errors_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Candidate tries to sign up' do
   scenario 'Candidate attempts to sign up without filling in an email address' do
     given_the_pilot_is_open
-    and_the_track_validation_errors_feature_is_on
 
     given_i_am_a_candidate_without_an_account
 
@@ -16,10 +15,6 @@ RSpec.feature 'Candidate tries to sign up' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_track_validation_errors_feature_is_on
-    FeatureFlag.activate('track_validation_errors')
   end
 
   def given_i_am_a_candidate_without_an_account

--- a/spec/system/candidate_interface/candidate_submits_application_with_full_course_location_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_with_full_course_location_spec.rb
@@ -4,8 +4,7 @@ RSpec.feature 'Candidate submits the application' do
   include CandidateHelper
 
   scenario 'The location that the candidate picked is full but others have vacancies' do
-    given_course_warnings_feature_is_active
-    and_i_complete_my_application
+    given_i_complete_my_application
     and_the_selected_course_options_is_now_full
     and_an_alternative_course_option_has_vacancies
     and_i_submit_my_application
@@ -14,11 +13,7 @@ RSpec.feature 'Candidate submits the application' do
     and_i_cannot_proceed
   end
 
-  def given_course_warnings_feature_is_active
-    FeatureFlag.activate('unavailable_course_option_warnings')
-  end
-
-  def and_i_complete_my_application
+  def given_i_complete_my_application
     candidate_completes_application_form
   end
 

--- a/spec/system/candidate_interface/candidate_submits_application_with_full_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_with_full_course_study_mode_spec.rb
@@ -4,8 +4,7 @@ RSpec.feature 'Candidate submits the application' do
   include CandidateHelper
 
   scenario 'The location that the candidate picked has no full-time vacancies but does have part-time vacancies' do
-    given_course_warnings_feature_is_active
-    and_i_complete_my_application
+    given_i_complete_my_application
     and_the_selected_full_time_course_option_is_now_full
     and_the_selected_course_is_available_part_time_at_the_same_location
     and_i_submit_my_application
@@ -14,11 +13,7 @@ RSpec.feature 'Candidate submits the application' do
     and_i_cannot_proceed
   end
 
-  def given_course_warnings_feature_is_active
-    FeatureFlag.activate('unavailable_course_option_warnings')
-  end
-
-  def and_i_complete_my_application
+  def given_i_complete_my_application
     candidate_completes_application_form
   end
 

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   scenario 'Can apply again' do
     given_the_pilot_is_open
-    and_apply_again_feature_flag_is_active
     and_i_am_signed_in_as_a_candidate
 
     when_i_have_an_unsuccessful_application
@@ -41,10 +40,6 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_apply_again_feature_flag_is_active
-    FeatureFlag.activate('apply_again')
   end
 
   def and_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature 'A candidate withdraws her application' do
   scenario 'successful withdrawal' do
     given_i_am_signed_in_as_a_candidate
     and_the_covid_19_feature_flag_is_on
-    and_the_apply_again_flag_is_on
     and_i_have_multiple_application_choice_awaiting_provider_decision
 
     when_i_visit_the_application_dashboard
@@ -55,10 +54,6 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def and_the_covid_19_feature_flag_is_on
     FeatureFlag.activate('covid_19')
-  end
-
-  def and_the_apply_again_flag_is_on
-    FeatureFlag.activate('apply_again')
   end
 
   def and_i_have_multiple_application_choice_awaiting_provider_decision

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   include CourseOptionHelpers
 
   scenario 'when a candidate arrives at the dashboard they can follow the replace course flow' do
-    given_the_replace_full_or_withdrawn_application_choices_is_active?
-    and_i_have_submitted_my_application
+    given_i_have_submitted_my_application
     and_my_course_is_only_available_on_ucas
 
     when_i_arrive_at_my_application_dashboard
@@ -136,11 +135,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     and_i_can_see_my_new_course_with_multiple_sites_and_study_modes
   end
 
-  def given_the_replace_full_or_withdrawn_application_choices_is_active?
-    FeatureFlag.activate('replace_full_or_withdrawn_application_choices')
-  end
-
-  def and_i_have_submitted_my_application
+  def given_i_have_submitted_my_application
     candidate_completes_application_form
     candidate_submits_application
     @course_option = @application.application_choices.first.course_option

--- a/spec/system/candidate_interface/course_selection/candidate_replaces_a_full_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_replaces_a_full_course_spec.rb
@@ -4,8 +4,7 @@ RSpec.feature 'Selecting a course' do
   include CandidateHelper
 
   scenario 'Candidate selects a course choice' do
-    given_the_replace_full_or_withdrawn_application_choices_is_active
-    and_i_have_submitted_my_application
+    given_i_have_submitted_my_application
     and_one_of_my_application_choices_has_become_full
     and_there_are_course_options
 
@@ -67,11 +66,7 @@ RSpec.feature 'Selecting a course' do
     and_i_cannot_see_my_old_course_choice
   end
 
-  def given_the_replace_full_or_withdrawn_application_choices_is_active
-    FeatureFlag.activate('replace_full_or_withdrawn_application_choices')
-  end
-
-  def and_i_have_submitted_my_application
+  def given_i_have_submitted_my_application
     candidate_completes_application_form
     candidate_submits_application
     @course_choice = @application.application_choices.first

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -13,17 +13,6 @@ RSpec.feature 'Decline by default' do
 
     and_when_the_decline_by_default_limit_has_been_exceeded
     then_the_application_choice_is_declined
-    and_the_candidate_receives_an_email
-    and_the_provider_receives_an_email
-
-    given_the_apply_again_flag_is_on
-
-    when_i_have_an_offer_waiting_for_my_decision
-    and_the_time_limit_before_decline_by_default_date_has_been_exceeded
-    then_i_receive_an_email_to_make_a_decision
-
-    and_when_the_decline_by_default_limit_has_been_exceeded
-    then_the_application_choice_is_declined
     and_the_candidate_receives_a_decline_by_default_without_rejection_email
     and_the_provider_receives_an_email
 
@@ -79,20 +68,10 @@ RSpec.feature 'Decline by default' do
     expect(@application_choice.reload.status).to eql('declined')
   end
 
-  def and_the_candidate_receives_an_email
-    open_email(@application_form.candidate.email_address)
-
-    expect(current_email.subject).to include('Application withdrawn automatically')
-  end
-
   def and_the_provider_receives_an_email
     open_email(@provider_user.email_address)
 
     expect(current_email.subject).to include('Harry Potter’s application withdrawn automatically')
-  end
-
-  def given_the_apply_again_flag_is_on
-    FeatureFlag.activate('apply_again')
   end
 
   def and_the_candidate_receives_a_decline_by_default_without_rejection_email

--- a/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature 'Entering their contact details' do
   scenario 'Candidate submits their contact details' do
     given_i_am_signed_in
     and_i_visit_the_site
-    and_the_track_validation_errors_feature_is_on
 
     when_i_click_on_contact_details
     and_i_incorrectly_fill_in_my_phone_number
@@ -54,10 +53,6 @@ RSpec.feature 'Entering their contact details' do
 
   def and_i_visit_the_site
     visit candidate_interface_application_form_path
-  end
-
-  def and_the_track_validation_errors_feature_is_on
-    FeatureFlag.activate('track_validation_errors')
   end
 
   def when_i_click_on_contact_details

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Validation errors' do
 
   scenario 'Review validation errors' do
     given_i_am_a_candidate
-    and_the_track_validation_errors_feature_is_on
     and_i_enter_invalid_contact_details
 
     given_i_am_a_support_user
@@ -29,10 +28,6 @@ RSpec.feature 'Validation errors' do
 
   def given_i_am_a_candidate
     create_and_sign_in_candidate
-  end
-
-  def and_the_track_validation_errors_feature_is_on
-    FeatureFlag.activate('track_validation_errors')
   end
 
   def and_i_enter_invalid_contact_details

--- a/spec/system/support_interface/validation_errors_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_summary_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'Validation errors summary' do
 
   scenario 'Review validation error summary' do
     given_i_am_a_candidate
-    and_the_track_validation_errors_feature_is_on
     and_i_enter_invalid_contact_details
 
     given_i_am_a_support_user
@@ -20,10 +19,6 @@ RSpec.feature 'Validation errors summary' do
 
   def given_i_am_a_candidate
     create_and_sign_in_candidate
-  end
-
-  def and_the_track_validation_errors_feature_is_on
-    FeatureFlag.activate('track_validation_errors')
   end
 
   def and_i_enter_invalid_contact_details

--- a/spec/workers/send_course_full_notifications_worker_spec.rb
+++ b/spec/workers/send_course_full_notifications_worker_spec.rb
@@ -2,90 +2,50 @@ require 'rails_helper'
 
 RSpec.describe SendCourseFullNotificationsWorker do
   describe '#perform', sidekiq: true do
-    context 'with feature flag inactive' do
-      it 'sends a Slack notification but no email' do
-        application_choice = create :application_choice
-        application_choice.course_option.update(vacancy_status: :no_vacancies)
-        allow(SlackNotificationWorker).to receive(:perform_async)
-        allow(CandidateMailer).to receive(:course_unavailable_notification)
-        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-        SendCourseFullNotificationsWorker.new.perform
-        expect(CandidateMailer).not_to have_received(:course_unavailable_notification)
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).not_to be_present
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(
-          "#{application_choice.course.name_and_code} at #{application_choice.course.provider.name} became full while #{application_choice.application_form.first_name} was awaiting references",
-          Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form),
-        )
-      end
-
-      it 'does not send repeated Slack notification if ChaserSent record is already present' do
-        application_choice = create :application_choice
-        application_choice.course_option.update(vacancy_status: :no_vacancies)
-        allow(SlackNotificationWorker).to receive(:perform_async)
-        allow(CandidateMailer).to receive(:course_unavailable_notification)
-        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-        ChaserSent.create!(
-          chased: application_choice,
-          chaser_type: :course_unavailable_slack_notification,
-        )
-        SendCourseFullNotificationsWorker.new.perform
-        expect(CandidateMailer).not_to have_received(:course_unavailable_notification)
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).not_to be_present
-        expect(SlackNotificationWorker).not_to have_received(:perform_async)
-      end
+    it 'sends emails to candidates that applied to a course that is now withdrawn' do
+      application_choice = create :application_choice
+      application_choice.course.update(withdrawn: true)
+      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+      SendCourseFullNotificationsWorker.new.perform
+      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_withdrawn).at_least(:once)
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
     end
 
-    context 'with feature flag active' do
-      before do
-        FeatureFlag.activate(:unavailable_course_notifications)
-      end
+    it 'sends emails to candidates that applied to a course that is now full' do
+      application_choice = create :application_choice
+      application_choice.course_option.update(vacancy_status: :no_vacancies)
+      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+      SendCourseFullNotificationsWorker.new.perform
+      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_full).at_least(:once)
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
+    end
 
-      it 'sends emails to candidates that applied to a course that is now withdrawn' do
-        application_choice = create :application_choice
-        application_choice.course.update(withdrawn: true)
-        allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
-        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-        SendCourseFullNotificationsWorker.new.perform
-        expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_withdrawn).at_least(:once)
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
-      end
+    it 'sends emails to candidates that applied to a course that is now full at the selected location' do
+      application_choice = create :application_choice
+      application_choice.course_option.update(vacancy_status: :no_vacancies)
+      create :course_option, course: application_choice.course
+      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+      SendCourseFullNotificationsWorker.new.perform
+      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :location_full).at_least(:once)
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
+    end
 
-      it 'sends emails to candidates that applied to a course that is now full' do
-        application_choice = create :application_choice
-        application_choice.course_option.update(vacancy_status: :no_vacancies)
-        allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
-        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-        SendCourseFullNotificationsWorker.new.perform
-        expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_full).at_least(:once)
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
-      end
-
-      it 'sends emails to candidates that applied to a course that is now full at the selected location' do
-        application_choice = create :application_choice
-        application_choice.course_option.update(vacancy_status: :no_vacancies)
-        create :course_option, course: application_choice.course
-        allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
-        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-        SendCourseFullNotificationsWorker.new.perform
-        expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :location_full).at_least(:once)
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
-      end
-
-      it 'sends emails to candidates that applied to a course that is now full for the selected study mode' do
-        application_choice = create :application_choice
-        application_choice.course_option.update(vacancy_status: :no_vacancies, study_mode: :full_time)
-        create :course_option, course: application_choice.course, site: application_choice.course_option.site, study_mode: :part_time
-        allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
-        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-        SendCourseFullNotificationsWorker.new.perform
-        expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :study_mode_full).at_least(:once)
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
-        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
-      end
+    it 'sends emails to candidates that applied to a course that is now full for the selected study mode' do
+      application_choice = create :application_choice
+      application_choice.course_option.update(vacancy_status: :no_vacancies, study_mode: :full_time)
+      create :course_option, course: application_choice.course, site: application_choice.course_option.site, study_mode: :part_time
+      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+      SendCourseFullNotificationsWorker.new.perform
+      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :study_mode_full).at_least(:once)
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
+      expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_slack_notification)).to be_present
     end
   end
 end


### PR DESCRIPTION
## Context

A bunch of feature flags have been on for quite a while now.

This PR removes them.

## Changes proposed in this pull request
Removes the following feature flags:

- apply_again
- replace_full_or_withdrawn_application_choices 
- unavailable_course_option_warnings
- track_validation_errors
- unavailable_course_notifications
- hesa_degree_data

## Guidance for review 

There's 1 ff per commit.

## Link to Trello card

https://trello.com/c/nRcWlpuH/1900-remove-replacefullorwithdrawnapplicationchoices-feature-flag

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
