### PR TITLE
Sections should redirect to the beginning of the flow if all entries are deleted

### DIFF
--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -15,7 +15,11 @@ module CandidateInterface
 
         current_application.update!(degrees_completed: false)
 
-        redirect_to candidate_interface_degrees_review_path
+        if current_application.application_qualifications.degrees.blank?
+          redirect_to candidate_interface_new_degree_path
+        else
+          redirect_to candidate_interface_degrees_review_path
+        end
       end
 
     private

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -10,13 +10,7 @@ module CandidateInterface
       def complete
         @application_form = current_application
 
-        if @application_form.application_qualifications.degrees.count.zero?
-          flash[:warning] = 'You cannot mark this section complete without adding a degree.'
-
-          @application_form.degrees_completed = false
-
-          render :show
-        elsif @application_form.incomplete_degree_information?
+        if @application_form.incomplete_degree_information?
           flash[:warning] = 'You cannot mark this section complete with incomplete degree information.'
           render :show
         else

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -3,6 +3,8 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def show
+      redirect_to candidate_interface_new_other_qualification_type_path and return if current_application.application_qualifications.other.blank?
+
       @application_form = current_application
     end
 

--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -14,8 +14,11 @@ module CandidateInterface
         .destroy!
 
       current_application.update!(volunteering_completed: false)
-
-      redirect_to candidate_interface_review_volunteering_path
+      if current_application.application_volunteering_experiences.blank?
+        redirect_to candidate_interface_volunteering_experience_path
+      else
+        redirect_to candidate_interface_review_volunteering_path
+      end
     end
 
   private

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -3,23 +3,16 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
 
     def show
+      redirect_to candidate_interface_work_history_length_path if current_application.application_work_experiences.blank? &&
+        current_application.work_history_explanation.nil?
+
       @application_form = current_application
     end
 
     def complete
-      @application_form = current_application
+      current_application.update!(application_form_params)
 
-      if @application_form.application_work_experiences.blank? && @application_form.work_history_explanation.blank?
-        flash[:warning] = 'Please complete your work history or tell us why you’ve been out of the workplace'
-
-        @application_form.work_history_completed = false
-
-        render :show
-      else
-        @application_form.update!(application_form_params)
-
-        redirect_to candidate_interface_application_form_path
-      end
+      redirect_to candidate_interface_application_form_path
     end
 
   private

--- a/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
@@ -10,15 +10,6 @@ RSpec.feature 'Candidate deletes their work history' do
     and_i_click_on_work_history
     and_i_choose_more_than_5_years
     and_i_fill_in_the_job_form
-    and_i_click_on_delete_entry
-    and_i_click_on_confirm
-
-    when_i_mark_this_section_as_completed
-    and_i_click_on_continue
-    then_i_should_be_told_i_need_to_give_additional_information
-
-    when_i_click_on_add_job
-    and_i_fill_in_the_job_form
     and_i_mark_this_section_as_completed
     and_i_click_on_continue
     then_the_work_history_section_should_be_marked_as_complete

--- a/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
@@ -51,9 +51,7 @@ RSpec.feature 'Entering their degrees' do
     # Delete and replace
     when_i_click_on_delete_degree
     and_i_confirm_that_i_want_to_delete_my_degree
-    when_i_mark_this_section_as_completed
-    and_i_click_on_continue
-    then_i_am_told_i_need_to_add_a_degree_to_complete_the_section
+    then_i_see_the_undergraduate_degree_form
 
     when_i_add_my_degree_back_in
     and_i_click_on_continue
@@ -221,7 +219,6 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def when_i_add_my_degree_back_in
-    when_i_click_on_add_another_degree
     when_i_fill_in_the_degree_type
     and_i_click_on_save_and_continue
 

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -82,6 +82,14 @@ RSpec.feature 'Entering their other qualifications' do
     and_i_click_on_continue
     then_i_should_see_the_form
     and_that_the_section_is_completed
+
+    when_i_click_on_other_qualifications
+    and_i_delete_my_remaining_qualifications
+    then_i_see_the_select_qualification_type_page
+
+    when_i_click_back_to_application_form
+    then_i_should_see_the_form
+    and_that_the_section_is_not_marked_as_complete_or_incomplete
   end
 
   def given_i_am_signed_in
@@ -294,5 +302,20 @@ RSpec.feature 'Entering their other qualifications' do
 
   def then_i_see_the_qualification_type_error
     expect(page).to have_content 'Enter the type of qualification'
+  end
+
+  def and_i_delete_my_remaining_qualifications
+    when_i_click_on_delete_my_first_qualification
+    and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    when_i_click_on_delete_my_first_qualification
+    and_i_confirm_that_i_want_to_delete_my_additional_qualification
+  end
+
+  def when_i_click_back_to_application_form
+    click_link 'Back to application'
+  end
+
+  def and_that_the_section_is_not_marked_as_complete_or_incomplete
+    expect(page).not_to have_css('#academic-and-other-relevant-qualifications-badge-id')
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -31,9 +31,10 @@ RSpec.feature 'Entering volunteering and school experience' do
 
     when_i_delete_my_volunteering_role
     and_i_confirm
-    then_i_no_longer_see_my_volunteering_role
+    then_i_am_asked_if_i_have_experience_volunteering_with_young_people_or_in_school
 
-    when_i_click_add_another_role
+    when_i_choose_yes_experience
+    and_i_submit_the_volunteering_experience_form
     then_i_see_the_add_volunteering_role_form
 
     when_i_fill_in_another_volunteering_role
@@ -135,6 +136,7 @@ RSpec.feature 'Entering volunteering and school experience' do
 
   def then_i_check_my_volunteering_role
     expect(page).to have_content('Classroom Volunteer')
+    expect(current_candidate.current_application.application_volunteering_experiences.count).to eq 1
   end
 
   def when_i_click_on_continue

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -25,9 +25,9 @@ RSpec.feature 'Entering their work history' do
 
     when_i_click_on_delete_entry
     and_i_confirm
-    then_i_should_be_asked_for_an_explanation
+    then_i_should_see_a_list_of_work_lengths
 
-    when_i_click_on_add_job
+    when_i_choose_more_than_5_years
     and_i_fill_in_the_job_form # 5/2014 - 1/2019
     then_i_should_see_my_completed_job
 
@@ -142,10 +142,6 @@ RSpec.feature 'Entering their work history' do
 
   def and_i_confirm
     click_button t('application_form.work_history.sure_delete_entry')
-  end
-
-  def then_i_should_be_asked_for_an_explanation
-    expect(page).to have_content('Explanation of why you’ve been out of the workplace')
   end
 
   def when_i_click_on_add_job


### PR DESCRIPTION
## Context

If a candidate deletes all of their entries on a qualification or work/volunteering section, they should be redirected to the beginning of the sections flow.

Currently the following sections they are returned to the empty review page on the following sections
 
- work history
- volunteering
- degrees
- other qualifications
  
## Changes proposed in this pull request

- Redirect from the work history review controller to the work history length page if there are no jobs/work break explanations
- Redirect to the volunteering experience page after destroying the last volunteering experience
- Redirect to the degree type page when the last degree is destroyed
- Redirect to the new other qualification type page if the last other qualification is destroyed

## Guidance to review

Going to leave a comment on one section explaining the thought process for an additional link in

## Link to Trello card

https://trello.com/c/rMMKY1rS/1949-bug-candidates-seeing-empty-review-page-not-section-start-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
