### PR TITLE
Make /application/:id/offer idempotent

### DIFF
--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -14,6 +14,12 @@ class ChangeOffer
     @auth = ProviderAuthorisation.new(actor: actor)
   end
 
+  def identical_to_existing_offer?
+    course_option.present? && \
+      course_option == application_choice.offered_option && \
+      application_choice.offer['conditions'] == @offer_conditions
+  end
+
   def save
     @auth.assert_can_make_decisions! application_choice: @application_choice, course_option_id: @course_option.id
     if valid?
@@ -43,8 +49,7 @@ private
   end
 
   def validate_offer_is_not_identical
-    if course_option.present? && course_option == application_choice.offered_option \
-      && application_choice.offer['conditions'] == @offer_conditions
+    if identical_to_existing_offer?
       errors.add(:base, 'The new offer is identical to the current offer')
     end
   end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -4,7 +4,7 @@ class ChangeOffer
   attr_reader :application_choice, :course_option
 
   validates :course_option, presence: true
-  validate :validate_course_option_is_not_the_same_as_existing_course_option
+  validate :validate_offer_is_not_identical
   validate :validate_course_option_is_open_on_apply
 
   def initialize(actor:, application_choice:, course_option:, offer_conditions: nil)
@@ -36,15 +36,16 @@ class ChangeOffer
 
 private
 
-  def validate_course_option_is_not_the_same_as_existing_course_option
-    if course_option.present? && course_option == application_choice.offered_option
-      errors.add(:course_option, :no_change)
-    end
-  end
-
   def validate_course_option_is_open_on_apply
     if course_option.present? && !course_option.course.open_on_apply
       errors.add(:course_option, :not_open_on_apply)
+    end
+  end
+
+  def validate_offer_is_not_identical
+    if course_option.present? && course_option == application_choice.offered_option \
+      && application_choice.offer['conditions'] == @offer_conditions
+      errors.add(:base, 'The new offer is identical to the current offer')
     end
   end
 end

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,5 +1,13 @@
 ### 10th August 2020
 
+- `POST /application/:id/offer` is now idempotent and will continue to return 200
+if the same offer details are POSTed repeatedly
+- `POST /application/:id/offer` now supports changing the conditions on an offer
+while retaining the original offered course. Previously this returned a 422 error
+saying it was necessary to offer a different course.
+
+### 10th August 2020
+
 - Deprecate `Withdrawal.reason`, which was supposed to hold a candidate’s reason for
 withdrawing their application. The Apply service will not collect this information
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,7 +228,6 @@ en:
         change_offer:
           attributes:
             course_option:
-              no_change: is the same as the course currently offered
               blank: could not be found
               not_open_on_apply: is not open for applications via the Apply service
         make_an_offer:

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -97,30 +97,6 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(error_response['message']).to match 'The requested course is not open for applications via the Apply service'
     end
 
-    it 'returns an error when making an offer on the same course twice' do
-      application_choice = create_application_choice_for_currently_authenticated_provider(
-        status: 'awaiting_provider_decision',
-      )
-
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
-        'data' => {
-          'conditions' => [],
-        },
-      }
-
-      expect(response).to have_http_status(200)
-
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
-        'data' => {
-          'conditions' => [],
-        },
-      }
-
-      expect(response).to have_http_status(422)
-      expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'The new course is the same as the course currently offered'
-    end
-
     it 'returns an error when specifying a course that does not exist' do
       application_choice = create_application_choice_for_currently_authenticated_provider(
         status: 'awaiting_provider_decision',
@@ -284,6 +260,26 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
         post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
       }.to(change { choice.reload.offer })
     end
+
+    it 'returns 200 OK when sending the same offer & conditions repeatedly' do
+      choice = create(:application_choice, :with_offer,
+                      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+                      offer: { 'conditions' => ['DBS check'] })
+
+      request_body = {
+        "data": {
+          "conditions": [
+            'DBS check',
+          ],
+          "course": course_option_to_course_payload(choice.offered_option),
+        },
+      }
+
+      expect {
+        post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
+      }.not_to(change { choice.reload })
+
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -265,6 +265,28 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
     expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
   end
 
+  describe 'changing offers' do
+    it 'can change the offer conditions' do
+      choice = create(:application_choice, :with_offer,
+                      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+                      offer: { 'conditions' => ['DBS check'] })
+
+      request_body = {
+        "data": {
+          "conditions": [
+            'Change your sheets',
+            'Wash your clothes',
+          ],
+        },
+      }
+
+      expect {
+        post_api_request "/api/v1/applications/#{choice.id}/offer", params: request_body
+      }.to(change { choice.reload.offer })
+    end
+    end
+  end
+
   def course_option_to_course_payload(course_option)
     {
       'recruitment_cycle_year' => course_option.course.recruitment_cycle_year,

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -65,12 +65,13 @@ RSpec.describe ChangeOffer do
       expect(change.errors[:course_option]).to include('could not be found')
     end
 
-    it 'checks the course option is different from the current option' do
-      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option)
+    it 'checks the course option and conditions are different from the current option' do
+      application_choice.update(offer: { 'conditions' => ['DBS check'] })
+      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
 
       expect(change).not_to be_valid
 
-      expect(change.errors[:course_option]).to include('is the same as the course currently offered')
+      expect(change.errors[:base]).to include('The new offer is identical to the current offer')
     end
 
     it 'checks the course is open on apply' do

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -83,4 +83,27 @@ RSpec.describe ChangeOffer do
       expect(change.errors[:course_option]).to include('is not open for applications via the Apply service')
     end
   end
+
+  describe '#is_identical_to_existing_offer?' do
+    it 'returns true when offer and conditions match' do
+      application_choice.update(offer: { 'conditions' => ['DBS check'] })
+      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
+
+      expect(change).to be_identical_to_existing_offer
+    end
+
+    it 'returns false when offer matches, but not conditions' do
+      application_choice.update(offer: { 'conditions' => ['Different things'] })
+      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: application_choice.offered_option, offer_conditions: ['DBS check'])
+
+      expect(change).not_to be_identical_to_existing_offer
+    end
+
+    it 'returns false when conditions match, but not offer' do
+      application_choice.update(offer: { 'conditions' => ['DBS check'] })
+      change = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option: new_course_option, offer_conditions: ['DBS check'])
+
+      expect(change).not_to be_identical_to_existing_offer
+    end
+  end
 end


### PR DESCRIPTION
## Context

A vendor is concerned that offers will get lost due to transient network issues and have requested that this endpoint in particular be made idempotent. Presumably the reliability of on-premise networks at providers varies quite a bit, so we might want to do this for other endpoints in time.

We can turn it into a proper PUT in a future version of the API.

## Changes proposed in this pull request

- cause `ChangeOffer` to throw a validation error only when it receives a changeset which would not change the offer OR conditions. Old behaviour was to reject anything that would not change the offer, ignoring the conditions. As a (beneficial) side effect it is now possible to change conditions without changing the offered course.
- one option was to not raise a validation error under those circs and simply no-op. But having the `save` method return `true` after doing nothing seems confusing and likely to encourage bugs. Therefore to implement idempotence I decided to...
- expose `ChangeOffer#identical_to_existing_offer?` so clients can check if they're going to submit such an offer. Check this in the API `DecisionsController` and behave accordingly

## Guidance to review

- Do you agree with the above reasoning?
- Fire up an HTTP client and make some repeated offers. See that they do not 422.

## Link to Trello card

https://trello.com/c/0rHELylc/2518-allow-repeated-posts-to-the-offer-endpoint-with-the-same-details

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
