### PR TITLE
Make support interface deal better with courses from multiple cycles

### DIFF
--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -1,6 +1,6 @@
 <% course_name_and_status = capture do %>
   <%= govuk_link_to(
-    application_choice.offered_course.name_and_code,
+    application_choice.offered_course.year_name_and_code,
     support_interface_course_path(application_choice.offered_course)
   ) %>
 
@@ -26,6 +26,7 @@
 <% end %>
 
 <% rows = [
+  { key: 'Recruitment cycle', value: application_choice.offered_option.course.recruitment_cycle_year },
   { key: 'Provider', value: govuk_link_to(application_choice.offered_course.provider.name_and_code, support_interface_provider_path(application_choice.offered_course.provider)) },
   { key: 'Course', value: course_name_and_status },
   { key: 'Location', value: location_and_status },

--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -1,12 +1,12 @@
 <table class='govuk-table'>
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header'>Cycle</th>
       <th scope='col' class='govuk-table__header'>Course</th>
       <% if providers_vary? %>
         <th scope='col' class='govuk-table__header'>Provider</th>
       <% end %>
       <th scope='col' class='govuk-table__header'>Level</th>
-      <th scope='col' class='govuk-table__header'>Recruitment Cycle</th>
       <th scope='col' class='govuk-table__header'>Apply from Find</th>
       <th scope='col' class='govuk-table__header'>Page on Find</th>
       <% if accredited_bodies_vary? %>
@@ -18,12 +18,12 @@
   <tbody class='govuk-table__body'>
     <% course_rows.each do |course| %>
       <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'><%= course[:recruitment_cycle_year] %></td>
         <td class='govuk-table__cell'><%= course[:course_link] %></td>
         <% if providers_vary? %>
           <td class='govuk-table__cell'><%= course[:provider_link] %></td>
         <% end %>
         <td class='govuk-table__cell'><%= course[:level] %></td>
-        <td class='govuk-table__cell'><%= course[:recruitment_cycle_year] %></td>
         <td class='govuk-table__cell'>
           <% if course[:apply_from_find_link] %>
             <%= course[:apply_from_find_link] %>
@@ -50,4 +50,3 @@
     <% end %>
   </tbody>
 </table>
-

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -13,6 +13,7 @@ class Course < ApplicationRecord
   scope :exposed_in_find, -> { where(exposed_in_find: true) }
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.current_year) }
   scope :previous_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.previous_year) }
+  scope :in_cycle, ->(year) { where(recruitment_cycle_year: year) }
 
   CODE_LENGTH = 4
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -57,6 +57,10 @@ class Course < ApplicationRecord
     "#{name} #{accredited_provider&.name} #{description}"
   end
 
+  def year_name_and_code
+    "#{recruitment_cycle_year}: #{name} (#{code})"
+  end
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -110,6 +110,10 @@ class Course < ApplicationRecord
     Course.find_by(recruitment_cycle_year: recruitment_cycle_year - 1, provider_id: provider_id, code: code)
   end
 
+  def in_next_cycle
+    Course.find_by(recruitment_cycle_year: recruitment_cycle_year + 1, provider_id: provider_id, code: code)
+  end
+
   def application_forms
     ApplicationForm
       .includes(:candidate, :application_choices)

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -16,6 +16,8 @@
   'Financial support' => @course.financial_support,
   'Info page' => govuk_link_to('View on Find', @course.find_url),
   'Start on Apply' => govuk_link_to('View on Apply (candidate)', candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code)),
+  'Course in previous cycle' => @course.in_previous_cycle ? govuk_link_to(@course.in_previous_cycle.year_name_and_code, support_interface_course_path(@course.in_previous_cycle)) : 'None',
+  'Course in next cycle' => @course.in_next_cycle ? govuk_link_to(@course.in_next_cycle.year_name_and_code, support_interface_course_path(@course.in_next_cycle)) : 'None',
 })) %>
 
 <h2 class='govuk-heading-m'>Vacancies</h2>

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -1,15 +1,15 @@
 <% content_for :context, @course.provider.name_and_code %>
