### PR TITLE
Add last-signed-in-at to active provider user export

### DIFF
--- a/app/services/support_interface/active_provider_users_export.rb
+++ b/app/services/support_interface/active_provider_users_export.rb
@@ -8,6 +8,7 @@ module SupportInterface
           name: provider_user.full_name,
           email_address: provider_user.email_address,
           providers: provider_user.providers.map(&:name).join(', '),
+          last_signed_in_at: provider_user.last_signed_in_at,
         }
       end
     end

--- a/spec/services/support_interface/active_provider_users_export_spec.rb
+++ b/spec/services/support_interface/active_provider_users_export_spec.rb
@@ -3,30 +3,35 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ActiveProviderUsersExport do
   describe '#call' do
     it 'returns provider_users who have have signed in at least once' do
-      provider1 = create(:provider)
-      provider2 = create(:provider)
-      provider_user1 = create(:provider_user, providers: [provider1], last_signed_in_at: 5.days.ago)
-      provider_user2 = create(:provider_user, providers: [provider2], last_signed_in_at: 5.days.ago)
-      provider_user3 = create(:provider_user, providers: [provider1, provider2], last_signed_in_at: 5.days.ago)
-      create(:provider_user, providers: [provider1])
+      Timecop.freeze(2020, 5, 1, 12, 0, 0) do
+        provider1 = create(:provider)
+        provider2 = create(:provider)
+        provider_user1 = create(:provider_user, providers: [provider1], last_signed_in_at: 5.days.ago)
+        provider_user2 = create(:provider_user, providers: [provider2], last_signed_in_at: 5.days.ago)
+        provider_user3 = create(:provider_user, providers: [provider1, provider2], last_signed_in_at: 3.days.ago)
+        create(:provider_user, providers: [provider1])
 
-      expect(described_class.call).to match_array([
-        {
-          name: provider_user1.full_name,
-          email_address: provider_user1.email_address,
-          providers: provider1.name,
-        },
-        {
-          name: provider_user2.full_name,
-          email_address: provider_user2.email_address,
-          providers: provider2.name,
-        },
-        {
-          name: provider_user3.full_name,
-          email_address: provider_user3.email_address,
-          providers: "#{provider1.name}, #{provider2.name}",
-        },
-      ])
+        expect(described_class.call).to match_array([
+          {
+            name: provider_user1.full_name,
+            email_address: provider_user1.email_address,
+            providers: provider1.name,
+            last_signed_in_at: 5.days.ago,
+          },
+          {
+            name: provider_user2.full_name,
+            email_address: provider_user2.email_address,
+            providers: provider2.name,
+            last_signed_in_at: 5.days.ago,
+          },
+          {
+            name: provider_user3.full_name,
+            email_address: provider_user3.email_address,
+            providers: "#{provider1.name}, #{provider2.name}",
+            last_signed_in_at: 3.days.ago,
+          },
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

User researchers can use this field to guide them to providers who might be good for user research bc they are active users.

## Changes proposed in this pull request

Add the last-signed-in-at date to the list of active providers.

## Guidance to review

Is it right?

## Link to Trello card

Polite request on slack for trivial change https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1596700477269600

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
