### PR TITLE
If one application choice is cancelled, still send the others

### DIFF
--- a/app/queries/get_application_forms_ready_to_send_to_providers.rb
+++ b/app/queries/get_application_forms_ready_to_send_to_providers.rb
@@ -7,7 +7,10 @@ class GetApplicationFormsReadyToSendToProviders
       .group(:id)
 
     forms.select do |f|
-      f.application_choices.all? { |application_choice| application_choice.status == 'application_complete' }
+      offered_statuses    = Set.new(f.application_choices.map(&:status))
+      acceptable_statuses = Set.new(%w[application_complete cancelled])
+
+      acceptable_statuses.superset? offered_statuses
     end
   end
 end

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -1,6 +1,9 @@
 class ApplicationStateChange
   include Workflow
 
+  # unsubmitted Apply Again applications may go straight to the provider
+  # as they do not need references or the 7-day cooling off period
+  STATES_THAT_MAY_BE_SENT_TO_PROVIDER = %i[application_complete unsubmitted].freeze
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete cancelled].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited enrolled].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -1,4 +1,6 @@
 class SendApplicationToProvider
+  class ApplicationNotReadyToSendError < RuntimeError; end
+
   attr_accessor :application_choice
 
   def initialize(application_choice:)
@@ -6,7 +8,9 @@ class SendApplicationToProvider
   end
 
   def call
-    return false unless ApplicationStateChange::STATES_THAT_MAY_BE_SENT_TO_PROVIDER.include?(application_choice.status.to_sym)
+    unless ApplicationStateChange::STATES_THAT_MAY_BE_SENT_TO_PROVIDER.include?(application_choice.status.to_sym)
+      raise ApplicationNotReadyToSendError, "Tried to send an application in the #{application_choice.status} state to a provider"
+    end
 
     ActiveRecord::Base.transaction do
       application_choice.update!(sent_to_provider_at: Time.zone.now)

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -6,7 +6,7 @@ class SendApplicationToProvider
   end
 
   def call
-    return false unless application_choice.unsubmitted? || application_choice.application_complete?
+    return false unless ApplicationStateChange::STATES_THAT_MAY_BE_SENT_TO_PROVIDER.include?(application_choice.status.to_sym)
 
     ActiveRecord::Base.transaction do
       application_choice.update!(sent_to_provider_at: Time.zone.now)

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -1,9 +1,11 @@
 class SendApplicationsToProvider
   def call
     GetApplicationFormsReadyToSendToProviders.call.each do |application_form|
-      application_form.application_choices.each do |choice|
-        SendApplicationToProvider.new(application_choice: choice).call
-      end
+      application_form
+        .application_choices
+        .where(status: ApplicationStateChange::STATES_THAT_MAY_BE_SENT_TO_PROVIDER).each do |choice|
+          SendApplicationToProvider.new(application_choice: choice).call
+        end
 
       CandidateMailer.application_sent_to_provider(application_form).deliver_later
     end

--- a/spec/queries/get_application_forms_ready_to_send_to_providers_spec.rb
+++ b/spec/queries/get_application_forms_ready_to_send_to_providers_spec.rb
@@ -66,4 +66,25 @@ RSpec.describe GetApplicationFormsReadyToSendToProviders do
       expect(returned_application_forms.count).to eq 1
     end
   end
+
+  context 'when one application_choice is application_complete and the other is cancelled' do
+    before do
+      create(:application_choice, application_form: application_form, status: :application_complete)
+      create(:application_choice, application_form: application_form, status: :cancelled)
+    end
+
+    it 'returns the form' do
+      expect(returned_application_forms.first).to eq application_form
+    end
+  end
+
+  context 'when the only application is cancelled' do
+    before do
+      create(:application_choice, application_form: application_form, status: :cancelled)
+    end
+
+    it 'does not return the form' do
+      expect(returned_application_forms).to be_empty
+    end
+  end
 end

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe SendApplicationToProvider do
     end
 
     it 'does not work for another status' do
-      SendApplicationToProvider.new(application_choice: application_choice(status: 'awaiting_references')).call
-
-      expect(application_choice.reload.status).to eq 'awaiting_references'
+      expect {
+        SendApplicationToProvider.new(application_choice: application_choice(status: 'awaiting_references')).call
+      }.to raise_error(SendApplicationToProvider::ApplicationNotReadyToSendError)
     end
   end
 end

--- a/spec/services/send_applications_to_provider_spec.rb
+++ b/spec/services/send_applications_to_provider_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SendApplicationsToProvider do
+  it 'sends the form’s choices to the provider' do
+    form = create(:completed_application_form, :with_completed_references, :ready_to_send_to_provider)
+    create(:application_choice, application_form: form, status: :application_complete)
+    create(:application_choice, application_form: form, status: :application_complete)
+
+    SendApplicationsToProvider.new.call
+
+    expect(form.application_choices.map(&:status)).to eq %w[awaiting_provider_decision awaiting_provider_decision]
+  end
+
+  it 'sends application_complete choices to the provider if the other choices are cancelled' do
+    form = create(:completed_application_form, :with_completed_references, :ready_to_send_to_provider)
+    create(:application_choice, application_form: form, status: :application_complete)
+    create(:application_choice, application_form: form, status: :cancelled)
+
+    SendApplicationsToProvider.new.call
+
+    expect(form.application_choices.map(&:status)).to match_array %w[awaiting_provider_decision cancelled]
+  end
+end


### PR DESCRIPTION
## Context

We had a bug in production where application choices were stuck unsent for weeks because their siblings were in the `cancelled` state.

This was because of the way we decided which applications to send to providers: we looked for forms where all the application choices were `application_complete`. Once applications became `cancelled` these forms were passed over.

## Changes proposed in this pull request

**`GetApplicationFormsReadyToSendToProvider`**
- now returns forms with only `application_complete` or `cancelled` statuses — not just `application_complete` — to the...

**`SendApplicationsToProvider` job:**
- which delivers only the `application_complete` choices for a given form using...

**`SendApplicationToProvider`**
- which now throws an exception if we get an application we can't send

## Guidance to review

Does it fix the bug? https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1598356707044000

## Link to Trello card

https://trello.com/c/Q6jlA1Sd/

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
