### PR TITLE
Don't automatically carry over test applications

### DIFF
--- a/app/workers/carry_over_unsubmitted_applications_worker.rb
+++ b/app/workers/carry_over_unsubmitted_applications_worker.rb
@@ -15,6 +15,10 @@ private
       .where(submitted_at: nil)
       .where('courses.recruitment_cycle_year' => RecruitmentCycle.previous_year)
       .where(
+        'application_forms.candidate_id NOT IN (:hidden_candidates)',
+        hidden_candidates: Candidate.where(hide_in_reporting: true).select(:id),
+      )
+      .where(
         'application_forms.id NOT IN (:duplicated_applications)',
         duplicated_applications: ApplicationForm.where.not(previous_application_form_id: nil).select(:previous_application_form_id),
       )

--- a/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/carry_over_unsubmitted_applications_worker_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
         course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)),
       )
 
+      hidden_application_from_last_year = create(
+        :completed_application_form,
+        submitted_at: nil,
+        candidate: create(:candidate, hide_in_reporting: true),
+      )
+      create(
+        :application_choice,
+        status: :unsubmitted,
+        application_form: hidden_application_from_last_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year)),
+      )
+
       unsubmitted_application_from_this_year = create(
         :completed_application_form,
         submitted_at: nil,
@@ -40,6 +52,7 @@ RSpec.describe CarryOverUnsubmittedApplicationsWorker do
       expect(unsubmitted_application_from_last_year.reload.subsequent_application_form).to be_present
       expect(unsubmitted_application_from_this_year.reload.subsequent_application_form).not_to be_present
       expect(rejected_application_from_last_year.reload.subsequent_application_form).not_to be_present
+      expect(hidden_application_from_last_year.reload.subsequent_application_form).not_to be_present
 
       carried_over_application_form = unsubmitted_application_from_last_year.reload.subsequent_application_form
 


### PR DESCRIPTION
## Context

We sometimes make test applications on productions, which are hidden from reporting via `hide_in_reporting`. 

## Changes proposed in this pull request

This excludes them from the automatic carryover. Saves about 40 applications.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/x6hpRtsT

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
