### PR TITLE
Prevent candidates adding courses after the cycle has ended

### DIFF
--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -3,6 +3,8 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def index
+      redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+
       @application_choices = current_candidate.current_application.application_choices
 
       if @application_choices.any?

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -1,8 +1,14 @@
 module CandidateInterface
   module CourseChoices
     class BaseController < CandidateInterfaceController
-      before_action :redirect_to_dashboard_if_submitted
+      before_action :redirect_to_dashboard_if_submitted, :redirect_to_dashboard_if_cycle_is_over
       rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+    private
+
+      def redirect_to_dashboard_if_cycle_is_over
+        redirect_to candidate_interface_application_complete_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module CourseChoices
     module ReplaceChoices
       class BaseController < CandidateInterfaceController
-        before_action :redirect_to_dashboard_if_no_choices_need_replacing
+        before_action :redirect_to_dashboard_if_no_choices_need_replacing, :redirect_to_dashboard_if_cycle_is_over
 
         def pick_choice_to_replace
           if only_one_course_choice_needs_replacing?
@@ -30,6 +30,10 @@ module CandidateInterface
         end
 
       private
+
+        def redirect_to_dashboard_if_cycle_is_over
+          redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+        end
 
         def redirect_to_dashboard_if_no_choices_need_replacing
           redirect_to candidate_interface_application_complete_path if current_application.course_choices_that_need_replacing.blank?

--- a/app/controllers/candidate_interface/find_course_selections_controller.rb
+++ b/app/controllers/candidate_interface/find_course_selections_controller.rb
@@ -4,6 +4,8 @@ module CandidateInterface
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def confirm_selection
+      redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+
       course = Course.find(params[:course_id])
       @course_selection_form = CourseSelectionForm.new(course)
     end

--- a/app/services/candidate_interface/end_of_cycle_policy.rb
+++ b/app/services/candidate_interface/end_of_cycle_policy.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  class EndOfCyclePolicy
+    def self.can_add_course_choice?(application_form:)
+      return true if Time.zone.now.to_date >= EndOfCycleTimetable.next_cycles_courses_open
+      return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_1_deadline && application_form.apply_1?
+      return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_2_deadline && application_form.apply_2?
+
+      false
+    end
+  end
+end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -2,6 +2,7 @@ class EndOfCycleTimetable
   DATES = {
     apply_1_deadline: Date.new(2020, 8, 24),
     apply_2_deadline: Date.new(2020, 9, 18),
+    next_cycles_courses_open: Date.new(2020, 10, 13),
   }.freeze
 
   def self.show_apply_1_deadline_banner?
@@ -10,6 +11,18 @@ class EndOfCycleTimetable
 
   def self.show_apply_2_deadline_banner?
     Time.zone.now < date(:apply_2_deadline)
+  end
+
+  def self.apply_1_deadline
+    date(:apply_1_deadline)
+  end
+
+  def self.apply_2_deadline
+    date(:apply_2_deadline)
+  end
+
+  def self.next_cycles_courses_open
+    date(:next_cycles_courses_open)
   end
 
   def self.date(name)

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,18 +1,28 @@
 <% missing_error = @errors && @errors.any? %>
 <% application_choice_error = @application_choice_errors && @application_choice_errors.any? %>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
+<% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: @application_form)%>
+  <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
+    <%= t('page_titles.course_choices') %>
+  </h2>
 
-<%= render(
-  CandidateInterface::CourseChoicesReviewComponent.new(
-    application_form: application_form,
-    editable: editable,
-    heading_level: 3,
-    show_incomplete: true,
-    missing_error: missing_error,
-    application_choice_error: application_choice_error,
-  )
-) %>
+  <p class="govuk-body">
+    You can apply for courses from 13 October.
+  </p>
+<% else %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
+
+  <%= render(
+    CandidateInterface::CourseChoicesReviewComponent.new(
+      application_form: application_form,
+      editable: editable,
+      heading_level: 3,
+      show_incomplete: true,
+      missing_error: missing_error,
+      application_choice_error: application_choice_error,
+    )
+  ) %>
+<% end %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -4,7 +4,7 @@
 <% new_application_choice_needed_component = CandidateInterface::NewCourseChoiceNeededBannerComponent.new(application_form: @application_form) %>
 <% if new_references_needed_component.render? %>
   <%= render new_references_needed_component %>
