### PR TITLE
Add DSA success page with contextual content

### DIFF
--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -12,11 +12,15 @@ module ProviderInterface
 
     def create_data_sharing_agreement
       @provider_agreement = ProviderAgreement.new(provider_agreement_params.merge(provider_user: current_provider_user))
-      if @provider_agreement.save
-        redirect_to provider_interface_path
-      else
-        render :data_sharing_agreement
-      end
+
+      render :data_sharing_agreement and return unless @provider_agreement.save
+
+      @provider_setup = ProviderSetup.new(provider_user: current_provider_user)
+      @provider_relationship_pending = @provider_setup.next_relationship_pending.present?
+
+      render :success and return if @provider_setup.next_agreement_pending.blank?
+
+      redirect_to provider_interface_new_data_sharing_agreement_path
     end
 
   private

--- a/app/views/provider_interface/provider_agreements/success.html.erb
+++ b/app/views/provider_interface/provider_agreements/success.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        Thank you for signing up to our data sharing agreement
+        You've successfully signed the data sharing agreement
       </h1>
     </div>
     <% if @provider_relationship_pending %>

--- a/app/views/provider_interface/provider_agreements/success.html.erb
+++ b/app/views/provider_interface/provider_agreements/success.html.erb
@@ -1,0 +1,41 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Thank you for signing up to our data sharing agreement
+      </h1>
+    </div>
+    <% if @provider_relationship_pending %>
+      <h2 class="govuk-heading-m">
+        Next steps
+      </h2>
+      <p class="govuk-body">
+        You need to set up permissions for your organisation before you do anything else. We'll guide you through this process.
+      </p>
+      <p>
+        <%= govuk_button_link_to 'Set up permissions', provider_interface_provider_relationship_permissions_organisations_path %>
+      </p>
+    <% else %>
+      <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
+        <h2 class="govuk-heading-m">
+          Inviting users
+        </h2>
+
+        <p class="govuk-body govuk-!-margin-bottom-4">
+          Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
+        </p>
+      <% end %>
+
+      <h2 class="govuk-heading-m">
+        Manage your applications
+      </h2>
+
+      <p class="govuk-body">
+        Continue to your applications.
+      </p>
+      <p>
+        <%= govuk_button_link_to 'Continue', provider_interface_applications_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
@@ -98,13 +98,13 @@ RSpec.feature 'Accept data sharing agreement' do
   end
 
   def then_i_can_see_the_data_sharing_agreement_success_page
-    expect(page).to have_content('Thank you for signing up to our data sharing agreement')
+    expect(page).to have_content("You've successfully signed the data sharing agreement")
     expect(page).to have_content('Continue to your applications.')
     expect(page).to have_link('Continue')
   end
 
   def then_i_can_see_the_data_sharing_agreement_success_page_with_organisation_setup_steps
-    expect(page).to have_content('Thank you for signing up to our data sharing agreement')
+    expect(page).to have_content("You've successfully signed the data sharing agreement")
     expect(page).to have_content('You need to set up permissions for your organisation before you do anything else')
     expect(page).to have_link('Set up permissions')
   end

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'Accept data sharing agreement' do
     and_i_am_presented_with_a_data_sharing_agreement
     and_i_cannot_navigate_to_pages_i_do_not_have_access_to
     when_i_agree_to_the_data_sharing_agreement
+    then_i_can_see_the_data_sharing_agreement_success_page
     then_i_can_navigate_to_the_provider_interface
   end
 
@@ -27,7 +28,20 @@ RSpec.feature 'Accept data sharing agreement' do
     when_i_agree_to_the_data_sharing_agreement
     then_i_am_redirected_to_the_data_sharing_agreement_pages
     when_i_agree_to_the_data_sharing_agreement_again
+    then_i_can_see_the_data_sharing_agreement_success_page
     then_i_can_navigate_to_the_provider_interface
