### PR TITLE
Require tests to be explicit about which feature flags they rely on

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -57,12 +57,6 @@ class FeatureFlag
     FEATURES[feature_name].feature.active?
   end
 
-  def self.reset!
-    return if Rails.env.production?
-
-    Feature.update_all(active: false)
-  end
-
   def self.sync_with_database(feature_name, active)
     feature = Feature.find_or_initialize_by(name: feature_name)
     feature.active = active

--- a/azure/pipelines/build.yml
+++ b/azure/pipelines/build.yml
@@ -226,16 +226,34 @@ stages:
   - template: templates/rspec-job.yml
     parameters:
       testCommand: 'integration-tests'
-      displayName: 'Integration Tests'
-      jobId: 'integration_tests'
+      displayName: 'Integration Tests with all features off'
+      jobId: 'integration_tests_features_off'
       jobAttempt: $(System.JobAttempt)
+      featureFlagState: 'off'
 
   - template: templates/rspec-job.yml
     parameters:
       testCommand: 'unit-tests'
-      displayName: 'Unit Tests'
-      jobId: 'unit_tests'
+      displayName: 'Unit Tests with all features off'
+      jobId: 'unit_tests_features_off'
       jobAttempt: $(System.JobAttempt)
+      featureFlagState: 'off'
+
+  - template: templates/rspec-job.yml
+    parameters:
+      testCommand: 'integration-tests'
+      displayName: 'Integration Tests with all features on'
+      jobId: 'integration_tests_features_on'
+      jobAttempt: $(System.JobAttempt)
+      featureFlagState: 'on'
+
+  - template: templates/rspec-job.yml
+    parameters:
+      testCommand: 'unit-tests'
+      displayName: 'Unit Tests with all features on'
+      jobId: 'unit_tests_features_on'
+      jobAttempt: $(System.JobAttempt)
+      featureFlagState: 'on'
 
 
 - stage: deploy_qa

--- a/azure/pipelines/templates/rspec-job.yml
+++ b/azure/pipelines/templates/rspec-job.yml
@@ -6,7 +6,9 @@ parameters:
   - name: jobId
     type: string
   - name: jobAttempt
-    type: string 
+    type: string
+  - name: featureFlagState
+    type: string
 
 jobs:
 - job: ${{ parameters.jobId }}
@@ -44,15 +46,16 @@ jobs:
       FIND_BASE_URL: $(findBaseUrl)
       GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
       SANDBOX: $(sandbox)
-  
+
   - template: cancel-build-if-not-latest.yml
     parameters:
       sourceBranchName: $(Build.SourceBranchName)
- 
+
   - template: run-rspec-test.yml
     parameters:
       testCommand: ${{ format('ci.{0}', parameters.testCommand) }}
       testResultsFile: ${{ format('testArtifacts/rspec-{0}-results.xml', parameters.testCommand) }}
+      featureFlagState: ${{ parameters.featureFlagState }}
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()
@@ -66,4 +69,4 @@ jobs:
     displayName: 'Publish Test Artifacts'
     inputs:
       path: '$(System.DefaultWorkingDirectory)/testArtifacts/'
-      artifactName: ${{ format('rspec-{0}-{1}', parameters.testCommand, parameters.jobAttempt) }}
+      artifactName: ${{ format('rspec-{0}-{1}', parameters.jobId, parameters.jobAttempt) }}

--- a/azure/pipelines/templates/run-rspec-test.yml
+++ b/azure/pipelines/templates/run-rspec-test.yml
@@ -3,9 +3,12 @@ parameters:
     type: string
   - name: testResultsFile
     type: string
+  - name: featureFlagState
+    type: string
 
 steps:
   - script: |
+      echo $DEFAULT_FEATURE_FLAG_STATE
       make ${{ parameters.testCommand }}
       test_result=$?
       if [ "$test_result" == "0" ]
@@ -45,3 +48,4 @@ steps:
       FIND_BASE_URL: $(findBaseUrl)
       GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
       SANDBOX: $(sandbox)
+      DEFAULT_FEATURE_FLAG_STATE: ${{ parameters.featureFlagState }}

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -30,3 +30,4 @@ services:
       - UCAS_UPLOAD_BASEURL
       - UCAS_UPLOAD_FOLDER
       - SANDBOX
+      - DEFAULT_FEATURE_FLAG_STATE

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
 
   context 'when other qualifications are editable' do
     before do
+      FeatureFlag.deactivate(:international_other_qualifications)
+
       allow(application_form).to receive(:application_qualifications).and_return(
         ActiveRecordRelationStub.new(ApplicationQualification, [qualification1, qualification2], scopes: [:other]),
       )

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
+  before { FeatureFlag.deactivate(:enforce_provider_to_provider_permissions) }
+
   let(:training_provider) { create(:provider) }
   let(:ratifying_provider) { create(:provider) }
   let(:course) { create(:course, provider: training_provider, accredited_provider: ratifying_provider) }

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::DegreeTypeForm do
+  before { FeatureFlag.deactivate(:international_degrees) }
+
   describe '#save' do
     context 'when the description matches an entry in the HESA data' do
       let(:form) do

