### PR TITLE
Fix query timeout in UCAS export

### DIFF
--- a/app/services/ucas_matching/matching_data_export.rb
+++ b/app/services/ucas_matching/matching_data_export.rb
@@ -56,6 +56,8 @@ module UCASMatching
       ApplicationForm
         .includes(
           :candidate,
+        )
+        .preload(
           :application_choices,
           :application_qualifications,
           :application_work_experiences,


### PR DESCRIPTION
## Context

The query generated here is huge, and that times out on production:

https://sentry.io/organizations/dfe-bat/issues/1846622196



## Changes proposed in this pull request

Using preload we can force Rails to use separate queries, which is fine for our use cases. The only place where we can't do that is candidates, because it's part of the WHERE clause.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
