### PR TITLE
Add validation message to EFL qualification status

### DIFF
--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -574,10 +574,14 @@ en:
               blank: Enter your graduation year
               invalid: Enter a real graduation year
               greater_than_limit: Enter a year before %{date}
+        candidate_interface/english_foreign_language/start_form:
+          attributes:
+            qualification_status:
+              blank: Do you have an English as a foreign language qualification?
         candidate_interface/english_foreign_language/type_form:
           attributes:
             type:
-              blank: Choose your qualification type
+              blank: Select your qualification type
         candidate_interface/english_foreign_language/ielts_form:
           attributes:
             trf_number:


### PR DESCRIPTION
## Context

Missing validation message for `candidate_interface/english_foreign_language/start_form`.

## Changes proposed in this pull request

Before:

<img width="640" alt="Before screenshot" src="https://user-images.githubusercontent.com/813383/92256387-90015680-eecb-11ea-9b3d-085e02316790.png">

After:

<img width="655" alt="After screenshot" src="https://user-images.githubusercontent.com/813383/92256397-94c60a80-eecb-11ea-80de-a9fff7012701.png">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
