### PR TITLE
Implement the provider permissions setup flow

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -71,14 +71,14 @@ module ProviderInterface
       if @provider_setup.next_agreement_pending
         redirect_to provider_interface_new_data_sharing_agreement_path
       elsif @provider_setup.next_relationship_pending
-        # redirect_to provider_interface_provider_relationship_permissions_setup_path
-        # TODO: Implement this
+        redirect_to provider_interface_provider_relationship_permissions_organisations_path
       end
     end
 
     def performing_provider_organisation_setup?
       [
         ProviderInterface::ProviderAgreementsController,
+        ProviderInterface::ProviderRelationshipPermissionsSetupController,
       ].include?(request.controller_class)
     end
 

--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -47,18 +47,24 @@ module ProviderInterface
     end
 
     def check
-     @wizard = wizard_for(current_step: 'check')
-     @wizard.save_state!
-     @permissions_models = ProviderRelationshipPermissions
-       .includes(:training_provider, :ratifying_provider)
-       .where(id: @wizard.provider_relationships)
+      @wizard = wizard_for(current_step: 'check')
+      @wizard.save_state!
+      @permissions_models = ProviderRelationshipPermissions
+        .includes(:training_provider, :ratifying_provider)
+        .where(id: @wizard.provider_relationships)
     end
 
     def commit
       @wizard = wizard_for({})
-      # TODO: Save permissions
-      @wizard.clear_state!
-      redirect_to provider_interface_provider_relationship_permissions_success_path
+      if SetupProviderRelationshipPermissions.call(@wizard.provider_relationship_permissions)
+        @wizard.clear_state!
+        redirect_to provider_interface_provider_relationship_permissions_success_path
+      else
+        redirect_to(
+          provider_interface_check_provider_relationship_permissions_path,
+          warning: 'Unable to save permissions, please try again. If problems persist please contact support',
+        )
+      end
     end
 
     def success; end

--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -1,0 +1,56 @@
+module ProviderInterface
+  class ProviderRelationshipPermissionsSetupController < ProviderInterfaceController
+    before_action :require_feature_flag!
+    before_action :require_manage_organisations_permission!
+
+    def start
+      @wizard = wizard_for(current_step: 'start')
+      @wizard.save_state!
+    end
+
+    def organisations
+      @wizard = wizard_for(current_step: 'provider_relationships')
+      @wizard.save_state!
+    end
+
+    def info
+      @wizard = wizard_for(current_step: 'info')
+      @wizard.save_state!
+    end
+
+    def setup_permissions
+      @wizard = wizard_for(current_step: 'permissions')
+      @wizard.save_state!
+    end
+
+    def save_permissions
+      @wizard = wizard_for(current_step: 'permissions')
+      @wizard.save_state!
+    end
+
+    def check
+      @wizard = wizard_for(current_step: 'check')
+      @wizard.save_state!
+    end
+
+    def commit
+      @wizard = wizard_for({})
+      @wizard.save_state!
+    end
+
+  private
+
+    def wizard_for(options)
+      options[:checking_answers] = true if params[:checking_answers] == 'true'
+      ProviderRelationshipPermissionsSetupWizard.new(session, options)
+    end
+
+    def require_feature_flag!
+      render_404 unless FeatureFlag.active?(:enforce_provider_to_provider_permissions)
+    end
+
+    def require_manage_organisations_permission!
+      render_404 unless current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+    end
+  end
+end

--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -2,37 +2,57 @@ module ProviderInterface
   class ProviderRelationshipPermissionsSetupController < ProviderInterfaceController
     before_action :require_feature_flag!
     before_action :require_manage_organisations_permission!
+    before_action :require_access_to_manage_provider_relationship_permissions!, only: %i[setup_permissions save_permissions]
 
     def organisations
       @grouped_provider_names_from_relationships = grouped_provider_names_from_relationships
-      @wizard = wizard_for(current_step: 'provider_relationships')
+      @wizard = wizard_for(provider_relationships_attrs.merge(current_step: 'provider_relationships'))
       @wizard.save_state!
     end
 
     def info
+      @permissions_model = provider_relationship_permissions_needing_setup.first
       @wizard = wizard_for(current_step: 'info')
       @wizard.save_state!
     end
 
     def setup_permissions
-      @permissions_model = provider_relationship_permissions_needing_setup.first
+      @permissions_model = ProviderRelationshipPermissions.find(params[:id])
       @wizard = wizard_for(current_step: 'permissions')
       @wizard.save_state!
     end
 
     def save_permissions
-      @wizard = wizard_for(current_step: 'permissions')
-      @wizard.save_state!
+      @wizard = wizard_for(permissions_params.merge(current_step: 'permissions'))
+
+      if @wizard.valid?(:permissions)
+        @wizard.save_state!
+
+        next_step, id = @wizard.next_step
+
+        if next_step == :permissions
+          redirect_to provider_interface_setup_provider_relationship_permissions_path(id)
+        else
+          redirect_to provider_interface_check_provider_relationship_permissions_path
+        end
+      else
+        @permissions_model = ProviderRelationshipPermissions.find(params[:id])
+        render :setup_permissions
+      end
     end
 
     def check
       @wizard = wizard_for(current_step: 'check')
+      @permissions_models = ProviderRelationshipPermissions
+        .includes(:training_provider, :ratifying_provider)
+        .where(id: @wizard.provider_relationships)
       @wizard.save_state!
     end
 
     def commit
       @wizard = wizard_for({})
-      @wizard.save_state!
+      # TODO: Save permissions
+      @wizard.clear_state!
     end
 
   private
@@ -47,8 +67,13 @@ module ProviderInterface
 
     def provider_relationship_permissions_needing_setup
       current_provider_user.authorisation
-        .training_providers_that_actor_can_manage_organisations_for
+        .training_provider_relationships_that_actor_can_manage_organisations_for
         .where(setup_at: nil)
+        .order(created_at: :asc)
+    end
+
+    def provider_relationships_attrs
+      { provider_relationships: provider_relationship_permissions_needing_setup.pluck(:id) }
     end
 
     def wizard_for(options)
@@ -62,6 +87,21 @@ module ProviderInterface
 
     def require_manage_organisations_permission!
       render_404 unless current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+    end
+
+    def require_access_to_manage_provider_relationship_permissions!
+      provider_relationship_permissions = ProviderRelationshipPermissions.find(params[:id])
+      permitted_relationship_permissions = current_provider_user.authorisation.training_provider_relationships_that_actor_can_manage_organisations_for
+
+      render_403 unless permitted_relationship_permissions.include?(provider_relationship_permissions)
+    end
+
+    def permissions_params
+      return {} unless params.key?(:provider_interface_provider_relationship_permissions_setup_wizard)
+
+      params.require(:provider_interface_provider_relationship_permissions_setup_wizard)
+        .permit(make_decisions: [], view_safeguarding_information: []).to_h
+        .merge(current_provider_relationship_id: params[:id])
     end
   end
 end

--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -3,6 +3,7 @@ module ProviderInterface
     before_action :require_feature_flag!
     before_action :require_manage_organisations_permission!
     before_action :require_access_to_manage_provider_relationship_permissions!, only: %i[setup_permissions save_permissions]
+    before_action :redirect_unless_permissions_to_setup, except: %i[success]
 
     def organisations
       @grouped_provider_names_from_relationships = grouped_provider_names_from_relationships
@@ -108,6 +109,10 @@ module ProviderInterface
       permitted_relationship_permissions = current_provider_user.authorisation.training_provider_relationships_that_actor_can_manage_organisations_for
 
       render_403 unless permitted_relationship_permissions.include?(provider_relationship_permissions)
+    end
+
+    def redirect_unless_permissions_to_setup
+      redirect_to provider_interface_applications_path if provider_relationship_permissions_needing_setup.blank?
     end
 
     def permissions_params

