### PR TITLE
Store ProviderRelationshipPermissions wizard data in Redis

### DIFF
--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -112,7 +112,10 @@ module ProviderInterface
 
     def wizard_for(options)
       options[:checking_answers] = true if params[:checking_answers] == 'true'
-      ProviderRelationshipPermissionsSetupWizard.new(session, options)
+      ProviderRelationshipPermissionsSetupWizard.new(
+        WizardStateStores::SessionStore.new(session: session, key: persistence_key_for_current_user),
+        options,
+      )
     end
 
     def require_feature_flag!
@@ -146,6 +149,10 @@ module ProviderInterface
       @permissions_form = ProviderInterface::ProviderRelationshipPermissionsSetupWizard::PermissionsForm.new(
         @wizard.permissions_for_relationship(@permissions_model.id).merge(id: @permissions_model.id),
       )
+    end
+
+    def persistence_key_for_current_user
+      "provider_user_permissions_wizard-#{current_provider_user.id}"
     end
   end
 end

--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -113,7 +113,7 @@ module ProviderInterface
     def wizard_for(options)
       options[:checking_answers] = true if params[:checking_answers] == 'true'
       ProviderRelationshipPermissionsSetupWizard.new(
-        WizardStateStores::SessionStore.new(session: session, key: persistence_key_for_current_user),
+        WizardStateStores::RedisStore.new(key: persistence_key_for_current_user),
         options,
       )
     end

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -113,7 +113,11 @@ module ProviderInterface
 
     def wizard_for(options)
       options[:checking_answers] = true if params[:checking_answers] == 'true'
-      ProviderUserInvitationWizard.new(session, options)
+
+      ProviderUserInvitationWizard.new(
+        WizardStateStores::SessionStore.new(session: session, key: persistence_key_for_current_user),
+        options,
+      )
     end
 
     def path_for(step, provider_id)
@@ -156,6 +160,10 @@ module ProviderInterface
         provider_id: @provider.id,
         permissions: @wizard.permissions_for_provider(@provider.id),
       )
+    end
+
+    def persistence_key_for_current_user
+      "provider_user_invitation_wizard-#{current_provider_user.id}"
     end
   end
 end

--- a/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb
@@ -1,7 +1,6 @@
 module ProviderInterface
   class ProviderRelationshipPermissionsSetupWizard
     include ActiveModel::Model
-    STATE_STORE_KEY = :provider_relationship_permissions_setup_wizard
 
     attr_accessor :current_step, :current_provider_relationship_id, :checking_answers
     attr_writer :provider_relationships, :provider_relationship_permissions, :state_store
@@ -73,11 +72,11 @@ module ProviderInterface
     end
 
     def save_state!
-      @state_store[STATE_STORE_KEY] = state
+      @state_store.write(state)
     end
 
     def clear_state!
-      @state_store.delete(STATE_STORE_KEY)
+      @state_store.delete
     end
 
   private
@@ -87,7 +86,13 @@ module ProviderInterface
     end
 
     def last_saved_state
-      JSON.parse(@state_store[STATE_STORE_KEY].presence || '{}')
+      state = @state_store.read
+
+      if state
+        JSON.parse(state)
+      else
+        {}
+      end
     end
 
     def next_provider_relationship_id

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -135,11 +135,11 @@ module ProviderInterface
     end
 
     def save_state!
-      @state_store[STATE_STORE_KEY] = state
+      @state_store.write(state)
     end
 
     def clear_state!
-      @state_store.delete(STATE_STORE_KEY)
+      @state_store.delete
     end
 
     def new_user?
@@ -157,7 +157,13 @@ module ProviderInterface
     end
 
     def last_saved_state
-      JSON.parse(@state_store[STATE_STORE_KEY].presence || '{}')
+      saved_state = @state_store.read
+
+      if saved_state
+        JSON.parse(saved_state)
+      else
+        {}
+      end
     end
 
     def next_provider_id

--- a/app/lib/wizard_state_stores/redis_store.rb
+++ b/app/lib/wizard_state_stores/redis_store.rb
@@ -8,7 +8,7 @@ module WizardStateStores
     end
 
     def write(value)
-      @redis.set(@key, value)
+      @redis.set(@key, value, ex: ActiveSupport::Duration::SECONDS_PER_DAY)
     end
 
     def read

--- a/app/lib/wizard_state_stores/redis_store.rb
+++ b/app/lib/wizard_state_stores/redis_store.rb
@@ -1,0 +1,22 @@
+require 'redis'
+
+module WizardStateStores
+  class RedisStore
+    def initialize(key:)
+      @redis = Redis.new
+      @key = key
+    end
+
+    def write(value)
+      @redis.set(@key, value)
+    end
+
+    def read
+      @redis.get(@key)
+    end
+
+    def delete
+      @redis.del(@key)
+    end
+  end
+end

