### PR TITLE
Update back links to use gov_back_link_to so that they work contextually from both review screens

### DIFF
--- a/app/views/candidate_interface/degrees/base/edit.html.erb
+++ b/app/views/candidate_interface/degrees/base/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_degree'), @degree.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/degrees/grade/edit.html.erb
+++ b/app/views/candidate_interface/degrees/grade/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_grade'), @degree_grade_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/degrees/institution/edit.html.erb
+++ b/app/views/candidate_interface/degrees/institution/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_institution'), @degree_institution_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/degrees/naric_statement/edit.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_naric_statement'), @degree_naric_statement_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/degrees/subject/edit.html.erb
+++ b/app/views/candidate_interface/degrees/subject/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.degree_subject'), @degree_subject_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/degrees/type/edit.html.erb
+++ b/app/views/candidate_interface/degrees/type/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_degree_type'), @degree_type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/degrees/year/edit.html.erb
+++ b/app/views/candidate_interface/degrees/year/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.when_did_you_study_for_your_degree'), @degree_year_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/other_qualifications/details/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.qualification_details'), @qualification.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/other_qualifications/type/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_other_qualification'), @qualification_type.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/personal_details/base/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/base/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.personal_details'), @personal_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_show_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/personal_details/languages/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/languages/edit.html.erb
@@ -1,4 +1,4 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.languages'), @languages_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_show_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <%= render partial: 'shared_form' %>

--- a/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.nationalities'), @nationalities_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_show_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.right_to_work'), @right_to_work_or_study_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_show_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/referees/edit.html.erb
+++ b/app/views/candidate_interface/referees/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_referee'), @referee.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_referees_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/referees/type.html.erb
+++ b/app/views/candidate_interface/referees/type.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix('What kind of reference are you adding?', @reference_type_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_referees_path) %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/volunteering/base/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/base/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_volunteering_role'), @volunteering_role.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_volunteering_path) %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/break/edit.html.erb
+++ b/app/views/candidate_interface/work_history/break/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_break'), @work_break.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/breaks/edit.html.erb
+++ b/app/views/candidate_interface/work_history/breaks/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.work_history_breaks'), @work_breaks_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/work_history/edit/edit.html.erb
+++ b/app/views/candidate_interface/work_history/edit/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.edit_job'), @work_experience_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Change the context of the back links so that they direct to the correct review page dependent on where the last

## Guidance to review

Using the review app check that all links flow correctly to the review page. From the individual and application review pages.

## Link to Trello card

https://trello.com/c/x7Hw1Waq/1896-%F0%9F%94%99-when-editing-information-back-links-and-save-buttons-should-return-candidate-to-relevant-review-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
