### PR TITLE
Carry over unsuccessful applications manually

### DIFF
--- a/app/components/candidate_interface/apply_again_banner_component.html.erb
+++ b/app/components/candidate_interface/apply_again_banner_component.html.erb
@@ -3,9 +3,9 @@
     <div class="govuk-heading-m">
       <p>
       <% if @application_form.application_choices.all?(&:cancelled?) %>
-        Your application has been withdrawn. <%= govuk_link_to 'Do you want to apply again?', candidate_interface_start_apply_again_path %>
+        Your application has been withdrawn. <%= govuk_link_to 'Do you want to apply again?', start_path %>
       <% else %>
-        <%= govuk_link_to 'Do you want to apply again?', candidate_interface_start_apply_again_path %>
+        <%= govuk_link_to 'Do you want to apply again?', start_path %>
       <% end %>
       </p>
 

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -14,5 +14,13 @@ module CandidateInterface
     def render?
       !EndOfCycleTimetable.between_cycles_apply_2?
     end
+
+    def start_path
+      if EndOfCycleTimetable.current_cycle?(@application_form)
+        candidate_interface_start_apply_again_path
+      else
+        candidate_interface_start_carry_over_path
+      end
+    end
   end
 end

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -24,6 +24,12 @@ module CandidateInterface
       redirect_to candidate_interface_before_you_start_path
     end
 
+    def carry_over
+      CarryOverApplication.new(current_application).call
+      flash[:success] = 'Your new application is ready for editing'
+      redirect_to candidate_interface_before_you_start_path
+    end
+
     def edit
       redirect_to candidate_interface_application_complete_path and return unless current_application.can_edit_after_submission?
 

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
 
     def carry_over
       CarryOverApplication.new(current_application).call
-      flash[:success] = 'Your new application is ready for editing'
+      flash[:success] = 'Your application is ready for editing'
       redirect_to candidate_interface_before_you_start_path
     end
 

--- a/app/services/carry_over_application.rb
+++ b/app/services/carry_over_application.rb
@@ -19,7 +19,7 @@ private
 
   def application_from_current_cycle?
     @application_form.application_choices.any? do |application_choice|
-      application_choice.course.recruitment_cycle_year == EndOfCycleTimetable.current_cycle_year
+      application_choice.course.recruitment_cycle_year == RecruitmentCycle.current_year
     end
   end
 end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -90,7 +90,7 @@ class EndOfCycleTimetable
   end
 
   def self.current_cycle?(application_form)
-    application_form.application_choices.all? do |application_choice|
+    application_form.application_choices.includes(:course).all? do |application_choice|
       application_choice.course.recruitment_cycle_year == RecruitmentCycle.current_year
     end
   end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -92,4 +92,10 @@ class EndOfCycleTimetable
       next_cycle_opens: 26.weeks.from_now.to_date,
     }
   end
+
+  def self.current_cycle?(application_form)
+    application_form.application_choices.all? do |application_choice|
+      application_choice.course.recruitment_cycle_year == RecruitmentCycle.current_year
+    end
+  end
 end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -65,10 +65,6 @@ class EndOfCycleTimetable
     DATES[name]
   end
 
-  def self.current_cycle_year
-    RecruitmentCycle.current_year
-  end
-
   def self.next_cycle_year
     RecruitmentCycle.current_year + 1
   end

--- a/app/views/candidate_interface/submitted_application_form/start_carry_over.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/start_carry_over.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, t('page_titles.start_carry_over') %>
+
+<h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over') %></h1>
+
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <p class="govuk-body">If you apply again we'll:</p>
+    <p class="govuk-body">
+      <ul class="govuk-body">
+        <li>edit your saved application, so you do not need to start again</li>
+        <li>keep your references, so you will not need to request new ones</li>
+      </ul>
+    </p>
+
+    <%= button_to 'Start now', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+
+    <p class="govuk-body">or</p>
+
+    <%= govuk_link_to 'Go to your dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,7 @@ en:
       confirm: Confirm offer
     covid_19_guidance: "Coronavirus (COVID-19): deadlines for processing applications extended to 31 May 2020"
     start_apply_again: Do you want to apply again?
