### PR TITLE
Reject applications that are awaiting references at the end of the cycle

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -25,7 +25,7 @@ module CandidateInterface
         :blue
       when 'recruited'
         :green
-      when 'declined', 'withdrawn', 'cancelled'
+      when 'declined', 'withdrawn', 'cancelled', 'rejected_at_end_of_cycle'
         :orange
       when 'conditions_not_met'
         :red

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -23,7 +23,7 @@ module ProviderInterface
         :blue
       when 'recruited'
         :green
-      when 'rejected', 'conditions_not_met', 'offer_withdrawn'
+      when 'rejected', 'conditions_not_met', 'offer_withdrawn', 'rejected_at_end_of_cycle'
         :orange
       when 'declined', 'withdrawn'
         :red

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -13,6 +13,7 @@ module ProviderInterface
       'awaiting_provider_decision' => 'Application submitted',
       'withdrawn' => 'Application withdrawn',
       'rejected' => 'Application rejected',
+      'rejected_at_end_of_cycle' => 'Rejected at end of cycle',
       'offer_withdrawn' => 'Offer withdrawn',
       'offer' => 'Offer made',
       'pending_conditions' => 'Offer accepted',

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -23,7 +23,7 @@ module SupportInterface
         :blue
       when 'recruited'
         :green
-      when 'conditions_not_met', 'declined', 'rejected', 'offer_withdrawn', 'withdrawn', 'cancelled'
+      when 'conditions_not_met', 'declined', 'rejected', 'offer_withdrawn', 'withdrawn', 'cancelled', 'rejected_at_end_of_cycle'
         :red
       when 'enrolled'
         :default

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -26,6 +26,7 @@ class ApplicationChoice < ApplicationRecord
     recruited: 'recruited',
     enrolled: 'enrolled',
     rejected: 'rejected',
+    rejected_at_end_of_cycle: 'rejected_at_end_of_cycle',
     offer_withdrawn: 'offer_withdrawn',
     declined: 'declined',
     withdrawn: 'withdrawn',

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -56,8 +56,11 @@ module VendorAPI
     attr_reader :application_choice, :application_form
 
     # V2: for backwards compatibility `offer_withdrawn` state is displayed as `rejected` in the API.
+    # V2: for backwards compatibility `rejected_at_end_of_cycle` state is displayed as `rejected` in the API.
     def status
       if application_choice.offer_withdrawn?
+        'rejected'
+      elsif application_choice.rejected_at_end_of_cycle?
         'rejected'
       else
         application_choice.status

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -8,7 +8,7 @@ class ApplicationStateChange
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited enrolled].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
-  UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn].freeze
+  UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn rejected_at_end_of_cycle].freeze
   DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
 
   attr_reader :application_choice
@@ -32,6 +32,7 @@ class ApplicationStateChange
     state :awaiting_references do
       event :references_complete, transitions_to: :application_complete
       event :cancel, transitions_to: :cancelled
+      event :reject_at_end_of_cycle, transitions_to: :rejected_at_end_of_cycle
     end
 
     state :application_complete do
@@ -49,6 +50,8 @@ class ApplicationStateChange
     state :rejected do
       event :make_offer, transitions_to: :offer
     end
+
+    state :rejected_at_end_of_cycle
 
     state :offer do
       event :make_offer, transitions_to: :offer

--- a/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
+++ b/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class GetPreviousCyclesAwaitingReferencesCourseChoices
+    def self.call
+      return [] unless EndOfCycleTimetable.between_cycles_apply_2?
+
+      ApplicationChoice.includes(:course).awaiting_references
+    end
+  end
+end

--- a/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
+++ b/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     def self.call
       return [] unless EndOfCycleTimetable.between_cycles_apply_2?
 
-      ApplicationChoice.includes(:course).awaiting_references
+      ApplicationChoice.includes(:course).joins(:course).where('courses.recruitment_cycle_year': RecruitmentCycle.current_year - 1).awaiting_references
     end
   end
 end

--- a/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
+++ b/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     def self.call
       return [] unless EndOfCycleTimetable.between_cycles_apply_2?
 
