### PR TITLE
Add inset text styles and h2 to awaiting decision application header

### DIFF
--- a/app/views/provider_interface/application_choices/_application_choice_header.html.erb
+++ b/app/views/provider_interface/application_choices/_application_choice_header.html.erb
@@ -5,11 +5,17 @@
 
 <% if @application_choice.status == 'awaiting_provider_decision' && flash.empty? && @provider_can_respond -%>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        <%= "You have #{days_to_respond_to(@application_choice)} days to respond to this application. On #{@application_choice.reject_by_default_at.to_s(:govuk_date)} this application will be automatically rejected." %>
-      </p>
-      <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <div class="govuk-inset-text govuk-!-margin-top-0">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
+          Respond to application
+        </h2>
+
+        <p class="govuk-body">
+          <%= "You have #{days_to_respond_to(@application_choice)} days to respond to this application. On #{@application_choice.reject_by_default_at.to_s(:govuk_date)} this application will be automatically rejected." %>
+        </p>
+        <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>
+      </div>
     </div>
   </div>
 <% end -%>


### PR DESCRIPTION
## Context

The design for this part of the application page has changed.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

### Before
![application-respond-to-before](https://user-images.githubusercontent.com/93511/92122793-d1263780-edf3-11ea-90ff-77e9bbcbf98c.jpg)

### After
![image](https://user-images.githubusercontent.com/93511/92122716-b8b61d00-edf3-11ea-933b-53f07f4ff107.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/vytVuuFM/2712-new-format-for-action-required-eg-respond-to-this-block-at-the-top-of-application-pages

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
