### PR TITLE
Stop applications with unavailable course options after Sep 7

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -262,8 +262,8 @@ class CandidateMailer < ApplicationMailer
       @application_form,
       subject: I18n.t!(
         'candidate_mailer.eoc_choice_unavailable_has_other_choices.subject',
-        course_name: application_choice.course.name_and_code,
-        provider_name: application_choice.course.provider.name,
+        course_name: application_choice.course_option.course.name_and_code,
+        provider_name: application_choice.course_option.course.provider.name,
       ),
     )
   end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -253,6 +253,16 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def eoc_choice_unavailable_and_no_other_choices(application_choice)
+    @application_choice = application_choice
+    @application_form = application_choice.application_form
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.eoc_choice_unavailable_no_other_choices.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -253,6 +253,21 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def eoc_choice_unavailable_and_still_waiting_on_other_choices(application_choice)
+    @application_choice = application_choice
+    @application_form = application_choice.application_form
+    @other_choices = @application_form.application_choices - [application_choice]
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!(
+        'candidate_mailer.eoc_choice_unavailable_has_other_choices.subject',
+        course_name: application_choice.course.name_and_code,
+        provider_name: application_choice.course.provider.name,
+      ),
+    )
+  end
+
   def eoc_choice_unavailable_and_no_other_choices(application_choice)
     @application_choice = application_choice
     @application_form = application_choice.application_form

--- a/app/services/candidate_interface/end_of_cycle_policy.rb
+++ b/app/services/candidate_interface/end_of_cycle_policy.rb
@@ -7,5 +7,13 @@ module CandidateInterface
 
       false
     end
+
+    def self.cancel_application_because_option_unavailable?(application_choice)
+      EndOfCycleTimetable.stop_applications_to_unavailable_course_options? &&
+        (
+          application_choice.course_option_full? ||
+          application_choice.course_withdrawn?
+        )
+    end
   end
 end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -21,6 +21,8 @@ class EndOfCycleTimetable
   end
 
   def self.stop_applications_to_unavailable_course_options?
