### PR TITLE
Show the selected course option's study mode in the API response

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -100,7 +100,7 @@ module VendorAPI
         provider_code: course_option.course.provider.code,
         site_code: course_option.site.code,
         course_code: course_option.course.code,
-        study_mode: course_option.course.study_mode,
+        study_mode: course_option.study_mode,
       }
     end
 

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,8 @@
+### 24th August 2020
+
+- Fix a bug where the study mode of a chosen or offered course appeared as
+  "full_or_part_time" instead of "full_time" or "part_time" as appropriate.
+
 ### 10th August 2020
 
 - `POST /application/:id/offer` is now idempotent and will continue to return 200


### PR DESCRIPTION
We accidentally showed the available study modes for the course, which meant that if you e.g. offered a part time place on a course that also supported full time, you would see 'full_or_part_time' in this field instead of 'part_time'.

## Context

Noticed while investigating an API issue for UCB (https://trello.com/c/3iC0aiNg/2648-investigate-bug-report-from-ucb)

## Changes proposed in this pull request

Show the correct data, which is `course_option.study_mode`, not `course.study_mode`.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
