### PR TITLE
Add null option to GCSE grade select

### DIFF
--- a/app/forms/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_details_form.rb
@@ -14,7 +14,7 @@ module CandidateInterface
     Grade = Struct.new(:value, :option)
 
     def self.all_grade_drop_down_options
-      ALL_GCSE_GRADES.map { |g| Grade.new(g, g) }
+      ALL_GCSE_GRADES.map { |g| Grade.new(g, g) }.unshift(Grade.new(nil, nil))
     end
 
     def self.build_from_qualification(qualification)


### PR DESCRIPTION
Not doing so defaults to the first option in the list. This leads to a confusing UI when autocomplete JS is applied to the element, as you can only see a few matches that start with the first option (ie - grades beginning with '9').

## Context

<!-- Why are you making this change? What might surprise someone about it? -->
See Trello card.
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/0GhLI2EE/2053-drop-down-arrow-not-working-and-grade-pre-filled-for-gcse
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
