### PR TITLE
Ensure support UI can handle long email addresses

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -11,6 +11,10 @@ module ViewHelper
     link_to(body, url, class: 'govuk-back-link govuk-!-display-none-print')
   end
 
+  def break_email_address(email_address)
+    email_address.gsub(/@/, '<wbr>@').html_safe
+  end
+
   def bat_contact_mail_to(name = 'becomingateacher<wbr>@digital.education.gov.uk', html_options: {})
     html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
 

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -1,15 +1,11 @@
 <% content_for :content do %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if yield(:context).present? %>
-        <span class="govuk-caption-xl"><%= yield :context %></span>
-      <% end %>
+  <% if yield(:context).present? %>
+    <span class="govuk-caption-xl"><%= yield :context %></span>
+  <% end %>
 
-      <% if yield(:title).present? && controller_name != 'errors' %>
-        <h1 class='govuk-heading-xl'><%= yield :title %></h1>
-      <% end %>
-    </div>
-  </div>
+  <% if yield(:title).present? && controller_name != 'errors' %>
+    <h1 class='govuk-heading-xl'><%= yield :title %></h1>
+  <% end %>
 
   <%= yield %>
 <% end %>

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :browser_title, "Application history – Application ##{@application_form.id}" %>
 <% content_for :title do %>
-  <span class="govuk-caption-xl"><%= @application_form.candidate.email_address %></span>
+  <span class="govuk-caption-xl"><%= break_email_address(@application_form.candidate.email_address) %></span>
   Application history
 <% end %>
 
@@ -11,7 +11,7 @@
         <%= link_to 'Applications', support_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @application_form.candidate.email_address, support_interface_application_form_path(@application_form), class: 'govuk-breadcrumbs__link' %>
+        <%= link_to break_email_address(@application_form.candidate.email_address), support_interface_application_form_path(@application_form), class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item" aria-current="page">
         Application history

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, title_with_success_prefix("Application ##{@application_form.id}", flash[:success].present?) %>
 <% content_for :title do %>
   <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
-  <%= @application_form.candidate.email_address %>
+  <%= break_email_address(@application_form.candidate.email_address) %>
 <% end %>
 
 <% content_for :before_content do %>
@@ -11,7 +11,7 @@
         <%= link_to 'Applications', support_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <%= link_to @application_form.candidate.email_address, support_interface_candidate_path(@application_form.candidate), class: 'govuk-breadcrumbs__link' %>
+        <%= link_to break_email_address(@application_form.candidate.email_address), support_interface_candidate_path(@application_form.candidate), class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item" aria-current="page">
         <span class="govuk-visually-hidden">Support reference</span>


### PR DESCRIPTION
## Context

Exceedingly long email addresses don’t wrap in the support UI, but instead overflow the page container.

## Changes proposed in this pull request

* Removes the two-third column restriction on all page titles within the support UI
* Replaces `@` with `<wbr>@` on candidate application page

## Guidance to review

Added `candidate_email_address` definition in `application_forms_controller.rb`, aliased to `@candidate_email_address` for the `show` and `audit` views. Is this correct approach?

## Link to Trello card

https://trello.com/c/6nIW7SJ9
