### PR TITLE
Conditionally show Diversity information on an individual application page

### DIFF
--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,4 +1,8 @@
+<% if display_diversity_information? -%>
+  <%= render SummaryListComponent.new(rows: rows) %>
+<% else -%>
   <p class="govuk-body"><%= message %></p>
   <% if diversity_information_declared? -%>
     <p class="govuk-body"><%= details %></p>
   <% end -%>
+<% end -%>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,1 +1,4 @@
   <p class="govuk-body"><%= message %></p>
+  <% if diversity_information_declared? -%>
+    <p class="govuk-body"><%= details %></p>
+  <% end -%>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,0 +1,1 @@
+  <p class="govuk-body"><%= message %></p>

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -21,10 +21,10 @@ module ProviderInterface
 
     def details
       if [current_user_has_permission_to_view_diversity_information?, application_in_correct_state?].all?(false)
-        return 'This will become available to users with permissions to `view diversity information` when an offer has been accepted'
+        return "This will become available to users with permissions to `view diversity information` when #{offer_context} offer has been accepted"
       end
 
-      return 'You will be able to view this when an offer has been accepted.' if current_user_has_permission_to_view_diversity_information?
+      return "You will be able to view this when #{offer_context} offer has been accepted." if current_user_has_permission_to_view_diversity_information?
 
       'This section is only available to users with permissions to `view diversity information`.' if application_in_correct_state?
     end
@@ -43,6 +43,10 @@ module ProviderInterface
     end
 
   private
+
+    def offer_context
+      application_choice.offer? ? 'your' : 'an'
+    end
 
     def disability_status
       return 'Prefer not to say' if equality_and_diversity['disabilities'].include?('Prefer not to say')

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -15,10 +15,29 @@ module ProviderInterface
       'No information shared'
     end
 
-  private
+    def details
+      if [current_user_has_permission_to_view_diversity_information?, application_in_correct_state?].all?(false)
+        return 'This will become available to users with permissions to `view diversity information` when an offer has been accepted'
+      end
+
+      return 'You will be able to view this when an offer has been accepted.' if current_user_has_permission_to_view_diversity_information?
+
+      'This section is only available to users with permissions to `view diversity information`.' if application_in_correct_state?
+    end
 
     def diversity_information_declared?
       application_choice.application_form.equality_and_diversity_answers_provided?
+    end
+
+  private
+
+    def application_in_correct_state?
+      ApplicationStateChange::POST_OFFERED_STATES.include?(application_choice.status.to_sym)
+    end
+
+    def current_user_has_permission_to_view_diversity_information?
+      current_provider_user.authorisation
+        .can_view_diversity_information?(course: application_choice.course)
     end
   end
 end

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -15,6 +15,10 @@ module ProviderInterface
       'No information shared'
     end
 
+    def display_diversity_information?
+      diversity_information_declared? && current_user_has_permission_to_view_diversity_information? && application_in_correct_state?
+    end
+
     def details
       if [current_user_has_permission_to_view_diversity_information?, application_in_correct_state?].all?(false)
         return 'This will become available to users with permissions to `view diversity information` when an offer has been accepted'
@@ -25,11 +29,37 @@ module ProviderInterface
       'This section is only available to users with permissions to `view diversity information`.' if application_in_correct_state?
     end
 
+    def rows
+      rows = [{ key: 'Sex', value: equality_and_diversity['sex'].capitalize },
+              { key: 'Ethnic group', value: equality_and_diversity['ethnic_group'] }]
+      rows << { key: 'Ethnic background', value: equality_and_diversity['ethnic_background'] } if equality_and_diversity['ethnic_background'].present?
+      rows << { key: 'Disabled', value: disability_status }
+      rows << { key: 'Disabilities', value: disability_value.html_safe } if disability_status == 'Yes'
+      rows
+    end
+
     def diversity_information_declared?
       application_choice.application_form.equality_and_diversity_answers_provided?
     end
 
   private
