### PR TITLE
Do not create reflexive Provider relationships

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -162,6 +162,7 @@ private
 
   def add_provider_relationships(course)
     return if course.accredited_provider.blank?
+    return if course.accredited_provider == course.provider
 
     ProviderRelationshipPermissions.find_or_create_by!(
       training_provider: provider,

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -161,6 +161,19 @@ RSpec.describe SyncProviderFromFind do
         }.not_to change(ProviderRelationshipPermissions, :count)
       end
 
+      it 'does not create provider relationships when the course accredited_provider attribute points back to the same provider' do
+        stub_find_api_provider_200_with_accredited_provider(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          accredited_provider_code: 'ABC',
+          findable: true,
+        )
+
+        expect {
+          SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
+        }.not_to change(ProviderRelationshipPermissions, :count)
+      end
+
       it 'stores full_time/part_time information within courses' do
         stub_find_api_provider_200_with_accredited_provider(
           provider_code: 'ABC',


### PR DESCRIPTION
Some of the courses we get from Publish have an accredited_provider key which points back to the training provider, and we create that relationship. Usually courses not requiring an accredited provider have a blank in that field.

These relationships don't make any sense and will cause problems - definitely in the onboarding flow, probably elsewhere - so don't create them.

## Context

![image (1)](https://user-images.githubusercontent.com/642279/89771137-c11e7f00-daf7-11ea-8102-fe3c08c3748b.png)

https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1596790769300400

## Changes proposed in this pull request

- stop creating the relationships on sync

We'll need to delete the existing relationships (28 of them) on production after this.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/Tz7fmaTQ/2579-dont-create-reflexive-provider-relationships

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
