### PR TITLE
Adapt apply again for unsuccessful candidates between cycles

### DIFF
--- a/app/components/candidate_interface/apply_again_banner_component.html.erb
+++ b/app/components/candidate_interface/apply_again_banner_component.html.erb
@@ -1,18 +1,32 @@
 <div class="app-banner">
   <div class="app-banner__message">
     <div class="govuk-heading-m">
-      <p>
-      <% if @application_form.application_choices.all?(&:cancelled?) %>
-        Your application has been withdrawn. <%= govuk_link_to 'Do you want to apply again?', start_path %>
-      <% else %>
-        <%= govuk_link_to 'Do you want to apply again?', start_path %>
-      <% end %>
-      </p>
-
-      <% if show_deadline_copy? %>
-        <p class='govuk-body govuk-!-font-size-24'>
-          The deadline when applying again is 18 September for courses starting this academic year.
+      <% if EndOfCycleTimetable.between_cycles_apply_2? %>
+        <p>
+          Do you want to continue applying?
         </p>
+
+        <p class='govuk-body govuk-!-font-size-24'>
+          You'll be able to find courses from <%= find_reopen_date %> and submit from <%= reopen_date %>.
+        </p>
+
+        <p class='govuk-body govuk-!-font-size-24'>
+          You can <%= govuk_link_to 'make changes to your application', start_path %> until then.
+        </p>
+      <% else %> 
+        <p>
+        <% if @application_form.application_choices.all?(&:cancelled?) %>
+          Your application has been withdrawn. <%= govuk_link_to 'Do you want to apply again?', start_path %>
+        <% else %>
+          <%= govuk_link_to 'Do you want to apply again?', start_path %>
+        <% end %>
+        </p>
+
+        <% if show_deadline_copy? %>
+          <p class='govuk-body govuk-!-font-size-24'>
+            The deadline when applying again is 18 September for courses starting this academic year.
+          </p>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -11,16 +11,25 @@ module CandidateInterface
       EndOfCycleTimetable.show_apply_2_deadline_banner? && FeatureFlag.active?(:deadline_notices)
     end
 
-    def render?
-      !EndOfCycleTimetable.between_cycles_apply_2?
-    end
+    # def render?
+    #   !EndOfCycleTimetable.between_cycles_apply_2?
+    # end
 
     def start_path
-      if EndOfCycleTimetable.current_cycle?(@application_form)
+      if EndOfCycleTimetable.current_cycle?(@application_form) &&
+          !EndOfCycleTimetable.between_cycles_apply_2?
         candidate_interface_start_apply_again_path
       else
         candidate_interface_start_carry_over_path
       end
+    end
+
+    def reopen_date
+      EndOfCycleTimetable.date(:apply_reopens).to_s(:govuk_date)
+    end
+
+    def find_reopen_date
+      EndOfCycleTimetable.date(:find_reopens).to_s(:govuk_date)
     end
   end
 end

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -11,10 +11,6 @@ module CandidateInterface
       EndOfCycleTimetable.show_apply_2_deadline_banner? && FeatureFlag.active?(:deadline_notices)
     end
 
-    # def render?
-    #   !EndOfCycleTimetable.between_cycles_apply_2?
-    # end
-
     def start_path
       if EndOfCycleTimetable.current_cycle?(@application_form) &&
           !EndOfCycleTimetable.between_cycles_apply_2?

--- a/app/components/candidate_interface/reopen_banner_component.rb
+++ b/app/components/candidate_interface/reopen_banner_component.rb
@@ -32,6 +32,6 @@ private
   end
 
   def reopen_date
-    EndOfCycleTimetable.date(:next_cycle_opens).to_s(:govuk_date)
+    EndOfCycleTimetable.date(:apply_reopens).to_s(:govuk_date)
   end
 end

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -24,6 +24,10 @@ module CandidateInterface
       redirect_to candidate_interface_before_you_start_path
     end
 
+    def start_carry_over
+      render EndOfCycleTimetable.between_cycles_apply_2? ? :start_carry_over_between_cycles : :start_carry_over
+    end
+
     def carry_over
       CarryOverApplication.new(current_application).call
       flash[:success] = 'Your application is ready for editing'

