### PR TITLE
Small improvements to UCAS matching UX

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -20,6 +20,7 @@ module SupportInterface
         edit_by_row,
         last_updated_row,
         state_row,
+        ucas_match_row,
         previous_application_row,
         subsequent_application_row,
       ].compact
@@ -68,6 +69,19 @@ module SupportInterface
       }
     end
 
+    def ucas_match_row
+      value = if ucas_match
+                govuk_link_to('View matching data', support_interface_ucas_match_path(ucas_match))
+              else
+                'No matching data'
+              end
+
+      {
+        key: 'UCAS matching data for this candidate',
+        value: value,
+      }
+    end
+
     def previous_application_row
       return unless application_form.previous_application_form
 
@@ -91,6 +105,10 @@ module SupportInterface
       name = I18n.t!("candidate_flow_application_states.#{process_state}.name")
       desc = I18n.t!("candidate_flow_application_states.#{process_state}.description")
       "#{name} – #{desc}"
+    end
+
+    def ucas_match
+      application_form.candidate.ucas_match
     end
 
     attr_reader :application_form

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -10,6 +10,7 @@ class Candidate < ApplicationRecord
                             length: { maximum: 100 },
                             email_address: true
 
+  has_one :ucas_match
   has_many :application_forms
   belongs_to :course_from_find, class_name: 'Course', optional: true
 

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -109,7 +109,11 @@ module UCASMatching
         end
       end
 
-      message = ":dfe: :ucas: Hello, this is the Apply/UCAS matching robot. I’ve just received a new file from UCAS. It contained #{new_matches} new matches, #{updated_matches} updated matches, and #{existing_matches} matches that we’ve already seen."
+      new_matches_string = "#{new_matches} new #{'match'.pluralize(new_matches)}"
+      updated_matches_string = "#{updated_matches} updated #{'match'.pluralize(updated_matches)}"
+      existing_matches_string = "#{existing_matches} #{'match'.pluralize(existing_matches)}"
+
+      message = ":dfe: :ucas: Hello, this is the Apply/UCAS matching robot. I’ve just received a new file from UCAS. It contained #{new_matches_string}, #{updated_matches_string}, and #{existing_matches_string} we’ve already seen."
       url = Rails.application.routes.url_helpers.support_interface_ucas_matches_url
       SlackNotificationWorker.perform_async(message, url)
     end

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationSummaryComponent do
+  describe '#rows' do
+    it 'includes a link to a UCAS match if present' do
+      candidate = create(:candidate)
+      application_form = create(:application_form, candidate: candidate)
+      create(:ucas_match, candidate: candidate, matching_state: 'new_match')
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('UCAS matching data for this candidate')
+      expect(result.css('.govuk-summary-list__value').text).to include('View matching data')
+    end
+
+    it 'reports no UCAS matches if there are none' do
+      candidate = create(:candidate)
+      application_form = create(:application_form, candidate: candidate)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('UCAS matching data for this candidate')
+      expect(result.css('.govuk-summary-list__value').text).to include('No matching data')
+    end
+  end
+end

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
   end
 
   def then_we_have_received_a_slack_message
-    expect_slack_message_with_text('It contained 1 new matches, 1 updated matches, and 1 matches that we’ve already seen.')
+    expect_slack_message_with_text('It contained 1 new match, 1 updated match, and 1 match we’ve already seen.')
   end
 
   def when_i_visit_the_ucas_matches_page_in_support


### PR DESCRIPTION
## Changes proposed in this pull request

It's a bit painful to find a UCAS match for a given candidate in support (visit `/ucas-matches` and find on page). Instead, link directly from the candidate's application to any UCAS match we hold for them.

Correctly pluralise the messages from the UCAS-matching Slackbot.

See new row at the bottom of the `ApplicationSummaryComponent`:

<img width="1031" alt="Screenshot 2020-08-28 at 10 02 19" src="https://user-images.githubusercontent.com/642279/91542537-ed1e6a80-e915-11ea-9207-00f11eda61a0.png">

<img width="1065" alt="Screenshot 2020-08-28 at 10 02 29" src="https://user-images.githubusercontent.com/642279/91542548-f0b1f180-e915-11ea-85d2-ba1a5c8b3bb2.png">

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
