### PR TITLE
Fix ActiveRecord::RecordInvalid in TestApplications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -8,7 +8,7 @@ class TestApplications
     1.upto(count).flat_map do
       create_application(
         states: [:awaiting_provider_decision] * courses_per_application,
-        courses_to_apply_to: Course.current_cycle.open_on_apply.where(provider: provider),
+        courses_to_apply_to: Course.current_cycle.includes(:course_options).joins(:course_options).distinct.open_on_apply.where(provider: provider),
       )
     end
   end
@@ -38,7 +38,7 @@ class TestApplications
       )
     end
 
-    courses_to_apply_to ||= Course.joins(:course_options).open_on_apply
+    courses_to_apply_to ||= Course.includes(:course_options).joins(:course_options).distinct.open_on_apply
     courses_to_apply_to =
       if course_full
         # Always use the first n courses, so that we can reliably generate


### PR DESCRIPTION
## Context

https://sentry.io/organizations/dfe-bat/issues/1809123768/?project=1765973&referrer=slack

https://sentry.io/organizations/dfe-bat/issues/1848896914/?project=1765973&referrer=slack

## Changes proposed in this pull request

When generating test applications, we call

```ruby
Course.joins(:course_options).open_on_apply
```

Then later:

```ruby
course.course_options.first
```

But `.course_options` can be `[]`.

To filter for records with at least one `course_option`, we need to `.uniq` in addition to the `join`. I don't understand why, the following article says so, and I have tested that it does work:

https://solidfoundationwebdev.com/blog/posts/how-to-find-records-based-on-has_many-relationship-being-empty-or-not-in-rails

I've also added a couple of `.includes` to fix an N+1 query.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/xtxdpCey/1971-investigate-sentry-errors

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)