--- a/app/services/candidate_interface/end_of_cycle_policy.rb
+++ b/app/services/candidate_interface/end_of_cycle_policy.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class EndOfCyclePolicy
     def self.can_add_course_choice?(application_form)
-      return true if Time.zone.now.to_date >= EndOfCycleTimetable.next_cycle_opens
+      return true if Time.zone.now.to_date >= EndOfCycleTimetable.apply_reopens
       return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_1_deadline && application_form.apply_1?
       return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_2_deadline && application_form.apply_2?
 

--- a/app/services/carry_over_application.rb
+++ b/app/services/carry_over_application.rb
@@ -18,8 +18,10 @@ private
   end
 
   def application_from_current_cycle?
+    new_recruitment_cycle_year = EndOfCycleTimetable.between_cycles_apply_2? ? EndOfCycleTimetable.next_cycle_year : RecruitmentCycle.current_year
+
     @application_form.application_choices.any? do |application_choice|
-      application_choice.course.recruitment_cycle_year == RecruitmentCycle.current_year
+      application_choice.course.recruitment_cycle_year == new_recruitment_cycle_year
     end
   end
 end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -13,7 +13,7 @@ class EndOfCycleTimetable
 
   def self.stop_applications_to_unavailable_course_options?
     Time.zone.now > date(:stop_applications_to_unavailable_course_options).end_of_day &&
-      Time.zone.now < date(:next_cycle_opens).beginning_of_day
+      Time.zone.now < date(:apply_reopens).beginning_of_day
   end
 
   def self.apply_1_deadline
@@ -40,18 +40,18 @@ class EndOfCycleTimetable
     Time.zone.now.between?(find_closes.end_of_day, find_reopens.beginning_of_day)
   end
 
-  def self.next_cycle_opens
-    date(:next_cycle_opens)
+  def self.apply_reopens
+    date(:apply_reopens)
   end
 
   def self.between_cycles_apply_1?
     Time.zone.now > date(:apply_1_deadline).end_of_day &&
-      Time.zone.now < date(:next_cycle_opens).beginning_of_day
+      Time.zone.now < date(:apply_reopens).beginning_of_day
   end
 
   def self.between_cycles_apply_2?
     Time.zone.now > date(:apply_2_deadline).end_of_day &&
-      Time.zone.now < date(:next_cycle_opens).beginning_of_day
+      Time.zone.now < date(:apply_reopens).beginning_of_day
   end
 
   def self.date(name)
@@ -80,7 +80,7 @@ class EndOfCycleTimetable
         apply_2_deadline: Date.new(2020, 9, 18),
         find_closes: Date.new(2020, 9, 19),
         find_reopens: Date.new(2020, 10, 3),
-        next_cycle_opens: Date.new(2020, 10, 13),
+        apply_reopens: Date.new(2020, 10, 13),
       },
       today_is_between_cycles: {
         apply_1_deadline: 5.days.ago.to_date,
@@ -88,7 +88,7 @@ class EndOfCycleTimetable
         apply_2_deadline: 2.days.ago.to_date,
         find_closes: 1.day.ago.to_date,
         find_reopens: 5.days.from_now.to_date,
-        next_cycle_opens: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
+        apply_reopens: Date.new(2020, 10, 13) > Time.zone.today ? Date.new(2020, 10, 13) : (Time.zone.today + 1),
       },
       today_applications_are_unavailable_to_stopped_courses: {
         apply_1_deadline: 5.days.ago.to_date,
@@ -96,7 +96,7 @@ class EndOfCycleTimetable
         apply_2_deadline: 1.day.from_now.to_date,
         find_closes: 2.days.from_now.to_date,
         find_reopens: 4.days.from_now.to_date,
-        next_cycle_opens: 4.days.from_now.to_date,
+        apply_reopens: 4.days.from_now.to_date,
       },
       today_is_mid_cycle: {
         apply_1_deadline: 20.weeks.from_now.to_date,
@@ -104,7 +104,7 @@ class EndOfCycleTimetable
         apply_2_deadline: 22.weeks.from_now.to_date,
         find_closes: 22.weeks.from_now.to_date,
         find_reopens: 25.weeks.from_now.to_date,
-        next_cycle_opens: 26.weeks.from_now.to_date,
+        apply_reopens: 26.weeks.from_now.to_date,
       },
     }
   end

