### PR TITLE
Generate safeguarding issues correctly

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -57,8 +57,15 @@ class TestApplications
     end
 
     Audited.audit_class.as_user(candidate) do
+      traits = %i[
+        with_safeguarding_issues_disclosed
+        with_no_safeguarding_issues_to_declare
+        with_safeguarding_issues_never_asked
+      ].sample
+
       @application_form = FactoryBot.create(
         :completed_application_form,
+        traits,
         application_choices_count: 0,
         full_work_history: true,
         volunteering_experiences_count: 1,

--- a/app/services/generate_test_data.rb
+++ b/app/services/generate_test_data.rb
@@ -22,6 +22,9 @@ class GenerateTestData
       Audited.audit_class.as_user(candidate) do
         traits = [:with_completed_references]
         traits << :with_equality_and_diversity_data if rand < 0.55
+        traits << %i[with_safeguarding_issues_disclosed
+                     with_no_safeguarding_issues_to_declare
+                     with_safeguarding_issues_never_asked].sample
         application_form = FactoryBot.create(
           :completed_application_form,
           *traits,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -41,7 +41,6 @@ FactoryBot.define do
       work_history_explanation { Faker::Lorem.paragraph_by_chars(number: 600) }
       work_history_breaks { Faker::Lorem.paragraph_by_chars(number: 400) }
       volunteering_experience { [true, false, nil].sample }
-      safeguarding_issues { 'I have a criminal conviction.' }
       phase { :apply_1 }
 
       # Checkboxes to mark a section as complete
@@ -117,6 +116,19 @@ FactoryBot.define do
             other_disability: (disabilities.include?('Other') ? Faker::Lorem.paragraph(sentence_count: 2) : nil),
           }
         end
+      end
+
+      trait :with_safeguarding_issues_disclosed do
+        safeguarding_issues_status { 'has_safeguarding_issues_to_declare' }
+        safeguarding_issues { 'I have a criminal conviction.' }
+      end
+
+      trait :with_no_safeguarding_issues_to_declare do
+        safeguarding_issues_status { 'no_safeguarding_issues_to_declare' }
+      end
+
+      trait :with_safeguarding_issues_never_asked do
+        safeguarding_issues_status { 'never_asked' }
       end
 
       after(:build) do |application_form, evaluator|


### PR DESCRIPTION
## Context

We have `safeguarding_issues_status` column in a database which is set to "not_answered_yet" by default.
There is also `safeguarding_issues` column which contains whatever the candidate disclosed. 

The factory sets `safeguarding_issues` but the `safeguarding_issues_status` is "not_answered_yet".
If something is disclosed, the `safeguarding_issues_status` should be "has_safeguarding_issues_to_declare".

## Changes proposed in this pull request

Update GenerateTestData and TestApplication class used by the worker to set the status and `safeguarding_issues` correctly by introducing new factory traits. 

## Guidance to review

- test GenerateTestData: `GenerateTestData.new(10).generate`
- test the worker
  - Comment out all the states in except `create states: [:awaiting_provider_decision]` in app/workers/generate_test_applications.rb
  - Comment out throwing exemption when applying to the same course multiple times in app/lib/test_applications.rb L55-57
  - Create some courses open on apply `FactoryBot.create(:course_option, course: FactoryBot.create(:course, :open_on_apply))`
  - Run the worker  `GenerateTestApplications.new.perform`


## Link to Trello card

https://trello.com/c/9NxZFKHc/2397-correctly-display-the-criminal-convictions-and-professional-misconduct-answer-to-providers-when-there-is-no-information-provided

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
