### PR TITLE
Communicate date 2021 cycles open

### DIFF
--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
     end
 
     def render?
-        !EndOfCycleTimetable.show_apply_2_reopen_banner?
+      !EndOfCycleTimetable.show_apply_2_reopen_banner?
     end
   end
 end

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -10,5 +10,13 @@ module CandidateInterface
     def show_deadline_copy?
       EndOfCycleTimetable.show_apply_2_deadline_banner? && FeatureFlag.active?(:deadline_notices)
     end
+
+    def render?
+      if @application_form.apply_1?
+        !EndOfCycleTimetable.show_apply_1_reopen_banner?
+      else
+        !EndOfCycleTimetable.show_apply_2_reopen_banner?
+      end
+    end
   end
 end

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -12,11 +12,7 @@ module CandidateInterface
     end
 
     def render?
-      if @application_form.apply_1?
-        !EndOfCycleTimetable.show_apply_1_reopen_banner?
-      else
         !EndOfCycleTimetable.show_apply_2_reopen_banner?
-      end
     end
   end
 end

--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -1,0 +1,10 @@
+<% if show_reopen_banner? %>
+  <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+    <div class="app-banner__message">
+      <h2 class="govuk-heading-m" id="success-message">Applications for courses starting this academic year have now closed</h2>
+      <p class='govuk-body govuk-!-font-size-24'>
+        Submit your application from <%= reopen_date %> for courses starting in the next academic year.
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/reopen_banner_component.html.erb
+++ b/app/components/candidate_interface/reopen_banner_component.html.erb
@@ -1,4 +1,4 @@
-<% if show_reopen_banner? %>
+<% if show? %>
   <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
     <div class="app-banner__message">
       <h2 class="govuk-heading-m" id="success-message">Applications for courses starting this academic year have now closed</h2>

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -1,0 +1,43 @@
+class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
+  attr_accessor :phase, :flash_empty
+
+  def initialize(phase:, flash_empty:)
+    @phase = phase
+    @flash_empty = flash_empty
+  end
+
+  def show?
+    flash_empty &&
+      (show_apply_1_deadline_banner? || show_apply_2_deadline_banner?)
+  end
+
+  def
+    apply_1? ? apply_1_deadline : apply_2_deadline
+  end
+
+private
+
+  def show_apply_1_deadline_banner?
+    apply_1? &&
+      EndOfCycleTimetable.show_apply_1_deadline_banner? &&
+      FeatureFlag.active?(:deadline_notices)
+  end
+
+  def show_apply_2_deadline_banner?
+    apply_2? &&
+      EndOfCycleTimetable.show_apply_2_deadline_banner? &&
+      FeatureFlag.active?(:deadline_notices)
+  end
+
+  def apply_1?
+    phase == 'apply_1'
+  end
+
+  def apply_2?
+    phase == 'apply_2'
+  end
+
+  def apply_1_deadline
+    EndOfCycleTimetable.date(:apply_1_deadline).strftime('%d %B')
+  end
+end

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -16,13 +16,13 @@ private
   def show_apply_1_reopen_banner?
     apply_1? &&
       EndOfCycleTimetable.show_apply_1_reopen_banner?
-      # FeatureFlag.active?(:deadline_notices)
+    # FeatureFlag.active?(:deadline_notices)
   end
 
   def show_apply_2_reopen_banner?
     apply_2? &&
       EndOfCycleTimetable.show_apply_2_reopen_banner?
-      # FeatureFlag.active?(:deadline_notices)
+    # FeatureFlag.active?(:deadline_notices)
   end
 
   def apply_1?

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -15,14 +15,14 @@ private
 
   def show_apply_1_reopen_banner?
     apply_1? &&
-      EndOfCycleTimetable.show_apply_1_reopen_banner? &&
-      FeatureFlag.active?(:deadline_notices)
+      EndOfCycleTimetable.show_apply_1_reopen_banner?
+      # FeatureFlag.active?(:deadline_notices)
   end
 
   def show_apply_2_reopen_banner?
     apply_2? &&
-      EndOfCycleTimetable.show_apply_2_reopen_banner? &&
-      FeatureFlag.active?(:deadline_notices)
+      EndOfCycleTimetable.show_apply_2_reopen_banner?
+      # FeatureFlag.active?(:deadline_notices)
   end
 
   def apply_1?

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -16,13 +16,11 @@ private
   def show_apply_1_reopen_banner?
     apply_1? &&
       EndOfCycleTimetable.show_apply_1_reopen_banner?
