### PR TITLE
Be strict about how clients use TextOrdinalizer

### DIFF
--- a/app/components/candidate_interface/links_to_previous_applications_component.rb
+++ b/app/components/candidate_interface/links_to_previous_applications_component.rb
@@ -14,7 +14,7 @@ module CandidateInterface
   private
 
     def ordinalize(application_form)
-      "#{TextOrdinalizer::ORDINALIZE_MAPPING[ordinal(application_form)].capitalize} application"
+      "#{TextOrdinalizer.call(ordinal(application_form)).capitalize} application"
     end
 
     def ordinal(application_form)

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -6,7 +6,7 @@
 
 <% @application_form.application_references.includes(:application_form).each do |referee| %>
   <%= render(SummaryCardComponent.new(rows: referee_rows(referee), editable: @editable && referee.editable?)) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: "#{TextOrdinalizer::ORDINALIZE_MAPPING[referee.ordinal]&.capitalize} referee", heading_level: @heading_level)) do %>
+    <%= render(SummaryCardHeaderComponent.new(title: "#{TextOrdinalizer.call(referee.ordinal).capitalize} referee", heading_level: @heading_level)) do %>
 
       <% if referee.feedback_requested? %>
         <div class="app-summary-card__actions">

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -70,7 +70,7 @@ module CandidateInterface
     def edit
       head :unprocessable_entity and return unless @referee.editable?
 
-      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[@referee.ordinal].capitalize} referee"
+      @nth_referee = "#{TextOrdinalizer.call(@referee.ordinal).capitalize} referee"
     end
 
     def update
@@ -159,7 +159,7 @@ module CandidateInterface
     end
 
     def set_nth_referee
-      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[(@referees.count + 1)].capitalize} referee"
+      @nth_referee = "#{TextOrdinalizer.call(@referees.count + 1).capitalize} referee"
     end
 
     def referee_type_param

--- a/app/lib/text_ordinalizer.rb
+++ b/app/lib/text_ordinalizer.rb
@@ -1,13 +1,13 @@
 class TextOrdinalizer
-  ORDINALIZE_MAPPING = %w[zeroth first second third fourth fifth sixth seventh
-                          eighth ninth tenth].freeze
-
   def self.call(value)
     text_ordinalize(value)
   end
 
   class << self
   private
+
+    ORDINALIZE_MAPPING = %w[zeroth first second third fourth fifth sixth seventh
+                            eighth ninth tenth].freeze
 
     def text_ordinalize(value)
       ORDINALIZE_MAPPING[value] || value.ordinalize


### PR DESCRIPTION
## Context

Not a likely scenario irl, but a user had > 10 applications  on the sandbox: https://sentry.io/organizations/dfe-bat/issues/1861573888/?referrer=slack

`LinksToPreviousApplicationsComponent` blew up because it (legitimately) tried to ordinalize a number > 10 without going through `TextOrdinalizer`'s proper interface, and ended up with an unexpected nil.

Being strict about the public interface of `TextOrdinalizer` means this isn't possible any more. This change does not damage `LinksToPreviousApplicationsComponent` (or the other call sites) because `TextOrdinalizer`'s fallback to Rails's `#ordinalize` method will return eg `11th` which noops when you try to `#capitalize` it.

## Changes proposed in this pull request

See commit

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/1861573888/?referrer=slack

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
