### PR TITLE
Make magic links single-use and add confirmation page

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -14,7 +14,14 @@ module CandidateInterface
 
     def confirm_authentication
       candidate = retrieve_candidate_by_token || retrieve_candidate_by_user_id
-      redirect_to action: :new if candidate.nil?
+
+      redirect_to(action: :new) and return if candidate.nil?
+
+      if FindCandidateByToken.token_not_expired?(candidate)
+        render 'confirm_authentication'
+      else
+        redirect_to candidate_interface_expired_sign_in_path(u: params[:u])
+      end
     end
 
     def authenticate

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class SignInController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
-    before_action :redirect_to_application_if_signed_in, except: %i[authenticate]
+    before_action :redirect_to_application_if_signed_in, except: %i[confirm_authentication authenticate]
 
     def new
       candidate = Candidate.new
@@ -12,23 +12,27 @@ module CandidateInterface
       SignInCandidate.new(candidate_params[:email_address], self).call
     end
 
+    def confirm_authentication
+      candidate = retrieve_candidate_by_token || retrieve_candidate_by_user_id
+      redirect_to action: :new if candidate.nil?
+    end
+
     def authenticate
-      candidate = FindCandidateByToken.call(raw_token: params[:token])
+      candidate = retrieve_candidate_by_token
       token_not_expired = FindCandidateByToken.token_not_expired?(candidate)
 
-      if candidate.nil? && params[:u]
-        candidate_id = Encryptor.decrypt(params[:u])
-        candidate = Candidate.find(candidate_id) if candidate_id
+      if candidate.nil?
+        candidate = retrieve_candidate_by_user_id
       end
 
-      if candidate.nil?
-        redirect_to action: :new
-      elsif token_not_expired
+      redirect_to(action: :new) and return if candidate.nil?
+
+      if token_not_expired
         flash[:success] = t('apply_from_find.account_created_message') if candidate.last_signed_in_at.nil?
         sign_in(candidate, scope: :candidate)
         add_identity_to_log candidate.id
         candidate.update!(last_signed_in_at: Time.zone.now)
-
+        candidate.expire_magic_link_token!
         redirect_to candidate_interface_interstitial_path
       else
         encrypted_candidate_id = Encryptor.encrypt(candidate.id)
@@ -59,6 +63,15 @@ module CandidateInterface
 
     def candidate_params
       params.require(:candidate).permit(:email_address)
+    end
+
+    def retrieve_candidate_by_token
+      FindCandidateByToken.call(raw_token: params[:token])
+    end
+
+    def retrieve_candidate_by_user_id
+      candidate_id = Encryptor.decrypt(params[:u])
+      Candidate.find(candidate_id) if candidate_id
     end
   end
 end

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class SignInController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
-    before_action :redirect_to_application_if_signed_in, except: %i[confirm_authentication authenticate]
+    before_action :redirect_to_application_if_signed_in, except: %i[authenticate]
 
     def new
       candidate = Candidate.new

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -29,7 +29,7 @@ module CandidateInterface
         add_identity_to_log candidate.id
         candidate.update!(last_signed_in_at: Time.zone.now)
 
-        redirect_to candidate_interface_interstitial_path(providerCode: params[:providerCode], courseCode: params[:courseCode])
+        redirect_to candidate_interface_interstitial_path
       else
         encrypted_candidate_id = Encryptor.encrypt(candidate.id)
         redirect_to candidate_interface_expired_sign_in_path(u: encrypted_candidate_id)

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -31,8 +31,7 @@ module CandidateInterface
         flash[:success] = t('apply_from_find.account_created_message') if candidate.last_signed_in_at.nil?
         sign_in(candidate, scope: :candidate)
         add_identity_to_log candidate.id
