### PR TITLE
Prevent submitting applications between cycles

### DIFF
--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -12,7 +12,7 @@ module CandidateInterface
     end
 
     def render?
-      !EndOfCycleTimetable.show_apply_2_reopen_banner?
+      !EndOfCycleTimetable.between_cycles_apply_2?
     end
   end
 end

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -15,12 +15,12 @@ private
 
   def show_apply_1_reopen_banner?
     apply_1? &&
-      EndOfCycleTimetable.show_apply_1_reopen_banner?
+      EndOfCycleTimetable.between_cycles_apply_1?
   end
 
   def show_apply_2_reopen_banner?
     apply_2? &&
-      EndOfCycleTimetable.show_apply_2_reopen_banner?
+      EndOfCycleTimetable.between_cycles_apply_2?
   end
 
   def apply_1?

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class UnsubmittedApplicationFormController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_application_if_between_cycles, except: %w[show review]
 
     def before_you_start; end
 
@@ -49,6 +50,14 @@ module CandidateInterface
         :further_information_details,
       )
         .transform_values(&:strip)
+    end
+
+    def redirect_to_application_if_between_cycles
+      if EndOfCycleTimetable.between_cycles?(current_application.phase)
+        flash[:warning] = 'Applications for courses starting this academic year have now closed.'
+        redirect_to candidate_interface_application_form_path and return false
+      end
+      true
     end
   end
 end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -5,6 +5,10 @@ class EndOfCycleTimetable
     next_cycles_courses_open: Date.new(2020, 10, 13),
   }.freeze
 
+  def self.between_cycles?(phase)
+    phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?
+  end
+
   def self.show_apply_1_deadline_banner?
     Time.zone.now < date(:apply_1_deadline).end_of_day
   end
@@ -25,12 +29,12 @@ class EndOfCycleTimetable
     date(:next_cycles_courses_open)
   end
 
-  def self.show_apply_1_reopen_banner?
+  def self.between_cycles_apply_1?
     Time.zone.now > date(:apply_1_deadline).end_of_day &&
       Time.zone.now < date(:next_cycles_courses_open).beginning_of_day
   end
 
-  def self.show_apply_2_reopen_banner?
+  def self.between_cycles_apply_2?
     Time.zone.now > date(:apply_2_deadline).end_of_day &&
       Time.zone.now < date(:next_cycles_courses_open).beginning_of_day
   end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -42,4 +42,8 @@ class EndOfCycleTimetable
   def self.date(name)
     DATES[name]
   end
+
+  def self.next_cycle_year
+    date(:next_cycles_courses_open).year + 1
+  end
 end

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -28,4 +28,6 @@
 
 <%= render 'candidate_interface/application_form/review', application_form: @application_form, editable: true %>
 
-<%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>
+<% unless EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
+  <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>
+<% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -224,6 +224,9 @@
 
     <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
       <h2 class="govuk-heading-m govuk-!-font-size-27">Review</h2>
+      <p class="govuk-body">
+        Applications for courses starting in 2021 open from 13 October. You can continue to make changes to your application until then.
+      </p>
       <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
     <% else %>
       <h2 class="govuk-heading-m govuk-!-font-size-27">Check and submit</h2>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -222,8 +222,13 @@
       </li>
     </ul>
 
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Check and submit</h2>
-    <%= govuk_button_link_to 'Check and submit your application', candidate_interface_application_review_path %>
+    <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">Review</h2>
+      <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
+    <% else %>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">Check and submit</h2>
+      <%= govuk_button_link_to 'Check and submit your application', candidate_interface_application_review_path %>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -225,7 +225,7 @@
     <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
       <h2 class="govuk-heading-m govuk-!-font-size-27">Review</h2>
       <p class="govuk-body">
-        Applications for courses starting in 2021 open from 13 October. You can continue to make changes to your application until then.
+        Applications for courses starting in <%= EndOfCycleTimetable.next_cycle_year %> open from <%= EndOfCycleTimetable.next_cycles_courses_open.to_s(:govuk_date) %>. You can continue to make changes to your application until then.
       </p>
       <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
     <% else %>

--- a/spec/components/candidate_interface/reopen_banner_component_spec.rb
+++ b/spec/components/candidate_interface/reopen_banner_component_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
       application_form.phase = phase
       FeatureFlag.activate(:deadline_notices)
       allow(flash).to receive(:empty?).and_return true
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_reopen_banner?).and_return(true)
-      allow(EndOfCycleTimetable).to receive(:show_apply_2_reopen_banner?).and_return(true)
+      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_1?).and_return(true)
+      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_2?).and_return(true)
     end
 
     it 'renders the banner for an Apply 1 app' do
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::ReopenBannerComponent do
 
     it 'does NOT render when we are not between cycles' do
       set_conditions_for_rendering_banner('apply_1')
