### PR TITLE
Prevent new candidates from signing up between cycles

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -5,10 +5,14 @@ module CandidateInterface
     before_action :show_pilot_holding_page_if_not_open
 
     def new
+      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.between_cycles_apply_1?
+
       @sign_up_form = CandidateInterface::SignUpForm.new
     end
 
     def create
+      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.between_cycles_apply_1?
+
       @sign_up_form = CandidateInterface::SignUpForm.new(candidate_sign_up_form_params)
 
       if @sign_up_form.existing_candidate?

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -25,7 +25,7 @@ module CandidateInterface
     end
 
     def eligibility
-      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.apply_1_closed?
+      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.between_cycles_apply_1?
 
       @eligibility_form = EligibilityForm.new
     end

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -25,6 +25,8 @@ module CandidateInterface
     end
 
     def eligibility
+      redirect_to candidate_interface_applications_closed_path and return if EndOfCycleTimetable.apply_1_closed?
+
       @eligibility_form = EligibilityForm.new
     end
 
@@ -40,12 +42,14 @@ module CandidateInterface
       end
     end
 
+    def applications_closed; end
+
+  private
+
     def eligibility_params
       params.fetch(:candidate_interface_eligibility_form, {}).permit(:eligible_citizen, :eligible_qualifications)
         .transform_values(&:strip)
     end
-
-  private
 
     def create_account_or_sign_in_params
       params.require(:candidate_interface_create_account_or_sign_in_form).permit(:existing_account, :email)

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -62,7 +62,7 @@ class EndOfCycleTimetable
   end
 
   def self.current_cycle_year
-    Time.zone.now > next_cycles_courses_open ? next_cycle_year : Time.zone.today.year
+    Time.zone.now > next_cycle_opens ? next_cycle_year : Time.zone.today.year
   end
 
   def self.next_cycle_year

--- a/app/views/candidate_interface/start_page/applications_closed.html.erb
+++ b/app/views/candidate_interface/start_page/applications_closed.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, t('page_titles.application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.applications_closed') %>
+    </h1>
+
+    <p class="govuk-body">Applications for courses starting this year have closed.</p>
+
+    <p class="govuk-body">You can create an account and submit an application from <%= EndOfCycleTimetable.next_cycle_opens.to_s(:govuk_date).strip %>.</p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
     withdraw_application: Are you sure you want to withdraw your application?
     gcse_naric_reference: Do you have a NARIC statement of comparability for your maths qualification?
     guidance: User guidance
+    applications_closed: Create an Apply for teacher training account
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
     post '/eligibility' => 'start_page#determine_eligibility'
     get '/not-eligible', to: 'start_page#not_eligible', as: :not_eligible
 
+    get '/applications-closed' => 'start_page#applications_closed', as: :applications_closed
+
     get '/sign-up', to: 'sign_up#new', as: :sign_up
     post '/sign-up', to: 'sign_up#create'
     get '/sign-up/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_up

--- a/spec/system/candidate_interface/candidate_without_account_arrives_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_without_account_arrives_between_cycles_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate without an acccount arrives after the apply1 deadline' do
+  around do |example|
+    Timecop.freeze(EndOfCycleTimetable.find_reopens.end_of_day + 1.hour) do
+      example.run
+    end
+  end
+
+  scenario 'Candidate is told they can apply when the next cycle launches' do
+    given_the_pilot_is_open
+    and_i_am_a_candidate_without_an_account
+
+    when_i_arrive_at_the_site
+    and_click_start_now
+    and_choose_that_i_dont_have_an_account
+    then_i_am_told_that_applicatons_have_closed_for_this_cycle
+
+    when_i_try_to_visit_the_sign_up_page
+    then_i_am_told_that_applicatons_have_closed_for_this_cycle
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_i_am_a_candidate_without_an_account; end
+
+  def when_i_arrive_at_the_site
+    visit candidate_interface_start_path
+  end
+
+  def and_click_start_now
+    click_link 'Start now'
+  end
+
+  def and_choose_that_i_dont_have_an_account
+    choose 'No, I need to create an account'
+    click_button 'Continue'
+  end
+
+  def then_i_am_told_that_applicatons_have_closed_for_this_cycle
+    expect(page).to have_content 'Applications for courses starting this year have closed.'
+  end
+
+  def when_i_try_to_visit_the_sign_up_page
+    visit candidate_interface_applications_closed_path
+  end
+end


### PR DESCRIPTION
## Context

New candidates should not be able to sign up between the apply1 deadline on the 25/08 and the new cycle launching on 13/10.

## Changes proposed in this pull request

Add an applications_closed page that is hit if it is between(apply_1_deadline..new_cycle_launches) and: 
- a candidate selects they do not have an account
- a candidate visits the sign-up path

![image](https://user-images.githubusercontent.com/42515961/90417011-18e65880-e0ab-11ea-91be-d91b07b1a94f.png)


## Guidance to review

I grabbed the content from the screenshot in the Trello card.

## Link to Trello card

https://trello.com/c/qffjeXbB/1932-dev-%F0%9F%9A%B2%F0%9F%94%9A-prevent-new-candidates-from-signing-up-for-the-service-between-cycles

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
