### PR TITLE
Use print helper from govuk-frontend

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -16,9 +16,9 @@
     <div class="govuk-header__content">
       <%= link_to service_name, service_url, class: 'govuk-header__link govuk-header__link--service-name' %>
       <% if navigation_items.any? %>
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-!-print-display-none" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle govuk-!-display-none-print" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
         <nav>
-          <ul id="navigation" class="govuk-header__navigation app-!-print-display-none" aria-label="Top Level Navigation">
+          <ul id="navigation" class="govuk-header__navigation govuk-!-display-none-print" aria-label="Top Level Navigation">
             <% navigation_items.each do |nav_item| %>
               <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
                 <% if nav_item.href %>

--- a/app/components/phase_banner.html.erb
+++ b/app/components/phase_banner.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-width-container">
-  <div class="govuk-phase-banner <%= @no_border ? 'app-phase-banner__no-border' : '' %> app-!-print-display-none">
+  <div class="govuk-phase-banner <%= @no_border ? 'app-phase-banner__no-border' : '' %> govuk-!-display-none-print">
     <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--<%= HostingEnvironment.environment_name %>">
       <%= HostingEnvironment.phase %>
     </strong>

--- a/app/components/provider_interface/header_component.html.erb
+++ b/app/components/provider_interface/header_component.html.erb
@@ -20,7 +20,7 @@
       <% if navigation_items.any? %>
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
         <nav>
-          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
+          <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end govuk-!-display-none-print" aria-label="Top Level Navigation">
             <% navigation_items.each do |nav_item| %>
               <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
                 <% if nav_item.href %>

--- a/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.html.erb
+++ b/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.html.erb
@@ -1,3 +1,3 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
-<%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0 app-!-print-display-none' %>
+<%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print' %>

--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -4,7 +4,7 @@
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
 <% if provider_can_respond %>
-<p class="govuk-body govuk-!-margin-bottom-0 app-!-print-display-none">
+<p class="govuk-body govuk-!-margin-bottom-0 govuk-!-display-none-print">
   <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
 </p>
 <% end %>

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -3,5 +3,5 @@
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
 <% if provider_can_respond %>
-<%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0  app-!-print-display-none' %>
+<%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0  govuk-!-display-none-print' %>
 <% end %>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -18,13 +18,13 @@
 
       <% if row[:change_path] %>
         <dd class="govuk-summary-list__actions">
-          <%= link_to row[:change_path], class: 'govuk-link app-!-print-display-none' do %>
+          <%= link_to row[:change_path], class: 'govuk-link govuk-!-display-none-print' do %>
             Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
           <% end %>
         </dd>
       <% elsif row[:action_path] %>
         <dd class="govuk-summary-list__actions">
-          <%= link_to row[:action], row[:action_path], class: 'govuk-link app-!-print-display-none' %>
+          <%= link_to row[:action], row[:action_path], class: 'govuk-link govuk-!-display-none-print' %>
         </dd>
       <% elsif any_row_has_action_span? %>
         <span class="govuk-summary-list__actions"></span>

--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -1,8 +1,4 @@
 @include govuk-media-query($media-type: print) {
-  .app-\!-print-display-none {
-    display: none !important;
-  }
-
   // TODO: Remove when breadcrumbs are a component
   .govuk-breadcrumbs {
     display: none;

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -8,7 +8,7 @@ module ViewHelper
   end
 
   def govuk_back_link_to(url, body = 'Back')
-    link_to(body, url, class: 'govuk-back-link app-!-print-display-none')
+    link_to(body, url, class: 'govuk-back-link govuk-!-display-none-print')
   end
 
   def bat_contact_mail_to(name = 'becomingateacher<wbr>@digital.education.gov.uk', html_options: {})

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer govuk-footer--app app-!-print-display-none" role="contentinfo">
+<footer class="govuk-footer govuk-footer--app govuk-!-display-none-print" role="contentinfo">
   <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'application_choice_header' %>
 
-<p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
+<p class="govuk-body govuk-!-margin-bottom-9 govuk-!-display-none-print">
   <%= govuk_link_to(
     'Download application (PDF)',
     provider_interface_application_choice_path(@application_choice.id, format: :pdf),
@@ -19,7 +19,7 @@
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>
 
     <% unless HostingEnvironment.production? %>
-      <div class="app-status-box app-status-box--sandbox app-!-print-display-none">
+      <div class="app-status-box app-status-box--sandbox govuk-!-display-none-print">
         <p class="govuk-body">
           <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--sandbox">
             sandbox feature

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe ViewHelper, type: :helper do
     it 'returns an anchor tag with the govuk-back-link class and defaults to "Back"' do
       anchor_tag = helper.govuk_back_link_to('https://localhost:0103/snek/ssss')
 
-      expect(anchor_tag).to eq('<a class="govuk-back-link app-!-print-display-none" href="https://localhost:0103/snek/ssss">Back</a>')
+      expect(anchor_tag).to eq('<a class="govuk-back-link govuk-!-display-none-print" href="https://localhost:0103/snek/ssss">Back</a>')
     end
 
     it 'returns an anchor tag with the govuk-back-link class and with the body if given' do
       anchor_tag = helper.govuk_back_link_to('https://localhost:0103/lion/roar', 'Back to application')
 
-      expect(anchor_tag).to eq('<a class="govuk-back-link app-!-print-display-none" href="https://localhost:0103/lion/roar">Back to application</a>')
+      expect(anchor_tag).to eq('<a class="govuk-back-link govuk-!-display-none-print" href="https://localhost:0103/lion/roar">Back to application</a>')
     end
   end
 


### PR DESCRIPTION
`govuk-frontend` v3.6.0 introduced a new utility helper `govuk-!-display-none-print`, which replicates the custom one we created (`app-!-print-display-none`). Given we are now on `govuk-frontend` v3.8.0, we can use the helper in frontend instead of our own.