### PR TITLE
End of Cycle Deadline Banners

### DIFF
--- a/app/components/candidate_interface/apply_again_banner_component.html.erb
+++ b/app/components/candidate_interface/apply_again_banner_component.html.erb
@@ -1,11 +1,19 @@
 <div class="app-banner">
   <div class="app-banner__message">
-    <h2 class="govuk-heading-m">
+    <div class="govuk-heading-m">
+      <p>
       <% if @application_form.application_choices.all?(&:cancelled?) %>
         Your application has been withdrawn. <%= govuk_link_to 'Do you want to apply again?', candidate_interface_start_apply_again_path %>
       <% else %>
         <%= govuk_link_to 'Do you want to apply again?', candidate_interface_start_apply_again_path %>
       <% end %>
-    </h2>
+      </p>
+
+      <% if show_deadline_copy? %>
+        <p class='govuk-body govuk-!-font-size-24'>
+          The deadline when applying again is 18 September for courses starting this academic year.
+        </p>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -6,5 +6,9 @@ module CandidateInterface
     def initialize(application_form:)
       @application_form = application_form
     end
+
+    def show_deadline_copy?
+      EndOfCycleTimetable.show_apply_2_deadline_banner? && FeatureFlag.active?(:deadline_notices)
+    end
   end
 end