+  end
+
+  scenario 'Provider user with an organisation to set up accepts the data sharing agreement' do
+    given_i_am_an_authorised_provider_user
+    and_no_data_sharing_agreement_for_my_provider_has_been_accepted
+    and_the_provider_permissions_feature_is_enabled
+    and_i_need_to_set_up_organisation_permissions
+    and_i_am_presented_with_a_data_sharing_agreement
+    and_i_cannot_navigate_to_pages_i_do_not_have_access_to
+    when_i_agree_to_the_data_sharing_agreement
+    then_i_can_see_the_data_sharing_agreement_success_page_with_organisation_setup_steps
+    and_i_can_proceed_to_set_up_organisation_permissions
   end
 
   def given_i_am_an_authorised_provider_user
@@ -48,6 +62,17 @@ RSpec.feature 'Accept data sharing agreement' do
     provider2.provider_users << provider_user
     ProviderAgreement.data_sharing_agreements.for_provider(provider1).destroy_all
     ProviderAgreement.data_sharing_agreements.for_provider(provider2).destroy_all
+  end
+
+  def and_the_provider_permissions_feature_is_enabled
+    FeatureFlag.activate('enforce_provider_to_provider_permissions')
+  end
+
+  def and_i_need_to_set_up_organisation_permissions
+    provider_user = ProviderUser.find_by_dfe_sign_in_uid 'DFE_SIGN_IN_UID'
+    provider = Provider.find_by_code('ABC')
+    provider_user.provider_permissions.where(provider: provider).update_all(manage_organisations: true)
+    create(:provider_relationship_permissions, setup_at: nil, training_provider: provider)
   end
 
   def when_i_navigate_to_the_provider_interface
@@ -72,7 +97,20 @@ RSpec.feature 'Accept data sharing agreement' do
     click_on 'Continue'
   end
 
+  def then_i_can_see_the_data_sharing_agreement_success_page
+    expect(page).to have_content('Thank you for signing up to our data sharing agreement')
+    expect(page).to have_content('Continue to your applications.')
+    expect(page).to have_link('Continue')
+  end
+
+  def then_i_can_see_the_data_sharing_agreement_success_page_with_organisation_setup_steps
+    expect(page).to have_content('Thank you for signing up to our data sharing agreement')
+    expect(page).to have_content('You need to set up permissions for your organisation before you do anything else')
+    expect(page).to have_link('Set up permissions')
+  end
+
   def then_i_can_navigate_to_the_provider_interface
+    click_on 'Continue'
     expect(page).to have_current_path provider_interface_applications_path
   end
 
@@ -82,5 +120,11 @@ RSpec.feature 'Accept data sharing agreement' do
     expect(page).not_to have_link 'Users'
     expect(page).not_to have_link 'Account'
     expect(page).not_to have_link 'Applications'
+  end
+
+  def and_i_can_proceed_to_set_up_organisation_permissions
+    click_on 'Set up permissions'
+
+    expect(page).to have_content('Set up permissions for your organisation')
   end
 end


### PR DESCRIPTION
## Context

When a user who needs to set up organisation permissions agrees to all DSAs they are currently taken straight to the permissions wizard first step. In order to make the journey less surprising we're adding a bridging page which explains next steps.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a page which acts as a mid-step when a user has accepted all DSAs and needs to then set up permissions for their organisation.
If the user does not have permissions to set up org permissions they see a link which can take them to their applications.
In this scenario they may also see content about managing users if they have the relevant permissions.

<!-- If there are UI changes, please include Before and After screenshots. -->

### User has org permissions to set up

![image](https://user-images.githubusercontent.com/93511/90621243-5d890580-e20b-11ea-81b5-350e1cad3e65.png)


### User has no org permissions to set up

![image](https://user-images.githubusercontent.com/93511/90619112-bdca7800-e208-11ea-9c15-4812516063cc.png)


## Guidance to review

Reviewing is quite tricky given the preconditions needed on the provider and permissions data.

To see the permissions based DSA success page you'll need to: 

- Add a new provider for your provider user (or delete an existing DSA)
- Find or create a ProviderRelationshipPermissions record where the same provider is the training provider, set the `setup_at` timestamp to `nil`
- Log in and you should have to agree to the DSA then you should see the permissions-based success page.

To see the DSA success page without the permissions flow content:

- Add a new provider for your provider user (or delete an existing DSA)
- Log in and you should have to agree to the DSA then you should see the confirmation success page.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/pMFlaOle/2644-build-interstitial-page-for-end-of-dsa-start-of-org-permissions-wizard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