--- a/app/views/candidate_interface/start_page/applications_closed.html.erb
+++ b/app/views/candidate_interface/start_page/applications_closed.html.erb
@@ -8,6 +8,6 @@
 
     <p class="govuk-body">Applications for courses starting this year have closed.</p>
 
-    <p class="govuk-body">You can create an account and submit an application from <%= EndOfCycleTimetable.next_cycle_opens.to_s(:govuk_date).strip %>.</p>
+    <p class="govuk-body">You can create an account and submit an application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date).strip %>.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/submitted_application_form/start_carry_over_between_cycles.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/start_carry_over_between_cycles.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t('page_titles.start_carry_over_between_cycles', reopen_date: EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)) %>
+
+<h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over_between_cycles', reopen_date: EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)) %></h1>
+
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Your last application has been saved, so you do not need to start again.</p>
+    <p class="govuk-body">You can make changes to your application whenever you like.</p>
+    <p class="govuk-body">You will be able to choose courses from <%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date) %> and submit from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>. </p>
+    <p class="govuk-body">You'll have 3 course choices.</p>
+
+    <%= button_to 'Start now', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+
+    <p class="govuk-body">or</p>
+
+    <%= govuk_link_to 'Go to your dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
+  </div>
+</div>
+

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -225,7 +225,7 @@
     <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
       <h2 class="govuk-heading-m govuk-!-font-size-27">Review</h2>
       <p class="govuk-body">
-        Applications for courses starting in <%= EndOfCycleTimetable.next_cycle_year %> open from <%= EndOfCycleTimetable.next_cycle_opens.to_s(:govuk_date) %>. You can continue to make changes to your application until then.
+        Applications for courses starting in <%= EndOfCycleTimetable.next_cycle_year %> open from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>. You can continue to make changes to your application until then.
       </p>
       <%= govuk_button_link_to 'Review your application', candidate_interface_application_review_path %>
     <% else %>

--- a/app/views/support_interface/docs/cycles.html.erb
+++ b/app/views/support_interface/docs/cycles.html.erb
@@ -26,7 +26,7 @@
   'Apply 2 deadline' => EndOfCycleTimetable.apply_2_deadline.to_s(:govuk_date),
   'Find closes on' => EndOfCycleTimetable.find_closes.to_s(:govuk_date),
   'Find reopens on' => EndOfCycleTimetable.find_reopens.to_s(:govuk_date),
-  'Next cycle opens on' => EndOfCycleTimetable.next_cycle_opens.to_s(:govuk_date),
+  'Apply reopens on' => EndOfCycleTimetable.apply_reopens.to_s(:govuk_date),
 }) %>
 
 <h2 class='govuk-heading-m'>Flags</h2>

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -22,7 +22,7 @@ class Clock
   every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 
   every(1.day, 'RejectAwaitingReferencesCourseChoices', at: '00:01', if: ->(t) { t.to_date == EndOfCycleTimetable.date(:apply_2_deadline) + 1 }) { RejectAwaitingReferencesCourseChoicesWorker.perform_async }
-  every(1.day, 'CarryOverUnsubmittedApplications', at: '00:01', if: ->(t) { t.to_date == EndOfCycleTimetable.date(:next_cycle_opens) }) { CarryOverUnsubmittedApplicationsWorker.perform_async }
+  every(1.day, 'CarryOverUnsubmittedApplications', at: '00:01', if: ->(t) { t.to_date == EndOfCycleTimetable.date(:apply_reopens) }) { CarryOverUnsubmittedApplicationsWorker.perform_async }
 
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
     if Time.zone.today.weekday?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,7 @@ en:
     covid_19_guidance: "Coronavirus (COVID-19): deadlines for processing applications extended to 31 May 2020"
     start_apply_again: Do you want to apply again?
     start_carry_over: Do you want to apply again?