+    return true if FeatureFlag.active?(:simulate_stop_applications_to_unavailable_course_options)
+
     Time.zone.now > date(:stop_applications_to_unavailable_course_options).end_of_day &&
       Time.zone.now < date(:next_cycle_opens).beginning_of_day
   end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -1,6 +1,7 @@
 class EndOfCycleTimetable
   DATES = {
     apply_1_deadline: Date.new(2020, 8, 24),
+    stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
     apply_2_deadline: Date.new(2020, 9, 18),
     find_closes: Date.new(2020, 9, 19),
     find_reopens: Date.new(2020, 10, 3),
@@ -17,6 +18,11 @@ class EndOfCycleTimetable
 
   def self.show_apply_2_deadline_banner?
     Time.zone.now < date(:apply_2_deadline).end_of_day
+  end
+
+  def self.stop_applications_to_unavailable_course_options?
+    Time.zone.now > date(:stop_applications_to_unavailable_course_options).end_of_day &&
+      Time.zone.now < date(:next_cycle_opens).beginning_of_day
   end
 
   def self.apply_1_deadline

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,6 +23,7 @@ class FeatureFlag
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
     [:simulate_time_between_cycles, 'Simulates the time between recruitment cycles so that EoC features can be tested', 'Steve Hook'],
     [:simulate_time_mid_cycle, 'Simulates the mid recruitment cycle time so that normal functionality can be tested between cycles', 'Steve Hook'],
+    [:simulate_stop_applications_to_unavailable_course_options, 'Simulate EoC behaviour where applications to unavailable options are cancelled before they can be sent to the provider', 'Malcolm Baig'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -18,6 +18,9 @@ class SendApplicationsToProvider
 
       if application_choices.any?(&:awaiting_provider_decision?)
         CandidateMailer.application_sent_to_provider(application_form).deliver_later
+        cancelled_choices.each do |choice|
+          CandidateMailer.eoc_choice_unavailable_and_still_waiting_on_other_choices(choice).deliver_later
+        end
       else
         cancelled_choices.each do |choice|
           CandidateMailer.eoc_choice_unavailable_and_no_other_choices(choice).deliver_later

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -1,13 +1,28 @@
 class SendApplicationsToProvider
   def call
     GetApplicationFormsReadyToSendToProviders.call.each do |application_form|
-      application_form
+      application_choices = application_form
         .application_choices
-        .where(status: ApplicationStateChange::STATES_THAT_MAY_BE_SENT_TO_PROVIDER).each do |choice|
+        .where(status: ApplicationStateChange::STATES_THAT_MAY_BE_SENT_TO_PROVIDER)
+
+      cancelled_choices = []
+
+      application_choices.each do |choice|
+        if CandidateInterface::EndOfCyclePolicy.cancel_application_because_option_unavailable?(choice)
+          ApplicationStateChange.new(choice).cancel!
+          cancelled_choices << choice
+        else
           SendApplicationToProvider.new(application_choice: choice).call
         end
+      end
 
-      CandidateMailer.application_sent_to_provider(application_form).deliver_later
+      if application_choices.any?(&:awaiting_provider_decision?)
+        CandidateMailer.application_sent_to_provider(application_form).deliver_later
+      else
+        cancelled_choices.each do |choice|
+          CandidateMailer.eoc_choice_unavailable_and_no_other_choices(choice).deliver_later
+        end
+      end
     end
   end
 end

--- a/app/views/candidate_mailer/eoc_choice_unavailable_and_no_other_choices.text.erb
+++ b/app/views/candidate_mailer/eoc_choice_unavailable_and_no_other_choices.text.erb
@@ -1,0 +1,23 @@
+Dear <%= @application_form.first_name %>
+
+# You may still be able to get on a course
+
+Due to <%= @application_choice.course.name_and_code %> filling up at <%= @application_choice.provider.name %>, your recent application did not lead to a place on a course.
+
+# Re-submit no later than 18 September
+
+You can re-submit your application for an available course until the 18 September.
+
+Find out if there are any other suitable courses available:
+
+https://www.find-postgraduate-teacher-training.service.gov.uk/
+
+We’ve saved your last application, so all you have to do is sign-in, choose a course and resubmit.
+
+Sign back into your account and re-submit no later than 18 September:
+
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
+
+# Get help from a teacher training adviser
+
+You can talk to a teacher training adviser on the phone or online: https://register.getintoteaching.education.gov.uk/register

--- a/app/views/candidate_mailer/eoc_choice_unavailable_and_no_other_choices.text.erb
+++ b/app/views/candidate_mailer/eoc_choice_unavailable_and_no_other_choices.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>
 
 # You may still be able to get on a course
 
-Due to <%= @application_choice.course.name_and_code %> filling up at <%= @application_choice.provider.name %>, your recent application did not lead to a place on a course.
+Due to <%= @application_choice.course_option.course.name_and_code %> filling up at <%= @application_choice.course_option.course.provider.name %>, your recent application did not lead to a place on a course.
 
 # Re-submit no later than 18 September
 

--- a/app/views/candidate_mailer/eoc_choice_unavailable_and_no_other_choices.text.erb
+++ b/app/views/candidate_mailer/eoc_choice_unavailable_and_no_other_choices.text.erb
@@ -4,19 +4,17 @@ Dear <%= @application_form.first_name %>
 
 Due to <%= @application_choice.course_option.course.name_and_code %> filling up at <%= @application_choice.course_option.course.provider.name %>, your recent application did not lead to a place on a course.
 
-# Re-submit no later than 18 September
+# Resubmit no later than 18 September
 
-You can re-submit your application for an available course until the 18 September.
+You can resubmit your application for an available course until the 18 September.
 
 Find out if there are any other suitable courses available:
 
 https://www.find-postgraduate-teacher-training.service.gov.uk/
 
-We’ve saved your last application, so all you have to do is sign-in, choose a course and resubmit.
+If you find a course, continue your application:
 
-Sign back into your account and re-submit no later than 18 September:
-
-<%= candidate_magic_link(@application_choice.application_form.candidate) %>
+<%= candidate_interface_start_apply_again_url %>
 
 # Get help from a teacher training adviser
 

--- a/app/views/candidate_mailer/eoc_choice_unavailable_and_still_waiting_on_other_choices.text.erb
+++ b/app/views/candidate_mailer/eoc_choice_unavailable_and_still_waiting_on_other_choices.text.erb
@@ -2,9 +2,9 @@ Dear <%= @application_form.first_name %>
 
 # Application could not be sent for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.provider.name %>
 
-Due to <%= @application_choice.course_option.course.name_and_code %> filling up at <%= @application_choice.course_option.provider.name %>, we could not send your application for consideration for this course.
+Due to places filling up for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.provider.name %>, we could not send your application for consideration for this course.
 
-However, you’re waiting to hear back about other course(s).
+However, you’re waiting to hear back about <%= @other_choices.count > 1 ? 'other courses' : 'another course'%>.
 
 # Your other <%= 'course'.pluralize(@other_choices.count) %>
 

--- a/app/views/candidate_mailer/eoc_choice_unavailable_and_still_waiting_on_other_choices.text.erb
+++ b/app/views/candidate_mailer/eoc_choice_unavailable_and_still_waiting_on_other_choices.text.erb
@@ -1,0 +1,20 @@
+Dear <%= @application_form.first_name %>
+
+# Application could not be sent for <%= @application_choice.course.name_and_code %> at <%= @application_choice.provider.name %>
+
+Due to <%= @application_choice.course.name_and_code %> filling up at <%= @application_choice.provider.name %>, we could not send your application for consideration for this course.
+
+However, you’re waiting to hear back about other course(s).
+
+# Your other <%= pluralize(@other_choices.count, 'course') %>
+
+You’re waiting to hear back about:
+
+<%= @other_choices.each do |choice| %>
+  - <%= choice.course.name_and_code %>
+<% end %>
+
+You can check the progress of your application anytime by signing in to your account:
+
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
+

--- a/app/views/candidate_mailer/eoc_choice_unavailable_and_still_waiting_on_other_choices.text.erb
+++ b/app/views/candidate_mailer/eoc_choice_unavailable_and_still_waiting_on_other_choices.text.erb
@@ -1,17 +1,17 @@
 Dear <%= @application_form.first_name %>
 
-# Application could not be sent for <%= @application_choice.course.name_and_code %> at <%= @application_choice.provider.name %>
+# Application could not be sent for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.provider.name %>
 
-Due to <%= @application_choice.course.name_and_code %> filling up at <%= @application_choice.provider.name %>, we could not send your application for consideration for this course.
+Due to <%= @application_choice.course_option.course.name_and_code %> filling up at <%= @application_choice.course_option.provider.name %>, we could not send your application for consideration for this course.
 
 However, you’re waiting to hear back about other course(s).
 
-# Your other <%= pluralize(@other_choices.count, 'course') %>
+# Your other <%= 'course'.pluralize(@other_choices.count) %>
 
 You’re waiting to hear back about:
 
-<%= @other_choices.each do |choice| %>
-  - <%= choice.course.name_and_code %>
+<% @other_choices.each do |choice| %>
+  - <%= choice.course_option.course.name_and_code %>
 <% end %>
 
 You can check the progress of your application anytime by signing in to your account:

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -117,6 +117,9 @@ en:
       name: Cancelled
       description: |
         The application was cancelled before it was sent to the provider.
+      emails:
+        - candidate_mailer-eoc_choice_unavailable_and_no_other_choices
+        - candidate_mailer-eoc_choice_unavailable_and_still_waiting_on_other_choices
 
     offer:
       name: Offer made

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -2,6 +2,8 @@ en:
   candidate_mailer:
     eoc_choice_unavailable_no_other_choices:
       subject: Find a different course and re-submit your application
+    eoc_choice_unavailable_has_other_choices:
+      subject: Application could not be sent for %{course_name} at %{provider_name}
     survey_email:
       subject: Was applying for teacher training easy?
     survey_chaser_email:

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -1,5 +1,7 @@
 en:
   candidate_mailer:
+    eoc_choice_unavailable_no_other_choices:
+      subject: Find a different course and re-submit your application
     survey_email:
       subject: Was applying for teacher training easy?
     survey_chaser_email:

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -385,6 +385,29 @@ class CandidateMailerPreview < ActionMailer::Preview
     )
   end
 
+  def eoc_choice_unavailable_and_still_waiting_on_other_choices
+    application_form = application_form_with_course_choices(
+      [
+        FactoryBot.build_stubbed(:application_choice, course_option: course_option),
+        FactoryBot.build_stubbed(:application_choice, course_option: course_option),
+        FactoryBot.build_stubbed(:application_choice, course_option: course_option),
+      ],
+    )
+    CandidateMailer.eoc_choice_unavailable_and_still_waiting_on_other_choices(
+      application_form.application_choices.first,
+    )
+  end
+
+  def eoc_choice_unavailable_and_no_other_choices
+    application_form = application_form_with_course_choices(
+      [FactoryBot.build_stubbed(:application_choice, course_option: course_option)],
+    )
+
+    CandidateMailer.eoc_choice_unavailable_and_no_other_choices(
+      application_form.application_choices.first,
+    )
+  end
+
 private
 
   def candidate

--- a/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
+++ b/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
@@ -60,4 +60,67 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
       end
     end
   end
+
+  describe 'cancel_application_because_option_unavailable?(application_choice)' do
+    context 'the EOC timetable says we should be stopping applications' do
+      before do
+        allow(EndOfCycleTimetable)
+          .to receive(:stop_applications_to_unavailable_course_options?)
+          .and_return(true)
+      end
+
+      it 'is true if the course option is full ' do
+        application_choice = create(
+          :application_choice,
+          course_option: create(:course_option, :no_vacancies),
+        )
+
+        expect(described_class.cancel_application_because_option_unavailable?(application_choice)).to eq true
+      end
+
+      it 'is true if the course is withdrawn' do
+        application_choice = create(
+          :application_choice,
+          course_option: create(:course_option, course: create(:course, withdrawn: true)),
+        )
+
+        expect(described_class.cancel_application_because_option_unavailable?(application_choice)).to eq true
+      end
+
+      it 'is false if the course option is still available' do
+        application_choice = create(
+          :application_choice,
+          course_option: create(:course_option),
+        )
+
+        expect(described_class.cancel_application_because_option_unavailable?(application_choice)).to eq false
+      end
+    end
+
+    context 'the EOC timetable says we should not be stopping applications' do
+      before do
+        allow(EndOfCycleTimetable)
+          .to receive(:stop_applications_to_unavailable_course_options?)
+          .and_return(false)
+      end
+
+      it 'is false if the course option is full ' do
+        application_choice = create(
+          :application_choice,
+          course_option: create(:course_option, :no_vacancies),
+        )
+
+        expect(described_class.cancel_application_because_option_unavailable?(application_choice)).to eq false
+      end
+
+      it 'is false if the course is withdrawn' do
+        application_choice = create(
+          :application_choice,
+          course_option: create(:course_option, course: create(:course, withdrawn: true)),
+        )
+
+        expect(described_class.cancel_application_because_option_unavailable?(application_choice)).to eq false
+      end
+    end
+  end
 end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -272,4 +272,24 @@ RSpec.describe EndOfCycleTimetable do
       ).to be false
     end
   end