-      allow(EndOfCycleTimetable).to receive(:show_apply_1_reopen_banner?).and_return(false)
+      allow(EndOfCycleTimetable).to receive(:between_cycles_apply_1?).and_return(false)
 
       result = render_inline(
         described_class.new(

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -29,42 +29,42 @@ RSpec.describe EndOfCycleTimetable do
     end
   end
 
-  describe '.show_apply_1_reopen_banner?' do
+  describe '.between_cycles_apply_1?' do
     it 'returns false before the configured date' do
       Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be false
+        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
       end
     end
 
     it 'returns true after the configured date' do
       Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be true
+        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_1_reopen_banner?).to be false
+        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
       end
     end
   end
 
-  describe '.show_apply_2_reopen_banner?' do
+  describe '.between_cycles_apply_2?' do
     it 'returns false before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be false
+      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0,)) do
+        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
       end
     end
 
     it 'returns true after the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be true
+      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0,)) do
+        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
       end
     end
 
     it 'returns false after the new cycle opens' do
       Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_2_reopen_banner?).to be false
+        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
       end
     end
   end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe EndOfCycleTimetable do
 
   describe '.between_cycles_apply_2?' do
     it 'returns false before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0,)) do
+      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
         expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
       end
     end
 
     it 'returns true after the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0,)) do
+      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
         expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
       end
     end
@@ -65,6 +65,14 @@ RSpec.describe EndOfCycleTimetable do
     it 'returns false after the new cycle opens' do
       Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
         expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+      end
+    end
+  end
+
+  describe '.next_cycle_year' do
+    it 'returns 2021 when in 2020 cycle' do
+      Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
+        expect(EndOfCycleTimetable.next_cycle_year).to eq 2021
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
     then_i_see_that_i_can_add_new_course_choices_in_october
     and_there_is_not_a_link_to_the_course_choices_section
 
-    when_i_click_check_and_submit_my_application
+    when_i_click_review_your_application
     then_i_see_that_i_can_add_new_course_choices_in_october
 
     when_i_try_to_visit_the_pick_provider_page
@@ -92,8 +92,8 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
     expect(page).not_to have_link('Course choices')
   end
 
-  def when_i_click_check_and_submit_my_application
-    click_link 'Check and submit your application'
+  def when_i_click_review_your_application
+    click_link 'Review your application'
   end
 
   def when_i_try_to_visit_the_pick_provider_page

--- a/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -16,6 +16,15 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
 
     then_i_can_only_review_my_application
     and_i_cannot_submit_my_application
+
+    when_i_return_after_new_cycle_opens
+    and_i_log_in_again
+    and_i_visit_the_application_form_page
+    then_i_can_see_the_submit_link
+  end
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
   end
 
   def given_i_am_signed_in
@@ -36,16 +45,24 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
 
   def then_i_can_only_review_my_application
     expect(page).not_to have_link 'Check and submit your application'
+    expect(page).to have_content 'Applications for courses starting in 2021 open from 13 October'
     click_link 'Review your application'
   end
 
-  # def then_i_should_see_all_sections_are_complete
-  #   CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
-  #     expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
-  #   end
-  # end
-
   def and_i_cannot_submit_my_application
     expect(page).not_to have_link 'Continue'
+  end
+
+  def when_i_return_after_new_cycle_opens
+    Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0))
+  end
+
+  def and_i_log_in_again
+    logout
+    create_and_sign_in_candidate
+  end
+
+  def then_i_can_see_the_submit_link
+    expect(page).to have_link 'Check and submit your application'
   end
 end

--- a/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -17,6 +17,9 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
     then_i_can_only_review_my_application
     and_i_cannot_submit_my_application
 
+    when_i_try_to_visit_the_submit_page
+    then_i_am_redirected_to_the_application_page
+
     when_i_return_after_new_cycle_opens
     and_i_log_in_again
     and_i_visit_the_application_form_page
@@ -51,6 +54,15 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
 
   def and_i_cannot_submit_my_application
     expect(page).not_to have_link 'Continue'
