### PR TITLE
Change reject awaiting refs at EoC to a one-off job

### DIFF
--- a/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
+++ b/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     def self.call
       return [] unless EndOfCycleTimetable.between_cycles_apply_2?
 
-      ApplicationChoice.includes(:course).joins(:course).where('courses.recruitment_cycle_year': RecruitmentCycle.previous_year).awaiting_references
+      ApplicationChoice.includes(:course).joins(:course).where('courses.recruitment_cycle_year': RecruitmentCycle.current_year).awaiting_references
     end
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -21,7 +21,7 @@ class Clock
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
-  every(1.hour, 'RejectAwaitingReferencesCourseChoices', at: '**:50') { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
+  every(1.day, 'RejectAwaitingReferencesCourseChoices', at: '00:01', if: ->(t) { t.to_date == EndOfCycleTimetable.date(:apply_2_deadline) + 1 }) { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
   every(1.day, 'CarryOverUnsubmittedApplications', at: '00:01', if: ->(t) { t.to_date == EndOfCycleTimetable.date(:next_cycle_opens) }) { CarryOverUnsubmittedApplicationsWorker.perform_async }
 
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -22,6 +22,7 @@ class Clock
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
   every(1.hour, 'RejectAwaitingReferencesCourseChoices', at: '**:50') { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
+  every(1.day, 'CarryOverUnsubmittedApplications', at: '00:01', if: ->(t) { t.to_date == EndOfCycleTimetable.date(:next_cycle_opens) }) { CarryOverUnsubmittedApplicationsWorker.perform_async }
 
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
     if Time.zone.today.weekday?

--- a/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
+++ b/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices do
   describe '#call' do
-    let!(:course_option_from_last_year) { create(:course_option, :previous_year) }
-    let!(:application_choice1) { create(:awaiting_references_application_choice, course_option: course_option_from_last_year) }
+    let!(:application_choice1) { create(:awaiting_references_application_choice) }
 
     before do
       create(:application_choice, :with_offer)

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe Clockwork do
     { worker: SendAdditionalReferenceChaseEmailToBothPartiesWorker, task: 'SendAdditionalReferenceChaseEmailToCandidates' },
     { worker: SendChaseEmailToProvidersWorker, task: 'SendChaseEmailToProviders' },
     { worker: SendChaseEmailToCandidatesWorker, task: 'SendChaseEmailToCandidates' },
-    { worker: RejectAwaitingReferencesCourseChoicesWorker, task: 'RejectAwaitingReferencesCourseChoices' },
   ].each do |worker|
     describe 'worker schedule' do
       it 'runs the job every hour' do
@@ -125,6 +124,32 @@ RSpec.describe Clockwork do
         file: './config/clock.rb',
       )
       expect(Clockwork::Test.times_run('CarryOverUnsubmittedApplications')).to eq 0
+    end
+  end
+
+  describe 'RejectAwaitingReferencesCourseChoices schedule' do
+    it 'runs the job once on day that Apply 2 applications close' do
+      start_time = Time.zone.local(2020, 9, 19, 0, 0, 0)
+      end_time = Time.zone.local(2020, 9, 19, 23, 59, 59)
+      Clockwork::Test.run(
+        start_time: start_time,
+        end_time: end_time,
+        tick_speed: 1.minute,
+        file: './config/clock.rb',
+      )
+      expect(Clockwork::Test.times_run('RejectAwaitingReferencesCourseChoices')).to eq 1
+    end
+
+    it 'does NOT run the job on other days' do
+      start_time = Time.zone.local(2020, 8, 1, 0, 0, 0)
+      end_time = Time.zone.local(2020, 8, 1, 1, 0, 0)
+      Clockwork::Test.run(
+        start_time: start_time,
+        end_time: end_time,
+        tick_speed: 1.minute,
+        file: './config/clock.rb',
+      )
+      expect(Clockwork::Test.times_run('RejectAwaitingReferencesCourseChoices')).to eq 0
     end
   end
 end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -101,4 +101,30 @@ RSpec.describe Clockwork do
       end
     end
   end
+
+  describe 'CarryOverUnsubmittedApplications schedule' do
+    it 'runs the job once on first day of new cycle' do
+      start_time = Time.zone.local(2020, 10, 13, 0, 0, 0)
+      end_time = Time.zone.local(2020, 10, 13, 23, 59, 59)
+      Clockwork::Test.run(
+        start_time: start_time,
+        end_time: end_time,
+        tick_speed: 1.minute,
+        file: './config/clock.rb',
+      )
+      expect(Clockwork::Test.times_run('CarryOverUnsubmittedApplications')).to eq 1
+    end
+
+    it 'does NOT run the job on other days' do
+      start_time = Time.zone.local(2020, 8, 1, 0, 0, 0)
+      end_time = Time.zone.local(2020, 8, 1, 1, 0, 0)
+      Clockwork::Test.run(
+        start_time: start_time,
+        end_time: end_time,
+        tick_speed: 1.minute,
+        file: './config/clock.rb',
+      )
+      expect(Clockwork::Test.times_run('CarryOverUnsubmittedApplications')).to eq 0
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
@@ -16,7 +16,6 @@ RSpec.feature 'Candidates awaiting references application choices are rejected w
   end
 
   def when_the_apply_2_deadline_has_passed
-    FeatureFlag.activate('switch_to_2021_recruitment_cycle')
     Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
       RejectAwaitingReferencesCourseChoicesWorker.new.perform
     end


### PR DESCRIPTION
## Context

This is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/2763 to ensure that the background job that processes awaiting references applications at the end of cycle runs only once.

## Changes proposed in this pull request

- [x] Change clock entry to run at one minute past midnight on 19 September (right after the apply 2 deadline).
- [x] Change logic in query to return applications in the same cycle because the new cycle we not have started at the point this runs.

## Guidance to review

- Is the assumption that the 2021 cycle doesn't begin until October (6th or 13th?) Is that correct?

## Link to Trello card

https://trello.com/c/hX5tD7PX/1959-dev-🚲🔚-reject-all-submitted-applications-including-apply-again-as-incomplete-which-havent-been-sent-to-providers-at-the-end-of-t

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
