### PR TITLE
Replace dumb quotes with smart ones

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -17,7 +17,7 @@
       </ul>
     <% elsif application_choice.course_closed_on_apply? %>
       <p class='app-review-warning__primary-message'><%= application_choice.course_closed_on_apply_error %>.</p>
-      <p class='govuk-body'>You can still apply for '<%= application_choice.course.name_and_code %>' on UCAS.</p>
+      <p class='govuk-body'>You can still apply for ‘<%= application_choice.course.name_and_code %>’ on UCAS.</p>
       <p class='govuk-body'>You can:</p>
       <ul class='govuk-list govuk-list--bullet'>
         <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(application_choice.id) %></li>

--- a/app/components/candidate_interface/replacement_action_component.html.erb
+++ b/app/components/candidate_interface/replacement_action_component.html.erb
@@ -35,7 +35,7 @@
       <% if course_only_available_on_ucas? %>
         <%= f.govuk_radio_button :replacement_action, 'apply_through_ucas', label: { text: "Apply for this course through UCAS" } %>
         <%= f.govuk_radio_button :replacement_action, 'replace_course', label: { text: 'Choose a different course on Apply for teacher training' } %>
-        <%= f.govuk_radio_button :replacement_action, 'keep_choice', label: { text: 'Keep this course choice anyway' }, hint_text: "When your references come in we'll send your application to #{provider_name}, but there’s no guarantee they’ll consider it." %>
+        <%= f.govuk_radio_button :replacement_action, 'keep_choice', label: { text: 'Keep this course choice anyway' }, hint_text: "When your references come in we’ll send your application to #{provider_name}, but there’s no guarantee they’ll consider it." %>
       <% else %>
         <% if other_locations_available? %>
           <%= f.govuk_radio_button :replacement_action, 'replace_location', label: { text: 'Choose a different location' } %>
@@ -45,7 +45,7 @@
         <% end %>
           <%= f.govuk_radio_button :replacement_action, 'replace_course', label: { text: 'Choose a different course' } %>
           <%= f.govuk_radio_button :replacement_action, 'remove_course', label: { text: 'Remove course from application' } %>
-          <%= f.govuk_radio_button :replacement_action, 'keep_choice', label: { text: 'Keep this course choice anyway' }, hint_text: "When your references come in we'll send your application to #{provider_name}, but there’s no guarantee they’ll consider it." %>
+          <%= f.govuk_radio_button :replacement_action, 'keep_choice', label: { text: 'Keep this course choice anyway' }, hint_text: "When your references come in we’ll send your application to #{provider_name}, but there’s no guarantee they’ll consider it." %>
       <% end %>
     <% end %>
 

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -161,7 +161,7 @@ module RefereeInterface
     end
 
     def send_slack_notification
-      message = ":sadparrot: A referee declined to give feedback for #{reference.application_form.first_name}'s application"
+      message = ":sadparrot: A referee declined to give feedback for #{reference.application_form.first_name}’s application"
       url = helpers.support_interface_application_form_url(reference.application_form)
 
       SlackNotificationWorker.perform_async(message, url)

--- a/app/forms/referee_interface/reference_review_form.rb
+++ b/app/forms/referee_interface/reference_review_form.rb
@@ -12,7 +12,7 @@ module RefereeInterface
 
     def questions_complete
       if reference.feedback.nil? || reference.safeguarding_concerns.nil? || reference.relationship_correction.nil?
-        errors.add(:base, 'Can\'t submit a reference without answers to all questions')
+        errors.add(:base, 'Can’t submit a reference without answers to all questions')
       end
     end
   end

--- a/app/forms/support_interface/add_course_to_application_form.rb
+++ b/app/forms/support_interface/add_course_to_application_form.rb
@@ -33,7 +33,7 @@ module SupportInterface
     def course_option_exists
       return if course_option
 
-      errors[:base] << "There's no course option with ID #{course_option_id}"
+      errors[:base] << "There’s no course option with ID #{course_option_id}"
     end
 
     def awaiting_references?

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -32,31 +32,31 @@ class StateChangeNotifier
       text = "#{application_form.first_name} has just submitted their application"
       url = helpers.support_interface_application_form_url(application_form)
     when :send_application_to_provider
-      text = "#{applicant}'s application is ready to be reviewed by #{provider_name}"
+      text = "#{applicant}’s application is ready to be reviewed by #{provider_name}"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :make_an_offer
-      text = "#{provider_name} has just made an offer to #{applicant}'s application"
+      text = "#{provider_name} has just made an offer to #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :change_an_offer
-      text = "#{provider_name} has just changed an offer for #{applicant}'s application"
+      text = "#{provider_name} has just changed an offer for #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application
-      text = "#{provider_name} has just rejected #{applicant}'s application"
+      text = "#{provider_name} has just rejected #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application_by_default
-      text = "#{applicant}'s application has just been rejected by default"
+      text = "#{applicant}’s application has just been rejected by default"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :offer_accepted
-      text = ":handshake: #{applicant} has accepted #{provider_name}'s offer"
+      text = ":handshake: #{applicant} has accepted #{provider_name}’s offer"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :offer_declined
-      text = ":no_good: #{applicant} has declined #{provider_name}'s offer"
+      text = ":no_good: #{applicant} has declined #{provider_name}’s offer"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :withdraw
       text = ":runner: #{applicant} has withdrawn their application for #{course_name} at #{provider_name}"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :withdraw_offer
-      text = ":no_good: #{provider_name} has just withdrawn #{applicant}'s offer"
+      text = ":no_good: #{provider_name} has just withdrawn #{applicant}’s offer"
       url = helpers.support_interface_application_form_url(application_form_id)
     else
       raise 'StateChangeNotifier: unsupported state transition event'

--- a/app/views/candidate_interface/course_choices/replace_choices/cancel/confirm_withdraw.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/cancel/confirm_withdraw.html.erb
@@ -7,7 +7,7 @@
 
     <p class="govuk-body">Cancelling this course choice means your application will be withdrawn.</p>
 
-    <p class="govuk-body">You'll have to make a new application later if you still want to apply.</p>
+    <p class="govuk-body">You’ll have to make a new application later if you still want to apply.</p>
 
     <p class="govuk-body"><%= govuk_link_to 'Go back to edit your course choice', candidate_interface_replace_course_choice_path(@course_choice.id) %>.</p>
 

--- a/app/views/candidate_interface/course_choices/shared/_full.html.erb
+++ b/app/views/candidate_interface/course_choices/shared/_full.html.erb
@@ -4,7 +4,7 @@
       <%= t('page_titles.full_course') %>
     </h1>
 
-    <p class="govuk-body">The course '<%= @course.name_and_code %>' is full.</p>
+    <p class="govuk-body">The course ‘<%= @course.name_and_code %>’ is full.</p>
     <p class="govuk-body">You can:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
       <li>

--- a/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
@@ -4,7 +4,7 @@
   <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I do not have an English as a foreign language qualification' } do %>
     <p class='govuk-hint'>If English is a foreign language to you, or if you do not have an English GCSE or equivalent, you may have to give evidence for your level of English.</p>
     <p class='govuk-hint'>Contact your provider for advice about showing your level of English.</p>