+    start_carry_over_between_cycles: "Get your application ready to submit from %{reopen_date}"
     pick_choice_to_replace: Some of your choices are not available anymore
     pick_replacement_action: Update course choice
     confirm_replacement_course_choice: Your updated course choice

--- a/spec/components/candidate_interface/apply_again_banner_component_spec.rb
+++ b/spec/components/candidate_interface/apply_again_banner_component_spec.rb
@@ -76,17 +76,17 @@ RSpec.describe CandidateInterface::ApplyAgainBannerComponent do
   end
 
   describe 'visibility of banner between cycles' do
-    it 'is rendered' do
+    it 'is rendered with apply again call to action before apply 2 closes' do
       Timecop.freeze(Time.zone.local(2020, 9, 17, 12, 0, 0)) do
         result = render_inline(described_class.new(application_form: application_form))
         expect(result.text).to include('Do you want to apply again?')
       end
     end
 
-    it 'is not rendered' do
+    it 'is rendered with continue application call to action after apply 2 closes' do
       Timecop.freeze(Time.zone.local(2020, 9, 25, 12, 0, 0)) do
         result = render_inline(described_class.new(application_form: application_form))
-        expect(result.text).to eq('')
+        expect(result.text).to include('Do you want to continue applying?')
       end
     end
   end

--- a/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
+++ b/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.next_cycle_opens) do
+          Timecop.travel(EndOfCycleTimetable.apply_reopens) do
             expect(execute_service).to eq true
           end
         end
@@ -53,7 +53,7 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
 
       context 'when the date is post find reopening' do
         it 'returns true' do
-          Timecop.travel(EndOfCycleTimetable.next_cycle_opens) do
+          Timecop.travel(EndOfCycleTimetable.apply_reopens) do
             expect(execute_service).to eq true
           end
         end

--- a/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
+++ b/spec/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoi
 
     context 'after the new cycle has launched' do
       it 'returns []' do
-        Timecop.travel(EndOfCycleTimetable.next_cycle_opens + 1.day) do
+        Timecop.travel(EndOfCycleTimetable.apply_reopens + 1.day) do
           expect(described_class.call).to eq []
         end
       end

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -29,9 +29,21 @@ RSpec.describe CarryOverApplication do
     it_behaves_like 'duplicates application form', 'apply_1'
   end
 
-  context 'when original application is from the current recruitment cycle' do
+  context 'when original application is from the current open recruitment cycle' do
     it 'raises an error' do
-      expect { described_class.new(original_application_form).call }.to raise_error(ArgumentError)
+      Timecop.freeze(Time.zone.local(2020, 8, 1, 12, 0, 0)) do
+        expect { described_class.new(original_application_form).call }.to raise_error(ArgumentError)
+      end
     end
+  end
+
+  context 'when original application is from the current recruitment cycle but that cycle has now closed' do
+    around do |example|
+      Timecop.freeze(Time.zone.local(2020, 9, 19, 12, 0, 0)) do
+        example.run
+      end
+    end
+
+    it_behaves_like 'duplicates application form', 'apply_1'
   end
 end

--- a/spec/services/end_of_cycle_timetable_spec.rb
+++ b/spec/services/end_of_cycle_timetable_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe EndOfCycleTimetable do
   end
 
   describe 'stop_applications_to_unavailable_course_options?' do
-    it 'is true when between "stop_applications_to_unavailable_course_options" and "next_cycle_opens"' do
+    it 'is true when between "stop_applications_to_unavailable_course_options" and "apply_reopens"' do
       Timecop.travel(Time.zone.local(2020, 9, 7).end_of_day + 1.minute) do
         expect(EndOfCycleTimetable.stop_applications_to_unavailable_course_options?).to be true
       end

--- a/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
   end
 
   def given_the_new_cycle_is_open
-    Timecop.travel(EndOfCycleTimetable.next_cycle_opens + 1.day)
+    Timecop.travel(EndOfCycleTimetable.apply_reopens + 1.day)
   end
 
   def and_i_logout

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   def when_the_2020_apply2_deadline_passes
     Timecop.safe_mode = false
     Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0))