+
+    def disability_status
+      return 'Prefer not to say' if equality_and_diversity['disabilities'].include?('Prefer not to say')
+
+      return 'Yes' if equality_and_diversity['disabilities'].any?
+
+      'No'
+    end
+
+    def disability_value
+      disabilities = equality_and_diversity['disabilities'].map do |disability|
+        "<li>#{disability} </li>"
+      end
+
+      "<p class=\"govuk-body govuk-margin-top-0>\">The candidate disclosed the following #{'disability'.pluralize(disabilities.count)}:</p>
+      <ul class=\"govuk-list govuk-list--bullet\">#{disabilities.join}</ul>"
+    end
 
     def application_in_correct_state?
       ApplicationStateChange::POST_OFFERED_STATES.include?(application_choice.status.to_sym)
@@ -38,6 +68,10 @@ module ProviderInterface
     def current_user_has_permission_to_view_diversity_information?
       current_provider_user.authorisation
         .can_view_diversity_information?(course: application_choice.course)
+    end
+
+    def equality_and_diversity
+      @equality_and_diversity ||= application_choice.application_form.equality_and_diversity
     end
   end
 end

--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -1,0 +1,24 @@
+module ProviderInterface
+  class DiversityInformationComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :application_choice, :current_provider_user
+
+    def initialize(application_choice:, current_provider_user:)
+      @application_choice = application_choice
+      @current_provider_user = current_provider_user
+    end
+
+    def message
+      return 'The candidate disclosed information in the equality and diversity questionnaire.' if diversity_information_declared?
+
+      'No information shared'
+    end
+
+  private
+
+    def diversity_information_declared?
+      application_choice.application_form.equality_and_diversity_answers_provided?
+    end
+  end
+end

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -4,6 +4,7 @@ class ApplicationStateChange
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete cancelled].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited enrolled].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
+  POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
   UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn].freeze
   DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
 

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -80,5 +80,9 @@
         <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference) %>
       <% end %>
     <% end %>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-8">Diversity information</h2>
+
+    <%= render ProviderInterface::DiversityInformationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
   </div>
 </div>

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -192,5 +192,35 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
         end
       end
     end
+
+    context 'when the application status is offer' do
+      let!(:application_choice) do
+        build(:application_choice,
+              application_form: application_form,
+              course: course,
+              status: 'offer')
+      end
+
+      context 'when provider user can view diversity information' do
+        it 'displays the correct text with correct offer context' do
+          provider_relationship_permissions
+          provider_user.provider_permissions.find_by(provider: training_provider)
+            .update!(view_diversity_information: true)
+          result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
+
+          expect(result.text).to include('You will be able to view this when your offer has been accepted.')
+        end
+      end
+
+      context 'when provider user does not have permissions to view diversity information' do
+        it 'displays the correct text with correct offer context' do
+          provider_user.provider_permissions.find_by(provider: training_provider)
+            .update!(view_diversity_information: false)
+          result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
+
+          expect(result.text).to include('This will become available to users with permissions to `view diversity information` when your offer has been accepted')
+        end
+      end
+    end
   end
 end

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::DiversityInformationComponent do
+  let(:training_provider) { create(:provider) }
+  let(:ratifying_provider) { create(:provider) }
+  let(:course) { create(:course, provider: training_provider, accredited_provider: ratifying_provider) }
+  let(:provider_relationship_permissions) do
+    create(
+      :provider_relationship_permissions,
+      training_provider: training_provider,
+      ratifying_provider: ratifying_provider,
+      training_provider_can_view_diversity_information: true,
+    )
+  end
+  let(:provider_user) { create(:provider_user, providers: [training_provider]) }
+  let(:diversity_info) do
+    { 'sex' => 'male',
+      'disabilities' => ['Mental health condition', 'Social or communication impairment', 'Acquired brain injury'],
+      'ethnic_group' => 'Asian or Asian British',
+      'ethnic_background' => 'Chinese' }
+  end
+
+  context 'when the candidate has not shared diversity information' do
+    it 'displays the correct text' do
+      application_form = build_stubbed(
+        :application_form,
+        equality_and_diversity: nil,
+      )
+      application_choice = build(:application_choice,
+                                 application_form: application_form,
+                                 course: course)
+      result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
+
+      expect(result.text).to include('No information shared')
+    end
+  end
+
+  context 'when the candidate has shared diversity information' do
+    let(:application_form) do
+      build_stubbed(
+        :application_form,
+        equality_and_diversity: diversity_info,
+      )
+    end
+        it 'displays the correct text' do
+          provider_user.provider_permissions.find_by(provider: training_provider)
+            .update!(view_diversity_information: false)
+          result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
+
+          expect(result.text).to include('The candidate disclosed information in the equality and diversity questionnaire.')
+        end
+  end
+end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_i_should_see_the_candidates_language_skills
     and_i_should_see_the_candidates_references
     and_i_should_see_the_disability_disclosure