-    # FeatureFlag.active?(:deadline_notices)
   end
 
   def show_apply_2_reopen_banner?
     apply_2? &&
       EndOfCycleTimetable.show_apply_2_reopen_banner?
-    # FeatureFlag.active?(:deadline_notices)
   end
 
   def apply_1?
@@ -34,6 +32,6 @@ private
   end
 
   def reopen_date
-    EndOfCycleTimetable.date(:reopen_date).to_s(:govuk_date)
+    EndOfCycleTimetable.date(:next_cycles_courses_open).to_s(:govuk_date)
   end
 end

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -8,24 +8,20 @@ class CandidateInterface::ReopenBannerComponent < ViewComponent::Base
 
   def show?
     flash_empty &&
-      (show_apply_1_deadline_banner? || show_apply_2_deadline_banner?)
-  end
-
-  def
-    apply_1? ? apply_1_deadline : apply_2_deadline
+      (show_apply_1_reopen_banner? || show_apply_2_reopen_banner?)
   end
 
 private
 
-  def show_apply_1_deadline_banner?
+  def show_apply_1_reopen_banner?
     apply_1? &&
-      EndOfCycleTimetable.show_apply_1_deadline_banner? &&
+      EndOfCycleTimetable.show_apply_1_reopen_banner? &&
       FeatureFlag.active?(:deadline_notices)
   end
 
-  def show_apply_2_deadline_banner?
+  def show_apply_2_reopen_banner?
     apply_2? &&
-      EndOfCycleTimetable.show_apply_2_deadline_banner? &&
+      EndOfCycleTimetable.show_apply_2_reopen_banner? &&
       FeatureFlag.active?(:deadline_notices)
   end
 
@@ -37,7 +33,7 @@ private
     phase == 'apply_2'
   end
 
-  def apply_1_deadline
-    EndOfCycleTimetable.date(:apply_1_deadline).strftime('%d %B')
+  def reopen_date
+    EndOfCycleTimetable.date(:reopen_date).to_s(:govuk_date)
   end
 end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -26,11 +26,13 @@ class EndOfCycleTimetable
   end
 
   def self.show_apply_1_reopen_banner?
-    Time.zone.now > date(:apply_1_deadline).end_of_day
+    Time.zone.now > date(:apply_1_deadline).end_of_day &&
+      Time.zone.now < date(:reopen_date).beginning_of_day
   end
 
   def self.show_apply_2_reopen_banner?
-    Time.zone.now > date(:apply_2_deadline).end_of_day
+    Time.zone.now > date(:apply_2_deadline).end_of_day &&
+      Time.zone.now < date(:reopen_date).beginning_of_day
   end
 
   def self.date(name)

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -27,12 +27,12 @@ class EndOfCycleTimetable
 
   def self.show_apply_1_reopen_banner?
     Time.zone.now > date(:apply_1_deadline).end_of_day &&
-      Time.zone.now < date(:reopen_date).beginning_of_day
+      Time.zone.now < date(:next_cycles_courses_open).beginning_of_day
   end
 
   def self.show_apply_2_reopen_banner?
     Time.zone.now > date(:apply_2_deadline).end_of_day &&
-      Time.zone.now < date(:reopen_date).beginning_of_day
+      Time.zone.now < date(:next_cycles_courses_open).beginning_of_day
   end
 
   def self.date(name)

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -25,6 +25,14 @@ class EndOfCycleTimetable
     date(:next_cycles_courses_open)
   end
 
+  def self.show_apply_1_reopen_banner?
+    Time.zone.now > date(:apply_1_deadline).end_of_day
+  end
+
+  def self.show_apply_2_reopen_banner?
+    Time.zone.now > date(:apply_2_deadline).end_of_day
+  end
+
   def self.date(name)
     DATES[name]
   end

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -12,6 +12,7 @@
 
 <% if @application_form.ended_without_success? %>
   <%= render CandidateInterface::ApplyAgainBannerComponent.new(application_form: @application_form) %>
