### PR TITLE
Fix bug in the nationalities component

### DIFF
--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -5,6 +5,7 @@ const nationalitiesComponent = () => {
   const secondSelectEl = document.getElementById(
     "candidate-interface-nationalities-form-other-nationality2-field"
   );
+  if (!secondSelectEl) return;
 
   const thirdSelectEl = document.getElementById(
     "candidate-interface-nationalities-form-other-nationality3-field"


### PR DESCRIPTION
## Context

The nationalities component is throwing an error on every page as it has not been scoped to the nationalities page.

## Changes proposed in this pull request

Only run component if `candidate-interface-nationalities-form-other-nationality2-field` is present.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
