### PR TITLE
Carry over unsubmitted applications automatically

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -37,7 +37,7 @@ class DuplicateApplication
       )
     end
 
-    original_application_form.application_references.feedback_provided.each do |w|
+    original_application_form.application_references.where(feedback_status: %w[feedback_provided not_requested_yet]).each do |w|
       new_application_form.application_references.create!(
         w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
       )

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -62,11 +62,11 @@ class EndOfCycleTimetable
   end
 
   def self.current_cycle_year
-    Time.zone.now > next_cycle_opens ? next_cycle_year : Time.zone.today.year
+    RecruitmentCycle.current_year
   end
 
   def self.next_cycle_year
-    date(:next_cycle_opens).year + 1
+    RecruitmentCycle.current_year + 1
   end
 
   def self.simulate_time_between_cycles_dates

--- a/app/workers/carry_over_unsubmitted_applications_worker.rb
+++ b/app/workers/carry_over_unsubmitted_applications_worker.rb
@@ -1,0 +1,17 @@
+class CarryOverUnsubmittedApplicationsWorker
+  include Sidekiq::Worker
+
+  def perform
+    unsubmitted_applications_from_earlier_cycle.each do |application_form|
+      CarryOverApplication.new(application_form).call
+    end
+  end
+
+private
+
+  def unsubmitted_applications_from_earlier_cycle
+    # TODO: Remove hard-coded year
+    # TODO: Omit applications that have already been carried over (have a subsequent_application_form)
+    ApplicationForm.joins(application_choices: :course).where(submitted_at: nil).where('courses.recruitment_cycle_year' => 2020).distinct
+  end
+end

--- a/app/workers/carry_over_unsubmitted_applications_worker.rb
+++ b/app/workers/carry_over_unsubmitted_applications_worker.rb
@@ -11,7 +11,14 @@ private
 
   def unsubmitted_applications_from_earlier_cycle
     # TODO: Remove hard-coded year
-    # TODO: Omit applications that have already been carried over (have a subsequent_application_form)
-    ApplicationForm.joins(application_choices: :course).where(submitted_at: nil).where('courses.recruitment_cycle_year' => 2020).distinct
+    ApplicationForm
+      .joins(application_choices: :course)
+      .where(submitted_at: nil)
+      .where('courses.recruitment_cycle_year' => 2020)
+      .where(
+        'application_forms.id NOT IN (:duplicated_applications)',
+        duplicated_applications: ApplicationForm.where.not(previous_application_form_id: nil).select(:previous_application_form_id),
+      )
+      .distinct
   end
 end

--- a/app/workers/carry_over_unsubmitted_applications_worker.rb
+++ b/app/workers/carry_over_unsubmitted_applications_worker.rb
@@ -10,11 +10,10 @@ class CarryOverUnsubmittedApplicationsWorker
 private
 
   def unsubmitted_applications_from_earlier_cycle
-    # TODO: Remove hard-coded year
     ApplicationForm
       .joins(application_choices: :course)
       .where(submitted_at: nil)
