### PR TITLE
Fix change offer component preview

### DIFF
--- a/spec/components/previews/provider_interface/change_offer_preview.rb
+++ b/spec/components/previews/provider_interface/change_offer_preview.rb
@@ -83,16 +83,12 @@ module ProviderInterface
       )
     end
 
-    def provider_user
-      @provider_user ||= ProviderUser.find_by dfe_sign_in_uid: 'dev-support'
-    end
-
     def available_providers
-      provider_user.providers
+      Provider.where(sync_courses: true)
     end
 
     def available_choices
-      provider_user.providers.first.application_choices
+      available_providers.first.application_choices
     end
 
     def initial_step(step)


### PR DESCRIPTION
## Context

The previewer tries to find the `dev-support` ProviderUser, but this does not exist on the QA environment, which means the component previews that rely on this are broken.

## Changes proposed in this pull request

Use `Provider.where(sync_courses: true)` instead of `provider_user.providers`.

## Guidance to review

Check the Heroku review app for `/rails/view_components/provider_interface/change_offer/existing_offer_start_at_1_provider`.

Does this make sense?

## Link to Trello card

https://trello.com/c/Ejg12FYm

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)