### PR TITLE
Add support page with all info about recruitment cycles

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -83,6 +83,12 @@ module ViewHelper
     (application_choice.reject_by_default_at.to_date - Date.current).to_i
   end
 
+  def boolean_to_word(boolean)
+    return nil if boolean.nil?
+
+    boolean ? 'Yes' : 'No'
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -1,27 +1,31 @@
 <% if try(:current_support_user) %>
-  <h2 class="govuk-heading-m">Product development</h2>
+  <h2 class="govuk-heading-m">Docs</h2>
 
-  <ul class="govuk-footer__inline-list">
-    <li class="govuk-footer__inline-list-item">
+  <ul class="govuk-footer__list">
+    <li class="govuk-footer__list-item">
       <%= govuk_link_to 'Provider application flow', support_interface_provider_flow_path %>
     </li>
 
-    <li class="govuk-footer__inline-list-item">
+    <li class="govuk-footer__list-item">
       <%= govuk_link_to 'Candidate application flow', support_interface_candidate_flow_path %>
     </li>
 
-    <li class="govuk-footer__inline-list-item">
+    <li class="govuk-footer__list-item">
       <%= govuk_link_to 'When emails are sent', support_interface_when_emails_are_sent_path %>
     </li>
 
+    <li class="govuk-footer__list-item">
+      <%= govuk_link_to 'Recruitment cycles', support_interface_cycles_path %>
+    </li>
+
     <% if Rails.application.config.action_mailer.show_previews %>
-    <li class="govuk-footer__inline-list-item">
+    <li class="govuk-footer__list-item">
       <%= govuk_link_to 'Mail previews', '/support/mailers' %>
     </li>
     <% end %>
 
     <% if Rails.application.config.view_component.show_previews %>
-    <li class="govuk-footer__inline-list-item">
+    <li class="govuk-footer__list-item">
       <%= govuk_link_to 'Component previews', '/rails/view_components' %>
     </li>
     <% end %>

--- a/app/views/support_interface/docs/candidate_flow.html.erb
+++ b/app/views/support_interface/docs/candidate_flow.html.erb
@@ -5,6 +5,7 @@
     { name: 'Provider application flow', url: support_interface_provider_flow_path },
     { name: 'Candidate application flow', url: support_interface_candidate_flow_path, current: true },
     { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path },
+    { name: 'Recruitment cycles', url: support_interface_cycles_path },
   ]) %>
 <% end %>
 

--- a/app/views/support_interface/docs/cycles.html.erb
+++ b/app/views/support_interface/docs/cycles.html.erb
@@ -1,0 +1,40 @@
+<%= content_for :title, 'Recruitment cycles' %>
+
+<% content_for :before_content do %>
+  <%= render SubNavigationComponent.new(items: [
+    { name: 'Provider application flow', url: support_interface_provider_flow_path },
+    { name: 'Candidate application flow', url: support_interface_candidate_flow_path },
+    { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path },
+    { name: 'Recruitment cycles', url: support_interface_cycles_path },
+  ]) %>
+<% end %>
+
+<h2 class='govuk-heading-m'>Cycle years</h2>
+
+<%= render SummaryListComponent.new(rows: {
+  'Previous cycle year' => RecruitmentCycle.previous_year,
+  'Current cycle year' => RecruitmentCycle.current_year,
+  'Next cycle year' => EndOfCycleTimetable.next_cycle_year,
+  'Years visible to providers' => RecruitmentCycle.visible_years.to_sentence,
+}) %>
+
+<h2 class='govuk-heading-m'>Deadlines</h2>
+
+<%= render SummaryListComponent.new(rows: {
+  'Appy 1 deadline' => EndOfCycleTimetable.apply_1_deadline.to_s(:govuk_date),
+  'Apply 2 deadline' => EndOfCycleTimetable.apply_2_deadline.to_s(:govuk_date),
+  'Find closes on' => EndOfCycleTimetable.find_closes.to_s(:govuk_date),
+  'Find reopens on' => EndOfCycleTimetable.find_reopens.to_s(:govuk_date),
+  'Next cycle opens on' => EndOfCycleTimetable.next_cycle_opens.to_s(:govuk_date),
+}) %>
+
+<h2 class='govuk-heading-m'>Flags</h2>
+
+<%= render SummaryListComponent.new(rows: {
+  'Show Apply 1 deadline banner?' => boolean_to_word(EndOfCycleTimetable.show_apply_1_deadline_banner?),
+  'Show Apply 2 deadline banner?' => boolean_to_word(EndOfCycleTimetable.show_apply_2_deadline_banner?),
+  'Are we between cycles for Apply 1?' => boolean_to_word(EndOfCycleTimetable.between_cycles_apply_1?),
+  'Are we between cycles for Apply 2?' => boolean_to_word(EndOfCycleTimetable.between_cycles_apply_2?),
+  'Stop applications to unavailable course options?' => boolean_to_word(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?),
+  'Is find down?' => boolean_to_word(EndOfCycleTimetable.find_down?),
+}) %>

--- a/app/views/support_interface/docs/provider_flow.html.erb
+++ b/app/views/support_interface/docs/provider_flow.html.erb
@@ -5,6 +5,7 @@
     { name: 'Provider application flow', url: support_interface_provider_flow_path, current: true },
     { name: 'Candidate application flow', url: support_interface_candidate_flow_path },
     { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path },
+    { name: 'Recruitment cycles', url: support_interface_cycles_path },
   ]) %>
 <% end %>
 

--- a/app/views/support_interface/docs/when_emails_are_sent.html.erb
+++ b/app/views/support_interface/docs/when_emails_are_sent.html.erb
@@ -5,6 +5,7 @@
     { name: 'Provider application flow', url: support_interface_provider_flow_path },
     { name: 'Candidate application flow', url: support_interface_candidate_flow_path },
     { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path, current: true },
+    { name: 'Recruitment cycles', url: support_interface_cycles_path },
   ]) %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -645,6 +645,7 @@ Rails.application.routes.draw do
     get '/provider-flow', to: 'docs#provider_flow', as: :provider_flow
     get '/candidate-flow', to: 'docs#candidate_flow', as: :candidate_flow
     get '/when-emails-are-sent', to: 'docs#when_emails_are_sent', as: :when_emails_are_sent
+    get '/docs/cycles', to: 'docs#cycles', as: :cycles
 
     get '/email-log', to: 'email_log#index', as: :email_log
 

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -11,6 +11,9 @@ RSpec.feature 'Docs' do
 
     when_i_click_on_candidate_flow_documentation
     then_i_see_the_candidate_flow_documentation
+
+    when_i_click_on_the_recruitment_cycle_link
+    then_i_see_the_cycle_information
   end
 
   def given_i_am_a_support_user
@@ -60,5 +63,15 @@ RSpec.feature 'Docs' do
 
   def then_i_see_the_candidate_flow_documentation
     expect(page).to have_title 'Candidate application flow'
+  end
+
+  def when_i_click_on_the_recruitment_cycle_link
+    within '.govuk-tabs' do
+      click_on 'Recruitment cycles'
+    end
+  end
+
+  def then_i_see_the_cycle_information
+    expect(page).to have_title 'Recruitment cycles'
   end
 end


### PR DESCRIPTION
## Context

We have a lot of settings related to recruitment cycles. They can be overridden by feature flags and per-environment. 

## Changes proposed in this pull request

Add a page in support that exposes all the current variables and derived flags:

![image](https://user-images.githubusercontent.com/233676/91845393-fa5a9280-ec50-11ea-9b21-8d14af018c53.png)


## Guidance to review

Are there other interesting bits of info that we can display?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
