### PR TITLE
Add user guidance page to support interface regarding GDPR

### DIFF
--- a/app/controllers/support_interface/guidance_controller.rb
+++ b/app/controllers/support_interface/guidance_controller.rb
@@ -1,0 +1,5 @@
+module SupportInterface
+  class GuidanceController < SupportInterfaceController
+    def index; end
+  end
+end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -28,6 +28,7 @@ class NavigationItems
           NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance course_options])),
           NavigationItem.new('Tasks', support_interface_tasks_path, is_active(current_controller, 'tasks')),
           NavigationItem.new('Users', support_interface_users_path, is_active(current_controller, 'users')),
+          NavigationItem.new('Guidance', support_interface_guidance_path, is_active(current_controller, 'guidance')),
           NavigationItem.new(current_support_user.email_address, nil, false),
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),
         ]

--- a/app/views/support_interface/guidance/index.html.erb
+++ b/app/views/support_interface/guidance/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t('page_titles.guidance') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Within the support console there is sensitive information and personal data about the users of the Apply for teacher training service which we store inline with our Data Protection Agreement and Privacy Notice.</p>
+
+    <p class="govuk-body">As a user of the Apply support console there are specific things you should be aware of and practices to ensure you use data in the appropriate manner and we are not at risk of mis-use or breach of GDPR and other data security policies.</p>
+
+    <p class="govuk-body">Most practice in line with GDPR is common sense but the key messages are:
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-left-2  govuk-!-margin-right-2">
+        <li>only access what data you need to</li>
+        <li>think whether there is a reason to view what you’re accessing</li>
+        <li>do not copy data and store in other locations</li>
+        <li>do not share data outside the team</li>
+        <li>do not copy or share personal data onto slack, please use URLs or support reference numbers</li>
+        <li>Only give access to the support console to approved users</li>
+      </ul>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,7 @@ en:
     remove_course_choice: Remove your course choice
     withdraw_application: Are you sure you want to withdraw your application?
     gcse_naric_reference: Do you have a NARIC statement of comparability for your maths qualification?
+    guidance: User guidance
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -731,6 +731,8 @@ Rails.application.routes.draw do
       end
     end
 
+    get '/guidance' => 'guidance#index', as: :guidance
+
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
 

--- a/spec/system/support_interface/see_user_guidance_spec.rb
+++ b/spec/system/support_interface/see_user_guidance_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.feature 'User guidance' do
+  include DfESignInHelpers
+
+  scenario 'Support user can see user guidance' do
+    given_i_am_a_support_user
+
+    when_i_visit_the_guidance_page
+    then_i_should_see_the_user_guidance
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def when_i_visit_the_guidance_page
+    visit support_interface_guidance_path
+  end
+
+  def then_i_should_see_the_user_guidance
+    expect(page).to have_content('Most practice in line with GDPR is common sense but the key messages are:')
+  end
+end


### PR DESCRIPTION
## Context

We need this to be GDPR compliant

## Changes proposed in this pull request

- Add a user guidance page to the support interface

![image](https://user-images.githubusercontent.com/42515961/89917541-d3301880-dbf0-11ea-8ec8-e5810914f019.png)

## Guidance to review

Content can be found here 

https://docs.google.com/document/d/1dlm54MyV-juFOjw3YAW_Cawbya5XlYExRd_03WJADqc/edit#

## Link to Trello card

https://trello.com/c/LlPe6FWD/1931-add-guidance-to-the-support-console-and-onboarding-packs

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
