### PR TITLE
Add a JSON 500 error response to API

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -18,6 +18,21 @@ class ErrorsController < ApplicationController
   end
 
   def internal_server_error
-    render 'internal_server_error.html', status: :internal_server_error
+    respond_to do |format|
+      format.json do
+        render json: {
+          errors: [
+            {
+              error: 'InternalServerError',
+              message: 'The server encountered an unexpected condition that prevented it from fulfilling the request',
+            },
+          ],
+        }, status: :internal_server_error
+      end
+
+      format.any do
+        render 'internal_server_error.html', status: :internal_server_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

If API clients trigger 500s they get a splurge of HTML, which looks unprofessional and isn't useful
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a JSON format handler in `ErrorsController` to catch unexpected errors
- Responds with a machine readable error

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/90385015-639bac80-e07a-11ea-96e0-d50dfa2a0d23.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/D4aVT7Ar/2599-we-dont-have-a-json-500-error-response
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
