### PR TITLE
Send a slack notification when a ProviderUser is added

### DIFF
--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -14,6 +14,7 @@ class InviteProviderUser
     invite_user_to_dfe_sign_in
 
     send_welcome_email
+    send_slack_notification
   end
 
   def dfe_invite_url
@@ -40,6 +41,14 @@ private
 
   def send_welcome_email
     ProviderMailer.account_created(@provider_user).deliver_later
+  end
+
+  def send_slack_notification
+    providers = @provider_user.providers.map(&:name).to_sentence
+    message = "#{@provider_user.first_name} has been invited to join #{providers}"
+    url = Rails.application.routes.url_helpers.support_interface_provider_user_url(@provider_user)
+
+    SlackNotificationWorker.perform_async(message, url)
   end
 
   def lookup_provider_user


### PR DESCRIPTION
## Context

We'd like to have a sense of how users are using access controls and to know when a new user is added, in case we want to follow up with them.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Sends a slack notification when a provider user is invited.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/HIpayjgd/2671-send-a-slack-notification-when-a-provideruser-adds-another-provideruser

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