-      ApplicationChoice.includes(:course).joins(:course).where('courses.recruitment_cycle_year': RecruitmentCycle.current_year - 1).awaiting_references
+      ApplicationChoice.includes(:course).joins(:course).where('courses.recruitment_cycle_year': RecruitmentCycle.previous_year).awaiting_references
     end
   end
 end

--- a/app/services/candidate_interface/reject_awaiting_references_application.rb
+++ b/app/services/candidate_interface/reject_awaiting_references_application.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  class RejectAwaitingReferencesApplication
+    def self.call(application_choice)
+      ActiveRecord::Base.transaction do
+        ApplicationStateChange.new(application_choice).reject_at_end_of_cycle!
+        application_choice.update!(
+          rejection_reason: 'Awaiting references when the recruitment cycle closed.',
+          rejected_at: Time.zone.now,
+        )
+      end
+    end
+  end
+end

--- a/app/workers/carry_over_unsubmitted_applications_worker.rb
+++ b/app/workers/carry_over_unsubmitted_applications_worker.rb
@@ -13,7 +13,7 @@ private
     ApplicationForm
       .joins(application_choices: :course)
       .where(submitted_at: nil)
-      .where('courses.recruitment_cycle_year' => RecruitmentCycle.current_year - 1)
+      .where('courses.recruitment_cycle_year' => RecruitmentCycle.previous_year)
       .where(
         'application_forms.id NOT IN (:duplicated_applications)',
         duplicated_applications: ApplicationForm.where.not(previous_application_form_id: nil).select(:previous_application_form_id),

--- a/app/workers/reject_awaiting_references_course_choices_worker.rb
+++ b/app/workers/reject_awaiting_references_course_choices_worker.rb
@@ -1,7 +1,7 @@
 class RejectAwaitingReferencesCourseChoicesWorker
   include Sidekiq::Worker
 
-  def self.perform
+  def perform
     CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices.call.each do |application_choice|
       CandidateInterface::RejectAwaitingReferencesApplication.call(application_choice)
     end

--- a/app/workers/reject_awaiting_references_course_choices_worker.rb
+++ b/app/workers/reject_awaiting_references_course_choices_worker.rb
@@ -1,0 +1,9 @@
+class RejectAwaitingReferencesCourseChoicesWorker
+  include Sidekiq::Worker
+
+  def self.perform
+    CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices.call.each do |application_choice|
+      CandidateInterface::RejectAwaitingReferencesApplication.call(application_choice)
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -21,6 +21,8 @@ class Clock
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
+  every(1.hour, 'RejectAwaitingReferencesCourseChoices', at: '**:50') { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
+
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
     if Time.zone.today.weekday?
       UCASMatching::UploadMatchingData.perform_async

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -21,8 +21,6 @@ class Clock
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
-  every(1.hour, 'RejectAwaitingReferencesCourseChoices', at: '**:50') { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
-
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
     if Time.zone.today.weekday?
       UCASMatching::UploadMatchingData.perform_async

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -54,6 +54,7 @@ en:
     pending_conditions: Offer accepted
     recruited: Conditions met
     rejected: Unsuccessful
+    rejected_at_end_of_cycle: Rejected at end of cycle
     unsubmitted: Not submitted yet
     withdrawn: Application withdrawn
     conditions_not_met: Conditions not met
@@ -61,6 +62,7 @@ en:
     application_complete: Submitted
     awaiting_provider_decision: Submitted
     awaiting_references: Awaiting references
+    rejected_at_end_of_cycle: Rejected at end of cycle
     cancelled: Application cancelled
     declined: Declined
     enrolled: Enrolled
@@ -93,6 +95,10 @@ en:
         - candidate_mailer-chase_reference_again
         - referee_mailer-reference_request_chaser_email
         - referee_mailer-reference_request_chase_again_email
+
+    rejected_at_end_of_cycle:
+      name: Reject at the end of the cycle
+      description: Application choices that are awaiting references are automatically rejected at the end of the cycle
 
     application_complete:
       name: Waiting to be sent
@@ -218,6 +224,11 @@ en:
       name: Candidate cancels
       by: candidate
       description: If the application has not been sent to the provider, the candidate can still cancel the application.
+
+    awaiting_references-reject_at_end_of_cycle:
+      name: Awaiting references applications rejected
+      by: system
+      description: Application choices that are awaiting references are automatically rejected at the end of the cycle
 
     application_complete-cancel:
       name: Candidate cancels

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -394,6 +394,7 @@ components:
           - pending_conditions
           - recruited
           - rejected
+          - rejected_at_end_of_cycle
           - withdrawn
           example: awaiting_provider_decision
         phase:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -394,7 +394,6 @@ components:
           - pending_conditions
           - recruited
           - rejected
-          - rejected_at_end_of_cycle
           - withdrawn
           example: awaiting_provider_decision
         phase:

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
   context 'when application is for an earlier cycle' do
     it 'renders component with correct values' do
       application_choice = create(:application_choice, :with_rejection, application_form: application_form)
-      application_choice.course.update(recruitment_cycle_year: RecruitmentCycle.current_year - 1)
+      application_choice.course.update(recruitment_cycle_year: RecruitmentCycle.previous_year)
 
       result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ApplicationStateChange do
     it 'has corresponding entries in the OpenAPI spec' do
       valid_states_in_openapi = VendorAPISpecification.as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
-      expect(ApplicationStateChange.states_visible_to_provider - %i[offer_withdrawn])
+      expect(ApplicationStateChange.states_visible_to_provider - %i[offer_withdrawn rejected_at_end_of_cycle])
         .to match_array(valid_states_in_openapi.map(&:to_sym))
     end
   end

--- a/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
+++ b/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices do
   describe '#call' do
-    let!(:application_choice1) { create(:awaiting_references_application_choice) }
+    let!(:course_option_from_last_year) { create(:course_option, :previous_year) }
+    let!(:application_choice1) { create(:awaiting_references_application_choice, course_option: course_option_from_last_year) }
 
     before do
       create(:application_choice, :with_offer)

--- a/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
+++ b/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices do
+  describe '#call' do
+    let!(:application_choice1) { create(:awaiting_references_application_choice) }
+
+    before do
+      create(:application_choice, :with_offer)
+    end
+
+    context 'between the apply_2_deadline and the new cycle launching' do
+      it 'returns application forms in the awaiting reference state' do
+        Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
+          expect(described_class.call).to eq [application_choice1]
+        end
+      end
+    end
+
+    context 'before the apply2 deadline' do
+      it 'returns []' do
+        Timecop.travel(EndOfCycleTimetable.apply_2_deadline - 1.day) do
+          expect(described_class.call).to eq []
+        end
+      end
+    end
+
+    context 'after the new cycle has launched' do
+      it 'returns []' do
+        Timecop.travel(EndOfCycleTimetable.next_cycle_opens + 1.day) do
+          expect(described_class.call).to eq []
+        end
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/reject_awaiting_references_application_spec.rb
+++ b/spec/services/candidate_interface/reject_awaiting_references_application_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RejectAwaitingReferencesApplication do
+  describe '#call' do
+    let(:application_choice) { create(:awaiting_references_application_choice) }
+
+    it 'rejects an application at the end of the cycle' do
+      Timecop.freeze do
+        described_class.call(application_choice)
+
+        expect(application_choice.status).to eq 'rejected_at_end_of_cycle'
+        expect(application_choice.rejection_reason).to eq 'Awaiting references when the recruitment cycle closed.'
+        expect(application_choice.rejected_at).to eq Time.zone.now
+      end
+    end
+  end
+end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe EndOfCycleTimetable do
 
     it 'returns false for an application for courses in the previous cycle' do
       expect(
-        described_class.current_cycle?(create_application_for(RecruitmentCycle.current_year - 1)),
+        described_class.current_cycle?(create_application_for(RecruitmentCycle.previous_year)),
       ).to be false
     end
   end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Clockwork do
     { worker: SendAdditionalReferenceChaseEmailToBothPartiesWorker, task: 'SendAdditionalReferenceChaseEmailToCandidates' },
     { worker: SendChaseEmailToProvidersWorker, task: 'SendChaseEmailToProviders' },
     { worker: SendChaseEmailToCandidatesWorker, task: 'SendChaseEmailToCandidates' },
+    { worker: RejectAwaitingReferencesCourseChoicesWorker, task: 'RejectAwaitingReferencesCourseChoices' },
   ].each do |worker|
     describe 'worker schedule' do
       it 'runs the job every hour' do

--- a/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
@@ -16,8 +16,9 @@ RSpec.feature 'Candidates awaiting references application choices are rejected w
   end
 
   def when_the_apply_2_deadline_has_passed
+    FeatureFlag.activate('switch_to_2021_recruitment_cycle')
     Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
-      RejectAwaitingReferencesCourseChoicesWorker.perform
+      RejectAwaitingReferencesCourseChoicesWorker.new.perform
     end
   end
 

--- a/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidates awaiting references application choices are rejected when the new cycle launches' do
+  include CandidateHelper
+
+  scenario 'An application is rejected when find opens for a new cycle' do
+    given_i_have_submitted_my_application
+
+    when_the_apply_2_deadline_has_passed
+    then_the_candidates_application_choices_should_be_rejected
+  end
+
+  def given_i_have_submitted_my_application
+    candidate_completes_application_form
+    candidate_submits_application
+  end
+
+  def when_the_apply_2_deadline_has_passed
+    Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
+      RejectAwaitingReferencesCourseChoicesWorker.perform
+    end
+  end
+
+  def then_the_candidates_application_choices_should_be_rejected
+    expect(@application.application_choices.reload.first.status).to eq 'rejected_at_end_of_cycle'
+    expect(@application.application_choices.reload.first.rejection_reason).to eq 'Awaiting references when the recruitment cycle closed.'
+  end
+end

--- a/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
         :application_choice,
         status: :unsubmitted,
         application_form: unsubmitted_application_from_last_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year - 1)),
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)),
       )
 
       unsubmitted_application_from_this_year = create(
@@ -32,7 +32,7 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
         :application_choice,
         status: :rejected,
         application_form: rejected_application_from_last_year,
-        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year - 1)),
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)),
       )
 
       described_class.new.perform