+    start_carry_over: Do you want to apply again?
     pick_choice_to_replace: Some of your choices are not available anymore
     pick_replacement_action: Update course choice
     confirm_replacement_course_choice: Your updated course choice

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
       get '/edit' => 'submitted_application_form#edit', as: :application_edit
       get '/start-apply-again' => 'submitted_application_form#start_apply_again', as: :start_apply_again
       post '/apply-again' => 'submitted_application_form#apply_again', as: :apply_again
+      get '/start-carry-over' => 'submitted_application_form#start_carry_over', as: :start_carry_over
+      post '/carry-over' => 'submitted_application_form#carry_over', as: :carry_over
 
       scope '/personal-details' do
         get '/' => 'personal_details/base#new', as: :personal_details_new

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -1,77 +1,48 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
+RSpec.describe CandidateInterface::CarryOverBannerComponent do
   let(:application_form) { create(:completed_application_form) }
 
-  context 'when all course choices have been cancelled' do
-    it 'renders component with correct values' do
-      create(:application_choice, application_form: application_form, status: 'cancelled')
-      create(:application_choice, application_form: application_form, status: 'cancelled')
-      result = render_inline(described_class.new(application_form: application_form))
+  context 'when latest application is unsuccessful and in the current recruitment cycle' do
+    it 'renders nothing' do
+      Timecop.freeze(Time.zone.local(2020, 8, 1, 12, 0, 0)) do
+        create(:application_choice, application_form: application_form, status: 'cancelled')
+        result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Your application has been withdrawn. Do you want to apply again?')
-      expect(result.text).not_to include('The deadline when applying again is')
+        expect(result.text).to be_blank
+      end
     end
   end
 
-  context 'when some course choices were not cancelled' do
+  context 'when latest application is unsuccessful and in the previous recruitment cycle' do
     it 'renders component with correct values' do
-      create(:application_choice, application_form: application_form, status: 'cancelled')
-      create(:application_choice, :with_rejection, application_form: application_form)
-      result = render_inline(described_class.new(application_form: application_form))
+      Timecop.freeze(Time.zone.local(2020, 8, 1, 12, 0, 0)) do
+        create(:application_choice, application_form: application_form, status: 'cancelled')
+        Timecop.freeze(Time.zone.local(2020, 10, 24, 12, 0, 0)) do
+          result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Do you want to apply again?')
-      expect(result.text).not_to include('Your application has been withdrawn.')
-      expect(result.text).not_to include('The deadline when applying again is')
+          expect(result.text).to eq 'foo'
+        end
+      end
     end
   end
 
   describe 'deadline copy' do
-    before do
-      # Set required conditions to display deadline copy
-      FeatureFlag.activate(:deadline_notices)
-      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return true
-    end
-
-    it 'is displayed when conditions are met' do
-      create(:application_choice, application_form: application_form, status: 'cancelled')
-      result = render_inline(described_class.new(application_form: application_form))
-
-      expect(result.text).to include 'The deadline when applying again is'
-    end
-
-    it 'is not displayed when the feature flag is off' do
-      FeatureFlag.deactivate(:deadline_notices)
-
-      create(:application_choice, application_form: application_form, status: 'cancelled')
-      result = render_inline(described_class.new(application_form: application_form))
-
-      expect(result.text).not_to include 'The deadline when applying again is'
-    end
-
-    it 'is not displayed when it\'s not the right time' do
-      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return false
-
-      create(:application_choice, application_form: application_form, status: 'cancelled')
-      result = render_inline(described_class.new(application_form: application_form))
-
-      expect(result.text).not_to include 'The deadline when applying again is'
-    end
   end
 
   describe 'visibility of banner between cycles' do
-    it 'is rendered' do
-      Timecop.freeze(Time.zone.local(2020, 9, 17, 12, 0, 0)) do
-        result = render_inline(described_class.new(application_form: application_form))
-        expect(result.text).to include('Do you want to apply again?')
-      end
-    end
+    # it 'is rendered during cycle' do
+    #   Timecop.freeze(Time.zone.local(2020, 9, 17, 12, 0, 0)) do
+    #     result = render_inline(described_class.new(application_form: application_form))
+    #     expect(result.text).to include('Do you want to apply again?')
+    #   end
+    # end
 
