### PR TITLE
Remove institution_name from other qualification

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -105,7 +105,7 @@ module CandidateInterface
 
     def country_value(qualification)
       if non_uk_qualification?(qualification) && qualification.institution_country.present?
-        "#{COUNTRIES[qualification.institution_country]}"
+        COUNTRIES[qualification.institution_country].to_s
       else
         set_rows_value(qualification.institution_country)
       end

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -14,12 +14,31 @@ module CandidateInterface
     end
 
     def other_qualifications_rows(qualification)
-      [
-        qualification_row(qualification),
-        subject_row(qualification),
-        award_year_row(qualification),
-        grade_row(qualification),
-      ]
+      if FeatureFlag.active?('international_other_qualifications')
+        if qualification.institution_country.present?
+          [
+            qualification_row(qualification),
+            subject_row(qualification),
+            country_row(qualification),
+            award_year_row(qualification),
+            grade_row(qualification),
+          ]
+        else
+          [
+            qualification_row(qualification),
+            subject_row(qualification),
+            award_year_row(qualification),
+            grade_row(qualification),
+          ]
+        end
+      else
+        [
+          qualification_row(qualification),
+          subject_row(qualification),
+          award_year_row(qualification),
+          grade_row(qualification),
+        ]
+      end
     end
 
     def show_missing_banner?
@@ -75,22 +94,22 @@ module CandidateInterface
       end
     end
 
-    # def institution_row(qualification)
-    #   {
-    #     key: t('application_form.other_qualification.institution.label'),
-    #     value: institution_value(qualification),
-    #     action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.institution.change_action')),
-    #     change_path: edit_other_qualification_details_path(qualification),
-    #   }
-    # end
+    def country_row(qualification)
+      {
+        key: t('application_form.other_qualification.country.label'),
+        value: country_value(qualification),
+        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.country.change_action')),
+        change_path: edit_other_qualification_details_path(qualification),
+      }
+    end
 
-    # def institution_value(qualification)
-    #   if non_uk_qualification?(qualification) && qualification.institution_country.present?
-    #     "#{qualification.institution_name}, #{COUNTRIES[qualification.institution_country]}"
-    #   else
-    #     set_rows_value(qualification.institution_name)
-    #   end
-    # end
+    def country_value(qualification)
+      if non_uk_qualification?(qualification) && qualification.institution_country.present?
+        "#{COUNTRIES[qualification.institution_country]}"
+      else
+        set_rows_value(qualification.institution_country)
+      end
+    end
 
     def non_uk_qualification?(qualification)
       qualification.non_uk_qualification_type.present?

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -17,7 +17,6 @@ module CandidateInterface
       [
         qualification_row(qualification),
         subject_row(qualification),
-        institution_row(qualification),
         award_year_row(qualification),
         grade_row(qualification),
       ]
@@ -76,22 +75,22 @@ module CandidateInterface
       end
     end
 
-    def institution_row(qualification)
-      {
-        key: t('application_form.other_qualification.institution.label'),
-        value: institution_value(qualification),
-        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.institution.change_action')),
-        change_path: edit_other_qualification_details_path(qualification),
-      }
-    end
+    # def institution_row(qualification)
+    #   {
+    #     key: t('application_form.other_qualification.institution.label'),
+    #     value: institution_value(qualification),
+    #     action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.institution.change_action')),
+    #     change_path: edit_other_qualification_details_path(qualification),
+    #   }
+    # end
 
-    def institution_value(qualification)
-      if non_uk_qualification?(qualification) && qualification.institution_country.present?
-        "#{qualification.institution_name}, #{COUNTRIES[qualification.institution_country]}"
-      else
-        set_rows_value(qualification.institution_name)
-      end
-    end
+    # def institution_value(qualification)
+    #   if non_uk_qualification?(qualification) && qualification.institution_country.present?
+    #     "#{qualification.institution_name}, #{COUNTRIES[qualification.institution_country]}"
+    #   else
+    #     set_rows_value(qualification.institution_name)
+    #   end
+    # end
 
     def non_uk_qualification?(qualification)
       qualification.non_uk_qualification_type.present?
@@ -137,7 +136,7 @@ module CandidateInterface
 
     def generate_action(qualification:, attribute: '')
       "#{attribute.presence} for #{qualification.get_qualification_name}, #{qualification.subject}, "\