-        candidate.update!(last_signed_in_at: Time.zone.now)
-        candidate.expire_magic_link_token!
+        candidate.update_sign_in_fields!
         redirect_to candidate_interface_interstitial_path
       else
         encrypted_candidate_id = Encryptor.encrypt(candidate.id)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -36,6 +36,13 @@ class Candidate < ApplicationRecord
     magic_link_token.raw
   end
 
+  def expire_magic_link_token!
+    update!(
+      magic_link_token: nil,
+      magic_link_token_sent_at: nil,
+    )
+  end
+
   def encrypted_id
     Encryptor.encrypt(id)
   end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -36,10 +36,11 @@ class Candidate < ApplicationRecord
     magic_link_token.raw
   end
 
-  def expire_magic_link_token!
+  def update_sign_in_fields!
     update!(
       magic_link_token: nil,
       magic_link_token_sent_at: nil,
+      last_signed_in_at: Time.zone.now,
     )
   end
 

--- a/app/queries/find_candidate_by_token.rb
+++ b/app/queries/find_candidate_by_token.rb
@@ -9,6 +9,8 @@ class FindCandidateByToken
 
   def self.token_not_expired?(candidate)
     return false if candidate.nil?
+    return false if candidate.magic_link_token.nil?
+    return false if candidate.magic_link_token_sent_at.nil?
 
     Time.zone.now < (candidate.magic_link_token_sent_at + MAX_TOKEN_DURATION)
   end

--- a/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
+++ b/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, t('authentication.confirm_authentication.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: candidate_interface_authenticate_path, method: :post do |f| %>
+      <h1 class="govuk-heading-xl">
+        <%= t('authentication.confirm_authentication.heading') %>
+      </h1>
+      <p class="govuk-body">
+        Click below to sign in
+      </p>
+      <%= hidden_field_tag :token, params[:token] %>
+      <%= hidden_field_tag :u, params[:u] %>
+      <%= f.govuk_submit t('authentication.confirm_authentication.button_continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -7,7 +7,7 @@
         <%= t('authentication.expired_token.heading') %>
       </h1>
       <p class="govuk-body">
-        Sign in links only work for one hour, so you need to request a new one. We’ll send this by email.
+        Sign in links only work once and expire after one hour, so you need to request a new one. We’ll send this by email.
       </p>
 
       <%= hidden_field_tag :u, params[:u] %>

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -33,3 +33,6 @@ en:
     expired_token:
       heading: The link you clicked has expired
       button: Email me a new link
+    confirm_authentication:
+      heading: Confirm sign in
+      button_continue: Continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
 
     get '/confirm_authentication', to: 'sign_in#confirm_authentication', as: :authenticate
     post '/confirm_authentication', to: 'sign_in#authenticate'
+    get '/authenticate', to: 'sign_in#expired'
 
     get '/apply', to: 'apply_from_find#show', as: :apply_from_find
     post '/apply', to: 'apply_from_find#ucas_or_apply'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,8 @@ Rails.application.routes.draw do
     get '/sign-in/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_in
     get '/sign-in/expired', to: 'sign_in#expired', as: :expired_sign_in
 
-    get '/authenticate', to: 'sign_in#authenticate', as: :authenticate
+    get '/confirm_authentication', to: 'sign_in#confirm_authentication', as: :authenticate
+    post '/confirm_authentication', to: 'sign_in#authenticate'
 
     get '/apply', to: 'apply_from_find#show', as: :apply_from_find
     post '/apply', to: 'apply_from_find#ucas_or_apply'

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it 'sends an email with a magic link and encrypted candidate id' do
       allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/confirm_authentication?token=#{token}&u=secret",
       )
     end
 
@@ -52,7 +52,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it 'sends an email with a magic link and encrypted candidate id' do
       allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/confirm_authentication?token=#{token}&u=secret",
       )
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
       'RBD time limit' => "to make an offer within #{TimeLimitCalculator.new(rule: :reject_by_default, effective_date: Time.zone.today).call.fetch(:days)} working days",