-    it 'is not rendered' do
-      Timecop.freeze(Time.zone.local(2020, 9, 25, 12, 0, 0)) do
-        result = render_inline(described_class.new(application_form: application_form))
-        expect(result.text).to eq('')
-      end
-    end
+    # it 'is not rendered between cycles' do
+    #   Timecop.freeze(Time.zone.local(2020, 9, 25, 12, 0, 0)) do
+    #     result = render_inline(described_class.new(application_form: application_form))
+    #     expect(result.text).to eq('')
+    #   end
+    # end
   end
 end

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -1,48 +1,93 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::CarryOverBannerComponent do
+RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
   let(:application_form) { create(:completed_application_form) }
 
-  context 'when latest application is unsuccessful and in the current recruitment cycle' do
-    it 'renders nothing' do
-      Timecop.freeze(Time.zone.local(2020, 8, 1, 12, 0, 0)) do
-        create(:application_choice, application_form: application_form, status: 'cancelled')
-        result = render_inline(described_class.new(application_form: application_form))
+  context 'when all course choices have been cancelled' do
+    it 'renders component with correct values' do
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      result = render_inline(described_class.new(application_form: application_form))
 
-        expect(result.text).to be_blank
-      end
+      expect(result.text).to include('Your application has been withdrawn. Do you want to apply again?')
+      expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_apply_again_path)
+      expect(result.text).not_to include('The deadline when applying again is')
     end
   end
 
-  context 'when latest application is unsuccessful and in the previous recruitment cycle' do
+  context 'when some course choices were not cancelled' do
     it 'renders component with correct values' do
-      Timecop.freeze(Time.zone.local(2020, 8, 1, 12, 0, 0)) do
-        create(:application_choice, application_form: application_form, status: 'cancelled')
-        Timecop.freeze(Time.zone.local(2020, 10, 24, 12, 0, 0)) do
-          result = render_inline(described_class.new(application_form: application_form))
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      create(:application_choice, :with_rejection, application_form: application_form)
+      result = render_inline(described_class.new(application_form: application_form))
 
-          expect(result.text).to eq 'foo'
-        end
-      end
+      expect(result.text).to include('Do you want to apply again?')
+      expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_apply_again_path)
+      expect(result.text).not_to include('Your application has been withdrawn.')
+      expect(result.text).not_to include('The deadline when applying again is')
+    end
+  end
+
+  context 'when application is for an earlier cycle' do
+    it 'renders component with correct values' do
+      application_choice = create(:application_choice, :with_rejection, application_form: application_form)
+      application_choice.course.update(recruitment_cycle_year: RecruitmentCycle.current_year - 1)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include('Do you want to apply again?')
+      expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_carry_over_path)
+      expect(result.text).not_to include('Your application has been withdrawn.')
+      expect(result.text).not_to include('The deadline when applying again is')
     end
   end
 
   describe 'deadline copy' do
+    before do
+      # Set required conditions to display deadline copy
+      FeatureFlag.activate(:deadline_notices)
+      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return true
+    end
+
+    it 'is displayed when conditions are met' do
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include 'The deadline when applying again is'
+    end
+
+    it 'is not displayed when the feature flag is off' do
+      FeatureFlag.deactivate(:deadline_notices)
+
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).not_to include 'The deadline when applying again is'
+    end
+
+    it 'is not displayed when it\'s not the right time' do
+      allow(EndOfCycleTimetable).to receive(:show_apply_2_deadline_banner?).and_return false
+
+      create(:application_choice, application_form: application_form, status: 'cancelled')
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).not_to include 'The deadline when applying again is'
+    end
   end
 
   describe 'visibility of banner between cycles' do
-    # it 'is rendered during cycle' do
-    #   Timecop.freeze(Time.zone.local(2020, 9, 17, 12, 0, 0)) do
-    #     result = render_inline(described_class.new(application_form: application_form))
-    #     expect(result.text).to include('Do you want to apply again?')
-    #   end
-    # end
+    it 'is rendered' do
+      Timecop.freeze(Time.zone.local(2020, 9, 17, 12, 0, 0)) do
+        result = render_inline(described_class.new(application_form: application_form))
+        expect(result.text).to include('Do you want to apply again?')
+      end
+    end
 
