### PR TITLE
Fix autocomplete error styles

### DIFF
--- a/app/frontend/styles/_autocomplete.scss
+++ b/app/frontend/styles/_autocomplete.scss
@@ -5,15 +5,12 @@
 }
 
 .govuk-form-group--error {
-  .autocomplete__input--default {
-    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+  .autocomplete__input {
+    border-color: $govuk-error-colour;
   }
 
   .autocomplete__input--focused {
     border-color: $govuk-input-border-colour;
-    // Remove `box-shadow` inherited from `:focus` as
-    // `autocomplete__input--default` already has the thicker border.
-    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
## Context

As of the latest version of `govuk-frontend`:
* When a field has an error, its border turns red but it maintains the same thickness.
* When a field has focus, regardless of its error state, it has a thick black border.

This PR ensures that autocompletes use this same styling.

I discovered a related bug, unrelated to styling, where autocompletes that don’t enhance a select element, don’t appear within `govuk-form-group` so don’t pick up this styling. I will file this as a separate issue.

## Changes proposed in this pull request

### Before

<img width="652" alt="Screenshot 2020-09-02 at 18 39 25" src="https://user-images.githubusercontent.com/813383/92017433-b1d3cf80-ed4b-11ea-8acf-ed7aac218a2b.png">
<img width="662" alt="Screenshot 2020-09-02 at 18 39 31" src="https://user-images.githubusercontent.com/813383/92017439-b304fc80-ed4b-11ea-8208-e1b16431c0a4.png">

### After

<img width="657" alt="Screenshot 2020-09-02 at 18 32 53" src="https://user-images.githubusercontent.com/813383/92017456-b8624700-ed4b-11ea-94b9-f34ae06e5949.png">
<img width="686" alt="Screenshot 2020-09-02 at 18 33 04" src="https://user-images.githubusercontent.com/813383/92017459-b9937400-ed4b-11ea-82b6-8a1d8dc1a45c.png">

## Link to Trello cards

https://trello.com/c/sPUrh75s
https://trello.com/c/fKDLiVtQ
