### PR TITLE
Don't generate enrolled test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -181,11 +181,6 @@ class TestApplications
       make_offer(choice)
       accept_offer(choice)
       confirm_offer_conditions(choice)
-    when :enrolled
-      make_offer(choice)
-      accept_offer(choice)
-      confirm_offer_conditions(choice)
-      confirm_enrollment(choice)
     when :withdrawn
       withdraw_application(choice)
     end
@@ -251,14 +246,6 @@ class TestApplications
       fast_forward(1..3)
       ConfirmOfferConditions.new(actor: actor, application_choice: choice).save
       choice.update_columns(recruited_at: time)
-    end
-  end
-
-  def confirm_enrollment(choice)
-    as_provider_user(choice) do
-      fast_forward(1..3)
-      ConfirmEnrolment.new(actor: actor, application_choice: choice).save
-      choice.update_columns(enrolled_at: time)
     end
   end
 

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -26,7 +26,6 @@ class GenerateTestApplications
     create states: [:accepted_no_conditions]
     create states: [:recruited]
     create states: [:conditions_not_met]
-    create states: [:enrolled]
     create states: [:withdrawn]
     create states: [:awaiting_provider_decision], apply_again: true
   end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe TestApplications do
     expect(choices.count).to eq(2)
   end
 
-  it 'creates a realistic timeline for an enrolled application' do
+  it 'creates a realistic timeline for an recruited application' do
     courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(states: %i[enrolled], courses_to_apply_to: courses_we_want).first
+    application_choice = TestApplications.new.create_application(states: %i[recruited], courses_to_apply_to: courses_we_want).first
 
     application_form = application_choice.application_form
     candidate = application_form.candidate
@@ -26,7 +26,6 @@ RSpec.describe TestApplications do
     expect(days_between_ignoring_time_of_day(application_choice.sent_to_provider_at, application_form.submitted_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_choice.offered_at, application_choice.sent_to_provider_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_choice.accepted_at, application_choice.offered_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_choice.enrolled_at, application_choice.accepted_at)).to be >= 1
   end
 
   it 'creates a realistic timeline for an offered application' do
@@ -45,7 +44,7 @@ RSpec.describe TestApplications do
   it 'attributes actions to candidates', with_audited: true do
     courses_we_want = create_list(:course_option, 1, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(states: %i[enrolled], courses_to_apply_to: courses_we_want).first
+    application_choice = TestApplications.new.create_application(states: %i[recruited], courses_to_apply_to: courses_we_want).first
     application_form = application_choice.application_form
     candidate = application_form.candidate
 
@@ -57,10 +56,10 @@ RSpec.describe TestApplications do
   it 'attributes actions to provider users', with_audited: true do
     courses_we_want = create_list(:course_option, 1, course: create(:course, :open_on_apply)).map(&:course)
 
-    application_choice = TestApplications.new.create_application(states: %i[enrolled], courses_to_apply_to: courses_we_want).first
+    application_choice = TestApplications.new.create_application(states: %i[recruited], courses_to_apply_to: courses_we_want).first
     provider_user = application_choice.provider.provider_users.first
 
-    offer_audit = application_choice.reload.audits.where("audited_changes @> '{\"status\": [\"recruited\", \"enrolled\"]}'").first
+    offer_audit = application_choice.reload.audits.where("audited_changes @> '{\"status\": [\"recruited\"]}'").first
     expect(offer_audit).not_to be_nil
     expect(offer_audit.user).to eq provider_user
   end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe GenerateTestApplications do
     create(:course_option, course: create(:course, :open_on_apply))
   end
 
-  it 'generates 18 test candidates with applications in various states' do
+  it 'generates test candidates with applications in various states' do
     GenerateTestApplications.new.perform
 
-    expect(Candidate.count).to be 18
     expect(ApplicationChoice.pluck(:status)).to include(
       'unsubmitted',
       'awaiting_provider_decision',
@@ -20,7 +19,6 @@ RSpec.describe GenerateTestApplications do
       'declined',
       'withdrawn',
       'recruited',
-      'enrolled',
     )
     # there is at least one unsubmitted application to a full course
     expect(ApplicationChoice.where(status: 'unsubmitted').map(&:course_option).select(&:no_vacancies?)).not_to be_empty


### PR DESCRIPTION
##  Context

We're going to remove the enrolment feature in https://github.com/DFE-Digital/apply-for-teacher-training/pull/2694. To do that we first have to delete all existing enrolled applications (they're in test).

## Changes proposed in this pull request

Stop generating applications in the "enrolled" state.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/1DdTHKQI/2604-remove-enrolment-state

