### PR TITLE
Remove references to the 2020 cycle

### DIFF
--- a/app/controllers/api_docs/pages_controller.rb
+++ b/app/controllers/api_docs/pages_controller.rb
@@ -29,6 +29,7 @@ module APIDocs
     def render_content_page(page_name)
       @converted_markdown = Govuk::MarkdownRenderer.render(File.read("app/views/api_docs/pages/#{page_name}.md")).html_safe
       @page_name = page_name
+
       render 'rendered_markdown_template'
     end
   end

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -2,6 +2,7 @@ module ContentHelper
   def render_content_page(page_name)
     @converted_markdown = Govuk::MarkdownRenderer.render(File.read("app/views/content/#{page_name}.md")).html_safe
     @page_name = page_name
+    @recruitment_cycle_span = "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}"
     render 'rendered_markdown_template'
   end
 end

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -40,14 +40,14 @@ class TimeLimitConfig
   RULES = {
     reject_by_default: [
       Rule.new(nil, nil, 40),
-      Rule.new(Time.zone.local(2020, 7, 1), nil, 20),
+      Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 20),
     ],
     decline_by_default: [
       Rule.new(nil, nil, 10),
     ],
     chase_provider_before_rbd: [
       Rule.new(nil, nil, 20),
-      Rule.new(Time.zone.local(2020, 7, 1), nil, 10),
+      Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 10),
     ],
     chase_candidate_before_dbd: [
       Rule.new(nil, nil, 5),

--- a/app/lib/ucas.rb
+++ b/app/lib/ucas.rb
@@ -1,5 +1,5 @@
 module UCAS
   def self.apply_url
-    'https://2020.teachertraining.apply.ucas.com/apply/student/login.do'
+    "https://#{RecruitmentCycle.current_year}.teachertraining.apply.ucas.com/apply/student/login.do"
   end
 end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,6 +1,6 @@
 module RecruitmentCycle
   def self.current_year
-    if FeatureFlag.active?('switch_to_2021_recruitment_cycle')
+    if FeatureFlag.active?('switch_to_next_recruitment_cycle')
       2021
     else
       2020
@@ -9,6 +9,10 @@ module RecruitmentCycle
 
   def self.previous_year
     current_year - 1
+  end
+
+  def self.next_year
+    current_year + 1
   end
 
   def self.visible_years

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -18,8 +18,8 @@ class FeatureFlag
     [:dfe_sign_in_fallback, 'Use this when DfE Sign-in is down', 'Tijmen Brommet'],
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
-    [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to 2020 end-of-cycle with link to static page', 'Steve Hook'],
-    [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
+    [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to the end-of-cycle with link to static page', 'Steve Hook'],
+    [:switch_to_next_recruitment_cycle, 'Sync and serve courses for the next recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
   ].freeze
 

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Use <%= govuk_link_to service_name, candidate_interface_start_path %> if the courses you want to do are listed on this page.</p>
-    <p class="govuk-body">Otherwise, apply through <%= govuk_link_to 'UCAS Teacher Training', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %>.</p>
+    <p class="govuk-body">Otherwise, apply through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %>.</p>
     <p class="govuk-body">Do not apply for the same courses on both services.<p>
     <p class="govuk-body">You can apply for up to 3 courses in total.<p>
     <%= render GroupedProviderCoursesComponent.new(courses_by_provider_and_region: @courses_by_provider_and_region) %>

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -12,7 +12,7 @@
 
       <p class="govuk-body">This service is new so it’s not ready for everyone yet. Check if we’re ready for you by answering the questions below.</p>
 
-      <p class="govuk-body govuk-!-margin-bottom-6">If you cannot use our service, you can still apply for teacher training through&nbsp;<%= govuk_link_to 'UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %>.</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">If you cannot use our service, you can still apply for teacher training through&nbsp;<%= govuk_link_to 'UCAS', UCAS.apply_url %>.</p>
 
       <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK or the EU?', tag: 'span' } do %>
         <%= f.govuk_radio_button :eligible_citizen, 'yes', label: { text: 'Yes' }, link_errors: true %>

--- a/app/views/provider_interface/content/rendered_markdown_template.html.erb
+++ b/app/views/provider_interface/content/rendered_markdown_template.html.erb
@@ -1,9 +1,8 @@
-<%= content_for :browser_title, t("page_titles.#{@page_name}") %>
+<%= content_for :title, t("page_titles.#{@page_name}", recruitment_cycle_span: @recruitment_cycle_span) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t("page_titles.#{@page_name}") %></h1>
-
+    <h1 class="govuk-heading-xl"><%= t("page_titles.#{@page_name}", recruitment_cycle_span: @recruitment_cycle_span) %></h1>
     <div class="app-styled-content">
       <%= @converted_markdown %>
     </div>

--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -18,44 +18,5 @@ class RecalculateDates
         SetDeclineByDefault.new(application_form: application_form).call
       end
     end
-
-    ucas_1st_june_adjustment
-  end
-
-  def ucas_1st_june_adjustment
-    # All code related to the UCAS adjustment can be removed 2020-06-01.
-    #
-    # For the second freeze period, UCAS have introduced a manual adjustment to
-    # how RBDs and DBDs should be recalculated.
-    #
-    adjustment_date = Time.zone.local(2020, 6, 1).end_of_day
-    #
-    # All applications submitted to a provider before the 7th of March should
-    # have an RBD of the 1st of June.
-    #
-    sent_to_provider_at_cutoff = Time.zone.parse('2020-03-07')
-    application_choices_that_need_new_rbd = ApplicationChoice
-      .where(status: :awaiting_provider_decision)
-      .where('sent_to_provider_at <= ?', sent_to_provider_at_cutoff)
-      .where.not(reject_by_default_at: adjustment_date)
-    #
-    # All applications that have received an offer before the 20th of April
-    # should have a DBD of the 1st of June.
-    #
-    offered_at_cutoff = Time.zone.parse('2020-04-20')
-    application_choices_that_need_new_dbd = ApplicationChoice
-      .where(status: :offer)
-      .where('offered_at <= ?', offered_at_cutoff)
-      .where.not(decline_by_default_at: adjustment_date)
-
-    Audited.audit_class.as_user('RecalculateDates worker UCAS 1st June adjustment') do
-      application_choices_that_need_new_rbd.find_each do |application_choice|
-        application_choice.update!(reject_by_default_at: adjustment_date)
-      end
-
-      application_choices_that_need_new_dbd.find_each do |application_choice|
-        application_choice.update!(decline_by_default_at: adjustment_date)
-      end
-    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     privacy_policy: How we look after your personal data
     terms_candidate: Terms of use
     service_guidance_provider: "Using the Manage teacher training applications service: guidance for teacher training providers"
-    getting_ready_for_next_cycle: Getting ready for the next cycle (2020 to 2021)
+    getting_ready_for_next_cycle: "Getting ready for the next cycle (%{recruitment_cycle_span})"
     cookies_candidate: Cookies
     cookies_provider: Cookies
     contact_details: Contact details

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe RecruitmentCycle do
       expect(RecruitmentCycle.current_year).to eq(2020)
     end
 
-    it 'can be changed to 2021 using a feature flag' do
-      FeatureFlag.activate('switch_to_2021_recruitment_cycle')
+    it 'can be changed to the next cycle using a feature flag' do
+      FeatureFlag.activate('switch_to_next_recruitment_cycle')
       expect(RecruitmentCycle.current_year).to eq(2021)
     end
   end


### PR DESCRIPTION
## Context

References to the 2020 cycle in the codebase should either be removed or refactored to be cycle aware.


## Changes proposed in this pull request

- Use RecruitmentCycle.current_cycle rather than '2020' throughout the codebase

## Guidance to review

I'm not sure to what extent we want t make the EndOfCycleTimetable cycle aware. Tjmen is using the hardcoded apply_opens date to determine the current_cycle in #2826 

Also, the dates are going to change each year as find/apply1/apply2 seem to always close on a Friday and reopen on a Monday. 

I'm sure we could design a cool little solution (something like always using the last Friday of August for the apply1 deadline then extrapolating further dates from there), but I'm not 100% sure it's worth it right now. 

Any thoughts?

## Link to Trello card

https://trello.com/c/FjlIAtIP/2025-dev-%F0%9F%9A%B2%F0%9F%94%9A-update-references-to-2020-cycle-in-code

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
