### PR TITLE
Add missing audible label for first line of address

### DIFF
--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -17,7 +17,7 @@
               <%= t('page_titles.address') %>
             </h1>
           </legend>
-          <%= f.govuk_text_field :address_line1, label: { text: t('application_form.contact_details.address_line1.label') }, autocomplete: 'address-line1' %>
+          <%= f.govuk_text_field :address_line1, label: ->{ safe_join([t('application_form.contact_details.address_line1.label'), ' ', tag.span(t('application_form.contact_details.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
           <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
           <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
           <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -69,6 +69,7 @@ en:
         change_action: address
       address_line1:
         label: Building and street
+        hidden: line 1 of 2
       address_line2:
         label: Building and street line 2 of 2
       address_line3:

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -145,7 +145,7 @@ module CandidateHelper
     fill_in t('application_form.contact_details.phone_number.label'), with: '07700 900 982'
     click_button t('application_form.contact_details.base.button')
 
-    fill_in t('application_form.contact_details.address_line1.label'), with: '42 Much Wow Street'
+    find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
     fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
     fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'
     click_button t('application_form.contact_details.address.button')

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Entering their contact details' do
     and_i_select_live_in_uk
     and_i_incorrectly_fill_in_my_address
     and_i_submit_my_address
+    then_i_should_see_validation_errors_for_my_address
 
     when_i_fill_in_my_address
     and_i_submit_my_address
@@ -105,7 +106,7 @@ RSpec.feature 'Entering their contact details' do
   end
 
   def when_i_fill_in_my_address
-    fill_in t('application_form.contact_details.address_line1.label'), with: '42 Much Wow Street'
+    find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
     fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
     fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'
   end

--- a/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature 'Entering their contact details' do
   end
 
   def when_i_fill_in_my_address
-    fill_in t('application_form.contact_details.address_line1.label'), with: '42 Much Wow Street'
+    find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
     fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
     fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'
   end
@@ -138,7 +138,7 @@ RSpec.feature 'Entering their contact details' do
   end
 
   def when_i_fill_in_a_different_address
-    fill_in t('application_form.contact_details.address_line1.label'), with: '99'
+    find(:css, "[autocomplete='address-line1']").fill_in with: '99'
     fill_in t('application_form.contact_details.address_line2.label'), with: 'Problems Street'
   end
 


### PR DESCRIPTION
## Context

According to [the pattern described in the design system](https://design-system.service.gov.uk/patterns/addresses/), the label for first line of the address should announce that it is the first line of 2 (the second label is entirely hidden, and announces that it is line 2 of 2).

## Changes proposed in this pull request

Add the missing (but visually hidden) `line 1 of 2` text to the label for `address_line1`. This follows the method recommended by @peteryates in https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues/177#issuecomment-674234646

## Guidance to review

Are we happy using an inline `safe_join` method?

## Link to Trello card

https://trello.com/c/lQPig396