--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -19,7 +19,11 @@ module ProviderInterface
 
     def setup_permissions
       @permissions_model = ProviderRelationshipPermissions.find(params[:id])
-      @wizard = wizard_for(current_step: 'permissions', current_provider_relationship_id: params[:id])
+      @wizard = wizard_for(
+        current_step: 'permissions',
+        current_provider_relationship_id: params[:id],
+        checking_answers: params[:checking_answers],
+      )
       @wizard.save_state!
 
       setup_permissions_form
@@ -69,6 +73,21 @@ module ProviderInterface
     end
 
     def success; end
+
+    def previous_page
+      step, id = @wizard.previous_step
+
+      path_info = {
+        organisations: { action: :organisations },
+        permissions: { action: :setup_permissions, id: id },
+        info: { action: :info },
+        check: { action: :check },
+      }.fetch(step)
+
+      path_info[:checking_answers] = true if params[:checking_answers]
+      path_info
+    end
+    helper_method :previous_page
 
   private
 
@@ -120,7 +139,7 @@ module ProviderInterface
 
       params.require(:provider_interface_provider_relationship_permissions_setup_wizard)
         .permit(provider_relationship_permissions: {}).to_h
-        .merge(current_provider_relationship_id: params[:id], skip_further_permissions: params[:skip_further_permissions])
+        .merge(current_provider_relationship_id: params[:id], checking_answers: params[:checking_answers])
     end
 
     def setup_permissions_form

--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -120,7 +120,7 @@ module ProviderInterface
 
       params.require(:provider_interface_provider_relationship_permissions_setup_wizard)
         .permit(provider_relationship_permissions: {}).to_h
-        .merge(current_provider_relationship_id: params[:id])
+        .merge(current_provider_relationship_id: params[:id], skip_further_permissions: params[:skip_further_permissions])
     end
 
     def setup_permissions_form

--- a/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
@@ -1,0 +1,106 @@
+module ProviderInterface
+  class ProviderRelationshipPermissionsSetupWizard
+    include ActiveModel::Model
+    STATE_STORE_KEY = :provider_relationship_permissions_setup_wizard
+
+    attr_accessor :current_step, :current_provider_relationship_id, :checking_answers
+    attr_writer :provider_relationships, :provider_relationship_permissions, :state_store
+
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(last_saved_state.deep_merge(attrs))
+
+      self.checking_answers = false if current_step == 'check'
+    end
+
+    def provider_relationships
+      if @provider_relationships
+        @provider_relationships.reject(&:blank?).map(&:to_i)
+      else
+        []
+      end
+    end
+
+    def provider_relationship_permissions
+      @provider_relationship_permissions || {}
+    end
+
+    # [provider_relationships info permissions... check]
+    def next_step
+      if checking_answers
+        if any_provider_relationship_needs_permissions_setup?
+          [:permissions, next_provider_relationship_needing_permissions_setup]
+        else
+          [:check]
+        end
+      elsif current_step == 'provider_relationships'
+        [:info]
+      elsif current_step == 'info'
+        [:permissions, next_provider_relationship_id]
+      elsif current_step == 'permissions' && next_provider_relationship_id.present?
+        [:permissions, next_provider_relationship_id]
+      else
+        [:check]
+      end
+    end
+
+    def previous_step
+      if checking_answers
+        [:check]
+      elsif current_step == 'info'
+        [:provider_relationships]
+      elsif current_step == 'provider_relationships'
+        [:start]
+      elsif current_step == 'permissions'
+        previous_provider_relationship_id.present? ? [:permissions, previous_provider_relationship_id] : [:info]
+      elsif current_step == 'check'
+        [:permissions, provider_relationships.last]
+      else
+        [:check]
+      end
+    end
+
+    def save_state!
+      @state_store[STATE_STORE_KEY] = state
+    end
+
+    def clear_state!
+      @state_store.delete(STATE_STORE_KEY)
+    end
+
+  private
+
+    def state
+      as_json(except: %w[state_store errors validation_context current_step]).to_json
+    end
+
+    def last_saved_state
+      JSON.parse(@state_store[STATE_STORE_KEY].presence || '{}')
+    end
+
+    def next_provider_relationship_id
+      if current_provider_relationship_id.blank?
+        provider_relationships.first
+      else
+        provider_relationships.drop_while { |provider_relationship_id| provider_relationship_id != current_provider_relationship_id.to_i }[1]
+      end
+    end
+
+    def previous_provider_relationship_id
+      if current_provider_relationship_id.blank?
+        provider_relationships.last
+      else
+        provider_relationships.reverse.drop_while { |provider_relationship_id| provider_relationship_id != current_provider_relationship_id.to_i }[1]
+      end
+    end
+
+    def next_provider_relationship_needing_permissions_setup
+      ProviderRelationshipPermissions.where(setup_at: nil).order(:created_at)
+    end
+
+    def any_provider_relationship_needs_permissions_setup?
+      next_provider_relationship_needing_permissions_setup.present?
+    end
+  end
+end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -41,6 +41,15 @@ class ProviderAuthorisation
     Provider.where(id: manageable_provider_ids).order(:name)
   end
 
+  def training_provider_relationships_that_actor_can_manage_organisations_for
+    manageable_provider_ids = ProviderPermissions
+      .where(provider_user: @actor, manage_organisations: true)
+      .pluck(:provider_id)
+
+    ProviderRelationshipPermissions
+      .where(training_provider: manageable_provider_ids)
+  end
+
   def can_manage_organisations_for_at_least_one_provider?
     providers_that_actor_can_manage_organisations_for.any?
   end

--- a/app/services/provider_interface/setup_provider_relationship_permissions.rb
+++ b/app/services/provider_interface/setup_provider_relationship_permissions.rb
@@ -1,0 +1,27 @@
+module ProviderInterface
+  class PermissionsSetupError < StandardError; end
+
+  class SetupProviderRelationshipPermissions
+    def self.call(permissions_data = {})
+      ProviderRelationshipPermissions.transaction do
+        permissions_data.each do |id, permissions|
+          record = ProviderRelationshipPermissions.find(id)
+          raise PermissionsSetupError, 'Permissions record has already been setup' if record.setup_at.present?
+
+          record.update!(permissions_attributes_for_persistence(permissions))
+        end
+      end
+
+      true
+    end
+
+    def self.permissions_attributes_for_persistence(permissions)
+      %w[training ratifying].reduce({ setup_at: Time.zone.now }) do |hash, role|
+        hash.merge({
+          "#{role}_provider_can_make_decisions" => permissions.fetch('make_decisions', []).include?(role),
+          "#{role}_provider_can_view_safeguarding_information" => permissions.fetch('view_safeguarding_information', []).include?(role),
+        })
+      end
+    end
+  end
+end

