### PR TITLE
Send "find another course" email for unavailable choices at end of cycle

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -286,6 +286,20 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def find_another_course(application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course_option.course.name_and_code
+    @provider_name = application_choice.course_option.provider.name
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.find_another_course.subject', {
+        course_name_and_code: @course_name_and_code,
+        provider_name: @provider_name,
+      }),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/views/candidate_mailer/find_another_course.erb
+++ b/app/views/candidate_mailer/find_another_course.erb
@@ -1,0 +1,23 @@
+Dear <%= @application_form.first_name %>,
+
+# Your course is not available anymore
+
+<%= @course_name_and_code %> at <%= @provider_name %> is not available anymore.
+
+We cannot send your application to <%= @provider_name %> to be considered for this course.
+
+# You may be able to find another course
+
+Find out if there are any other suitable courses available:
+
+https://www.find-postgraduate-teacher-training.service.gov.uk/
+
+If you find a course, sign in to your account to add the course as soon as possible:
+
+<%= candidate_magic_link(@candidate) %>
+
+As soon as your references come in, your application will be sent for consideration for the courses you’ve chosen - but not for any courses that are full.
+
+# Get help from a teacher training adviser
+
+You can talk to a teacher training adviser on the phone or online: https://register.getintoteaching.education.gov.uk/register

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -8,7 +8,11 @@ class SendCourseFullNotificationsWorker
         chased: application_choice,
         chaser_type: :course_unavailable_notification,
       )
-      CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
+      if EndOfCycleTimetable.stop_applications_to_unavailable_course_options?
+        CandidateMailer.find_another_course(application_choice).deliver_later
+      else
+        CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
+      end
       send_slack_message(application_choice, reason)
     end
   end

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -22,6 +22,8 @@ en:
       subject: "Chase %{referee_name}: they have not given a reference yet"
     chase_reference_again:
       subject: "Give new referee as soon as possible: %{referee_name} has not responded"
+    find_another_course:
+      subject: "Find another course - %{course_name_and_code} at %{provider_name} is not available"
     new_referee_request:
       not_responded:
         subject: "Give details of a new referee: %{referee_name} has not responded"

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -412,6 +412,10 @@ class CandidateMailerPreview < ActionMailer::Preview
     )
   end
 
+  def find_another_course
+    CandidateMailer.find_another_course(application_choice_awaiting_references)
+  end
+
 private
 
   def candidate
@@ -470,6 +474,7 @@ private
   def application_choice_awaiting_references
     FactoryBot.build_stubbed(
       :application_choice,
+      application_form: application_form,
       status: 'awaiting_references',
       course_option: FactoryBot.build_stubbed(
         :course_option,

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -36,6 +36,7 @@ RSpec.feature 'Docs' do
       provider_mailer-fallback_sign_in_email
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification
+      candidate_mailer-find_another_course
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
+++ b/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
@@ -2,11 +2,14 @@ require 'rails_helper'
 
 RSpec.describe RejectAwaitingReferencesCourseChoicesWorker do
   describe '#perform' do
-    it 'calls the `GetAwaitingReferencesCourseChoicesForPreviousCycle` service' do
-      allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to receive(:call).and_return([])
+    it 'calls the appropriate services' do
+      application_choice = create(:application_choice, :awaiting_references)
+      allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to receive(:call).and_return([application_choice.application_form])
+      allow(CandidateMailer).to receive(:application_on_pause).and_call_original
       RejectAwaitingReferencesCourseChoicesWorker.new.perform
 
       expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to have_received(:call)
+      expect(CandidateMailer).to have_received(:application_on_pause).with(application_choice.application_form)
     end
   end
 end


### PR DESCRIPTION
## Context

We need to send candidates a different email when they have unavailable course choices and are awaiting references at the end of the cycle.

## Changes proposed in this pull request

Add the new email and sent it through the existing service if we're at the end of the cycle.

I also updated the tests from my previous PR.

## Guidance to review

Makes sense?

Preview:

<img width="720" alt="Screenshot 2020-09-04 at 13 48 04" src="https://user-images.githubusercontent.com/1650875/92239257-f9c53480-eeba-11ea-82dd-8cfbc87b8840.png">


## Link to Trello card

https://trello.com/c/nGoLoCQa/2026-dev-🚲🔚-4x-emails-for-candidates-waiting-for-references-after-7th-sept

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)