+
+  describe 'stop_applications_to_unavailable_course_options?' do
+    it 'is true when between "stop_applications_to_unavailable_course_options" and "next_cycle_opens"' do
+      Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day + 1.minute) do
+        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be true
+      end
+    end
+
+    it 'is false when before the window' do
+      Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day - 1.minute) do
+        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be false
+      end
+    end
+
+    it 'is false when after the window' do
+      Timecop.travel(Time.zone.local(2020, 10, 13).beginning_of_day) do
+        expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be false
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_submits_application_to_unavailable_course_option_as_end_of_cycle_approaches_but_has_other_options_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_to_unavailable_course_option_as_end_of_cycle_approaches_but_has_other_options_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.feature 'Stopping applications to unavailable course options as we approach the end of the cycle' do
+  include CandidateHelper
+
+  around do |example|
+    given_applications_to_unavailable_courses_are_now_being_stopped(example)
+  end
+
+  scenario 'Candidate submits application to full course option but has another option that is not full' do
+    given_i_have_an_application_that_is_ready_to_send_to_a_provider
+    and_one_of_my_chosen_options_is_full
+    when_the_system_sends_applications_to_providers
+    then_my_application_to_the_full_option_is_cancelled
+    and_i_receive_an_email_explaining_this
+    and_my_other_option_is_being_considered
+  end
+
+  def given_applications_to_unavailable_courses_are_now_being_stopped(example)
+    Timecop.freeze(
+      EndOfCycleTimetable.date(:stop_applications_to_unavailable_course_options).end_of_day + 1.hour,
+    ) do
+      example.run
+    end
+  end
+
+  def given_i_have_an_application_that_is_ready_to_send_to_a_provider
+    @candidate = create(:candidate)
+    create(
+      :completed_application_form,
+      :with_completed_references,
+      application_choices_count: 2,
+      references_count: 2,
+      candidate: @candidate,
+      edit_by: Time.zone.now - 1.hour,
+    )
+    @candidate.current_application.application_choices.each do |choice|
+      ApplicationStateChange.new(choice).references_complete!
+    end
+    login_as(@candidate)
+    visit candidate_interface_application_form_path
+  end
+
+  def and_one_of_my_chosen_options_is_full
+    application_choice = @candidate.current_application.application_choices.first
+    @option_that_is_full = application_choice.course_option
+    @option_that_is_full.no_vacancies!
+  end
+
+  def when_the_system_sends_applications_to_providers
+    SendApplicationsToProviderWorker.new.perform
+  end
+
+  def then_my_application_to_the_full_option_is_cancelled
+    expect(@candidate.current_application.application_choices.first).to be_cancelled
+  end
+
+  def and_i_receive_an_email_explaining_this
+    open_email(@candidate.email_address)
+
+    explanatory_email = all_emails.find do |e|
+      e.subject.include? "Application could not be sent for #{@option_that_is_full.course.name_and_code}"
+    end
+
+    expect(explanatory_email).to be_present
+  end
+
+  def and_my_other_option_is_being_considered
+    other_option = @candidate.current_application.application_choices.last
+    expect(other_option).to be_awaiting_provider_decision
+  end
+end

