### PR TITLE
Add logic to default ApplicationForm#recruitment_cycle_year to current year

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -53,6 +53,8 @@ class ApplicationForm < ApplicationRecord
   }
   attribute :address_type, :string, default: 'uk'
 
+  attribute :recruitment_cycle_year, :integer, default: -> { RecruitmentCycle.current_year }
+
   before_create lambda {
     self.support_reference ||= GenerateSupportRef.call
   }

--- a/db/migrate/20200903170404_drop_application_forms_recruitment_cycle_year_default.rb
+++ b/db/migrate/20200903170404_drop_application_forms_recruitment_cycle_year_default.rb
@@ -1,0 +1,5 @@
+class DropApplicationFormsRecruitmentCycleYearDefault < ActiveRecord::Migration[6.0]
+  def change
+    change_column :application_forms, :recruitment_cycle_year, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_03_155450) do
+ActiveRecord::Schema.define(version: 2020_09_03_170404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -126,7 +126,7 @@ ActiveRecord::Schema.define(version: 2020_09_03_155450) do
     t.string "third_nationality"
     t.string "fourth_nationality"
     t.string "fifth_nationality"
-    t.integer "recruitment_cycle_year", default: 2020, null: false
+    t.integer "recruitment_cycle_year", null: false
     t.index ["candidate_id"], name: "index_application_forms_on_candidate_id"
     t.index ["submitted_at"], name: "index_application_forms_on_submitted_at"
   end


### PR DESCRIPTION
## Context

This PR is a follow-up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/2828 to remove the hard-coded database default for `ApplicationForm#recruitment_cycle_year` and specify a default at the model level depending on the current recruitment cycle. It should be deployed after https://github.com/DFE-Digital/apply-for-teacher-training/pull/2828

## Changes proposed in this pull request

- [x] Migration to remove database default
- [x] Declaration on the model to populate `ApplicationForm#recruitment_cycle_year` with the value of `RecruitmentCycle.current_year`.

## Guidance to review

- Does this make sense?

## Link to Trello card

https://trello.com/c/DagOgy6H/2077-unsubmitted-applications-should-be-carried-over-to-next-recruitment-cycle-manually

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