--- a/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
@@ -1,0 +1,47 @@
+<% content_for :before_content do %>
+  <%= link_to 'Back', provider_interface_setup_provider_relationship_permissions_path(@permissions_models.last), class: 'govuk-back-link' %>
+<% end %>
+
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds govuk-body">
+		<span class="govuk-caption-xl">Set up permissions</span>
+		<h1 class="govuk-heading-xl">Check permissions</h1>
+    <% @permissions_models.each do |permissions_model| %>
+      <h2 class="govuk-heading-m">
+        For courses run by <%= permissions_model.training_provider.name %> and ratified by <%= permissions_model.ratifying_provider.name %>
+      </h2>
+      <p>The following organisation(s) can make decisions:</p>
+      <ul class="govuk-list make-decisions">
+      <% provider_types_with_enabled_permissions = @wizard.permissions_for_relationship(permissions_model.id).fetch('make_decisions', []) %>
+      <% if provider_types_with_enabled_permissions.include?('training') %>
+        <li><%= render CheckIcon.new %> <%= permissions_model.training_provider.name %></li>
+      <% end %>
+      <% if provider_types_with_enabled_permissions.include?('ratifying') %>
+        <li><%= render CheckIcon.new %> <%= permissions_model.ratifying_provider.name %></li>
+      <% end %>
+      </ul>
+
+      <p class="govuk-!-margin-bottom-8"><%= govuk_link_to 'Change', provider_interface_setup_provider_relationship_permissions_path(permissions_model) %></p>
+
+      <p>The following organisation(s) can view safeguarding information:</p>
+
+      <ul class="govuk-list view-safeguarding-information">
+      <% provider_types_with_enabled_permissions = @wizard.permissions_for_relationship(permissions_model.id).fetch('view_safeguarding_information', []) %>
+      <% if provider_types_with_enabled_permissions.include?('training') %>
+        <li><%= render CheckIcon.new %> <%= permissions_model.training_provider.name %></li>
+      <% end %>
+      <% if provider_types_with_enabled_permissions.include?('ratifying') %>
+        <li><%= render CheckIcon.new %> <%= permissions_model.ratifying_provider.name %></li>
+      <% end %>
+      </ul>
+
+      <p class="govuk-!-margin-bottom-8"><%= govuk_link_to 'Change', provider_interface_setup_provider_relationship_permissions_path(permissions_model) %></p>
+    <% end %>
+
+    <%= form_with model: @wizard, url: provider_interface_commit_provider_relationship_permissions_path do |f| %>
+		  <button class="govuk-button" data-module="govuk-button">
+			  Save permissions
+      </button>
+    <% end %>
+	</div>
+</div>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
@@ -3,45 +3,73 @@
 <% end %>
 
 <div class="govuk-grid-row">
-	<div class="govuk-grid-column-two-thirds govuk-body">
-		<span class="govuk-caption-xl">Set up permissions</span>
-		<h1 class="govuk-heading-xl">Check permissions</h1>
+  <div class="govuk-grid-column-two-thirds govuk-body">
+    <span class="govuk-caption-xl">Set up permissions</span>
+    <h1 class="govuk-heading-xl">Check permissions</h1>
     <% @permissions_models.each do |permissions_model| %>
       <h2 class="govuk-heading-m">
         For courses run by <%= permissions_model.training_provider.name %> and ratified by <%= permissions_model.ratifying_provider.name %>
       </h2>
-      <p>The following organisation(s) can make decisions:</p>
-      <ul class="govuk-list make-decisions">
-      <% provider_types_with_enabled_permissions = @wizard.permissions_for_relationship(permissions_model.id).fetch('make_decisions', []) %>
-      <% if provider_types_with_enabled_permissions.include?('training') %>
-        <li><%= render CheckIcon.new %> <%= permissions_model.training_provider.name %></li>
-      <% end %>
-      <% if provider_types_with_enabled_permissions.include?('ratifying') %>
-        <li><%= render CheckIcon.new %> <%= permissions_model.ratifying_provider.name %></li>
-      <% end %>
-      </ul>
-
-      <p class="govuk-!-margin-bottom-8"><%= govuk_link_to 'Change', provider_interface_setup_provider_relationship_permissions_path(permissions_model) %></p>
-
-      <p>The following organisation(s) can view safeguarding information:</p>
-
-      <ul class="govuk-list view-safeguarding-information">
-      <% provider_types_with_enabled_permissions = @wizard.permissions_for_relationship(permissions_model.id).fetch('view_safeguarding_information', []) %>
-      <% if provider_types_with_enabled_permissions.include?('training') %>
-        <li><%= render CheckIcon.new %> <%= permissions_model.training_provider.name %></li>
-      <% end %>
-      <% if provider_types_with_enabled_permissions.include?('ratifying') %>
-        <li><%= render CheckIcon.new %> <%= permissions_model.ratifying_provider.name %></li>
-      <% end %>
-      </ul>
-
-      <p class="govuk-!-margin-bottom-8"><%= govuk_link_to 'Change', provider_interface_setup_provider_relationship_permissions_path(permissions_model) %></p>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Which organisations can make decisions?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <ul class="govuk-list make-decisions">
+              <% provider_types_with_enabled_permissions = @wizard.permissions_for_relationship(permissions_model.id).fetch('make_decisions', []) %>
+              <% if provider_types_with_enabled_permissions.include?('training') %>
+                <li><%= render CheckIcon.new %> <%= permissions_model.training_provider.name %></li>
+              <% end %>
+              <% if provider_types_with_enabled_permissions.include?('ratifying') %>
+                <li><%= render CheckIcon.new %> <%= permissions_model.ratifying_provider.name %></li>
+              <% end %>
+            </ul>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= govuk_link_to(
+              'Change',
+              provider_interface_setup_provider_relationship_permissions_path(
+                permissions_model,
+                anchor: "provider-interface-provider-relationship-permissions-setup-wizard-provider-relationship-permissions-#{permissions_model.id}-make-decisions-training-field",
+                skip_further_permissions: true,
+              ),
+            )%>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Which organisations can view safeguarding information?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <ul class="govuk-list view-safeguarding-information">
+              <% provider_types_with_enabled_permissions = @wizard.permissions_for_relationship(permissions_model.id).fetch('view_safeguarding_information', []) %>
+              <% if provider_types_with_enabled_permissions.include?('training') %>
+                <li><%= render CheckIcon.new %> <%= permissions_model.training_provider.name %></li>
+              <% end %>
+              <% if provider_types_with_enabled_permissions.include?('ratifying') %>
+                <li><%= render CheckIcon.new %> <%= permissions_model.ratifying_provider.name %></li>
+              <% end %>
+            </ul>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= govuk_link_to(
+              'Change',
+              provider_interface_setup_provider_relationship_permissions_path(
+                permissions_model,
+                anchor: "provider-interface-provider-relationship-permissions-setup-wizard-provider-relationship-permissions-#{permissions_model.id}-view-safeguarding-information-training-field",
+                skip_further_permissions: true,
+              ),
+            ) %>
+          </dd>
+        </div>
+      </dl>
     <% end %>
 
     <%= form_with model: @wizard, url: provider_interface_commit_provider_relationship_permissions_path do |f| %>
-		  <button class="govuk-button" data-module="govuk-button">
-			  Save permissions
+      <button class="govuk-button" data-module="govuk-button">
+        Save permissions
       </button>
     <% end %>
-	</div>
+  </div>
 </div>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content do %>
-  <%= link_to 'Back', provider_interface_setup_provider_relationship_permissions_path(@permissions_models.last), class: 'govuk-back-link' %>
+  <%= link_to 'Back', previous_page, class: 'govuk-back-link' %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -32,7 +32,7 @@
               provider_interface_setup_provider_relationship_permissions_path(
                 permissions_model,
                 anchor: "provider-interface-provider-relationship-permissions-setup-wizard-provider-relationship-permissions-#{permissions_model.id}-make-decisions-training-field",
-                skip_further_permissions: true,
+                checking_answers: true,
               ),
             )%>
           </dd>
@@ -58,7 +58,7 @@
               provider_interface_setup_provider_relationship_permissions_path(
                 permissions_model,
                 anchor: "provider-interface-provider-relationship-permissions-setup-wizard-provider-relationship-permissions-#{permissions_model.id}-view-safeguarding-information-training-field",
-                skip_further_permissions: true,
+                checking_answers: true,
               ),
             ) %>
           </dd>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/info.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/info.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content do %>
