### PR TITLE
Add feedback link for sandbox users

### DIFF
--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -16,7 +16,7 @@
       <li>test Apply’s <%= govuk_link_to 'API integrations', 'https://www.apply-for-teacher-training.service.gov.uk/api-docs' %></li>
     </ul>
 
-    <p class='govuk-body'>Throughout, you’ll be able to give us feedback so we can improve the service.</p>
+    <p class='govuk-body'>Throughout, you’ll be able to <a class="govuk-link" href="#give-feedback">give us feedback</a> so we can improve the service.</p>
 
     <h2 class='govuk-heading-l'>Get started as a candidate</h2>
 
@@ -85,5 +85,10 @@
     <h2 class='govuk-heading-l'>Help and support</h2>
 
     <p class='govuk-body'>Email us at <%= bat_contact_mail_to %> for support using Apply sandbox or any other aspect of the Apply for teacher training service.
+
+    <h2 class='govuk-heading-l' id='give-feedback'>To give feedback</h2>
+
+    <p class='govuk-body'>To give feedback about the service, <a href="#" class="govuk-link">fill in our feedback form</a>.</p>
+
   </div>
 </div>

--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -263,8 +263,16 @@ To request a remote demonstration of the service as a whole or a particular feat
 
 To report a problem or get help, email us on <becomingateacher@digital.education.gov.uk>.
 
+<!-- <% if HostingEnvironment.sandbox_mode? %> -->
+###To give feedback
+To give feedback about the service, [fill in our feedback form](#).
+
+<!-- <% end %> -->
+
 ###Take part in user research and give feedback
 
 We welcome feedback on all aspects of Manage teacher training applications. When you participate in user research, you help shape current and future service features.
 
-Please [complete this 30-second form](https://docs.google.com/forms/d/1QgmaQzLsQ9dMcIgnTjr-7faAz7VpKuPXjHoF6hU22Po) and we’ll be in touch. Or, simply give us your feedback over email at <becomingateacher@digital.education.gov.uk>.
+Please [complete this 30-second form](https://docs.google.com/forms/d/1QgmaQzLsQ9dMcIgnTjr-7faAz7VpKuPXjHoF6hU22Po) and we’ll be in touch.
+
+<!-- Or, simply give us your feedback over email at <becomingateacher@digital.education.gov.uk>. -->

--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -264,15 +264,22 @@ To request a remote demonstration of the service as a whole or a particular feat
 To report a problem or get help, email us on <becomingateacher@digital.education.gov.uk>.
 
 <!-- <% if HostingEnvironment.sandbox_mode? %> -->
+
 ###To give feedback
 To give feedback about the service, [fill in our feedback form](#).
 
-<!-- <% end %> -->
-
-###Take part in user research and give feedback
+###Take part in user research
 
 We welcome feedback on all aspects of Manage teacher training applications. When you participate in user research, you help shape current and future service features.
 
 Please [complete this 30-second form](https://docs.google.com/forms/d/1QgmaQzLsQ9dMcIgnTjr-7faAz7VpKuPXjHoF6hU22Po) and we’ll be in touch.
 
-<!-- Or, simply give us your feedback over email at <becomingateacher@digital.education.gov.uk>. -->
+<!-- <% else %> -->
+
+###Take part in user research and give feedback
+
+We welcome feedback on all aspects of Manage teacher training applications. When you participate in user research, you help shape current and future service features.
+
+Please [complete this 30-second form](https://docs.google.com/forms/d/1QgmaQzLsQ9dMcIgnTjr-7faAz7VpKuPXjHoF6hU22Po) and we’ll be in touch. Or, simply give us your feedback over email at <becomingateacher@digital.education.gov.uk>.
+
+<!-- <% end %> -->

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -5,6 +5,11 @@
   <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
 </ul>
 
+
+<% if HostingEnvironment.sandbox_mode? %>
+  <p class="govuk-footer__meta-custom govuk-!-font-size-16">To give feedback about the service, <%= link_to 'fill in our feedback form', '#', class: 'govuk-footer__link' %></p>
+<% end %>
+
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.accessibility'), candidate_interface_accessibility_path, class: 'govuk-footer__link' %>

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -6,6 +6,11 @@
   <p class="govuk-body">
   For questions or to report a problem, email us on <%= link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk', class: 'govuk-footer__link' %>
   </p>
+  <% if HostingEnvironment.sandbox_mode? %>
+    <p class="govuk-body">
+    To give feedback about the service, <%= link_to 'fill in our feedback form', '#', class: 'govuk-footer__link' %>
+    </p>
+  <% end %>
 </div>
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">


### PR DESCRIPTION
## Context

Adding a link to a feedback form as the primary way of getting feedback (on sandbox only), rather than email.

## Changes proposed in this pull request

I've added a link to places that seemed sensible, including:
* The footers of both services
* The guidance page for providers
* The sandbox introduction page.
* I've used the sandbox environment variable to scope the changes

## Still to do

[x] content review
[ ] confirm destination url
[ ] should probably use translation file for content
[ ] developer pick up to ensure it works correctly
[ ] the guidance page for providers needs to be dynamic - how to do this?

## Link to Trello card

https://trello.com/c/deat1wN8/2510-add-google-form-link-for-feedback-from-the-sandbox-environment


## Screenshots

### Apply footer
<img width="1064" alt="Screenshot 2020-08-05 at 15 27 38" src="https://user-images.githubusercontent.com/2204224/89424908-3f61d680-d730-11ea-9a51-55fbe0755502.png">

### Provider footer
<img width="1048" alt="Screenshot 2020-08-05 at 15 28 11" src="https://user-images.githubusercontent.com/2204224/89424967-4daff280-d730-11ea-8833-b8e4033c8a7f.png">

### Provider guidance page
<img width="1108" alt="Screenshot 2020-08-05 at 15 36 35" src="https://user-images.githubusercontent.com/2204224/89425965-856b6a00-d731-11ea-9202-c74839908778.png">


### Sandbox intro
<img width="772" alt="Screenshot 2020-08-05 at 15 28 35" src="https://user-images.githubusercontent.com/2204224/89425010-5b657800-d730-11ea-942a-72db930a7f04.png">
<img width="1175" alt="Screenshot 2020-08-05 at 15 30 16" src="https://user-images.githubusercontent.com/2204224/89425193-99629c00-d730-11ea-9204-5fcabbf341d7.png">
