### PR TITLE
Provide context for answers for disability, safeguarding, interview and qualifications sections of application

### DIFF
--- a/app/components/interview_preferences_component.html.erb
+++ b/app/components/interview_preferences_component.html.erb
@@ -1,1 +1,21 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Interview needs</h2>
+    <p class="govuk-body">Interviews usually take place over the course of a day. You'll need to attend in person.</p>
+    <p class="govuk-body">Training providers might not have much flexibility when setting a date and time for interview.</p>
+    <p class="govuk-body">If there's a reason why you need some flexibility you can tell us about it here.</p>
+    <p class="govuk-body">For example:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+      <li>you have commitments such as employment or caring responsibilities</li>
+      <li>you'll be travelling a long way to get to the interview</li>
+      <li>you'll need some adjustments because you're disabled</li>
+    </ul>
+  </div>
+</details>
+
 <%= simple_format interview_preferences, class: 'govuk-body' %>

--- a/app/components/personal_statement_component.html.erb
+++ b/app/components/personal_statement_component.html.erb
@@ -1,9 +1,40 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
+    <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
+    <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
+    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <a href="https://getintoteaching.education.gov.uk/" class="govuk-body">Get into Teaching</a> for help from a teacher training adviser.</p>
+    <p class="govuk-body govuk-!-font-weight-bold">Suggested topics to cover include:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>why you want to be a teacher</li>
+      <li>your passion for your subject and the age group you’ve chosen to teach</li>
+      <li>the welfare and education of children and/or young people</li>
+      <li>the demands and rewards of the profession</li>
+      <li>personal qualities that will make you a good teacher</li>
+      <li>your contribution to the life of the school outside the classroom – for example, running extra-curricular activities and clubs</li>
+      <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
+    </ul>
+    <h2 class="govuk-heading-m">What do you know about the subject you want to teach?</h2>
+    <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to your course choice.</p>
+    <p class="govuk-body">Evidence can include:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the subject of your undergraduate degree</li>
+      <li>modules you studied as part of your degree</li>
+      <li>postgraduate degrees (for example, a Masters or PhD)</li>
+      <li>your A level subjects</li>
+      <li>expertise you’ve gained at work</li>
+    </ul>
+  </div>
+</details>
+
 <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Vocation</h3>
-<p class="govuk-hint govuk-!-margin-top-0">Question to candidate: “Why do you want to be a teacher?”</p>
 <%= simple_format becoming_a_teacher, class: 'govuk-body' %></p>
 <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Subject knowledge</h3>
-<p class="govuk-hint govuk-!-margin-top-0">Question to candidate: “Your knowledge about the subject you want to teach”</p>
 <%= simple_format subject_knowledge, class: 'govuk-body' %></p>
 <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Further information</h3>
-<p class="govuk-hint govuk-!-margin-top-0">Question to candidate: “Is there anything else you would like to tell us about your application?”</p>
 <%= simple_format further_information, class: 'govuk-body' %></p>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,3 +1,23 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Equality and diversity</h2>
+    <p class="govuk-body">
+      The equality and diversity questionnaire is optional and has no impact on the progress of your application.
+    </p>
+    <p class="govuk-body">
+      We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.
+    </p>
+    <p class="govuk-body">
+      Your data will only be shared with training providers when you are enrolled on a course.
+    </p>
+  </div>
+</details>
+
 <% if display_diversity_information? -%>
   <%= render SummaryListComponent.new(rows: rows) %>
 <% else -%>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,3 +1,23 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Declaring any safeguarding issues</h2>