-    <%= f.govuk_text_area :no_qualification_details, max_words: 200, label: { text: "If you're working towards  a qualification, give details here", size: 's'} %>
+    <%= f.govuk_text_area :no_qualification_details, max_words: 200, label: { text: "If you’re working towards a qualification, give details here", size: 's'} %>
   <% end %>
 <% end %>
 

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -33,7 +33,7 @@
       </p>
 
       <p class="govuk-body">
-        Contact your provider if you're concerned about the interview process.
+        Contact your provider if you’re concerned about the interview process.
       </p>
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -30,7 +30,7 @@
 
     <% if @application_form.can_edit_after_submission? %>
       <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
-      <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>
+      <p class="govuk-body">You have <%= @editable_days %> to edit your application. We’ll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>
       <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
     <% else %>
       <h2 class="govuk-heading-m">Track or withdraw</h2>

--- a/app/views/content/getting_ready_for_next_cycle.md
+++ b/app/views/content/getting_ready_for_next_cycle.md
@@ -49,7 +49,7 @@ Training providers will need to respond to all outstanding applications for the 
 
 ## Deferring offers
 
-The [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) team is working on a new feature allowing training providers to defer offers to the next cycle. We'll email you when the feature is ready to use.
+The [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) team is working on a new feature allowing training providers to defer offers to the next cycle. We’ll email you when the feature is ready to use.
 
 Please bear in mind that deferrals can only be made at the request of the candidate.
 
@@ -63,7 +63,7 @@ When the 2020 to 2021 cycle opens in mid-October, you’ll be guided through the
 
 ### Changing the details of a deferred offer when you check and confirm
 