-<% content_for :title, @course.name_and_code %>
+<% content_for :title, @course.year_name_and_code %>
 <% content_for :before_content, govuk_back_link_to(support_interface_provider_path(@course.provider), 'Back to provider') %>
 
 <h2 class='govuk-heading-m'>Course info</h2>
 
 <%= render(SummaryCardComponent.new(rows: {
+  'Recruitment cycle year' => @course.recruitment_cycle_year,
   'Name' => @course.name_and_code,
   'Provider' => govuk_link_to(@course.provider.name_and_code, support_interface_provider_path(@course.provider)),
   'Accredited body' => @course.accredited_provider&.name_and_code || 'None',
   'Level' => @course.level.humanize,
-  'Recruitment cycle year' => @course.recruitment_cycle_year,
   'Last updated' => @course.updated_at.to_s(:govuk_date_and_time),
   'Study modes' => @course.study_mode.humanize,
   'Funding type' => Course.human_attribute_name("funding_type.#{@course.funding_type}"),

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -19,10 +19,12 @@
   <% end %>
 <% end %>
 
-<h2 class='govuk-heading-l'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.open_on_apply.size %> on DfE Apply)</h2>
-<%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accredited_provider))) %>
+<% %w[2021 2020 2019].each do |year| %>
+  <h2 class='govuk-heading-l'><%= year %>: <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.where(recruitment_cycle_year: year).open_on_apply.size %> on DfE Apply)</h2>
+  <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accredited_provider).where(recruitment_cycle_year: year))) %>
 
-<% if @provider.accredited_courses.any? %>
-  <h2 class='govuk-heading-l'>Ratifies <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
-  <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses)) %>
+  <% if @provider.accredited_courses.where(recruitment_cycle_year: year).any? %>
+    <h2 class='govuk-heading-l'><%= year %>: ratifies <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.where(recruitment_cycle_year: year).open_on_apply.size %> on DfE Apply)</h2>
+    <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses.where(recruitment_cycle_year: year))) %>
+  <% end %>
 <% end %>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -20,11 +20,11 @@
 <% end %>
 
 <% %w[2021 2020 2019].each do |year| %>
-  <h2 class='govuk-heading-l'><%= year %>: <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.where(recruitment_cycle_year: year).open_on_apply.size %> on DfE Apply)</h2>
-  <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accredited_provider).where(recruitment_cycle_year: year))) %>
+  <h2 class='govuk-heading-l'><%= year %>: <%= pluralize(@provider.courses.in_cycle(year).size, 'course') %> (<%= @provider.courses.in_cycle(year).open_on_apply.size %> on DfE Apply)</h2>
+  <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accredited_provider).in_cycle(year))) %>
 
-  <% if @provider.accredited_courses.where(recruitment_cycle_year: year).any? %>
-    <h2 class='govuk-heading-l'><%= year %>: ratifies <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.where(recruitment_cycle_year: year).open_on_apply.size %> on DfE Apply)</h2>
-    <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses.where(recruitment_cycle_year: year))) %>
+  <% if @provider.accredited_courses.in_cycle(year).any? %>
+    <h2 class='govuk-heading-l'><%= year %>: ratifies <%= pluralize(@provider.accredited_courses.in_cycle(year).size, 'course') %> (<%= @provider.accredited_courses.in_cycle(year).open_on_apply.size %> on DfE Apply)</h2>
+    <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses.in_cycle(year))) %>
   <% end %>
 <% end %>

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
 
       expect(fields['Course']).to eq('My course (ABC)')
       expect(fields['Level']).to eq('Secondary')
-      expect(fields['Recruitment Cycle']).to eq('2020')
+      expect(fields['Cycle']).to eq('2020')
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
       expect(fields).not_to have_key('Accredited body')
@@ -70,7 +70,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
 
       expect(fields['Course']).to eq('My course (ABC)')
       expect(fields['Level']).to eq('Secondary')
-      expect(fields['Recruitment Cycle']).to eq('2020')
+      expect(fields['Cycle']).to eq('2020')
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
       expect(fields).to have_key('Accredited body')

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'See providers' do
+RSpec.feature 'Providers and courses' do
   include DfESignInHelpers
   include FindAPIHelper
 
@@ -174,7 +174,7 @@ RSpec.feature 'See providers' do
     course = Course.find_by(code: 'ABC-1')
     create(:application_choice, course_option: course.course_options.first)
     create(:application_choice, course_option: course.course_options.first)
-    first('table').click_link('ABC-1')
+    click_link('ABC-1')
   end
 
   def then_i_see_the_course_information


### PR DESCRIPTION
## Context

We want to start syncing courses from the 2021 cycle. This starts to make the support UI deal with that better.

## Changes proposed in this pull request

Before:

![image](https://user-images.githubusercontent.com/233676/91970399-859a5d80-ed0f-11ea-9be0-97c5a4349ece.png)

After:

![image](https://user-images.githubusercontent.com/233676/91971314-e5ddcf00-ed10-11ea-8ef5-e0eb44ba75d4.png)



## Guidance to review

See individual commits.

## Link to Trello card

https://trello.com/c/lMdqoepW/2069-make-sure-that-syncing-courses-from-the-new-cycle-works

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
