### PR TITLE
Take candidate to the personal details review section if sections have been completed

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -42,11 +42,15 @@
     </h2>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
+        <% all_sections_completed =  @application_form.first_name.present? &&
+                                      @application_form.first_nationality.present? &&
+                                      (!@application_form.english_main_language.nil? ||
+                                      @application_form.right_to_work_or_study.present?) %>
         <%= render(
           TaskListItemComponent.new(
             text: t('page_titles.personal_details'),
             completed: @application_form_presenter.personal_details_completed?,
-            path: @application_form_presenter.personal_details_completed? ? candidate_interface_personal_details_show_path : candidate_interface_personal_details_new_path
+            path: all_sections_completed ? candidate_interface_personal_details_show_path : candidate_interface_personal_details_new_path
           )
         ) %>
       </li>

--- a/spec/system/candidate_interface/international/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_enters_their_personal_details_spec.rb
@@ -65,6 +65,10 @@ RSpec.feature 'Entering their personal details' do
     then_i_see_the_personal_details_review_page
     and_i_can_see_my_updated_right_to_work
 
+    when_i_vist_the_homepage
+    and_i_click_on_personal_details
+    then_i_see_the_personal_details_review_page
+
     when_i_mark_the_section_as_completed
     and_i_submit_my_details
     then_i_should_see_my_application_form
@@ -230,6 +234,14 @@ RSpec.feature 'Entering their personal details' do
   def and_i_can_see_my_updated_right_to_work
     expect(page).to have_content "Borders? I don't believe in no stinking borders."
     expect(page).to have_content 'I have the right to work or study in the UK'
+  end
+
+  def when_i_vist_the_homepage
+    and_i_visit_the_site
+  end
+
+  def and_i_click_on_personal_details
+    when_i_click_on_personal_details
   end
 
   def when_i_mark_the_section_as_completed


### PR DESCRIPTION
## Context

If a candidate adds their personal details but does not complete the section, when they click the personal details section they are taken back through the journey without prefilled values for the nationalities section.

## Changes proposed in this pull request

- Change the personal details section link to go to the personal details review page if all sections have previously been filled

## Link to Trello card

https://trello.com/c/2vw5TYJB/1912-international-personal-details-no-prefilled-nationality-if-a-candidate-does-not-mark-the-section-as-complete-and-comes-back

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
