### PR TITLE
[SPIKE] Stop candidates being able to add a course/be sent to find 

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,6 +1,6 @@
 <% @application_choices.each do |application_choice| %>
   <div id='course-choice-<%= application_choice.id %>' class='qa-application-choice-<%= application_choice.id %> <%= warning_container_css_class(application_choice) %>'>
-  <% if @editable %>
+  <% if !EndOfCycleTimetable.find_down? && @editable %>
     <% if application_choice.course_not_available? %>
       <p class='app-review-warning__primary-message'><%= application_choice.course_not_available_error %>.</p>
       <p class='govuk-body'><%= application_choice.provider.name %> have decided not to run this course.</p>
@@ -11,10 +11,8 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <% unless EndOfCycleTimetable.find_down? %>
-            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-            to discuss alternatives
-          <% end %>
+          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+          to discuss alternatives
         </li>
       </ul>
     <% elsif application_choice.course_closed_on_apply? %>
@@ -26,12 +24,10 @@
         <% if course_change_path(application_choice) %>
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
-        <% unless EndOfCycleTimetable.find_down? %>
-          <li>
-            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-            to discuss alternatives
-          </li>
-        <% end %>
+        <li>
+          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+          to discuss alternatives
+        </li>
         <li>
           <%= govuk_link_to 'apply for this course on UCAS', "#{UCAS.apply_url}" %>
         </li>
@@ -45,10 +41,8 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <% unless EndOfCycleTimetable.find_down? %>
-            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-            to see if the course will re-open or discuss alternatives
-          <% end %>
+          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+          to see if the course will re-open or discuss alternatives
         </li>
       </ul>
     <% elsif application_choice.site_full? %>
@@ -63,10 +57,8 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <% unless EndOfCycleTimetable.find_down? %>
-            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-            to see if the course will re-open or discuss alternatives
-          <% end %>
+          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+          to see if the course will re-open or discuss alternatives
         </li>
       </ul>
     <% elsif application_choice.study_mode_full? %>
@@ -81,10 +73,8 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <% unless EndOfCycleTimetable.find_down? %>
-            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-            to see if the course will re-open or discuss alternatives
-          <% end %>
+          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+          to see if the course will re-open or discuss alternatives
         </li>
       </ul>
     <% end %>

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -11,8 +11,10 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to discuss alternatives
+          <% unless EndOfCycleTimetable.find_down? %>
+            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+            to discuss alternatives
+          <% end %>
         </li>
       </ul>
     <% elsif application_choice.course_closed_on_apply? %>
@@ -24,10 +26,12 @@
         <% if course_change_path(application_choice) %>
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
-        <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to discuss alternatives
-        </li>
+        <% unless EndOfCycleTimetable.find_down? %>
+          <li>
+            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+            to discuss alternatives
+          </li>
+        <% end %>
         <li>
           <%= govuk_link_to 'apply for this course on UCAS', "#{UCAS.apply_url}" %>
         </li>
@@ -41,8 +45,10 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to see if the course will re-open or discuss alternatives
+          <% unless EndOfCycleTimetable.find_down? %>
+            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+            to see if the course will re-open or discuss alternatives
+          <% end %>
         </li>
       </ul>
     <% elsif application_choice.site_full? %>
@@ -57,8 +63,10 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to see if the course will re-open or discuss alternatives
+          <% unless EndOfCycleTimetable.find_down? %>
+            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+            to see if the course will re-open or discuss alternatives
+          <% end %>
         </li>
       </ul>
     <% elsif application_choice.study_mode_full? %>
@@ -73,8 +81,10 @@
           <li><%= govuk_link_to 'change to another course', course_change_path(application_choice) %></li>
         <% end %>
         <li>
-          <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
-          to see if the course will re-open or discuss alternatives
+          <% unless EndOfCycleTimetable.find_down? %>
+            <%= govuk_link_to 'contact the training provider', "#{application_choice.course.find_url}#section-contact" %>
+            to see if the course will re-open or discuss alternatives
+          <% end %>
         </li>
       </ul>
     <% end %>

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,6 +1,6 @@
 <% @application_choices.each do |application_choice| %>
   <div id='course-choice-<%= application_choice.id %>' class='qa-application-choice-<%= application_choice.id %> <%= warning_container_css_class(application_choice) %>'>
