### PR TITLE
Start syncing courses from 2021

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],
+    [:start_syncing_2021_courses, 'Sync the courses for the 2021 recruitment cycle', 'Tijmen Brommet'],
     [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
     [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],

--- a/app/services/sync_all_providers_from_find.rb
+++ b/app/services/sync_all_providers_from_find.rb
@@ -4,8 +4,15 @@ class SyncAllProvidersFromFind
     #
     # For the full response, see:
     # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers
-    find_providers = FindAPI::Provider.recruitment_cycle(RecruitmentCycle.current_year).all
-    sync_providers(find_providers)
+    sync_providers(
+      FindAPI::Provider.recruitment_cycle(2020).all,
+    )
+
+    if FeatureFlag.active?(:start_syncing_2021_courses)
+      sync_providers(
+        FindAPI::Provider.recruitment_cycle(2021).all,
+      )
+    end
 
     FindSyncCheck.set_last_sync(Time.zone.now)
   rescue JsonApiClient::Errors::ApiError

--- a/spec/services/sync_all_providers_from_find_spec.rb
+++ b/spec/services/sync_all_providers_from_find_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe SyncAllProvidersFromFind do
   include FindAPIHelper
 
+  before do
+    stub_new_recruitment_year_sync
+  end
+
   describe 'ingesting providers' do
     it 'correctly creates all the providers when the database is empty' do
       stub_find_api_all_providers_200([

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -7,6 +7,23 @@ module FindAPIHelper
     @stubbed_recruitment_cycle_year || 2020
   end
 
+  # Stub out the 2021 sync. Once we've transitioned to the new recruitment cycle year,
+  # we'll set 2021 as the default and this method won't be necessary anymore.
+  def stub_new_recruitment_year_sync
+    stub_request(
+      :get,
+      "#{ENV.fetch('FIND_BASE_URL')}recruitment_cycles/2021/providers",
+    )
+    .to_return(
+      status: 200,
+      headers: { 'Content-Type': 'application/vnd.api+json' },
+      body: {
+        data: [],
+        jsonapi: { version: '1.0' },
+      }.to_json,
+    )
+  end
+
   def stub_find_api_provider_200(
     provider_code: 'ABC',
     provider_name: 'Dummy Provider',

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -4,6 +4,10 @@ RSpec.feature 'See provider course syncing' do
   include DfESignInHelpers
   include FindAPIHelper
 
+  before do
+    stub_new_recruitment_year_sync
+  end
+
   scenario 'User switches sync courses on Provider' do
     given_i_am_a_support_user
     and_a_provider_exists

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -4,6 +4,10 @@ RSpec.feature 'See providers' do
   include DfESignInHelpers
   include FindAPIHelper
 
+  before do
+    stub_new_recruitment_year_sync
+  end
+
   scenario 'User visits providers page' do
     given_i_am_a_support_user
     and_providers_are_configured_to_be_synced


### PR DESCRIPTION
## Context

We currently only sync the courses from 2020. Find already exposes some courses for the new 2021 recruitment cycle, so we can start syncing these as well.

## Changes proposed in this pull request

Add 2021 to the sync job. It doesn't replace 2020 because we still need up-to-date info on the current recruitment cycle. It's behind a feature flag so we can test it on QA and be sure that syncing extra courses doesn't interfere with the current cycle. I've stubbed the second API call to make the tests pass - I think that's alright.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/lMdqoepW/2725-make-sure-that-syncing-courses-from-the-new-cycle-works

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