-<% elsif new_application_choice_needed_component.render? %>
+<% elsif CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application) && new_application_choice_needed_component.render? %>
   <%= render new_application_choice_needed_component %>
 <% elsif flash.empty? %>
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -18,7 +18,15 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
-    <% if @application_form.candidate_has_previously_applied? %>
+    <% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: @application_form)%>
+      <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
+        <%= t('page_titles.course_choices') %>
+      </h2>
+
+      <p class="govuk-body">
+        You can apply for courses from 13 October.
+      </p>
+    <% elsif @application_form.candidate_has_previously_applied? %>
       <% if @application_form.previous_application_form.application_choices.rejected.any?  %>
         <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
       <% end %>

--- a/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
+++ b/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EndOfCyclePolicy do
+  describe '#can_add_course_choice?' do
+    let(:execute_service) { described_class.can_add_course_choice?(application_form: application_form) }
+
+    context 'application form is in the apply1 state' do
+      let(:application_form) { build_stubbed(:application_form) }
+
+      context 'when the date is after the apply1 submission deadline' do
+        it 'returns false' do
+          Timecop.travel(EndOfCycleTimetable.apply_1_deadline + 1.day) do
+            expect(execute_service).to eq false
+          end
+        end
+      end
+
+      context 'when the date is before the apply1 submission deadline' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.apply_1_deadline) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+
+      context 'when the date is post find reopening' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.next_cycles_courses_open) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+    end
+
+    context 'application form is in the apply again state' do
+      let(:application_form) { build_stubbed(:application_form, phase: :apply_2) }
+
+      context 'when the date is after the apply again submission deadline' do
+        it 'returns false' do
+          Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
+            expect(execute_service).to eq false
+          end
+        end
+      end
+
+      context 'when the date is before the apply again submission deadline' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.apply_2_deadline) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+
+      context 'when the date is post find reopening' do
+        it 'returns true' do
+          Timecop.travel(EndOfCycleTimetable.next_cycles_courses_open) do
+            expect(execute_service).to eq true
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
 
     when_i_visit_the_site
     then_there_is_a_link_to_the_course_choices_section
+
+    given_it_is_before_before_the_apply_1_deadline
+    and_i_have_submitted_my_application
+    and_the_apply_1_deadline_passes
+    and_one_of_my_courses_has_become_full
+
+    when_i_arrive_at_my_application_dashboard
+    then_i_see_do_not_see_the_banner_to_replace_my_course_choice
   end
 
   def given_i_am_signed_in
@@ -82,6 +90,10 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
 
   def and_there_is_not_a_link_to_the_course_choices_section
     expect(page).not_to have_link('Course choices')
+  end
+
+  def when_i_click_check_and_submit_my_application
+    click_link 'Check and submit your application'
   end
 
   def when_i_try_to_visit_the_pick_provider_page
@@ -114,5 +126,35 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
 
   def given_it_is_the_day_after_the_apply2_deadline
     Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day)
+  end
+
+  def given_it_is_the_day_before_the_apply_2_deadline
+    and_it_is_the_day_before_the_apply_2_deadline
+  end
+
+  def given_it_is_before_before_the_apply_1_deadline
+    Timecop.travel(EndOfCycleTimetable.apply_1_deadline)
+  end
+
+  def and_i_have_submitted_my_application
+    current_candidate.current_application.destroy!
+    candidate_completes_application_form
+    candidate_submits_application
+  end
+
+  def and_the_apply_1_deadline_passes
+    given_it_is_the_day_after_the_apply1_deadline
+  end
+
+  def and_one_of_my_courses_has_become_full
+    current_candidate.current_application.application_choices.first.course_option.no_vacancies!
+  end
+
+  def when_i_arrive_at_my_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_see_do_not_see_the_banner_to_replace_my_course_choice
+    expect(page).not_to have_content 'One of your choices is not available anymore.'
   end
 end

