### PR TITLE
Remove ‘suggest’ from page title

### DIFF
--- a/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/before_you_start.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl">We suggest you choose a course first</h1>
+<h1 class="govuk-heading-xl">Choose a course first</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

We should not use ‘suggest’ on GOV.UK. It sends an unclear message to the user about what to do.

## Changes proposed in this pull request

This is the only place in the candidate facing journey that we use ‘suggest’.

## Link to Trello card

https://trello.com/c/K0y4u70z

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