+  end
+
+  def when_i_try_to_visit_the_submit_page
+    visit candidate_interface_application_submit_show_path
+  end
+
+  def then_i_am_redirected_to_the_application_page
+    expect(page).to have_content('Applications for courses starting this academic year have now closed')
+    expect(page).to have_current_path(candidate_interface_application_form_path)
   end
 
   def when_i_return_after_new_cycle_opens

--- a/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate attempts to submit the application after the end-of-cycle cutoff' do
+  include CandidateHelper
+
+  around do |example|
+    Timecop.freeze(Date.new(2020, 8, 30)) { example.run }
+  end
+
+  scenario 'Candidate with an unsubmitted application between cycles' do
+    given_i_am_signed_in
+
+    when_i_have_completed_my_application
+
+    and_i_review_my_application
+
+    then_i_should_see_all_sections_are_complete
+    and_i_cannot_confirm_my_application
+    and_i_cannot_confirm_my_application
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_have_completed_my_application
+    candidate_completes_application_form
+  end
+
+  def and_i_review_my_application
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  alias_method :when_i_review_my_application_again, :and_i_review_my_application
+
+  def and_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  alias_method :when_i_visit_the_application_form_page, :and_i_visit_the_application_form_page
+
+  def then_i_should_see_all_sections_are_complete
+    CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
+      expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
+    end
+  end
+
+  def and_i_cannot_confirm_my_application
+    expect(page).not_to have_link 'Check and submit your application'
+  end
+
+  def and_i_cannot_confirm_my_application
+    expect(page).not_to have_link 'Continue'
+  end
+end

--- a/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -4,19 +4,18 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
   include CandidateHelper
 
   around do |example|
-    Timecop.freeze(Date.new(2020, 8, 30)) { example.run }
+    Timecop.freeze(Date.new(2020, 8, 24)) { example.run }
   end
 
   scenario 'Candidate with an unsubmitted application between cycles' do
     given_i_am_signed_in
 
     when_i_have_completed_my_application
+    and_i_return_after_submission_deadline
+    and_i_visit_the_application_form_page
 
-    and_i_review_my_application
-
-    then_i_should_see_all_sections_are_complete
-    and_i_cannot_confirm_my_application
-    and_i_cannot_confirm_my_application
+    then_i_can_only_review_my_application
+    and_i_cannot_submit_my_application
   end
 
   def given_i_am_signed_in
@@ -27,30 +26,26 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
     candidate_completes_application_form
   end
 
-  def and_i_review_my_application
-    and_i_visit_the_application_form_page
-    when_i_click_on_check_your_answers
+  def and_i_return_after_submission_deadline
+    Timecop.travel(Time.zone.local(2020, 8, 25, 12, 0, 0))
   end
-
-  alias_method :when_i_review_my_application_again, :and_i_review_my_application
 
   def and_i_visit_the_application_form_page
     visit candidate_interface_application_form_path
   end
 
-  alias_method :when_i_visit_the_application_form_page, :and_i_visit_the_application_form_page
-
-  def then_i_should_see_all_sections_are_complete
-    CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
-      expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
-    end
-  end
-
-  def and_i_cannot_confirm_my_application
+  def then_i_can_only_review_my_application
     expect(page).not_to have_link 'Check and submit your application'
+    click_link 'Review your application'
   end
 
-  def and_i_cannot_confirm_my_application
+  # def then_i_should_see_all_sections_are_complete
+  #   CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
+  #     expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
+  #   end
+  # end
+
+  def and_i_cannot_submit_my_application
     expect(page).not_to have_link 'Continue'
   end
 end


### PR DESCRIPTION
## Context

We need to prevent candidates from submitting their application during the 'closed period' between recruitment cycles.

## Changes proposed in this pull request

- [x] The 'Review and submit your application' button is replaced with a 'Review' section and notice to explain that submissions are closed when between cycles:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/450843/90347354-b9933480-e027-11ea-878d-c843a8fdeef8.png">

- [x] The 'Submit' button is removed from the 'Review' page between cycles.
- [x] System spec to cover these changes.
- [x] Refactored and re-named a couple of methods on `EndOfCycleTimetable` to generalise them.

## Guidance to review

- Testing manually is tricky without resetting your system clock. We've discussed ways to make this easier for all the end-of-cycle features and this will be the subject of a separate PR.
- Are the tests sufficient?
- Do the renamings in `EndOfCycleTimetable` make sense?

## Link to Trello card

https://trello.com/c/XhLkMhQ9/1902-dev-🚲🔚-prevent-candidates-with-unsubmitted-applications-from-submitting-their-application

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
