### PR TITLE
Remove links to Find when the service is down

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,6 +1,6 @@
 <% @application_choices.each do |application_choice| %>
   <div id='course-choice-<%= application_choice.id %>' class='qa-application-choice-<%= application_choice.id %> <%= warning_container_css_class(application_choice) %>'>
-  <% if @editable %>
+  <% if CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_choice.application_form) && @editable %>
     <% if application_choice.course_not_available? %>
       <p class='app-review-warning__primary-message'><%= application_choice.course_not_available_error %>.</p>
       <p class='govuk-body'><%= application_choice.provider.name %> have decided not to run this course.</p>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -88,10 +88,18 @@ module CandidateInterface
     def course_row(application_choice)
       {
         key: 'Course',
-        value: govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code})", application_choice.offered_course.find_url, target: '_blank', rel: 'noopener'),
+        value: course_row_value(application_choice),
         action: "course choice for #{application_choice.course.name_and_code}",
         change_path: course_change_path(application_choice),
       }
+    end
+
+    def course_row_value(application_choice)
+      if EndOfCycleTimetable.find_down?
+        "#{application_choice.offered_course.name} (#{application_choice.offered_course.code})"
+      else
+        govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code})", application_choice.offered_course.find_url, target: '_blank', rel: 'noopener')
+      end
     end
 
     def location_row(application_choice)

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -19,10 +19,18 @@ module CandidateInterface
     def course_details_row(application_choice)
       {
         key: 'Course',
-        value: govuk_link_to(application_choice.offered_course.name_and_code,
-                             application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') +
-          tag.p(application_choice.course.description, class: 'govuk-body'),
+        value: course_details_row_value(application_choice),
       }
+    end
+
+    def course_details_row_value(application_choice)
+      if EndOfCycleTimetable.find_down?
+        tag.p(application_choice.offered_course.name_and_code, class: 'govuk-!-margin-bottom-0') + tag.p(application_choice.course.description, class: 'govuk-body')
+      else
+        govuk_link_to(application_choice.offered_course.name_and_code,
+                      application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') +
+          tag.p(application_choice.course.description, class: 'govuk-body')
+      end
     end
 
     def rejection_reasons_row(application_choice)

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -32,6 +32,6 @@ private
   end
 
   def reopen_date
-    EndOfCycleTimetable.date(:next_cycles_courses_open).to_s(:govuk_date)
+    EndOfCycleTimetable.date(:next_cycle_opens).to_s(:govuk_date)
   end
 end

--- a/app/components/grouped_provider_courses_component.html.erb
+++ b/app/components/grouped_provider_courses_component.html.erb
@@ -10,9 +10,15 @@
         </header>
         <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
           <ul class="govuk-list govuk-list--bullet">
-            <% provider.courses.sort_by(&:name).each do |course| %>
-              <li><%= govuk_link_to course.name_and_code, course.find_url %></li>
-            <% end %>
+            <% if EndOfCycleTimetable.find_down? %>
+             <% provider.courses.sort_by(&:name).each do |course| %>
+               <li><%= course.name_and_code %></li>
+             <% end %>
+           <% else %>
+             <% provider.courses.sort_by(&:name).each do |course| %>
+               <li><%= govuk_link_to course.name_and_code, course.find_url %></li>
+             <% end %>
+           <% end %>
           </ul>
         </div>
       </section>

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def index
-      redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+      redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(current_application)
 
       @application_choices = current_candidate.current_application.application_choices
 

--- a/app/controllers/candidate_interface/course_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/base_controller.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     private
 
       def redirect_to_dashboard_if_cycle_is_over
-        redirect_to candidate_interface_application_complete_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+        redirect_to candidate_interface_application_complete_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(current_application)
       end
     end
   end

--- a/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/base_controller.rb
@@ -32,7 +32,7 @@ module CandidateInterface
       private
 
         def redirect_to_dashboard_if_cycle_is_over
-          redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+          redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(current_application)
         end
 
         def redirect_to_dashboard_if_no_choices_need_replacing

--- a/app/controllers/candidate_interface/find_course_selections_controller.rb
+++ b/app/controllers/candidate_interface/find_course_selections_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def confirm_selection
-      redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application)
+      redirect_to candidate_interface_application_form_path and return unless CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(current_application)
 
       course = Course.find(params[:course_id])
       @course_selection_form = CourseSelectionForm.new(course)

--- a/app/services/candidate_interface/end_of_cycle_policy.rb
+++ b/app/services/candidate_interface/end_of_cycle_policy.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class EndOfCyclePolicy
-    def self.can_add_course_choice?(application_form:)
-      return true if Time.zone.now.to_date >= EndOfCycleTimetable.next_cycles_courses_open
+    def self.can_add_course_choice?(application_form)
+      return true if Time.zone.now.to_date >= EndOfCycleTimetable.next_cycle_opens
       return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_1_deadline && application_form.apply_1?
       return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_2_deadline && application_form.apply_2?
 

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -2,7 +2,9 @@ class EndOfCycleTimetable
   DATES = {
     apply_1_deadline: Date.new(2020, 8, 24),
     apply_2_deadline: Date.new(2020, 9, 18),
-    next_cycles_courses_open: Date.new(2020, 10, 13),
+    find_closes: Date.new(2020, 9, 19),
+    find_reopens: Date.new(2020, 10, 3),
+    next_cycle_opens: Date.new(2020, 10, 13),
   }.freeze
 
   def self.between_cycles?(phase)
@@ -25,18 +27,30 @@ class EndOfCycleTimetable
     date(:apply_2_deadline)
   end
 
-  def self.next_cycles_courses_open
-    date(:next_cycles_courses_open)
+  def self.find_closes
+    date(:find_closes)
+  end
+
+  def self.find_reopens
+    date(:find_reopens)
+  end
+
+  def self.find_down?
+    Time.zone.now.between?(find_closes.end_of_day, find_reopens.beginning_of_day)
+  end
+
+  def self.next_cycle_opens
+    date(:next_cycle_opens)
   end
 
   def self.between_cycles_apply_1?
     Time.zone.now > date(:apply_1_deadline).end_of_day &&
-      Time.zone.now < date(:next_cycles_courses_open).beginning_of_day
+      Time.zone.now < date(:next_cycle_opens).beginning_of_day
   end
 
   def self.between_cycles_apply_2?
     Time.zone.now > date(:apply_2_deadline).end_of_day &&
-      Time.zone.now < date(:next_cycles_courses_open).beginning_of_day
+      Time.zone.now < date(:next_cycle_opens).beginning_of_day
   end
 
   def self.date(name)
@@ -48,14 +62,16 @@ class EndOfCycleTimetable
   end
 
   def self.next_cycle_year
-    date(:next_cycles_courses_open).year + 1
+    date(:next_cycle_opens).year + 1
   end
 
   def self.simulate_time_between_cycles_dates
     {
       apply_1_deadline: 5.days.ago.to_date,
       apply_2_deadline: 2.days.ago.to_date,
-      next_cycles_courses_open: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
+      find_closes: 1.day.ago.to_date,
+      find_reopens: 5.days.from_now.to_date,
+      next_cycle_opens: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
     }
   end
 end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,7 +1,7 @@
 <% missing_error = @errors && @errors.any? %>
 <% application_choice_error = @application_choice_errors && @application_choice_errors.any? %>
 
-<% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: @application_form)%>
+<% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(@application_form)%>
   <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
     <%= t('page_titles.course_choices') %>
   </h2>

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -4,7 +4,7 @@
 <% new_application_choice_needed_component = CandidateInterface::NewCourseChoiceNeededBannerComponent.new(application_form: @application_form) %>
 <% if new_references_needed_component.render? %>
   <%= render new_references_needed_component %>