-      .where('courses.recruitment_cycle_year' => RecruitmentCycle.current_year)
+      .where('courses.recruitment_cycle_year' => RecruitmentCycle.current_year - 1)
       .where(
         'application_forms.id NOT IN (:duplicated_applications)',
         duplicated_applications: ApplicationForm.where.not(previous_application_form_id: nil).select(:previous_application_form_id),

--- a/app/workers/carry_over_unsubmitted_applications_worker.rb
+++ b/app/workers/carry_over_unsubmitted_applications_worker.rb
@@ -14,7 +14,7 @@ private
     ApplicationForm
       .joins(application_choices: :course)
       .where(submitted_at: nil)
-      .where('courses.recruitment_cycle_year' => 2020)
+      .where('courses.recruitment_cycle_year' => RecruitmentCycle.current_year)
       .where(
         'application_forms.id NOT IN (:duplicated_applications)',
         duplicated_applications: ApplicationForm.where.not(previous_application_form_id: nil).select(:previous_application_form_id),

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -305,7 +305,7 @@ FactoryBot.define do
     code { Faker::Alphanumeric.alphanumeric(number: 4, min_alpha: 1).upcase }
     name { Faker::Educator.subject }
     level { 'primary' }
-    recruitment_cycle_year { 2020 }
+    recruitment_cycle_year { RecruitmentCycle.current_year }
     description { 'PGCE with QTS full time' }
     course_length { 'OneYear' }
     start_date { Faker::Date.between(from: 1.month.from_now, to: 1.year.from_now) }

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe CarryOverApplication do
         with_gces: true,
         full_work_history: true,
       )
-      create_list(:reference, 2, feedback_status: :feedback_provided, application_form: application_form)
+      create(:reference, feedback_status: :feedback_provided, application_form: application_form)
+      create(:reference, feedback_status: :not_requested_yet, application_form: application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: application_form)
       application_form
     end

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -33,7 +33,7 @@ RSpec.shared_examples 'duplicates application form' do |expected_phase|
 
   it 'copies application references' do
     expect(duplicate_application_form.application_references.count).to eq 2
-    expect(duplicate_application_form.application_references).to all(be_feedback_provided)
+    expect(duplicate_application_form.application_references).to all(be_feedback_provided.or(be_not_requested_yet))
   end
 
   it 'copies work and volunteering experiences' do

--- a/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+
+RSpec.feature 'Automatically carry over unsubmitted applications' do
+  include CandidateHelper
+
+  around do |example|
+    Timecop.freeze(Date.new(2020, 8, 1)) do
+      example.run
+    end
+  end
+
+  scenario 'Carry over application and remove all application choices' do
+    given_i_am_signed_in_as_a_candidate
+    when_i_have_an_unsubmitted_application
+    and_the_recruitment_cycle_ends
+    and_the_unsubmitted_application_carry_over_worker_runs
+
+    when_i_sign_in_again
+    and_i_visit_the_application_dashboard
+    then_i_see_a_copy_of_my_application
+
+    when_i_view_referees
+    then_i_can_see_the_referees_i_previously_added
+
+    when_i_view_courses
+    then_i_can_see_that_i_need_to_select_courses
+
+    and_i_select_a_course
+    and_i_submit_my_application
+    and_my_application_is_awaiting_references
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def when_i_have_an_unsubmitted_application
+    @application_form = create(
+      :completed_application_form,
+      submitted_at: nil,
+      candidate: @candidate,
+      with_gces: true,
+      safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+    )
+    create(
+      :application_choice,
+      status: :unsubmitted,
+      application_form: @application_form,
+    )
+    @completed_references = create_list(:reference, 2, feedback_status: :not_requested_yet, application_form: @application_form)
+  end
+
+  def and_the_recruitment_cycle_ends
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 10, 15, 12, 0, 0))
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def and_the_unsubmitted_application_carry_over_worker_runs
+    # TODO
+  end
+
+  def when_i_sign_in_again
+    logout
+    login_as(@candidate)
+  end
+
+  def and_i_visit_the_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def when_i_click_go_to_my_application_form
+    click_link 'Go to your application form'
+  end
+
+  def then_i_see_a_copy_of_my_application
+    expect(page).to have_title('Your application')
+  end
+
+  def when_i_view_referees
+    click_on 'Referees'
+  end
+
+  def then_i_can_see_the_referees_i_previously_added
+    pending
+  end
+
+  def when_i_view_courses
+    pending
+  end
+
+  def then_i_can_see_that_i_need_to_select_courses
+    pending
+  end
+
+  def when_i_complete_the_section
+    check t('application_form.completed_checkbox')
+    click_button t('application_form.continue')
+  end
+
+  def and_i_select_a_course
+    click_link 'Back to application'
+    save_and_open_page
+    click_link 'Course choice', exact: true
+    given_courses_exist
+
+    click_link 'Continue'
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+
+    select 'Gorse SCITT (1N1)'
+    click_button 'Continue'
+
+    choose 'Primary (2XT2)'
+    click_button 'Continue'
+
+    expect(page).to have_link 'Delete choice'
+    expect(page).to have_content 'I have completed this section'
+    expect(page).to have_button 'Add another course'
+  end
+
+  def and_i_submit_my_application
+    check t('application_form.courses.complete.completed_checkbox')
+    click_button 'Continue'
+    @new_application_form = candidate_submits_application
+  end
+
+  def and_my_application_is_awaiting_references
+    application_choice = @new_application_form.application_choices.first
+    expect(application_choice.status).to eq 'awaiting_references'
+  end
+end