-You'll be able to change the details of a deferred offer when you check and confirm it at the start of the next cycle. If you need to alter any details – for example, the location, course or conditions – you should first explain and agree those changes with the candidate directly, via email or phone.
+You’ll be able to change the details of a deferred offer when you check and confirm it at the start of the next cycle. If you need to alter any details – for example, the location, course or conditions – you should first explain and agree those changes with the candidate directly, via email or phone.
 
 You can then use [Manage teacher training applications](https://www.apply-for-teacher-training.education.gov.uk/provider) to send an amended offer to the candidate, who will also receive a formal notification.
 

--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -6,7 +6,7 @@ Until that date, Apply for teacher training will run alongside UCAS Teacher Trai
 
 We’ll continue to make improvements to the service as we roll out. We’ll keep you informed of new features with our newsletter, which is sent out to all onboarded providers.
 
-##Contents
+## Contents
 
 [What you can expect from us](#what-you-can-expect-from-us)
 
@@ -22,32 +22,29 @@ We’ll continue to make improvements to the service as we roll out. We’ll kee
 
 [Help, support and feedback](#help-support-and-feedback)
 
+## <a name="what-you-can-expect-from-us"></a>What you can expect from us
 
-
-
-##<a name="what-you-can-expect-from-us"></a>What you can expect from us
-
-###Support for training providers
+### Support for training providers
 
 You can contact us with problems or questions at <becomingateacher@digital.education.gov.uk>.
 
 Our dedicated training provider support team will respond to urgent queries within 1 working day, and non-urgent queries within 5 working days.
 
-###Support for candidates
+### Support for candidates
 
 Our support team is also on hand to guide candidates through the application process and help with any technical issues they may have when using the service.
 
 We prioritise as urgent any problems preventing application submission.
 
-###Fees
+### Fees
 
 Apply and Manage are free services for both candidates and providers.
 
-####Still to come: fraud and plagiarism checks
+#### Still to come: fraud and plagiarism checks
 
-For now, we don't provide fraud and plagiarism checks on candidate applications.
+For now, we don’t provide fraud and plagiarism checks on candidate applications.
 
-##<a name="onboarding"></a>Onboarding
+## <a name="onboarding"></a>Onboarding
 
 Onboarding is quick and easy, usually taking place over a single working day.
 
@@ -63,18 +60,18 @@ Onboarding is quick and easy, usually taking place over a single working day.
 
 We’re available to give you full support at every stage.
 
-##<a name="using-the-service"></a>Using the service
+## <a name="using-the-service"></a>Using the service
 [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider) allows you to process applications from submission through to conditions met.
 
-###Viewing applications
+### Viewing applications
 
 Users with access to the Manage service will be able to view applications to courses you run as a training provider or ratify as an accredited provider.
 
-###Filtering applications
+### Filtering applications
 
 You can filter applications by candidate name, application status, training provider and ratifying provider.
 
-###Making decisions on applications
+### Making decisions on applications
 
 Users in your team will be able to:
 
@@ -84,7 +81,7 @@ Users in your team will be able to:
 * withdraw
 * reject, with reasons
 
-###Setting permissions for your team members
+### Setting permissions for your team members
 
 The permissions feature allows you to control:
 
@@ -92,7 +89,7 @@ The permissions feature allows you to control:
 * who can view sensitive information disclosed by the candidate (in the safeguarding or equality and diversity sections of the application)
 * who can invite other users, and set their permissions
 
-####For example, you may wish to:
+#### For example, you may wish to:
 
 * give members of your admission team access to all applications, but not the ability to make decisions
 * give academic decision-makers access to all applications, but not to sensitive information
@@ -100,7 +97,7 @@ The permissions feature allows you to control:
 
 Everyone on your team who uses the Manage service will be able to view all applications your organisation is involved with. You do not need to set permissions for this.
 
-###How to ‘Manage users’
+### How to ‘Manage users’
 
 The ‘Manage users’ permission allows you to:
 
@@ -108,66 +105,66 @@ The ‘Manage users’ permission allows you to:
 * invite new users
 * delete users
 
-####‘Manage users’ for training providers who are already part of our pilot
+#### ‘Manage users’ for training providers who are already part of our pilot
 
 We have automatically given the person in your organisation who signed the data-sharing agreement ‘Manage users’ permission. (If you’re not sure who signed the agreement, get in touch with us on <becomingateacher@digital.education.gov.uk>.)
 
-####‘Manage users’ for training providers now being onboarded
+#### ‘Manage users’ for training providers now being onboarded
 
-As part of your onboarding, we asked you to nominate team members to fill the ‘Manage users’ role. (Get in touch with us on <becomingateacher@digital.education.gov.uk> if you've yet to nominate a person for this role.)
+As part of your onboarding, we asked you to nominate team members to fill the ‘Manage users’ role. (Get in touch with us on <becomingateacher@digital.education.gov.uk> if you’ve yet to nominate a person for this role.)
 
-####Resetting the ‘Manage users’ permission
+#### Resetting the ‘Manage users’ permission
 
 You can reassign the ‘Manage users’ permission to different team members, as and when you need to.
 
-####Default settings for training providers who are already part of our pilot
+#### Default settings for training providers who are already part of our pilot
 
 For training providers who are already using the service, we’ve created some default settings to avoid disruption to your workflow:
 
 * all users can make decisions on applications
 * no users can access safeguarding information
 
-####Resetting permissions to suit your team
+#### Resetting permissions to suit your team
 
 When you sign into [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider) you’ll see a ‘Users’ menu item at the top of the screen.
 
 By selecting this menu item, and then selecting users from the list, the member of your team with ‘Manage users’ permission can edit the permissions assigned to each of your team members.
 
-####Settings for training providers now being onboarded
+#### Settings for training providers now being onboarded
 
-When you sign into [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider) for the first time, you'll be guided through the process of setting permissions for your team. You can customise permissions to suit your ways of working, and continue to edit them as and when you need.
+When you sign into [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider) for the first time, you’ll be guided through the process of setting permissions for your team. You can customise permissions to suit your ways of working, and continue to edit them as and when you need.
 
-####Still to come: setting permissions between organisations
+#### Still to come: setting permissions between organisations
 
 We’ll soon be releasing a further improvement to the Permissions feature, allowing you to set permissions between you and the organisations you work with (for example, your accredited body).
 
-We'll update this page when we release organisational permissions.
+We’ll update this page when we release organisational permissions.
 
-###Email alerts
+### Email alerts
 
-You'll receive an email every time an application's status changes, for example from 'Offer' to 'Offer accepted'.
+You’ll receive an email every time an application’s status changes, for example from ‘Offer’ to ‘Offer accepted’.
 
-###Notes
+### Notes
 
 Notes allow you and your colleagues to add extra information or points to consider to individual applications. Notes are not seen by the candidate.
 
-###Timeline
+### Timeline
 
 Individual applications also come with a time-stamped audit trail recording what decisions have been made, when and by whom.
 
-###Downloading and printing
+### Downloading and printing
 
 You can download and print applications to distribute to your team. Compliance with General Data Protection Regulation (GDPR) is your responsibility.
 
-####Still to come: interviews
+#### Still to come: interviews
 
 For now, interview scheduling is not part of the Manage service.
 
-##<a name="deadlines-and-terms-of-use"></a>Deadlines and terms of use
+## <a name="deadlines-and-terms-of-use"></a>Deadlines and terms of use
 
 For clarity and fairness, while Apply for teacher training and UCAS Teacher Training run side by side (until October 2021), we’ve kept the rules governing applications closely aligned.
 
-###Reject by default and decline by default deadlines
+### Reject by default and decline by default deadlines
 
 Training providers have 40 working days to respond to an application (starting from the date when references have been submitted).
 
@@ -175,7 +172,7 @@ Candidates have 10 working days to accept or reject offer(s) (starting from the 
 
 As currently, the reject by default deadline changes over the summer. In 2020, for all applications received between 1 July and 3 October, providers have 20 working days to respond before the application is automatically rejected.
 
-###Changing the terms of an offer
+### Changing the terms of an offer
 
 When you respond to an application, the service allows you change the details of the offer, including the course, main training location and training provider (for example, to another organisation with courses you run or ratify).
 
@@ -185,7 +182,7 @@ The candidate will receive a formal notification of the changed offer, but you s
 
 Once the candidate has accepted your offer, you can’t change the terms of the offer without their permission.
 
-###Apply again (Apply 2)
+### Apply again (Apply 2)
 
 Candidates can now use [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk/candidate) to apply again if they are rejected by all their providers, or decline by default or withdraw their applications.
 
@@ -198,9 +195,9 @@ As currently, in this phase candidates can make an unlimited number of single, s
 Candidates will also be able to use UCAS’s Apply 2 service for this part of their journey.
 
 
-##<a name="troubleshooting"></a>Troubleshooting
+## <a name="troubleshooting"></a>Troubleshooting
 
-###Informing candidates your courses are on Apply
+### Informing candidates your courses are on Apply
 
 Your courses will automatically be uploaded to [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk) as part of our onboarding process.
 
@@ -208,14 +205,14 @@ When candidates use [Find postgraduate teacher training](https://www.find-postgr
 
 When candidates bypass [Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) and come directly to Apply for teacher training via a search engine or a provider website, they will also be offered a choice between Apply and UCAS.
 
-###Stopping candidates making multiple applications through Apply and UCAS
+### Stopping candidates making multiple applications through Apply and UCAS
 
 We are developing data sharing arrangements with UCAS to monitor candidates who attempt to:
 
 * apply to the same course twice (by using both the Apply and UCAS services)
 * apply to more than 3 courses in the Apply 1 stage of their application (by using both the Apply and UCAS services)
 
-###Helping candidates apply to training providers not yet onboarded to Manage teacher training applications
+### Helping candidates apply to training providers not yet onboarded to Manage teacher training applications
 
 Non-onboarded training providers continue to be available through UCAS Teacher Training. This will remain the case until the UCAS service is switched off in October 2021.
 
@@ -229,24 +226,24 @@ We provide a clear route to UCAS for candidates who choose non-onboarded provide
 
 4. Within [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk), if candidates select a non-onboarded provider as one of their additional course choices, they are directed back to UCAS to apply using that service.
 
-###Onboarding for providers with courses ratified by an accredited body
+### Onboarding for providers with courses ratified by an accredited body
 
 If your courses are ratified by an accredited body, or you are part of a partnership of teacher training organisations, you will need to make sure your partners are ready to be onboarded to Manage.
 
 They may find our [introduction to the service](https://www.apply-for-teacher-training.service.gov.uk/provider) helpful. We’re available to answer any questions they may have on <becomingateacher@digital.education.gov.uk>.
 
-###Candidates who apply for your courses through UCAS
+### Candidates who apply for your courses through UCAS
 
 Candidates are given a choice about which service to use to apply for your courses. It’s important that you continue to check UCAS for candidates applying via that service. You’ll need to process these applications through UCAS in the normal way.
 
-###COVID-19
+### COVID-19
 
 The Department for Education has not changed delivery timetables for the roll-out of the Apply and Manage services.
 
 For questions related to COVID-19, please email our dedicated helpline on <dfe.coronavirushelpline@education.gov.uk> or call us at <a href="tel:0800 046 8687">0800 046 8687</a>.
 Lines are open 8am to 6pm (Monday to Friday) 10am to 4pm (Saturday and Sunday).
 
-##<a name="publicising-apply"></a>Publicising Apply for teacher training
+## <a name="publicising-apply"></a>Publicising Apply for teacher training
 
 Some providers find that becoming an early adopter of a streamlined, modern GOV.UK service is a useful marketing aid.
 
@@ -254,16 +251,16 @@ You can direct candidates to the new service by linking from your website to you
 
 Our [marketing tool kit](https://docs.google.com/presentation/d/1dCZ5HF_mpJMAOpmr305VqlUo_wqW2jWmzOWi9vxStI0/edit#slide=id.g73a2eda7b8_0_40) may be helpful for your website and social media feeds.
 
-##<a name="help-support-and-feedback"></a>Help, support and feedback
+## <a name="help-support-and-feedback"></a>Help, support and feedback
 
-###See a demo
+### See a demo
 To request a remote demonstration of the service as a whole or a particular feature, email us on <becomingateacher@digital.education.gov.uk>.
 
-###Report a problem
+### Report a problem
 
 To report a problem or get help, email us on <becomingateacher@digital.education.gov.uk>.
 
-###Take part in user research and give feedback
+### Take part in user research and give feedback
 
 We welcome feedback on all aspects of Manage teacher training applications. When you participate in user research, you help shape current and future service features.
 

--- a/app/views/provider_interface/provider_users/confirm_remove.html.erb
+++ b/app/views/provider_interface/provider_users/confirm_remove.html.erb
@@ -10,7 +10,7 @@
         Are you sure you want to delete this user’s account?
       </h1>
 
-      <%= f.submit "Yes I'm sure - delete this account",
+      <%= f.submit "Yes I’m sure - delete this account",
         class: 'govuk-button govuk-button--warning',
         data: { module: 'govuk-button' } %>
 

--- a/app/views/provider_interface/provider_users_invitations/check.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/check.html.erb
@@ -11,7 +11,7 @@
 
       <%= render ProviderInterface::ProviderUserInvitationDetailsComponent.new(wizard: @wizard) %>
 
-      <p class="govuk-body">We'll send the user an email guiding them through DfE Sign-In and giving them access to their account.</p>
+      <p class="govuk-body">We’ll send the user an email guiding them through DfE Sign-In and giving them access to their account.</p>
 
       <%= f.govuk_submit 'Invite user' %>
     <% end %>

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -18,7 +18,7 @@
         <strong class="govuk-warning-text__text">
           <span class="govuk-warning-text__assistive">Warning</span>
           Anyone you invite to your organisation will be able to view all applications to courses you
-          look after. They'll be able to make decisions about applications and view sensitive information,
+          look after. They’ll be able to make decisions about applications and view sensitive information,
           if you give them permission.
         </strong>
       </div>

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl">Are you sure you won’t give <%= @application.full_name %> a reference?</h1>
 
     <%= form_with model: @reference, url: referee_interface_refuse_feedback_path(token: @token_param), method: :patch do |f| %>
-      <%= f.govuk_submit 'Yes - I\'m sure' %>
+      <%= f.govuk_submit 'Yes - I’m sure' %>
     <% end %>
 
     <p class="govuk-body">

--- a/app/views/support_interface/change_course/confirm_cancel_application.html.erb
+++ b/app/views/support_interface/change_course/confirm_cancel_application.html.erb
@@ -10,7 +10,7 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>This will withdraw the candidate from all course choices</li>
       <li>The candidate will have to go through Apply 2 (UCAS only) if they want to apply again</li>
-      <li>We'll cancel the references, and email referees that their feedback is no longer required</li>
+      <li>We’ll cancel the references, and email referees that their feedback is no longer required</li>
     </ul>
 
     <%= form_with model: @application_form, url: support_interface_cancel_application_path(@application_form), method: :post do |f| %>

--- a/app/views/support_interface/change_course/select_course_to_add.html.erb
+++ b/app/views/support_interface/change_course/select_course_to_add.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix("Add a course to #{@form.application_form.full_name}'s application", @form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix("Add a course to #{@form.application_form.full_name}’s application", @form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_change_course_path(@form.application_form)) %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class='govuk-heading-xl'>
-        Add a course to <%= @form.application_form.full_name %>'s application
+        Add a course to <%= @form.application_form.full_name %>’s application
       </h1>
 
       <p class="govuk-body">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -87,8 +87,8 @@ en:
         label: Where do you live?
         change_action: where I live
         values:
-          uk: 'In the UK'
-          international: 'Outside the UK'
+          uk: In the UK
+          international: Outside the UK
       country:
         label: Which country?
         default_option: Select a country
@@ -204,12 +204,12 @@ en:
         review_label: Comparable UK degree
         change_action: NARIC statement
         values:
-          bachelor_ordinary_degree: 'Bachelor (Ordinary) degree'
-          bachelor_honours_degree: 'Bachelor (Honours) degree'
-          postgraduate_certificate_or_diploma: 'Postgraduate Certificate / Postgraduate Diploma'
-          masters_degree: 'Master’s degree / Integrated Master’s degree'
-          doctor_of_philosophy: 'Doctor of Philosophy degree'
-          post_doctoral_award: 'Post Doctoral award'
+          bachelor_ordinary_degree: Bachelor (Ordinary) degree
+          bachelor_honours_degree: Bachelor (Honours) degree
+          postgraduate_certificate_or_diploma: Postgraduate Certificate / Postgraduate Diploma
+          masters_degree: Master’s degree / Integrated Master’s degree
+          doctor_of_philosophy: Doctor of Philosophy degree
+          post_doctoral_award: Post Doctoral award
     gcse:
       qualification:
         label: Qualification
@@ -278,7 +278,7 @@ en:
         complete_form_button: Continue
       subject_knowledge:
         key: Your knowledge about the subject you want to teach
-        change_action:  evidence of subject knowledge
+        change_action: evidence of subject knowledge
         label: Tell us what you know about the subject you want to teach
         complete_form_button: Continue
       interview_preferences:
@@ -370,7 +370,7 @@ en:
       review:
         button: Continue
       sure_delete_entry: Yes I’m sure - delete this referee
-      sure_cancel_entry: Yes I'm sure - cancel this reference request
+      sure_cancel_entry: Yes I’m sure - cancel this reference request
       chase: Chase this referee and notify the candidate
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:
@@ -572,11 +572,11 @@ en:
             start_year:
               blank: Enter your start year
               invalid: Enter a real start year
-              greater_than_award_year: 'Enter a start year before graduation year'
+              greater_than_award_year: Enter a start year before graduation year
             award_year:
               blank: Enter your graduation year
               invalid: Enter a real graduation year
-              greater_than_limit: 'Enter a year before %{date}'
+              greater_than_limit: Enter a year before %{date}
         candidate_interface/english_foreign_language/type_form:
           attributes:
             type:
@@ -637,7 +637,7 @@ en:
             award_year:
               blank: Enter the year the qualification was awarded
               invalid: Enter a real year
-              in_the_future: 'Enter a year before %{date}'
+              in_the_future: Enter a year before %{date}
             choice:
               blank: Do you want to add another qualification?
         candidate_interface/work_experience_form:

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -197,11 +197,11 @@ en:
       by: candidate
       description: |
         When candidates apply again after an initial unsuccesful application,
-        they may have all the references they need already. They also don't have to
-        wait 7 days, as we don't have the edit window because the chance is lower
+        they may have all the references they need already. They also don’t have to
+        wait 7 days, as we don’t have the edit window because the chance is lower
         that they wish to edit their application the 2nd time around.
 
-        This means we'll send the application immediately to the provider.
+        This means we’ll send the application immediately to the provider.
       emails:
         - candidate_mailer-application_sent_to_provider
         - provider_mailer-application_submitted

--- a/config/locales/apply_from_find.yml
+++ b/config/locales/apply_from_find.yml
@@ -4,4 +4,4 @@ en:
     ucas_apply_button: Apply through UCAS
     find_button: Find postgraduate teacher training
     heading_not_found: We couldn’t find the course you’re looking for
-    account_created_message: 'Your Apply for teacher training account has been created'
+    account_created_message: Your Apply for teacher training account has been created

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -69,9 +69,9 @@ en:
         study_mode_withdrawn: "%{provider_name} is not running %{study_mode} places for %{course_name} anymore: update your course choice now"
         study_mode_location_full: "There are no more %{study_mode} places at your choice of location for %{course_name} at %{provider_name}: update your course choice now"
         study_mode_location_withdrawn: "%{provider_name} is not running %{study_mode} places at your choice of location for %{course_name}: update your course choice now"
-        course_withdrawn: '%{course_name} at %{provider_name} is not running anymore: update your course choice now'
+        course_withdrawn: "%{course_name} at %{provider_name} is not running anymore: update your course choice now"
       slack_message:
-        course_withdrawn: '%{course_name} at %{provider_name} was withdrawn while %{candidate_name} was awaiting references'
+        course_withdrawn: "%{course_name} at %{provider_name} was withdrawn while %{candidate_name} was awaiting references"
         course_full: "%{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"
         location_full: "%{course_name} at %{provider_name} became full at %{location} while %{candidate_name} was awaiting references"
         study_mode_full: "%{study_mode} places for %{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,8 +39,8 @@ en:
     accessibility: Accessibility statement
     privacy_policy: How we look after your personal data
     terms_candidate: Terms of use
-    service_guidance_provider: 'Using the Manage teacher training applications service: guidance for teacher training providers'
-    getting_ready_for_next_cycle: 'Getting ready for the next cycle (2020 to 2021)'
+    service_guidance_provider: "Using the Manage teacher training applications service: guidance for teacher training providers"
+    getting_ready_for_next_cycle: Getting ready for the next cycle (2020 to 2021)
     cookies_candidate: Cookies
     cookies_provider: Cookies
     contact_details: Contact details
@@ -244,7 +244,7 @@ en:
             rejection_reason:
               blank: Explain why you’re rejecting the application
               too_long: |
-                The explanation for why you're rejecting the application must be
+                The explanation for why you’re rejecting the application must be
                 %{count} characters or fewer
         provider_interface/provider_user_invitation_wizard:
           attributes:
@@ -320,11 +320,11 @@ en:
       too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course_name_and_code}.
       apply_again_course_already_chosen: You cannot choose more than 1 course when you apply again. You must delete your existing choice if you want to apply to %{course_name_and_code}
     application_choices:
-      course_not_available: You cannot apply to '%{descriptor}' because it is not running
-      course_full: You cannot apply to '%{descriptor}' because it has no vacancies
-      site_full: Your chosen location for '%{descriptor}' has no vacancies
-      study_mode_full: Your chosen location for '%{descriptor}' has no %{study_mode} vacancies
-      course_closed_on_apply: "'%{course_name_and_code}' at %{provider_name} is not available on Apply for teacher training anymore"
+      course_not_available: You cannot apply to ‘%{descriptor}’ because it is not running
+      course_full: You cannot apply to ‘%{descriptor}’ because it has no vacancies
+      site_full: Your chosen location for ‘%{descriptor}’ has no vacancies
+      study_mode_full: Your chosen location for ‘%{descriptor}’ has no %{study_mode} vacancies
+      course_closed_on_apply: ‘%{course_name_and_code}’ at %{provider_name} is not available on Apply for teacher training anymore
       already_added: You have already added %{course_name_and_code}
   date:
     formats:

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -1,8 +1,8 @@
 en:
   provider_mailer:
     offer_accepted:
-      subject: '%{candidate_name} has accepted your offer'
+      subject: "%{candidate_name} has accepted your offer"
     decline_by_default:
-      subject: '%{candidate_name}’s application withdrawn automatically'
+      subject: "%{candidate_name}’s application withdrawn automatically"
     declined:
-      subject: '%{candidate_name} declined an offer'
+      subject: "%{candidate_name} declined an offer"

--- a/config/locales/provider_notifications.yml
+++ b/config/locales/provider_notifications.yml
@@ -7,10 +7,10 @@ en:
       subject: Application received for %{course_name_and_code}
   provider_application_rejected_by_default:
     email:
-      subject: '%{candidate_name}’s application was rejected automatically'
+      subject: "%{candidate_name}’s application was rejected automatically"
   provider_application_waiting_for_decision:
     email:
-      subject: 'Respond to %{candidate_name}’s application'
+      subject: "Respond to %{candidate_name}’s application"
   provider_application_withdrawn:
     email:
-      subject: '%{candidate_name} withdrew their application'
+      subject: "%{candidate_name} withdrew their application"

--- a/config/locales/provider_regions.yml
+++ b/config/locales/provider_regions.yml
@@ -1,15 +1,15 @@
 en:
   provider_regions:
-    east_midlands: 'East Midlands'
-    eastern: 'Eastern'
-    london: 'London'
-    no_region: 'No region'
-    no_region_specified: 'No region specified'
-    north_east: 'North East'
-    north_west: 'North West'
-    scotland: 'Scotland'
-    south_east: 'South East'
-    south_west: 'South West'
-    wales: 'Wales'
-    west_midlands: 'West Midlands'
-    yorkshire_and_the_humber: 'Yorkshire and the Humber'
+    east_midlands: East Midlands
+    eastern: Eastern
+    london: London
+    no_region: No region
+    no_region_specified: No region specified
+    north_east: North East
+    north_west: North West
+    scotland: Scotland
+    south_east: South East
+    south_west: South West
+    wales: Wales
+    west_midlands: West Midlands
+    yorkshire_and_the_humber: Yorkshire and the Humber

--- a/config/locales/reference.yml
+++ b/config/locales/reference.yml
@@ -1,16 +1,16 @@
 en:
   reference_status:
-    cancelled: 'Cancelled'
-    not_requested_yet: 'Not requested yet'
-    feedback_requested: 'Requested'
-    feedback_provided: 'Feedback provided'
-    feedback_refused: 'Reference declined'
-    email_bounced: 'Email bounced'
+    cancelled: Cancelled
+    not_requested_yet: Not requested yet
+    feedback_requested: Requested
+    feedback_provided: Feedback provided
+    feedback_refused: Reference declined
+    email_bounced: Email bounced
   candidate_reference_status:
-    cancelled: 'Cancelled'
-    not_requested_yet: 'Not requested yet'
-    feedback_requested: 'Awaiting response'
-    feedback_provided: 'Reference given'
-    feedback_refused: 'Reference declined'
-    email_bounced: 'Email address incorrect'
-    feedback_overdue: 'Response overdue'
+    cancelled: Cancelled
+    not_requested_yet: Not requested yet
+    feedback_requested: Awaiting response
+    feedback_provided: Reference given
+    feedback_refused: Reference declined
+    email_bounced: Email address incorrect
+    feedback_overdue: Response overdue

--- a/config/locales/safeguarding.yml
+++ b/config/locales/safeguarding.yml
@@ -1,14 +1,14 @@
 en:
   provider_interface:
     safeguarding_declaration_component:
-      has_safeguarding_issues_to_declare: 'The candidate has disclosed sensitive material related to safeguarding.'
-      not_answered_yet: 'Not answered yet.'
-      never_asked: 'Never asked.'
-      no_safeguarding_issues_to_declare: 'No information shared.'
-      has_safeguarding_issues_to_declare_no_permissions: 'The candidate has disclosed information related to safeguarding. Access is restricted to users with permissions to view sensitive material.'
+      has_safeguarding_issues_to_declare: The candidate has disclosed sensitive material related to safeguarding.
+      not_answered_yet: Not answered yet.
+      never_asked: Never asked.
+      no_safeguarding_issues_to_declare: No information shared.
+      has_safeguarding_issues_to_declare_no_permissions: The candidate has disclosed information related to safeguarding. Access is restricted to users with permissions to view sensitive material.
   support_interface:
     safeguarding_issues_component:
-      has_safeguarding_issues_to_declare: 'The candidate has shared information related to safeguarding.'
-      not_answered_yet: 'Not answered yet.'
-      never_asked: 'Never asked.'
-      no_safeguarding_issues_to_declare: 'No information shared.'
+      has_safeguarding_issues_to_declare: The candidate has shared information related to safeguarding.
+      not_answered_yet: Not answered yet.
+      never_asked: Never asked.
+      no_safeguarding_issues_to_declare: No information shared.

--- a/config/locales/support_interface.yml
+++ b/config/locales/support_interface.yml
@@ -8,7 +8,6 @@ en:
 
     change_course:
       page_title: What do you want to do?
-
-      add_course: 'Add another course choice'
-      remove_course: 'Withdraw a course choice'
-      cancel_application: 'Cancel the application and withdraw all choices'
+      add_course: Add another course choice
+      remove_course: Withdraw a course choice
+      cancel_application: Cancel the application and withdraw all choices

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -7,7 +7,7 @@ info:
     name: DfE
     email: becomingateacher@digital.education.gov.uk
   description: |
-    API for DfE's Apply for postgraduate teacher training service.
+    API for DfE’s Apply for teacher training service.
     Endpoints with the `/applications` prefix are considered stable.
     Experimental endpoints prefixed with `/test-data` may change or be removed.
 servers:
@@ -33,7 +33,7 @@ paths:
           and time. Times should be in ISO 8601 format.
         in: query
         required: true
-        example: '2019-12-06T12:00:00Z'
+        example: 2019-12-06T12:00:00Z
         schema:
           type: string
           format: date-time
@@ -224,7 +224,7 @@ paths:
       - Application management
       summary: Reject application
       description: |
-        Reject the candidate's application with a reason.
+        Reject the candidate’s application with a reason.
 
         This will transition the application to the [rejected state](/api-docs/lifecycle#rejected).
       parameters:
@@ -377,7 +377,7 @@ components:
       properties:
         support_reference:
           type: string
-          description: The candidate's reference number for their application in the Apply system
+          description: The candidate’s reference number for their application in the Apply system
           maxLength: 10
           example: AB1234
         status:
@@ -411,18 +411,18 @@ components:
           type: string
           format: date-time
           description: Time of submission
-          example: '2019-06-13T10:44:31Z'
+          example: 2019-06-13T10:44:31Z
         updated_at:
           type: string
           format: date-time
           description: Time of last change
-          example: '2019-06-13T10:44:31Z'
+          example: 2019-06-13T10:44:31Z
         reject_by_default_at:
           type: string
           format: date-time
           nullable: true
           description: Time when the application is due to be rejected by default
-          example: '2019-06-13T23:59:59Z'
+          example: 2019-06-13T23:59:59Z
         personal_statement:
           type: string
           maxLength: 10240
@@ -505,7 +505,7 @@ components:
           type: string
           format: date
           description: The candidate’s date of birth
-          example: '1985-02-02'
+          example: 1985-02-02
         nationality:
           type: array
           items:
@@ -527,7 +527,7 @@ components:
           type: string
           maxLength: 10240
           nullable: true
-          description: About this candidate's English language qualifications, if
+          description: About this candidate’s English language qualifications, if
             English is not their main language
           example: I have a degree in English Language and Literature from the University
             of Munich
@@ -535,7 +535,7 @@ components:
           type: string
           maxLength: 10240
           nullable: true
-          description: Details of the candidate's fluency in other languages
+          description: Details of the candidate’s fluency in other languages
           example: I am bilingual in Finnish and English
         disability_disclosure:
           type: string
@@ -547,7 +547,7 @@ components:
     ContactDetails:
       type: object
       additionalProperties: false
-      description: UK addresses have country code 'GB' and `address_line1`, `address_line2`,
+      description: UK addresses have country code `GB` and `address_line1`, `address_line2`,
         `address_line3`, `address_line4` and `postcode` attributes. International addresses have
         a valid `country` value and the address itself is serialised to `address_line1`.
       required:
@@ -600,7 +600,7 @@ components:
           type: string
           description: The candidate’s phone number
           maxLength: 50
-          example: '07944386555'
+          example: "07944386555"
     Course:
       type: object
       additionalProperties: false
@@ -632,7 +632,7 @@ components:
           maxLength: 5
         study_mode:
           type: string
-          description: Can be 'full_time' or 'part_time'
+          description: Can be `full_time` or `part_time`
           example: full_time
           enum:
           - full_time
@@ -708,18 +708,18 @@ components:
           type: string
           maxLength: 256
           description: The grade awarded
-          example: '2:1'
+          example: "2:1"
         start_year:
           type: string
           nullable: true
           maxLength: 4
           description: The year the candidate started qualification
-          example: '1989'
+          example: "1989"
         award_year:
           type: string
           maxLength: 4
           description: The year the award was made
-          example: '1992'
+          example: "1992"
         institution_details:
           type: string
           description: Details about the institution and awarding body
@@ -783,7 +783,7 @@ components:
           type: string
           format: date-time
           description: Time of the rejection or offer withdrawal
-          example: '2019-09-18T15:33:49.216Z'
+          example: 2019-09-18T15:33:49.216Z
     Withdrawal:
       type: object
       additionalProperties: false
@@ -801,7 +801,7 @@ components:
           type: string
           format: date-time
           description: Time of the withdrawal
-          example: '2019-09-18T15:33:49.216Z'
+          example: 2019-09-18T15:33:49.216Z
     Qualifications:
       type: object
       additionalProperties: false
@@ -829,8 +829,8 @@ components:
           maxLength: 10240
           description: If the candidate lacks any required GCSEs, this field will
             contain their free-text explanation of why this is the case.
-          example: 'Maths GCSE or equivalent: I will take Maths GCSE at my local training
-            provider on 18th August 2020'
+          example: "Maths GCSE or equivalent: I will take Maths GCSE at my local training
+            provider on 18th August 2020"
     WorkExperiences:
       type: object
       additionalProperties: false
@@ -853,7 +853,7 @@ components:
           type: string
           nullable: true
           description: The candidate’s explanation for any breaks in work history.
-            Will be null if there aren't any breaks in the candidate’s work history.
+            Will be null if there aren’t any breaks in the candidate’s work history.
             We define a break in work history as more than a month between 2 jobs.
           maxLength: 10240
           example: I spent time volunteering overseas...
@@ -883,13 +883,13 @@ components:
           type: string
           format: date
           description: The date the position began
-          example: '2020-09-10'
+          example: 2020-09-10
         end_date:
           type: string
           format: date
           nullable: true
           description: The date the position finished, if applicable
-          example: '2019-04-01'
+          example: 2019-04-01
         role:
           type: string
           description: The position held by the candidate
@@ -928,51 +928,51 @@ components:
           type: string
           nullable: true
           description: The candidate’s sex as a [1-digit HESA code for Sex](https://www.hesa.ac.uk/collection/c19053/e/sexid)
-          example: '1'
+          example: "1"
           enum:
-          - '1'
-          - '2'
-          - '3'
+          - "1"
+          - "2"
+          - "3"
         disability:
           type: string
           nullable: true
           description: The candidate’s disability as [a 2-digit HESA code for Disability](https://www.hesa.ac.uk/collection/c19053/e/disable)
-          example: '00'
+          example: "00"
           enum:
-          - '00'
-          - '08'
-          - '51'
-          - '53'
-          - '54'
-          - '55'
-          - '56'
-          - '57'
-          - '58'
-          - '96'
+          - "00"
+          - "08"
+          - "51"
+          - "53"
+          - "54"
+          - "55"
+          - "56"
+          - "57"
+          - "58"
+          - "96"
         ethnicity:
           type: string
           nullable: true
           description: The candidate’s ethnicity as [a 2-digit HESA code for Ethnicity](https://www.hesa.ac.uk/collection/c19053/e/ethnic)
-          example: '10'
+          example: "10"
           enum:
-          - '10'
-          - '15'
-          - '21'
-          - '22'
-          - '29'
-          - '31'
-          - '32'
-          - '33'
-          - '34'
-          - '39'
-          - '41'
-          - '42'
-          - '43'
-          - '49'
-          - '50'
-          - '80'
-          - '90'
-          - '98'
+          - "10"
+          - "15"
+          - "21"
+          - "22"
+          - "29"
+          - "31"
+          - "32"
+          - "33"
+          - "34"
+          - "39"
+          - "41"
+          - "42"
+          - "43"
+          - "49"
+          - "50"
+          - "80"
+          - "90"
+          - "98"
     Attribution:
       type: object
       additionalProperties: false
@@ -995,10 +995,10 @@ components:
           type: string
           description: The ID of the user in the Student Record System, used for disambiguation
           maxLength: 100
-          example: '12345'
+          example: "12345"
     MetaData:
       type: object
-      description: Required under a "meta" key in the body of every POST or PUT request
+      description: Required under a ‘meta’ key in the body of every POST or PUT request
       additionalProperties: false
       required:
       - attribution
@@ -1010,7 +1010,7 @@ components:
           type: string
           description: The time this update was made
           format: date-time
-          example: '2019-03-01T15:33:49.216Z'
+          example: 2019-03-01T15:33:49.216Z
     Error:
       type: object
       additionalProperties: false
@@ -1067,7 +1067,7 @@ components:
             "$ref": "#/components/schemas/Error"
           example:
           - error: ParameterMissing
-            message: 'param is missing or the value is empty: parameter_name'
+            message: "param is missing or the value is empty: parameter_name"
     UnprocessableEntityResponse:
       type: object
       required:
@@ -1081,7 +1081,7 @@ components:
             "$ref": "#/components/schemas/Error"
           example:
           - error: UnprocessableEntity
-            message: A 'meta' key was not included on the request body
+            message: A ‘meta’ key was not included on the request body
     OkResponse:
       type: object
       required:

--- a/spec/forms/referee_interface/reference_review_form_spec.rb
+++ b/spec/forms/referee_interface/reference_review_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RefereeInterface::ReferenceReviewForm do
       it 'is invalid' do
         expect(review_form).not_to be_valid
         expect(review_form.errors.full_messages).to eq(
-          ["Can't submit a reference without answers to all questions"],
+          ['Can’t submit a reference without answers to all questions'],
         )
       end
     end
@@ -25,7 +25,7 @@ RSpec.describe RefereeInterface::ReferenceReviewForm do
       it 'is invalid' do
         expect(review_form).not_to be_valid
         expect(review_form.errors.full_messages).to eq(
-          ["Can't submit a reference without answers to all questions"],
+          ['Can’t submit a reference without answers to all questions'],
         )
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe RefereeInterface::ReferenceReviewForm do
       it 'is invalid' do
         expect(review_form).not_to be_valid
         expect(review_form.errors.full_messages).to eq(
-          ["Can't submit a reference without answers to all questions"],
+          ['Can’t submit a reference without answers to all questions'],
         )
       end
     end

--- a/spec/forms/support_interface/add_course_to_application_form_spec.rb
+++ b/spec/forms/support_interface/add_course_to_application_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SupportInterface::AddCourseToApplicationForm, type: :model do
 
       form.validate
 
-      expect(form.errors.full_messages).to include "There's no course option with ID 7125871235812"
+      expect(form.errors.full_messages).to include 'There’s no course option with ID 7125871235812'
     end
   end
 end

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe StateChangeNotifier do
       before { StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice) }
 
       it 'mentions applicant\'s first name and provider name' do
-        arg1 = "#{applicant}'s application is ready to be reviewed by #{provider_name}"
+        arg1 = "#{applicant}’s application is ready to be reviewed by #{provider_name}"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -45,8 +45,8 @@ RSpec.describe StateChangeNotifier do
     describe ':make_an_offer' do
       before { StateChangeNotifier.call(:make_an_offer, application_choice: application_choice) }
 
-      it 'mentions applicant\s first name and provider name' do
-        arg1 = "#{provider_name} has just made an offer to #{applicant}'s application"
+      it 'mentions applicant\'s first name and provider name' do
+        arg1 = "#{provider_name} has just made an offer to #{applicant}’s application"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -59,8 +59,8 @@ RSpec.describe StateChangeNotifier do
     describe ':change_an_offer' do
       before { StateChangeNotifier.call(:change_an_offer, application_choice: application_choice) }
 
-      it 'mentions applicant\s first name and provider name' do
-        arg1 = "#{provider_name} has just changed an offer for #{applicant}'s application"
+      it 'mentions applicant\'s first name and provider name' do
+        arg1 = "#{provider_name} has just changed an offer for #{applicant}’s application"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -73,8 +73,8 @@ RSpec.describe StateChangeNotifier do
     describe ':reject_application' do
       before { StateChangeNotifier.call(:reject_application, application_choice: application_choice) }
 
-      it 'mentions applicant\s first name and provider name' do
-        arg1 = "#{provider_name} has just rejected #{applicant}'s application"
+      it 'mentions applicant\'s first name and provider name' do
+        arg1 = "#{provider_name} has just rejected #{applicant}’s application"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -87,8 +87,8 @@ RSpec.describe StateChangeNotifier do
     describe ':reject_application_by_default' do
       before { StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice) }
 
-      it 'mentions applicant\s first name' do
-        arg1 = "#{applicant}'s application has just been rejected by default"
+      it 'mentions applicant\'s first name' do
+        arg1 = "#{applicant}’s application has just been rejected by default"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -116,7 +116,7 @@ RSpec.describe StateChangeNotifier do
       before { StateChangeNotifier.call(:withdraw_offer, application_choice: application_choice) }
 
       it 'includes the applicant name and course identifier' do
-        arg1 = ":no_good: #{provider_name} has just withdrawn #{applicant}'s offer"
+        arg1 = ":no_good: #{provider_name} has just withdrawn #{applicant}’s offer"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 

--- a/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
+++ b/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
         )
     end
 
-    it 'redirects to Candidate Interface if candidate associated with user\'s providers' do
+    it 'redirects to Candidate Interface if candidate associated with user’s providers' do
       post provider_interface_impersonate_candidate_path(application_choice.application_form.candidate)
       expect(response).to have_http_status 302
 
@@ -29,7 +29,7 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
       expect(response).to have_http_status 200 # a 200 response suggests a candidate session
     end
 
-    it 'redirects back to Provider Interface if candidate is not associated with user\'s providers' do
+    it 'redirects back to Provider Interface if candidate is not associated with user’s providers' do
       unrelated_application = create(:application_choice, status: 'awaiting_provider_decision')
 
       post provider_interface_impersonate_candidate_path(unrelated_application.application_form.candidate)

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def then_a_slack_notification_is_sent
-    expect_slack_message_with_text "Harry has accepted #{@course_option.course.provider.name}'s offer"
+    expect_slack_message_with_text "Harry has accepted #{@course_option.course.provider.name}’s offer"
   end
 
   def and_i_see_that_i_accepted_the_offer

--- a/spec/system/candidate_interface/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_declines_offer_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Candidate declines an offer' do
   end
 
   def then_a_slack_notification_is_sent
-    expect_slack_message_with_text "Harry has declined #{@course_option.course.provider.name}'s offer"
+    expect_slack_message_with_text "Harry has declined #{@course_option.course.provider.name}’s offer"
   end
 
   def and_i_see_that_i_declined_the_offer

--- a/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
 
   def then_i_see_a_warning_that_my_course_is_no_longer_on_apply
     expect(page).to have_content(course_closed_on_apply_message)
-    expect(page).to have_content("You can still apply for '#{@option_where_course_not_running.course.name_and_code}' on UCAS.")
+    expect(page).to have_content("You can still apply for ‘#{@option_where_course_not_running.course.name_and_code}’ on UCAS.")
   end
 
   def then_i_see_error_messages_for_the_course_closed_on_apply_i_was_warned_about
@@ -109,18 +109,18 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
 private
 
   def course_not_running_message
-    "You cannot apply to '#{@option_where_course_not_running.course.provider_and_name_code}' because it is not running"
+    "You cannot apply to ‘#{@option_where_course_not_running.course.provider_and_name_code}’ because it is not running"
   end
 
   def course_has_no_vacancies_message
-    "You cannot apply to '#{@option_where_course_has_no_vacancies.course.provider_and_name_code}' because it has no vacancies"
+    "You cannot apply to ‘#{@option_where_course_has_no_vacancies.course.provider_and_name_code}’ because it has no vacancies"
   end
 
   def chosen_site_has_no_vacancies_message
-    "Your chosen location for '#{@option_where_no_vacancies_at_chosen_site.course.provider_and_name_code}' has no vacancies"
+    "Your chosen location for ‘#{@option_where_no_vacancies_at_chosen_site.course.provider_and_name_code}’ has no vacancies"
   end
 
   def course_closed_on_apply_message
-    "'#{@option_where_course_not_running.course.name_and_code}' at #{@option_where_course_not_running.course.provider.name} is not available on Apply for teacher training anymore"
+    "‘#{@option_where_course_not_running.course.name_and_code}’ at #{@option_where_course_not_running.course.provider.name} is not available on Apply for teacher training anymore"
   end
 end

--- a/spec/system/candidate_interface/candidate_submits_application_with_full_course_location_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_with_full_course_location_spec.rb
@@ -36,12 +36,12 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def then_i_see_a_warning_that_there_are_no_vacancies_at_my_chosen_location
-    expect(page).to have_content("Your chosen location for '#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}' has no vacancies")
+    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no vacancies")
   end
 
   def and_i_cannot_proceed
     click_link 'Continue'
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content("Your chosen location for '#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}' has no vacancies")
+    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no vacancies")
   end
 end

--- a/spec/system/candidate_interface/candidate_submits_application_with_full_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_with_full_course_study_mode_spec.rb
@@ -37,12 +37,12 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def then_i_see_a_warning_that_there_are_no_full_time_vacancies
-    expect(page).to have_content("Your chosen location for '#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}' has no full time vacancies")
+    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no full time vacancies")
   end
 
   def and_i_cannot_proceed
     click_link 'Continue'
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content("Your chosen location for '#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}' has no full time vacancies")
+    expect(page).to have_content("Your chosen location for ‘#{current_candidate.current_application.application_choices.first.course.provider_and_name_code}’ has no full time vacancies")
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe 'Selecting a full course' do
 
   def then_i_see_a_page_telling_me_i_cannot_apply
     expect(page).to have_text('You cannot apply to this course because it has no vacancies')
-    expect(page).to have_text("The course '#{@course.name_and_code}' is full")
+    expect(page).to have_text("The course ‘#{@course.name_and_code}’ is full")
   end
 end

--- a/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Declare no EFL qualification' do
   def when_i_declare_i_have_no_qualification
     choose 'No, I do not have an English as a foreign language qualification'
     fill_in(
-      "If you're working towards a qualification, give details here",
+      'If you’re working towards a qualification, give details here',
       with: "I'm working towards an IELTS.",
     )
     click_button 'Continue'

--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Removing a provider user' do
   end
 
   def and_i_confirm_i_want_to_delete_this_user
-    click_on "Yes I'm sure - delete this account"
+    click_on 'Yes I’m sure - delete this account'
   end
 
   def then_the_deleted_user_has_no_visible_provider_permissions

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -44,11 +44,11 @@ RSpec.feature 'Refusing to give a reference' do
   end
 
   def and_a_slack_notification_is_sent
-    expect_slack_message_with_text ":sadparrot: A referee declined to give feedback for #{@application.first_name}'s application"
+    expect_slack_message_with_text ":sadparrot: A referee declined to give feedback for #{@application.first_name}’s application"
   end
 
   def and_i_confirm_that_i_wont_give_a_reference
-    click_button 'Yes - I\'m sure'
+    click_button 'Yes - I’m sure'
   end
 
   def then_an_email_is_sent_to_the_candidate

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Stop submission of incomplete references', with_audited: true do
 
   def then_i_cannot_submit_the_reference
     click_button 'Submit reference'
-    expect(page).to have_content "Can't submit a reference without answers to all questions"
+    expect(page).to have_content 'Can’t submit a reference without answers to all questions'
     expect(ApplicationReference.feedback_provided).to be_empty
   end
 end


### PR DESCRIPTION
…because we’re not animals.

* Replaces all user-facing ‘dumb’ quotes I could find with ‘smart’ ones
* Adds some consistency around quoting in YAML in the few places I came across while doing this (not exhaustive)
* Tidies up header syntax in a markdown file