-  <%= link_to 'Back', provider_interface_provider_relationship_permissions_organisations_path, class: 'govuk-back-link' %>
+  <%= link_to 'Back', previous_page, class: 'govuk-back-link' %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_relationship_permissions_setup/info.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/info.html.erb
@@ -1,0 +1,28 @@
+<% content_for :before_content do %>
+  <%= link_to 'Back', provider_interface_provider_relationship_permissions_organisations_path, class: 'govuk-back-link' %>
+<% end %>
+
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+		<h1 class="govuk-heading-xl">
+			Understanding access and permissions
+		</h1>
+	</div>
+</div>
+
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds govuk-body">
+		<h2 class="govuk-heading-l">Access to applications</h2>
+		<p>All users at your organisation and ratifying organisation(s) will be able to view applications to your courses. You don't need to set permissions for this.</p>
+		<h2 class="govuk-heading-l">Permission to make decisions</h2>
+		<p>You can allow your organisation and ratifying organisation(s) to make offers, amend offers and reject applications.</p>
+		<h2 class="govuk-heading-l">Permission to view safeguarding information</h2>
+		<p>You can give your organisation and ratifying organisation(s) access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
+		<p>This may include highly sensitive material about the candidate.</p>
+		<h2 class="govuk-heading-l">Permission to view diversity information</h2>
+		<p>You can give your organisation and ratifying organisation(s) access to information disclosed by the candidate in the ‘equality and diversity’ section of the application.</p>
+		<p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted.</p>
+
+		<%= govuk_link_to 'Continue', provider_interface_setup_provider_relationship_permissions_path, class: 'govuk-button' %>
+	</div>
+</div>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/info.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/info.html.erb
@@ -3,26 +3,28 @@
 <% end %>
 
 <div class="govuk-grid-row">
-	<div class="govuk-grid-column-two-thirds">
-		<h1 class="govuk-heading-xl">
-			Understanding access and permissions
-		</h1>
-	</div>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Understanding access and permissions
+    </h1>
+  </div>
 </div>
 
 <div class="govuk-grid-row">
-	<div class="govuk-grid-column-two-thirds govuk-body">
-		<h2 class="govuk-heading-l">Access to applications</h2>
-		<p>All users at your organisation and ratifying organisation(s) will be able to view applications to your courses. You don't need to set permissions for this.</p>
-		<h2 class="govuk-heading-l">Permission to make decisions</h2>
-		<p>You can allow your organisation and ratifying organisation(s) to make offers, amend offers and reject applications.</p>
-		<h2 class="govuk-heading-l">Permission to view safeguarding information</h2>
-		<p>You can give your organisation and ratifying organisation(s) access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
-		<p>This may include highly sensitive material about the candidate.</p>
-		<h2 class="govuk-heading-l">Permission to view diversity information</h2>
-		<p>You can give your organisation and ratifying organisation(s) access to information disclosed by the candidate in the ‘equality and diversity’ section of the application.</p>
-		<p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted.</p>
+  <div class="govuk-grid-column-two-thirds govuk-body">
+    <h2 class="govuk-heading-l">Access to applications</h2>
+    <p>All users at your organisation and ratifying organisation(s) will be able to view applications to your courses. You don't need to set permissions for this.</p>
+    <h2 class="govuk-heading-l">Permission to make decisions</h2>
+    <p>You can allow your organisation and ratifying organisation(s) to make offers, amend offers and reject applications.</p>
+    <h2 class="govuk-heading-l">Permission to view safeguarding information</h2>
+    <p>You can give your organisation and ratifying organisation(s) access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
+    <p>This may include highly sensitive material about the candidate.</p>
+    <%#
+    <h2 class="govuk-heading-l">Permission to view diversity information</h2>
+    <p>You can give your organisation and ratifying organisation(s) access to information disclosed by the candidate in the ‘equality and diversity’ section of the application.</p>
+    <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted.</p>
+    %>
 
-		<%= govuk_link_to 'Continue', provider_interface_setup_provider_relationship_permissions_path, class: 'govuk-button' %>
-	</div>
+    <%= govuk_link_to 'Continue', provider_interface_setup_provider_relationship_permissions_path(@permissions_model), class: 'govuk-button' %>
+  </div>
 </div>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/organisations.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/organisations.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Set up permissions for your organisation
+      Set up permissions for your <%= 'organisation'.pluralize(@grouped_provider_names_from_relationships.keys.size) %>
     </h1>
   </div>
 </div>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/organisations.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/organisations.html.erb
@@ -1,0 +1,35 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Set up permissions for your organisation
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body">
+    <p>You can control who has access to sensitive information, and who can make decisions about applications.</p>
+    <p>We’ll ask you to set up the permissions between you and the organisations that ratify your courses.</p>
+    <p>You’ll then be able to choose permissions for any individual users you add to your organisation.</p>
+    <p>You can change these settings at any time.</p>
+
+    <h2 class="govuk-heading-m">The organisations you’ll need to set up</h2>
+
+    <% @grouped_provider_names_from_relationships.each do |training_provider_name, ratifying_provider_names| %>
+      <div class="app-application-card govuk-!-margin-bottom-7">
+        <div>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-0"><%= training_provider_name %></h2>
+
+          <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1 govuk-body">Organisations that ratify your courses:</p>
+          <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+          <% ratifying_provider_names.each do |ratifying_provider_name| %>
+            <li><%= ratifying_provider_name %></li>
+          <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+		<%= govuk_link_to 'Continue', provider_interface_provider_relationship_permissions_info_path, class: 'govuk-button' %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -1,0 +1,53 @@
+<% content_for :before_content do %>
+  <%= link_to 'Back', provider_interface_provider_relationship_permissions_info_path, class: 'govuk-back-link' %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl">Set up permissions</span>
+    <h1 class="govuk-heading-xl">For courses run by North Tomas SCITT and ratified by Dorotheaside Academy Alliance</h1>
+    <div class="app-banner">
+      <div class="app-banner__message">
+        <p>All users at your organisation and ratifying organisation(s) will be able to view applications to these courses. You don't need to set permissions for this.</p>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              More about permissions
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <h2 class="govuk-heading-m">Permission to make decisions</h2>
+            <p>You can allow an organisation to make offers, amend offers and reject applications.</p>
+            <h2 class="govuk-heading-m">Permission to view safeguarding information</h2>
+            <p>You can give an organisation access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
+            <p>This may include highly sensitive material about the candidate.</p>
+
+            <h2 class="govuk-heading-m">Permission to view diversity information</h2>
+            <p>You can give an organisation access to information disclosed by the candidate in the ‘equality and diversity’ section of the application. </p>
+
+            <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted. </p>
+          </div>
+        </details>
+      </div>
+    </div>
+
+    <%= form_with model: @wizard, url: provider_interface_save_provider_relationship_permissions_path(@permissions_model) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
+        <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">
+          <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: t("provider_relationship_permissions.form.fieldset.#{permission_name}") } do %>
+            <%= hidden_field_tag "#{f.object_name}[#{permission_name}][]", '' %>
+            <%= f.govuk_check_box permission_name, 'training', link_errors: true,
+                                  label: { text: @permissions_model.training_provider.name } %>
+
+            <%= f.govuk_check_box permission_name, 'ratifying',
+                                  label: { text: @permissions_model.ratifying_provider.name } %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -1,16 +1,17 @@
 <% content_for :before_content do %>
-  <%= link_to 'Back', provider_interface_provider_relationship_permissions_info_path, class: 'govuk-back-link' %>
+  <%= link_to 'Back', previous_page, class: 'govuk-back-link' %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">Set up permissions</span>
-    <h1 class="govuk-heading-xl">For courses run by <%= @permissions_model.training_provider.name %> and ratified by <%= @permissions_model.ratifying_provider.name %></h1>
 
     <%= form_with model: @wizard, url: provider_interface_save_provider_relationship_permissions_path(@permissions_model) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= hidden_field_tag :skip_further_permissions, params[:skip_further_permissions] %>
