### PR TITLE
Use title_with_error_prefix helper for DSA page, too

### DIFF
--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :browser_title, t('page_titles.data_sharing_agreement') %>
+<%= content_for :browser_title, title_with_error_prefix(t('page_titles.data_sharing_agreement'), @provider_agreement.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

We've started prepending 'Error: ' to page titles when validation fails (see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2622). 

## Changes proposed in this pull request

Do this for validation errors on the DSA page, too.

## Guidance to review

Submit the form without ticking the box.

## Link to Trello card

No card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
