### PR TITLE
Show DSA errors at top of the page without the ul bullet

### DIFF
--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -19,15 +19,6 @@ module ProviderInterface
       end
     end
 
-    def show_data_sharing_agreement
-      @provider_agreement = ProviderAgreement.find_by_id params[:id]
-      if @provider_agreement
-        render :data_sharing_agreement
-      else
-        redirect_to provider_interface_path
-      end
-    end
-
   private
 
     def provider_agreement_params

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -1,17 +1,13 @@
 <%= content_for :browser_title, t('page_titles.data_sharing_agreement') %>
 
-<% if @provider_agreement.persisted? %>
-  <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-9">
-    <div class="govuk-panel__body">
-      <strong><%= @provider_agreement.provider.name %></strong>
-      agreed with the practices outlined in this document on
-      <%= @provider_agreement.accepted_at.to_s(:govuk_date_and_time) %>
-    </div>
-  </div>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+  <%= form_with model: @provider_agreement, url: provider_interface_create_data_sharing_agreement_path, html: { novalidate: false } do |f| %>
+
+    <%= f.govuk_error_summary %>
+    <%= f.hidden_field :agreement_type %>
+    <%= f.hidden_field :provider_id %>
+
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"><%= t('page_titles.data_sharing_agreement') %></h1>
     <p class="govuk-body-l">This agreement applies to personal data shared between the Department for Education (DfE) and <%= @provider_agreement.provider.name %>, ‘the provider’, as part of Apply for teacher training.</p>
 
@@ -350,17 +346,17 @@
       </ul>
       <p>In the event of a significant security breach or other serious breach of the terms of this DSA by either participant, the DSA will be terminated or suspended immediately without notice.</p>
 
-      <% if !@provider_agreement.persisted? %>
-        <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-        <%= form_with model: @provider_agreement, url: provider_interface_create_data_sharing_agreement_path, html: { novalidate: false } do |f| %>
-          <%= f.govuk_error_summary %>
-          <%= f.hidden_field :agreement_type %>
-          <%= f.hidden_field :provider_id %>
-          <% declaration = "#{@provider_agreement.provider.name} agrees to comply with the data sharing practices outlined in this agreement" %>
-          <%= f.govuk_check_box :accept_agreement, true, multiple: false, link_errors: true, label: { text: declaration } %>
-          <%= f.govuk_submit 'Continue' %>
-        <% end %>
+      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+
+      <% declaration = "#{@provider_agreement.provider.name} agrees to comply with the data sharing practices outlined in this agreement" %>
+
+      <%= f.govuk_check_boxes_fieldset :accept_agreement do %>
+        <%= f.govuk_check_box :accept_agreement, true, multiple: false, link_errors: true, label: { text: declaration } %>
       <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
     </div>
+
+  <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -530,7 +530,6 @@ Rails.application.routes.draw do
 
     get '/data-sharing-agreements/new', to: 'provider_agreements#new_data_sharing_agreement', as: :new_data_sharing_agreement
     post '/data-sharing-agreements', to: 'provider_agreements#create_data_sharing_agreement', as: :create_data_sharing_agreement
-    get '/data-sharing-agreements/:id', to: 'provider_agreements#show_data_sharing_agreement', as: :show_data_sharing_agreement
 
     get '/applications' => 'application_choices#index'
 


### PR DESCRIPTION
## Context

Error summaries are meant to be shown at the top of the page, with a link to the relevant field that failed validation. This is what currently happens if a provider users submits the data sharing agreement form without ticking the box:

![image](https://user-images.githubusercontent.com/107591/89427182-de87cd80-d732-11ea-9f07-e36bcf68aa8e.png)

## Changes proposed in this pull request

I've removed a conditional showing details of when the DSA was signed if the agreement has already been signed, as we never really used this. This made it easier to open the form at the top of the page and move the error summary there.

![image](https://user-images.githubusercontent.com/107591/89427434-2575c300-d733-11ea-9a0d-9646adbd4f60.png)

and

![image](https://user-images.githubusercontent.com/107591/89523889-835de580-d7db-11ea-87e5-f007642298a3.png)
## Guidance to review

Is there another form helper I should be using instead of `form_with`?

## Link to Trello card

https://trello.com/c/fUwbkTAn

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