-        "#{institution_value(qualification)}, #{qualification.award_year}"
+        "#{qualification.award_year}"
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -61,14 +61,14 @@ module CandidateInterface
     def other_qualification_params
       if FeatureFlag.active?('international_other_qualifications')
         params.require(:candidate_interface_other_qualification_form).permit(
-          :subject, :institution_name, :grade, :award_year, :choice, :institution_country
+          :subject, :grade, :award_year, :choice, :institution_country
         ).merge!(id: params[:id],
                  qualification_type: get_qualification.qualification_type,
                  non_uk_qualification_type: get_qualification.non_uk_qualification_type,
                  other_uk_qualification_type: get_qualification.other_uk_qualification_type)
       else
         params.require(:candidate_interface_other_qualification_form).permit(
-          :subject, :institution_name, :grade, :award_year, :choice, :institution_country,
+          :subject, :grade, :award_year, :choice, :institution_country,
           :other_uk_qualification_type, :non_uk_qualification_type
         ).merge!(
           id: params[:id],

--- a/app/forms/candidate_interface/other_qualification_form.rb
+++ b/app/forms/candidate_interface/other_qualification_form.rb
@@ -3,11 +3,11 @@ module CandidateInterface
     include ActiveModel::Model
     include ValidationUtils
 
-    attr_accessor :id, :qualification_type, :subject, :institution_name, :grade,
+    attr_accessor :id, :qualification_type, :subject, :grade,
                   :award_year, :choice, :non_uk_qualification_type, :other_uk_qualification_type,
                   :institution_country
 
-    validates :qualification_type, :institution_name, :award_year, presence: true
+    validates :qualification_type, :award_year, presence: true
 
     validates :subject, :grade, presence: true, unless: -> { qualification_type == 'non_uk' || qualification_type == 'Other' }
 
@@ -15,7 +15,7 @@ module CandidateInterface
 
     validates :institution_country, inclusion: { in: COUNTRIES }, if: -> { qualification_type == 'non_uk' }
 
-    validates :qualification_type, :subject, :institution_name, :grade, length: { maximum: 255 }
+    validates :qualification_type, :subject, :grade, length: { maximum: 255 }
 
     validate :award_year_is_date_and_before_current_year, if: :award_year
 
@@ -34,7 +34,6 @@ module CandidateInterface
         if last_two_qualifications_are_of_same_type(qualifications)
           new(
             qualification_type: qualifications[-2].qualification_type,
-            institution_name: qualifications[-2].institution_name,
             institution_country: qualifications[-2].institution_country,
             award_year: qualifications[-2].award_year,
             non_uk_qualification_type: qualifications[-1].non_uk_qualification_type,
@@ -56,7 +55,6 @@ module CandidateInterface
           id: qualification.id,
           qualification_type: qualification.qualification_type,
           subject: qualification.subject,
-          institution_name: qualification.institution_name,
           institution_country: qualification.institution_country,
           grade: qualification.grade,
           award_year: qualification.award_year,
@@ -88,7 +86,6 @@ module CandidateInterface
       qualification.update!(
         qualification_type: qualification_type,
         subject: subject,
-        institution_name: institution_name,
         institution_country: institution_country,
         grade: grade,
         predicted_grade: false,
@@ -105,7 +102,6 @@ module CandidateInterface
       qualification.update!(
         qualification_type: qualification_type,
         subject: subject,
-        institution_name: institution_name,
         institution_country: institution_country,
         grade: grade,
         predicted_grade: false,

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -12,14 +12,12 @@ class ApplicationQualification < ApplicationRecord
     qualification_type
     subject
     grade
-    institution_name
     award_year
   ].freeze
 
   EXPECTED_INTERNATIONAL_OTHER_QUALIFICATION_DATA = %i[
     qualification_type
     non_uk_qualification_type
-    institution_name
     institution_country
     award_year
   ].freeze

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -2,13 +2,11 @@
 
   <% if @qualification.non_uk_qualification_type.present? %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.optional_label'), size: 'm' } %>
-    <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% else %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
-    <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% end %>
@@ -18,20 +16,17 @@
   <% if @qualification.non_uk_qualification_type.present? %>
     <%= f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.optional_label'), size: 'm' } %>
-    <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% elsif @qualification.qualification_type == 'Other' || @qualification.non_uk_qualification_type.present? %>
     <%= f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
-    <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% else %>
     <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.hint_text') %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
-    <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
   <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -251,8 +251,6 @@ en:
         change_action: subject
       institution_country:
         label: Country where you studied
-      institution_name:
-        label: Institution where you studied
       country:
         label: Country
         change_action: country

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -253,9 +253,9 @@ en:
         label: Country where you studied
       institution_name:
         label: Institution where you studied
-      institution:
-        label: Institution
-        change_action: institution
+      country:
+        label: Country
+        change_action: country
       grade:
         label: Grade
         optional_label: Grade (optional)

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       level: 'other',
       qualification_type: 'A-Level',
       subject: 'Making Doggo Sounds',
-      institution_name: 'Doggo Sounds College',
       grade: 'A',
       predicted_grade: false,
       award_year: '2012',
@@ -37,18 +36,13 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
 
       expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.qualification.label'))
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.institution.label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('A-Level')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Making Doggo Sounds')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Doggo Sounds College')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_details_path(qualification1),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.other_qualification.qualification.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
-      )
-      expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.other_qualification.institution.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+        "Change #{t('application_form.other_qualification.qualification.change_action')} for A-Level, Making Doggo Sounds, 2012",
       )
     end
 