--- a/spec/system/candidate_interface/candidate_submits_application_to_unavailable_course_option_as_end_of_cycle_approaches_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_to_unavailable_course_option_as_end_of_cycle_approaches_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.feature 'Stopping applications to unavailable course options as we approach the end of the cycle' do
+  include CandidateHelper
+
+  around do |example|
+    given_applications_to_unavailable_courses_are_now_being_stopped(example)
+  end
+
+  scenario 'Candidate submits application to full course option' do
+    given_i_have_an_application_that_is_ready_to_send_to_a_provider
+    and_the_course_i_chose_is_now_full
+    when_the_system_sends_applications_to_providers
+    then_my_application_is_cancelled
+    and_i_receive_an_email_explaining_this
+  end
+
+  def given_applications_to_unavailable_courses_are_now_being_stopped(example)
+    Timecop.freeze(
+      EndOfCycleTimetable.date(:stop_applications_to_unavailable_course_options).end_of_day + 1.hour,
+    ) do
+      example.run
+    end
+  end
+
+  def given_i_have_an_application_that_is_ready_to_send_to_a_provider
+    @candidate = create(:candidate)
+    create(
+      :completed_application_form,
+      :with_completed_references,
+      application_choices_count: 1,
+      references_count: 2,
+      candidate: @candidate,
+      edit_by: Time.zone.now - 1.hour,
+    )
+    ApplicationStateChange.new(@candidate.current_application.application_choices.first).references_complete!
+    login_as(@candidate)
+    visit candidate_interface_application_form_path
+  end
+
+  def and_the_course_i_chose_is_now_full
+    application_choice = @candidate.current_application.application_choices.first
+    application_choice.course_option.no_vacancies!
+  end
+
+  def when_the_system_sends_applications_to_providers
+    SendApplicationsToProviderWorker.new.perform
+  end
+
+  def then_my_application_is_cancelled
+    expect(@candidate.current_application.application_choices.first).to be_cancelled
+  end
+
+  def and_i_receive_an_email_explaining_this
+    open_email(@candidate.email_address)
+    expect(current_email.subject).to include 'Find a different course and re-submit your application'
+    expect(current_email.text).to include 'your recent application did not lead to a place on a course'
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Providers don't expect to receive applications to full or withdrawn course options after Sep 7th. We need to stop these at the point they're ready to send and notify the candidate.

