### PR TITLE
Prevent SVGs in candidate application flow doc from overflowing

### DIFF
--- a/app/views/support_interface/docs/candidate_flow.html.erb
+++ b/app/views/support_interface/docs/candidate_flow.html.erb
@@ -23,6 +23,10 @@
   </div>
 </details>
 
+<style>
+  svg { max-width: 100%; }
+</style>
+
 <% ProcessState.workflow_spec.states.each do |_, state| %>
   <%= render StateExplanationComponent.new(state: state, machine: ProcessState, development_details: true) %>
   <hr class='govuk-section-break govuk-section-break--xl govuk-section-break--visible'>


### PR DESCRIPTION
## Context

The SVG were overflowing. We use the same fix in 'provider flow' and 'when emails are sent' docs.

## Changes proposed in this pull request

**Before**
<img width="500" alt="Screenshot 2020-08-27 at 15 54 13" src="https://user-images.githubusercontent.com/38078064/91459278-5c488000-e87e-11ea-8a2e-136967d36ba6.png">

**After**
<img width="500" alt="Screenshot 2020-08-27 at 15 54 42" src="https://user-images.githubusercontent.com/38078064/91459294-610d3400-e87e-11ea-8ab1-e42234f8b264.png">


## Guidance to review

🚢 

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
