### PR TITLE
Modify back to application links to back links on additional referee and work history views

### DIFF
--- a/app/views/candidate_interface/additional_referees/confirm.html.erb
+++ b/app/views/candidate_interface/additional_referees/confirm.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, 'Check your referee’s details before confirming' %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_additional_referee_path(@references.last), 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_additional_referee_path(@references.last), 'Back') %>
 
 <h1 class="govuk-heading-xl">
   Check your referee’s details before confirming

--- a/app/views/candidate_interface/work_history/explanation/show.html.erb
+++ b/app/views/candidate_interface/work_history/explanation/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_explanation'), @work_explanation_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

This is made as a follow up to some comments on https://github.com/DFE-Digital/apply-for-teacher-training/pull/2754 after it was merged. 

## Changes proposed in this pull request

I have changed the type of link to a back link on

## Guidance to review

Check that both views render the links correctly.

## Link to Trello card

https://trello.com/c/vA6z2vH7/2003-remaining-incorrect-back-links

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