-    # it 'is not rendered between cycles' do
-    #   Timecop.freeze(Time.zone.local(2020, 9, 25, 12, 0, 0)) do
-    #     result = render_inline(described_class.new(application_form: application_form))
-    #     expect(result.text).to eq('')
-    #   end
-    # end
+    it 'is not rendered' do
+      Timecop.freeze(Time.zone.local(2020, 9, 25, 12, 0, 0)) do
+        result = render_inline(described_class.new(application_form: application_form))
+        expect(result.text).to eq('')
+      end
+    end
   end
 end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -248,4 +248,28 @@ RSpec.describe EndOfCycleTimetable do
       end
     end
   end
+
+  describe '.current_cycle?' do
+    def create_application_for(recruitment_cycle_year)
+      application_form = create :application_form
+      create(
+        :application_choice,
+        application_form: application_form,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: recruitment_cycle_year)),
+      )
+      application_form
+    end
+
+    it 'returns true for an application for courses in the current cycle' do
+      expect(
+        described_class.current_cycle?(create_application_for(RecruitmentCycle.current_year)),
+      ).to be true
+    end
+
+    it 'returns false for an application for courses in the previous cycle' do
+      expect(
+        described_class.current_cycle?(create_application_for(RecruitmentCycle.current_year - 1)),
+      ).to be false
+    end
+  end
 end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     and_i_am_in_the_2020_recruitment_cycle
     and_i_have_an_application_with_a_rejection
 
+    when_the_2020_recruitment_cycle_ends
+    and_i_visit_my_application_complete_page
+    then_i_cannot_apply_again
+
     when_the_2021_recruitment_cycle_begins
     and_i_visit_my_application_complete_page
     and_i_click_on_apply_again
@@ -36,6 +40,18 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     create(:application_choice, :with_rejection, application_form: @application_form)
   end
 
+  def when_the_2020_recruitment_cycle_ends
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 9, 20, 12, 0, 0))
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2021)
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def then_i_cannot_apply_again
+    expect(page).not_to have_link 'Do you want to apply again?'
+  end
+
   def when_the_2021_recruitment_cycle_begins
     Timecop.safe_mode = false
     Timecop.travel(Time.zone.local(2020, 10, 15, 12, 0, 0))
@@ -45,6 +61,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_visit_my_application_complete_page
+    logout
+    login_as(@candidate)
     visit candidate_interface_application_complete_path
   end
 

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
   scenario 'when an unsuccessful candidate returns in the next recruitment cycle they can re-apply by carrying over their original application' do
     given_i_am_signed_in
+    and_i_am_in_the_2020_recruitment_cycle
     and_i_have_an_application_with_a_rejection
 
-    when_the_next_recruitment_cycle_begins
+    when_the_2021_recruitment_cycle_begins
     and_i_visit_my_application_complete_page
     and_i_click_on_apply_again
     and_i_click_on_start_now
@@ -26,14 +27,19 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     login_as(@candidate)
   end
 
+  def and_i_am_in_the_2020_recruitment_cycle
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2020)
+  end
+
   def and_i_have_an_application_with_a_rejection
     @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
     create(:application_choice, :with_rejection, application_form: @application_form)
   end
 
-  def when_the_next_recruitment_cycle_begins
+  def when_the_2021_recruitment_cycle_begins
     Timecop.safe_mode = false
     Timecop.travel(Time.zone.local(2020, 10, 15, 12, 0, 0))
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2021)
   ensure
     Timecop.safe_mode = true
   end
@@ -56,10 +62,12 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def then_i_can_see_application_details
-    pending
+    # pending
   end
 
   def and_i_can_see_that_no_courses_are_selected
-    pending
+    expect(page).to have_content('Course choice Incomplete')
+    click_link 'Course choice'
+    save_and_open_page
   end
 end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_apply_again
-    # TODO: Work out what the link copy should be
     click_link 'Do you want to apply again?'
   end
 
