### PR TITLE
Don't ask candidate if they want to another job when editing one

### DIFF
--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -28,10 +28,3 @@
 <% end %>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-<%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
-  <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>
-  <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, not at the moment' } %>
-<% end %>
-
-<%= f.govuk_submit t('application_form.work_history.complete_form_button') %>

--- a/app/views/candidate_interface/work_history/edit/edit.html.erb
+++ b/app/views/candidate_interface/work_history/edit/edit.html.erb
@@ -12,6 +12,8 @@
       </h1>
 
       <%= render 'form', f: f %>
+
+      <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -12,6 +12,14 @@
       </h1>
 
       <%= render 'form', f: f %>
+
+
+      <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
+        <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>
+        <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, not at the moment' } %>
+      <% end %>
+
+      <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>
     <% end %>
   </div>
 </div>

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -32,7 +32,9 @@ RSpec.feature 'Entering their work history' do
     then_i_should_see_my_completed_job
 
     when_i_click_on_change
-    and_i_change_the_job_title_to_be_blank
+    then_i_should_not_be_asked_if_i_want_to_add_another_job
+
+    when_i_change_the_job_title_to_be_blank
     then_i_should_see_validation_errors
 
     when_i_change_the_job_title
@@ -160,7 +162,11 @@ RSpec.feature 'Entering their work history' do
     first('.govuk-summary-list__actions').click_link 'Change'
   end
 
-  def and_i_change_the_job_title_to_be_blank
+  def then_i_should_not_be_asked_if_i_want_to_add_another_job
+    expect(page).not_to have_content 'Do you want to add another job?'
+  end
+
+  def when_i_change_the_job_title_to_be_blank
     fill_in t('application_form.work_history.role.label'), with: ''
     click_button t('application_form.work_history.complete_form_button')
   end


### PR DESCRIPTION
## Context

Currently, when a candidate adds a job, then edits it, they are asked if they would like to add an additional job.

## Changes proposed in this pull request

- Remove the add another job radio buttons from the edit page

| Before | After |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/42515961/90344977-f22a1280-e015-11ea-937d-9eecd5f4d722.png)| ![image](https://user-images.githubusercontent.com/42515961/90344990-0706a600-e016-11ea-8a96-f4f49cbc96e7.png) |

## Link to Trello card

https://trello.com/c/ARqbsJBV/1948-dont-ask-if-want-to-add-another-job-when-editing-a-job

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