+      <%= hidden_field_tag :checking_answers, params[:checking_answers] %>
+
+      <span class="govuk-caption-xl">Set up permissions</span>
+      <h1 class="govuk-heading-xl">For courses run by <%= @permissions_model.training_provider.name %> and ratified by <%= @permissions_model.ratifying_provider.name %></h1>
 
       <div class="app-banner">
         <div class="app-banner__message">

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -5,46 +5,51 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">Set up permissions</span>
-    <h1 class="govuk-heading-xl">For courses run by North Tomas SCITT and ratified by Dorotheaside Academy Alliance</h1>
-    <div class="app-banner">
-      <div class="app-banner__message">
-        <p>All users at your organisation and ratifying organisation(s) will be able to view applications to these courses. You don't need to set permissions for this.</p>
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              More about permissions
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <h2 class="govuk-heading-m">Permission to make decisions</h2>
-            <p>You can allow an organisation to make offers, amend offers and reject applications.</p>
-            <h2 class="govuk-heading-m">Permission to view safeguarding information</h2>
-            <p>You can give an organisation access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
-            <p>This may include highly sensitive material about the candidate.</p>
-
-            <h2 class="govuk-heading-m">Permission to view diversity information</h2>
-            <p>You can give an organisation access to information disclosed by the candidate in the ‘equality and diversity’ section of the application. </p>
-
-            <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted. </p>
-          </div>
-        </details>
-      </div>
-    </div>
+    <h1 class="govuk-heading-xl">For courses run by <%= @permissions_model.training_provider.name %> and ratified by <%= @permissions_model.ratifying_provider.name %></h1>
 
     <%= form_with model: @wizard, url: provider_interface_save_provider_relationship_permissions_path(@permissions_model) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
-        <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">
-          <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: t("provider_relationship_permissions.form.fieldset.#{permission_name}") } do %>
-            <%= hidden_field_tag "#{f.object_name}[#{permission_name}][]", '' %>
-            <%= f.govuk_check_box permission_name, 'training', link_errors: true,
-                                  label: { text: @permissions_model.training_provider.name } %>
+      <%= hidden_field_tag :skip_further_permissions, params[:skip_further_permissions] %>
 
-            <%= f.govuk_check_box permission_name, 'ratifying',
-                                  label: { text: @permissions_model.ratifying_provider.name } %>
-          <% end %>
+      <div class="app-banner">
+        <div class="app-banner__message">
+          <p>All users at your organisation and ratifying organisation(s) will be able to view applications to these courses. You don't need to set permissions for this.</p>
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                More about permissions
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <h2 class="govuk-heading-m">Permission to make decisions</h2>
+              <p>You can allow an organisation to make offers, amend offers and reject applications.</p>
+              <h2 class="govuk-heading-m">Permission to view safeguarding information</h2>
+              <p>You can give an organisation access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
+              <p>This may include highly sensitive material about the candidate.</p>
+
+              <h2 class="govuk-heading-m">Permission to view diversity information</h2>
+              <p>You can give an organisation access to information disclosed by the candidate in the ‘equality and diversity’ section of the application. </p>
+
+              <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted. </p>
+            </div>
+          </details>
         </div>
+      </div>
+
+      <%= f.fields_for "provider_relationship_permissions[]", @permissions_form do |pf| %>
+        <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
+          <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">
+            <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: t("provider_relationship_permissions.form.fieldset.#{permission_name}") } do %>
+              <%= hidden_field_tag "#{pf.object_name}[#{permission_name}][]", '' %>
+              <%= pf.govuk_check_box permission_name, 'training', link_errors: true,
+                                     label: { text: @permissions_model.training_provider.name } %>
+
+              <%= pf.govuk_check_box permission_name, 'ratifying',
+                                     label: { text: @permissions_model.ratifying_provider.name } %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -39,7 +39,7 @@
 
       <%= f.fields_for "provider_relationship_permissions[]", @permissions_form do |pf| %>
         <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
-          <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">
+          <div class="govuk-form-group <%= permission_name.to_s.dasherize %>" id="<%= permission_name %>">
             <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: t("provider_relationship_permissions.form.fieldset.#{permission_name}") } do %>
               <%= hidden_field_tag "#{pf.object_name}[#{permission_name}][]", '' %>
               <%= pf.govuk_check_box permission_name, 'training', link_errors: true,

--- a/app/views/provider_interface/provider_relationship_permissions_setup/success.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/success.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Permissions successfully set up
+      </h1>
+    </div>
+
+    <h2 class="govuk-heading-m">
+      Changing permissions
+    </h2>
+
+    <p class="govuk-body">
+      Select <%= govuk_link_to 'Organisations', provider_interface_organisations_path %> (at the top of every page) to update your permissions.
+    </p><p>
+
+    </p><h2 class="govuk-heading-m">
+      Inviting users
+    </h2>
+
+    <p class="govuk-body">
+      Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
+    </p><p>
+
+    </p><h2 class="govuk-heading-m">
+      Manage your applications
+    </h2>
+
+    <p class="govuk-body">
+      Continue to your applications.
+    </p>
+    <p>
+      <%= govuk_link_to 'Continue', provider_interface_applications_path, class: 'govuk-button' %>
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -597,16 +597,27 @@ Rails.application.routes.draw do
 
     resources :organisations, only: %i[index show], path: 'organisations'
 
-    get '/provider-relationship-permissions/setup' => 'provider_relationship_permissions#setup',
-        as: :provider_relationship_permissions_setup
-    get '/provider-relationship-permissions/:id/success' => 'provider_relationship_permissions#success',
-        as: :provider_relationship_permissions_success
-    get '/provider-relationship-permissions/:id/edit' => 'provider_relationship_permissions#edit',
-        as: :edit_provider_relationship_permissions
-    patch '/provider-relationship-permissions/:id/confirm' => 'provider_relationship_permissions#confirm',
-          as: :confirm_provider_relationship_permissions
-    patch '/provider-relationship-permissions/:id' => 'provider_relationship_permissions#update',
-          as: :update_provider_relationship_permissions
+    scope path: '/provider-relationship-permissions' do
+      get '/start' => 'provider_relationship_permissions_start#start',
+          as: :provider_relationship_permissions_start
+      get '/providers' => 'provider_relationship_permissions_setup#organisations',
+          as: :provider_relationship_permissions_organisations
+      get '/information' => 'provider_relationship_permissions_setup#info',
+          as: :provider_relationship_permissions_info
+      get '/:id/setup' => 'provider_relationship_permissions_setup#setup_permissions',
+          as: :setup_provider_relationship_permissions
+      patch '/:id/create' => 'provider_relationship_permissions_setup#save_permissions',
+            as: :save_provider_relationship_permissions
+      get '/:id/check' => 'provider_relationship_permissions_setup#check',
+          as: :check_provider_relationship_permissions
+      patch '/:id/commit' => 'provider_relationship_permissions#commit',
+            as: :commit_provider_relationship_permissions
+
+      get '/:id/edit' => 'provider_relationship_permissions#edit',
+          as: :edit_provider_relationship_permissions
+      patch '/:id' => 'provider_relationship_permissions#update',
+            as: :update_provider_relationship_permissions
+    end
   end
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -610,6 +610,8 @@ Rails.application.routes.draw do
           as: :check_provider_relationship_permissions
       post '/commit' => 'provider_relationship_permissions_setup#commit',
            as: :commit_provider_relationship_permissions
+      get '/success' => 'provider_relationship_permissions_setup#success',
+          as: :provider_relationship_permissions_success
 
       get '/:id/edit' => 'provider_relationship_permissions#edit',
           as: :edit_provider_relationship_permissions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -598,20 +598,18 @@ Rails.application.routes.draw do
     resources :organisations, only: %i[index show], path: 'organisations'
 
     scope path: '/provider-relationship-permissions' do