--- a/app/components/candidate_interface/deadline_banner_component.html.erb
+++ b/app/components/candidate_interface/deadline_banner_component.html.erb
@@ -1,0 +1,10 @@
+<% if show_deadline_banner? %>
+  <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+    <div class="app-banner__message">
+      <h2 class="govuk-heading-m" id="success-message">The deadline for applying to courses starting this academic year is <%= deadline %></h2>
+      <p class='govuk-body govuk-!-font-size-24'>
+        Courses may fill up before then. Check course availability with your provider.
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/deadline_banner_component.rb
+++ b/app/components/candidate_interface/deadline_banner_component.rb
@@ -1,0 +1,47 @@
+class CandidateInterface::DeadlineBannerComponent < ViewComponent::Base
+  attr_accessor :phase, :flash_empty
+
+  def initialize(phase:, flash_empty:)
+    @phase = phase
+    @flash_empty = flash_empty
+  end
+
+  def show_deadline_banner?
+    flash_empty &&
+      (show_apply_1_deadline_banner? || show_apply_2_deadline_banner?)
+  end
+
+  def deadline
+    apply_1? ? apply_1_deadline : apply_2_deadline
+  end
+
+private
+
+  def show_apply_1_deadline_banner?
+    apply_1? &&
+      EndOfCycleTimetable.show_apply_1_deadline_banner? &&
+      FeatureFlag.active?(:deadline_notices)
+  end
+
+  def show_apply_2_deadline_banner?
+    apply_2? &&
+      EndOfCycleTimetable.show_apply_2_deadline_banner? &&
+      FeatureFlag.active?(:deadline_notices)
+  end
+
+  def apply_1?
+    phase == 'apply_1'
+  end
+
+  def apply_2?
+    phase == 'apply_2'
+  end
+
+  def apply_1_deadline
+    EndOfCycleTimetable.date(:apply_1_deadline).strftime('%d %B')
+  end
+
+  def apply_2_deadline
+    EndOfCycleTimetable.date(:apply_2_deadline).strftime('%d %B')
+  end
+end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -1,0 +1,18 @@
+class EndOfCycleTimetable
+  DATES = {
+    apply_1_deadline: Date.new(2020, 8, 24),
+    apply_2_deadline: Date.new(2020, 9, 18),
+  }.freeze
+
+  def self.show_apply_1_deadline_banner?
+    Time.zone.now < date(:apply_1_deadline)
+  end
+
+  def self.show_apply_2_deadline_banner?
+    Time.zone.now < date(:apply_2_deadline)
+  end
+
+  def self.date(name)
+    DATES[name]
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -20,6 +20,7 @@ class FeatureFlag
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
     [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to 2020 end-of-cycle with link to static page', 'Steve Hook'],
     [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
+    [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -8,6 +8,8 @@
   </div>
 <% end %>
 
+<%= render(CandidateInterface::DeadlineBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
+
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
   <%= t('page_titles.application_form') %>
 </h1>

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include('Your application has been withdrawn. Do you want to apply again?')
+      expect(result.text).not_to include('The deadline when applying again is')
     end
   end
 
@@ -21,6 +22,40 @@ RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
 
       expect(result.text).to include('Do you want to apply again?')
       expect(result.text).not_to include('Your application has been withdrawn.')
+      expect(result.text).not_to include('The deadline when applying again is')
+    end
+  end
+
+  describe 'deadline copy' do
+    before do
+      # Set required conditions to display deadline copy
+      FeatureFlag.activate(:deadline_notices)
+      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return true
+    end
+
+    it 'is displayed when conditions are met' do
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include 'The deadline when applying again is'
+    end
+
+    it 'is not displayed when the feature flag is off' do
+      FeatureFlag.deactivate(:deadline_notices)
+
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).not_to include 'The deadline when applying again is'
+    end
+
+    it 'is not displayed when it\'s not the right time' do
+      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return false
+
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).not_to include 'The deadline when applying again is'
     end
   end
 end

--- a/spec/components/candidate_interface/deadline_banner_component_spec.rb
+++ b/spec/components/candidate_interface/deadline_banner_component_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::DeadlineBannerComponent, type: :component do
+  describe '#render' do
+    let(:application_form) { build(:application_form) }
+    let(:flash) { double }
+
+    def set_conditions_for_rendering_banner(phase)
+      application_form.phase = phase
+      FeatureFlag.activate(:deadline_notices)
+      allow(flash).to receive(:empty?).and_return true
+      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(true)
+      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(true)
+    end
+
+    it 'renders the Apply 1 banner when the right conditions are met' do
+      set_conditions_for_rendering_banner('apply_1')
+
+      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+
+      expect(result.text).to include('The deadline for applying to courses starting this academic year is 24 August')
+    end
+
+    it 'renders the Apply 2 banner when the right conditions are met' do
+      set_conditions_for_rendering_banner('apply_2')
+
+      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+
+      expect(result.text).to include('The deadline for applying to courses starting this academic year is 18 September')
+    end
+
+    it 'renders nothing if feature flag is inactive' do
+      set_conditions_for_rendering_banner('apply_1')
+      FeatureFlag.deactivate(:deadline_notices)
+
+      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+
+      expect(result.text).to be_blank
+    end
+
+    it 'renders nothing if the flash contains something' do
+      set_conditions_for_rendering_banner('apply_1')
+      allow(flash).to receive(:empty?).and_return false
+
+      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+
+      expect(result.text).to be_blank
+    end
+
+    it 'renders nothing if it\'s not the right time to show the banner' do
+      set_conditions_for_rendering_banner('apply_1')
+      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
+      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return(false)
+
+      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+
+      expect(result.text).to be_blank
+    end
+
+    it 'renders a banner if the timetable says only one of them should be shown' do
+      set_conditions_for_rendering_banner('apply_2')
+      allow(EndOfCycleTimetable).to receive(:show_apply_1_deadline_banner?).and_return(false)
+
+      result = render_inline(described_class.new(phase: application_form.phase, flash_empty: flash.empty?))
+
+      expect(result.text).to include('The deadline for applying to courses starting this academic year is 18 September')
+    end
+  end
+end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe EndOfCycleTimetable do
+  describe '.show_apply_1_deadline_banner?' do
+    it 'returns true before the configured date' do
+      Timecop.travel(Date.new(2020, 8, 23)) do
+        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
+      end
+    end
+
+    it 'returns false after the configured date' do
+      Timecop.travel(Date.new(2020, 8, 24) + 1.hour) do
+        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
+      end
+    end
+  end
+
+  describe '.show_apply_2_deadline_banner?' do
+    it 'returns true before the configured date' do
+      Timecop.travel(Date.new(2020, 9, 17)) do
+        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
+      end
+    end
+
+    it 'returns false after the configured date' do
+      Timecop.travel(Date.new(2020, 9, 18) + 1.hour) do
+        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
As a candidate
I need to know that an application deadline is approaching
So that I can submit my application to providers in time
## Changes proposed in this pull request
- Add a timetable class to hold deadlines and provide helper methods around them
- Conditionally add copy to the existing Apply Again banner
- Conditionally add banners containing deadline details for in-progress applications in both Apply 1 and Apply 2.

<!-- If there are UI changes, please include Before and After screenshots. -->
### Apply 1 application
![Screenshot_20200806_162640](https://user-images.githubusercontent.com/519250/89550546-a4d1c800-d801-11ea-8b4d-2f2980f9cdcc.png)

### Apply 2 application (banner renders correctly alongside other banners)
![Screenshot_20200806_162423](https://user-images.githubusercontent.com/519250/89550316-63411d00-d801-11ea-8d98-ccb2792e51ac.png)

### Updated Apply Again banner on an unsuccessful app
![Screenshot_20200806_162752](https://user-images.githubusercontent.com/519250/89550641-c8950e00-d801-11ea-8a91-7629c92a163d.png)

## Guidance to review

Can be tested by signing in as candidates in various states via the support console, checking as follows:

- Pre-submission (Apply 1 banner should appear)
- Unsuccessful app (Apply 2 banner copy update)
- Apply 2 app in-progress (Apply 2 banner should appear)

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/EDvTJYRV
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
