### PR TITLE
Allow providers to filter applications by recruitment cycle

### DIFF
--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -17,7 +17,7 @@
             </div>
             <div class="moj-filter__heading-action">
               <p class="govuk-body">
-              <%= link_to "Clear", provider_interface_applications_path(sort_by: @page_state.sort_by) %>
+              <%= govuk_link_to "Clear", provider_interface_applications_path(sort_by: @page_state.sort_by), class: 'govuk-link--no-visited-state' %>
               </p>
             </div>
           </div>

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -16,8 +16,8 @@ class TestApplications
   def create_application(states:, courses_to_apply_to: nil, apply_again: false, course_full: false)
     candidate = nil
 
-    min_days_in_the_past = courses_to_apply_to&.first&.recruitment_cycle_year == RecruitmentCycle.previous_year ? 395 : 30
-    travel_to rand(min_days_in_the_past..(min_days_in_the_past + 60)).days.ago
+    min_days_in_the_past = courses_to_apply_to&.first&.recruitment_cycle_year == RecruitmentCycle.previous_year ? 385 : 20
+    travel_to rand(min_days_in_the_past..(min_days_in_the_past + 30)).days.ago
 
     if apply_again
       raise OnlyOneCourseWhenApplyingAgainError, 'You can only apply to one course when applying again' unless states.one?
@@ -116,7 +116,7 @@ class TestApplications
         # time to decide whether edit_by has passed, temporarily set edit_by to
         # a date in the future relative to now
         @application_form.application_choices.each { |choice| choice.update_columns(updated_at: time) }
-        @application_form.update_columns(submitted_at: time, edit_by: Time.zone.now + 1.day, updated_at: time)
+        @application_form.update_columns(submitted_at: time, edit_by: Time.zone.now + 7.days, updated_at: time)
 
         return if states.include? :awaiting_references
 
@@ -159,10 +159,10 @@ class TestApplications
     travel_to(choice.application_form.edit_by) if choice.application_form.edit_by > time
     SendApplicationToProvider.new(application_choice: choice).call
     choice.update_columns(sent_to_provider_at: time)
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
     SetRejectByDefault.new(choice).call
     choice.update_columns(updated_at: time)
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
 
     return if state == :awaiting_provider_decision
 
@@ -202,21 +202,21 @@ class TestApplications
     fast_forward(1..3)
     AcceptOffer.new(application_choice: choice).save!
     choice.update_columns(accepted_at: time, updated_at: time)
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def withdraw_application(choice)
     fast_forward(1..3)
     WithdrawApplication.new(application_choice: choice).save!
     choice.update_columns(withdrawn_at: time, updated_at: time)
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def decline_offer(choice)
     fast_forward(1..3)
     DeclineOffer.new(application_choice: choice).save!
     choice.update_columns(declined_at: time, updated_at: time)
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def make_offer(choice, conditions: ['Complete DBS'])
@@ -230,7 +230,7 @@ class TestApplications
       ).save
       choice.update_columns(offered_at: time, updated_at: time)
     end
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def reject_application(choice)
@@ -239,7 +239,7 @@ class TestApplications
       RejectApplication.new(actor: actor, application_choice: choice, rejection_reason: 'Some').save
       choice.update_columns(rejected_at: time, updated_at: time)
     end
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def withdraw_offer(choice)
@@ -248,7 +248,7 @@ class TestApplications
       WithdrawOffer.new(actor: actor, application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
       choice.update_columns(withdrawn_at: time, updated_at: time)
     end
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def conditions_not_met(choice)
@@ -257,7 +257,7 @@ class TestApplications
       ConditionsNotMet.new(actor: actor, application_choice: choice).save
       choice.update_columns(conditions_not_met_at: time, updated_at: time)
     end
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def confirm_offer_conditions(choice)
@@ -266,7 +266,7 @@ class TestApplications
       ConfirmOfferConditions.new(actor: actor, application_choice: choice).save
       choice.update_columns(recruited_at: time, updated_at: time)
     end
-    choice.audits.last.update_columns(created_at: time)
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def add_note(choice)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,6 +12,7 @@ class Course < ApplicationRecord
   scope :open_on_apply, -> { exposed_in_find.where(open_on_apply: true) }
   scope :exposed_in_find, -> { where(exposed_in_find: true) }
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.current_year) }
+  scope :previous_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.previous_year) }
 
   CODE_LENGTH = 4
 

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -57,6 +57,8 @@ module ProviderInterface
     end
 
     def recruitment_cycle_filter
+      return nil unless FeatureFlag.active?(:providers_can_filter_by_recruitment_cycle)
+
       current_year = RecruitmentCycle.current_year
       previous_year = RecruitmentCycle.previous_year
 

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -18,7 +18,7 @@ module ProviderInterface
     end
 
     def filters
