### PR TITLE
Implement design for permissions not yet set by provider

### DIFF
--- a/app/components/provider_relationship_permissions_list.html.erb
+++ b/app/components/provider_relationship_permissions_list.html.erb
@@ -28,13 +28,8 @@
   </ul>
 <% end %>
 
-<% if show_view_applications_only_section? %>
-  <% providers_that_can_only_view_applications = providers_that_can('view_applications_only') %>
+<% if show_view_applications_only_section? && permission_model.setup_at.present? %>
   <p class="govuk-!-margin-bottom-5 govuk-body">
-    <% if providers_that_can_only_view_applications.size > 1 %>
-      <%= training_provider.name %> has not set up permissions for this partnership yet.
-    <% else %>
-      <%= providers_that_can('view_applications_only').first.name %> can only view applications.
-    <% end %>
+    <%= providers_that_can('view_applications_only').first.name %> can only view applications.
   </p>
 <% end %>

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -7,7 +7,13 @@
       </h2>
       <div class="app-banner govuk-!-margin-bottom-4">
         <div class="app-banner__message">
-          Contact <%= permissions.training_provider.name %> to change permissions.
+          <p>
+            <%= permissions.training_provider.name %> have not set up permissions yet - only they can set up permissions. Contact them to do this.
+          </p>
+
+          <p>
+            Staff at <%= permissions.ratifying_provider.name %> can still view applications in the meantime.
+          </p>
         </div>
       </div>
 

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -7,13 +7,17 @@
       </h2>
       <div class="app-banner govuk-!-margin-bottom-4">
         <div class="app-banner__message">
-          <p>
-            <%= permissions.training_provider.name %> have not set up permissions yet - only they can set up permissions. Contact them to do this.
-          </p>
+          <% if permissions.setup_at.blank? %>
+            <p>
+              <%= permissions.training_provider.name %> have not set up permissions yet - only they can set up permissions. Contact them to do this.
+            </p>
 
-          <p>
-            Staff at <%= permissions.ratifying_provider.name %> can still view applications in the meantime.
-          </p>
+            <p>
+              Staff at <%= permissions.ratifying_provider.name %> can still view applications in the meantime.
+            </p>
+          <% else %>
+            Contact <%= permissions.training_provider.name %> to change permissions.
+          <% end %>
         </div>
       </div>
 

--- a/spec/components/provider_relationship_permissions_list_spec.rb
+++ b/spec/components/provider_relationship_permissions_list_spec.rb
@@ -41,24 +41,4 @@ RSpec.describe ProviderRelationshipPermissionsList do
 
     expect(result.css('.govuk-body')[3].text).to include("#{ratifying_provider.name} can only view applications.")
   end
-
-  context 'when the permissions for a provider relationship have not been set up' do
-    let(:provider_relationship_permissions) do
-      create(
-        :provider_relationship_permissions,
-        training_provider: training_provider,
-        ratifying_provider: ratifying_provider,
-        training_provider_can_make_decisions: false,
-        training_provider_can_view_safeguarding_information: false,
-        training_provider_can_view_diversity_information: false,
-        setup_at: nil,
-      )
-    end
-
-    it 'renders a message about setup' do
-      result = render_inline(described_class.new(provider_relationship_permissions))
-
-      expect(result.css('.govuk-body')[0].text).to include("#{training_provider.name} has not set up permissions for this partnership yet.")
-    end
-  end
 end

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'See organisation permissions' do
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
     and_the_ratifying_provider_has_courses_run_by_another_provider
-    and_the_ratifying_provider_has_courses_run_by_unmanagable_provider
+    and_the_ratifying_provider_has_courses_run_by_unmanagable_providers
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_provider_organisations_page
@@ -74,18 +74,22 @@ RSpec.feature 'See organisation permissions' do
     )
   end
 
-  def and_the_ratifying_provider_has_courses_run_by_unmanagable_provider
+  def and_the_ratifying_provider_has_courses_run_by_unmanagable_providers
     @unmanageable_training_provider = create(:provider)
     create(
       :provider_relationship_permissions,
       ratifying_provider: @ratifying_provider,
       training_provider: @unmanageable_training_provider,
       training_provider_can_make_decisions: false,
-      ratifying_provider_can_make_decisions: true,
-      ratifying_provider_can_view_safeguarding_information: true,
       training_provider_can_view_safeguarding_information: false,
-      ratifying_provider_can_view_diversity_information: true,
       training_provider_can_view_diversity_information: false,
+      setup_at: nil,
+    )
+    @another_unmanageable_training_provider = create(:provider)
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @another_unmanageable_training_provider,
       setup_at: Time.zone.now,
     )
   end
@@ -106,8 +110,11 @@ RSpec.feature 'See organisation permissions' do
 
   def then_i_can_see_permissions_for_the_ratifying_provider
     expect(page.text).to include("For courses ratified by #{@ratifying_provider.name} and run by #{@unmanageable_training_provider.name}")
-    expect(page).to have_content("The following organisation(s) can see safeguarding information:\n#{@ratifying_provider.name}")
+    expect(page).to have_content("The following organisation(s) can view safeguarding information:\n#{@ratifying_provider.name}")
     expect(page).to have_content("#{@unmanageable_training_provider.name} have not set up permissions yet - only they can set up permissions. Contact them to do this.")
+
+    expect(page.text).to include("For courses ratified by #{@ratifying_provider.name} and run by #{@another_unmanageable_training_provider.name}")
+    expect(page).to have_content("Contact #{@another_unmanageable_training_provider.name} to change permissions")
   end
 
   def and_i_can_see_permissions_for_the_training_provider

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -106,8 +106,8 @@ RSpec.feature 'See organisation permissions' do
 
   def then_i_can_see_permissions_for_the_ratifying_provider
     expect(page.text).to include("For courses ratified by #{@ratifying_provider.name} and run by #{@unmanageable_training_provider.name}")
-    expect(page).to have_content("The following organisation(s) can view safeguarding information:\n#{@ratifying_provider.name}")
-    expect(page.text).to include("Contact #{@unmanageable_training_provider.name} to change permissions.")
+    expect(page).to have_content("The following organisation(s) can see safeguarding information:\n#{@ratifying_provider.name}")
+    expect(page).to have_content("#{@unmanageable_training_provider.name} have not set up permissions yet - only they can set up permissions. Contact them to do this.")
   end
 
   def and_i_can_see_permissions_for_the_training_provider
@@ -123,7 +123,6 @@ RSpec.feature 'See organisation permissions' do
 
   def then_i_can_see_permissions_for_the_training_provider
     expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
-    expect(page).to have_content("#{@training_provider.name} can only view applications.")
 
     expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(@permissions))
   end


### PR DESCRIPTION
## Context

Ratifying providers may access permissions via the organisations pages. If permissions for these organisations have yet to be set up they should see an explanation as per the design.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

See design story:
https://trello.com/c/pYlxvx3H/2488-design-for-when-accredited-body-user-logs-in-and-org-permissions-not-set-up-yet-by-training-provider

- Adds explanation about permissions setup as per design 
- Removes duplicate explanation from permissions list component

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/90409952-b3da3500-e0a1-11ea-953e-3cc5e0830965.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/HE5czvGF/2625-implement-design-permissions-not-yet-set-by-provider
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
