### PR TITLE
Correct input width for IELTS score

### DIFF
--- a/app/frontend/packs/ielts-band-score-autocomplete.js
+++ b/app/frontend/packs/ielts-band-score-autocomplete.js
@@ -19,6 +19,9 @@ const initIeltsBandScoreAutocomplete = () => {
         showNoOptionsFound: true,
         confirmOnBlur: false
       });
+
+      const accessibleAutocompleteWrapper = document.querySelector(".govuk-form-group--ielts-band-score .autocomplete__wrapper");
+      accessibleAutocompleteWrapper.classList.add("govuk-input--width-5");
     });
   } catch (err) {
     console.error("Could not enhance IELTS score select:", err);

--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -10,6 +10,7 @@
   :option,
   label: { text: 'Overall band score', size: 'm' },
   hint_text: 'For example, 7.5',
+  form_group_classes: 'govuk-form-group--ielts-band-score'
   ) %>
 
 <%= f.govuk_text_field(


### PR DESCRIPTION
## Context

The autocomplete for IELTS band does not give an indication of the length of the expected value.

## Changes proposed in this pull request

Before:

<img width="665" alt="Screenshot 2020-09-04 at 15 52 45" src="https://user-images.githubusercontent.com/813383/92252910-cbe5ed00-eec6-11ea-9600-e3c788f3ec80.png">

After:

<img width="665" alt="Screenshot 2020-09-04 at 15 52 20" src="https://user-images.githubusercontent.com/813383/92252916-cf797400-eec6-11ea-821d-c49d5a27b19c.png">

## Guidance to review

This works, but will break should this page contain another autocomplete. Do we worry about that at this stage?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