-      'magic link to authenticate' => 'http://localhost:3000/candidate/authenticate?token=raw_token&u=encrypted_id',
+      'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id',
     )
 
     context 'when the covid-19 feature flag is on' do
@@ -73,7 +73,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'Your application is being considered',
         'heading' => 'Dear Bob',
         'working days the provider has to respond' => '10 working days',
-        'magic link to authenticate' => 'http://localhost:3000/candidate/authenticate?token=raw_token&u=encrypted_id'
+        'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id'
       )
     end
 

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -100,13 +100,16 @@ RSpec.describe Candidate, type: :model do
     end
   end
 
-  describe '#expire_magic_link_token!' do
-    it 'clears the magic link fields' do
-      candidate = create(:candidate, magic_link_token: 'token', magic_link_token_sent_at: Time.zone.now)
-      candidate.expire_magic_link_token!
+  describe '#update_sign_in_fields!' do
+    it 'clears the magic link fields and sets last_signed_in_at' do
+      Timecop.freeze(Time.zone.local(0)) do
+        candidate = create(:candidate, magic_link_token: 'token', magic_link_token_sent_at: Time.zone.now)
+        candidate.update_sign_in_fields!
 
-      expect(candidate.magic_link_token).to be_nil
-      expect(candidate.magic_link_token_sent_at).to be_nil
+        expect(candidate.magic_link_token).to be_nil
+        expect(candidate.magic_link_token_sent_at).to be_nil
+        expect(candidate.last_signed_in_at).to eq Time.zone.local(0)
+      end
     end
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -99,4 +99,14 @@ RSpec.describe Candidate, type: :model do
       expect(candidate.encrypted_id).to eq 'encrypted id value'
     end
   end
+
+  describe '#expire_magic_link_token!' do
+    it 'clears the magic link fields' do
+      candidate = create(:candidate, magic_link_token: 'token', magic_link_token_sent_at: Time.zone.now)
+      candidate.expire_magic_link_token!
+
+      expect(candidate.magic_link_token).to be_nil
+      expect(candidate.magic_link_token_sent_at).to be_nil
+    end
+  end
 end

--- a/spec/support/test_helpers/sign_in_helper.rb
+++ b/spec/support/test_helpers/sign_in_helper.rb
@@ -1,0 +1,10 @@
+module SignInHelper
+  def click_magic_link_in_email
+    current_email.find_css('a').first.click
+  end
+
+  def confirm_sign_in
+    expect(page).to have_content 'Confirm sign in'
+    click_button 'Continue'
+  end
+end

--- a/spec/support/test_helpers/sign_up.rb
+++ b/spec/support/test_helpers/sign_up.rb
@@ -1,8 +1,0 @@
-module TestHelpers
-  module SignUp
-    def fill_in_sign_up
-      fill_in t('authentication.sign_up.email_address.label'), with: 'april@pawnee.com'
-      click_on t('authentication.sign_up.button_continue')
-    end
-  end
-end

--- a/spec/system/candidate_interface/application_choices_are_delivered_to_providers_spec.rb
+++ b/spec/system/candidate_interface/application_choices_are_delivered_to_providers_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Candidate application choices are delivered to providers' do
+  include SignInHelper
+
   scenario 'the candidate receives an email' do
     given_my_application_is_ready_to_send_to_providers
 
@@ -29,7 +31,9 @@ RSpec.feature 'Candidate application choices are delivered to providers' do
     candidate = @application_choice.application_form.candidate
     open_email(candidate.email_address)
 
-    current_email.find_css('a').first.click
+    click_magic_link_in_email
+    confirm_sign_in
+
     expect(page).to have_content 'Application dashboard'
   end
 end

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Candidate account' do
+  include SignInHelper
+
   scenario 'Candidate signs up, out, and in again' do
     given_the_pilot_is_open
 
@@ -90,7 +92,8 @@ RSpec.feature 'Candidate account' do
   end
 
   def when_i_click_on_the_link_in_my_email
