### PR TITLE
Change respond banner to include date and add a button

### DIFF
--- a/app/views/provider_interface/application_choices/_application_choice_header.html.erb
+++ b/app/views/provider_interface/application_choices/_application_choice_header.html.erb
@@ -1,17 +1,18 @@
-<% if @application_choice.status == 'awaiting_provider_decision' && flash.empty? && @provider_can_respond -%>
-  <div class="app-banner">
-    <div class="app-banner__message">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-        You have <%= days_to_respond_to(@application_choice) %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
-      </h2>
-    </div>
-  </div>
-<% end -%>
-
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
   <%= @application_choice.application_form.full_name %>
   <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
 </h1>
+
+<% if @application_choice.status == 'awaiting_provider_decision' && flash.empty? && @provider_can_respond -%>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        <%= "You have #{days_to_respond_to(@application_choice)} days to respond to this application. On #{@application_choice.reject_by_default_at.to_s(:govuk_date)} this application will be automatically rejected." %>
+      </p>
+      <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>
+    </div>
+  </div>
+<% end -%>
 
 <% if @sub_navigation_items.count > 1 %>
   <%= render SubNavigationComponent.new(items: @sub_navigation_items) %>

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_should_see_a_prompt_to_respond_to_the_application
-    expect(page).to have_content(/You have \d+ days to send a response/)
+    expect(page).to have_content(/You have \d+ days to respond to this application./)
   end
 
   def when_i_click_to_respond_to_the_application


### PR DESCRIPTION
## Context

Change respond banner to include date and add a button to avoid banner blindness

## Changes proposed in this pull request

- **Before**
<kbd><img width="785" alt="Screenshot 2020-08-11 at 09 37 29" src="https://user-images.githubusercontent.com/38078064/89876260-51bb9480-dbb6-11ea-821c-c3214fbc1a62.png"></kbd>

- **After**
<kbd><img width="734" alt="Screenshot 2020-08-11 at 09 29 09" src="https://user-images.githubusercontent.com/38078064/89876282-58e2a280-dbb6-11ea-8f0c-58a93d562187.png"></kbd>

## Guidance to review

Is the html markup ok?

## Link to Trello card

https://trello.com/c/1DQQC3Ts/2575-change-respond-banner-to-include-date-and-add-a-button-to-avoid-banner-blindness

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