--- a/app/lib/wizard_state_stores/redis_store.rb
+++ b/app/lib/wizard_state_stores/redis_store.rb
@@ -3,7 +3,7 @@ require 'redis'
 module WizardStateStores
   class RedisStore
     def initialize(key:)
-      @redis = Redis.new
+      @redis = Redis.current
       @key = key
     end
 

--- a/app/lib/wizard_state_stores/session_store.rb
+++ b/app/lib/wizard_state_stores/session_store.rb
@@ -1,0 +1,20 @@
+module WizardStateStores
+  class SessionStore
+    def initialize(session:, key:)
+      @session = session
+      @key = key
+    end
+
+    def write(value)
+      @session[@key] = value
+    end
+
+    def read
+      @session[@key]
+    end
+
+    def delete
+      @session.delete(@key)
+    end
+  end
+end

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
   def state_store_for(state)
-    { described_class::STATE_STORE_KEY => state.to_json }
+    WizardStateStores::SessionStore.new(session: { 'key' => state.to_json }, key: 'key')
   end
 
   describe 'next_step' do
@@ -145,7 +145,7 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
 
       wizard.save_state!
 
-      expect(JSON.parse(state_store[described_class::STATE_STORE_KEY]).symbolize_keys).to eq({
+      expect(JSON.parse(state_store.read).symbolize_keys).to eq({
         provider_relationships: [123],
         provider_relationship_permissions: {
           '123' => {
@@ -164,7 +164,7 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
 
       wizard.clear_state!
 
-      expect(state_store[described_class::STATE_STORE_KEY]).to be_nil
+      expect(state_store.read).to be_nil
     end
   end
 end

--- a/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_user_invitation_wizard_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
   def state_store_for(state)
-    { described_class::STATE_STORE_KEY => state.to_json }
+    WizardStateStores::SessionStore.new(session: { 'key' => state.to_json }, key: 'key')
   end
 
   describe 'next_step' do
@@ -103,7 +103,7 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
 
       wizard.save_state!
 
-      expect(JSON.parse(state_store[described_class::STATE_STORE_KEY]).symbolize_keys).to eq({
+      expect(JSON.parse(state_store.read).symbolize_keys).to eq({
         first_name: 'Bob',
         last_name: 'Roberts',
         email_address: 'bob@roberts.com',
@@ -119,7 +119,7 @@ RSpec.describe ProviderInterface::ProviderUserInvitationWizard do
 
       wizard.clear_state!
 
-      expect(state_store[described_class::STATE_STORE_KEY]).to be_nil
+      expect(state_store.read).to be_nil
     end
   end
 


### PR DESCRIPTION
## Context

We used the session to hold data from the wizard. Unfortunately we overflowed it and this caused 500s because cookies can only be 4k. It's insane that there can be 4k of data in these things but it's possible that other things are taking up space in the session too (flash messages, DSI data, etc).

We had a choice: shrink the data, or change the persistence method. In this PR I have chosen to change the persistence method.

I tried compressing the data with Ruby's zlib library but it gave us < 50% compression per permission set, which wasn't enough to make me feel safe. We could probably have hand-rolled a compression scheme and stored all the data we need in a couple of bytes but that would have been difficult and complicated.

Therefore I chose to store the data in Redis instead. I did not choose to move the whole session into Redis because that's not a decision to take lightly and I want to fix this bug without having to make it.

## Changes proposed in this pull request

We have two wizards, one for invitations and one for setting permissions.

**Step 1** was to refactor the invitations wizard to depend on a `WizardStateStore::SessionStore` instead of a plain `session`.

**Step 2** was to do the same for the permissions wizard.

**Step 3** was to implement a `WizardStateStore::RedisStore` and have the permissions wizard use that.

There is a slight risk to changing the storage backend for one of these wizards because the user might have data in the session already. In the case of permissions this is not a risk because the feature is not live yet. Therefore this PR remains deployable. We could subsequently ship a PR which enabled Redis for the invitation wizard and migrated any extant sessions to Redis. Or, of course, we could simply YOLO it and switch it over in the middle of the night when no providers are at work. Note that in any case having `SessionStore` is handy because we can test the units without Redis.

Now that the backend is passed into the Wizard, the controller is in charge of setting the persistence key because it has the context of the current user etc. This doesn't seem too terrible.

## Guidance to review

Does all this make sense? Any suggestions for simplifying it? Should `SessionStore` be called `HashStore` or something? Could the persistence keys ever conflict with each other?

## Link to Trello card

2650-modifying-provider-permissions-loads-more-than-4kb-into-the-cookie-which-causes-a-cookieoverflow-error

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
