### PR TITLE
Fix international GCSEs and Other qualifications on the support app

### DIFF
--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -7,10 +7,14 @@ class QualificationTitleComponent < ViewComponent::Base
     if @qualification.level == 'gcse'
       return type_for_missing_qualification if @qualification.missing_qualification?
       return type_for_other_uk_qualification if @qualification.other_uk_qualification_type.present?
+      return type_for_non_uk_qualification if @qualification.non_uk_qualification_type.present?
 
       return type_for_gcse
     elsif @qualification.degree?
       return type_for_degree
+    elsif @qualification.level == 'other'
+      return type_for_other_uk_qualification if @qualification.other_uk_qualification_type.present?
+      return type_for_non_uk_qualification if @qualification.non_uk_qualification_type.present?
     end
 
     @qualification.qualification_type
@@ -38,6 +42,11 @@ private
   def type_for_other_uk_qualification
     I18n.t('application_form.gcse.qualification_types.other_uk')
       .concat(': ', @qualification.other_uk_qualification_type)
+  end
+
+  def type_for_non_uk_qualification
+    I18n.t('application_form.gcse.qualification_types.non_uk')
+      .concat(': ', @qualification.non_uk_qualification_type)
   end
 
   def type_for_gcse

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -68,4 +68,59 @@ RSpec.describe QualificationTitleComponent do
 
     expect(result.text).to include('Other UK qualification: A Level')
   end
+
+  it 'renders the correct title for an non_uk GCSE equivalent' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :gcse,
+      qualification_type: 'non_uk',
+      subject: 'maths',
+      non_uk_qualification_type: 'High School Diploma ',
+    )
+
+    result = render_inline(described_class.new(qualification: qualification))
+
+    expect(result.text).to include('Non-UK qualification: High School Diploma')
+  end
+
+  it 'renders the correct title for an other qualificaiton' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :other,
+      qualification_type: 'A Level',
+      subject: 'History',
+    )
+
+    result = render_inline(described_class.new(qualification: qualification))
+
+    expect(result.text).to include('A Level')
+  end
+
+  it 'renders the correct title for an other_uk other qualification' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :other,
+      qualification_type: 'other_uk',
+      subject: 'Maps and stuff',
+      other_uk_qualification_type: 'Orienteering',
+    )
+
+    result = render_inline(described_class.new(qualification: qualification))
+
+    expect(result.text).to include('Other UK qualification: Orienteering')
+  end
+
+  it 'renders the correct title for an non_uk other qualification' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :other,
+      qualification_type: 'other_uk',
+      subject: 'maths',
+      non_uk_qualification_type: 'High School Diploma',
+    )
+
+    result = render_inline(described_class.new(qualification: qualification))
+
+    expect(result.text).to include('Non-UK qualification: High School Diploma')
+  end
 end


### PR DESCRIPTION
## Context

International GCSEs and Other qualifications are not displaying the correct qualification type/name on the support interface

## Changes proposed in this pull request

- Add logic to the qualification title component to render the correct title

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/42515961/89883416-08704280-dbc0-11ea-8240-ea32125c8b19.png) | ![image](https://user-images.githubusercontent.com/42515961/89883344-eecefb00-dbbf-11ea-9379-9ca19ff5f77e.png) |

## Link to Trello card

https://trello.com/c/TGtkONbx/1914-international-gcse-and-other-qualifications-update-support-interface

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
