### PR TITLE
Minor UI tweaks to OtherQualifications

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -62,7 +62,7 @@ module CandidateInterface
     def subject_row(qualification)
       {
         key: subject_set_key(qualification),
-        value: qualification.subject,
+        value: set_rows_value(qualification.subject),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.subject.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
       }
@@ -89,7 +89,7 @@ module CandidateInterface
       if non_uk_qualification?(qualification) && qualification.institution_country.present?
         "#{qualification.institution_name}, #{COUNTRIES[qualification.institution_country]}"
       else
-        qualification.institution_name
+        set_rows_value(qualification.institution_name)
       end
     end
 
@@ -100,7 +100,7 @@ module CandidateInterface
     def award_year_row(qualification)
       {
         key: t('application_form.other_qualification.award_year.review_label'),
-        value: qualification.award_year,
+        value: set_rows_value(qualification.award_year),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.award_year.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
       }
@@ -109,7 +109,7 @@ module CandidateInterface
     def grade_row(qualification)
       {
         key: grade_set_key(qualification),
-        value: qualification.grade,
+        value: set_rows_value(qualification.grade),
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.grade.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
       }
@@ -121,6 +121,10 @@ module CandidateInterface
       else
         t('application_form.other_qualification.grade.label')
       end
+    end
+
+    def set_rows_value(value)
+      value || 'Not entered'
     end
 
     def edit_other_qualification_details_path(qualification)

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -61,11 +61,19 @@ module CandidateInterface
 
     def subject_row(qualification)
       {
-        key: t('application_form.other_qualification.subject.label'),
+        key: subject_set_key(qualification),
         value: qualification.subject,
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.subject.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
       }
+    end
+
+    def subject_set_key(qualification)
+      if qualification.qualification_type == 'non_uk'
+        t('application_form.other_qualification.subject.optional_label')
+      else
+        t('application_form.other_qualification.subject.label')
+      end
     end
 
     def institution_row(qualification)
@@ -100,11 +108,19 @@ module CandidateInterface
 
     def grade_row(qualification)
       {
-        key: t('application_form.other_qualification.grade.label'),
+        key: grade_set_key(qualification),
         value: qualification.grade,
         action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.grade.change_action')),
         change_path: edit_other_qualification_details_path(qualification),
       }
+    end
+
+    def grade_set_key(qualification)
+      if qualification.qualification_type == 'non_uk'
+        t('application_form.other_qualification.grade.optional_label')
+      else
+        t('application_form.other_qualification.grade.label')
+      end
     end
 
     def edit_other_qualification_details_path(qualification)

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -1,10 +1,10 @@
 <% if FeatureFlag.active?('international_other_qualifications') %>
 
   <% if @qualification.non_uk_qualification_type.present? %>
-    <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label') + ' (optional)', size: 'm' } %>
+    <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.optional_label'), size: 'm' } %>
     <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
-    <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label') + ' (optional)', size: 'm' }, width: 10 %>
+    <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% else %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
@@ -17,10 +17,10 @@
 
   <% if @qualification.non_uk_qualification_type.present? %>
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') %>
-    <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label') + ' (optional)', size: 'm' } %>
+    <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.optional_label'), size: 'm' } %>
     <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
-    <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label') + ' (optional)', size: 'm' }, width: 10 %>
+    <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% elsif @qualification.qualification_type == 'Other' || @qualification.non_uk_qualification_type.present? %>
     <%= f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -246,6 +246,7 @@ en:
           hint_text: For example, High school diploma, Higher Secondary School Certificate, Baccalauréat Général, Título de Bachiller
       subject:
         label: Subject
+        optional_label: Subject (optional)
         change_action: subject
       institution_country:
         label: Country where you studied
@@ -256,6 +257,7 @@ en:
         change_action: institution
       grade:
         label: Grade
+        optional_label: Grade (optional)
         change_action: grade
       award_year:
         label: Year qualification was awarded

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -126,6 +126,30 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
         "Change #{t('application_form.other_qualification.institution_name.change_action')} for Woof, Making Doggo Sounds, Doggo Sounds College, United States 2012"
       end
     end
+
+    context 'when a candidate has not provided the subject, grade, year_awarded and institution' do
+      let(:qualification1) do
+        build_stubbed(
+          :application_qualification,
+          level: 'other',
+          qualification_type: 'GCSE',
+          subject: nil,
+          institution_name: nil,
+          grade: nil,
+          award_year: nil,
+        )
+      end
+
+      it 'renders `Not entered` in the rows value' do
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__value')[0].text).to include('GCSE')
+        expect(result.css('.govuk-summary-list__value')[1].text).to include('Not entered')
+        expect(result.css('.govuk-summary-list__value')[2].text).to include('Not entered')
+        expect(result.css('.govuk-summary-list__value')[3].text).to include('Not entered')
+        expect(result.css('.govuk-summary-list__value')[4].text).to include('Not entered')
+      end
+    end
   end
 
   context 'when other qualifications are not editable' do

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -109,6 +109,13 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
         )
       end
 
+      it 'renders adds optional to the keys for subject and grade rows' do
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.subject.optional_label'))
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.grade.optional_label'))
+      end
+
       it 'renders the correct values for institution_name' do
         result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -203,7 +203,7 @@ RSpec.feature 'Entering their other qualifications' do
 
   def then_i_should_see_an_incomplete_as_level_qualification
     expect(page).to have_content('AS level')
-    expect(all('.govuk-summary-list__value').last.text).to eq ''
+    expect(all('.govuk-summary-list__value').last.text).to eq 'Not entered'
   end
 
   def when_i_click_on_delete_my_first_qualification


### PR DESCRIPTION
## Context

I ran through how other qualifications work with Paul. He made a couple of comments on how it needed to be changed.

This PR implements those changes.

## Changes proposed in this pull request

1. The key for each row should show optional if it is (for int quals this is subject and grade)
2. If a value has no been provided for a row, it should show 'Not entered'

| Before | After |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/42515961/90025172-b0b00500-dcad-11ea-8f07-19505d51bb2a.png) | ![image](https://user-images.githubusercontent.com/42515961/90025112-937b3680-dcad-11ea-8c79-249bd03e9b32.png) |

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