-  <% if !EndOfCycleTimetable.find_down? && @editable %>
+  <% if CandidateInterface::CanAddCourseChoice.can_add_course_choice?(application_form: application_choice.application_form) && @editable %>
     <% if application_choice.course_not_available? %>
       <p class='app-review-warning__primary-message'><%= application_choice.course_not_available_error %>.</p>
       <p class='govuk-body'><%= application_choice.provider.name %> have decided not to run this course.</p>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -88,7 +88,7 @@ module CandidateInterface
     def course_row(application_choice)
       {
         key: 'Course',
-        value: govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code})", application_choice.offered_course.find_url, target: '_blank', rel: 'noopener'),
+        value: course_row_value(application_choice),
         action: "course choice for #{application_choice.course.name_and_code}",
         change_path: course_change_path(application_choice),
       }
@@ -168,6 +168,14 @@ module CandidateInterface
 
     def has_multiple_courses?(application_choice)
       Course.current_cycle.where(provider: application_choice.provider).many?
+    end
+
+    def course_row_value(application_choice)
+      if EndOfCycleTimetable.find_down?
+        "#{application_choice.offered_course.name} (#{application_choice.offered_course.code})"
+      else
+        govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code})", application_choice.offered_course.find_url, target: '_blank', rel: 'noopener')
+      end
     end
   end
 end

--- a/app/components/candidate_interface/find_down_course_choices_banner.html.erb
+++ b/app/components/candidate_interface/find_down_course_choices_banner.html.erb
@@ -1,0 +1,15 @@
+<% if @find_down %>
+  <div class="app-banner">
+    <div class="app-banner__message">
+      <div class="govuk-heading-m">
+        <p>
+          The 2019/20 Application Cycle has ended.
+        </p>
+
+        <p class='govuk-body govuk-!-font-size-24'>
+          You will be able to add course choices for the 2020/21 Application Cycle from <%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date).strip %>.
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/find_down_course_choices_banner.html.erb
+++ b/app/components/candidate_interface/find_down_course_choices_banner.html.erb
@@ -1,4 +1,4 @@
-<% if @find_down %>
+<% unless CandidateInterface::CanAddCourseChoice.can_add_course_choice?(application_form: @application_form) %>
   <div class="app-banner">
     <div class="app-banner__message">
       <div class="govuk-heading-m">

--- a/app/components/candidate_interface/find_down_course_choices_banner.rb
+++ b/app/components/candidate_interface/find_down_course_choices_banner.rb
@@ -2,8 +2,8 @@ module CandidateInterface
   class FindDownCourseChoicesBanner < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(find_down: false)
-      @find_down = find_down
+    def initialize(application_form:)
+      @application_form = application_form
     end
   end
 end

--- a/app/components/candidate_interface/find_down_course_choices_banner.rb
+++ b/app/components/candidate_interface/find_down_course_choices_banner.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class FindDownCourseChoicesBanner < ViewComponent::Base
+    validates :application_form, presence: true
+
+    def initialize(find_down: false)
+      @find_down = find_down
+    end
+  end
+end

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -19,9 +19,7 @@ module CandidateInterface
     def course_details_row(application_choice)
       {
         key: 'Course',
-        value: govuk_link_to(application_choice.offered_course.name_and_code,
-                             application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') +
-          tag.p(application_choice.course.description, class: 'govuk-body'),
+        value: course_details_row_value(application_choice),
       }
     end
 
@@ -30,6 +28,16 @@ module CandidateInterface
         key: 'Feedback',
         value: application_choice.rejection_reason,
       }
