### PR TITLE
Refactor EndOfCycleTimetable

### DIFF
--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -20,6 +20,10 @@ class EndOfCycleTimetable
     date(:apply_1_deadline)
   end
 
+  def self.stop_applications_to_unavailable_course_options
+    date(:stop_applications_to_unavailable_course_options)
+  end
+
   def self.apply_2_deadline
     date(:apply_2_deadline)
   end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -1,13 +1,4 @@
 class EndOfCycleTimetable
-  DATES = {
-    apply_1_deadline: Date.new(2020, 8, 24),
-    stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
-    apply_2_deadline: Date.new(2020, 9, 18),
-    find_closes: Date.new(2020, 9, 19),
-    find_reopens: Date.new(2020, 10, 3),
-    next_cycle_opens: Date.new(2020, 10, 13),
-  }.freeze
-
   def self.between_cycles?(phase)
     phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?
   end
@@ -21,8 +12,6 @@ class EndOfCycleTimetable
   end
 
   def self.stop_applications_to_unavailable_course_options?
-    return true if FeatureFlag.active?(:simulate_stop_applications_to_unavailable_course_options)
-
     Time.zone.now > date(:stop_applications_to_unavailable_course_options).end_of_day &&
       Time.zone.now < date(:next_cycle_opens).beginning_of_day
   end
@@ -62,38 +51,57 @@ class EndOfCycleTimetable
   end
 
   def self.date(name)
-    if HostingEnvironment.test_environment? || HostingEnvironment.sandbox_mode?
-      if FeatureFlag.active?(:simulate_time_between_cycles)
-        return simulate_time_between_cycles_dates[name]
-      elsif FeatureFlag.active?(:simulate_time_mid_cycle)
-        return simulate_time_mid_cycle_dates[name]
-      end
-    end
+    schedule = schedules.fetch(current_cycle_schedule)
+    schedule.fetch(name)
+  end
 
-    DATES[name]
+  def self.current_cycle_schedule
+    return :real unless HostingEnvironment.test_environment? || HostingEnvironment.sandbox_mode?
+    return :today_is_between_cycles if FeatureFlag.active?(:simulate_time_between_cycles)
+    return :today_is_mid_cycle if FeatureFlag.active?(:simulate_time_mid_cycle)
+    return :today_applications_are_unavailable_to_stopped_courses if FeatureFlag.active?(:simulate_stop_applications_to_unavailable_course_options)
+
+    :real
   end
 
   def self.next_cycle_year
     RecruitmentCycle.current_year + 1
   end
 
-  def self.simulate_time_between_cycles_dates
+  def self.schedules
     {
-      apply_1_deadline: 5.days.ago.to_date,
-      apply_2_deadline: 2.days.ago.to_date,
-      find_closes: 1.day.ago.to_date,
-      find_reopens: 5.days.from_now.to_date,
-      next_cycle_opens: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
-    }
-  end
-
-  def self.simulate_time_mid_cycle_dates
-    {
-      apply_1_deadline: 20.weeks.from_now.to_date,
-      apply_2_deadline: 22.weeks.from_now.to_date,
-      find_closes: 22.weeks.from_now.to_date,
-      find_reopens: 25.weeks.from_now.to_date,
-      next_cycle_opens: 26.weeks.from_now.to_date,
+      real: {
+        apply_1_deadline: Date.new(2020, 8, 24),
+        stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
+        apply_2_deadline: Date.new(2020, 9, 18),
+        find_closes: Date.new(2020, 9, 19),
+        find_reopens: Date.new(2020, 10, 3),
+        next_cycle_opens: Date.new(2020, 10, 13),
+      },
+      today_is_between_cycles: {
+        apply_1_deadline: 5.days.ago.to_date,
+        stop_applications_to_unavailable_course_options: 3.days.ago.to_date,
+        apply_2_deadline: 2.days.ago.to_date,
+        find_closes: 1.day.ago.to_date,
+        find_reopens: 5.days.from_now.to_date,
+        next_cycle_opens: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
+      },
+      today_applications_are_unavailable_to_stopped_courses: {
+        apply_1_deadline: 5.days.ago.to_date,
+        stop_applications_to_unavailable_course_options: 1.day.ago.to_date,
+        apply_2_deadline: 1.day.from_now.to_date,
+        find_closes: 2.days.from_now.to_date,
+        find_reopens: 4.days.from_now.to_date,
+        next_cycle_opens: 4.days.from_now.to_date,
+      },
+      today_is_mid_cycle: {
+        apply_1_deadline: 20.weeks.from_now.to_date,
+        stop_applications_to_unavailable_course_options: 20.weeks.from_now.to_date,
+        apply_2_deadline: 22.weeks.from_now.to_date,
+        find_closes: 22.weeks.from_now.to_date,
+        find_reopens: 25.weeks.from_now.to_date,
+        next_cycle_opens: 26.weeks.from_now.to_date,
+      },
     }
   end
 

--- a/app/views/support_interface/docs/cycles.html.erb
+++ b/app/views/support_interface/docs/cycles.html.erb
@@ -22,6 +22,7 @@
 
 <%= render SummaryListComponent.new(rows: {
   'Appy 1 deadline' => EndOfCycleTimetable.apply_1_deadline.to_s(:govuk_date),
+  'Stop applications to unavailable course options' => EndOfCycleTimetable.stop_applications_to_unavailable_course_options.to_s(:govuk_date),
   'Apply 2 deadline' => EndOfCycleTimetable.apply_2_deadline.to_s(:govuk_date),
   'Find closes on' => EndOfCycleTimetable.find_closes.to_s(:govuk_date),
   'Find reopens on' => EndOfCycleTimetable.find_reopens.to_s(:govuk_date),


### PR DESCRIPTION
##  Context

We're trying to improve the testability of the end of cycle changes. This is a refactor to make that easier.

## Changes proposed in this pull request

This -hopefully- simplifies the time table code by introducing the concept of a "schedule", which can be either real (the one we'll use on production), or one of the simulated schedules (where we're currently in mid-cycle, course-stop, or between cycles).

The idea is that we can make the schedule a single setting in the database, instead of different feature flags (which are currently weird because they're mutually exclusive - you can't simulate both mid-cycle and between cycles at the same time).

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/pMh2jCZI/2064-improve-testability-reviewability-of-end-of-cycle-changes

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