--- a/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
+++ b/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RejectAwaitingReferencesCourseChoicesWorker do
   describe '#perform' do
     it 'calls the `GetAwaitingReferencesCourseChoicesForPreviousCycle` service' do
       allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices).to receive(:call).and_return([])
-      RejectAwaitingReferencesCourseChoicesWorker.perform
+      RejectAwaitingReferencesCourseChoicesWorker.new.perform
 
       expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices).to have_received(:call)
     end

--- a/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
+++ b/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe RejectAwaitingReferencesCourseChoicesWorker do
+  describe '#perform' do
+    it 'calls the `GetAwaitingReferencesCourseChoicesForPreviousCycle` service' do
+      allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices).to receive(:call).and_return([])
+      RejectAwaitingReferencesCourseChoicesWorker.perform
+
+      expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices).to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
Originally https://github.com/DFE-Digital/apply-for-teacher-training/pull/2755, but it broke QA.

Original PR context:

## Context

When the apply 2 deadline passes. All applications that are awaiting references should be rejected.

A new state 'rejected_at_end_of_cycle' is used (as discussed yesterday) and all the documentation has been updated.

## Changes proposed in this pull request

- Add a worker that runs between apply2 closing and the next cycle launches, that collects awaiting_references applications and rejects them
- Updated all the relevant docs


## Guidance to review


I'm not 100% sure on whether this new state should be exposed in the vendor API. I don't see why not? Might be worth checking with Provendor though.

## Link to Trello card

https://trello.com/c/hX5tD7PX/1959-dev-%F0%9F%9A%B2%F0%9F%94%9A-reject-all-submitted-applications-including-apply-again-as-incomplete-which-havent-been-sent-to-providers-at-the-end-of-t

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