@@ -62,12 +61,15 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def then_i_can_see_application_details
-    # pending
+    expect(page).to have_content('Personal details Completed')
+    click_link 'Personal details'
+    expect(page).to have_content(@application_form.full_name)
+    click_button 'Continue'
   end
 
   def and_i_can_see_that_no_courses_are_selected
     expect(page).to have_content('Course choice Incomplete')
     click_link 'Course choice'
-    save_and_open_page
+    expect(page).to have_content 'You can apply for up to 3 courses'
   end
 end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate can carry over unsuccessful application to a new recruitment cycle' do
+  around do |example|
+    Timecop.freeze(Date.new(2020, 8, 1)) do
+      example.run
+    end
+  end
+
+  scenario 'when an unsuccessful candidate returns in the next recruitment cycle they can re-apply by carrying over their original application' do
+    given_i_am_signed_in
+    and_i_have_an_application_with_a_rejection
+
+    when_the_next_recruitment_cycle_begins
+    and_i_visit_my_application_complete_page
+    and_i_click_on_apply_again
+    and_i_click_on_start_now
+    and_i_click_go_to_my_application_form
+
+    then_i_can_see_application_details
+    and_i_can_see_that_no_courses_are_selected
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_application_with_a_rejection
+    @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
+    create(:application_choice, :with_rejection, application_form: @application_form)
+  end
+
+  def when_the_next_recruitment_cycle_begins
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 10, 15, 12, 0, 0))
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def and_i_visit_my_application_complete_page
+    visit candidate_interface_application_complete_path
+  end
+
+  def and_i_click_on_apply_again
+    # TODO: Work out what the link copy should be
+    click_link 'Do you want to apply again?'
+  end
+
+  def and_i_click_on_start_now
+    click_button 'Start now'
+  end
+
+  def and_i_click_go_to_my_application_form
+    click_link 'Go to your application form'
+  end
+
+  def then_i_can_see_application_details
+    pending
+  end
+
+  def and_i_can_see_that_no_courses_are_selected
+    pending
+  end
+end


### PR DESCRIPTION
## Context

This PR implements the front-end that allows candidates to carry over applications that were unsuccessful in an earlier recruitment cycle. It is modelled on existing Apply Again functionality with some adjustments to the content and application flow.

## Changes proposed in this pull request

- [x] Implement new `carry_over` and `start_carry_over` actions for `SubmittedApplicationFormController`.
- [x] Adapt the `ApplyAgainBannerComponent` so that it can be used for both same-cycle (Apply 2) and later-cycle (carry over) re-applications. When the earlier application is from a different cycle it is now linked to the `SubmittedApplicationFormController#start_carry_over` rather than `start_apply_again` action.
- [x] System spec that walks through the carry over process.
- [x] Refine the content for the 'carry over application' journey 

I've made only minor changes to the copy on the pages that appear as part of the carry over flow. Just to remove the line _You could still get a place on a course this year_ and on the choose courses page removed the _new_ from the flash message _Your new application is ready for editing_ as well as the reference to only being able to pick one course.

We want to remove the _we suggest you choose a course first_ page but that will be covered in a different card/PR.

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/450843/91151977-46885e80-e6b6-11ea-82af-1622ae074c78.png">

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/450843/91152026-556f1100-e6b6-11ea-8083-8158038ec5c9.png">

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/450843/91368423-ece07b00-e800-11ea-9954-494d17423f45.png">

## Guidance to review

- To test manually you'll need some kind of unsuccessful application from 2020 (any of those created by the test application generator will do) and then change to the 2021 recruitment cycle by flipping the `switch_to_2021_recruitment_cycle` and `simulate time mid cycle` feature flags.
- Does the system spec make sense?
- For now at least it should only be possible to carry over an application after the 2021 cycle reopens so there is no feature to allow candidates to carry over mid cycle and start preparing their application before being able to submit it. Not sure whether this is going to be a requirement but I think it's best dealt with as a separate card/PR.

## Link to Trello card

https://trello.com/c/IzMDhv0p/1907-dev-🚲🔚-carried-over-applications-have-courses-removed

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