-      ([] << search_filter << status_filter << provider_filter << accredited_provider_filter).concat(provider_locations_filters).compact
+      ([] << search_filter << recruitment_cycle_filter << status_filter << provider_filter << accredited_provider_filter).concat(provider_locations_filters).compact
     end
 
     def filtered?
@@ -36,7 +36,7 @@ module ProviderInterface
   private
 
     def parse_params(params)
-      params.permit(:candidate_name, :sort_by, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
+      params.permit(:candidate_name, :sort_by, recruitment_cycle_year: [], provider: [], status: [], accredited_provider: [], provider_location: []).to_h
     end
 
     def save_filter_state!
@@ -53,6 +53,31 @@ module ProviderInterface
         heading: 'Candidate’s name',
         value: applied_filters[:candidate_name],
         name: 'candidate_name',
+      }
+    end
+
+    def recruitment_cycle_filter
+      current_year = RecruitmentCycle.current_year
+      previous_year = RecruitmentCycle.previous_year
+
+      label = {
+        current_year => "#{current_year} to #{current_year + 1} (Current)",
+        previous_year => "#{previous_year} to #{previous_year + 1}",
+      }
+
+      cycle_options = [current_year, previous_year].map do |year|
+        {
+          value: year,
+          label: label[year],
+          checked: applied_filters[:recruitment_cycle_year]&.include?(year.to_s),
+        }
+      end
+
+      {
+        type: :checkboxes,
+        heading: 'Cycle',
+        name: 'recruitment_cycle_year',
+        options: cycle_options,
       }
     end
 

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -6,4 +6,12 @@ module RecruitmentCycle
       2020
     end
   end
+
+  def self.previous_year
+    current_year - 1
+  end
+
+  def self.visible_years
+    [current_year, previous_year]
+  end
 end

--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -17,9 +17,9 @@ class GetApplicationChoicesForProviders
     ]
 
     ApplicationChoice.includes(*includes)
