### PR TITLE
Remove duplicated heading in API release notes

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -10,9 +10,6 @@ if the same offer details are POSTed repeatedly
 - `POST /application/:id/offer` now supports changing the conditions on an offer
 while retaining the original offered course. Previously this returned a 422 error
 saying it was necessary to offer a different course.
-
-### 10th August 2020
-
 - Deprecate `Withdrawal.reason`, which was supposed to hold a candidate’s reason for
 withdrawing their application. The Apply service will not collect this information
 


### PR DESCRIPTION
## Context

There was duplication in the release notes

## Changes proposed in this pull request

Remove it

## Guidance to review

Is it gone