### PR TITLE
Rough sketch of 'Cancel applications to full courses after 7th Sep'

### DIFF
--- a/app/services/end_of_cycle/cancel_application_to_full_course.rb
+++ b/app/services/end_of_cycle/cancel_application_to_full_course.rb
@@ -1,0 +1,12 @@
+module EndOfCycle
+  class CancelApplicationToFullCourse
+    def initialize(application_choice)
+      @application_choice = application_choice
+    end
+
+    def call
+      ApplicationStateChange.new(application_choice).cancel!
+      CandidateMailer.send_eoc_email_explaining_that_course_choice_was_cancelled_because_its_full
+    end
+  end
+end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -2,10 +2,16 @@ class EndOfCycleTimetable
   DATES = {
     apply_1_deadline: Date.new(2020, 8, 24),
     apply_2_deadline: Date.new(2020, 9, 18),
+    stop_sending_apply_1_to_providers: Date.new(2020, 9, 7),
     find_closes: Date.new(2020, 9, 19),
     find_reopens: Date.new(2020, 10, 3),
     next_cycle_opens: Date.new(2020, 10, 13),
   }.freeze
+
+  def self.stop_sending_apply_1_to_providers?
+    Time.zone.now > date(:stop_sending_apply_1_to_providers).end_of_day &&
+      Time.zone.now < date(:next_cycle_opens).beginning_of_day
+  end
 
   def self.between_cycles?(phase)
     phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?


### PR DESCRIPTION
## Context

From the card:

As a: DfE Apply
I need to: stop applications from being sent to providers of full courses after 7th September and reject as course full
So that: candidates are aware of what the status of their application is at the end of cycle and why the application was rejected


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add 7th Sep to the EndOfCycleTimetable and expose a helper that checks if we're between that date and the opening of the new cycle.
- When a reference is provided, if the helper returns true and the course choice is full, cancel the choice and send some kind of email.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

This PR illustrates a case-by-case approach that gets invoked on every reference submission. The alternative would be to batch cancel apps at the end of the 7th, but that wouldn't catch courses that become full somewhere between the 7th and the opening of the new cycle.

### Questions

- So we're clear, should we be checking that the chosen course option (study mode at a site) is full, or the whole course?
- What about withdrawn courses? Should we handle them the same way?
- What about courses that aren't full? Should they still go to providers after 7th Sep?

(these 3 addressed here: https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1598263053032300)


- It looks like we're tracking content design of the relevant emails on this card https://trello.com/c/gaGLhi6K/1976-eoc-email-content . 
  - Am I correct in thinking that emails 2 and 3 are the ones that we'd send in the scenario outlined in this PR? cc: @EmmaFrith 
  - Email 1 looks like a separate thing that we'd need to implement.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/iExqduky/1834-tech-spike-prevent-applications-to-full-courses-from-going-to-provider-after-7th-september
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
