### PR TITLE
Add clock entry for automatically carrying over unsubmitted apps

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -22,6 +22,7 @@ class Clock
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
   every(1.hour, 'RejectAwaitingReferencesCourseChoices', at: '**:50') { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
+  every(1.day, 'CarryOverUnsubmittedApplications', at: '00:01', if: ->(t) { t.to_date == EndOfCycleTimetable.date(:next_cycle_opens) }) { CarryOverUnsubmittedApplicationsWorker.perform_async }
 
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
     if Time.zone.today.weekday?

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -101,4 +101,30 @@ RSpec.describe Clockwork do
       end
     end
   end
+
+  describe 'CarryOverUnsubmittedApplications schedule' do
+    it 'runs the job once on first day of new cycle' do
+      start_time = Time.zone.local(2020, 10, 13, 0, 0, 0)
+      end_time = Time.zone.local(2020, 10, 13, 23, 59, 59)
+      Clockwork::Test.run(
+        start_time: start_time,
+        end_time: end_time,
+        tick_speed: 1.minute,
+        file: './config/clock.rb',
+      )
+      expect(Clockwork::Test.times_run('CarryOverUnsubmittedApplications')).to eq 1
+    end
+
+    it 'does NOT run the job on other days' do
+      start_time = Time.zone.local(2020, 8, 1, 0, 0, 0)
+      end_time = Time.zone.local(2020, 8, 1, 1, 0, 0)
+      Clockwork::Test.run(
+        start_time: start_time,
+        end_time: end_time,
+        tick_speed: 1.minute,
+        file: './config/clock.rb',
+      )
+      expect(Clockwork::Test.times_run('CarryOverUnsubmittedApplications')).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
## Context

This is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/2759 that sets up a clock entry to run the automatic carry over of unsubmitted applications to the new recruitment cycle.

## Changes proposed in this pull request

- Add clock entry to run existing `CarryOverUnsubmittedApplicationsWorker` (in Sidekiq) at 1 minute past midnight on the day that the new recruitment cycle opens.

## Guidance to review

- Is a one-off job the right approach here?

## Link to Trello card

https://trello.com/c/IzMDhv0p/1907-dev-🚲🔚-carried-over-applications-have-courses-removed

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
