### PR TITLE
Signing out of Manage should also sign you out of DfE Sign-In

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -28,6 +28,19 @@ class DfESignInController < ActionController::Base
 
   alias_method :bypass_callback, :callback
 
+  # This is called by a redirect from DfE Sign-in after visiting the signout
+  # link on DSI. We tell DSI to redirect here using the
+  # post_logout_redirect_uri parameter - see DfESignInUser#dsi_logout_url
+  #
+  # The interface we signed out from will appear here in the :state param.
+  def redirect_after_dsi_signout
+    if params[:state] == 'support'
+      redirect_to support_interface_path
+    else
+      redirect_to provider_interface_path
+    end
+  end
+
 private
 
   def send_support_sign_in_confirmation_email

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class SessionsController < ProviderInterfaceController
-    skip_before_action :authenticate_provider_user!
+    skip_before_action :authenticate_provider_user!, except: :destroy
     skip_before_action :redirect_if_setup_required
 
     def new

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -10,9 +10,14 @@ module ProviderInterface
     end
 
     def destroy
-      DfESignInUser.end_session!(session)
+      post_signout_redirect = if dfe_sign_in_user.needs_dsi_signout?
+                                dfe_sign_in_user.provider_interface_dsi_logout_url
+                              else
+                                provider_interface_path
+                              end
 
-      redirect_to action: :new
+      DfESignInUser.end_session!(session)
+      redirect_to post_signout_redirect
     end
 
     def sign_in_by_email

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class SessionsController < SupportInterfaceController
-    skip_before_action :authenticate_support_user!
+    skip_before_action :authenticate_support_user!, except: :destroy
 
     def new
       session['post_dfe_sign_in_path'] ||= support_interface_path
@@ -13,7 +13,7 @@ module SupportInterface
       post_signout_redirect = if dfe_sign_in_user.needs_dsi_signout?
                                 dfe_sign_in_user.support_interface_dsi_logout_url
                               else
-                                provider_interface_path
+                                support_interface_path
                               end
 
       DfESignInUser.end_session!(session)

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -10,9 +10,14 @@ module SupportInterface
     end
 
     def destroy
-      DfESignInUser.end_session!(session)
+      post_signout_redirect = if dfe_sign_in_user.needs_dsi_signout?
+                                dfe_sign_in_user.support_interface_dsi_logout_url
+                              else
+                                provider_interface_path
+                              end
 
-      redirect_to action: :new
+      DfESignInUser.end_session!(session)
+      redirect_to post_signout_redirect
     end
 
     def sign_in_by_email

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -67,14 +67,12 @@ private
   # a URL the user can visit to log them out of DSI and be redirected to our
   # after-sign-out path where we'll delete their local session
   def dsi_logout_url(interface:)
-    logout_url = URI.parse("#{ENV.fetch('DFE_SIGN_IN_ISSUER')}/session/end").tap do |url|
-      url.query = {
-        post_logout_redirect_uri: auth_dfe_sign_out_url,
-        id_token_hint: @id_token,
-        state: interface,
-      }.to_query
-    end
+    query = {
+      post_logout_redirect_uri: auth_dfe_sign_out_url,
+      id_token_hint: @id_token,
+      state: interface,
+    }
 
-    logout_url.to_s
+    "#{ENV.fetch('DFE_SIGN_IN_ISSUER')}/session/end?#{query.to_query}"
   end
 end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -2,11 +2,27 @@ class DfESignInUser
   attr_reader :email_address, :dfe_sign_in_uid
   attr_accessor :first_name, :last_name
 
-  def initialize(email_address:, dfe_sign_in_uid:, first_name:, last_name:)
+  # we need to be able to redirect back to our sign-out callback path
+  include Rails.application.routes.url_helpers
+
+  def initialize(email_address:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil)
     @email_address = email_address&.downcase
     @dfe_sign_in_uid = dfe_sign_in_uid
     @first_name = first_name
     @last_name = last_name
+    @id_token = id_token
+  end
+
+  def provider_interface_dsi_logout_url
+    dsi_logout_url(interface: :provider)
+  end
+
+  def support_interface_dsi_logout_url
+    dsi_logout_url(interface: :support)
+  end
+
+  def needs_dsi_signout?
+    @id_token.present?
   end
 
   def self.begin_session!(session, omniauth_payload)
@@ -16,6 +32,7 @@ class DfESignInUser
       'first_name' => omniauth_payload['info']['first_name'],
       'last_name' => omniauth_payload['info']['last_name'],
       'last_active_at' => Time.zone.now,
+      'id_token' => omniauth_payload['credentials']['id_token'],
     }
   end
 
