### PR TITLE
Remove content about withdrawing from application dashboard 

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -105,10 +105,6 @@
   </div>
 <% end %>
 
-<% if any_withdrawable? %>
-  <p class="govuk-body"><%= t('application_form.courses.withdrawal_information') %></p>
-<% end %>
-
 <% if show_missing_banner? %>
   <%= render(SectionMissingBannerComponent.new(section: :course_choices, section_path: candidate_interface_course_choices_index_path, error: @missing_error)) %>
 <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -15,10 +15,6 @@ en:
         completed_checkbox: I have completed this section
         button: Continue
       view_and_respond_to_offer: View and respond to offer
-      withdrawal_information: >
-        You can withdraw an application from a training provider at any point,
-        even after you’ve accepted an offer. You will not be penalised, but you
-        cannot substitute a different course or provider.
     personal_details:
       first_name:
         label: First name

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -319,12 +319,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.courses.withdraw'))
       expect(result.css('.app-summary-card__actions a[data-action=withdraw]')).to be_present
     end
-
-    it 'renders component with a withdrawal content' do
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
-
-      expect(result.text).to include(t('application_form.courses.withdrawal_information'))
-    end
   end
 
   context 'when an offer has been made to a course choice' do
@@ -367,12 +361,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_withdraw_path(course_id),
       )
-    end
-
-    it 'renders component with a withdrawal content' do
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
-
-      expect(result.text).to include(t('application_form.courses.withdrawal_information'))
     end
   end
 


### PR DESCRIPTION
## Context

~~Our current content talks about ‘penalising’ candidates which is too aggressive.~~

Remove content about withdrawing from application dashboard because:
* The link means its self evident you can withdraw your application
* We are unable to cover the different contexts this might appear in (one course, many courses, etc.)
* We show this content when you click the ‘Withdraw’ link

## Changes proposed in this pull request

Remove content shown on dashboard related to withdrawing.