### PR TITLE
Sent application paused email to candidates after apply_2_deadline

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,4 +1,12 @@
 class CandidateMailer < ApplicationMailer
+  def application_on_pause(application_form)
+    @candidate_magic_link = candidate_magic_link(application_form.candidate)
+
+    email_for_candidate(
+      application_form,
+    )
+  end
+
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
     @respond_within_days = TimeLimitCalculator.new(

--- a/app/services/candidate_interface/get_previous_cycles_awaiting_references_applications.rb
+++ b/app/services/candidate_interface/get_previous_cycles_awaiting_references_applications.rb
@@ -1,0 +1,16 @@
+module CandidateInterface
+  class GetPreviousCyclesAwaitingReferencesApplications
+    def self.call
+      return [] unless EndOfCycleTimetable.between_cycles_apply_2?
+
+      choices_awaiting_reference = ApplicationChoice
+        .includes(:course)
+        .joins(:course)
+        .where('courses.recruitment_cycle_year': RecruitmentCycle.current_year)
+        .awaiting_references
+
+      ApplicationForm
+        .where(id: choices_awaiting_reference.select(:application_form_id))
+    end
+  end
+end

--- a/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
+++ b/app/services/candidate_interface/get_previous_cycles_awaiting_references_course_choices.rb
@@ -1,9 +1,0 @@
-module CandidateInterface
-  class GetPreviousCyclesAwaitingReferencesCourseChoices
-    def self.call
-      return [] unless EndOfCycleTimetable.between_cycles_apply_2?
-
-      ApplicationChoice.includes(:course).joins(:course).where('courses.recruitment_cycle_year': RecruitmentCycle.current_year).awaiting_references
-    end
-  end
-end

--- a/app/views/candidate_mailer/application_on_pause.erb
+++ b/app/views/candidate_mailer/application_on_pause.erb
@@ -1,0 +1,21 @@
+Dear <%= @application_form.first_name %>,
+
+# Your application is on pause
+
+Your referees did not respond by the time courses closed.
+
+This means that your application cannot be considered for courses starting this academic year.
+
+# Resubmit in October for courses starting next academic year
+
+We’ll send you an email when courses reopen.
+
+Your last application has been saved, so all you have to do is sign in, choose your courses and resubmit.
+
+In the meantime, you can sign in anytime to make changes to your application:
+
+<%= @candidate_magic_link %>
+
+# Get help from a teacher training adviser
+
+You can talk to a teacher training adviser on the phone or online: [https://register.getintoteaching.education.gov.uk/register](https://register.getintoteaching.education.gov.uk/register)

--- a/app/workers/reject_awaiting_references_course_choices_worker.rb
+++ b/app/workers/reject_awaiting_references_course_choices_worker.rb
@@ -2,8 +2,11 @@ class RejectAwaitingReferencesCourseChoicesWorker
   include Sidekiq::Worker
 
   def perform
-    CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices.call.each do |application_choice|
-      CandidateInterface::RejectAwaitingReferencesApplication.call(application_choice)
+    CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications.call.each do |application_form|
+      application_form.application_choices.each do |application_choice|
+        CandidateInterface::RejectAwaitingReferencesApplication.call(application_choice)
+      end
+      CandidateMailer.application_on_pause(application_form).deliver_later
     end
   end
 end

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -211,9 +211,11 @@ en:
       description: If the application has not been sent to the provider, the candidate can still cancel the application.
 
     awaiting_references-reject_at_end_of_cycle:
-      name: Awaiting references applications rejected
+      name: Applications awaiting references are rejected at the end of the cycle
       by: system
       description: Application choices that are awaiting references are automatically rejected at the end of the cycle
+      emails:
+        - candidate_mailer-application_on_pause
 
     application_complete-cancel:
       name: Candidate cancels

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -1,5 +1,7 @@
 en:
   candidate_mailer:
+    application_on_pause:
+      subject: "Your application is on pause: resubmit in October for courses starting next academic year"
     eoc_choice_unavailable_no_other_choices:
       subject: Find a different course and re-submit your application
     eoc_choice_unavailable_has_other_choices:

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -1,4 +1,8 @@
 class CandidateMailerPreview < ActionMailer::Preview
+  def application_on_pause
+    CandidateMailer.application_on_pause(application_form)
+  end
+
   def application_submitted
     application_form = FactoryBot.build_stubbed(
       :completed_application_form,

--- a/spec/services/candidate_interface/get_previous_cycles_awaiting_references_applications_spec.rb
+++ b/spec/services/candidate_interface/get_previous_cycles_awaiting_references_applications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices do
+RSpec.describe CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications do
   describe '#call' do
     let!(:application_choice1) { create(:awaiting_references_application_choice) }
 
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoi
     context 'between the apply_2_deadline and the new cycle launching' do
       it 'returns application forms in the awaiting reference state' do
         Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day) do
-          expect(described_class.call).to eq [application_choice1]
+          expect(described_class.call).to eq [application_choice1.application_form]
         end
       end
     end

--- a/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
+++ b/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe RejectAwaitingReferencesCourseChoicesWorker do
   describe '#perform' do
     it 'calls the `GetAwaitingReferencesCourseChoicesForPreviousCycle` service' do
-      allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices).to receive(:call).and_return([])
+      allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to receive(:call).and_return([])
       RejectAwaitingReferencesCourseChoicesWorker.new.perform
 
-      expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesCourseChoices).to have_received(:call)
+      expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
## Context

When applications with pending references are rejected after the apply 2 deadline, we want to tell candidates that their application is paused, and what they can do.

## Changes proposed in this pull request

Piggy-back off of the existing `RejectAwaitingReferencesCourseChoices` service and add an email.

Rename `GetPreviousCyclesAwaitingReferencesCourseChoices` to `GetPreviousCyclesAwaitingReferencesApplications`.

## Guidance to review

TODO:

- [x] Tests

Email preview: `/rails/mailers/candidate_mailer/application_on_pause`

<img width="708" alt="Screenshot 2020-09-03 at 13 50 55" src="https://user-images.githubusercontent.com/1650875/92111373-7e954d00-edec-11ea-8ed3-4434bd694648.png">

`/support/when-emails-are-sent`:

<img width="1027" alt="Screenshot 2020-09-04 at 09 33 57" src="https://user-images.githubusercontent.com/1650875/92212132-c8843e80-ee91-11ea-8a86-6370c9a1a4e5.png">


## Link to Trello card

https://trello.com/c/nGoLoCQa

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
