### PR TITLE
EoC should be at end of deadline dates

### DIFF
--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -6,11 +6,11 @@ class EndOfCycleTimetable
   }.freeze
 
   def self.show_apply_1_deadline_banner?
-    Time.zone.now < date(:apply_1_deadline)
+    Time.zone.now < date(:apply_1_deadline).end_of_day
   end
 
   def self.show_apply_2_deadline_banner?
-    Time.zone.now < date(:apply_2_deadline)
+    Time.zone.now < date(:apply_2_deadline).end_of_day
   end
 
   def self.apply_1_deadline

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe EndOfCycleTimetable do
   describe '.show_apply_1_deadline_banner?' do
     it 'returns true before the configured date' do
-      Timecop.travel(Date.new(2020, 8, 23)) do
+      Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
         expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
       end
     end
 
     it 'returns false after the configured date' do
-      Timecop.travel(Date.new(2020, 8, 24) + 1.hour) do
+      Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
         expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
       end
     end
@@ -17,13 +17,13 @@ RSpec.describe EndOfCycleTimetable do
 
   describe '.show_apply_2_deadline_banner?' do
     it 'returns true before the configured date' do
-      Timecop.travel(Date.new(2020, 9, 17)) do
+      Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
         expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
       end
     end
 
     it 'returns false after the configured date' do
-      Timecop.travel(Date.new(2020, 9, 18) + 1.hour) do
+      Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
         expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
       end
     end


### PR DESCRIPTION
## Context

When working on https://github.com/DFE-Digital/apply-for-teacher-training/pull/2709 with @george-bit we noticed that deadline for the end of the 2020 recruitment cycle is at the start of 24 August (for Apply 1) whereas the start of the closed period is not until the beginning of 25 August. Reading the various specs together it looks like the deadline should be at the end of 18 August (2020-08-24 23:59:59 rather than just 2020-08-24). This is a quick fix to put that right.

## Changes proposed in this pull request

- Change the logic in `EndOfCycleTimetable` to allow permit application submissions until just before midnight local time on the deadline dates (2020-08-24 23:59:59 for Apply 1 and 2020-09-18 23:59:59 for Apply 2).
- Changed the tests to use times for comparison to make things a bit more explicit.

## Guidance to review

- We need to check that this makes sense wrt to the requirements.

## Link to Trello card

No card for this change but it relates to https://trello.com/c/EDvTJYRV/1901-dev-🚲🔚-communicate-deadline-when-applications-for-2020-close

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