## Changes proposed in this pull request

- Add methods to `EndOfCyclePolicy` and `EndOfCycleTimetable` to handle checking if we should apply this behaviour.
- Update `SendApplicationsToProvider` to cancel the application if appropriate.
- Send one of two notification emails to the candidate depending on their application state.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Per-commit recommended
- Mailer preview paths:
  - /rails/mailers/candidate_mailer/eoc_choice_unavailable_and_no_other_choices
  - /rails/mailers/candidate_mailer/eoc_choice_unavailable_and_still_waiting_on_other_choices
- The card states that these applications should be "rejected as full". This isn't a pre-existing state transition from `application_complete`, so for simplicity I've opted to use the existing transition to `cancelled`. Are there likely to be any issues with this?

---

### Email sent when there are no other active course choices on the application:

**Subject: Find a different course and re-submit your application**

![Screenshot_20200828_113436](https://user-images.githubusercontent.com/519250/91551674-7b005280-e922-11ea-8d63-9a82aeaaf4d9.png)



---

### Email sent when there are other active course choices on the application:

**Subject: Application could not be sent for (course name and code) at (provider name)**

#### One other course choice
![Screenshot_20200828_114748](https://user-images.githubusercontent.com/519250/91552805-5016fe00-e924-11ea-8c6d-cdee67fa2c00.png)


#### More than one other course choice
![Screenshot_20200828_114404](https://user-images.githubusercontent.com/519250/91552498-d1ba5c00-e923-11ea-8565-0646ee5c95dd.png)


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/iExqduky

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