+    and_i_should_see_diversity_information_section
     and_i_should_see_a_link_to_download_as_pdf
   end
 
@@ -87,6 +88,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
       disability_disclosure: 'I am hard of hearing',
       safeguarding_issues: 'I have something to say...',
       safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      equality_and_diversity: { 'sex' => 'male',
+                                'disabilities' => ['Mental health condition'],
+                                'ethnic_group' => 'Asian or Asian British',
+                                'ethnic_background' => 'Chinese' },
     )
 
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)
@@ -250,6 +255,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def and_i_should_see_the_disability_disclosure
     expect(page).to have_content 'I am hard of hearing'
+  end
+
+  def and_i_should_see_diversity_information_section
+    expect(page).to have_content 'The candidate disclosed information in the equality and diversity questionnaire.'
   end
 
   def and_i_should_see_a_link_to_download_as_pdf


### PR DESCRIPTION
## Context

Add a new section `Diversity information` that is shown on the application.

The section will have a summary list with their answers, but this is hidden until an offer has been accepted and then only to users with the right permission - before that, we show a placeholder sentence explaining why it can't be seen.

## Changes proposed in this pull request

- Questionnaire not completed
<kbd><img width="445" alt="Screenshot 2020-08-19 at 16 15 07" src="https://user-images.githubusercontent.com/38078064/90654402-444a7e00-e238-11ea-8cd3-6d6360123f1e.png">
</kbd>

- Questionnaire completed, application in progress, user has view rights
<kbd><img width="442" alt="Screenshot 2020-08-19 at 16 19 21" src="https://user-images.githubusercontent.com/38078064/90654421-490f3200-e238-11ea-908f-9c6e5bdef07f.png">
</kbd>

- Questionnaire completed, application in progress, user does not have view rights
<kbd><img width="446" alt="Screenshot 2020-08-19 at 16 48 48" src="https://user-images.githubusercontent.com/38078064/90658797-e3bd4000-e23b-11ea-8fc0-f2de6e7f758c.png">
</kbd>

- Questionnaire completed, offer accepted, user does not have view rights
<kbd><img width="452" alt="Screenshot 2020-08-19 at 16 45 52" src="https://user-images.githubusercontent.com/38078064/90658409-76111400-e23b-11ea-82d8-d91409066373.png"></kbd>

- Questionnaire completed, offer accepted, user has view rights
  - one disability
<kbd><img width="437" alt="Screenshot 2020-08-19 at 16 36 27" src="https://user-images.githubusercontent.com/38078064/90656089-2b42cc80-e23a-11ea-8f9e-402155cb1baf.png"></kbd>

  - multiple disabilities
<kbd><img width="441" alt="Screenshot 2020-08-19 at 16 31 07" src="https://user-images.githubusercontent.com/38078064/90655798-edde3f00-e239-11ea-8448-23bfe54d5d8c.png"></kbd>

  - no disabilities
<kbd><img width="441" alt="Screenshot 2020-08-19 at 16 34 46" src="https://user-images.githubusercontent.com/38078064/90655835-f8003d80-e239-11ea-9204-8b1b40a38de4.png"></kbd>

  - Disabled and ethic background - prefer not to say
<kbd><img width="447" alt="Screenshot 2020-08-19 at 16 33 46" src="https://user-images.githubusercontent.com/38078064/90655820-f3d42000-e239-11ea-845a-0eb48e423717.png"> </kbd>

## Guidance to review

Note that the factory needs fixing https://github.com/DFE-Digital/apply-for-teacher-training/compare/update-equality-diversity-factory

## Link to Trello card

https://trello.com/c/f1RbDOAg/2605-implement-diversity-permissions

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
