### PR TITLE
Introduce an API field indicating whether safeguarding information has been supplied

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -43,6 +43,7 @@ module VendorAPI
           rejection: get_rejection,
           withdrawal: withdrawal,
           further_information: application_form.further_information,
+          safeguarding_issues_status: application_form.safeguarding_issues_status,
         },
       }
       if application_choice.status == 'enrolled'

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -1,5 +1,7 @@
 module VendorAPI
   class SingleApplicationPresenter
+    include Rails.application.routes.url_helpers
+
     def initialize(application_choice)
       @application_choice = application_choice
       @application_form = application_choice.application_form
@@ -44,6 +46,7 @@ module VendorAPI
           withdrawal: withdrawal,
           further_information: application_form.further_information,
           safeguarding_issues_status: application_form.safeguarding_issues_status,
+          safeguarding_issues_details_url: safeguarding_issues_details_url,
         },
       }
       if application_choice.status == 'enrolled'
@@ -263,6 +266,10 @@ module VendorAPI
       else
         ''
       end
+    end
+
+    def safeguarding_issues_details_url
+      application_form.has_safeguarding_issues_to_declare? ? provider_interface_application_choice_url(application_choice, anchor: 'criminal-convictions-and-professional-misconduct') : nil
     end
   end
 end

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 28th August 2020
+
+New attributes:
+
+- `Application` now has a `safeguarding_issues_status` attribute of type string and an optional `safeguarding_issues_details_url` attribute of type string.
+
 ### 24th August 2020
 
 - Fix a bug where the study mode of a chosen or offered course appeared as

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -40,7 +40,7 @@
 
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
     <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user)%>
 
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -375,6 +375,7 @@ components:
       - further_information
       - work_experience
       - safeguarding_issues_status
+      - safeguarding_issues_details_url
       properties:
         support_reference:
           type: string
@@ -480,6 +481,11 @@ components:
           - has_safeguarding_issues_to_declare
           - never_asked
           example: has_safeguarding_issues_to_declare
+        safeguarding_issues_details_url:
+          type: string
+          description: URL to Apply system where safeguarding issues disclosed by the candidate can be access by users with permissions to view safeguarding information.
+          example: https://apply-for-teacher-training.service.gov.uk/provider/applications/1#criminal-convictions-and-professional-misconduct
+          nullable: true
     Candidate:
       type: object
       additionalProperties: false

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -374,6 +374,7 @@ components:
       - withdrawal
       - further_information
       - work_experience
+      - safeguarding_issues_status
       properties:
         support_reference:
           type: string
@@ -471,6 +472,14 @@ components:
           description: Other personal or professional issues relevant to the application
             which are not covered in the form
           example: I am expecting to be called for jury service in the next 12 months
+        safeguarding_issues_status:
+          type: string
+          description: Status of candidate's response to the safeguarding issues declaration
+          enum:
+          - no_safeguarding_issues_to_declare
+          - has_safeguarding_issues_to_declare
+          - never_asked
+          example: has_safeguarding_issues_to_declare
     Candidate:
       type: object
       additionalProperties: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
       uk_residency_status { 'I have the right to study and/or work in the UK' }
       disclose_disability { %w[true false].sample }
       disability_disclosure { Faker::Lorem.paragraph_by_chars(number: 300) }
+      safeguarding_issues_status { 'no_safeguarding_issues_to_declare' }
       submitted_at { Faker::Time.backward(days: 7, period: :day) }
       edit_by { submitted_at ? 5.business_days.after(submitted_at) : nil }
       phone_number { Faker::PhoneNumber.cell_phone }

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -216,6 +216,35 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.safeguarding_issues_details_url' do
+    it 'returns the url if the status is has_safeguarding_issues_to_declare' do
+      application_form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :safeguarding_issues_details_url)).to include("/provider/applications/#{application_choice.id}#criminal-convictions-and-professional-misconduct")
+    end
+
+    it 'returns nil if the status is no_safeguarding_issues_to_declare' do
+      application_form = create(:completed_application_form, :with_no_safeguarding_issues_to_declare)
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :safeguarding_issues_details_url)).to eq(nil)
+    end
+
+    it 'returns nil if the status is never_asked' do
+      application_form = create(:completed_application_form, :with_safeguarding_issues_never_asked)
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :safeguarding_issues_details_url)).to eq(nil)
+    end
+  end
+
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
       let(:application_choice) do

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -205,6 +205,17 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.safeguarding_issues_status' do
+    it 'returns the safeguarding issues status' do
+      application_form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :safeguarding_issues_status)).to eq('has_safeguarding_issues_to_declare')
+    end
+  end
+
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
       let(:application_choice) do

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -179,6 +179,7 @@ RSpec.feature 'Vendor receives the application' do
         reject_by_default_at: @application.application_choices.first.reject_by_default_at.iso8601,
         withdrawal: nil,
         further_information: '',
+        safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
         work_experience: {
           jobs: [
             {

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -180,6 +180,7 @@ RSpec.feature 'Vendor receives the application' do
         withdrawal: nil,
         further_information: '',
         safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
+        safeguarding_issues_details_url: Rails.application.routes.url_helpers.provider_interface_application_choice_url(@provider.application_choices.first.id, anchor: 'criminal-convictions-and-professional-misconduct'),
         work_experience: {
           jobs: [
             {


### PR DESCRIPTION
## Context

We do not want to send safeguarding information via the API as it means our clients become liable for looking after this sensitive data. They do need to know whether this information is present, though. Provider users will need to sign in to the web UI to see safeguarding information.

## Changes proposed in this pull request

Add new fields to the Application object:
- `safeguarding_issues_status`
- `safeguarding_issues_details_url`

## Guidance to review

- do the descriptions make sense?
- is the example URL (with id) ok?
- is it ok to include url_helpers?

## Link to Trello card

https://trello.com/c/4CO0fhJ7/2584-introduce-an-api-field-indicating-whether-safeguarding-information-has-been-supplied

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