-    allow(RecruitmentCycle).to receive(:current_year).and_return(2021)
   ensure
     Timecop.safe_mode = true
   end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate can carry over unsuccessful application to a new recruitment cycle between cycles' do
+  around do |example|
+    Timecop.freeze(Date.new(2020, 8, 1)) do
+      example.run
+    end
+  end
+
+  scenario 'when an unsuccessful candidate returns in the next recruitment cycle they can re-apply by carrying over their original application' do
+    given_i_am_signed_in
+    and_i_am_in_the_2020_recruitment_cycle
+    and_i_have_an_application_with_a_rejection
+
+    when_the_2020_apply2_deadline_passes
+    and_i_visit_my_application_complete_page
+    and_i_click_on_apply_again
+    and_i_click_on_start_now
+
+    then_i_can_see_application_details
+    and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
+
+    when_the_2021_cycle_opens
+    and_i_visit_my_application_complete_page
+    then_i_can_add_course_choices
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_am_in_the_2020_recruitment_cycle
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2020)
+  end
+
+  def and_i_have_an_application_with_a_rejection
+    @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
+    create(:application_choice, :with_rejection, application_form: @application_form)
+  end
+
+  def when_the_2020_apply2_deadline_passes
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 9, 19, 12, 0, 0))
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2021)
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def and_i_visit_my_application_complete_page
+    logout
+    login_as(@candidate)
+    visit candidate_interface_application_complete_path
+  end
+
+  def and_i_click_on_apply_again
+    expect(page).to have_content 'Do you want to continue applying?'
+    click_link 'make changes to your application'
+  end
+
+  def and_i_click_on_start_now
+    expect(page).to have_content "Get your application ready to submit from #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}"
+    expect(page).to have_content 'You\'ll have 3 course choices.'
+    click_button 'Start now'
+  end
+
+  def and_i_click_go_to_my_application_form
+    click_link 'Go to your application form'
+  end
+
+  def then_i_can_see_application_details
+    expect(page).to have_content('Personal details Completed')
+    click_link 'Personal details'
+    expect(page).to have_content(@application_form.full_name)
+    click_button 'Continue'
+  end
+
+  def and_i_can_see_that_no_courses_are_selected_and_i_cannot_add_any_yet
+    expect(page).to have_content('You can apply for courses from 13 October.')
+    expect(page).not_to have_link 'Course choice'
+  end
+
+  def when_the_2021_cycle_opens
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 10, 13, 12, 0, 0))
+    allow(RecruitmentCycle).to receive(:current_year).and_return(2021)
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def then_i_can_add_course_choices
+    expect(page).to have_content('Course choice Incomplete')
+    click_link 'Course choice'
+    expect(page).to have_content 'You can apply for up to 3 courses'
+  end
+end


### PR DESCRIPTION
## Context

This PR allows candidates who were unsuccessful in a closed recruitment cycle to begin the processing of carrying over their application to the next recruitment cycle before it begins.

## Changes proposed in this pull request

- [x] Change `CarryOverApplication` service to work between cycles (previously it only let you carry over after the new cycle started).
- [x] Update the `ApplyAgainBannerComponent` with the new content for this case.
- [x] Renamed `EndOfCycleTimetable.next_cycle_opens` to `apply_reopens`
- [x] System spec to cover the between cycles carry over journey

<img width="975" alt="image" src="https://user-images.githubusercontent.com/450843/91998623-601f4b00-ed33-11ea-9608-4a232c529d01.png">

<img width="850" alt="image" src="https://user-images.githubusercontent.com/450843/91998580-4f6ed500-ed33-11ea-8a05-eb47c2e75443.png">

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/450843/91997222-c4410f80-ed31-11ea-8498-1a69a0ee5e71.png"/>

## Guidance to review

- To test manually you can either mess about with your system clock or activate the simulate between cycles feature flag and set the 2021 recruitment cycle feature flag to inactive.
- Are the tests sufficient?

## Link to Trello card

https://trello.com/c/x6hpRtsT/2042-dev-🚲🔚-adapt-apply-again-journey-for-returners-on-6th-13th

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