+  <%= render CandidateInterface::ReopenBannerComponent.new(phase: 'apply_2', flash_empty: flash.empty?) %>
 <% end %>
 
 <h1 class="govuk-heading-xl govuk-heading-xl govuk-!-margin-bottom-2">

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -9,6 +9,7 @@
 <% end %>
 
 <%= render(CandidateInterface::DeadlineBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
+<%= render(CandidateInterface::ReopenBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
   <%= t('page_titles.application_form') %>

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -58,7 +58,19 @@ RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
       expect(result.text).not_to include 'The deadline when applying again is'
     end
   end
-  describe 'banner is not rendered between cycles' do
-    Timecop.zone
+  describe 'visibility of banner between cycles' do
+    it 'is rendered' do
+      Timecop.freeze(Time.zone.local(2020, 9, 17, 12, 0, 0)) do
+        result = render_inline(described_class.new(application_form: application_form))
+        expect(result.text).to include('Do you want to apply again?')
+      end
+    end
+
+    it 'is not rendered' do
+      Timecop.freeze(Time.zone.local(2020, 9, 25, 12, 0, 0)) do
+        result = render_inline(described_class.new(application_form: application_form))
+        expect(result.text).to eq('')
+      end
+    end
   end
 end

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
       expect(result.text).not_to include 'The deadline when applying again is'
     end
   end
+
   describe 'visibility of banner between cycles' do
     it 'is rendered' do
       Timecop.freeze(Time.zone.local(2020, 9, 17, 12, 0, 0)) do

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -58,4 +58,7 @@ RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
       expect(result.text).not_to include 'The deadline when applying again is'
     end
   end
+  describe 'banner is not rendered between cycles' do
+    Timecop.zone
+  end
 end

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ReopenBannerComponent do
+  describe '#render' do
+    let(:application_form) { build(:application_form) }
+    let(:flash) { double }
+
+    def set_conditions_for_rendering_banner(phase)
+      application_form.phase = phase
+      FeatureFlag.activate(:deadline_notices)
+      allow(flash).to receive(:empty?).and_return true
+      allow(EndOfCycleTimetable).to receive(:show_apply_1_reopen_banner?).and_return(true)
+      allow(EndOfCycleTimetable).to receive(:show_apply_2_reopen_banner?).and_return(true)
+    end
+
+    it 'renders the banner for an Apply 1 app' do
+      set_conditions_for_rendering_banner('apply_1')
+
+      result = render_inline(described_class.new(
+        phase: application_form.phase,
+        flash_empty: flash.empty?,
+      ))
+
+      expect(result.text).to include('Applications for courses starting this academic year have now closed')
+      expect(result.text).to include('Submit your application from 13 October 2020 for courses starting in the next academic year.')
+    end
+
+    it 'renders the banner for an Apply 2 app' do
+      set_conditions_for_rendering_banner('apply_2')
+
+      result = render_inline(described_class.new(
+        phase: application_form.phase,
+        flash_empty: flash.empty?,
+      ))
+
+      expect(result.text).to include('Applications for courses starting this academic year have now closed')
+      expect(result.text).to include('Submit your application from 13 October 2020 for courses starting in the next academic year.')
+    end
+
+    it 'does NOT render when we not between cycles' do
+      set_conditions_for_rendering_banner('apply_1')
+      allow(EndOfCycleTimetable).to receive(:show_apply_1_reopen_banner?).and_return(false)
+
+      result = render_inline(described_class.new(
+        phase: application_form.phase,
+        flash_empty: flash.empty?,
+      ))
+
+      expect(result.text).not_to include('Applications for courses starting this academic year have now closed')
+    end
+  end
+end

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       expect(result.text).to include('Submit your application from 13 October 2020 for courses starting in the next academic year.')
     end
 
-    it 'does NOT render when we not between cycles' do
+    it 'does NOT render when we are not between cycles' do
       set_conditions_for_rendering_banner('apply_1')
       allow(EndOfCycleTimetable).to receive(:show_apply_1_reopen_banner?).and_return(false)
 

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -16,10 +16,12 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
     it 'renders the banner for an Apply 1 app' do
       set_conditions_for_rendering_banner('apply_1')
 
-      result = render_inline(described_class.new(
-        phase: application_form.phase,
-        flash_empty: flash.empty?,
-      ))
+      result = render_inline(
+        described_class.new(
+          phase: application_form.phase,
+          flash_empty: flash.empty?,
+        ),
+      )
 
       expect(result.text).to include('Applications for courses starting this academic year have now closed')
       expect(result.text).to include('Submit your application from 13 October 2020 for courses starting in the next academic year.')
@@ -28,10 +30,12 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
     it 'renders the banner for an Apply 2 app' do
       set_conditions_for_rendering_banner('apply_2')
 
-      result = render_inline(described_class.new(
-        phase: application_form.phase,
-        flash_empty: flash.empty?,
-      ))
+      result = render_inline(
+        described_class.new(
+          phase: application_form.phase,
+          flash_empty: flash.empty?,
+        ),
+      )
 
       expect(result.text).to include('Applications for courses starting this academic year have now closed')
       expect(result.text).to include('Submit your application from 13 October 2020 for courses starting in the next academic year.')
@@ -41,10 +45,12 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       set_conditions_for_rendering_banner('apply_1')
       allow(EndOfCycleTimetable).to receive(:show_apply_1_reopen_banner?).and_return(false)
 
-      result = render_inline(described_class.new(
-        phase: application_form.phase,
-        flash_empty: flash.empty?,
-      ))
+      result = render_inline(
+        described_class.new(
+          phase: application_form.phase,
+          flash_empty: flash.empty?,
+        ),
+      )
 
       expect(result.text).not_to include('Applications for courses starting this academic year have now closed')
     end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe EndOfCycleTimetable do
 
   describe '.show_apply_1_reopen_banner?' do
     it 'returns false before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0,)) do
+      Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
         expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be false
       end
     end
@@ -41,18 +41,30 @@ RSpec.describe EndOfCycleTimetable do
         expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be true
       end
     end
+
+    it 'returns false after the new cycle opens' do
+      Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be false
+      end
+    end
   end
 
   describe '.show_apply_2_reopen_banner?' do
     it 'returns false before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0,)) do
+      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
         expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be false
       end
     end
 
     it 'returns true after the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0,)) do
+      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
         expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be true
+      end
+    end
+
+    it 'returns false after the new cycle opens' do
+      Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be false
       end
     end
   end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -28,4 +28,32 @@ RSpec.describe EndOfCycleTimetable do
       end
     end
   end
+
+  describe '.show_apply_1_reopen_banner?' do
+    it 'returns false before the configured date' do
+      Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0,)) do
+        expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be false
+      end
+    end
+
+    it 'returns true after the configured date' do
+      Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
+        expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be true
+      end
+    end
+  end
+
+  describe '.show_apply_2_reopen_banner?' do
+    it 'returns false before the configured date' do
+      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0,)) do
+        expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be false
+      end
+    end
+
+    it 'returns true after the configured date' do
+      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0,)) do
+        expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be true
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_views_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsubmitted_application_between_cycles_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.feature 'View application between cycles' do
+  include CandidateHelper
+
+  around do |example|
+    Timecop.freeze(Date.new(2020, 8, 1)) do
+      example.run
+    end
+  end
+
+  scenario 'Candidate submits their contact details' do
+    given_i_am_signed_in
+    and_the_international_addresses_flag_is_active
+    and_i_visit_the_site
+
+    # when_i_fill_in_my_phone_number
+    # and_i_submit_my_phone_number
+    # and_i_select_live_in_uk
+
+    given_we_are_between_2020_and_2021_cycles
+    # and_i_revisit_my_application
+    then_i_should_see_the_applications_closed_banner
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_international_addresses_flag_is_active
+    FeatureFlag.activate('international_addresses')
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def given_we_are_between_2020_and_2021_cycles
+    Timecop.travel(1.month.from_now)
+  end
+
+  def then_i_should_see_the_applications_closed_banner
+    expect(page).to have_content 'Applications for courses starting this academic year have now closed'
+  end
+end