+    <p class="govuk-body">Teacher training providers need to check that it’s safe for you to work with children and young people.</p>
+    <p class="govuk-body">As well as confirming your identity and your right to work in the UK, providers will check:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your criminal record in the UK (they'll do an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks" class="govuk-link">DBS check)</a> and abroad where relevant</li>
+      <li>whether you’ve been banned from teaching or working with children</li>
+      <li>your professional behaviour, such as whether you’ve been removed from teacher training and what your referees say about you</li>
+    </ul>
+    <p class="govuk-body">Tell your provider about any potential safeguarding issues, such as offences, cautions, reprimands and final warnings. They can give advice about whether this will affect your application.</p>
+    <p class="govuk-body">It won’t necessarily stop you becoming a teacher.</p>
+  </div>
+</details>
+
 <p class="govuk-body"><%= message %></p>
 <% if display_safeguarding_issues_details? %>
   <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,1 +1,26 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Asking for support if you have a disability or other needs</h2>
+    <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
+    <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
+    <p class="govuk-body">Examples of support could be:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>organising equipment like a hearing loop or an adapted keyboard</li>
+      <li>putting you in touch with support staff if you have a mental health condition</li>
+      <li>making sure classrooms are wheelchair accessible</li>
+    </ul>
+    <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work" class="govuk-link">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
+    <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
+    <p class="govuk-body">If you’re disabled, <a href="/getintoteaching/train-to-teach-with-a-disability" class="govuk-link">it’s against the law to discriminate against you</a>. Training providers must not:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
+      <li>reject your application because you’re disabled</li>
+    </ul>
+  </div>
+</details>
 <p class="govuk-body"><%= disability_disclosure %></p>

--- a/app/components/provider_interface/volunteering_history_component.html.erb
+++ b/app/components/provider_interface/volunteering_history_component.html.erb
@@ -1,3 +1,21 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Unpaid experience working with children and other volunteering</h2>
+    <p class="govuk-body">Tell us about any unpaid experience you have working with children or in a school. For example:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>one-off observations in a school</li>
+      <li>volunteering at a children's club</li>
+      <li>being a governor</li>
+    </ul>
+    <p class="govuk-body">You can also tell us about any other volunteering you’ve done, and how this supports your application to become a teacher.</p>
+  </div>
+</details>
+
 <% history.each do |item| %>
   <%= render ProviderInterface::WorkHistoryItemComponent.new(item: item) %>
 <% end %>

--- a/app/components/provider_interface/work_history_component.html.erb
+++ b/app/components/provider_interface/work_history_component.html.erb
@@ -1,3 +1,16 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+		<h2 class="govuk-heading-m">Work history</h2>
+		<p class="govuk-body">Training providers need a complete picture of the last 5 years of of your work history, including time out of the workplace, to safeguard children.</p>
+		<p class="govuk-body">Breaks in work history won’t impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
+  </div>
+</details>
+
 <% history.each do |item| %>
   <%= render ProviderInterface::WorkHistoryItemComponent.new(item: item) %>
 <% end %>

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -1,3 +1,17 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Academic and other relevant qualifications</h2>
+    <p class="govuk-body">Your undergraduate degree confirms your eligibility to teach. Enter the details of your degree as they appear on your certificate, translating them into English if necessary.</p>
+    <p class="govuk-body">You should also include any postgraduate degrees.</p>
+    <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>
+  </div>
+</details>
+
 <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.degrees, type_label: 'Degree') %>
 <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.gcses, type_label: 'GCSE or equivalent') %>
 <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, type_label: 'Academic or other qualification') %>

--- a/app/views/provider_interface/application_choices/_references_context.html.erb
+++ b/app/views/provider_interface/application_choices/_references_context.html.erb
@@ -1,0 +1,19 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <h2 class="govuk-heading-m">Choosing referees</h2>
+    <p class="govuk-body">Referees should not be family members, partners or friends.</p>
+    <p class="govuk-body">If you’re struggling to find a suitable referee, contact your provider to discuss this.</p>
+    <p class="govuk-body">Types of referee you can add:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Academic (for example, your university tutor or supervisor – choose an academic referee if you graduated in the last 5 years or you have a predicted grade for your degree)</li>
+      <li>Professional (for example, your current line manager or a previous employer –&nbsp;if you’re self-employed, you could use a client or supplier)</li>
+      <li>School-based (for example, a teacher at a school where you’ve volunteered or gained experience)</li>
+      <li>Character (choose a responsible person who can confirm you’re suitable for teaching – for example, a sports coach –&nbsp;and remember that training providers will only accept character references if there’s also an academic or professional reference)</li>
+    </ul>
+  </div>
+</details>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -36,44 +36,46 @@
 
     <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice)%>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="disabilities">Disability, access and other needs</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="disabilities">Disability, access and other needs</h2>
 
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
     <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user)%>
 
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Interview</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Interview</h2>
 
     <%= render InterviewPreferencesComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
 
     <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="work-history">Work history</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="work-history">Work history</h2>
 
     <div data-qa="work-history">
       <%= render ProviderInterface::WorkHistoryComponent.new(application_form: @application_choice.application_form) %>
     </div>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="volunteering">Unpaid experience and volunteering</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="volunteering">Unpaid experience and volunteering</h2>
 
     <div data-qa="volunteering">
       <%= render ProviderInterface::VolunteeringHistoryComponent.new(application_form: @application_choice.application_form) %>
     </div>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="language-skills">Language skills</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="language-skills">Language skills</h2>
 
     <%= render LanguageSkillsComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="personal-statement">Personal statement</h2>
 
     <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
 
     <% if @application_choice.application_form.application_references.any? %>
-      <h2 class="govuk-heading-l govuk-!-margin-top-8" id="personal-statement">References</h2>
+      <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="references">References</h2>
+
+      <%= render 'references_context' %>
 
       <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>
         <h2 class="govuk-heading-m govuk-!-margin-top-8"><%= "#{TextOrdinalizer.call((i + 1)).capitalize} referee" %></h2>
@@ -81,7 +83,7 @@
       <% end %>
     <% end %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8">Diversity information</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Diversity information</h2>
 
     <%= render ProviderInterface::DiversityInformationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
   </div>


### PR DESCRIPTION
## Context

Providers should be able to see the context of answers given on application.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds expanding static content providing context for disability, safeguarding, interview and qualifications sections.

![image](https://user-images.githubusercontent.com/93511/92137370-f53e4480-ee04-11ea-86a8-14adfe347203.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

https://trello.com/c/aRdy9Hhv/2720-provide-context-for-answers-in-manage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