-      get '/start' => 'provider_relationship_permissions_start#start',
-          as: :provider_relationship_permissions_start
-      get '/providers' => 'provider_relationship_permissions_setup#organisations',
+      get '/organisations-to-setup' => 'provider_relationship_permissions_setup#organisations',
           as: :provider_relationship_permissions_organisations
       get '/information' => 'provider_relationship_permissions_setup#info',
           as: :provider_relationship_permissions_info
       get '/:id/setup' => 'provider_relationship_permissions_setup#setup_permissions',
           as: :setup_provider_relationship_permissions
-      patch '/:id/create' => 'provider_relationship_permissions_setup#save_permissions',
-            as: :save_provider_relationship_permissions
-      get '/:id/check' => 'provider_relationship_permissions_setup#check',
+      post '/:id/create' => 'provider_relationship_permissions_setup#save_permissions',
+           as: :save_provider_relationship_permissions
+      get '/check' => 'provider_relationship_permissions_setup#check',
           as: :check_provider_relationship_permissions
-      patch '/:id/commit' => 'provider_relationship_permissions#commit',
-            as: :commit_provider_relationship_permissions
+      post '/commit' => 'provider_relationship_permissions_setup#commit',
+           as: :commit_provider_relationship_permissions
 
       get '/:id/edit' => 'provider_relationship_permissions#edit',
           as: :edit_provider_relationship_permissions

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
+  def state_store_for(state)
+    { described_class::STATE_STORE_KEY => state.to_json }
+  end
+
+  describe 'next_step' do
+    it 'returns the permissions info page from the provider relationships page' do
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, current_step: 'provider_relationships')
+      expect(wizard.next_step).to eq([:info])
+    end
+
+    it 'returns the first provider relationship permissions page from the info page' do
+      state_store = state_store_for({ provider_relationships: [123, 456] })
+      wizard = described_class.new(state_store, current_step: 'info')
+      expect(wizard.next_step).to eq([:permissions, 123])
+    end
+
+    it 'returns the second provider relationship permissions page from the first provider relationship permissions page' do
+      state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {} } })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '123')
+      expect(wizard.next_step).to eq([:permissions, 456])
+    end
+
+    it 'returns the review page from the last provider relationship permissions page' do
+      state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {}, 456 => {} } })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '456')
+      expect(wizard.next_step).to eq([:check])
+    end
+  end
+
+  describe 'previous_step' do
+    it 'returns the start page from the provider relationships page' do
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, current_step: 'provider_relationships')
+      expect(wizard.previous_step).to eq([:start])
+    end
+
+    it 'returns provider relationships page from the permissions info page' do
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, current_step: 'info')
+      expect(wizard.previous_step).to eq([:provider_relationships])
+    end
+
+    it 'returns the permissions information page from the first provider permissions page' do
+      state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {} } })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '123')
+      expect(wizard.previous_step).to eq([:info])
+    end
+
+    it 'returns the first provider relationship permissions page from the last provider relationship permissions page' do
+      state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {}, 456 => {} } })
+      wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '456')
+      expect(wizard.previous_step).to eq([:permissions, 123])
+    end
+
+    it 'returns the last provider relationship permissions page from the review page' do
+      state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {}, 456 => {} } })
+      wizard = described_class.new(state_store, current_step: 'check')
+      expect(wizard.previous_step).to eq([:permissions, 456])
+    end
+  end
+
+  describe 'initializer' do
+    it 'deserializes state' do
+      state_store = state_store_for({
+        provider_relationships: [123],
+        provider_relationship_permissions: { 123 => { make_decisions: %w[ratifying training], view_safeguarding_information: %w[training] } },
+      })
+
+      wizard = described_class.new(state_store, current_step: 'permissions')
+
+      expect(wizard.provider_relationships).to eq([123])
+      expect(wizard.provider_relationship_permissions['123']).to eq({
+        'make_decisions' => %w[ratifying training],
+        'view_safeguarding_information' => %w[training],
+      })
+    end
+  end
+
+  describe '#save_state!' do
+    it 'serializes state to state store' do
+      state_store = state_store_for({
+        provider_relationships: [123],
+        provider_relationship_permissions: { 123 => { make_decisions: %w[ratifying training], view_safeguarding_information: %w[training] } },
+      })
+      wizard = described_class.new(state_store)
+
+      wizard.save_state!
+
+      expect(JSON.parse(state_store[described_class::STATE_STORE_KEY]).symbolize_keys).to eq({
+        provider_relationships: [123],
+        provider_relationship_permissions: {
+          '123' => {
+            'make_decisions' => %w[ratifying training],
+            'view_safeguarding_information' => %w[training],
+          },
+        },
+      })
+    end
+  end
+
+  describe '#clear_state!' do
+    it 'purges all state' do
+      state_store = state_store_for({})
+      wizard = described_class.new(state_store, current_step: 'info')
+
+      wizard.clear_state!
+
+      expect(state_store[described_class::STATE_STORE_KEY]).to be_nil
+    end
+  end
+end

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
   describe 'next_step' do
     it 'returns the permissions info page from the provider relationships page' do
       state_store = state_store_for({})
-      wizard = described_class.new(state_store, current_step: 'provider_relationships')
+      wizard = described_class.new(state_store, current_step: 'organisations')
       expect(wizard.next_step).to eq([:info])
     end
 
@@ -30,10 +30,10 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
       expect(wizard.next_step).to eq([:check])
     end
 
-    context 'with skip_further_permissions param present' do
+    context 'with checking_answers param present' do
       it 'returns the review page from the first provider relationship permissions page' do
         state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {}, 456 => {} } })
-        wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '123', skip_further_permissions: true)
+        wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '123', checking_answers: true)
         expect(wizard.next_step).to eq([:check])
       end
     end
@@ -42,14 +42,14 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
   describe 'previous_step' do
     it 'returns the start page from the provider relationships page' do
       state_store = state_store_for({})
-      wizard = described_class.new(state_store, current_step: 'provider_relationships')
+      wizard = described_class.new(state_store, current_step: 'organisations')
       expect(wizard.previous_step).to eq([:start])
     end
 
     it 'returns provider relationships page from the permissions info page' do
       state_store = state_store_for({})
       wizard = described_class.new(state_store, current_step: 'info')
-      expect(wizard.previous_step).to eq([:provider_relationships])
+      expect(wizard.previous_step).to eq([:organisations])
     end
 
     it 'returns the permissions information page from the first provider permissions page' do
@@ -68,6 +68,14 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
       state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {}, 456 => {} } })
       wizard = described_class.new(state_store, current_step: 'check')
       expect(wizard.previous_step).to eq([:permissions, 456])
+    end
+
+    context 'with checking_answers param present' do
+      it 'returns to the review page from the last provider relationship permissions page' do
+        state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {}, 456 => {} } })
+        wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '456', checking_answers: true)
+        expect(wizard.previous_step).to eq([:check])
+      end
     end
   end
 

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
 
     it 'merges permissions attributes' do
       state_store = state_store_for({
-        provider_relationships: [123],
-        provider_relationship_permissions: { 123 => { make_decisions: %w[ratifying training], view_safeguarding_information: %w[training] } },
+        provider_relationships: [123, 456],
+        provider_relationship_permissions: { '123' => { 'make_decisions' => %w[ratifying training], 'view_safeguarding_information' => %w[training] } },
       })
 
       wizard = described_class.new(state_store, current_step: 'permissions')
@@ -90,9 +90,11 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
 
       attrs = {
         'current_step' => 'permissions',
-        'current_provider_relationship_id' => '456',
-        'make_decisions' => %w[training],
-        'view_safeguarding_information' => %w[training ratifying],
+        'provider_relationship_permissions' => {
+          '456' => {
+            'make_decisions' => %w[training], 'view_safeguarding_information' => %w[training ratifying]
+          },
+        },
       }
 
       wizard = described_class.new(state_store, attrs)