-<% elsif CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: current_application) && new_application_choice_needed_component.render? %>
+<% elsif CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(current_application) && new_application_choice_needed_component.render? %>
   <%= render new_application_choice_needed_component %>
 <% elsif flash.empty? %>
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -19,7 +19,7 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
-    <% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(application_form: @application_form)%>
+    <% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(@application_form)%>
       <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
         <%= t('page_titles.course_choices') %>
       </h2>
@@ -225,7 +225,7 @@
     <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
       <h2 class="govuk-heading-m govuk-!-font-size-27">Review</h2>
       <p class="govuk-body">
-        Applications for courses starting in <%= EndOfCycleTimetable.next_cycle_year %> open from <%= EndOfCycleTimetable.next_cycles_courses_open.to_s(:govuk_date) %>. You can continue to make changes to your application until then.
+        Applications for courses starting in <%= EndOfCycleTimetable.next_cycle_year %> open from <%= EndOfCycleTimetable.next_cycle_opens.to_s(:govuk_date) %>. You can continue to make changes to your application until then.
       </p>
       <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
     <% else %>

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
       expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.start_date.strftime('%B %Y'))
+      expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+    end
+
+    context 'when Find is down' do
+      it 'removes the link to Find' do
+        Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+          application_choice = application_form.application_choices.first
+          result = render_inline(described_class.new(application_form: application_form))
+
+          expect(result.css('.govuk-summary-list__value').to_html).to include("#{application_choice.course.name} (#{application_choice.course.code})")
+          expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+        end
+      end
     end
 
     context 'When multiple courses available at a provider' do

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::RejectionReasonsComponent do
   let(:application_form) { create(:completed_application_form) }
