### PR TITLE
Show provider name on provider user edit permissions page

### DIFF
--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -7,8 +7,8 @@
   <%= f.govuk_error_summary %>
   <%= f.hidden_field :provider_id %>
   <%= f.govuk_check_boxes_fieldset :permissions, {
-          legend: { text: "Select permissions: #{permissions_form.provider.name}", size: "xl" },
-          caption: { text: "Invite user", size: "xl" },
+          legend: { text: "Change permissions: #{permissions_form.provider.name}", size: "xl" },
+          caption: { text: permissions_form.provider_user.full_name, size: "xl" },
   } do %>
 
     <span class="govuk-hint">
@@ -16,7 +16,7 @@
     </span>
 
     <%= f.govuk_check_box :manage_organisations, true, multiple: false,
-                          label: { text: 'Manage organisation' },
+                          label: { text: 'Manage organisations' },
                           hint_text: 'Change permissions between organisations' %>
 
     <%= f.govuk_check_box :manage_users, true, multiple: false,


### PR DESCRIPTION
## Context

Just a small copy adjustment on the edit permissions page.

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/107591/89407111-1896a680-d716-11ea-85e7-531170023671.png)

After:
![image](https://user-images.githubusercontent.com/107591/89407023-fa30ab00-d715-11ea-90f2-ccb1469a7ad9.png)

## Guidance to review

Straightforward

## Link to Trello card

No trello card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
