### PR TITLE
Add spacing to account page permissions list consistent with design

### DIFF
--- a/app/components/permissions_list.html.erb
+++ b/app/components/permissions_list.html.erb
@@ -11,7 +11,7 @@
     <li>
       <%= render CheckIcon.new %><span class="govuk-!-font-weight-bold">Make decisions</span>
       <% if training_providers_that_can('make_decisions').any? %>
-        <div class="govuk-!-margin-left-5">
+        <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
           Applies to courses run by:
           <ul class="govuk-list">
             <% training_providers_that_can('make_decisions').each do |provider| %>
@@ -21,7 +21,7 @@
         </div>
       <% end %>
       <% if ratifying_providers_that_can('make_decisions').any? %>
-        <div class="govuk-!-margin-left-5">
+        <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
           Applies to courses ratified by:
           <ul class="govuk-list">
             <% ratifying_providers_that_can('make_decisions').each do |provider| %>
@@ -37,7 +37,7 @@
     <li>
       <%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">Access safeguarding information</span>
       <% if training_providers_that_can('view_safeguarding_information').any? %>
-        <div class="govuk-!-margin-left-5">
+        <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
           Applies to courses run by:
           <ul class="govuk-list">
             <% training_providers_that_can('view_safeguarding_information').each do |provider| %>
@@ -47,7 +47,7 @@
         </div>
       <% end %>
       <% if ratifying_providers_that_can('view_safeguarding_information').any? %>
-        <div class="govuk-!-margin-left-5">
+        <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
           Applies to courses ratified by:
           <ul class="govuk-list">
             <% ratifying_providers_that_can('view_safeguarding_information').each do |provider| %>
@@ -63,7 +63,7 @@
     <li>
       <%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">Access diversity information</span>
       <% if training_providers_that_can('view_diversity_information').any? %>
-        <div class="govuk-!-margin-left-5">
+        <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
           Applies to courses run by:
           <ul class="govuk-list">
             <% training_providers_that_can('view_diversity_information').each do |provider| %>
@@ -73,7 +73,7 @@
         </div>
       <% end %>
       <% if ratifying_providers_that_can('view_diversity_information').any? %>
-        <div class="govuk-!-margin-left-5">
+        <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
           Applies to courses ratified by:
           <ul class="govuk-list">
             <% ratifying_providers_that_can('view_diversity_information').each do |provider| %>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a top margin to make space below permission name consistent with design.

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/93511/90784012-af5b8980-e2f8-11ea-8a63-760bef02c04f.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/KGyBrG2W/2619-spacing-is-wrong-on-account-page
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
