### PR TITLE
Fix spec failures following end-of-cycle deadline

### DIFF
--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content', :chase_candidate_decision,
         I18n.t!('chase_candidate_decision_email.subject_singular'),
-        'Date to resbond by' => -> { "Respond by #{10.business_days.from_now.to_s(:govuk_date).strip}" }
+        'Date to respond by' => -> { "Respond by #{10.business_days.from_now.to_s(:govuk_date).strip}" }
       )
     end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     content.each do |key, expectation|
       it "sends an email containing the #{key} in the body" do
+        expectation = expectation.call if expectation.respond_to?(:call)
         expect(email.body).to include(expectation)
       end
     end
@@ -34,7 +35,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_submitted.subject'),
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
-      'RBD time limit' => "to make an offer within #{TimeLimitCalculator.new(rule: :reject_by_default, effective_date: Time.zone.today).call.fetch(:days)} working days",
+      'RBD time limit' => -> { "to make an offer within #{TimeLimitCalculator.new(rule: :reject_by_default, effective_date: Time.zone.today).call.fetch(:days)} working days" },
       'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id',
     )
 
@@ -95,7 +96,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a mail with subject and content', :chase_candidate_decision,
         I18n.t!('chase_candidate_decision_email.subject_singular'),
-        'Date to resbond by' => "Respond by #{10.business_days.from_now.to_s(:govuk_date).strip}"
+        'Date to resbond by' => -> { "Respond by #{10.business_days.from_now.to_s(:govuk_date).strip}" }
       )
     end
 
@@ -104,8 +105,8 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a mail with subject and content', :chase_candidate_decision,
         I18n.t!('chase_candidate_decision_email.subject_singular'),
         'heading' => 'Dear Bob',
-        'days left to respond' => "#{TimeLimitCalculator.new(rule: :chase_candidate_before_dbd, effective_date: Time.zone.today).call.fetch(:days)} working days",
-        'dbd date' => 10.business_days.from_now.to_s(:govuk_date).strip,
+        'days left to respond' => -> { "#{TimeLimitCalculator.new(rule: :chase_candidate_before_dbd, effective_date: Time.zone.today).call.fetch(:days)} working days" },
+        'dbd date' => -> { 10.business_days.from_now.to_s(:govuk_date).strip },
         'course name and code' => 'Applied Science (Psychology)',
         'provider name' => 'Brighthurst Technical College'
       )

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ProviderMailer, type: :mailer do
 
     content.each do |key, expectation|
       it "sends an email containing the #{key} in the body" do
+        expectation = expectation.call if expectation.respond_to?(:call)
         expect(email.body).to include(expectation)
       end
     end
@@ -70,7 +71,7 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'provider name' => 'Dear Johny English',
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
-                      'reject by default at' => (Time.zone.now + 40.days).to_s(:govuk_date).strip,
+                      'reject by default at' => -> { (Time.zone.now + 40.days).to_s(:govuk_date).strip },
                       'link to the application' => 'http://localhost:3000/provider/applications/')
     end
   end
@@ -84,7 +85,7 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
                       'reject by default days' => 'within 123 working days',
-                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip)
+                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip })
     end
 
     context 'with the covid_19 feature flag on' do
@@ -96,7 +97,7 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'provider name' => 'Dear Johny English',
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
-                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip)
+                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip })
     end
   end
 
@@ -113,8 +114,8 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
                       'time to respond' => 'Only 20 working days left to respond',
-                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
-                      'reject by default at' => 20.business_days.from_now.to_s(:govuk_date).strip,
+                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip },
+                      'reject by default at' => -> { 20.business_days.from_now.to_s(:govuk_date).strip },
                       'link to the application' => 'http://localhost:3000/provider/applications/')
     end
 
@@ -127,8 +128,8 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'provider name' => 'Dear Johny English',
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
-                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
-                      'reject by default at' => 20.business_days.from_now.to_s(:govuk_date).strip,
+                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip },
+                      'reject by default at' => -> { 20.business_days.from_now.to_s(:govuk_date).strip },
                       'link to the application' => 'http://localhost:3000/provider/applications/')
     end
   end

--- a/spec/support/dates.rb
+++ b/spec/support/dates.rb
@@ -1,4 +1,4 @@
-MID_CYCLE_DATE = Time.zone.local(2020, 1, 1, 12, 0, 0)
+MID_CYCLE_DATE = Time.zone.local(RecruitmentCycle.current_year, 1, 1, 12, 0, 0)
 
 RSpec.configure do |config|
   config.around do |example|

--- a/spec/support/dates.rb
+++ b/spec/support/dates.rb
@@ -1,0 +1,9 @@
+MID_CYCLE_DATE = Time.zone.local(2020, 6, 1, 12, 0, 0)
+
+RSpec.configure do |config|
+  config.around(:example) do |example|
+    Timecop.freeze(MID_CYCLE_DATE) do
+      example.run
+    end
+  end
+end

--- a/spec/support/dates.rb
+++ b/spec/support/dates.rb
@@ -2,7 +2,7 @@ MID_CYCLE_DATE = Time.zone.local(RecruitmentCycle.current_year, 1, 1, 12, 0, 0)
 
 RSpec.configure do |config|
   config.around do |example|
-    Timecop.freeze(MID_CYCLE_DATE) do
+    Timecop.travel(MID_CYCLE_DATE) do
       example.run
     end
   end

--- a/spec/support/dates.rb
+++ b/spec/support/dates.rb
@@ -1,7 +1,7 @@
-MID_CYCLE_DATE = Time.zone.local(2020, 6, 1, 12, 0, 0)
+MID_CYCLE_DATE = Time.zone.local(2020, 1, 1, 12, 0, 0)
 
 RSpec.configure do |config|
-  config.around(:example) do |example|
+  config.around do |example|
     Timecop.freeze(MID_CYCLE_DATE) do
       example.run
     end


### PR DESCRIPTION

## Context

Since the 2020 recruitment cycle ended last night some tests have begun to fail because they exercise functionality that is turned off by design between cycles.

## Changes proposed in this pull request

- [x] Run all specs on a mid-cycle date by default.
- [x] Adjusted a few specs that have expectations based on dates calculated relative to `now` outside examples to use lambdas so that they get evaluated inside the example.

## Guidance to review

I think this could be improved in a few ways. So we should iterate. Is this ok to get us back to a green state?

## Link to Trello card

n/a

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
