### PR TITLE
Tweaks for provider footer

### DIFF
--- a/app/views/candidate_interface/shared/_support.html.erb
+++ b/app/views/candidate_interface/shared/_support.html.erb
@@ -2,7 +2,6 @@
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title"><%= t('layout.support.title') %></h2>
   <ul class="govuk-list govuk-!-font-size-16">
     <li>Email: <%= bat_contact_mail_to(html_options: { subject: "Query about application #{support_reference}" }) %></li>
-    <li><%= t('layout.support.availability') %></li>
     <li><%= t('layout.support.response_time') %></li>
   </ul>
 </aside>

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -1,21 +1,20 @@
 <h2 class="govuk-heading-m"><%= t('layout.support.title') %></h2>
 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
   <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
-  <li><%= t('layout.support.availability') %></li>
   <li><%= t('layout.support.response_time') %></li>
 </ul>
-<h2 class="govuk-visually-hidden"><%= t('layout.support_links') %></h2>
+<h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
 <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.accessibility'), candidate_interface_accessibility_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.accessibility'), candidate_interface_accessibility_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.cookies'), candidate_interface_cookies_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.cookies'), candidate_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.privacy_policy'), candidate_interface_privacy_policy_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.privacy_policy'), candidate_interface_privacy_policy_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.terms_of_use'), candidate_interface_terms_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.terms_of_use'), candidate_interface_terms_path, class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -1,22 +1,20 @@
 <h2 class="govuk-heading-m"><%= t('layout.support.title') %></h2>
 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
   <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
-  <li><%= t('layout.support.availability') %></li>
   <li><%= t('layout.support.response_time') %></li>
 </ul>
-<h2 class="govuk-heading-m"><%= t('layout.guidance.title') %></h2>
 <p class="govuk-body govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-  <%= link_to t('layout.guidance.provider'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>
+  <%= link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>
 </p>
-<h2 class="govuk-visually-hidden"><%= t('layout.support_links') %></h2>
+<h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
 <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.accessibility'), provider_interface_accessibility_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.accessibility'), provider_interface_accessibility_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.cookies'), provider_interface_cookies_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.cookies'), provider_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.privacy_policy'), provider_interface_privacy_policy_path, class: 'govuk-footer__link' %>
+    <%= link_to t('layout.support_links.privacy_policy'), provider_interface_privacy_policy_path, class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,16 +146,14 @@ en:
   layout:
     support:
       title: Get support
-      availability: Monday to Friday (except public holidays)
       response_time: We respond within 5 working days, or one working day for more urgent queries
-    guidance:
-      title: Guidance
-      provider: How to use Manage teacher training applications
-    support_links: Support links
-    accessibility: Accessibility
-    cookies: Cookies
-    terms_of_use: Terms of use
-    privacy_policy: Privacy policy
+      provider_service_guidance: How to use Manage teacher training applications
+    support_links:
+      title: Support links
+      accessibility: Accessibility
+      cookies: Cookies
+      terms_of_use: Terms of use
+      privacy_policy: Privacy policy
   activemodel:
     attributes:
       vendor_api/metadata:

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Candidate content' do
   end
 
   def when_i_click_on_accessibility
-    within('.govuk-footer') { click_link t('layout.accessibility') }
+    within('.govuk-footer') { click_link t('layout.support_links.accessibility') }
   end
 
   def then_i_can_see_the_accessibility_statement
@@ -31,7 +31,7 @@ RSpec.feature 'Candidate content' do
   end
 
   def when_i_click_on_the_cookie_policy
-    within('.govuk-footer') { click_link t('layout.cookies') }
+    within('.govuk-footer') { click_link t('layout.support_links.cookies') }
   end
 
   def then_i_can_see_the_cookie_policy
@@ -40,7 +40,7 @@ RSpec.feature 'Candidate content' do
   end
 
   def when_i_click_on_the_privacy_policy
-    within('.govuk-footer') { click_link t('layout.privacy_policy') }
+    within('.govuk-footer') { click_link t('layout.support_links.privacy_policy') }
   end
 
   def then_i_can_see_the_privacy_policy
@@ -48,7 +48,7 @@ RSpec.feature 'Candidate content' do
   end
 
   def when_i_click_on_the_terms_of_use
-    within('.govuk-footer') { click_link t('layout.terms_of_use') }
+    within('.govuk-footer') { click_link t('layout.support_links.terms_of_use') }
   end
 
   def then_i_can_see_the_terms_candidate

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Provider content' do
   end
 
   def when_i_click_on_accessibility
-    within('.govuk-footer') { click_link t('layout.accessibility') }
+    within('.govuk-footer') { click_link t('layout.support_links.accessibility') }
   end
 
   def then_i_can_see_the_accessibility_statement
@@ -29,7 +29,7 @@ RSpec.feature 'Provider content' do
   end
 
   def when_i_click_on_the_cookie_policy
-    within('.govuk-footer') { click_link t('layout.cookies') }
+    within('.govuk-footer') { click_link t('layout.support_links.cookies') }
   end
 
   def then_i_can_see_the_cookie_policy
@@ -37,7 +37,7 @@ RSpec.feature 'Provider content' do
   end
 
   def when_i_click_on_the_privacy_policy
-    within('.govuk-footer') { click_link t('layout.privacy_policy') }
+    within('.govuk-footer') { click_link t('layout.support_links.privacy_policy') }
   end
 
   def then_i_can_see_the_privacy_policy
@@ -45,7 +45,7 @@ RSpec.feature 'Provider content' do
   end
 
   def when_i_click_on_the_service_guidance
-    within('.govuk-footer') { click_link t('layout.guidance.provider') }
+    within('.govuk-footer') { click_link t('layout.support.provider_service_guidance') }
   end
 
   def then_i_can_see_the_service_guidance_provider


### PR DESCRIPTION
## Context

* Remove support availability as implied in response time content
* Remove unnecessary ‘Guidance’ heading’

## Changes proposed in this pull request

Before:

![footer-manage-previous](https://user-images.githubusercontent.com/813383/92124943-51e63300-edf6-11ea-9559-703b1877b11a.png)

After:

![footer-manage-updated](https://user-images.githubusercontent.com/813383/92124954-56aae700-edf6-11ea-9885-3b069209894b.png)
