### PR TITLE
Section titles and ordering

### DIFF
--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -2,16 +2,10 @@
 <% application_choice_error = @application_choice_errors && @application_choice_errors.any? %>
 
 <% if !CandidateInterface::EndOfCyclePolicy.can_add_course_choice?(@application_form)%>
-  <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
-    <%= t('page_titles.course_choices') %>
-  </h2>
-
-  <p class="govuk-body">
-    You can apply for courses from 13 October.
-  </p>
+  <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2"><%= t('page_titles.course_choices') %></h2>
+  <p class="govuk-body">You can apply for courses from 13 October.</p>
 <% else %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
-
   <%= render(
     CandidateInterface::CourseChoicesReviewComponent.new(
       application_form: application_form,
@@ -27,56 +21,44 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 
 <h3 class="govuk-heading-m"><%= t('page_titles.personal_details') %></h3>
-
 <%= render(CandidateInterface::PersonalDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
 
 <h3 class="govuk-heading-m"><%= t('page_titles.contact_details') %></h3>
-
 <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
 <h3 class="govuk-heading-m"><%= t('page_titles.training_with_a_disability') %></h3>
-
 <%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.work_history') %></h2>
+<h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
+<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
+<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.work_history') %></h2>
 <%= render(WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.volunteering.short') %></h2>
-
 <%= render(VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
-
-<h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
-
-<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
 <h3 class="govuk-heading-m">Degree(s)</h3>
-
 <%= render(CandidateInterface::DegreesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
 
 <h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
-
 <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
 <h3 class="govuk-heading-m">English GCSE or equivalent</h3>
-
 <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
 <% if @application_form.science_gcse_needed? %>
   <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
-
   <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 <% end %>
 
 <h3 class="govuk-heading-m"><%= t('page_titles.other_qualification') %></h3>
-
 <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
 <% if @application_form.efl_section_required? %>
   <h3 class="govuk-heading-m">English as a foreign language qualification</h3>
-
   <% if @application_form.english_proficiency.present? %>
     <%= render(CandidateInterface::ChooseEflReviewComponent.call(@application_form.english_proficiency)) %>
   <% else %>
@@ -85,11 +67,9 @@
 <% end %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
-
 <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 <%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
-
 <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error, submitting_application: true)) %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -26,23 +26,23 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 
-<h3 class="govuk-heading-m">Personal details</h3>
+<h3 class="govuk-heading-m"><%= t('page_titles.personal_details') %></h3>
 
 <%= render(CandidateInterface::PersonalDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
 
-<h3 class="govuk-heading-m">Contact details</h3>
+<h3 class="govuk-heading-m"><%= t('page_titles.contact_details') %></h3>
 
 <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
-<h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
+<h3 class="govuk-heading-m"><%= t('page_titles.training_with_a_disability') %></h3>
 
 <%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
+<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.work_history') %></h2>
 
 <%= render(WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
+<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.volunteering.short') %></h2>
 
 <%= render(VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
 
@@ -70,7 +70,7 @@
   <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 <% end %>
 
-<h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>
+<h3 class="govuk-heading-m"><%= t('page_titles.other_qualification') %></h3>
 
 <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
@@ -90,6 +90,6 @@
 <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 <%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
+<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
 
 <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error, submitting_application: true)) %>

--- a/app/views/candidate_interface/volunteering/base/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/base/edit.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
+        <span class="govuk-caption-xl"><%= t('page_titles.volunteering.short') %></span>
         <%= t('page_titles.edit_volunteering_role') %>
       </h1>
 

--- a/app/views/candidate_interface/volunteering/base/new.html.erb
+++ b/app/views/candidate_interface/volunteering/base/new.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
+        <span class="govuk-caption-xl"><%= t('page_titles.volunteering.short') %></span>
         <%= t('page_titles.add_volunteering_role') %>
       </h1>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,8 +105,7 @@ en:
     thank_you: Thank you for your feedback
     volunteering:
       short: Unpaid experience and volunteering
-      long: "Unpaid experience working with children and other volunteering"
-      caption: Children and young people
+      long: Unpaid experience working with children and other volunteering
     add_volunteering_role: Add role
     edit_volunteering_role: Edit role
     destroy_volunteering_role: Are you sure you want to delete this role?


### PR DESCRIPTION
## Context

We’re using ‘Children and young people’ as a second abbreviated title for the volunteering section. Not sure where this came from, but it adds confusion having so many different variations for a section name, so reduced it to two. 

## Changes proposed in this pull request

* Use two variations for volunteering section title (removed `caption` variant)
* Also: Use localised strings on application review page
* Also: Correct position for safeguarding section on review page
* Also: White space on review page to make it clearer which headings relate to which components