### PR TITLE
Make Faker's fake university names more diverse

### DIFF
--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -32,7 +32,7 @@ module SupportInterface
     def create_fake_provider
       @new_provider = GenerateFakeProvider.generate_provider(
         {
-          name: Faker::Educator.unique.university,
+          name: Faker::University.name,
           code: Faker::Alphanumeric.unique.alphanumeric(number: 3).upcase,
         },
       )

--- a/config/locales/faker.yml
+++ b/config/locales/faker.yml
@@ -1,0 +1,7 @@
+en:
+  faker:
+    university:
+      name:
+        - "#{Name.last_name} #{University.suffix}"
+        - "#{Name.name} #{University.suffix}"
+        - "#{University.prefix} #{Name.last_name} #{University.suffix}"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -226,9 +226,9 @@ FactoryBot.define do
     predicted_grade { %w[true false].sample }
     start_year { Date.today.year }
     award_year { Faker::Date.between(from: 60.years.ago, to: 3.years.from_now).year }
-    institution_name { Faker::Educator.university }
+    institution_name { Faker::University.name }
     institution_country { Faker::Address.country_code }
-    awarding_body { Faker::Educator.university }
+    awarding_body { Faker::University.name }
     equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
 
     factory :gcse_qualification do
@@ -252,7 +252,7 @@ FactoryBot.define do
       qualification_type { 'Other' }
       other_uk_qualification_type { Faker::Educator.subject }
       subject { Faker::Educator.subject }
-      institution_name { Faker::Educator.university }
+      institution_name { Faker::University.name }
       grade { %w[pass merit distinction].sample }
       institution_country { 'GB' }
 
@@ -261,7 +261,7 @@ FactoryBot.define do
         qualification_type { 'non_uk' }
         non_uk_qualification_type { Faker::Educator.subject }
         subject { Faker::Educator.subject }
-        institution_name { Faker::Educator.university }
+        institution_name { Faker::University.name }
         grade { %w[pass merit distinction].sample }
         institution_country { Faker::Address.country_code }
       end
@@ -340,7 +340,7 @@ FactoryBot.define do
   factory :provider do
     initialize_with { Provider.find_or_initialize_by(code: code) }
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
-    name { Faker::Educator.university }
+    name { Faker::University.name }
 
     trait :with_signed_agreement do
       after(:create) do |provider|


### PR DESCRIPTION
## Context

We see flaky tests and our fake data generation is not very diverse because Faker::Educator.university only has a handful of possible combinations

## Changes proposed in this pull request

- Use Faker::University.name
- Stop it from assigning the names of American states to the universities it creates because that's not good fake data

## Link to Trello card

Flaky tests: https://trello.com/c/sd3pw4Lc/2636-two-flaky-tests

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