-    current_email.find_css('a').first.click
+    click_magic_link_in_email
+    confirm_sign_in
   end
 
   def then_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_clicking_on_expired_magic_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_clicking_on_expired_magic_link_spec.rb
@@ -37,7 +37,6 @@ RSpec.feature 'Candidate clicks on an expired magic link' do
       open_email(@candidate.email_address)
 
       click_magic_link_in_email
-      confirm_sign_in
     end
   end
 

--- a/spec/system/candidate_interface/candidate_clicking_on_expired_magic_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_clicking_on_expired_magic_link_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Candidate clicks on an expired magic link' do
+  include SignInHelper
+
   scenario 'Candidate clicks on a link with an id and expired token link in an email' do
     given_the_pilot_is_open
     and_i_am_a_candidate_with_an_application
@@ -34,7 +36,8 @@ RSpec.feature 'Candidate clicks on an expired magic link' do
     Timecop.travel(Time.zone.now + 1.hour + 1.minute) do
       open_email(@candidate.email_address)
 
-      current_email.find_css('a').first.click
+      click_magic_link_in_email
+      confirm_sign_in
     end
   end
 

--- a/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -14,10 +14,10 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     and_click_on_the_magic_link
     then_i_should_see_the_before_you_start_page
     and_i_should_see_an_account_created_flash_message
-
     when_i_click_choose_a_course
     then_i_should_see_the_course_choices_index_page
 
+    when_i_sign_out
     when_i_visit_apply
     and_i_click_start_now
     and_i_confirm_i_am_not_already_signed_up
@@ -32,7 +32,7 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     and_i_should_not_see_an_account_created_flash_message
 
     when_i_amend_my_application
-    and_i_sign_out
+    when_i_sign_out
 
     when_i_visit_apply
     and_i_click_start_now
@@ -128,7 +128,7 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     click_button 'Save and continue'
   end
 
-  def and_i_sign_out
+  def when_i_sign_out
     click_on 'Sign out'
   end
 end

--- a/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'A new candidate is encouraged to select a course' do
+  include SignInHelper
+
   scenario 'Candidate is redirected to the before you start page on their first sign in' do
     given_the_pilot_is_open
 
@@ -80,7 +82,8 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
 
   def and_click_on_the_magic_link
     open_email(@email)
-    current_email.find_css('a').first.click
+    click_magic_link_in_email
+    confirm_sign_in
   end
 
   def then_i_should_see_the_before_you_start_page

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Candidate tries to sign up using magic link with an invalid token' do
+  include SignInHelper
+
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_the_pilot_is_open
     and_the_covid_19_feature_flag_is_active
@@ -14,11 +16,13 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
     when_the_magic_link_token_is_overwritten
     and_i_click_on_the_link_in_my_email
+    and_i_confirm_the_sign_in
     then_i_am_taken_to_the_expired_link_page
 
     when_i_click_the_button_to_send_me_a_sign_in_email
     then_i_receive_an_email_inviting_me_to_sign_in
     and_i_click_on_the_link_in_my_email
+    and_i_confirm_the_sign_in
     then_i_see_the_before_you_start_page
     and_i_should_see_an_account_created_flash_message
     and_i_should_not_see_the_covid19_banner
@@ -75,7 +79,11 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
   end
 
   def and_i_click_on_the_link_in_my_email
-    current_email.find_css('a').first.click
+    click_magic_link_in_email
+  end
+
+  def and_i_confirm_the_sign_in
+    confirm_sign_in
   end
 
   def then_i_am_taken_to_the_expired_link_page

--- a/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
@@ -44,7 +44,6 @@ RSpec.feature 'Candidate account' do
 
   def and_i_try_to_resuse_the_same_magic_link
     @magic_link.click
-    confirm_sign_in
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link

