### PR TITLE
Add feature flag to enable normal features between recruitment cycles

### DIFF
--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -54,8 +54,12 @@ class EndOfCycleTimetable
   end
 
   def self.date(name)
-    if HostingEnvironment.test_environment? && FeatureFlag.active?(:simulate_time_between_cycles)
-      return simulate_time_between_cycles_dates[name]
+    if HostingEnvironment.test_environment? || HostingEnvironment.sandbox_mode?
+      if FeatureFlag.active?(:simulate_time_between_cycles)
+        return simulate_time_between_cycles_dates[name]
+      elsif FeatureFlag.active?(:simulate_time_mid_cycle)
+        return simulate_time_mid_cycle_dates[name]
+      end
     end
 
     DATES[name]
@@ -76,6 +80,16 @@ class EndOfCycleTimetable
       find_closes: 1.day.ago.to_date,
       find_reopens: 5.days.from_now.to_date,
       next_cycle_opens: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
+    }
+  end
+
+  def self.simulate_time_mid_cycle_dates
+    {
+      apply_1_deadline: 20.weeks.from_now.to_date,
+      apply_2_deadline: 22.weeks.from_now.to_date,
+      find_closes: 22.weeks.from_now.to_date,
+      find_reopens: 25.weeks.from_now.to_date,
+      next_cycle_opens: 26.weeks.from_now.to_date,
     }
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,6 +22,7 @@ class FeatureFlag
     [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
     [:simulate_time_between_cycles, 'Simulates the time between recruitment cycles so that EoC features can be tested', 'Steve Hook'],
+    [:simulate_time_mid_cycle, 'Simulates the mid recruitment cycle time so that normal functionality can be tested between cycles', 'Steve Hook'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe EndOfCycleTimetable do
-  context 'when `simulate_time_between_cycles` feature flag is NOT active' do
+  context 'when `simulate_time_between_cycles` and `simulate_time_mid_cycle` feature flags are NOT active' do
     describe '.show_apply_1_deadline_banner?' do
       it 'returns true before the configured date' do
         Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
@@ -60,6 +60,78 @@ RSpec.describe EndOfCycleTimetable do
       it 'returns true after the configured date' do
         Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
+        end
+      end
+
+      it 'returns false after the new cycle opens' do
+        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        end
+      end
+    end
+  end
+
+  context 'when `simulate_time_mid_cycle` feature flag is active' do
+    before { FeatureFlag.activate(:simulate_time_mid_cycle) }
+
+    describe '.show_apply_1_deadline_banner?' do
+      it 'returns true before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
+        end
+      end
+
+      it 'returns true after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
+        end
+      end
+    end
+
+    describe '.show_apply_2_deadline_banner?' do
+      it 'returns true before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
+        end
+      end
+
+      it 'returns true after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
+          expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
+        end
+      end
+    end
+
+    describe '.between_cycles_apply_1?' do
+      it 'returns false before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        end
+      end
+
+      it 'returns false after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        end
+      end
+
+      it 'returns false after the new cycle opens' do
+        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
+        end
+      end
+    end
+
+    describe '.between_cycles_apply_2?' do
+      it 'returns false before the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
+        end
+      end
+
+      it 'returns false after the configured date' do
+        Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
+          expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
         end
       end
 

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -1,16 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe EndOfCycleTimetable do
+  let(:one_hour_before_apply1_deadline) { Time.zone.local(2020, 8, 24, 23, 0, 0) }
+  let(:one_hour_after_apply1_deadline) { Time.zone.local(2020, 8, 25, 1, 0, 0) }
+  let(:one_hour_before_apply2_deadline) { Time.zone.local(2020, 9, 18, 23, 0, 0) }
+  let(:one_hour_after_apply2_deadline) { Time.zone.local(2020, 9, 19, 1, 0, 0) }
+  let(:one_hour_after_2021_cycle_opens) { Time.zone.local(2020, 10, 13, 1, 0, 0) }
+
   context 'when `simulate_time_between_cycles` and `simulate_time_mid_cycle` feature flags are NOT active' do
     describe '.show_apply_1_deadline_banner?' do
       it 'returns true before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
+        Timecop.travel(one_hour_before_apply1_deadline) do
           expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
         end
       end
 
       it 'returns false after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
+        Timecop.travel(one_hour_after_apply1_deadline) do
           expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
         end
       end
@@ -18,13 +24,13 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.show_apply_2_deadline_banner?' do
       it 'returns true before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
+        Timecop.travel(one_hour_before_apply2_deadline) do
           expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
         end
       end
 
       it 'returns false after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
+        Timecop.travel(one_hour_after_apply2_deadline) do
           expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
         end
       end
@@ -32,19 +38,19 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.between_cycles_apply_1?' do
       it 'returns false before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
+        Timecop.travel(one_hour_before_apply1_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
         end
       end
 
       it 'returns true after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
+        Timecop.travel(one_hour_after_apply1_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
         end
       end
 
       it 'returns false after the new cycle opens' do
-        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_2021_cycle_opens) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
         end
       end
@@ -52,19 +58,19 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.between_cycles_apply_2?' do
       it 'returns false before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
+        Timecop.travel(one_hour_before_apply2_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
         end
       end
 
       it 'returns true after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_apply2_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
         end
       end
 
       it 'returns false after the new cycle opens' do
-        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_2021_cycle_opens) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
         end
       end
@@ -76,13 +82,13 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.show_apply_1_deadline_banner?' do
       it 'returns true before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
+        Timecop.travel(one_hour_before_apply1_deadline) do
           expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
         end
       end
 
       it 'returns true after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
+        Timecop.travel(one_hour_after_apply1_deadline) do
           expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be true
         end
       end
@@ -90,13 +96,13 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.show_apply_2_deadline_banner?' do
       it 'returns true before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
+        Timecop.travel(one_hour_before_apply2_deadline) do
           expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
         end
       end
 
       it 'returns true after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
+        Timecop.travel(one_hour_after_apply2_deadline) do
           expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be true
         end
       end
@@ -104,19 +110,19 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.between_cycles_apply_1?' do
       it 'returns false before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
+        Timecop.travel(one_hour_before_apply1_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
         end
       end
 
       it 'returns false after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
+        Timecop.travel(one_hour_after_apply1_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
         end
       end
 
       it 'returns false after the new cycle opens' do
-        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_2021_cycle_opens) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be false
         end
       end
@@ -124,19 +130,19 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.between_cycles_apply_2?' do
       it 'returns false before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
+        Timecop.travel(one_hour_before_apply2_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
         end
       end
 
       it 'returns false after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_apply2_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
         end
       end
 
       it 'returns false after the new cycle opens' do
-        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_2021_cycle_opens) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be false
         end
       end
@@ -148,13 +154,13 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.show_apply_1_deadline_banner?' do
       it 'returns false before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 24, 23, 0, 0)) do
+        Timecop.travel(one_hour_before_apply1_deadline) do
           expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
         end
       end
 
       it 'returns false after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 25, 1, 0, 0)) do
+        Timecop.travel(one_hour_after_apply1_deadline) do
           expect(EndOfCycleTimetable.show_apply_1_deadline_banner?).to be false
         end
       end
@@ -162,13 +168,13 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.show_apply_2_deadline_banner?' do
       it 'returns false before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 18, 23, 0, 0)) do
+        Timecop.travel(one_hour_before_apply2_deadline) do
           expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
         end
       end
 
       it 'returns false after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 19, 1, 0, 0)) do
+        Timecop.travel(one_hour_after_apply2_deadline) do
           expect(EndOfCycleTimetable.show_apply_2_deadline_banner?).to be false
         end
       end
@@ -176,19 +182,19 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.between_cycles_apply_1?' do
       it 'returns true before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 24, 21, 0, 0)) do
+        Timecop.travel(one_hour_before_apply1_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
         end
       end
 
       it 'returns true after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 8, 25, 6, 0, 0)) do
+        Timecop.travel(one_hour_after_apply1_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
         end
       end
 
       it 'returns true after the new cycle opens' do
-        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_2021_cycle_opens) do
           expect(EndOfCycleTimetable.between_cycles_apply_1?).to be true
         end
       end
@@ -196,19 +202,19 @@ RSpec.describe EndOfCycleTimetable do
 
     describe '.between_cycles_apply_2?' do
       it 'returns true before the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 18, 12, 0, 0)) do
+        Timecop.travel(one_hour_before_apply2_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
         end
       end
 
       it 'returns true after the configured date' do
-        Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_apply2_deadline) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
         end
       end
 
       it 'returns true after the new cycle opens' do
-        Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0)) do
+        Timecop.travel(one_hour_after_2021_cycle_opens) do
           expect(EndOfCycleTimetable.between_cycles_apply_2?).to be true
         end
       end


### PR DESCRIPTION
## Context

Vendors/Providers cannot currently test 'normal' functionality (e.g. signing up candidates, adding courses and submitting applications normally) because we are between recruitment cycles. We need a simple way to configure a system to restore 'business as usual' behaviour at any time of the year rather than have them switched off between cycles.

## Changes proposed in this pull request

- [x] Add `simulate_time_mid_cycle` feature flag to simulate mid recruitment cycle behaviour
- [x] Implement feature flag in `EndOfCycleTimetable` by moving the dates for EoC into the fairly distant future.

## Guidance to review

- This solution assumes that all users of a given system, i.e. all providers and vendors using Sandbox will either be in a recruitment cycle or not.
- `EndOfCycleTimetable` is getting a bit big now. I don't think we should be adding any more to it after this.

## Link to Trello card

https://trello.com/c/ReTgYcOl/2023-providers-vendors-cannot-test-normal-functionality-in-sandbox-environment-between-recruitment-cycles

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
