### PR TITLE
Deprecate Withdrawal.reason in the API

### DIFF
--- a/app/presenters/api_docs/api_schema.rb
+++ b/app/presenters/api_docs/api_schema.rb
@@ -48,6 +48,10 @@ module APIDocs
         attributes['nullable']
       end
 
+      def deprecated?
+        attributes['deprecated']
+      end
+
       def type_description
         desc = [type]
         desc << ', ISO 8601 date with time and timezone' if attributes.format == 'date-time'

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,8 @@
+### 10th August 2020
+
+- Deprecate `Withdrawal.reason`, which was supposed to hold a candidate’s reason for
+withdrawing their application. The Apply service will not collect this information
+
 ### 7th July 2020
 
 Documentation has been amended to emphasise the stability of `/applications` endpoints

--- a/app/views/api_docs/reference/_properties_list.html.erb
+++ b/app/views/api_docs/reference/_properties_list.html.erb
@@ -22,6 +22,12 @@
           </p>
         <% end %>
 
+        <% if property.deprecated? %>
+          <p class="app-api-metadata govuk-!-font-weight-bold">
+            DEPRECATED
+          </p>
+        <% end %>
+
         <% if property.attributes.description %>
           <div class="app-styled-content govuk-!-margin-top-4">
             <%= markdown_to_html property.attributes.description %>

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -793,9 +793,10 @@ components:
       properties:
         reason:
           type: string
-          description: Optional. The candidate’s reason for withdrawing
+          description: Optional. The candidate’s reason for withdrawing. This field is deprecated because the Apply service does not collect this information
           maxLength: 10240
           nullable: true
+          deprecated: true
           example: Candidate is unwell
         date:
           type: string


### PR DESCRIPTION
## Context

We don't collect this information so this field has always been empty. We're now going to actually deprecate it.

## Changes proposed in this pull request

Deprecate the field 

- set `deprecated: true` in the openAPI spec
- show bold "DEPRECATED" text in the API docs for such fields
- add a note to the field description explaining that it's deprecated

## Link to Trello card

https://trello.com/c/nSOpT0Cs/2499-%F0%9F%8F%88-deprecate-candidate-reason-for-withdrawal-in-api-responses

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