--- a/spec/system/candidate_interface/candidate_views_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsubmitted_application_between_cycles_spec.rb
@@ -11,35 +11,39 @@ RSpec.feature 'View application between cycles' do
 
   scenario 'Candidate submits their contact details' do
     given_i_am_signed_in
-    and_the_international_addresses_flag_is_active
     and_i_visit_the_site
-
-    # when_i_fill_in_my_phone_number
-    # and_i_submit_my_phone_number
-    # and_i_select_live_in_uk
+    then_i_should_not_see_the_applications_reopen_banner
 
     given_we_are_between_2020_and_2021_cycles
-    # and_i_revisit_my_application
-    then_i_should_see_the_applications_closed_banner
+    and_i_logout
+    and_i_am_signed_in
+    and_i_visit_the_site
+    then_i_should_see_the_applications_reopen_banner
   end
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
   end
 
-  def and_the_international_addresses_flag_is_active
-    FeatureFlag.activate('international_addresses')
-  end
-
   def and_i_visit_the_site
     visit candidate_interface_application_form_path
+  end
+
+  def then_i_should_not_see_the_applications_reopen_banner
+    expect(page).not_to have_content 'Applications for courses starting this academic year have now closed'
   end
 
   def given_we_are_between_2020_and_2021_cycles
     Timecop.travel(1.month.from_now)
   end
 