+    end
+
+    def course_details_row_value(application_choice)
+      if EndOfCycleTimetable.find_down?
+        "#{application_choice.offered_course.name_and_code} <br> #{application_choice.course.description}".html_safe
+      else
+        govuk_link_to(application_choice.offered_course.name_and_code,
+                      application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') +
+          tag.p(application_choice.course.description, class: 'govuk-body')
+      end
     end
   end
 end

--- a/app/components/grouped_provider_courses_component.html.erb
+++ b/app/components/grouped_provider_courses_component.html.erb
@@ -10,8 +10,14 @@
         </header>
         <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
           <ul class="govuk-list govuk-list--bullet">
-            <% provider.courses.sort_by(&:name).each do |course| %>
-              <li><%= govuk_link_to course.name_and_code, course.find_url %></li>
+            <% if EndOfCycleTimetable.find_down? %>
+              <% provider.courses.sort_by(&:name).each do |course| %>
+                <li><%= course.name_and_code %></li>
+              <% end %>
+            <% else %>
+              <% provider.courses.sort_by(&:name).each do |course| %>
+                <li><%= govuk_link_to course.name_and_code, course.find_url %></li>
+              <% end %>
             <% end %>
           </ul>
         </div>

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -3,6 +3,8 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def index
+      redirect_to candidate_interface_course_choices_review_path and return if EndOfCycleTimetable.find_down?
+
       @application_choices = current_candidate.current_application.application_choices
 
       if @application_choices.any?

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def index
-      redirect_to candidate_interface_course_choices_review_path and return if EndOfCycleTimetable.find_down?
+      redirect_to candidate_interface_course_choices_review_path and return unless CandidateInterface::CanAddCourseChoice.can_add_course_choice?(application_form: current_application)
 
       @application_choices = current_candidate.current_application.application_choices
 

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -1,8 +1,14 @@
 module CandidateInterface
   module CourseChoices
     class BaseController < CandidateInterfaceController
-      before_action :redirect_to_dashboard_if_submitted
+      before_action :redirect_to_dashboard_if_submitted, :redirect_to_review_page_if_find_down
       rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+    private
+
+      def redirect_to_review_page_if_find_down
+        redirect_to candidate_interface_course_choices_review_path if EndOfCycleTimetable.find_down?
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -1,13 +1,13 @@
 module CandidateInterface
   module CourseChoices
     class BaseController < CandidateInterfaceController
-      before_action :redirect_to_dashboard_if_submitted, :redirect_to_review_page_if_find_down
+      before_action :redirect_to_dashboard_if_submitted, :redirect_to_dashboard_if_cycle_is_over
       rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     private
 
-      def redirect_to_review_page_if_find_down
-        redirect_to candidate_interface_course_choices_review_path if EndOfCycleTimetable.find_down?
+      def redirect_to_dashboard_if_cycle_is_over
+        redirect_to candidate_interface_course_choices_review_path and return unless CandidateInterface::CanAddCourseChoice.can_add_course_choice?(application_form: current_application)
       end
     end
   end

--- a/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module CourseChoices
     module ReplaceChoices
       class BaseController < CandidateInterfaceController
-        before_action :redirect_to_dashboard_if_no_choices_need_replacing
+        before_action :redirect_to_dashboard_if_no_choices_need_replacing, :redirect_to_dashboard_if_find_is_down
 
         def pick_choice_to_replace
           if only_one_course_choice_needs_replacing?
@@ -33,6 +33,10 @@ module CandidateInterface
 
         def redirect_to_dashboard_if_no_choices_need_replacing
           redirect_to candidate_interface_application_complete_path if current_application.course_choices_that_need_replacing.blank?
+        end
+
+        def redirect_to_dashboard_if_find_is_down
+          redirect_to candidate_interface_course_choices_review_path if EndOfCycleTimetable.find_down?
         end
 
         def only_one_course_choice_needs_replacing?

--- a/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module CourseChoices
     module ReplaceChoices
       class BaseController < CandidateInterfaceController
-        before_action :redirect_to_dashboard_if_no_choices_need_replacing, :redirect_to_dashboard_if_find_is_down
+        before_action :redirect_to_dashboard_if_no_choices_need_replacing, :redirect_to_dashboard_if_cycle_is_over
 
         def pick_choice_to_replace
           if only_one_course_choice_needs_replacing?
@@ -35,8 +35,8 @@ module CandidateInterface
           redirect_to candidate_interface_application_complete_path if current_application.course_choices_that_need_replacing.blank?
         end
 
-        def redirect_to_dashboard_if_find_is_down
-          redirect_to candidate_interface_course_choices_review_path if EndOfCycleTimetable.find_down?
+        def redirect_to_dashboard_if_cycle_is_over
+          redirect_to candidate_interface_course_choices_review_path and return unless CandidateInterface::CanAddCourseChoice.can_add_course_choice?(application_form: current_application)
         end
 
         def only_one_course_choice_needs_replacing?

--- a/app/services/candidate_interface/can_add_course_choice.rb
+++ b/app/services/candidate_interface/can_add_course_choice.rb
@@ -1,0 +1,16 @@
+module CandidateInterface
+  class CanAddCourseChoice
+    def self.can_add_course_choice?(application_form:)
+      case application_form.phase
+      when 'apply_1'
+        return true if Time.zone.now < EndOfCycleTimetable.apply_1_deadline
+        return true if Time.zone.now > EndOfCycleTimetable.find_reopens
+      else
+        return true if Time.zone.now < EndOfCycleTimetable.apply_2_deadline
+        return true if Time.zone.now > EndOfCycleTimetable.find_reopens
+      end
+
+      false
+    end
+  end
+end

--- a/app/services/candidate_interface/can_add_course_choice.rb
+++ b/app/services/candidate_interface/can_add_course_choice.rb
@@ -1,13 +1,13 @@
 module CandidateInterface
   class CanAddCourseChoice
     def self.can_add_course_choice?(application_form:)
+      return true if Time.zone.now > EndOfCycleTimetable.find_reopens
+
       case application_form.phase
       when 'apply_1'
         return true if Time.zone.now < EndOfCycleTimetable.apply_1_deadline
-        return true if Time.zone.now > EndOfCycleTimetable.find_reopens
       else
         return true if Time.zone.now < EndOfCycleTimetable.apply_2_deadline
-        return true if Time.zone.now > EndOfCycleTimetable.find_reopens
       end
 
       false

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -2,6 +2,8 @@ class EndOfCycleTimetable
   DATES = {
     apply_1_deadline: Date.new(2020, 8, 24),
     apply_2_deadline: Date.new(2020, 9, 18),
+    find_closes: Date.new(2020, 9, 19),
+    find_reopens: Date.new(2020, 10, 3),
   }.freeze
 
   def self.show_apply_1_deadline_banner?
@@ -10,6 +12,18 @@ class EndOfCycleTimetable
 
   def self.show_apply_2_deadline_banner?
     Time.zone.now < date(:apply_2_deadline)
+  end
+
+  def self.find_down?
+    Time.zone.today.between?(find_closes, find_reopens)
+  end
+
+  def self.find_closes
+    date(:find_closes)
+  end
+
+  def self.find_reopens
+    date(:find_reopens)
   end
 
   def self.date(name)

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -14,6 +14,14 @@ class EndOfCycleTimetable
     Time.zone.now < date(:apply_2_deadline)
   end
 
+  def self.apply_1_deadline
+    date(:apply_1_deadline)
+  end
+
+  def self.apply_2_deadline
+    date(:apply_2_deadline)
+  end
+
   def self.find_down?
     Time.zone.today.between?(find_closes, find_reopens)
   end

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('page_titles.course_choices') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<%= render CandidateInterface::FindDownCourseChoicesBanner.new(find_down: EndOfCycleTimetable.find_down?) %>
+<%= render CandidateInterface::FindDownCourseChoicesBanner.new(application_form: @application_form) %>
 
 <h1 class="govuk-heading-xl">
   <% if @application_form.candidate_can_choose_single_course? %>
@@ -18,7 +18,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if EndOfCycleTimetable.find_down? %>
+      <% if !CandidateInterface::CanAddCourseChoice.can_add_course_choice?(application_form: @application_form) %>
         <%= govuk_link_to 'Continue', candidate_interface_application_form_path, class: 'govuk-button' %>
       <% elsif @application_choices.present? %>
         <% if @application_form.can_add_more_choices? %>

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, t('page_titles.course_choices') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
+<%= render CandidateInterface::FindDownCourseChoicesBanner.new(find_down: EndOfCycleTimetable.find_down?) %>
+
 <h1 class="govuk-heading-xl">
   <% if @application_form.candidate_can_choose_single_course? %>
     <%= t('page_titles.course_choice') %>
@@ -16,7 +18,9 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if @application_choices.present? %>
+      <% if EndOfCycleTimetable.find_down? %>
+        <%= govuk_link_to 'Continue', candidate_interface_application_form_path, class: 'govuk-button' %>
+      <% elsif @application_choices.present? %>
         <% if @application_form.can_add_more_choices? %>
           <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
         <% end %>

--- a/app/views/candidate_interface/course_choices/shared/_full.html.erb
+++ b/app/views/candidate_interface/course_choices/shared/_full.html.erb
@@ -22,11 +22,13 @@
           ) %>
         <% end %>
       </li>
