### PR TITLE
Remove the between cycles banner from the application dashboard

### DIFF
--- a/app/components/candidate_interface/apply_again_banner_component.html.erb
+++ b/app/components/candidate_interface/apply_again_banner_component.html.erb
@@ -7,13 +7,13 @@
         </p>
 
         <p class='govuk-body govuk-!-font-size-24'>
-          You'll be able to find courses from <%= find_reopen_date %> and submit from <%= reopen_date %>.
+          Applications for this academic year <%= current_cycle_span %> are now closed.
         </p>
 
         <p class='govuk-body govuk-!-font-size-24'>
-          You can <%= govuk_link_to 'make changes to your application', start_path %> until then.
+          You can still <%= govuk_link_to 'continue with your application', start_path %> so it’s ready to submit for courses starting next academic year <%= next_cycle_span %>.
         </p>
-      <% else %> 
+      <% else %>
         <p>
         <% if @application_form.application_choices.all?(&:cancelled?) %>
           Your application has been withdrawn. <%= govuk_link_to 'Do you want to apply again?', start_path %>

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -27,5 +27,13 @@ module CandidateInterface
     def find_reopen_date
       EndOfCycleTimetable.date(:find_reopens).to_s(:govuk_date)
     end
+
+    def current_cycle_span
+      "(#{RecruitmentCycle.current_year} - #{RecruitmentCycle.next_year})"
+    end
+
+    def next_cycle_span
+      "(#{RecruitmentCycle.next_year} - #{RecruitmentCycle.next_year + 1})"
+    end
   end
 end

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -10,7 +10,6 @@
 
 <% if @application_form.ended_without_success? %>
   <%= render CandidateInterface::ApplyAgainBannerComponent.new(application_form: @application_form) %>
-  <%= render CandidateInterface::ReopenBannerComponent.new(phase: 'apply_2', flash_empty: flash.empty?) %>
 <% end %>
 
 <h1 class="govuk-heading-xl govuk-heading-xl govuk-!-margin-bottom-2">

--- a/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
@@ -9,12 +9,12 @@ RSpec.feature 'Candidate with unsuccessful application' do
     end
   end
 
-  scenario 'Sees between cycles banner and cannot apply again' do
+  scenario 'Sees the carry over application banner and cannot apply again' do
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_unsuccessful_application
     and_i_visit_the_application_dashboard
     then_i_do_not_see_an_apply_again_banner
-    and_i_do_see_a_reopen_banner
+    and_i_do_see_a_carry_over_application_banner
   end
 
   def given_i_am_signed_in_as_a_candidate
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
     expect(page).not_to have_content('Do you want to apply again?')
   end
 
-  def and_i_do_see_a_reopen_banner
-    expect(page).to have_content('Applications for courses starting this academic year have now closed')
+  def and_i_do_see_a_carry_over_application_banner
+    expect(page).to have_content('Do you want to continue applying?')
   end
 end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
   def and_i_click_on_apply_again
     expect(page).to have_content 'Do you want to continue applying?'
-    click_link 'make changes to your application'
+    click_link 'continue with your application'
   end
 
   def and_i_click_on_start_now


### PR DESCRIPTION
## Context

At the moment, the between cycles banner shows in addition to the carry over banner (see images)

## Changes proposed in this pull request

- Remove the carry over banner from the application dashboard

| Before | After |
|------------|------------|
| ![image](https://user-images.githubusercontent.com/42515961/92336952-c7276180-f09d-11ea-9d1e-fd81722dbfe0.png)| ![image](https://user-images.githubusercontent.com/42515961/92336859-ff7a7000-f09c-11ea-8deb-df03fa46dbd4.png)| 

## Link to Trello card

https://trello.com/c/y6VZsiQo/2040-dev-%F0%9F%9A%B2%F0%9F%94%9A-replace-courses-closed-banner-with-an-edited-apply-2-banner-for-candidates-who-submitted-before-18-september-but-did-not?menu=filter&filter=label:Dev

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
