### PR TITLE
Add support for testing EoC features

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,4 +1,6 @@
 module HostingEnvironment
+  TEST_ENVIRONMENTS = %w[development test qa review].freeze
+
   def self.application_url
     if Rails.env.production?
       "https://#{hostname}"
@@ -64,5 +66,9 @@ module HostingEnvironment
 
   def self.sandbox_mode?
     ENV.fetch('SANDBOX', 'false') == 'true'
+  end
+
+  def self.test_environment?
+    TEST_ENVIRONMENTS.include?(HostingEnvironment.environment_name)
   end
 end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -40,10 +40,22 @@ class EndOfCycleTimetable
   end
 
   def self.date(name)
+    if HostingEnvironment.test_environment? && FeatureFlag.active?(:simulate_time_between_cycles)
+      return simulate_time_between_cycles_dates[name]
+    end
+
     DATES[name]
   end
 
   def self.next_cycle_year
     date(:next_cycles_courses_open).year + 1
+  end
+
+  def self.simulate_time_between_cycles_dates
+    {
+      apply_1_deadline: 5.days.ago.to_date,
+      apply_2_deadline: 2.days.ago.to_date,
+      next_cycles_courses_open: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
+    }
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
     [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to 2020 end-of-cycle with link to static page', 'Steve Hook'],
     [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
+    [:simulate_time_between_cycles, 'Simulates the time between recruitment cycles so that EoC features can be tested', 'Steve Hook'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/workers/delete_test_applications.rb
+++ b/app/workers/delete_test_applications.rb
@@ -7,10 +7,8 @@ class DeleteTestApplications
     candidates_to_purge.delete_all
   end
 
-  TEST_ENVIRONMENTS = %w[development test qa review].freeze
-
   def self.can_run_in_this_environment?
-    TEST_ENVIRONMENTS.include?(HostingEnvironment.environment_name)
+    HostingEnvironment.test_environment?
   end
 
 private

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -1,70 +1,144 @@
 require 'rails_helper'
 
 RSpec.describe EndOfCycleTimetable do
-  describe '.show_apply_1_deadline_banner?' do
-    it 'returns true before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
+  context 'when `simulate_time_between_cycles` feature flag is NOT active' do
+    describe '.show_apply_1_deadline_banner?' do
+      it 'returns true before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
+        end
+      end
+
+      it 'returns false after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
+        end
       end
     end
 
-    it 'returns false after the configured date' do
-      Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
+    describe '.show_apply_2_deadline_banner?' do
+      it 'returns true before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
+        end
+      end
+
+      it 'returns false after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
+        end
+      end
+    end
+
+    describe '.between_cycles_apply_1?' do
+      it 'returns false before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        end
+      end
+
+      it 'returns true after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
+        end
+      end
+
+      it 'returns false after the new cycle opens' do
+        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        end
+      end
+    end
+
+    describe '.between_cycles_apply_2?' do
+      it 'returns false before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        end
+      end
+
+      it 'returns true after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+        end
+      end
+
+      it 'returns false after the new cycle opens' do
+        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        end
       end
     end
   end
 
-  describe '.show_apply_2_deadline_banner?' do
-    it 'returns true before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
+  context 'when `simulate_time_between_cycles` feature flag is active' do
+    before { FeatureFlag.activate(:simulate_time_between_cycles) }
+
+    describe '.show_apply_1_deadline_banner?' do
+      it 'returns true before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
+        end
+      end
+
+      it 'returns false after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
+        end
       end
     end
 
-    it 'returns false after the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
-        expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
+    describe '.show_apply_2_deadline_banner?' do
+      it 'returns true before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
+        end
       end
-    end
-  end
 
-  describe '.between_cycles_apply_1?' do
-    it 'returns false before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
-      end
-    end
-
-    it 'returns true after the configured date' do
-      Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
+      it 'returns false after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
+        end
       end
     end
 
-    it 'returns false after the new cycle opens' do
-      Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+    describe '.between_cycles_apply_1?' do
+      it 'returns false before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
+        end
+      end
+
+      it 'returns true after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
+        end
+      end
+
+      it 'returns false after the new cycle opens' do
+        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
+        end
       end
     end
-  end
 
-  describe '.between_cycles_apply_2?' do
-    it 'returns false before the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+    describe '.between_cycles_apply_2?' do
+      it 'returns false before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+        end
       end
-    end
 
-    it 'returns true after the configured date' do
-      Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+      it 'returns true after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+        end
       end
-    end
 
-    it 'returns false after the new cycle opens' do
-      Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
-        expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+      it 'returns false after the new cycle opens' do
+        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+        end
       end
     end
   end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe EndOfCycleTimetable do
     before { FeatureFlag.activate(:simulate_time_between_cycles) }
 
     describe '.show_apply_1_deadline_banner?' do
-      it 'returns true before the configured date' do
+      it 'returns false before the configured date' do
         Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
           expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
         end
@@ -89,7 +89,7 @@ RSpec.describe EndOfCycleTimetable do
     end
 
     describe '.show_apply_2_deadline_banner?' do
-      it 'returns true before the configured date' do
+      it 'returns false before the configured date' do
         Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
           expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
         end
@@ -103,7 +103,7 @@ RSpec.describe EndOfCycleTimetable do
     end
 
     describe '.between_cycles_apply_1?' do
-      it 'returns false before the configured date' do
+      it 'returns true before the configured date' do
         Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
         end
@@ -115,7 +115,7 @@ RSpec.describe EndOfCycleTimetable do
         end
       end
 
-      it 'returns false after the new cycle opens' do
+      it 'returns true after the new cycle opens' do
         Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
         end
@@ -123,7 +123,7 @@ RSpec.describe EndOfCycleTimetable do
     end
 
     describe '.between_cycles_apply_2?' do
-      it 'returns false before the configured date' do
+      it 'returns true before the configured date' do
         Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
         end
@@ -135,7 +135,7 @@ RSpec.describe EndOfCycleTimetable do
         end
       end
 
-      it 'returns false after the new cycle opens' do
+      it 'returns true after the new cycle opens' do
         Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
         end


### PR DESCRIPTION
## Context

Because most of the features we are implementing to support the changeover from 2020 to 2021 recruitment cycles are date dependent there is no simple way to test them in `qa`, review apps or local development systems. At a minimum we need to setup up a system to test the features that are activated when the current cycle ends but before the new one begins.

## Changes proposed in this pull request

- Add a `simulate_time_between_cycles` feature flag
- Use this feature flag to change the behaviour of `EndOfCycleTimetable` to return results consistent with the closed period between recruitment cycles regardless of the true date.
- Add a check to ensure that the new feature flag has no effect in production environments.

## Guidance to review

- This is meant to be the simplest thing that will work - to make the EoC features testable. There are better (more flexible) ways to do this such as storing the configuration for `EndOfCycleTimetable` in the database. In particular this implementation makes no distinction between Apply 1 & 2 applications (despite them having different deadlines in real life). Is this a reasonable first step?
- Do we need to cache the date values in `EndOfCycleTimetable` to avoid the repeated feature flag lookups (DB hits).

## Link to Trello card

https://trello.com/c/IWsNEUtT/1957-implement-a-way-to-test-eoc-features-in-qa-and-review-apps

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