--- a/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate vists their applicatin form after the cycle has ended' do
+  include CandidateHelper
+
+  around do |example|
+    Timecop.freeze(EndOfCycleTimetable.apply_1_deadline) do
+      example.run
+    end
+  end
+
+  scenario 'The candidate cannot add new courses to their application form' do
+    given_i_am_signed_in
+    and_my_application_forms_phase_is_apply_1
+    and_it_is_the_day_before_the_apply_1_deadline
+
+    when_i_visit_the_site
+    then_there_is_a_link_to_the_course_choices_section
+
+    given_it_is_the_day_after_the_apply1_deadline
+
+    when_i_visit_the_site
+    then_i_see_that_i_can_add_new_course_choices_in_october
+    and_there_is_not_a_link_to_the_course_choices_section
+
+    when_i_click_check_and_submit_my_application
+    then_i_see_that_i_can_add_new_course_choices_in_october
+
+    when_i_try_to_visit_the_pick_provider_page
+    then_i_am_redirected_back_to_the_application_form
+
+    given_the_new_cycle_is_open
+    and_i_logout
+    and_i_am_signed_in
+
+    when_i_visit_the_site
+    then_there_is_a_link_to_the_course_choices_section
+
+    given_my_application_forms_phase_is_apply_2
+    and_it_is_the_day_before_the_apply_2_deadline
+
+    when_i_visit_the_site
+    then_there_is_a_link_to_the_course_choices_section
+
+    given_it_is_the_day_after_the_apply2_deadline
+
+    when_i_visit_the_site
+    then_i_see_that_i_can_add_new_course_choices_in_october
+    and_there_is_not_a_link_to_the_course_choices_section
+
+    given_the_new_cycle_is_open
+    and_i_logout
+    and_i_am_signed_in
+
+    when_i_visit_the_site
+    then_there_is_a_link_to_the_course_choices_section
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_my_application_forms_phase_is_apply_1; end
+
+  def and_it_is_the_day_before_the_apply_1_deadline; end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_there_is_a_link_to_the_course_choices_section
+    expect(page).to have_link('Course choices')
+  end
+
+  def given_it_is_the_day_after_the_apply1_deadline
+    Timecop.travel(EndOfCycleTimetable.apply_1_deadline + 1.day)
+  end
+
+  def then_i_see_that_i_can_add_new_course_choices_in_october
+    expect(page).to have_content 'You can apply for courses from 13 October.'
+  end
+
+  def and_there_is_not_a_link_to_the_course_choices_section
+    expect(page).not_to have_link('Course choices')
+  end
+
+  def when_i_try_to_visit_the_pick_provider_page
+    visit candidate_interface_course_choices_provider_path
+  end
+
+  def then_i_am_redirected_back_to_the_application_form
+    expect(page).to have_current_path candidate_interface_application_form_path
+  end
+
+  def given_the_new_cycle_is_open
+    Timecop.travel(EndOfCycleTimetable.next_cycles_courses_open + 1.day)
+  end
+
+  def and_i_logout
+    logout
+  end
+
+  def and_i_am_signed_in
+    given_i_am_signed_in
+  end
+
+  def given_my_application_forms_phase_is_apply_2
+    current_candidate.current_application.apply_2!
+  end
+
+  def and_it_is_the_day_before_the_apply_2_deadline
+    Timecop.travel(EndOfCycleTimetable.apply_2_deadline)
+  end
+
+  def given_it_is_the_day_after_the_apply2_deadline
+    Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day)
+  end
+end


### PR DESCRIPTION
## Context

Once the deadline has passed for the relevant phase (apply1/apply2) candidates should no longer be able to add courses to their application.

If they have submitted their application and a course choice becomes full, they should not be able to replace it.

## Changes proposed in this pull request

- Extend the EndOfCycleTimetable to include courses reopening on the 13/10
- Add a service which checks whether a candidate can add courses based on their app forms phase and the current date
- If the candidate has not submitted before the EOC tell them they can add new courses from 13/10 on the app form show and review page
- Stop the replace course choice banner rendering post submission 
- Redirect to the application form/dashboard from the course choice/related controllers

unsubmitted application form review page

| Before | After |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/42515961/90124004-9c284700-dd57-11ea-9e5f-2bd2345b3168.png) | ![image](https://user-images.githubusercontent.com/42515961/90123532-e2c97180-dd56-11ea-9dc5-0c4052ad58ba.png) |

| Before | After |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/42515961/90123832-579cab80-dd57-11ea-9692-ba564320a7de.png) | ![image](https://user-images.githubusercontent.com/42515961/90123926-7bf88800-dd57-11ea-9ae7-2b1a873aced1.png) |



## Guidance to review

This spike PR is #2671 

There will be a follow-up PR which will remove all the links etc. to Find during its downtime.

## Link to Trello card

https://trello.com/c/Qpx3ib25/1934-dev-%F0%9F%9A%B2%F0%9F%94%9A-prevent-candidates-with-unsubmitted-applications-from-choosing-a-courses

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
