### PR TITLE
Run RejectAwaitingReferencesCourseChoicesWorker every hour

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -21,6 +21,8 @@ class Clock
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
+  every(1.hour, 'RejectAwaitingReferencesCourseChoices', at: '**:50') { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
+
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
     if Time.zone.today.weekday?
       UCASMatching::UploadMatchingData.perform_async


### PR DESCRIPTION
## Context

We added `RejectAwaitingReferencesCourseChoicesWorker` in https://github.com/DFE-Digital/apply-for-teacher-training/pull/2763 but didn't enable it to run every hour, because that could cause a race condition when deploying.

## Changes proposed in this pull request

This enables the worker to run every hour to clear out the applications that are meant to be rejected at the end of the cycle.

## Guidance to review

Does at :50 every hour makes sense?

Merge into master after https://github.com/DFE-Digital/apply-for-teacher-training/pull/2763 is deployed.

## Link to Trello card

https://trello.com/c/hX5tD7PX/1959-dev-🚲🔚-reject-all-submitted-applications-including-apply-again-as-incomplete-which-havent-been-sent-to-providers-at-the-end-of-t

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
