### PR TITLE
Carried over applications have courses removed

### DIFF
--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     end
 
     def apply_again
-      DuplicateApplication.new(current_application).duplicate
+      ApplyAgain.new(current_application).call
       flash[:success] = 'Your new application is ready for editing'
       redirect_to candidate_interface_before_you_start_path
     end

--- a/app/services/apply_again.rb
+++ b/app/services/apply_again.rb
@@ -1,0 +1,9 @@
+class ApplyAgain
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def call
+    DuplicateApplication.new(@application_form, target_phase: 'apply_2').duplicate
+  end
+end

--- a/app/services/carry_over_application.rb
+++ b/app/services/carry_over_application.rb
@@ -1,0 +1,11 @@
+class CarryOverApplication
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def call
+    # TODO: Raise error if we attempt to carry over an application from current cycle?
+
+    DuplicateApplication.new(@application_form, target_phase: 'apply_1').duplicate
+  end
+end

--- a/app/services/carry_over_application.rb
+++ b/app/services/carry_over_application.rb
@@ -4,8 +4,22 @@ class CarryOverApplication
   end
 
   def call
-    # TODO: Raise error if we attempt to carry over an application from current cycle?
+    raise_if_application_from_current_cycle
 
     DuplicateApplication.new(@application_form, target_phase: 'apply_1').duplicate
+  end
+
+private
+
+  def raise_if_application_from_current_cycle
+    if application_from_current_cycle?
+      raise ArgumentError, 'You can only carry an application over from a previous recruitment cycle'
+    end
+  end
+
+  def application_from_current_cycle?
+    @application_form.application_choices.any? do |application_choice|
+      application_choice.course.recruitment_cycle_year == EndOfCycleTimetable.current_cycle_year
+    end
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -1,8 +1,9 @@
 class DuplicateApplication
-  attr_reader :original_application_form
+  attr_reader :original_application_form, :target_phase
 
-  def initialize(original_application_form)
+  def initialize(original_application_form, target_phase:)
     @original_application_form = original_application_form
+    @target_phase = target_phase
   end
 
   IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference].freeze
@@ -12,7 +13,7 @@ class DuplicateApplication
     attrs = original_application_form.attributes.except(
       *IGNORED_ATTRIBUTES,
     ).merge(
-      phase: 'apply_2',
+      phase: target_phase,
       previous_application_form_id: original_application_form.id,
     )
 

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -43,6 +43,10 @@ class EndOfCycleTimetable
     DATES[name]
   end
 
+  def self.current_cycle_year
+    Time.zone.now > next_cycles_courses_open ? next_cycle_year : Time.zone.today.year
+  end
+
   def self.next_cycle_year
     date(:next_cycles_courses_open).year + 1
   end

--- a/spec/services/apply_again_spec.rb
+++ b/spec/services/apply_again_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'services/duplicate_application_shared_examples'
+
+RSpec.describe ApplyAgain do
+  def original_application_form
+    Timecop.travel(-1.day) do
+      @original_application_form ||= create(
+        :completed_application_form,
+        application_choices_count: 3,
+        work_experiences_count: 1,
+        volunteering_experiences_count: 1,
+        with_gces: true,
+        full_work_history: true,
+      )
+      create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
+      create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
+    end
+    @original_application_form
+  end
+
+  it_behaves_like 'duplicates application form', 'apply_2'
+end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -3,20 +3,34 @@ require 'services/duplicate_application_shared_examples'
 
 RSpec.describe CarryOverApplication do
   def original_application_form