-      <li>
-        contact
-        <%= govuk_link_to @course.provider.name, "#{@course.find_url}#section-contact" %>
-      to see if the course will re-open or discuss alternatives
-      </li>
+      <% unless EndOfCycleTimetable.find_down? %>
+        <li>
+          contact
+          <%= govuk_link_to @course.provider.name, "#{@course.find_url}#section-contact" %>
+        to see if the course will re-open or discuss alternatives
+        </li>
+      <% end %>
     </ul>
 
     <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_form_path %></p>

--- a/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
+++ b/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
@@ -7,18 +7,34 @@
         <%= t('confirm_selection.heading') %>
       </h1>
 
-      <div class="govuk-inset-text govuk-!-margin-top-0">
-        <%= link_to @course_selection_form.course.find_url,
-                    class: 'govuk-!-font-weight-bold govuk-link',
-                    style: 'text-decoration: none' do %>
-        <span class="govuk-!-font-size-19">
-          <%= @course_selection_form.course.provider.name %>
-        </span><br>
-        <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
-          <%= @course_selection_form.course.name_and_code %>
-        </span>
-        <% end %>
-      </div>
+      <% if EndOfCycleTimetable.find_down? %>
+
+        <div class="govuk-inset-text govuk-!-margin-top-0">
+          <span class="govuk-!-font-size-19">
+            <%= @course_selection_form.course.provider.name %>
+          </span>
+          <br>
+          <span class="search-result-link-name govuk-!-font-size-24 govuk-!-font-weight-bold">
+            <%= @course_selection_form.course.name_and_code %>
+          </span>
+        </div>
+
+      <% else %>
+
+        <div class="govuk-inset-text govuk-!-margin-top-0">
+          <%= link_to @course_selection_form.course.find_url,
+                      class: 'govuk-!-font-weight-bold govuk-link',
+                      style: 'text-decoration: none' do %>
+          <span class="govuk-!-font-size-19">
+            <%= @course_selection_form.course.provider.name %>
+          </span><br>
+          <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
+            <%= @course_selection_form.course.name_and_code %>
+          </span>
+          <% end %>
+        </div>
+
+      <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :confirm, legend: { size: 'm', text: t('confirm_selection.question') } do %>
         <%= f.govuk_radio_button :confirm, true, label: { text: 'Yes' } %>

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -4,7 +4,7 @@
 <% new_application_choice_needed_component = CandidateInterface::NewCourseChoiceNeededBannerComponent.new(application_form: @application_form) %>
 <% if new_references_needed_component.render? %>
   <%= render new_references_needed_component %>