--- a/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
   end
 
   def and_the_unsubmitted_application_carry_over_worker_runs
-    # TODO
+    CarryOverUnsubmittedApplicationsWorker.new.perform
   end
 
   def when_i_sign_in_again

--- a/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
       status: :unsubmitted,
       application_form: @application_form,
     )
-    @completed_references = create_list(:reference, 2, feedback_status: :not_requested_yet, application_form: @application_form)
+    @unrequested_references = create_list(:reference, 2, feedback_status: :not_requested_yet, application_form: @application_form)
   end
 
   def and_the_recruitment_cycle_ends
@@ -84,7 +84,11 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
   end
 
   def then_i_can_see_the_referees_i_previously_added
-    pending
+    expect(page).to have_content('First referee')
+    expect(page).to have_content('Second referee')
+    @unrequested_references.each do |reference|
+      expect(page).to have_content(reference.name)
+    end
   end
 
   def when_i_view_courses
@@ -102,7 +106,6 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
 
   def and_i_select_a_course
     click_link 'Back to application'
-    save_and_open_page
     click_link 'Course choice', exact: true
     given_courses_exist
 

--- a/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
 
   scenario 'Carry over application and remove all application choices' do
     given_i_am_signed_in_as_a_candidate
+    and_i_am_in_the_2020_recruitment_cycle
     when_i_have_an_unsubmitted_application
     and_the_recruitment_cycle_ends
     and_the_unsubmitted_application_carry_over_worker_runs
@@ -36,6 +37,10 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
     login_as(@candidate)
   end
 
+  def and_i_am_in_the_2020_recruitment_cycle
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2020)
+  end
+
   def when_i_have_an_unsubmitted_application
     @application_form = create(
       :completed_application_form,
@@ -49,10 +54,16 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
       status: :unsubmitted,
       application_form: @application_form,
     )
-    @unrequested_references = create_list(:reference, 2, feedback_status: :not_requested_yet, application_form: @application_form)
+    @unrequested_references = create_list(
+      :reference,
+      2,
+      feedback_status: :not_requested_yet,
+      application_form: @application_form,
+    )
   end
 
   def and_the_recruitment_cycle_ends
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2021)
     Timecop.safe_mode = false
     Timecop.travel(Time.zone.local(2020, 10, 15, 12, 0, 0))
   ensure

--- a/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/automatically_carry_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
     then_i_can_see_that_i_need_to_select_courses
 
     and_i_select_a_course
+    and_i_complete_the_section
     and_i_submit_my_application
     and_my_application_is_awaiting_references
   end
@@ -92,21 +93,15 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
   end
 
   def when_i_view_courses
-    pending
+    click_link 'Back to application'
+    click_link 'Course choice'
   end
 
   def then_i_can_see_that_i_need_to_select_courses
-    pending
-  end
-
-  def when_i_complete_the_section
-    check t('application_form.completed_checkbox')
-    click_button t('application_form.continue')
+    expect(page).to have_content 'You can apply for up to 3 courses'
   end
 
   def and_i_select_a_course
-    click_link 'Back to application'
-    click_link 'Course choice', exact: true
     given_courses_exist
 
     click_link 'Continue'
@@ -119,14 +114,18 @@ RSpec.feature 'Automatically carry over unsubmitted applications' do
     choose 'Primary (2XT2)'
     click_button 'Continue'
 
-    expect(page).to have_link 'Delete choice'
-    expect(page).to have_content 'I have completed this section'
-    expect(page).to have_button 'Add another course'
+    expect(page).to have_content 'You’ve added Primary (2XT2) to your application'
+    expect(page).to have_content 'You can choose 2 more courses'
+  end
+
+  def and_i_complete_the_section
+    choose 'No, not at the moment'
+    click_button 'Continue'
+    check t('application_form.completed_checkbox')
+    click_button 'Continue'
   end
 
   def and_i_submit_my_application
