### PR TITLE
Make magic links single-use

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
         sign_in(candidate, scope: :candidate)
         add_identity_to_log candidate.id
         candidate.update!(last_signed_in_at: Time.zone.now)
+        candidate.expire_magic_link_token!
 
         redirect_to candidate_interface_interstitial_path(providerCode: params[:providerCode], courseCode: params[:courseCode])
       else

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -37,6 +37,13 @@ class Candidate < ApplicationRecord
     magic_link_token.raw
   end
 
+  def expire_magic_link_token!
+    update!(
+      magic_link_token: nil,
+      magic_link_token_sent_at: nil,
+    )
+  end
+
   def encrypted_id
     Encryptor.encrypt(id)
   end

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -7,7 +7,7 @@
         <%= t('authentication.expired_token.heading') %>
       </h1>
       <p class="govuk-body">
-        Sign in links only work for one hour, so you need to request a new one. We’ll send this by email.
+        Sign in links only work once and expire after one hour, so you need to request a new one. We’ll send this by email.
       </p>
 
       <%= hidden_field_tag :u, params[:u] %>

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -99,4 +99,14 @@ RSpec.describe Candidate, type: :model do
       expect(candidate.encrypted_id).to eq 'encrypted id value'
     end
   end
+
+  describe '#expire_magic_link_token!' do
+    it 'clears the magic link fields' do
+      candidate = create(:candidate, magic_link_token: 'token', magic_link_token_sent_at: Time.zone.now)
+      candidate.expire_magic_link_token!
+
+      expect(candidate.magic_link_token).to be_nil
+      expect(candidate.magic_link_token_sent_at).to be_nil
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate account' do
+  include CandidateHelper
+
+  scenario 'Candidate tries to sign in more than once with same magic link' do
+    given_the_pilot_is_open
+    and_i_am_an_existing_candidate
+
+    when_i_sign_in_and_out
+    and_i_try_to_resuse_the_same_magic_link
+    then_i_am_prompted_to_get_a_new_magic_link
+
+    when_i_get_a_new_magic_link
+    then_i_can_sign_in_again
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_i_am_an_existing_candidate
+    current_candidate
+  end
+
+  def when_i_sign_in_and_out
+    visit candidate_interface_sign_in_path
+    fill_in 'Enter your email address', with: current_candidate.email_address
+    click_button 'Continue'
+    open_email(current_candidate.email_address)
+    expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+
+    @magic_link = current_email.find_css('a').first
+    @magic_link.click
+    within 'header' do
+      expect(page).to have_content current_candidate.email_address
+    end
+
+    click_link 'Sign out'
+    expect(page).to have_link 'Sign in'
+  end
+
+  def and_i_try_to_resuse_the_same_magic_link
+    @magic_link.click
+  end
+
+  def then_i_am_prompted_to_get_a_new_magic_link
+    expect(page).to have_content 'The link you clicked has expired'
+  end
+
+  def when_i_get_a_new_magic_link
+    click_button 'Email me a new link'
+
+    open_email(current_candidate.email_address)
+    @new_magic_link = current_email.find_css('a').first
+  end
+
+  def then_i_can_sign_in_again
+    @new_magic_link.click
+    within 'header' do
+      expect(page).to have_content current_candidate.email_address
+    end
+  end
+end

--- a/spec/system/candidate_interface/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/two_candidates_sign_in_on_same_machine_spec.rb
@@ -11,13 +11,10 @@ RSpec.feature 'Candidate account' do
     then_i_can_sign_up_and_sign_out(@second_email)
 
     when_i_click_the_link_in_the_email_for(@first_email)
-    then_i_am_signed_in_with(@first_email)
+    then_i_am_prompted_to_get_a_new_magic_link
 
     when_i_click_the_link_in_the_email_for(@second_email)
-    then_i_am_signed_in_with(@second_email)
-
-    when_i_click_the_link_in_the_email_after_an_hour_for(@first_email)
-    then_i_am_signed_in_with(@second_email)
+    then_i_am_prompted_to_get_a_new_magic_link
   end
 
   def then_i_can_sign_up_and_sign_out(email)
@@ -31,6 +28,11 @@ RSpec.feature 'Candidate account' do
     when_i_click_the_link_in_the_email_for(email)
     then_i_am_signed_in_with(email)
 
+    when_i_click_the_sign_out_button
+    then_i_should_be_signed_out
+  end
+
+  def when_i_sign_out
     when_i_click_the_sign_out_button
     then_i_should_be_signed_out
   end
@@ -72,6 +74,10 @@ RSpec.feature 'Candidate account' do
 
   def when_i_click_the_link_in_the_email_for(email)
     @email_link_for[email].click
+  end
+
+  def then_i_am_prompted_to_get_a_new_magic_link
+    expect(page).to have_content 'The link you clicked has expired'
   end
 
   def when_i_click_the_link_in_the_email_after_an_hour_for(email)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Magic links currently last for one hour, with no limit on their use
during that time. A recent pentest recommended that we make magic links
single-use.
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
- Expire the token after a successful sign in.
- Amend the copy on the expired page to reflect the new behaviour.
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/aNcIaroP

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
