### PR TITLE
Make 404 pages have meaningful headers

### DIFF
--- a/app/controllers/candidate_interface/errors_controller.rb
+++ b/app/controllers/candidate_interface/errors_controller.rb
@@ -1,0 +1,10 @@
+module CandidateInterface
+  class ErrorsController < CandidateInterfaceController
+    skip_before_action :verify_authenticity_token
+    skip_before_action :authenticate_candidate!
+
+    def not_found
+      render 'errors/not_found', status: :not_found
+    end
+  end
+end

--- a/app/controllers/provider_interface/errors_controller.rb
+++ b/app/controllers/provider_interface/errors_controller.rb
@@ -1,0 +1,10 @@
+module ProviderInterface
+  class ErrorsController < ProviderInterfaceController
+    skip_before_action :verify_authenticity_token
+    skip_before_action :authenticate_provider_user!
+
+    def not_found
+      render 'errors/not_found', status: :not_found
+    end
+  end
+end

--- a/app/controllers/support_interface/errors_controller.rb
+++ b/app/controllers/support_interface/errors_controller.rb
@@ -1,0 +1,10 @@
+module SupportInterface
+  class ErrorsController < SupportInterfaceController
+    skip_before_action :verify_authenticity_token
+    skip_before_action :authenticate_support_user!
+
+    def not_found
+      render 'errors/not_found', status: :not_found
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
   end
 
   def service_name
-    case intended_namespace
+    case current_namespace
     when 'candidate_interface'
       t('service_name.apply')
     when 'provider_interface'
@@ -21,7 +21,7 @@ module ApplicationHelper
     custom_link = content_for(:service_link)
     return custom_link if custom_link
 
-    case intended_namespace
+    case current_namespace
     when 'provider_interface'
       provider_interface_path
     when 'candidate_interface'
@@ -34,10 +34,11 @@ module ApplicationHelper
   end
 
   def current_namespace
-    params[:controller].split('/').first
-  end
-
-  def intended_namespace
-    "#{request.path.split('/').second}_interface"
+    section = request.path.split('/').second
+    if section == 'api-docs'
+      'api_docs'
+    else
+      "#{section}_interface"
+    end
   end
 end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -37,8 +37,8 @@ class NavigationItems
       end
     end
 
-    def for_provider_primary_nav(current_controller, performing_setup = false)
-      if performing_setup
+    def for_provider_primary_nav(current_provider_user, current_controller, performing_setup = false)
+      if !current_provider_user || performing_setup
         []
       else
         [NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes]))]

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -9,21 +9,10 @@
     <p class="govuk-body">
       If you pasted the web address, check you copied the entire address.
     </p>
-    <% if intended_namespace == 'provider_interface' %>
-      <p class="govuk-body">
-        You can
-        <%= govuk_link_to "return to #{service_name}", service_link %>.
-      </p>
-      <p class="govuk-body">
-        Or, if you need to speak to someone about this problem, email us on
-        <%= bat_contact_mail_to %>.
-      </p>
-    <% else %>
-      <p class="govuk-body">
-        If the web address is correct or you selected a link or button and you
-        need to speak to someone about this problem, contact the Becoming a Teacher team:
-        <%= bat_contact_mail_to %>.
-      </p>
-    <% end %>
+    <p class="govuk-body">
+      If the web address is correct or you selected a link or button and you
+      need to speak to someone about this problem, contact the Becoming a Teacher team:
+      <%= bat_contact_mail_to %>.
+    </p>
   </div>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <% case try(:intended_namespace) %>
+        <% case try(:current_namespace) %>
         <% when 'candidate_interface' %>
           <%= render 'layouts/footer_meta_candidate' %>
         <% when 'provider_interface' %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,19 +3,19 @@
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_candidate_interface(current_candidate, controller))) %>
+                                 navigation_items: NavigationItems.for_candidate_interface(try(:current_candidate), controller))) %>
                                <%= render PhaseBanner.new %>
 <% when 'support_interface' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_support_interface(current_support_user, controller))) %>