-    check t('application_form.courses.complete.completed_checkbox')
-    click_button 'Continue'
     @new_application_form = candidate_submits_application
   end
 

--- a/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe CarryOverUnsubmittedApplicationsWorker do
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 10, 15)) do
+      example.run
+    end
+  end
+
+  describe '#perform' do
+    it 'duplicates any unsubmitted applications from the last cycle' do
+      unsubmitted_application_from_last_year = create(
+        :completed_application_form,
+        submitted_at: nil,
+      )
+      create(
+        :application_choice,
+        status: :unsubmitted,
+        application_form: unsubmitted_application_from_last_year,
+      )
+
+      unsubmitted_application_from_this_year = create(
+        :completed_application_form,
+        submitted_at: nil,
+      )
+      create(
+        :application_choice,
+        status: :unsubmitted,
+        application_form: unsubmitted_application_from_this_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: 2021)),
+      )
+
+      rejected_application_from_last_year = create(
+        :completed_application_form,
+      )
+      create(
+        :application_choice,
+        status: :rejected,
+        application_form: rejected_application_from_last_year,
+      )
+
+      described_class.new.perform
+
+      expect(unsubmitted_application_from_last_year.reload.subsequent_application_form).to be_present
+      expect(unsubmitted_application_from_this_year.reload.subsequent_application_form).not_to be_present
+      expect(rejected_application_from_last_year.reload.subsequent_application_form).not_to be_present
+
+      expect(unsubmitted_application_from_last_year.reload.subsequent_application_form.application_choices).to be_empty
+    end
+  end
+end

--- a/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CarryOverUnsubmittedApplicationsWorker do
-  around do |example|
-    Timecop.freeze(Time.zone.local(2020, 10, 15)) do
-      example.run
-    end
-  end
-
   describe '#perform' do
     it 'duplicates any unsubmitted applications from the last cycle' do
       unsubmitted_application_from_last_year = create(
@@ -17,6 +11,7 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
         :application_choice,
         status: :unsubmitted,
         application_form: unsubmitted_application_from_last_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year - 1)),
       )
 
       unsubmitted_application_from_this_year = create(
@@ -27,7 +22,7 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
         :application_choice,
         status: :unsubmitted,
         application_form: unsubmitted_application_from_this_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: 2021)),
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
       )
 
       rejected_application_from_last_year = create(
@@ -37,6 +32,7 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
         :application_choice,
         status: :rejected,
         application_form: rejected_application_from_last_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year - 1)),
       )
 
       described_class.new.perform

--- a/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
@@ -45,7 +45,12 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
       expect(unsubmitted_application_from_this_year.reload.subsequent_application_form).not_to be_present
       expect(rejected_application_from_last_year.reload.subsequent_application_form).not_to be_present
 
-      expect(unsubmitted_application_from_last_year.reload.subsequent_application_form.application_choices).to be_empty
+      carried_over_application_form = unsubmitted_application_from_last_year.reload.subsequent_application_form
+
+      expect(carried_over_application_form.application_choices).to be_empty
+      expect(carried_over_application_form).to be_apply_1
+
+      expect { described_class.new.perform }.not_to(change { ApplicationForm.count })
     end
   end
 end


### PR DESCRIPTION
## Context

Applications that are unsubmitted when a recruitment cycle ends should be carried over to the new recruitment. Unlike unsuccessful applications the carry-over process for unsubmitted applications should be automatic.

## Changes proposed in this pull request

- [x] Add `CarryOverUnsubmittedApplicationsWorker` that searches for applications from the last cycle and automatically carries them across using the existing `CarryOverApplication` service.
- [x] Allow unrequested references to be carried across (was just completed references).

## Guidance to review

- It's not clear how `CarryOverUnsubmittedApplicationsWorker` should be invoked (or exactly when). I am assuming we trigger it with `clock` and it runs once as a Sidekiq job.
- I think there was some discussion about whether duplicating unsubmitted applications was necessary to move them into the new recruitment cycle. I've gone with this for now because it's consistent with other carry-overs and it allows us to retain the original course choices but this is open to debate.

## Link to Trello card

https://trello.com/c/IzMDhv0p/1907-dev-🚲🔚-carried-over-applications-have-courses-removed

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
