### PR TITLE
Add feature flag to simulate EoC cancellation behaviour

### DIFF
--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -21,6 +21,8 @@ class EndOfCycleTimetable
   end
 
   def self.stop_applications_to_unavailable_course_options?
+    return true if FeatureFlag.active?(:simulate_stop_applications_to_unavailable_course_options)
+
     Time.zone.now > date(:stop_applications_to_unavailable_course_options).end_of_day &&
       Time.zone.now < date(:next_cycle_opens).beginning_of_day
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,6 +23,7 @@ class FeatureFlag
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
     [:simulate_time_between_cycles, 'Simulates the time between recruitment cycles so that EoC features can be tested', 'Steve Hook'],
     [:simulate_time_mid_cycle, 'Simulates the mid recruitment cycle time so that normal functionality can be tested between cycles', 'Steve Hook'],
+    [:simulate_stop_applications_to_unavailable_course_options, 'Simulate EoC behaviour where applications to unavailable options are cancelled before they can be sent to the provider', 'Malcolm Baig'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [


### PR DESCRIPTION


## Context

Make it easier to manually test https://github.com/DFE-Digital/apply-for-teacher-training/pull/2788


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
For a specific time window towards the end of the cycle, we cancel any
applications to unavailable course options before they can be sent to
the provider.

When this feature flag is active, the time-related checks for whether or
not we apply that behaviour are stubbed. This makes manual testing
easier when outside of the time window.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/tGI5SMcV

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