--- a/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate account' do
+  include CandidateHelper
+  include SignInHelper
+
+  scenario 'Candidate tries to sign in more than once with same magic link' do
+    given_the_pilot_is_open
+    and_i_am_an_existing_candidate
+
+    when_i_sign_in_and_out
+    and_i_try_to_resuse_the_same_magic_link
+    then_i_am_prompted_to_get_a_new_magic_link
+
+    when_i_get_a_new_magic_link
+    then_i_can_sign_in_again
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_i_am_an_existing_candidate
+    current_candidate
+  end
+
+  def when_i_sign_in_and_out
+    visit candidate_interface_sign_in_path
+    fill_in 'Enter your email address', with: current_candidate.email_address
+    click_button 'Continue'
+    open_email(current_candidate.email_address)
+    expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+
+    @magic_link = current_email.find_css('a').first
+    @magic_link.click
+    confirm_sign_in
+    within 'header' do
+      expect(page).to have_content current_candidate.email_address
+    end
+
+    click_link 'Sign out'
+    expect(page).to have_link 'Sign in'
+  end
+
+  def and_i_try_to_resuse_the_same_magic_link
+    @magic_link.click
+    confirm_sign_in
+  end
+
+  def then_i_am_prompted_to_get_a_new_magic_link
+    expect(page).to have_content 'The link you clicked has expired'
+  end
+
+  def when_i_get_a_new_magic_link
+    click_button 'Email me a new link'
+
+    open_email(current_candidate.email_address)
+    @new_magic_link = current_email.find_css('a').first
+  end
+
+  def then_i_can_sign_in_again
+    @new_magic_link.click
+    confirm_sign_in
+    within 'header' do
+      expect(page).to have_content current_candidate.email_address
+    end
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'An existing candidate arriving from Find with a course and provider code (with course selection page)' do
   include CourseOptionHelpers
+  include SignInHelper
+
   scenario 'candidate is not signed in and retains their course selection through the sign in process' do
     given_the_pilot_is_open
 
@@ -11,7 +13,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_the_course_i_selected_only_has_one_site
     when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
     and_i_go_to_sign_in
-    and_click_on_the_magic_link
     then_i_should_see_the_course_selection_page
 
     when_i_click_on_the_courses_link
@@ -26,7 +27,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     when_i_sign_out
     when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
     and_i_go_to_sign_in
-    and_click_on_the_magic_link
     then_i_should_see_the_courses_review_page
     and_i_should_be_informed_i_have_already_selected_that_course
 
@@ -36,7 +36,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_have_less_than_3_application_options
     when_i_arrive_at_the_apply_from_find_page_with_the_multi_site_course_params
     and_i_go_to_sign_in
-    and_click_on_the_magic_link
     then_i_should_see_the_multi_site_course_selection_page
     when_i_say_yes
     and_i_select_the_part_time_study_mode
@@ -49,7 +48,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_have_3_application_options
     when_i_arrive_at_the_apply_from_find_page_with_the_multi_site_course_params
     and_i_go_to_sign_in
-    and_click_on_the_magic_link
     then_i_should_see_the_courses_review_page
     and_my_course_from_find_id_should_be_set_to_nil
     and_i_should_be_informed_i_already_have_3_courses
@@ -91,6 +89,10 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     choose 'Yes, sign in'
     fill_in 'Email', with: @email
     click_button 'Continue'
+
+    open_email(@email)
+    click_magic_link_in_email
+    confirm_sign_in
   end
 
   def and_i_have_less_than_3_application_options
@@ -100,12 +102,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def and_i_have_3_application_options
     application_choice_for_candidate(candidate: @candidate, application_choice_count: 3)
-  end
-
-  def and_click_on_the_magic_link
-    open_email(@email)
-
-    current_email.find_css('a').first.click
   end
 
   def then_i_should_see_the_course_selection_page
@@ -216,7 +212,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   def when_i_return_to_the_course_selection_page
     when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
     and_i_go_to_sign_in
