### PR TITLE
Improve the Slack message for UCAS matching

### DIFF
--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -110,7 +110,7 @@ module UCASMatching
       end
 
       message = "Hello, this is the UCAS matching robot. I've just received a new file from UCAS. It contained #{new_matches} new matches, #{updated_matches} updated matches, and #{existing_matches} matches that we've already seen."
-      url = Rails.application.routes.url_helpers.support_interface_path
+      url = Rails.application.routes.url_helpers.support_interface_ucas_matches_url
       SlackNotificationWorker.perform_async(message, url)
     end
   end

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -109,7 +109,7 @@ module UCASMatching
         end
       end
 
-      message = "Hello, this is the UCAS matching robot. I've just received a new file from UCAS. It contained #{new_matches} new matches, #{updated_matches} updated matches, and #{existing_matches} matches that we've already seen."
+      message = ":dfe: :ucas: Hello, this is the Apply/UCAS matching robot. I’ve just received a new file from UCAS. It contained #{new_matches} new matches, #{updated_matches} updated matches, and #{existing_matches} matches that we’ve already seen."
       url = Rails.application.routes.url_helpers.support_interface_ucas_matches_url
       SlackNotificationWorker.perform_async(message, url)
     end

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
   end
 
   def then_we_have_received_a_slack_message
-    expect_slack_message_with_text("It contained 1 new matches, 1 updated matches, and 1 matches that we've already seen.")
+    expect_slack_message_with_text("It contained 1 new matches, 1 updated matches, and 1 matches that we’ve already seen.")
   end
 
   def when_i_visit_the_ucas_matches_page_in_support

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
   end
 
   def then_we_have_received_a_slack_message
-    expect_slack_message_with_text("It contained 1 new matches, 1 updated matches, and 1 matches that we’ve already seen.")
+    expect_slack_message_with_text('It contained 1 new matches, 1 updated matches, and 1 matches that we’ve already seen.')
   end
 
   def when_i_visit_the_ucas_matches_page_in_support


### PR DESCRIPTION
## Context

The Slack message is formatted wrong (https://ukgovernmentdfe.slack.com/archives/CQA59PB98/p1597914628000900).

## Changes proposed in this pull request

Fix the link, add some emojis.

## Guidance to review

Did I fix the link? Are these the correct emojis?

## Link to Trello card

https://trello.com/c/vX5nXO2g/2331-arrange-matching-data-with-ucas

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