@@ -36,11 +53,28 @@ class DfESignInUser
       dfe_sign_in_uid: dfe_sign_in_session['dfe_sign_in_uid'],
       first_name: dfe_sign_in_session['first_name'],
       last_name: dfe_sign_in_session['last_name'],
+      id_token: dfe_sign_in_session['id_token'],
     )
   end
 
   def self.end_session!(session)
     session.delete('post_dfe_sign_in_path')
     session.delete('dfe_sign_in_user')
+  end
+
+private
+
+  # a URL the user can visit to log them out of DSI and be redirected to our
+  # after-sign-out path where we'll delete their local session
+  def dsi_logout_url(interface:)
+    logout_url = URI.parse("#{ENV.fetch('DFE_SIGN_IN_ISSUER')}/session/end").tap do |url|
+      url.query = {
+        post_logout_redirect_uri: auth_dfe_sign_out_url,
+        id_token_hint: @id_token,
+        state: interface,
+      }.to_query
+    end
+
+    logout_url.to_s
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -621,6 +621,7 @@ Rails.application.routes.draw do
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'
   post '/auth/developer/callback' => 'dfe_sign_in#bypass_callback'
+  get '/auth/dfe/sign-out' => 'dfe_sign_in#redirect_after_dsi_signout'
 
   namespace :integrations, path: '/integrations' do
     post '/notify/callback' => 'notify#callback'

--- a/spec/system/provider_interface/sign_out_spec.rb
+++ b/spec/system/provider_interface/sign_out_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'A provider user signs out of DSI as well as Apply' do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, email_address: 'provider@example.com', dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  scenario 'signing out destroys local session then redirects to DSI' do
+    given_i_am_registered_as_a_provider_user
+    and_i_have_a_dfe_sign_in_account
+    and_i_visit_the_provider_interface_sign_in_path
+    and_i_sign_in_via_dfe_sign_in
+
+    when_i_click_on_sign_out
+    then_i_am_redirected_to_dsi_end_session_endpoint
+    and_dsi_redirects_me_back_to_the_provider_interface
+    and_i_am_already_signed_out_of_the_provider_interface
+  end
+
+  def given_i_am_registered_as_a_provider_user
+    provider_user
+  end
+
+  def and_i_have_a_dfe_sign_in_account
+    provider_exists_in_dfe_sign_in(
+      email_address: 'provider@example.com',
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+    )
+  end
+
+  def and_i_visit_the_provider_interface_sign_in_path
+    visit provider_interface_sign_in_path
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    click_button 'Sign in using DfE Sign-in'
+  end
+
+  def when_i_click_on_sign_out
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(DfESignInUser).to receive(:needs_dsi_signout?).and_return(true)
+    # rubocop:enable RSpec/AnyInstance
+    ClimateControl.modify DFE_SIGN_IN_ISSUER: 'https://identityprovider.gov.uk' do
+      click_link 'Sign out'
+    end
+  end
+
+  def then_i_am_redirected_to_dsi_end_session_endpoint
+    expected_query = {
+      id_token_hint: nil,
+      post_logout_redirect_uri: "#{HostingEnvironment.application_url}/auth/dfe/sign-out",
+      state: :provider,
+    }
+
+    expected_url = "https://identityprovider.gov.uk/session/end?#{expected_query.to_query}"
+    expect(page.current_url).to eq(expected_url)
+  end
+
+  def and_dsi_redirects_me_back_to_the_provider_interface
+    # we'll just have to simulate the redirect here
+    return_from_dsi_logout_path = '/auth/dfe/sign-out?state=provider'
+    visit return_from_dsi_logout_path
+
+    expect(page).to have_current_path(provider_interface_path)
+  end
+
+  def and_i_am_already_signed_out_of_the_provider_interface
+    visit provider_interface_applications_path
+
+    expect(page).to have_current_path(provider_interface_sign_in_path)
+  end
+end

