### PR TITLE
Open button links in new window when specified in html_options

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -34,9 +34,9 @@ module ViewHelper
   def govuk_button_link_to(body, url, html_options = {}, &_block)
     html_options[:class] = prepend_css_class('govuk-button', html_options[:class])
 
-    return link_to(url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false) { yield } if block_given?
+    return link_to(url, role: 'button', class: html_options[:class], target: html_options[:target], rel: html_options[:rel], 'aria-describedby': html_options[:'aria-describedby'], 'data-module': 'govuk-button', draggable: false) { yield } if block_given?
 
-    link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
+    link_to(body, url, role: 'button', class: html_options[:class], target: html_options[:target], rel: html_options[:rel], 'aria-describedby': html_options[:'aria-describedby'], 'data-module': 'govuk-button', draggable: false)
   end
 
   def submitted_at_date

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -32,11 +32,16 @@ module ViewHelper
   end
 
   def govuk_button_link_to(body, url, html_options = {}, &_block)
-    html_options[:class] = prepend_css_class('govuk-button', html_options[:class])
+    html_options = {
+      class: prepend_css_class('govuk-button', html_options[:class]),
+      role: 'button',
+      data: { module: 'govuk-button' },
+      draggable: false,
+    }.merge(html_options)
 
-    return link_to(url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false) { yield } if block_given?
+    return link_to(url, html_options) { yield } if block_given?
 
-    link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
+    link_to(body, url, html_options)
   end
 
   def submitted_at_date

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -34,9 +34,9 @@ module ViewHelper
   def govuk_button_link_to(body, url, html_options = {}, &_block)
     html_options[:class] = prepend_css_class('govuk-button', html_options[:class])
 
-    return link_to(url, role: 'button', class: html_options[:class], target: html_options[:target], rel: html_options[:rel], 'aria-describedby': html_options[:'aria-describedby'], 'data-module': 'govuk-button', draggable: false) { yield } if block_given?
+    return link_to(url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false) { yield } if block_given?
 
-    link_to(body, url, role: 'button', class: html_options[:class], target: html_options[:target], rel: html_options[:rel], 'aria-describedby': html_options[:'aria-describedby'], 'data-module': 'govuk-button', draggable: false)
+    link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
   end
 
   def submitted_at_date

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -72,20 +72,20 @@ RSpec.describe ViewHelper, type: :helper do
     it 'returns an anchor tag with the govuk-button class, button role and data-module="govuk-button"' do
       anchor_tag = helper.govuk_button_link_to('Hoot', 'https://localhost:0103/owl/hoot')
 
-      expect(anchor_tag).to eq('<a role="button" class="govuk-button" data-module="govuk-button" draggable="false" href="https://localhost:0103/owl/hoot">Hoot</a>')
+      expect(anchor_tag).to eq('<a class="govuk-button" role="button" data-module="govuk-button" draggable="false" href="https://localhost:0103/owl/hoot">Hoot</a>')
     end
 
     it 'returns an anchor tag with additional HTML options' do
       anchor_tag = helper.govuk_button_link_to('Cluck', 'https://localhost:0103/chicken/cluck', class: 'govuk-button--start')
 
-      expect(anchor_tag).to eq('<a role="button" class="govuk-button govuk-button--start" data-module="govuk-button" draggable="false" href="https://localhost:0103/chicken/cluck">Cluck</a>')
+      expect(anchor_tag).to eq('<a class="govuk-button govuk-button--start" role="button" data-module="govuk-button" draggable="false" href="https://localhost:0103/chicken/cluck">Cluck</a>')
     end
 
     it 'accepts a block' do
       anchor_tag = helper.govuk_button_link_to(nil, 'https://localhost:0103/bee/buzz') do
         'Buzz'
       end
-      expect(anchor_tag).to eq('<a role="button" class="govuk-button" data-module="govuk-button" draggable="false" href="https://localhost:0103/bee/buzz">Buzz</a>')
+      expect(anchor_tag).to eq('<a class="govuk-button" role="button" data-module="govuk-button" draggable="false" href="https://localhost:0103/bee/buzz">Buzz</a>')
     end
   end
 


### PR DESCRIPTION
## Context

We have this button in the add course journey. It says the link opens in a new window, but it doesn’t.

<img width="180" alt="Start now button" src="https://user-images.githubusercontent.com/813383/92003088-8398c480-ed38-11ea-96c0-42999ed67296.png">

## Changes proposed in this pull request

It looks like `html_options` are not getting passed on to `link_to` method in the `govuk_button_link_to` helper. This PR adds the missing options (`target`, `rel`, `aria-describedby`).

## Guidance to review

Obviously this doesn’t account for other `html_options` that may be specified in `govuk_button_link_to`; is there a way to ensure all options get passed on to the `link_to` method?

## Link to Trello card

https://trello.com/c/kn9SaC6Q

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
