### PR TITLE
Fix AssociatedProvidersPermissionsListComponent on the edit user page

### DIFF
--- a/app/components/associated_providers_permissions_list_component.html.erb
+++ b/app/components/associated_providers_permissions_list_component.html.erb
@@ -1,6 +1,8 @@
 <% if training_providers_that_can(permission_name).any? %>
   <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
-    Applies to courses run by:
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      Applies to courses run by:
+    </p>
     <ul class="govuk-list">
       <% training_providers_that_can(permission_name).each do |provider| %>
         <li><%= render CheckIcon.new %> <%= provider.name %></li>
@@ -10,7 +12,9 @@
 <% end %>
 <% if ratifying_providers_that_can(permission_name).any? %>
   <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
-    Applies to courses ratified by:
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      Applies to courses ratified by:
+    </p>
     <ul class="govuk-list">
       <% ratifying_providers_that_can(permission_name).each do |provider| %>
         <li><%= render CheckIcon.new %> <%= provider.name %></li>

--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -26,17 +26,22 @@
     <%= f.govuk_check_box :make_decisions, true, multiple: false,
                           label: { text: 'Make decisions' },
                           hint_text: 'Make offers, amend offers and reject applications' %>
-    <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'make_decisions') %>
-
+    <div class="govuk-body govuk-!-margin-left-6">
+      <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'make_decisions') %>
+    </div>
     <%= f.govuk_check_box :view_safeguarding_information, true, multiple: false,
                           label: { text: 'Access safeguarding information' },
                           hint_text: 'View sensitive material about the candidate' %>
-    <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'view_safeguarding_information') %>
+    <div class="govuk-body govuk-!-margin-left-6">
+      <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'view_safeguarding_information') %>
+    </div>
 
     <%= f.govuk_check_box :view_diversity_information, true, multiple: false,
                           label: { text: 'Access diversity information' },
                           hint_text: 'View diversity information about the candidate' %>
-    <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'view_diversity_information') %>
+    <div class="govuk-body govuk-!-margin-left-6">
+      <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'view_diversity_information') %>
+    </div>
   <% end %>
 
   <%= f.govuk_submit 'Save' %>


### PR DESCRIPTION
## Context

The styling on the user edit page was wrong.

## Changes proposed in this pull request

- add `div` with appropriate margins
- add  `p` with govuk styling

| Before  | After |
| ------------- | ------------- |
| <img width="432" alt="Screenshot 2020-09-01 at 16 30 45" src="https://user-images.githubusercontent.com/38078064/91958421-3b10e500-ecff-11ea-8596-5c8e2b617ddc.png"> | <img width="436" alt="Screenshot 2020-09-01 at 16 41 54" src="https://user-images.githubusercontent.com/38078064/91958454-43692000-ecff-11ea-95f0-79d770435b71.png"> |

## Guidance to review

check pages which use this component:
- Account
- Users - Edit permissions
- Support - Users - Provider users
- Setup wizard - Check step

## Link to Trello card

https://trello.com/c/0o55KHwc/2704-when-editing-a-user-with-org-org-permissions-on-the-styling-is-broken

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