--- a/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
   describe 'validations' do
+    before { FeatureFlag.deactivate(:international_gcses) }
+
     it { is_expected.to validate_presence_of(:grade).on(:grade) }
     it { is_expected.to validate_presence_of(:award_year).on(:award_year) }
     it { is_expected.to validate_length_of(:grade).is_at_most(6).on(:grade) }

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
   describe '.build_from_application' do
     context 'with the international_personal_details flag off' do
       it 'creates an object based on the provided ApplicationForm' do
+        FeatureFlag.deactivate('international_personal_details')
+
         application_form = ApplicationForm.new(data)
         nationalities = CandidateInterface::NationalitiesForm.build_from_application(
           application_form,
@@ -100,6 +102,8 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
     context 'with the international_personal_details flag off' do
       it 'updates the provided ApplicationForm if valid' do
+        FeatureFlag.deactivate('international_personal_details')
+
         application_form = FactoryBot.create(:application_form)
         nationalities = CandidateInterface::NationalitiesForm.new(form_data)
 
@@ -137,6 +141,8 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
 
   describe 'validations' do
     context 'with the international_personal_details flag off' do
+      before { FeatureFlag.deactivate('international_personal_details') }
+
       it { is_expected.to validate_presence_of(:first_nationality) }
 
       it 'validates nationalities against the NATIONALITY_DEMONYMS list' do

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -37,6 +37,8 @@ end
 RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
   include Rails.application.routes.url_helpers
 
+  before { FeatureFlag.deactivate(:international_personal_details) }
+
   let(:default_personal_details_form) { build(:personal_details_form) }
   let(:default_nationalities_form) { build(:nationalities_form) }
   let(:default_languages_form) { build(:languages_form) }
@@ -103,7 +105,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
     end
 
     it 'includes a hash with up to 5 nationalities when international_personal_details is on' do
-      FeatureFlag.activate('international_personal_details')
+      FeatureFlag.activate(:international_personal_details)
+
       nationalities_form = build(
         :nationalities_form,
         british: 'British',
@@ -120,6 +123,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
   end
 
   context 'when presenting English as the main language' do
+    before { FeatureFlag.deactivate(:efl_section) }
+
     it 'includes a hash with "Yes"' do
       languages_form = build(
         :languages_form,
@@ -174,6 +179,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
   end
 
   context 'when presenting English not as the main language' do
+    before { FeatureFlag.deactivate(:efl_section) }
+
     it 'includes a hash with "No"' do
       languages_form = build(
         :languages_form,
@@ -245,9 +252,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
   end
 
   context 'when the international personal details flag is on and the candidate has selected they have the right to work' do
-    before do
-      FeatureFlag.activate('international_personal_details')
-    end
+    before { FeatureFlag.activate(:international_personal_details) }
 
     it 'renders the right to work row' do
       nationalities_form = build(
@@ -267,9 +272,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
   end
 
   context 'when the international personal details flag is on and the candidate is British or Irish' do
-    before do
-      FeatureFlag.activate('international_personal_details')
-    end
+    before { FeatureFlag.activate(:international_personal_details) }
 
     it 'renders the right to work row' do
       nationalities_form = build(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,7 +75,7 @@ RSpec.configure do |config|
     puts "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
   end
 
-  config.before(:each) do
+  config.before do
     if ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on'
       FeatureFlag::TEMPORARY_FEATURE_FLAGS.each do |name, _|
         # Avoid 2 queries by creating the flag enabled, instead of doing a find + update.

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -23,6 +23,11 @@ module CandidateHelper
   end
 
   def candidate_completes_application_form
+    FeatureFlag.deactivate(:international_addresses)
+    FeatureFlag.deactivate(:international_personal_details)
+    FeatureFlag.deactivate(:efl_section)
+    FeatureFlag.deactivate(:international_degrees)
+
     given_courses_exist
     create_and_sign_in_candidate
     visit candidate_interface_application_form_path

--- a/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualificaitons_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualificaitons_after_completing_the_section_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Candidates academic and other relevant qualifications' do
   include CandidateHelper
 
   scenario 'Candidate updates and deletes qualificaitons in a completed academic and other relevant qualifications section' do
+    FeatureFlag.deactivate(:international_other_qualifications)
+
     given_i_am_signed_in
     and_i_have_completed_the_other_qualifications_section
 

--- a/spec/system/candidate_interface/candidate_entering_degree_with_missing_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degree_with_missing_information_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Entering degree with missing info' do
   include CandidateHelper
 
   scenario 'Candidate attempts to submit an incomplete degree' do
+    FeatureFlag.deactivate(:international_degrees)
+
     given_i_am_viewing_my_application_form
     when_i_click_on_degree
     then_i_see_the_undergraduate_degree_form

--- a/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Entering their degrees' do
   include CandidateHelper
 
   scenario 'Candidate submits their degrees' do
+    FeatureFlag.deactivate(:international_degrees)
+
     given_i_am_signed_in
     and_i_visit_the_site
     when_i_click_on_degree

--- a/spec/system/candidate_interface/candidate_entering_gcse_other_uk_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_other_uk_qualification_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Candidate entering GCSE details' do
   include CandidateHelper
 
   scenario 'Candidate specifies GCSE maths with "Other UK qualification" type' do
+    FeatureFlag.deactivate(:international_gcses)
+
     given_i_am_signed_in
     and_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Candidate entering GCSE details' do
   include CandidateHelper
 
   scenario 'Candidate submits their maths GCSE details and then update them' do
+    FeatureFlag.deactivate(:international_gcses)
+
     given_i_am_signed_in
 
     when_i_visit_the_candidate_application_page

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Entering their other qualifications' do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications with the prompt_for_additional_qualifications on' do
+    FeatureFlag.deactivate(:international_other_qualifications)
+
     given_i_am_signed_in
     and_i_visit_the_site
 

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -4,6 +4,9 @@ RSpec.feature 'Entering their personal details' do
   include CandidateHelper
 
   scenario 'Candidate submits their personal details' do
+    FeatureFlag.deactivate(:international_personal_details)
+    FeatureFlag.deactivate(:efl_section)
+
     given_i_am_signed_in
     and_i_visit_the_site
 

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
 
   scenario 'Candidate provides a new referee because 2 did not respond' do
     FeatureFlag.activate('pilot_open')
+    FeatureFlag.deactivate(:separate_additional_referees)
 
     given_i_am_signed_in_as_a_candidate
     and_i_have_submitted_my_application

--- a/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
@@ -6,6 +6,8 @@ RSpec.feature 'Entering their contact details' do
   include CandidateHelper
 
   scenario 'Candidate submits their contact details' do
+    FeatureFlag.deactivate(:international_addresses)
+
     given_i_am_signed_in
     and_i_visit_the_site
 

--- a/spec/system/candidate_interface/international/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_enters_their_personal_details_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Entering their personal details' do
   include CandidateHelper
 
   scenario 'Candidate submits their personal details' do
+    FeatureFlag.deactivate(:efl_section)
+
     given_i_am_signed_in
     and_the_international_candidates_flag_is_active
     and_i_visit_the_site

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -5,6 +5,9 @@ RSpec.feature 'Candidate submits the application' do
   include EFLHelper
 
   scenario 'International candidate completes and submits an application' do
+    FeatureFlag.deactivate(:international_addresses)
+    FeatureFlag.deactivate(:international_degrees)
+
     given_i_am_signed_in
     and_the_efl_feature_flag_is_active
     and_the_international_personal_details_feature_flag_is_active

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Confirm conditions met' do
   include DfESignInHelpers
 
   scenario 'Provider user confirms offer conditions have been met by the candidate' do
+    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Confirm conditions not met' do
   include DfESignInHelpers
 
   scenario 'Provider user confirms offer conditions have not been met by the candidate' do
+    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface

--- a/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
+++ b/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Provider makes an offer' do
   include DfESignInHelpers
 
   scenario 'Provider fails to select a response (offer/reject)' do
+    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_application_choices_exist_for_my_provider
     and_i_am_permitted_to_see_applications_for_my_provider

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -10,6 +10,8 @@ RSpec.feature 'Provider rejects application' do
   end
 
   scenario 'Provider rejects application' do
+    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -16,6 +16,8 @@ RSpec.feature 'Provider responds to application' do
   end
 
   scenario 'Provider can respond to an application' do
+    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Provider withdraws an offer' do
   include DfESignInHelpers
 
   scenario 'Provider withdraws an offer' do
+    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
+
     given_i_am_a_provider_user_with_dfe_sign_in
     and_an_offered_application_choice_exists_for_my_provider
     and_i_am_permitted_to_see_applications_for_my_provider


### PR DESCRIPTION
## Context

There are 2 somewhat related issues with feature flags:

- It is possible to write code that isn't being tested by our integration tests. For example, if you were to add `raise if FeatureFlag.active?(:introduce_bug)` to a controller, the tests will pass without a problem because all flags are off by default.

- When introducing a feature flag, we typically add tests where we turn _on_ the flag and observe the behaviour. 

  When removing feature flags, I've often noticed that there are specs that fail because they actually rely on a feature flag being turned off. But since we don't explicitly turn it off in the code, it isn't easy to find these cases. What complicates the situation is that you have to go back into this failing test and understand it before you can make the changes. This is tricky because you don't have context on the feature, or you're not the person who wrote the tests.


## Changes proposed in this pull request

Run the RSpec tests once with all flags on by default, and once with all flags off by default. It all runs in parallel so it won't take more time.

This will force us to explicitly activate or deactivate flags when adding them, using:

```rb
before do
  FeatureFlag.deactivate(:whatever_feature)
end
```

```rb
before do
  FeatureFlag.activate(:whatever_feature)
end
```

It's a little more work upfront, but it'll make it easier and safer to remove feature flags.  

## Guidance to review

Is this sensible?

## Link to Trello card

https://trello.com/c/f6K25rS3/354-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
