### PR TITLE
Don't show details link if no safeguarding issues declared

### DIFF
--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body"><%= message %></p>
-<% if current_user_has_permission_to_view_safeguarding_information? %>
+<% if display_safeguarding_issues_details? %>
   <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -16,9 +16,8 @@ module ProviderInterface
       ).message
     end
 
-    def current_user_has_permission_to_view_safeguarding_information?
-      current_provider_user.authorisation
-        .can_view_safeguarding_information?(course: application_choice.course)
+    def display_safeguarding_issues_details?
+      safeguarding_issues_declared? && current_user_has_permission_to_view_safeguarding_information?
     end
 
     def details
@@ -33,6 +32,11 @@ module ProviderInterface
       else
         application_choice.application_form.safeguarding_issues_status
       end
+    end
+
+    def current_user_has_permission_to_view_safeguarding_information?
+      current_provider_user.authorisation
+        .can_view_safeguarding_information?(course: application_choice.course)
     end
 
     def safeguarding_issues_declared?

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
       result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
       expect(result.text).to include('No information shared.')
+      expect(result.text).not_to include('View information disclosed by the candidate')
     end
   end
 
@@ -109,6 +110,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
       result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
       expect(result.text).to include('Not answered yet')
+      expect(result.text).not_to include('View information disclosed by the candidate')
     end
   end
 end


### PR DESCRIPTION
## Context

The link to view details was showing when there were no issues disclosed

## Changes proposed in this pull request

Don't show the link to view details if no safeguarding issues declared

- **Before**
<kbd><img width="544" alt="Screenshot 2020-08-10 at 10 11 10" src="https://user-images.githubusercontent.com/38078064/89770345-88ca7100-daf6-11ea-9bed-f3943baae324.png"></kbd>

- **After**
<kbd><img width="515" alt="Screenshot 2020-08-10 at 10 15 30" src="https://user-images.githubusercontent.com/38078064/89770356-8e27bb80-daf6-11ea-84c6-5045849688fb.png"></kbd>


## Guidance to review

view this section of the application

## Link to Trello card

n/a

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