@@ -59,7 +53,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.award_year.review_label'))
       expect(result.css('.govuk-summary-list__value').text).to include('2012')
       expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.other_qualification.award_year.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+        "Change #{t('application_form.other_qualification.award_year.change_action')} for A-Level, Making Doggo Sounds, 2012",
       )
     end
 
@@ -70,7 +64,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.grade.label'))
       expect(result.css('.govuk-summary-list__value').text).to include('A')
       expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.other_qualification.grade.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+        "Change #{t('application_form.other_qualification.grade.change_action')} for A-Level, Making Doggo Sounds, 2012",
       )
     end
 
@@ -85,7 +79,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.app-summary-card__actions').text.strip).to include(
-        "#{t('application_form.other_qualification.delete')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+        "#{t('application_form.other_qualification.delete')} for A-Level, Making Doggo Sounds, 2012",
       )
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(qualification1),
@@ -103,7 +97,6 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
           qualification_type: 'non_uk',
           non_uk_qualification_type: 'Woof',
           subject: 'Making Doggo Sounds',
-          institution_name: 'Doggo Sounds College',
           institution_country: 'US',
           grade: 'A',
           predicted_grade: false,
@@ -118,25 +111,25 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.grade.optional_label'))
       end
 
-      it 'renders the correct values for institution_name' do
+      it 'renders the correct values for institution_country' do
+        FeatureFlag.activate('international_other_qualifications')
         result = render_inline(described_class.new(application_form: application_form))
 
         expect(result.css('.app-summary-card__title').text).to include('Woof Making Doggo Sounds')
-        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.institution.label'))
-        expect(result.css('.govuk-summary-list__value').text).to include('Doggo Sounds College, United States')
-        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.other_qualification.institution.change_action'))
-        "Change #{t('application_form.other_qualification.institution_name.change_action')} for Woof, Making Doggo Sounds, Doggo Sounds College, United States 2012"
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.country.label'))
+        expect(result.css('.govuk-summary-list__value').text).to include('United States')
+        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.other_qualification.country.change_action'))
+        "Change #{t('application_form.other_qualification.institution_country.change_action')} for Woof, Making Doggo Sounds, United States 2012"
       end
     end
 
-    context 'when a candidate has not provided the subject, grade, year_awarded and institution' do
+    context 'when a candidate has not provided the subject, grade and year_awarded' do
       let(:qualification1) do
         build_stubbed(
           :application_qualification,
           level: 'other',
           qualification_type: 'GCSE',
           subject: nil,
-          institution_name: nil,
           grade: nil,
           award_year: nil,
         )
@@ -149,7 +142,6 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
         expect(result.css('.govuk-summary-list__value')[1].text).to include('Not entered')
         expect(result.css('.govuk-summary-list__value')[2].text).to include('Not entered')
         expect(result.css('.govuk-summary-list__value')[3].text).to include('Not entered')
-        expect(result.css('.govuk-summary-list__value')[4].text).to include('Not entered')
       end
     end
   end

--- a/spec/forms/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_form_spec.rb
@@ -7,11 +7,9 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:qualification_type) }
-    it { is_expected.to validate_presence_of(:institution_name) }
     it { is_expected.to validate_presence_of(:award_year) }
     it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
     it { is_expected.to validate_length_of(:subject).is_at_most(255) }
-    it { is_expected.to validate_length_of(:institution_name).is_at_most(255) }
     it { is_expected.to validate_length_of(:grade).is_at_most(255) }
 
     describe 'subject' do
@@ -114,7 +112,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
           level: 'other',
           qualification_type: 'BTEC',
           subject: 'Being a Superhero',
-          institution_name: 'School of Heroes',
           grade: 'Distinction',
           predicted_grade: false,
           award_year: '2012',