@@ -105,7 +107,11 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
   describe 'validations' do
     context 'when no providers are selected for a permission' do
       it 'is invalid' do
-        wizard = described_class.new(state_store_for({}), make_decisions: [''], view_safeguarding_information: %w[training])
+        wizard = described_class.new(
+          state_store_for({}),
+          'current_provider_relationship_id' => '123',
+          'provider_relationship_permissions' => { '123' => { 'make_decisions' => [''], 'view_safeguarding_information' => %w[training] } },
+        )
 
         expect(wizard.valid?(:permissions)).to be false
         expect(wizard.errors.keys).to eq(%i[make_decisions])

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
       wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '456')
       expect(wizard.next_step).to eq([:check])
     end
+
+    context 'with skip_further_permissions param present' do
+      it 'returns the review page from the first provider relationship permissions page' do
+        state_store = state_store_for({ provider_relationships: [123, 456], provider_relationship_permissions: { 123 => {}, 456 => {} } })
+        wizard = described_class.new(state_store, current_step: 'permissions', current_provider_relationship_id: '123', skip_further_permissions: true)
+        expect(wizard.next_step).to eq([:check])
+      end
+    end
   end
 
   describe 'previous_step' do

--- a/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
@@ -107,4 +107,40 @@ RSpec.describe 'Set up ProviderRelationshipPermissions', type: :request do
       end
     end
   end
+
+  describe 'when the current user does not have permission to manage organisations' do
+    before do
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: create(:provider),
+        training_provider: provider,
+        setup_at: Time.zone.now,
+      )
+    end
+
+    it 'responds with 404' do
+      get provider_interface_provider_relationship_permissions_organisations_path
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe 'when no permissions need setup' do
+    before do
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: create(:provider),
+        training_provider: provider,
+        setup_at: Time.zone.now,
+      )
+      provider_user.provider_permissions.update_all(manage_organisations: true)
+    end
+
+    it 'redirects to the applications path' do
+      get provider_interface_provider_relationship_permissions_organisations_path
+
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to match(/\/provider\/applications$/)
+    end
+  end
 end