-    and_click_on_the_magic_link
     then_i_should_see_the_course_selection_page
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -14,11 +14,8 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
     and_i_go_to_sign_in
     then_i_should_see_the_course_selection_page
+    and_i_should_see_a_link_to_the_course_on_find
 
-    when_i_click_on_the_courses_link
-    then_i_should_be_redirected_to_the_course_on_find
-
-    when_i_return_to_the_course_selection_page
     when_i_say_yes
     then_i_should_see_the_courses_review_page
     and_i_should_see_the_course_name_and_code
@@ -31,6 +28,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_should_be_informed_i_have_already_selected_that_course
 
     # Multi-site course
+    given_i_am_signed_out
     given_the_course_i_selected_has_multiple_sites
     and_i_am_an_existing_candidate_on_apply
     and_i_have_less_than_3_application_options
@@ -43,6 +41,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_see_the_form_to_pick_a_location
     and_my_course_from_find_id_should_be_set_to_nil
 
+    given_i_am_signed_out
     and_the_course_i_selected_only_has_one_site
     and_i_am_an_existing_candidate_on_apply
     and_i_have_3_application_options
@@ -55,6 +54,10 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def given_i_am_signed_out
+    when_i_sign_out
   end
 
   def and_the_course_i_selected_only_has_one_site
@@ -201,18 +204,11 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     expect(page).to have_content "You have already selected #{@course.name_and_code}."
   end
 
-  def when_i_click_on_the_courses_link
-    click_link("#{@course.provider.name} #{@course.name_and_code}")
-  end
-
-  def then_i_should_be_redirected_to_the_course_on_find
-    expect(page.current_url).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}")
-  end
-
-  def when_i_return_to_the_course_selection_page
-    when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
-    and_i_go_to_sign_in
-    then_i_should_see_the_course_selection_page
+  def and_i_should_see_a_link_to_the_course_on_find
+    expect(page).to have_link(
+      "#{@course.provider.name} #{@course.name_and_code}",
+      href: "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}",
+    )
   end
 
 private

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Candidate tries to sign in after selecting a course in find without an account then says no to selecting the course' do
+  include SignInHelper
+
   scenario 'Candidate signs in and recieves an email inviting them to sign up and is prompted to select the course' do
     given_the_pilot_is_open
 
@@ -73,7 +75,8 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
   end
 
   def when_i_click_on_the_link_in_my_email
-    current_email.find_css('a').first.click
+    click_magic_link_in_email
+    confirm_sign_in
   end
 
   def then_i_am_taken_to_the_selected_course_page

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'A new candidate arriving from Find with a course and provider code' do
+  include SignInHelper
+
   scenario 'retaining their course selection through the sign up process' do
     given_the_pilot_is_open
     and_the_course_i_selected_only_has_one_site
@@ -95,7 +97,8 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
 
   def and_click_on_the_magic_link
     open_email(@email)
-    current_email.find_css('a').first.click
+    click_magic_link_in_email
+    confirm_sign_in
   end
 
   def then_i_should_see_the_course_selection_page

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
     and_i_choose_to_apply_on_apply
     and_i_choose_i_need_an_account
-
     when_i_fill_in_the_eligiblity_form_with_yes
-
     when_i_submit_my_email_address
     and_click_on_the_magic_link
     then_i_should_see_the_course_selection_page
@@ -26,7 +24,6 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
     and_my_last_signed_in_at_should_be_now
 
     given_the_course_i_selected_has_multiple_sites
-
     when_i_submit_my_email_address
     and_click_on_the_magic_link
     then_i_should_see_the_multi_site_course_selection_page
@@ -50,6 +47,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   end
 
   def given_the_course_i_selected_has_multiple_sites
+    click_on 'Sign out'
     @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
     @site2 = create(:site, provider: @course_with_multiple_sites.provider)

--- a/spec/system/candidate_interface/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/two_candidates_sign_in_on_same_machine_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Candidate account' do
+  include SignInHelper
   scenario 'Two candidates on the same machine sign in one after the other' do
     given_the_pilot_is_open
 
