### PR TITLE
Remove the 'Applications' breadcrumb

### DIFF
--- a/app/views/provider_interface/application_choices/notes.html.erb
+++ b/app/views/provider_interface/application_choices/notes.html.erb
@@ -1,21 +1,5 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Notes" %>
 
-<% content_for :before_content do %>
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to 'Applications', provider_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @application_choice.application_form.full_name, provider_interface_application_choice_path(@application_choice), class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        Notes
-      </li>
-    </ol>
-  </div>
-<% end %>
-
 <%= render 'application_choice_header' %>
 
 <%= link_to 'Add note', provider_interface_application_choice_new_note_path(@application_choice), class: 'govuk-button' %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -1,18 +1,5 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code}" %>
 
-<% content_for :before_content do %>
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to 'Applications', provider_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        <%= @application_choice.application_form.full_name %>
-      </li>
-    </ol>
-  </div>
-<% end %>
-
 <%= render 'application_choice_header' %>
 
 <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">

--- a/app/views/provider_interface/application_choices/timeline.html.erb
+++ b/app/views/provider_interface/application_choices/timeline.html.erb
@@ -1,21 +1,5 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Timeline" %>
 
-<% content_for :before_content do %>
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to 'Applications', provider_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @application_choice.application_form.full_name, provider_interface_application_choice_path(@application_choice), class: 'govuk-breadcrumbs__link' %>
-      </li>
-      <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        Timeline
-      </li>
-    </ol>
-  </div>
-<% end %>
-
 <%= render 'application_choice_header' %>
 
 <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>


### PR DESCRIPTION
#2099  Context

Since we introduced the two-level header, breadcrumbs pointing back to "Applications" don't make sense.

## Changes proposed in this pull request

Remove "Applications" breadrumbs

| Before | After |
| ------------- | ------------- |
| <img width="292" alt="Screenshot 2020-08-05 at 11 51 22" src="https://user-images.githubusercontent.com/38078064/89407627-05380b00-d717-11ea-871a-10c36d10f486.png">| <img width="287" alt="Screenshot 2020-08-05 at 11 51 38" src="https://user-images.githubusercontent.com/38078064/89407652-0ff2a000-d717-11ea-8323-64dfb66b590a.png">|
|<img width="305" alt="Screenshot 2020-08-05 at 11 50 26" src="https://user-images.githubusercontent.com/38078064/89407672-1719ae00-d717-11ea-8bf1-33e6bd23f86b.png">|<img width="285" alt="Screenshot 2020-08-05 at 11 50 37" src="https://user-images.githubusercontent.com/38078064/89407737-3adcf400-d717-11ea-81d2-0104a664a5c9.png">|

## Guidance to review

looks ok, missed anything?

## Link to Trello card

https://trello.com/c/jTDa8BdY/2470-remove-the-applications-breadcrumb-everywhere-in-manage

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