-  def then_i_should_see_the_applications_closed_banner
+  def and_i_logout
+    logout
+  end
+
+  alias_method :and_i_am_signed_in, :given_i_am_signed_in
+
+  def then_i_should_see_the_applications_reopen_banner
     expect(page).to have_content 'Applications for courses starting this academic year have now closed'
   end
 end

--- a/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
   include CandidateHelper
 
   around do |example|
-    Timecop.freeze(Time.zone.local(2020, 8, 25, 8, 56, 0)) do
+    Timecop.freeze(Time.zone.local(2020, 9, 25, 8, 56, 0)) do
       example.run
     end
   end
@@ -14,6 +14,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
     and_i_have_an_unsuccessful_application
     and_i_visit_the_application_dashboard
     then_i_do_not_see_an_apply_again_banner
+    and_i_do_see_a_reopen_banner
   end
 
   def given_i_am_signed_in_as_a_candidate
@@ -39,5 +40,9 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def then_i_do_not_see_an_apply_again_banner
     expect(page).not_to have_content('Do you want to apply again?')
+  end
+
+  def and_i_do_see_a_reopen_banner
+    expect(page).to have_content('Applications for courses starting this academic year have now closed')
   end
 end

--- a/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
@@ -3,30 +3,25 @@ require 'rails_helper'
 RSpec.feature 'Candidate with unsuccessful application' do
   include CandidateHelper
 
-  scenario 'Sees between cycles banner and cannot apply again' do
-    given_the_pilot_is_open
-    and_we_are_between_2020_and_2021_cycles
-    and_i_am_signed_in_as_a_candidate
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 8, 25, 8, 56, 0)) do
+      example.run
+    end
+  end
 
-    when_i_have_an_unsuccessful_application
+  scenario 'Sees between cycles banner and cannot apply again' do
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_an_unsuccessful_application
     and_i_visit_the_application_dashboard
     then_i_do_not_see_an_apply_again_banner
   end
 
-  def given_the_pilot_is_open
-    FeatureFlag.activate('pilot_open')
-  end
-
-  def and_we_are_between_2020_and_2021_cycles
-    Timecop.travel(Date.new(2020, 9, 21))
-  end
-
-  def and_i_am_signed_in_as_a_candidate
+  def given_i_am_signed_in_as_a_candidate
     @candidate = create(:candidate)
     login_as(@candidate)
   end
 
-  def when_i_have_an_unsuccessful_application
+  def and_i_have_an_unsuccessful_application
     @application_form = create(
       :completed_application_form,
       :with_completed_references,

--- a/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate with unsuccessful application' do
+  include CandidateHelper
+
+  scenario 'Sees between cycles banner and cannot apply again' do
+    given_the_pilot_is_open
+    and_we_are_between_2020_and_2021_cycles
+    and_i_am_signed_in_as_a_candidate
+
+    when_i_have_an_unsuccessful_application
+    and_i_visit_the_application_dashboard
+    then_i_do_not_see_an_apply_again_banner
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_we_are_between_2020_and_2021_cycles
+    Timecop.travel(Date.new(2020, 9, 21))
+  end
+
+  def and_i_am_signed_in_as_a_candidate
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def when_i_have_an_unsuccessful_application
+    @application_form = create(
+      :completed_application_form,
+      :with_completed_references,
+      references_count: 2,
+      with_gces: true,
+      candidate: @candidate,
+      safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+    )
+    create(:application_choice, status: :rejected, application_form: @application_form)
+  end
+
+  def and_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_do_not_see_an_apply_again_banner
+    expect(page).not_to have_content('Do you want to apply again?')
+  end
+end


### PR DESCRIPTION
## Context

As a candidate
I need to know when applications for courses starting in 2021 open
So that I can submit my application to providers

## Changes proposed in this pull request

Have created a new banner component to display reopening message and date. We have modified the apply again component to not show between cycles.

Before:
![image](https://user-images.githubusercontent.com/62567622/90162058-f80cc300-dd8b-11ea-9215-27ff3a9a0dc8.png)

After:
![image](https://user-images.githubusercontent.com/62567622/90161993-e0cdd580-dd8b-11ea-9530-aff2caf35a96.png)

## Guidance to review

Steve and I decided against a Feature flag on the basis that his is a relatively minor change that will have limited scope for error. Would be interested to know if there any differing views on this? As for the code please sanity check. In order to test the banner logic in practice you will need to load the review app and toggle your system clock to inside and then outside the between cycle window.

## Link to Trello card

https://trello.com/c/seZyyjfm/1933-dev-%F0%9F%9A%B2%F0%9F%94%9A-communicate-date-when-applications-for-2021-open

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