@@ -11,13 +12,12 @@ RSpec.feature 'Candidate account' do
     then_i_can_sign_up_and_sign_out(@second_email)
 
     when_i_click_the_link_in_the_email_for(@first_email)
-    then_i_am_signed_in_with(@first_email)
+    and_confirm_my_sign_in
+    then_i_am_prompted_to_get_a_new_magic_link
 
     when_i_click_the_link_in_the_email_for(@second_email)
-    then_i_am_signed_in_with(@second_email)
-
-    when_i_click_the_link_in_the_email_after_an_hour_for(@first_email)
-    then_i_am_signed_in_with(@second_email)
+    and_confirm_my_sign_in
+    then_i_am_prompted_to_get_a_new_magic_link
   end
 
   def then_i_can_sign_up_and_sign_out(email)
@@ -29,8 +29,14 @@ RSpec.feature 'Candidate account' do
     given_i_store_the_received_email_link_for(email)
 
     when_i_click_the_link_in_the_email_for(email)
+    and_confirm_my_sign_in
     then_i_am_signed_in_with(email)
 
+    when_i_click_the_sign_out_button
+    then_i_should_be_signed_out
+  end
+
+  def when_i_sign_out
     when_i_click_the_sign_out_button
     then_i_should_be_signed_out
   end
@@ -72,6 +78,14 @@ RSpec.feature 'Candidate account' do
 
   def when_i_click_the_link_in_the_email_for(email)
     @email_link_for[email].click
+  end
+
+  def and_confirm_my_sign_in
+    confirm_sign_in
+  end
+
+  def then_i_am_prompted_to_get_a_new_magic_link
+    expect(page).to have_content 'The link you clicked has expired'
   end
 
   def when_i_click_the_link_in_the_email_after_an_hour_for(email)

--- a/spec/system/candidate_interface/two_candidates_sign_in_on_same_machine_spec.rb
+++ b/spec/system/candidate_interface/two_candidates_sign_in_on_same_machine_spec.rb
@@ -12,11 +12,9 @@ RSpec.feature 'Candidate account' do
     then_i_can_sign_up_and_sign_out(@second_email)
 
     when_i_click_the_link_in_the_email_for(@first_email)
-    and_confirm_my_sign_in
     then_i_am_prompted_to_get_a_new_magic_link
 
     when_i_click_the_link_in_the_email_for(@second_email)
-    and_confirm_my_sign_in
     then_i_am_prompted_to_get_a_new_magic_link
   end
 

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Decline by default' do
     expected_subject = I18n.t('chase_candidate_decision_email.subject_singular')
     expect(current_email.subject).to include(expected_subject)
 
-    expect(current_email.body).to include('http://localhost:3000/candidate/authenticate')
+    expect(current_email.body).to include('http://localhost:3000/candidate/confirm_authentication')
   end
 
   def and_when_the_decline_by_default_limit_has_been_exceeded


### PR DESCRIPTION
## Context
Magic links currently last for one hour, with no limit on their use
during that time. A recent pentest recommended that we make magic links
single-use.

This is a continuation of https://github.com/DFE-Digital/apply-for-teacher-training/pull/2695 .

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Change magic links so that they point to a sign in confirmation page.
- When the user clicks 'Continue' from this page, expire their token and
  sign them in.
- Amend the copy on the expired token page to reflect the new behaviour.
<!-- If there are UI changes, please include Before and After screenshots. -->
<img width="520" alt="Screenshot 2020-08-18 at 20 32 01" src="https://user-images.githubusercontent.com/519250/90557103-e2cfd400-e191-11ea-88ca-4d62e80b34ac.png">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Any changes needed to content on the confirmation page?
- Per-commit review recommended
- May be easier to test multiple sign ins locally
- Do the spec changes make sense?

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/aNcIaroP
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