+                                 navigation_items: NavigationItems.for_support_interface(try(:current_support_user), controller))) %>
                                <%= render PhaseBanner.new %>
 <% when 'provider_interface' %>
   <%= render(ProviderInterface::HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  product_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_provider_account_nav(current_provider_user, controller, @provider_setup&.pending?))) %>
+                                 navigation_items: NavigationItems.for_provider_account_nav(try(:current_provider_user), controller, @provider_setup&.pending?))) %>
 
                                <% if controller.controller_name == 'start_page' %>
                                  <%= render PhaseBanner.new(no_border: true) %>
@@ -24,7 +24,7 @@
                                <% else %>
                                  <%= render PhaseBanner.new(no_border: true) %>
                                  <%= render(ProviderInterface::PrimaryNavigation.new(
-                                   navigation_items: NavigationItems.for_provider_primary_nav(controller, @provider_setup&.pending?))) %>
+                                   navigation_items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, @provider_setup&.pending?))) %>
                                <% end %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -5,7 +5,7 @@
         <span class="govuk-caption-xl"><%= yield :context %></span>
       <% end %>
 
-      <% if yield(:title).present? %>
+      <% if yield(:title).present? && controller_name != 'errors' %>
         <h1 class='govuk-heading-xl'><%= yield :title %></h1>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -472,6 +472,8 @@ Rails.application.routes.draw do
         get '/thank-you' => 'satisfaction_survey#thank_you', as: :satisfaction_survey_thank_you
       end
     end
+
+    get '*path', to: 'errors#not_found'
   end
 
   namespace :referee_interface, path: '/reference' do
@@ -617,6 +619,8 @@ Rails.application.routes.draw do
       patch '/:id' => 'provider_relationship_permissions#update',
             as: :update_provider_relationship_permissions
     end
+
+    get '*path', to: 'errors#not_found'
   end
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'
@@ -759,6 +763,8 @@ Rails.application.routes.draw do
 
     mount Sidekiq::Web => '/sidekiq', constraints: SupportUserConstraint.new
     get '/sidekiq', to: redirect('/support/sign-in'), status: 302
+
+    get '*path', to: 'errors#not_found'
   end
 
   namespace :api_docs, path: '/api-docs' do


### PR DESCRIPTION
## Context

We need to help users navigate away from 404 pages and back to somewhere useful. This completes the work started with https://github.com/DFE-Digital/apply-for-teacher-training/pull/2668.

## Changes proposed in this pull request

Create interface-specific error controllers so that we have access to `current_candidate`, `current_provider_user` and `current_support_user`. This way, the appropriate page headers can be shown, depending on the interface and whether a user is signed in.

This PR will still show the same page content in all cases, but the new controllers will allow us to use interface-specific copy when desired/designed.

This is how the 404 pages look in this PR (note the respective paths):

#### Candidate

![image](https://user-images.githubusercontent.com/107591/89883990-d01d3400-dbc0-11ea-9f34-cbd3f2380c49.png)

![image](https://user-images.githubusercontent.com/107591/89884009-d6131500-dbc0-11ea-9abf-6ed1d8994452.png)

#### Provider

![image](https://user-images.githubusercontent.com/107591/89884037-e1664080-dbc0-11ea-84a9-2535e4218d0d.png)

![image](https://user-images.githubusercontent.com/107591/89884049-e5925e00-dbc0-11ea-98b6-e9af43a607f8.png)

#### Support

![image](https://user-images.githubusercontent.com/107591/89884088-f216b680-dbc0-11ea-9164-b7ee12c6a6ea.png)

![image](https://user-images.githubusercontent.com/107591/89884102-f6db6a80-dbc0-11ea-8232-b1903f68556b.png)

#### Api docs

![image](https://user-images.githubusercontent.com/107591/89884336-4fab0300-dbc1-11ea-8713-fafb08e143a7.png)

#### Unknown

![image](https://user-images.githubusercontent.com/107591/89884133-ff33a580-dbc0-11ea-962f-a7af0c058443.png)

## Guidance to review

This PR focuses on 404 errors, other types of error (e.g. 500) are still handled as before.

## Link to Trello card

https://trello.com/c/xEwXApm3

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