-    Timecop.travel(-1.day) do
-      @original_application_form ||= create(
+    @original_application_form ||= Timecop.travel(-1.day) do
+      application_form = create(
         :completed_application_form,
-        application_choices_count: 3,
+        application_choices_count: 1,
         work_experiences_count: 1,
         volunteering_experiences_count: 1,
         with_gces: true,
         full_work_history: true,
       )
-      create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
-      create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
+      create_list(:reference, 2, feedback_status: :feedback_provided, application_form: application_form)
+      create(:reference, feedback_status: :feedback_refused, application_form: application_form)
+      application_form
     end
-    @original_application_form
   end
 
-  it_behaves_like 'duplicates application form', 'apply_1'
+  context 'when original application is from an earlier recruitment cycle' do
+    before do
+      original_application_form.application_choices.first.course.update(
+        recruitment_cycle_year: Time.zone.today.year - 1,
+      )
+    end
+
+    it_behaves_like 'duplicates application form', 'apply_1'
+  end
+
+  context 'when original application is from the current recruitment cycle' do
+    it 'raises an error' do
+      expect { described_class.new(original_application_form).call }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'services/duplicate_application_shared_examples'
+
+RSpec.describe CarryOverApplication do
+  def original_application_form
+    Timecop.travel(-1.day) do
+      @original_application_form ||= create(
+        :completed_application_form,
+        application_choices_count: 3,
+        work_experiences_count: 1,
+        volunteering_experiences_count: 1,
+        with_gces: true,
+        full_work_history: true,
+      )
+      create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
+      create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
+    end
+    @original_application_form
+  end
+
+  it_behaves_like 'duplicates application form', 'apply_1'
+end

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -1,26 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe DuplicateApplication do
-  def original_application_form
-    Timecop.travel(-1.day) do
-      @original_application_form ||= create(
-        :completed_application_form,
-        application_choices_count: 3,
-        work_experiences_count: 1,
-        volunteering_experiences_count: 1,
-        with_gces: true,
-        full_work_history: true,
-      )
-      create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
-      create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
-    end
-    @original_application_form
-  end
-
+RSpec.shared_examples 'duplicates application form' do |expected_phase|
   def duplicate_application_form
     return @duplicate_application_form if @duplicate_application_form
 
-    @duplicate_application_form ||= described_class.new(original_application_form).duplicate
+    @duplicate_application_form ||= described_class.new(original_application_form).call
   end
 
   it 'creates a new application form' do
@@ -43,8 +27,8 @@ RSpec.describe DuplicateApplication do
     expect(duplicate_application_form.course_choices_completed).to be false
   end
 
-  it 'sets the phase to `apply_2`' do
-    expect(duplicate_application_form).to be_apply_2
+  it "sets the phase to `#{expected_phase}`" do
+    expect(duplicate_application_form.phase).to eq expected_phase
   end
 
   it 'copies application references' do

--- a/spec/services/send_apply_again_call_to_action_spec.rb
+++ b/spec/services/send_apply_again_call_to_action_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SendApplyAgainCallToAction do
         status: :rejected,
         application_form: unsuccessful_application_form,
       )
-      DuplicateApplication.new(unsuccessful_application_form).duplicate
+      ApplyAgain.new(unsuccessful_application_form).call
 
       expect { described_class.new.perform }.not_to(change { ActionMailer::Base.deliveries.count })
     end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SubmitApplication do
         original_application_form.application_references << build(:reference, email_address: 'alice@example.com', feedback_status: :feedback_provided)
         original_application_form.application_references.reload
 
-        application_form = DuplicateApplication.new(original_application_form).duplicate
+        application_form = ApplyAgain.new(original_application_form).call
         application_form.application_choices << build(:application_choice, status: :unsubmitted)
 
         SubmitApplication.new(application_form).call
@@ -88,7 +88,7 @@ RSpec.describe SubmitApplication do
         original_application_form.application_references << build(:reference, email_address: 'alice@example.com', feedback_status: :not_requested_yet)
         original_application_form.application_references.reload
 
-        application_form = DuplicateApplication.new(original_application_form).duplicate
+        application_form = ApplyAgain.new(original_application_form).call
         application_form.application_choices << build(:application_choice, status: :unsubmitted)
 
         SubmitApplication.new(application_form).call


### PR DESCRIPTION
## Context

Incomplete applications from 2020 can be carried over to 2021 but courses are removed so that the candidate can pick ones from the new cycle. All carried over applications go into the `apply_1` phase. See https://github.com/DFE-Digital/apply-for-teacher-training/pull/2681

## Changes proposed in this pull request

- [x] Refactor the `DuplicateApplication` service into a separate `ApplyAgain` and `CarryOverApplication` services.
- [x] Specs for the new services.
- [x] Add an `EndOfCycleTimetable.current_cycle_year` method. 

Things not covered in this PR:

- Button for candidate to invoke the carry over function (when the next cycle opens).
- A mechanism to put incomplete applications into a new state at the end of cycle (mentioned in https://github.com/DFE-Digital/apply-for-teacher-training/pull/2703)

## Guidance to review

- Are the tests sufficient?
- What is missing to meet the requirement for this card?

## Link to Trello card

https://trello.com/c/IzMDhv0p/1907-dev-🚲🔚-carried-over-applications-have-courses-removed

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