-      .where('courses.provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.current_year)
+      .where('courses.provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.visible_years)
       .or(ApplicationChoice.includes(*includes)
-        .where('courses.accredited_provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.current_year))
+        .where('courses.accredited_provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.visible_years))
       .where('status IN (?)', ApplicationStateChange.states_visible_to_provider).includes([:accredited_provider])
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,6 +28,7 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
+    [:providers_can_filter_by_recruitment_cycle, 'Allows provider users to filter applications by recruitment cycle', 'Michael Nacos'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -14,6 +14,13 @@ class FilterApplicationChoicesForProviders
       application_choices.where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name}%")
     end
 
+    def recruitment_cycle_year(application_choices, years)
+      return application_choices if years.blank?
+
+      application_choices.where('courses.recruitment_cycle_year' => years)
+      # FIXME: what about carried over and offered_option
+    end
+
     def status(application_choices, statuses)
       return application_choices if statuses.blank?
 
@@ -40,6 +47,7 @@ class FilterApplicationChoicesForProviders
 
     def create_filter_query(application_choices, filters)
       filtered_application_choices = search(application_choices, filters[:candidate_name])
+      filtered_application_choices = recruitment_cycle_year(filtered_application_choices, filters[:recruitment_cycle_year])
       filtered_application_choices = provider(filtered_application_choices, filters[:provider])
       filtered_application_choices = accredited_provider(filtered_application_choices, filters[:accredited_provider])
       filtered_application_choices = status(filtered_application_choices, filters[:status])

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -18,7 +18,6 @@ class FilterApplicationChoicesForProviders
       return application_choices if years.blank?
 
       application_choices.where('courses.recruitment_cycle_year' => years)
-      # FIXME: what about carried over and offered_option
     end
 
     def status(application_choices, statuses)

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -17,6 +17,8 @@ class FilterApplicationChoicesForProviders
     def recruitment_cycle_year(application_choices, years)
       return application_choices if years.blank?
 
+      return application_choices unless FeatureFlag.active?(:providers_can_filter_by_recruitment_cycle)
+
       application_choices.where('courses.recruitment_cycle_year' => years)
     end
 

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -5,5 +5,18 @@ end
 
 desc 'Generate test applications for existing providers'
 task generate_test_applications: :environment do
-  GenerateTestApplications.new.perform
+  GenerateTestApplications.new(for_year: :previous_year).perform
+
+  GetApplicationChoicesReadyToRejectByDefault.call.find_each do |choice|
+    rbd = choice.reject_by_default_at
+    choice.update_columns(
+      status: 'rejected',
+      rejected_by_default: true,
+      rejected_at: rbd,
+      updated_at: rbd,
+    )
+    choice.application_form.update_columns(updated_at: rbd)
+  end
+
+  GenerateTestApplications.new(for_year: :current_year).perform
 end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -44,6 +44,7 @@ task sync_dev_providers_and_open_courses: :environment do
 
   provider_codes = HostingEnvironment.review? ? %w[1JA 24J] : %w[1JA 24J 1N1]
   provider_codes.each do |code|
+    SyncProviderFromFind.call(provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.previous_year)
     SyncProviderFromFind.call(provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -297,6 +297,10 @@ FactoryBot.define do
     trait :no_vacancies do
       vacancy_status { 'no_vacancies' }
     end
+
+    trait :previous_year do
+      course { create(:course, :previous_year) }
+    end
   end
 
   factory :course do
@@ -334,6 +338,10 @@ FactoryBot.define do
 
     trait :part_time do
       study_mode { :part_time }
+    end
+
+    trait :previous_year do
+      recruitment_cycle_year { RecruitmentCycle.previous_year }
     end
   end
 
@@ -463,6 +471,10 @@ FactoryBot.define do
       status { 'declined' }
       declined_at { Time.zone.now }
       declined_by_default { true }
+    end
+
+    trait :previous_year do
+      course_option { create(:course_option, :previous_year) }
     end
   end
 

--- a/spec/queries/get_application_choices_for_providers_spec.rb
+++ b/spec/queries/get_application_choices_for_providers_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe GetApplicationChoicesForProviders do
     )
 
     returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
-    expect(returned_applications.size).to be(2)
+    expect(returned_applications.size).to eq(2)
   end
 
   it 'returns the application for multiple providers' do
@@ -99,7 +99,7 @@ RSpec.describe GetApplicationChoicesForProviders do
     )
 
     returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
-    expect(returned_applications.size).to be(3)
+    expect(returned_applications.size).to eq(3)
   end
 
   it 'returns application_choice that the provider is the accredited body for' do

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     )
 
     get_api_request "/api/v1/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
-    expect(parsed_response['data'].size).to be(2)
+    expect(parsed_response['data'].size).to eq(2)
   end
 
   it 'returns applications filtered with `since`' do
@@ -38,7 +38,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     get_api_request "/api/v1/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
 
-    expect(parsed_response['data'].size).to be(1)
+    expect(parsed_response['data'].size).to eq(1)
   end
 
   it 'returns a response that is valid according to the OpenAPI schema' do
@@ -98,6 +98,6 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     get_api_request "/api/v1/applications?since=#{CGI.escape((Time.zone.now - 1.day).iso8601)}"
 
-    expect(parsed_response['data'].size).to be(2)
+    expect(parsed_response['data'].size).to eq(2)
   end
 end

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -182,7 +182,7 @@ RSpec.feature 'See providers' do
     expect(page).to have_content 'Primary (ABC-1) - Full time at Main site Vacancies'
 
     within '[data-qa="applications"]' do
-      expect(page.all('tbody tr').size).to be(2)
+      expect(page.all('tbody tr').size).to eq(2)
     end
   end
 


### PR DESCRIPTION
## Context

When the current recruitment cycle ends, all current applications will suddenly become previous year applications. Some of these applications will be carried over to the new cycle (handled in another piece of work), but many will remain in the previous cycle. Some of these will be actionable and should surface in the provider interface still. The plan is to break down the applications list into prioritised sections (see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2742).

This PR allows provider users to filter applications based on the recruitment cycle.

## Changes proposed in this pull request

Change the default visibility of applications to span two years (`:previous_year` and `:current_year`). Present users with the relevant controls.

![image](https://user-images.githubusercontent.com/107591/91165291-527d1c00-e6c8-11ea-8d43-1cf99b9c3b54.png)

I've reused the existing filtering mechanism, so combinations of search and status, provider, location filters can be used as well as recruitment_cycle. Changing the default visibility to span two years means that search will surface appllications from the previous year, too -- which has been identified as a user expectation in research.

To be able to merge this, I have created a feature flag `:providers_can_filter_by_recruitment_year`. When this flag is off, any cycle-related filtering param is ignored and the relevant UI controls are hidden.

This PR also changes the `setup_local_dev_data` task to sync courses from the previous year and generate test applications for the previous cycle, too. This is meant to assist with reviewing/testing this PR but all other End-of-Cycle bits of work, too. Finally, I've started adding `:previous_year` traits to `spec/factories.rb`.

## Guidance to review

Best way to test is interact with the review app. To test locally, you may have to drop, recreate your database and run `rake setup_local_dev_data`. You'll then need to turn the feature flag on to see the cycle filtering controls.

Is the feature flag needed? Should it be merged with `:switch_to_2021_recruitment_cycle`?

Some generated previous year applications may not look right, e.g. they should have been declined by default but aren't. I've dealt with rejection by default for previous cycle applications because we currently support sorting based on 'days left to respond', which depends on applications being rejected when they should be. In future work we could also handle 'decline by default' and automated application EoC transitions.

Sorting by 'days left to respond' may appear broken within the review app for the applications you cannot respond to, as we currently fall back to:
```
  reject_by_default_at ASC,
  application_choices.updated_at DESC
```
and there are many applications with `reject_by_default_at` in the past now, which takes precedence over `updated_at`. Not worth fixing, as we'll soon change the default applications order.

## Link to Trello card

https://trello.com/c/kO6hOtJG

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
