### PR TITLE
Automatically infer the current cycle from the schedule

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,9 +1,9 @@
 module RecruitmentCycle
   def self.current_year
-    if FeatureFlag.active?('switch_to_next_recruitment_cycle')
-      2021
-    else
+    if Time.zone.today < EndOfCycleTimetable.apply_reopens
       2020
+    else
+      2021
     end
   end
 

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -2,13 +2,16 @@ require 'rails_helper'
 
 RSpec.describe RecruitmentCycle do
   describe '.current_year' do
-    it 'is 2020' do
-      expect(RecruitmentCycle.current_year).to eq(2020)
+    it 'is 2020 before the end of cycle' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 12, 0, 0)) do
+        expect(RecruitmentCycle.current_year).to eq(2020)
+      end
     end
 
-    it 'can be changed to the next cycle using a feature flag' do
-      FeatureFlag.activate('switch_to_next_recruitment_cycle')
-      expect(RecruitmentCycle.current_year).to eq(2021)
+    it 'is 2021 in the new cycle' do
+      Timecop.travel(Time.zone.local(2020, 11, 1, 12, 0, 0)) do
+        expect(RecruitmentCycle.current_year).to eq(2021)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

We currently have the recruitment cycle hard coded.

## Changes proposed in this pull request

This changes it to be inferred from the cycle schedule that we're on. This means that if you change the cycle in support, you'll be able to test the system using the new recruitment cycle (and see things like filtering in the provider UI change).

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/pMh2jCZI/2064-improve-testability-reviewability-of-end-of-cycle-changes

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