@@ -132,7 +129,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
         have_attributes(
           qualification_type: 'BTEC',
           subject: 'Being a Superhero',
-          institution_name: 'School of Heroes',
           grade: 'Distinction',
           award_year: '2012',
         ),
@@ -162,7 +158,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
         level: 'other',
         qualification_type: 'BTEC',
         subject: 'Being a Sidekick',
-        institution_name: 'School of Sidekicks',
         grade: 'Merit',
         predicted_grade: false,
         award_year: '2010',
@@ -187,7 +182,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
       form_data = {
         qualification_type: 'BTEC',
         subject: 'Being a Superhero',
-        institution_name: 'School of Heroes',
         grade: 'Distinction',
         award_year: '2012',
         choice: 'no',
@@ -196,7 +190,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
       expected_attributes = {
         qualification_type: 'BTEC',
         subject: 'Being a Superhero',
-        institution_name: 'School of Heroes',
         grade: 'Distinction',
         award_year: '2012',
       }
@@ -223,7 +216,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
         level: 'other',
         qualification_type: 'BTEC',
         subject: 'Being a Everyday Hero',
-        institution_name: 'School of Hoomans',
         grade: 'Pass',
         predicted_grade: false,
         award_year: '2011',
@@ -232,7 +224,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
       form_data = {
         qualification_type: 'BTEC',
         subject: 'Being a Everyday Hero',
-        institution_name: 'School of Humans',
         grade: 'Distinction',
         award_year: '2011',
       }

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -182,7 +182,6 @@ module CandidateHelper
     choose 'A level'
     click_button 'Continue'
     fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
-    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
     fill_in t('application_form.other_qualification.grade.label'), with: 'A'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
     choose 'No, not at the moment'

--- a/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualifications_after_completing_the_section_spec.rb
@@ -62,7 +62,6 @@ RSpec.feature 'Candidates academic and other relevant qualifications' do
   def and_i_change_my_qualification
     fill_in t('application_form.other_qualification.qualification_type.label'), with: 'A-Level'
     fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
-    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
     fill_in t('application_form.other_qualification.grade.label'), with: 'A'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
   end

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Entering their other qualifications' do
     and_select_add_another_a_level
     and_click_save_and_continue
     then_i_see_the_other_qualifications_form
-    and_the_year_fields_is_pre_populated_with_my_previous_details
+    and_the_year_field_is_pre_populated_with_my_previous_details
 
     when_i_fill_out_the_remainder_of_the_form
     and_i_choose_a_different_type_of_qualification
@@ -146,7 +146,7 @@ RSpec.feature 'Entering their other qualifications' do
     click_button 'Save and continue'
   end
 
-  def and_the_year_fields_is_pre_populated_with_my_previous_details
+  def and_the_year_field_is_pre_populated_with_my_previous_details
     expect(page.find('#candidate-interface-other-qualification-form-award-year-field').value).to eq('2015')
   end
 

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Entering their other qualifications' do
     and_select_add_another_a_level
     and_click_save_and_continue
     then_i_see_the_other_qualifications_form
-    and_the_year_and_institution_fields_are_pre_populated_with_my_previous_details
+    and_the_year_fields_is_pre_populated_with_my_previous_details
 
     when_i_fill_out_the_remainder_of_the_form
     and_i_choose_a_different_type_of_qualification
@@ -37,7 +37,7 @@ RSpec.feature 'Entering their other qualifications' do
 
     when_i_choose_other
     and_i_click_continue
-    then_the_year_and_institution_fields_are_not_pre_populated_with_my_previous_details
+    then_the_year_field_is_not_pre_populated_with_my_previous_details
 
     when_i_fill_in_my_other_qualifications_details
     and_i_choose_not_to_add_additional_qualifications
@@ -129,12 +129,11 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def then_i_see_validation_errors_for_my_qualification
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/other_qualification_form.attributes.institution_name.blank')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/other_qualification_form.attributes.award_year.blank')
   end
 
   def when_i_fill_in_my_qualification
     fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
-    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
     fill_in t('application_form.other_qualification.grade.label'), with: 'A'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
   end
@@ -147,8 +146,7 @@ RSpec.feature 'Entering their other qualifications' do
     click_button 'Save and continue'
   end
 
-  def and_the_year_and_institution_fields_are_pre_populated_with_my_previous_details
-    expect(page.find('#candidate-interface-other-qualification-form-institution-name-field').value).to eq('Yugi College')
+  def and_the_year_fields_is_pre_populated_with_my_previous_details
     expect(page.find('#candidate-interface-other-qualification-form-award-year-field').value).to eq('2015')
   end
 