-<% elsif new_application_choice_needed_component.render? %>
+<% elsif !EndOfCycleTimetable.find_down? && new_application_choice_needed_component.render? %>
   <%= render new_application_choice_needed_component %>
 <% elsif flash.empty? %>
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -4,7 +4,7 @@
 <% new_application_choice_needed_component = CandidateInterface::NewCourseChoiceNeededBannerComponent.new(application_form: @application_form) %>
 <% if new_references_needed_component.render? %>
   <%= render new_references_needed_component %>
-<% elsif !EndOfCycleTimetable.find_down? && new_application_choice_needed_component.render? %>
+<% elsif CandidateInterface::CanAddCourseChoice.can_add_course_choice?(application_form: current_application) && new_application_choice_needed_component.render? %>
   <%= render new_application_choice_needed_component %>
 <% elsif flash.empty? %>
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>

--- a/spec/services/candidate_interface/can_add_course_choice_spec.rb
+++ b/spec/services/candidate_interface/can_add_course_choice_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::CanAddCourseChoice do
+  describe '#can_add_course_choice?' do
+    let(:execute_service) { described_class.can_add_course_choice?(application_form: application_form) }
+
+    context 'application form is in the apply1 state' do
+      let(:application_form) { build_stubbed(:application_form) }
+
+      context 'when the date is after the apply1 submission deadline' do
+        it 'returns false' do
+          Timecop.travel(EndOfCycleTimetable.apply_1_deadline + 1.day) do
+            expect(execute_service).to eq false
+          end
+        end
+      end
+
+      context 'when the date is before the apply1 submission deadline' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.apply_1_deadline - 1.day) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+
+      context 'when the date is post find reopening' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.find_reopens + 1.day) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+    end
+
+    context 'application form is in the apply again state' do
+      let(:application_form) { build_stubbed(:application_form, phase: :apply_2) }
+
+      context 'when the date is after the apply again submission deadline' do
+        it 'returns false' do
+          Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
+            expect(execute_service).to eq false
+          end
+        end
+      end
+
+      context 'when the date is before the apply again submission deadline' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.apply_2_deadline - 1.day) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+
+      context 'when the date is post find reopening' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.find_reopens + 1.day) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is a spike related to adding/replacing courses around the EOC.

This PR tackles three issues.

1. Candidates should not be able to add new course once their applications phases deadline has passed (apply1/apply again)
2. Same with replacing an existing course
3. All links to Find need to be removed while Find is down
 
## Changes proposed in this pull request

- Remove all links to FIND outside of the add/replace course flow when Find is down
- Redirect the add/replace course choice controllers to the review/dashboard page if a candidate cannot add a new course
- Remove the replace course banner (post-submission)
- Add a new banner on the review page informing candidates the current cycle has finished 

## Guidance to review

This is very light on tests. Happy to add more. I'm not 100% sure how many you should be writing while spiking.

I'm assuming we are still going to use a feature flag for testing purposes so all our other tests don't just start suddenly failing during these time periods.

Have I missed anything?

## Link to Trello card

https://trello.com/c/MaIKxcbX/1909-spike-freeze-stop-candidates-looking-at-new-courses-during-find-close-down-25-8-a1-19-septaa

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