--- a/spec/system/support_interface/sign_out_spec.rb
+++ b/spec/system/support_interface/sign_out_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'A support user signs out of DSI as well as Apply' do
+  include DfESignInHelpers
+
+  let(:support_user) { create(:support_user, email_address: 'support@example.com', dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  scenario 'signing out destroys local session then redirects to DSI' do
+    given_i_am_registered_as_a_support_user
+    and_i_have_a_dfe_sign_in_account
+    and_i_visit_the_support_interface_sign_in_path
+    and_i_sign_in_via_dfe_sign_in
+
+    when_i_click_on_sign_out
+    then_i_am_redirected_to_dsi_end_session_endpoint
+    and_dsi_redirects_me_back_to_the_support_interface
+    and_i_am_already_signed_out_of_the_support_interface
+  end
+
+  def given_i_am_registered_as_a_support_user
+    support_user
+  end
+
+  def and_i_have_a_dfe_sign_in_account
+    user_exists_in_dfe_sign_in(
+      email_address: 'provider@example.com',
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+    )
+  end
+
+  def and_i_visit_the_support_interface_sign_in_path
+    visit support_interface_sign_in_path
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    click_button 'Sign in using DfE Sign-in'
+  end
+
+  def when_i_click_on_sign_out
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(DfESignInUser).to receive(:needs_dsi_signout?).and_return(true)
+    # rubocop:enable RSpec/AnyInstance
+    ClimateControl.modify DFE_SIGN_IN_ISSUER: 'https://identityprovider.gov.uk' do
+      click_link 'Sign out'
+    end
+  end
+
+  def then_i_am_redirected_to_dsi_end_session_endpoint
+    expected_query = {
+      id_token_hint: nil,
+      post_logout_redirect_uri: "#{HostingEnvironment.application_url}/auth/dfe/sign-out",
+      state: :support,
+    }
+
+    expected_url = "https://identityprovider.gov.uk/session/end?#{expected_query.to_query}"
+    expect(page.current_url).to eq(expected_url)
+  end
+
+  def and_dsi_redirects_me_back_to_the_support_interface
+    # we'll just have to simulate the redirect here
+    return_from_dsi_logout_path = '/auth/dfe/sign-out?state=support'
+    visit return_from_dsi_logout_path
+
+    expect(page).to have_current_path(support_interface_sign_in_path)
+  end
+
+  def and_i_am_already_signed_out_of_the_support_interface
+    visit support_interface_candidates_path
+
+    expect(page).to have_current_path(support_interface_sign_in_path)
+  end
+end


### PR DESCRIPTION
## Context

This PR tweaks a previous spike https://github.com/DFE-Digital/apply-for-teacher-training/pull/2433 and prepares the code for release.

Currently, provider and support users signing out of Apply retain their DSI session and are able to sign-in to Apply again as the same user, unchallenged, simply by clicking on the Sign-in button. This is problematic, as:
- one provider/support user may easily impersonate another (even inadvertently), when sharing computers
- users with multiple identities find it hard to switch between different DSI profiles 

This PR addresses such cases by attempting to log out provider and support users from DSI immediately after destroying their Apply session. This is not guaranteed to succeed, of course, but should work fine in the majority of cases. 

The focus here is Apply-initiated logouts. If the user signs out of DSI either directly from their pages or via a similar logout process triggered by another DfE service, our service will not know until the Apply session expires. There is nothing we can do about this unless DSI starts supporting back-channel logout flows, at which point we should probably start persisting `id_token` values in the database.

## Changes proposed in this pull request

Only minor changes to the original spike code were necessary (https://github.com/DFE-Digital/apply-for-teacher-training/pull/2710/commits/ced4912752851ca44d06934a62cbb300fe68ab7e).

I investigated whether we could use the built-in redirect provided by the `omniauth_openid_connect` gem. If you visit to `/auth/dfe/logout`, the gem is pre-programmed to redirect you to `end_session_endpoint`, which is configured automatically via the discovery process (see https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/config/initializers/omniauth.rb#L10). This auto-discovered endpoint resolves to the same IdP path `/session/end` that we have hardcoded. However, this built-in redirect seems to lack query params such as `id_token_hint` (which perhaps we could pass) and we have decided to first destroy the Apply session, then redirect, so it's not worth pursuing this, especially as `end_session_endpoint` is unlikely to ever change.

I have also verified this PR does not break the DSI bypass mechanism we use for development and review apps or sign-outs for real users who have signed-in before this code goes live (and therefore lack an `id_token` in their session. Signing-in and out when `:dfe_sign_in_fallback` feature flag is on works as expected, too.

## Guidance to review

I've fixed a few things mentioned in the original PR but did not change:
- The name of `id_token`. 'ID Token' is a very specific OIDC term, and such tokens are required for logout flows. OIDC can be a little obscure, but anyone familiar with the spec will instantly recognise it. The rest of us can probably read the code and see it's only ever used for logging out. :)
- The values passed to `state=`. `provider` and `support` are concise and clear to anyone familiar with this service.

Finally, the defensive `dfe_sign_in_user&.needs_dsi_signout?` code is there in case the redirect to `end_session_endpoint` fails for some reason (DSI misconfiguration or outage) and the user clicks 'Back' on their browser, which will take them back to the destroy action without a `dfe_sign_in_user`.

To test interactively, a working DfE Sign-In integration is needed. Then the DSI service configuration needs to be altered to include the relevant logout redirect for your environment. For example,

![image](https://user-images.githubusercontent.com/107591/90179687-bee14c80-dda5-11ea-8a2b-337459cc51ef.png)

Do we need more tests?

## Link to Trello card

https://trello.com/c/k9crMTdY

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