-  let(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
+  let!(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
 
   it 'renders component with correct values' do
-    application_choice
     result = render_inline(described_class.new(application_form: application_form))
 
     expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
@@ -14,5 +13,17 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
     expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
     expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
     expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
+    expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+  end
+
+  context 'when Find is down' do
+    it 'removes the link to Find' do
+      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__value').to_html).to include("#{application_choice.course.name} (#{application_choice.course.code})")
+        expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+      end
+    end
   end
 end

--- a/spec/components/grouped_provider_courses_component_spec.rb
+++ b/spec/components/grouped_provider_courses_component_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe GroupedProviderCoursesComponent do
+  let(:course) { create(:course) }
+
   before do
     @courses_by_provider_and_region = {
       'north_west' => [
-        CandidateInterface::ContentController::RegionProviderCourses.new('north_west', 'Northerly College', []),
+        CandidateInterface::ContentController::RegionProviderCourses.new('north_west', course.provider, [course]),
         CandidateInterface::ContentController::RegionProviderCourses.new('north_west', 'Westerly Sixth Form', []),
       ],
       'south_east' => [
@@ -22,8 +24,21 @@ RSpec.describe GroupedProviderCoursesComponent do
     result = render_inline(
       described_class.new(courses_by_provider_and_region: @courses_by_provider_and_region),
     )
+
     expect(result.css('h2').text).to include('South East')
     expect(result.css('h2').text).to include('North West')
     expect(result.css('h2').text).to include('No region')
+    expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}")
+  end
+
+  context 'when find is down' do
+    it 'does not include a link to find' do
+      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+        result = render_inline(
+          described_class.new(courses_by_provider_and_region: @courses_by_provider_and_region),
+        )
+        expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}")
+      end
+    end
   end
 end

--- a/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
+++ b/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::EndOfCyclePolicy do
   describe '#can_add_course_choice?' do
-    let(:execute_service) { described_class.can_add_course_choice?(application_form: application_form) }
+    let(:execute_service) { described_class.can_add_course_choice?(application_form) }
 
     context 'application form is in the apply1 state' do
       let(:application_form) { build_stubbed(:application_form) }
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.next_cycles_courses_open) do
+          Timecop.travel(EndOfCycleTimetable.next_cycle_opens) do
             expect(execute_service).to eq true
           end
         end
@@ -53,7 +53,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.next_cycles_courses_open) do
+          Timecop.travel(EndOfCycleTimetable.next_cycle_opens) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -150,4 +150,24 @@ RSpec.describe EndOfCycleTimetable do
       end
     end
   end
+
+  describe '.find_down?' do
+    it 'returns false before find closes' do
+      Timecop.travel(EndOfCycleTimetable.find_closes.beginning_of_day - 1.hour) do
+        expect(EndOfCycleTimetable.find_down?).to be false
+      end
+    end
+
+    it 'returns false after find_reopens' do
+      Timecop.travel(EndOfCycleTimetable.find_reopens.end_of_day + 1.hour) do
+        expect(EndOfCycleTimetable.find_down?).to be false
+      end
+    end
+
+    it 'returns true between find_closes and find_reopens' do
+      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+        expect(EndOfCycleTimetable.find_down?).to be true
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
   end
 
   def given_the_new_cycle_is_open
-    Timecop.travel(EndOfCycleTimetable.next_cycles_courses_open + 1.day)
+    Timecop.travel(EndOfCycleTimetable.next_cycle_opens + 1.day)
   end
 
   def and_i_logout


### PR DESCRIPTION
## Context

Find is down between 19/09 - 03/10. During this period all links to Find need to be removed

## Changes proposed in this pull request

- Remove links from the rejection reason component

| Before | After |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/42515961/90344388-41ba0f80-e011-11ea-9eca-1f752cfc1af1.png) | ![image](https://user-images.githubusercontent.com/42515961/90344378-2bac4f00-e011-11ea-8705-dffd9fa5eec4.png) |

- Remove links from the course choice component

| Before | After |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/42515961/90344365-0586af00-e011-11ea-98b8-16e5d7527625.png) | ![image](https://user-images.githubusercontent.com/42515961/90344369-16cfbb80-e011-11ea-8a9f-bc818309b3ed.png) |

- Remove links from the grouped providers page

| Before | After |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/42515961/90344328-bfc9e680-e010-11ea-9847-daf40872222b.png)| ![image](https://user-images.githubusercontent.com/42515961/90344338-d3754d00-e010-11ea-9b0c-82f2ec0c7a26.png) |

## Guidance to review

Did I miss anything?

## Link to Trello card

https://trello.com/c/Qpx3ib25/1934-dev-%F0%9F%9A%B2%F0%9F%94%9A-prevent-candidates-with-unsubmitted-applications-from-choosing-a-courses

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