--- a/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'Set up ProviderRelationshipPermissions', type: :request do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    FeatureFlag.activate(:enforce_provider_to_provider_permissions)
+
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  describe 'invalid provider relationship params' do
+    context 'GET edit' do
+      it 'responds with 404' do
+        get provider_interface_provider_relationship_permissions_organisations_path
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'GET info' do
+      it 'responds with 404' do
+        get provider_interface_provider_relationship_permissions_info_path
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'GET set_permissions' do
+      it 'responds with 404' do
+        get provider_interface_setup_provider_relationship_permissions_path(id: 1)
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'POST save_permissions' do
+      it 'responds with 404' do
+        post provider_interface_save_provider_relationship_permissions_path(id: 1)
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'GET check' do
+      it 'responds with 404' do
+        get provider_interface_check_provider_relationship_permissions_path
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context 'POST commit' do
+      it 'responds with 404' do
+        post provider_interface_commit_provider_relationship_permissions_path
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe 'with a provider relationship not associated with the current user' do
+    let(:ratifying_provider) { create(:provider) }
+    let(:training_provider) { create(:provider) }
+
+    let(:permissions) do
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: training_provider,
+        setup_at: nil,
+      )
+    end
+
+    before do
+      create(
+        :provider_relationship_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: provider,
+        setup_at: nil,
+      )
+      provider_user.provider_permissions.update_all(manage_organisations: true)
+    end
+
+    context 'GET setup_permissions' do
+      it 'responds with 403 Forbidden' do
+        get provider_interface_setup_provider_relationship_permissions_path(permissions.id)
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    describe 'POST save_permissions' do
+      it 'responds with 403 Forbidden' do
+        post provider_interface_save_provider_relationship_permissions_path(permissions.id)
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/services/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/services/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::SetupProviderRelationshipPermissions do
+  describe '.call' do
+    let(:permission_1) { create(:provider_relationship_permissions, setup_at: nil) }
+    let(:permission_2) { create(:provider_relationship_permissions, setup_at: nil) }
+
+    context 'with valid data' do
+      let(:permissions_data) do
+        {
+          permission_1.id => { 'make_decisions' => %w[training], 'view_safeguarding_information' => %w[training ratifying] },
+          permission_2.id => { 'make_decisions' => %w[ratifying], 'view_safeguarding_information' => %w[training] },
+        }
+      end
+
+      it 'returns true' do
+        expect(described_class.call(permissions_data)).to be true
+      end
+
+      it 'updates a batch of ProviderRelationshipPermissions records' do
+        described_class.call(permissions_data)
+        permission_1.reload
+        permission_2.reload
+
+        expect(permission_1.setup_at).not_to be_a DateTime
+        expect(permission_1.training_provider_can_make_decisions).to be true
+        expect(permission_1.ratifying_provider_can_make_decisions).to be false
+        expect(permission_1.training_provider_can_view_safeguarding_information).to be true
+        expect(permission_1.ratifying_provider_can_view_safeguarding_information).to be true
+
+        expect(permission_2.setup_at).not_to be_a DateTime
+        expect(permission_2.training_provider_can_make_decisions).to be false
+        expect(permission_2.ratifying_provider_can_make_decisions).to be true
+        expect(permission_2.training_provider_can_view_safeguarding_information).to be true
+        expect(permission_2.ratifying_provider_can_view_safeguarding_information).to be false
+      end
+    end
+
+    context 'when attempting to update a record which does not exist' do
+      it 'raises the underlying ActiveRecord error' do
+        expect { described_class.call('666' => {}) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when attempting to update raises an error' do
+      let(:permissions_data) do
+        {
+          permission_1.id => { 'make_decisions' => %w[training], 'view_safeguarding_information' => %w[ratifying] },
+          permission_2.id => { 'make_decisions' => [''], 'view_safeguarding_information' => [''] },
+        }
+      end
+
+      it 'returns false and rolls back updates to other permissions in the call' do
+        expect { described_class.call(permissions_data) }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(permission_1.reload.setup_at).to be nil
+      end
+    end
+
+    context 'when a record has been set up' do
+      let(:permission) { create(:provider_relationship_permissions) }
+      let(:permissions_data) { { permission.id => { 'make_decisions' => %w[training], 'view_safeguarding_information' => %w[ratifying] } } }
+
+      it 'raises ProviderInterface::PermissionsSetupError' do
+        expect { described_class.call(permissions_data) }.to raise_error(ProviderInterface::PermissionsSetupError)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -20,8 +20,12 @@ RSpec.feature 'Setting up provider relationship permissions' do
 
     when_i_choose_permissions_for_the_first_provider_relationship
     and_i_choose_permissions_for_the_next_provider_relationship
-    and_i_confirm_my_choices
+    then_i_can_see_the_permissions_summary_page
 
+    when_i_change_permissions_for_the_first_provider_relationship
+    then_i_return_to_the_permissions_summary_page
+
+    when_i_confirm_the_updated_permissions
     then_i_see_permissions_setup_has_finished
 
     when_i_click_continue
@@ -112,11 +116,65 @@ RSpec.feature 'Setting up provider relationship permissions' do
     click_on 'Continue'
   end
 
-  def and_i_confirm_my_choices
-    expect(page).to have_content("The following organisation(s) can make decisions:\n#{@training_provider.name}")
-    expect(page).to have_content("The following organisation(s) can view safeguarding information:\n#{@another_ratifying_provider.name}")
+  def then_i_can_see_the_permissions_summary_page
+    expect(page).to have_content(
+      [
+        "For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}",
+        'Which organisations can make decisions?',
+        @training_provider.name,
+        'Change',
+        'Which organisations can view safeguarding information?',
+        @training_provider.name,
+      ].join("\n"),
+    )
+
+    expect(page).to have_content(
+      [
+        "For courses run by #{@another_training_provider.name} and ratified by #{@another_ratifying_provider.name}",
+        'Which organisations can make decisions?',
+        @another_ratifying_provider.name,
+        'Change',
+        'Which organisations can view safeguarding information?',
+        @another_ratifying_provider.name,
+      ].join("\n"),
+    )
+  end
+
+  def when_i_confirm_the_updated_permissions
+    expect(page).to have_content(
+      [
+        "For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}",
+        'Which organisations can make decisions?',
+        "#{@training_provider.name} #{@ratifying_provider.name}",
+        'Change',
+        'Which organisations can view safeguarding information?',
+        @training_provider.name,
+      ].join("\n"),
+    )
+
+    expect(page).to have_content(
+      [
+        "For courses run by #{@another_training_provider.name} and ratified by #{@another_ratifying_provider.name}",
+        'Which organisations can make decisions?',
+        @another_ratifying_provider.name,
+        'Change',
+        'Which organisations can view safeguarding information?',
+        @another_ratifying_provider.name,
+      ].join("\n"),
+    )
 
     click_on 'Save permissions'
+  end
+
+  def when_i_change_permissions_for_the_first_provider_relationship
+    click_on 'Change', match: :first
+
+    within(find('.make-decisions')) { check @ratifying_provider.name }
+    click_on 'Continue'
+  end
+
+  def then_i_return_to_the_permissions_summary_page
+    expect(page).to have_content("Which organisations can make decisions?\n#{@training_provider.name} #{@ratifying_provider.name}\n")
   end
 
   def then_i_see_permissions_setup_has_finished

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.feature 'Setting up provider relationship permissions' do
+  include DfESignInHelpers
+
+  scenario 'Provider user sets up permissions for their organisation' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_permissions_feature_is_enabled
+    and_i_can_manage_organisations
+    and_my_organisations_have_not_had_permissions_setup
+
+    when_i_sign_in_to_the_provider_interface
+    then_i_can_see_the_organisations_needing_permissions_setup
+
+    when_i_click_continue
+    then_i_can_see_general_information_about_permissions
+
+    when_i_click_continue
+    then_i_can_see_the_permissions_setup_page
+
+    when_i_choose_permissions_for_the_first_provider_relationship
+    and_i_choose_permissions_for_the_next_provider_relationship
+    and_i_confirm_my_choices
+
+    then_i_see_permissions_setup_has_finished
+
+    when_i_click_continue
+    then_i_can_see_candidate_applications
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def and_the_provider_permissions_feature_is_enabled
+    FeatureFlag.activate('enforce_provider_to_provider_permissions')
+  end
+
+  def and_i_can_manage_organisations
+    @provider_user = ProviderUser.last
+    @training_provider = Provider.find_by(code: 'ABC')
+    @ratifying_provider = Provider.find_by(code: 'DEF')
+
+    @another_training_provider = create(:provider, :with_signed_agreement)
+    @another_ratifying_provider = create(:provider, :with_signed_agreement)
+    @provider_user.providers << @another_training_provider
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
+  end
+
+  def and_my_organisations_have_not_had_permissions_setup
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @training_provider,
+      training_provider_can_make_decisions: false,
+      training_provider_can_view_safeguarding_information: false,
+      setup_at: nil,
+    )
+
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @another_ratifying_provider,
+      training_provider: @another_training_provider,
+      training_provider_can_make_decisions: false,
+      training_provider_can_view_safeguarding_information: false,
+      setup_at: nil,
+    )
+  end
+
+  alias_method :when_i_sign_in_to_the_provider_interface, :and_i_sign_in_to_the_provider_interface
+
+  def then_i_can_see_the_organisations_needing_permissions_setup
+    expect(page).to have_content('Set up permissions for your organisation')
+    expect(page).to have_content('The organisations you’ll need to set up')
+    expect(page).to have_content(@training_provider.name)
+    expect(page).to have_content(@ratifying_provider.name)
+    expect(page).to have_content(@another_training_provider.name)
+    expect(page).to have_content(@another_ratifying_provider.name)
+  end
+
+  def when_i_click_continue
+    click_on 'Continue'
+  end
+
+  alias_method :and_i_click_continue, :when_i_click_continue
+
+  def then_i_can_see_general_information_about_permissions
+    expect(page).to have_content('Understanding access and permissions')
+    expect(page).to have_content('Access to applications')
+    expect(page).to have_content('Permission to make decisions')
+    expect(page).to have_content('Permission to view safeguarding information')
+  end
+
+  def then_i_can_see_the_permissions_setup_page
+    expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
+  end
+
+  def when_i_choose_permissions_for_the_first_provider_relationship
+    within(find('.make-decisions')) { check @training_provider.name }
+    within(find('.view-safeguarding-information')) { check @training_provider.name }
+
+    click_on 'Continue'
+  end
+
+  def and_i_choose_permissions_for_the_next_provider_relationship
+    expect(page).to have_content("For courses run by #{@another_training_provider.name} and ratified by #{@another_ratifying_provider.name}")
+
+    within(find('.make-decisions')) { check @another_ratifying_provider.name }
+    within(find('.view-safeguarding-information')) { check @another_ratifying_provider.name }
+
+    click_on 'Continue'
+  end
+
+  def and_i_confirm_my_choices
+    expect(page).to have_content("The following organisation(s) can make decisions:\n#{@training_provider.name}")
+    expect(page).to have_content("The following organisation(s) can view safeguarding information:\n#{@another_ratifying_provider.name}")
+
+    click_on 'Save permissions'
+  end
+
+  def then_i_see_permissions_setup_has_finished
+    expect(page).to have_content('Permissions successfully set up')
+  end
+
+  def then_i_can_see_candidate_applications
+    expect(page).to have_css('h1.govuk-heading-xl', text: 'Applications')
+  end
+end


### PR DESCRIPTION
## Context

When a new provider organisation is onboarded an elected user will need to select organisation permissions for the training and ratifying provider if such a relationship exists.

See https://manage-applications-beta.herokuapp.com/onboard/step1

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a setup wizard for `ProviderRelationshipPermissions` - these are records which store permissions where a training provider runs courses ratified by another provider, these permissions can be shared between the providers.

The wizard has several steps and one recursive permissions setting step for each relationship record for the training provider.

Users can change permissions on the confirmation screen, in this case they are returned directly to the confirmation screen instead of repeating permissions setup for other relationships.

To start the wizard:
https://apply-for-te-2495-imple-kmf77h.herokuapp.com/provider/provider-relationship-permissions/organisations-to-setup

 
<!-- If there are UI changes, please include Before and After screenshots. -->

### Step 1. Provider relationships requiring permissions setup

![image](https://user-images.githubusercontent.com/93511/89528854-a8eeed00-d7e3-11ea-8e79-48edca5770f7.png)

### Step 2. General permissions information

![image](https://user-images.githubusercontent.com/93511/89528907-bdcb8080-d7e3-11ea-8e9c-a2b55902a0e7.png)

### Step 3. Set permissions for first provider relationship

![image](https://user-images.githubusercontent.com/93511/89528961-d340aa80-d7e3-11ea-822c-a50b62b7a7ba.png)

### Step 3. Set permissions for second provider relationship

![image](https://user-images.githubusercontent.com/93511/89529024-ece1f200-d7e3-11ea-83bf-bf9a309d2a51.png)

### Step 4. Confirm permissions

![image](https://user-images.githubusercontent.com/93511/89802122-f2fc0980-db28-11ea-8128-4edf30b6e09d.png)

### Step 5. End of wizard

![image](https://user-images.githubusercontent.com/93511/89529813-4139a180-d7e5-11ea-908b-3ed99b0db260.png)



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/V6FgAN6g/2495-implement-the-provider-permissions-setup-flow

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
