### PR TITLE
Fix international personal details section in the support app

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -63,12 +63,22 @@ private
   end
 
   def nationality_row
-    formatted_nationalities = [application_form.first_nationality, application_form.second_nationality].reject(&:blank?).to_sentence
-
     {
       key: 'Nationality',
       value: formatted_nationalities,
     }
+  end
+
+  def formatted_nationalities
+    [
+      @application_form.first_nationality,
+      @application_form.second_nationality,
+      @application_form.third_nationality,
+      @application_form.fourth_nationality,
+      @application_form.fifth_nationality,
+    ]
+    .reject(&:blank?)
+    .to_sentence
   end
 
   def date_of_birth_row

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -89,18 +89,29 @@ private
   end
 
   def address_row
-    full_address = [
-      application_form.address_line1,
-      application_form.address_line2,
-      application_form.address_line3,
-      application_form.address_line4,
-      application_form.postcode,
-    ].reject(&:blank?)
-
     {
       key: 'Address',
       value: full_address,
     }
+  end
+
+  def full_address
+    if @application_form.international?
+      [
+        @application_form.international_address,
+        COUNTRIES[@application_form.country],
+      ]
+        .reject(&:blank?)
+    else
+      [
+        @application_form.address_line1,
+        @application_form.address_line2,
+        @application_form.address_line3,
+        @application_form.address_line4,
+        @application_form.postcode,
+      ]
+        .reject(&:blank?)
+    end
   end
 
   def support_reference_row

--- a/spec/components/personal_details_component_spec.rb
+++ b/spec/components/personal_details_component_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe PersonalDetailsComponent do
     expect(result.css('.govuk-summary-list__value').text).to include(application_form.candidate.email_address)
   end
 
-  it 'renders the candidate address and postcode' do
+  it 'renders the candidate address and postcode for uk addresses' do
     full_address = [
       application_form.address_line1,
       application_form.address_line2,
@@ -54,5 +54,18 @@ RSpec.describe PersonalDetailsComponent do
     ].reject(&:blank?).join
 
     expect(result.css('.govuk-summary-list__value').text).to include(full_address)
+  end
+
+  it 'renders the candidate address and postcode for international addresses' do
+    application_form = build_stubbed(:completed_application_form, :international_address)
+
+    international_address = [
+      application_form.international_address,
+      COUNTRIES[application_form.country],
+    ].reject(&:blank?).join
+
+    result = render_inline(PersonalDetailsComponent.new(application_form: application_form))
+
+    expect(result.css('.govuk-summary-list__value').text).to include(international_address)
   end
 end

--- a/spec/components/personal_details_component_spec.rb
+++ b/spec/components/personal_details_component_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe PersonalDetailsComponent do
       :completed_application_form,
       support_reference: 'AB123',
       date_of_birth: Date.new(2000, 1, 1),
+      first_nationality: 'British',
+      second_nationality: 'Irish',
+      third_nationality: 'Spanish',
     )
   end
 
@@ -29,8 +32,8 @@ RSpec.describe PersonalDetailsComponent do
     expect(result.css('.govuk-summary-list__value').text).to include('1 January 2000')
   end
 
-  it 'renders the candidate nationality' do
-    expect(result.css('.govuk-summary-list__value').text).to include(application_form.first_nationality)
+  it 'renders the candidates nationalities' do
+    expect(result.css('.govuk-summary-list__value').text).to include('British, Irish, and Spanish')
   end
 
   it 'renders the candidate phone number' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -72,6 +72,15 @@ FactoryBot.define do
         with_degree { false }
       end
 
+      trait :international_address do
+        address_type { :international }
+        international_address { Faker::Address.city }
+        country { Faker::Address.country_code }
+        address_line1 { nil }
+        address_line2 { nil }
+        address_line3 { nil }
+      end
+
       trait :ready_to_send_to_provider do
         edit_by { 1.day.ago }
       end


### PR DESCRIPTION
## Context

The personal details section of the support interface is not rendering nationalities and international details correctly.

## Changes proposed in this pull request

- Show 3rd, 4th and 5th nationalities if present
- Show international addresses

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/42515961/89892488-a408af80-dbce-11ea-856b-4d159787dfa9.png) | ![image](https://user-images.githubusercontent.com/42515961/89892189-365c8380-dbce-11ea-92b8-af4b4c29e0d2.png) |

## Link to Trello card

https://trello.com/c/HcTAcE8K/1913-international-personal-details-update-support-interface
https://trello.com/c/LTtIILuC/1911-international-addresses-update-support-and-provider-interface

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
