### PR TITLE
SPIKE change sorting to support the new applications Task View and its groupings

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -9,17 +9,17 @@ module ProviderInterface
         state_store: session,
       )
 
-      application_choices = GetApplicationChoicesForProviders.call(
-        providers: current_provider_user.providers,
+      # Adding GetApplicationChoicesForProviders as a subquery preserves
+      # the virtual attributes from the SELECT in SortApplicationChoices
+      application_choices = ProviderInterface::SortApplicationChoices.call(
+        application_choices: ApplicationChoice.where(
+          id: GetApplicationChoicesForProviders.call(providers: available_providers),
+        ),
       )
 
       application_choices = FilterApplicationChoicesForProviders.call(
         application_choices: application_choices,
         filters: @page_state.applied_filters,
-      )
-
-      application_choices = ProviderInterface::SortApplicationChoices.call(
-        application_choices: application_choices,
       )
 
       @application_choices = application_choices.page(params[:page] || 1).per(15)

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -9,17 +9,19 @@ module ProviderInterface
         state_store: session,
       )
 
-      # Adding GetApplicationChoicesForProviders as a subquery preserves
-      # the virtual attributes from the SELECT in SortApplicationChoices
-      application_choices = ProviderInterface::SortApplicationChoices.call(
-        application_choices: ApplicationChoice.where(
-          id: GetApplicationChoicesForProviders.call(providers: available_providers),
-        ),
+      application_choices = GetApplicationChoicesForProviders.call(
+        providers: available_providers,
       )
 
       application_choices = FilterApplicationChoicesForProviders.call(
         application_choices: application_choices,
         filters: @page_state.applied_filters,
+      )
+
+      # Using id: below turns all previous queries into a subquery for sorting
+      # which preserves the virtual attributes from the sorting SELECT
+      application_choices = ProviderInterface::SortApplicationChoices.call(
+        application_choices: ApplicationChoice.where(id: application_choices),
       )
 
       @application_choices = application_choices.page(params[:page] || 1).per(15)

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -20,7 +20,6 @@ module ProviderInterface
 
       application_choices = ProviderInterface::SortApplicationChoices.call(
         application_choices: application_choices,
-        sort_by: @page_state.sort_by,
       )
 
       @application_choices = application_choices.page(params[:page] || 1).per(15)

--- a/app/frontend/styles/provider/_application-card.scss
+++ b/app/frontend/styles/provider/_application-card.scss
@@ -1,12 +1,16 @@
-.app-application-card:first-of-type {
-  border-top: 1px solid govuk-colour('mid-grey');
-  padding-top: govuk-spacing(3);
+.app-application-cards {
+  h2.task_view_group_header {
+    padding-top: govuk-spacing(5);
+  }
+  h2.task_view_group_header:first-of-type {
+    padding-top: 0;
+  }
 }
 
 .app-application-card {
   border-bottom: 1px solid govuk-colour('mid-grey');
-  margin-bottom: govuk-spacing(3);
-  
+  margin-bottom: govuk-spacing(4);
+
   h3 {
     margin-bottom: 0;
   }

--- a/app/helpers/task_view_helper.rb
+++ b/app/helpers/task_view_helper.rb
@@ -1,0 +1,17 @@
+module TaskViewHelper
+  def task_view_header(choice)
+    case choice&.task_view_group
+    when 1 then 'deferredOffersPendingReconfirmation'
+    when 2 then 'previousCyclePendingConditions'
+    when 3 then 'Give feedback: you did not respond in time'
+    when 4 then 'Deadline approaching: respond to candidate'
+    when 5 then 'Ready for review'
+    when 6 then 'waitingOn'
+    when 7 then 'pendingConditions'
+    when 8 then 'conditionsMet'
+    when 9 then 'deferredOffers'
+    else
+      'Other'
+    end
+  end
+end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -6,4 +6,12 @@ module RecruitmentCycle
       2020
     end
   end
+
+  def self.previous_year
+    current_year - 1
+  end
+
+  def self.visible_years
+    [current_year, previous_year]
+  end
 end

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -17,9 +17,9 @@ class GetApplicationChoicesForProviders
     ]
 
     ApplicationChoice.includes(*includes)
-      .where('courses.provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.current_year)
+      .where('courses.provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.visible_years)
       .or(ApplicationChoice.includes(*includes)
-        .where('courses.accredited_provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.current_year))
+        .where('courses.accredited_provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.visible_years))
       .where('status IN (?)', ApplicationStateChange.states_visible_to_provider).includes([:accredited_provider])
   end
 end

--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -7,34 +7,77 @@ module ProviderInterface
     def self.for_task_view(application_choices)
       application_choices.from <<~WITH_TASK_VIEW_GROUP.squish
         (
-          SELECT *,
+          SELECT a.*, c.recruitment_cycle_year,
             CASE
-              WHEN #{awaiting_provider_decision} THEN 1
-              WHEN #{offered} THEN 2
+              WHEN #{deferred_offers_pending_reconfirmation} THEN 1
+              WHEN #{previous_cycle_pending_conditions} THEN 2
+              WHEN #{about_to_be_rejected_automatically} THEN 3
+              WHEN #{awaiting_provider_decision} THEN 4
+              WHEN #{waiting_on_candidate} THEN 5
               ELSE 999
             END AS task_view_group,
             #{pg_days_left_to_respond} AS pg_days_left_to_respond
 
-            FROM application_choices
+            FROM application_choices a
+            LEFT JOIN courses c ON c.id = a.course_option_id
         ) AS application_choices
       WITH_TASK_VIEW_GROUP
+    end
+
+    def self.deferred_offers_pending_reconfirmation
+      # TODO: this query depends on deferrals implementation
+      <<~DEFERRED_OFFERS_PENDING_RECONFIRMATION.squish
+        (
+          status='deferred'
+            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+        )
+      DEFERRED_OFFERS_PENDING_RECONFIRMATION
+    end
+
+    def self.previous_cycle_pending_conditions
+      <<~PREVIOUS_CYCLE_PENDING_CONDITIONS.squish
+        (
+          status='pending_conditions'
+            AND c.recruitment_cycle_year = #{RecruitmentCycle.previous_year}
+        )
+      PREVIOUS_CYCLE_PENDING_CONDITIONS
+    end
+
+    def self.about_to_be_rejected_automatically
+      <<~AWAITING_PROVIDER_DECISION.squish
+        (
+          status='awaiting_provider_decision'
+            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
+            AND (
+              DATE(reject_by_default_at)
+              BETWEEN
+                DATE('#{Time.zone.now.iso8601}')
+              AND
+                DATE('#{3.business_days.after(Time.zone.now).iso8601}')
+            )
+        )
+      AWAITING_PROVIDER_DECISION
     end
 
     def self.awaiting_provider_decision
       <<~AWAITING_PROVIDER_DECISION.squish
         (
           status='awaiting_provider_decision'
-          AND (DATE(reject_by_default_at) > '#{Time.zone.now.iso8601}')
+            AND (
+              DATE(reject_by_default_at) >
+                DATE('#{3.business_days.after(Time.zone.now).iso8601}')
+            )
         )
       AWAITING_PROVIDER_DECISION
     end
 
-    def self.offered
-      <<~OFFERED.squish
+    def self.waiting_on_candidate
+      <<~WAITING_ON_CANDIDATE.squish
         (
           status='offer'
+            AND c.recruitment_cycle_year = #{RecruitmentCycle.current_year}
         )
-      OFFERED
+      WAITING_ON_CANDIDATE
     end
 
     def self.pg_days_left_to_respond

--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -11,9 +11,9 @@ module ProviderInterface
             CASE
               WHEN #{deferred_offers_pending_reconfirmation} THEN 1
               WHEN #{previous_cycle_pending_conditions} THEN 2
-              WHEN #{about_to_be_rejected_automatically} THEN 3
-              WHEN #{awaiting_provider_decision} THEN 4
-              WHEN #{waiting_on_candidate} THEN 5
+              WHEN #{about_to_be_rejected_automatically} THEN 4
+              WHEN #{awaiting_provider_decision} THEN 5
+              WHEN #{waiting_on_candidate} THEN 6
               ELSE 999
             END AS task_view_group,
             #{pg_days_left_to_respond} AS pg_days_left_to_respond

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -40,15 +40,17 @@
 <div class='moj-filter-layout'>
   <%= render ProviderInterface::FilterComponent.new(page_state: @page_state) %>
   <div class='moj-filter-layout__content'>
-    <div class="moj-action-bar">
-      <div class="moj-action-bar__filter">
-        <div class="filter-toggle-button"></div>
-      </div>
-      <%= render(ProviderInterface::SortOrderComponent.new(page_state: @page_state)) %>
-    </div>
     <% if @application_choices.any? %>
       <div class="app-application-cards">
+        <% previous_header = '' %>
         <% @application_choices.each_with_index do |choice, index| %>
+          <% group_header = task_view_header choice %>
+          <% if group_header != previous_header %>
+            <h2 class='govuk-heading-m task_view_group_header'>
+              <%= group_header %>
+            </h2>
+            <% previous_header = group_header %>
+          <% end %>
           <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, show_date: @page_state.sort_by) %>
         <% end %>
       </div>


### PR DESCRIPTION
Not for merging!

## Context

In the proposed design (as per prototype), the Applications page contains a set of search results that are grouped based on discrete fixed criteria. The filters determine whether an application is included in the results set, and the group criteria determine which group an application belongs in.

Concerns were raised around the complexity of implementing the design so we need to validate prior to committing to implementation.
![image](https://user-images.githubusercontent.com/107591/90528763-e734c680-e16a-11ea-9950-3917f4e62969.png)

The more we can re-use existing code for filters and pagination, the better. The best way to achieve this is to perform all grouping and pagination in a single Postgresql query, which will also be good for performance and scalability.

To summarise, we need to:
- [x] show applications in groups
- [x] sort these groups using a custom order
- [x] have a defined header/title for each group
- [x] sort applications within groups by either updated_at or RBD (if awaiting provider decision)
- [x] restrict at least one of the groups to one cycle
- [x] paginate applications as before, across categories. This means a page may start and/or finish with an incomplete group.

## Changes proposed in this pull request

Change the `SortApplicationChoices` service to split applications into groups. The criteria for these groups vary, but tend to rely on combinations of `status`, `reject_by_default_at` and `recruitment_cycle_year`.

In the controller, ActiveRecord combines queries for us in order to satisfy concerns such as authorisation, filtering, sorting and pagination. I've kept to this approach, but modified the sorting code to generate and use some virtual/computed columns in Postgresql: `task_view_group`, `pg_days_left_to_respond` and `recruitment_cycle_year`.

According to the current End-of-Cycle plans, provider users will be able to access applications from both the current and the previous cycle (e.g. they should be able to see applications with `pending_conditions` status from the previous year). Therefore, some groups will be restricted to `current_year`, others to `previous_year`, while some could show applications from both.

Unfortunately, while 
```ruby
ProviderInterface::SortApplicationChoices.call(
  application_choices: ApplicationChoice.all,
).first.task_view_group
```
returns a number,
```ruby
ProviderInterface::SortApplicationChoices.call(
  application_choices:  GetApplicationChoicesForProviders.call(providers: providers),
).first.task_view_group
```
throws an exception, because the resulting SQL is more complex and the virtual attributes are lost. This means we may have to add another presentation layer for the section/group headers, mirroring the criteria for groups such as `previous_cycle_pending_conditions` etc. Unless we find a way to preserve `task_view_group` in the combined queries, in which case we could do an enum-style mapping.

UPDATE: this is fixed now by making the sorting SELECT the root of the query tree.

This PR's approach seems to satisfy all requirements so far, ~~except specifying how headers/titles are maintained and displayed for each group, which requires further exploration~~.

## Guidance to review

Check the applications list loads and the number of applications shown is what you'd expect for your user. Then inspect the grouping, sorting and pagination. In this version of the code, the 'order by' dropdown is broken, as we'll probably end up removing it entirely or changing it completely. Also, the applications list page is not broken up into groups visibly, but records will appear sorted by a combination of status, RBD and updated_at within their groups. The order of these groups is also defined in the code.

I've also added a `TaskViewHelper` for defining and looking up the appropriate header titles for each `task_view_group`, in order to implement a proof-of-concept Task View applications list.

![image](https://user-images.githubusercontent.com/107591/90626387-ce7feb80-e212-11ea-94f9-2e21f7899607.png)

----
Filtering and searching are expected to work as before:
![image](https://user-images.githubusercontent.com/107591/90629603-93cc8200-e217-11ea-9590-ddb20cbe737c.png)

You can interact with the review app here: https://apply-for-te-2594-spike-6vrvxm.herokuapp.com/provider/applications?sort_by=days_left_to_respond

## Link to Trello card

https://trello.com/c/lf6NTGQW

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
