### PR TITLE
Banners don’t need bottom margin class

### DIFF
--- a/app/components/candidate_interface/apply_again_banner_component.html.erb
+++ b/app/components/candidate_interface/apply_again_banner_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-banner govuk-!-margin-bottom-7">
+<div class="app-banner">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m">
       <% if @application_form.application_choices.all?(&:cancelled?) %>

--- a/app/components/candidate_interface/covid19_dashboard_banner_component.html.erb
+++ b/app/components/candidate_interface/covid19_dashboard_banner_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-banner govuk-!-margin-bottom-7">
+<div class="app-banner">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
     <p class="govuk-body">

--- a/app/components/candidate_interface/ucas_downtime_component.html.erb
+++ b/app/components/candidate_interface/ucas_downtime_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
+<div class="app-banner app-banner--warning">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m">UCAS planned maintenance</h2>
     <p class="govuk-body">UCAS services won’t be available from 6pm on Friday 24 April until Sunday 26 April.</p>

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -12,7 +12,7 @@
 
       <p class="govuk-body">This service is new so it’s not ready for everyone yet. Check if we’re ready for you by answering the questions below.</p>
 
-      <p class="govuk-body govuk-!-margin-bottom-7">If you can’t use our service, you can still apply for teacher training through&nbsp;<%= govuk_link_to 'UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %>.</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">If you can’t use our service, you can still apply for teacher training through&nbsp;<%= govuk_link_to 'UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %>.</p>
 
       <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK or the EU?', tag: 'span' } do %>
         <%= f.govuk_radio_button :eligible_citizen, 'yes', label: { text: 'Yes' }, link_errors: true %>

--- a/app/views/provider_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/provider_interface/sessions/authentication_fallback.html.erb
@@ -3,11 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
-        <div class="app-banner__message">
-          <h2 class="govuk-heading-m">Temporary login</h2>
-          <p>DfE Sign In is is experiencing problems. You need to sign in using your email address.</p>
-        </div>
+    <div class="app-banner app-banner--warning">
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m">Temporary login</h2>
+        <p>DfE Sign In is is experiencing problems. You need to sign in using your email address.</p>
+      </div>
     </div>
 
     <h1 class="govuk-heading-xl">

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -5,11 +5,11 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% if FeatureFlag.active?('banner_about_problems_with_dfe_sign_in') %>
-      <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
-          <div class="app-banner__message">
-            <h2 class="govuk-heading-m">You might have problems signing in</h2>
-            <p>Some of our users are having trouble signing in. We’re working on the problem now. If you can’t sign in, try again soon.</p>
-          </div>
+      <div class="app-banner app-banner--warning">
+        <div class="app-banner__message">
+          <h2 class="govuk-heading-m">You might have problems signing in</h2>
+          <p>Some of our users are having trouble signing in. We’re working on the problem now. If you can’t sign in, try again soon.</p>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/support_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/support_interface/sessions/authentication_fallback.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
+    <div class="app-banner app-banner--warning">
       <div class="app-banner__message">
         <h2 class="govuk-heading-m">Temporary login</h2>
         <p>DfE Sign In is is experiencing problems. You need to sign in using your email address.</p>


### PR DESCRIPTION
## Context

In a few places we’ve added the `govuk-!-margin-bottom-7` utility class, but the banner component already has a (responsive) bottom margin, so this is unnecessary and introduce an inconsistency.

## Changes proposed in this pull request

Removes `govuk-!-margin-bottom-7` from a number of banners. Adjusts some whitespace, and tweaks margin bottom value on service eligibility page.
