### PR TITLE
Correct button markup for invite and delete provider user actions

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -17,8 +17,10 @@ module ViewHelper
     mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
   end
 
-  def govuk_button_link_to(body, url, html_options = {})
+  def govuk_button_link_to(body, url, html_options = {}, &_block)
     html_options[:class] = prepend_css_class('govuk-button', html_options[:class])
+
+    return link_to(url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false) { yield } if block_given?
 
     link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
   end

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if @application_choices.present? %>
         <% if @application_form.can_add_more_choices? %>
-          <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
+          <%= govuk_button_link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button--secondary govuk-!-margin-bottom-9' %>
         <% end %>
 
         <% if @application_choices.count >= 1 %>

--- a/app/views/candidate_interface/course_choices/replace_choices/review/confirm_choice.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/review/confirm_choice.html.erb
@@ -23,6 +23,6 @@
 
     <%= render(CandidateInterface::CourseOptionReviewComponent.new(course_option: @replacement_course_option)) %>
 
-    <%= govuk_link_to 'Replace course choice', candidate_interface_update_replacement_course_choice_path(@course_choice.id, @replacement_course_option.id), class: 'govuk-button' %>
+    <%= govuk_button_link_to 'Replace course choice', candidate_interface_update_replacement_course_choice_path(@course_choice.id, @replacement_course_option.id) %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/shared/_go_to_find.html.erb
+++ b/app/views/candidate_interface/course_choices/shared/_go_to_find.html.erb
@@ -6,7 +6,7 @@
 
     <p class="govuk-body-l">Search for courses near you on Find postgraduate teacher&nbsp;training.</p>
 
-    <%= link_to 'https://www.find-postgraduate-teacher-training.service.gov.uk', role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-2 govuk-button--start', target: '_blank', rel: 'noopener', 'data-module': 'govuk-button', 'aria-describedby': 'find-new-window' do %>
+    <%= govuk_button_link_to nil, 'https://www.find-postgraduate-teacher-training.service.gov.uk', class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-2 govuk-button--start', target: '_blank', rel: 'noopener', 'aria-describedby': 'find-new-window' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -23,7 +23,7 @@
     <p class="govuk-body">Training providers should be able to tell you how they can support you to attend the interview or do the course.</p>
     <p class="govuk-body"><%= govuk_link_to('Learn more about training to teach if you’re disabled', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability') %></p>
 
-    <%= link_to candidate_interface_create_account_or_sign_in_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-4 govuk-button--start', 'data-module': 'govuk-button' do %>
+    <%= govuk_button_link_to nil, candidate_interface_create_account_or_sign_in_path, class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-4 govuk-button--start' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -40,6 +40,6 @@
 
     <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
     <p class="govuk-body">Your feedback will help us improve.</p>
-    <%= govuk_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path, class: 'govuk-button' %>
+    <%= govuk_button_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path %>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
@@ -9,7 +9,7 @@
 
     <hr class="govuk-section-break govuk-section-break--m">
 
-    <%= govuk_link_to 'Choose a course', candidate_interface_course_choices_index_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+    <%= govuk_button_link_to 'Choose a course', candidate_interface_course_choices_index_path, class: 'govuk-!-margin-bottom-5' %>
     <p class="govuk-body">or</p>
     <%= govuk_link_to 'Go to your application form', candidate_interface_application_form_path, class: 'govuk-body' %>
   </div>

--- a/app/views/provider_interface/application_choices/notes.html.erb
+++ b/app/views/provider_interface/application_choices/notes.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'application_choice_header' %>
 
-<%= link_to 'Add note', provider_interface_application_choice_new_note_path(@application_choice), class: 'govuk-button' %>
+<%= govuk_button_link_to 'Add note', provider_interface_application_choice_new_note_path(@application_choice) %>
 
 <% unless @notes.empty? %>
   <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -2,10 +2,9 @@
 
 <h1 class="govuk-heading-xl">Users</h1>
 
-<%= link_to(
+<%= govuk_button_link_to(
   'Invite user',
   provider_interface_edit_invitation_basic_details_path,
-  class: 'govuk-button',
 ) %>
 
 <div class="govuk-body">

--- a/app/views/provider_interface/provider_users/show.html.erb
+++ b/app/views/provider_interface/provider_users/show.html.erb
@@ -20,10 +20,10 @@
       possible_permissions: @possible_permissions,
     ) %>
 
-    <%= govuk_link_to(
+    <%= govuk_button_link_to(
       'Delete user',
       provider_interface_provider_user_remove_provider_user_path(@provider_user),
-      class: 'govuk-button govuk-button--warning',
+      class: 'govuk-button--warning',
     ) %>
   </div>
 </div>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -8,7 +8,7 @@
         <div class="app-masthead__description">
           <p class="govuk-body-l">Try our new service to see how easy it is to use. It’s free for providers and candidates.</p>
         </div>
-        <%= link_to @pilot_enrolment_form_url, role: 'button', class: 'govuk-button govuk-!-margin-bottom-0 govuk-button--start app-button--inverted', 'data-module': 'govuk-button' do %>
+        <%= govuk_button_link_to nil, @pilot_enrolment_form_url, class: 'govuk-!-margin-bottom-0 govuk-button--start app-button--inverted' do %>
           Get started
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Provider users' %>
 
-<%= link_to 'Add provider user', new_support_interface_provider_user_path, class: 'govuk-button' %>
+<%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
@@ -20,6 +20,6 @@
   ]) %>
 <% end %>
 
-<%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path, class: 'govuk-button' %>
+<%= govuk_button_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %>
 
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider_users)) %>

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,6 +1,6 @@
 <%= render 'provider_navigation', title: 'Users' %>
 
-<%= link_to 'Add provider user', new_support_interface_provider_user_path, class: 'govuk-button' %>
+<%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
 
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider.provider_users)) %>
 

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Support users' %>
 
-<%= link_to 'Add support user', new_support_interface_support_user_path, class: 'govuk-button' %>
+<%= govuk_button_link_to 'Add support user', new_support_interface_support_user_path %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe ViewHelper, type: :helper do
 
       expect(anchor_tag).to eq('<a role="button" class="govuk-button govuk-button--start" data-module="govuk-button" draggable="false" href="https://localhost:0103/chicken/cluck">Cluck</a>')
     end
+
+    it 'accepts a block' do
+      anchor_tag = helper.govuk_button_link_to(nil, 'https://localhost:0103/bee/buzz') do
+        'Buzz'
+      end
+      expect(anchor_tag).to eq('<a role="button" class="govuk-button" data-module="govuk-button" draggable="false" href="https://localhost:0103/bee/buzz">Buzz</a>')
+    end
   end
 
   describe 'application date helpers' do


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We've [defined a helper method](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/helpers/view_helper.rb#L20-L24) to consistently render links in the style of `govuk-button` so we should use it throughout the app where applicable.

## Changes proposed in this pull request

- Changes candidate, provider and support interface instances of `link_to` and `govuk_link_to` with the `govuk-button` class
- Removes any duplicated attributes provided by helper.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/wLY6kAjh/2542-correct-button-markup-for-invite-and-delete-provider-user-actions
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
