### PR TITLE
Help users move on from error pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
   end
 
   def service_name
-    case current_namespace
+    case intended_namespace
     when 'candidate_interface'
       t('service_name.apply')
     when 'provider_interface'
@@ -21,7 +21,7 @@ module ApplicationHelper
     custom_link = content_for(:service_link)
     return custom_link if custom_link
 
-    case current_namespace
+    case intended_namespace
     when 'provider_interface'
       provider_interface_path
     when 'candidate_interface'
@@ -35,5 +35,9 @@ module ApplicationHelper
 
   def current_namespace
     params[:controller].split('/').first
+  end
+
+  def intended_namespace
+    "#{request.path.split('/').second}_interface"
   end
 end

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -9,10 +9,21 @@
     <p class="govuk-body">
       If you pasted the web address, check you copied the entire address.
     </p>
-    <p class="govuk-body">
-      If the web address is correct or you selected a link or button and you
-      need to speak to someone about this problem, contact the Becoming a Teacher team:
-      <%= bat_contact_mail_to %>.
-    </p>
+    <% if intended_namespace == 'provider_interface' %>
+      <p class="govuk-body">
+        You can
+        <%= govuk_link_to "return to #{service_name}", service_link %>.
+      </p>
+      <p class="govuk-body">
+        Or, if you need to speak to someone about this problem, email us on
+        <%= bat_contact_mail_to %>.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        If the web address is correct or you selected a link or button and you
+        need to speak to someone about this problem, contact the Becoming a Teacher team:
+        <%= bat_contact_mail_to %>.
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <% case try(:current_namespace) %>
+        <% case try(:intended_namespace) %>
         <% when 'candidate_interface' %>
           <%= render 'layouts/footer_meta_candidate' %>
         <% when 'provider_interface' %>

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -1,4 +1,4 @@
-<% if current_support_user %>
+<% if try(:current_support_user) %>
   <h2 class="govuk-heading-m">Product development</h2>
 
   <ul class="govuk-footer__inline-list">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -37,7 +37,7 @@
   <% components_name = 'ViewComponent Previews' if request.path.match(/^\/rails\/view_components/) %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: components_name || try(:service_name),
-                                 service_url: components_url || try(:service_url),
+                                 service_url: components_url || try(:service_link),
                                  navigation_items: [])) %>
                                <%= render PhaseBanner.new %>
 <% end %>


### PR DESCRIPTION
## Context

Our current error pages trap users, as the link at the top of the page just mirrors the requested url (which is how you got to this page in the first place). The text of the link is always 'Apply for teacher training', even if you were visiting a provider or support-interface page.

## Changes proposed in this pull request

Make error pages reflect the interface the user intended to visit by varying the header title. Link to the start page of each interface so that the user can get unstuck. 

![image](https://user-images.githubusercontent.com/107591/89520505-de8cd980-d7d5-11ea-8add-975adb7bc508.png)
![image](https://user-images.githubusercontent.com/107591/89520513-e2b8f700-d7d5-11ea-8ec2-466f639697c2.png)
![image](https://user-images.githubusercontent.com/107591/89520530-e77dab00-d7d5-11ea-8ddd-4658b40b3f58.png)

## Guidance to review

Easiest way to test is request pages that do not exist. Additional work may be needed for custom 'Manage' error pages.

## Link to Trello card

https://trello.com/c/xEwXApm3

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