@@ -165,15 +163,13 @@ RSpec.feature 'Entering their other qualifications' do
     choose 'Other'
   end
 
-  def then_the_year_and_institution_fields_are_not_pre_populated_with_my_previous_details
-    expect(page.find('#candidate-interface-other-qualification-form-institution-name-field').value).to eq(nil)
+  def then_the_year_field_is_not_pre_populated_with_my_previous_details
     expect(page.find('#candidate-interface-other-qualification-form-award-year-field').value).to eq(nil)
   end
 
   def when_i_fill_in_my_other_qualifications_details
     fill_in t('application_form.other_qualification.qualification_type.label'), with: 'Access Course'
     fill_in t('application_form.other_qualification.subject.label'), with: 'History, English and Psychology'
-    fill_in t('application_form.other_qualification.institution_name.label'), with: 'College'
     fill_in t('application_form.other_qualification.grade.label'), with: 'Distinction'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2012'
   end
@@ -240,7 +236,6 @@ RSpec.feature 'Entering their other qualifications' do
   def then_i_see_my_qualification_filled_in
     expect(page).to have_selector("input[value='A level']")
     expect(page).to have_selector("input[value='Oh']")
-    expect(page).to have_selector("input[value='Yugi College']")
     expect(page).to have_selector("input[value='B']")
     expect(page).to have_selector("input[value='2015']")
   end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -126,7 +126,6 @@ RSpec.feature 'Candidate submits the application' do
 
   def and_i_can_see_my_other_qualification
     expect(page).to have_content 'A level Believing in the Heart of the Cards'
-    expect(page).to have_content 'Yugi College'
     expect(page).to have_content 'A'
     expect(page).to have_content '2015'
   end

--- a/spec/system/candidate_interface/international/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_enters_their_other_qualification_spec.rb
@@ -119,7 +119,6 @@ RSpec.feature 'Non-uk Other qualifications' do
 
   def when_i_fill_in_my_qualification
     fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
-    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
     select 'Japan'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
   end
@@ -139,7 +138,6 @@ RSpec.feature 'Non-uk Other qualifications' do
   def and_i_should_see_my_qualification
     expect(page).to have_content('Master Rules')
     expect(page).to have_content('Believing in the Heart of the Cards')
-    expect(page).to have_content('Yugi College, Japan')
     expect(page).to have_content('2015')
   end
 
@@ -192,13 +190,12 @@ RSpec.feature 'Non-uk Other qualifications' do
   end
 
   def and_i_fill_in_the_year_institution_and_country
-    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Clown College'
     select 'United States'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
   end
 
   def then_i_should_see_my_second_qualification
-    expect(page).to have_content('Clown College, United States')
+    expect(page).to have_content('United States')
     expect(page).to have_content('2015')
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature 'Vendor receives the application' do
               grade: 'A',
               start_year: nil,
               award_year: '2015',
-              institution_details: 'Yugi College',
+              institution_details: nil,
               awarding_body: nil,
               equivalency_details: nil,
             },


### PR DESCRIPTION
## Context

Removing institution from other qualification form and review screen as per request.  Also allowing country to show in it's place if international other qualification Feature Flag is turned on.

## Changes proposed in this pull request

Have removed institution_name form view, controller and updated component with logic to show country when relevant.

Before (feature flag on):

Before (feature flag off):

feature flag on:
![image](https://user-images.githubusercontent.com/62567622/91328700-2a241900-e7bf-11ea-81ab-b107f7bc9347.png)
![image](https://user-images.githubusercontent.com/62567622/91329100-aa4a7e80-e7bf-11ea-8d6f-02d31ccb1022.png)
![image](https://user-images.githubusercontent.com/62567622/91330344-327d5380-e7c1-11ea-8216-eb9b50ce9019.png)


feature flag off:
![image](https://user-images.githubusercontent.com/62567622/91330109-ea5e3100-e7c0-11ea-83f7-a80c12863ddc.png)
![image](https://user-images.githubusercontent.com/62567622/91330236-1083d100-e7c1-11ea-83a0-4d1d3ea81858.png)
![image](https://user-images.githubusercontent.com/62567622/91331720-095dc280-e7c3-11ea-816a-87bfd3dde9a2.png)


## Guidance to review

Check to see that other qualification no longer has institution and that country is displayed on the review when relevant.

## Link to Trello card

https://trello.com/c/H3qniVJ9/1853-remove-institution-for-non-degree-qualifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
