### PR TITLE
Filter component width doesnt match prototype

### DIFF
--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -48,7 +48,7 @@
 
             <div class="govuk-form-group">
               <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
                   <%= filter[:heading] %>
                 </legend>
                 <% if filter[:type] == :search %>

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -1,4 +1,5 @@
 .moj-filter-layout__content {
+  overflow-x: hidden;
   .moj-action-bar {
     height: 60px;
   }

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -24,7 +24,7 @@
 
 @media (min-width: 48.0625em) {
   .moj-filter-layout__filter {
-    max-width: 350px;
+    max-width: 300px;
   }
 }
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
The application filter component `max-width` value is 50px larger than the design prototype. 

See https://manage-applications-beta.herokuapp.com/

## Changes proposed in this pull request

- Reduce filter component `max-width` to `300px`, same as design prototype.
- Reduce filter component labels to smaller font size similar to design prototype.
- Hide horizontal overflow on filter content similar to design.

<!-- If there are UI changes, please include Before and After screenshots. -->

### Before (QA)

![image](https://user-images.githubusercontent.com/93511/90009756-90288080-dc96-11ea-9c5b-bf63789a607b.png)

### After

![image](https://user-images.githubusercontent.com/93511/90009625-4fc90280-dc96-11ea-8d5c-f6a9dc7153e9.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZsRsXAuV/2565-filter-width-doesnt-match-prototype

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
