### PR TITLE
Move degree autocompletes into correct form group

### DIFF
--- a/app/frontend/packs/degree-grade-autocomplete.js
+++ b/app/frontend/packs/degree-grade-autocomplete.js
@@ -15,6 +15,12 @@ const initDegreeGradeAutocomplete = () => {
       const container = document.getElementById(containerId);
       if (!container) return;
 
+      // Move autocomplete to the form group containing the input to be replaced
+      const inputFormGroup = container.previousElementSibling
+      if (inputFormGroup.contains(input)) {
+        inputFormGroup.appendChild(container)
+      }
+
       const sourceData = JSON.parse(container.dataset.source);
 
       accessibleAutocomplete({

--- a/app/frontend/packs/degree-institution-autocomplete.js
+++ b/app/frontend/packs/degree-institution-autocomplete.js
@@ -15,6 +15,12 @@ const initDegreeInstitutionAutocomplete = () => {
       const container = document.getElementById(containerId);
       if (!container) return;
 
+      // Move autocomplete to the form group containing the input to be replaced
+      const inputFormGroup = container.previousElementSibling
+      if (inputFormGroup.contains(input)) {
+        inputFormGroup.appendChild(container)
+      }
+
       const sourceData = JSON.parse(container.dataset.source);
 
       accessibleAutocomplete({

--- a/app/frontend/packs/degree-subject-autocomplete.js
+++ b/app/frontend/packs/degree-subject-autocomplete.js
@@ -15,6 +15,12 @@ const initDegreeSubjectAutocomplete = () => {
       const container = document.getElementById(containerId);
       if (!container) return;
 
+      // Move autocomplete to the form group containing the input to be replaced
+      const inputFormGroup = container.previousElementSibling
+      if (inputFormGroup.contains(input)) {
+        inputFormGroup.appendChild(container)
+      }
+
       const sourceData = JSON.parse(container.dataset.source);
 
       accessibleAutocomplete({

--- a/app/frontend/packs/degree-type-autocomplete.js
+++ b/app/frontend/packs/degree-type-autocomplete.js
@@ -27,6 +27,12 @@ const initDegreeTypeAutocomplete = () => {
       const container = document.getElementById(containerId);
       if (!container) return;
 
+      // Move autocomplete to the form group containing the input to be replaced
+      const inputFormGroup = container.previousElementSibling
+      if (inputFormGroup.contains(input)) {
+        inputFormGroup.appendChild(container)
+      }
+
       const sourceData = JSON.parse(container.dataset.source);
 
       accessibleAutocomplete({

--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -37,7 +37,7 @@
 
     <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
       <%= f.govuk_text_field :other_grade, label: { text: t('application_form.degree.grade.other.conditional.label') }, width: 10 %>
-      <%= tag.div(id: 'degree-grade-autocomplete', class: 'govuk-form-group', data: { source: @other_grades }) %>
+      <%= tag.div(id: 'degree-grade-autocomplete', data: { source: @other_grades }) %>
     <% end %>
 
     <%= f.govuk_radio_divider %>

--- a/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
@@ -23,7 +23,7 @@
     :institution_name,
     label: { text: t('application_form.degree.institution_name.label'), size: 'xl' }
   ) %>
-  <%= tag.div(id: 'degree-institution-autocomplete', class: 'govuk-form-group', data: { source: @institutions }) %>
+  <%= tag.div(id: 'degree-institution-autocomplete', data: { source: @institutions }) %>
 
 <% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/subject/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/subject/_form_fields.html.erb
@@ -4,7 +4,7 @@
   hint_text: t('application_form.degree.subject.hint_text')
 ) %>
 <% unless @degree_subject_form.international? %>
-  <%= tag.div(id: 'degree-subject-autocomplete', class: 'govuk-form-group', data: { source: @subjects }) %>
+  <%= tag.div(id: 'degree-subject-autocomplete', data: { source: @subjects }) %>
 <% end %>
 
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -7,7 +7,7 @@
         label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
         hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
       ) %>
-      <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
+      <%= tag.div(id: 'degree-type-autocomplete', data: { source: @degree_types }) %>
     <% end %>
     <%= f.govuk_radio_button :uk_degree, 'no', label: { text: t('application_form.degree.non_uk_degree.label') } do %>
       <%= f.govuk_text_field(
@@ -25,7 +25,7 @@
     label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
     hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate')
   ) %>
-  <%= tag.div(id: 'degree-type-autocomplete', class: 'govuk-form-group', data: { source: @degree_types }) %>
+  <%= tag.div(id: 'degree-type-autocomplete', data: { source: @degree_types }) %>
 
 <% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>


### PR DESCRIPTION
## Context

Most degree autocompletes, rather than enhance a `select`, instead use a `div` with a data source. This `div` is placed below the form group that contains the original `input`, which is removed. However, in the error state, this means the autocomplete doesn’t inherit the error styling, or appear inside the form group which shows a border down it’s left side. 

## Changes proposed in this pull request

Update the JavaScript for these autocompletes to find the form group that is a `previousElementSibling`, and if that contains the `input` we’re replacing, appends the autocomplete container to that form group.

Before:

<img width="670" alt="Screenshot 2020-09-04 at 14 36 07" src="https://user-images.githubusercontent.com/813383/92245440-4a895d00-eebc-11ea-8fff-95746411d070.png">

After:

<img width="670" alt="Screenshot 2020-09-04 at 14 34 53" src="https://user-images.githubusercontent.com/813383/92245449-4f4e1100-eebc-11ea-8ec1-40405db41dda.png">

## Guidance to review

I think it’s probably wise to ensure the form group contains the input we’re replacing, but is using `previousElementSibling` too defensive?

## Link to Trello card

https://trello.com/c/GynRIQqK

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
