### PR TITLE
Generate test applications with correct equality and diversity data

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -57,15 +57,14 @@ class TestApplications
     end
 
     Audited.audit_class.as_user(candidate) do
-      traits = %i[
-        with_safeguarding_issues_disclosed
-        with_no_safeguarding_issues_to_declare
-        with_safeguarding_issues_never_asked
-      ].sample
+      traits = [%i[with_safeguarding_issues_disclosed
+                   with_no_safeguarding_issues_to_declare
+                   with_safeguarding_issues_never_asked].sample]
+      traits << :with_equality_and_diversity_data if rand < 0.55
 
       @application_form = FactoryBot.create(
         :completed_application_form,
-        traits,
+        *traits,
         application_choices_count: 0,
         full_work_history: true,
         volunteering_experiences_count: 1,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -114,15 +114,14 @@ FactoryBot.define do
       trait :with_equality_and_diversity_data do
         equality_and_diversity do
           ethnicity = Class.new.extend(EthnicBackgroundHelper).all_combinations.sample
-          all_disabilities = CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.map(&:first) << 'Other'
-          disabilities = all_disabilities.sample([*1..3].sample)
+          other_disability = 'Acquired brain injury'
+          all_disabilities = CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.map(&:second) << other_disability
+          disabilities = rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
           {
             sex: ['male', 'female', 'intersex', 'Prefer not to say'].sample,
             ethnic_group: ethnicity.first,
             ethnic_background: ethnicity.last,
-            disability_status: 'yes',
             disabilities: disabilities,
-            other_disability: (disabilities.include?('Other') ? Faker::Lorem.paragraph(sentence_count: 2) : nil),
           }
         end
       end


### PR DESCRIPTION
## Context

How we generate `equality_and_diversity` on application form is different to what it is in production.

## Changes proposed in this pull request

1. Update the factory trait:
- Remove `other_disability` and `disability_status` keys as they are not saved
  in the database. When other_disability is declared it gets added to
`disabilities` array. When disability_status is 'no', `disabilities` is an
empty array, when it’s 'Prefer not to say’, this string gets added to
disabilities.
- Use long names of disabilities as they are saved in the database
- When sampling disability array allow it to be empty which represents that
  user answered "No"
- Add 'Prefer not to say' as a disability option


2. Update the worked to generate test applications with equality and diversity data.

## Guidance to review

Generate some applications

Note: I decided not to generate other_disability so it's easier to test. We are not doing it for safeguarding issues either.

## Link to Trello card

https://trello.com/c/vRibYMne/2643-fix-how-we-generate-equalityanddiversity-data

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
