### PR TITLE
Change rejected_at_end_of_cycle to applications_not_sent

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -19,7 +19,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.all_withdrawn') %>
   </h2>
-<% elsif application_not_sent? %>
+<% elsif all_applications_not_sent? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.application_not_sent', count: choice_count) %>
   </h2>

--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -19,6 +19,10 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.all_withdrawn') %>
   </h2>
+<% elsif application_not_sent? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= t('application_complete.dashboard.application_not_sent', count: choice_count) %>
+  </h2>
 <% elsif all_provider_decisions_made? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.all_provider_decisions_made', count: choice_count) %>

--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -14,7 +14,8 @@ module CandidateInterface
              :any_awaiting_provider_decision?,
              :all_choices_withdrawn?,
              :any_recruited?,
-             :any_offers?, to: :application_form
+             :any_offers?,
+             :application_not_sent?, to: :application_form
 
     def editable?
       @dates.form_open_to_editing?

--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -15,7 +15,7 @@ module CandidateInterface
              :all_choices_withdrawn?,
              :any_recruited?,
              :any_offers?,
-             :application_not_sent?, to: :application_form
+             :all_applications_not_sent?, to: :application_form
 
     def editable?
       @dates.form_open_to_editing?

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -1,1 +1,7 @@
 <%= render TagComponent.new(text: text, type: type) %>
+
+<% if @application_choice.application_not_sent? %>
+  <p class="govuk-body govuk-body govuk-!-margin-top-2">
+    Your application was not sent for this course because references were not given before the deadline.
+  </p>
+<% end %>

--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -25,7 +25,7 @@ module CandidateInterface
         :blue
       when 'recruited'
         :green
-      when 'declined', 'withdrawn', 'cancelled', 'rejected_at_end_of_cycle'
+      when 'declined', 'withdrawn', 'cancelled', 'application_not_sent'
         :orange
       when 'conditions_not_met'
         :red

--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -25,8 +25,10 @@ module CandidateInterface
         :blue
       when 'recruited'
         :green
-      when 'declined', 'withdrawn', 'cancelled', 'application_not_sent'
+      when 'declined', 'withdrawn', 'cancelled'
         :orange
+      when 'application_not_sent'
+        :pink
       when 'conditions_not_met'
         :red
       when 'offer_deferred'

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -157,12 +157,7 @@ module CandidateInterface
     end
 
     def status_row_value(application_choice)
-      if ApplicationStatusTagComponent.new(application_choice: application_choice).status == 'application_not_sent'
-        render(ApplicationStatusTagComponent.new(application_choice: application_choice)) +
-          tag.p('Your application was not sent for this course because references were not given before the deadline.', class: 'govuk-body govuk-body govuk-!-margin-top-2')
-      else
-        render(ApplicationStatusTagComponent.new(application_choice: application_choice))
-      end
+      render(ApplicationStatusTagComponent.new(application_choice: application_choice))
     end
 
     def rejection_reason_row(application_choice)

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -152,8 +152,17 @@ module CandidateInterface
     def status_row(application_choice)
       {
         key: 'Status',
-        value: render(ApplicationStatusTagComponent.new(application_choice: application_choice)),
+        value: status_row_value(application_choice),
       }
+    end
+
+    def status_row_value(application_choice)
+      if ApplicationStatusTagComponent.new(application_choice: application_choice).status == 'application_not_sent'
+        render(ApplicationStatusTagComponent.new(application_choice: application_choice)) +
+          tag.p('Your application was not sent for this course because references were not given before the deadline.', class: 'govuk-body govuk-body govuk-!-margin-top-2')
+      else
+        render(ApplicationStatusTagComponent.new(application_choice: application_choice))
+      end
     end
 
     def rejection_reason_row(application_choice)

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -23,7 +23,7 @@ module ProviderInterface
         :blue
       when 'recruited'
         :green
-      when 'rejected', 'conditions_not_met', 'offer_withdrawn', 'rejected_at_end_of_cycle'
+      when 'rejected', 'conditions_not_met', 'offer_withdrawn', 'application_not_sent'
         :orange
       when 'declined', 'withdrawn'
         :red

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -23,8 +23,10 @@ module ProviderInterface
         :blue
       when 'recruited'
         :green
-      when 'rejected', 'conditions_not_met', 'offer_withdrawn', 'application_not_sent'
+      when 'rejected', 'conditions_not_met', 'offer_withdrawn'
         :orange
+      when 'application_not_sent'
+        :pink
       when 'declined', 'withdrawn'
         :red
       when 'offer_deferred'

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -13,7 +13,6 @@ module ProviderInterface
       'awaiting_provider_decision' => 'Application submitted',
       'withdrawn' => 'Application withdrawn',
       'rejected' => 'Application rejected',
-      'application_not_sent' => 'Application not sent',
       'offer_withdrawn' => 'Offer withdrawn',
       'offer' => 'Offer made',
       'pending_conditions' => 'Offer accepted',

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -13,7 +13,7 @@ module ProviderInterface
       'awaiting_provider_decision' => 'Application submitted',
       'withdrawn' => 'Application withdrawn',
       'rejected' => 'Application rejected',
-      'rejected_at_end_of_cycle' => 'Rejected at end of cycle',
+      'application_not_sent' => 'Application not sent',
       'offer_withdrawn' => 'Offer withdrawn',
       'offer' => 'Offer made',
       'pending_conditions' => 'Offer accepted',

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -23,7 +23,7 @@ module SupportInterface
         :blue
       when 'recruited'
         :green
-      when 'conditions_not_met', 'declined', 'rejected', 'offer_withdrawn', 'withdrawn', 'cancelled', 'rejected_at_end_of_cycle'
+      when 'conditions_not_met', 'declined', 'rejected', 'offer_withdrawn', 'withdrawn', 'cancelled', 'application_not_sent'
         :red
       else
         raise "You need to define a colour for the #{status} state"

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -25,7 +25,7 @@ class ApplicationChoice < ApplicationRecord
     pending_conditions: 'pending_conditions',
     recruited: 'recruited',
     rejected: 'rejected',
-    rejected_at_end_of_cycle: 'rejected_at_end_of_cycle',
+    application_not_sent: 'application_not_sent',
     offer_withdrawn: 'offer_withdrawn',
     declined: 'declined',
     withdrawn: 'withdrawn',

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -121,8 +121,11 @@ class ApplicationForm < ApplicationRecord
     application_choices.map.any?(&:offer?)
   end
 
-  def application_not_sent?
-    application_choices.map.all?(&:application_not_sent?)
+  def all_applications_not_sent?
+    application_choices.any?(&:application_not_sent?) &&
+      application_choices.all? do |application_choice|
+        application_choice.application_not_sent? || application_choice.withdrawn?
+      end
   end
 
   def science_gcse_needed?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -121,6 +121,10 @@ class ApplicationForm < ApplicationRecord
     application_choices.map.any?(&:offer?)
   end
 
+  def application_not_sent?
+    application_choices.map.all?(&:application_not_sent?)
+  end
+
   def science_gcse_needed?
     application_choices.includes(%i[course_option course]).any? do |application_choice|
       application_choice.course_option.course.primary_course?

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -60,11 +60,11 @@ module VendorAPI
     attr_reader :application_choice, :application_form
 
     # V2: for backwards compatibility `offer_withdrawn` state is displayed as `rejected` in the API.
-    # V2: for backwards compatibility `rejected_at_end_of_cycle` state is displayed as `rejected` in the API.
+    # V2: for backwards compatibility `application_not_sent` state is displayed as `rejected` in the API.
     def status
       if application_choice.offer_withdrawn?
         'rejected'
-      elsif application_choice.rejected_at_end_of_cycle?
+      elsif application_choice.application_not_sent?
         'rejected'
       else
         application_choice.status

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -4,8 +4,8 @@ class ApplicationStateChange
   # unsubmitted Apply Again applications may go straight to the provider
   # as they do not need references or the 7-day cooling off period
   STATES_THAT_MAY_BE_SENT_TO_PROVIDER = %i[application_complete unsubmitted].freeze
-  STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete cancelled].freeze
-  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn application_not_sent offer_deferred].freeze
+  STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete cancelled application_not_sent].freeze
+  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -5,11 +5,11 @@ class ApplicationStateChange
   # as they do not need references or the 7-day cooling off period
   STATES_THAT_MAY_BE_SENT_TO_PROVIDER = %i[application_complete unsubmitted].freeze
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete cancelled].freeze
-  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn rejected_at_end_of_cycle offer_deferred].freeze
+  STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn application_not_sent offer_deferred].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
-  UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn rejected_at_end_of_cycle].freeze
+  UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent].freeze
   DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
   TERMINAL_STATES = UNSUCCESSFUL_END_STATES + %i[recruited].freeze
 
@@ -34,7 +34,7 @@ class ApplicationStateChange
     state :awaiting_references do
       event :references_complete, transitions_to: :application_complete
       event :cancel, transitions_to: :cancelled
-      event :reject_at_end_of_cycle, transitions_to: :rejected_at_end_of_cycle
+      event :reject_at_end_of_cycle, transitions_to: :application_not_sent
     end
 
     state :application_complete do
@@ -53,7 +53,7 @@ class ApplicationStateChange
       event :make_offer, transitions_to: :offer
     end
 
-    state :rejected_at_end_of_cycle
+    state :application_not_sent
 
     state :offer do
       event :make_offer, transitions_to: :offer

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -3,6 +3,9 @@ en:
     dashboard:
       edit_link: Edit your application
       some_provider_decisions_made: Some of your training providers have not reached a decision yet
+      application_not_sent:
+        one: Course you applied to
+        other: Courses you applied to
       all_provider_decisions_made:
         one: Your training provider has now reached a decision
         other: All your training providers have now reached a decision

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -53,7 +53,7 @@ en:
     pending_conditions: Offer accepted
     recruited: Conditions met
     rejected: Unsuccessful
-    rejected_at_end_of_cycle: Rejected at end of cycle
+    application_not_sent: Application not sent
     unsubmitted: Not submitted yet
     withdrawn: Application withdrawn
     conditions_not_met: Conditions not met
@@ -62,7 +62,7 @@ en:
     application_complete: Submitted
     awaiting_provider_decision: Submitted
     awaiting_references: Awaiting references
-    rejected_at_end_of_cycle: Rejected at end of cycle
+    application_not_sent: Application not sent
     cancelled: Application cancelled
     declined: Declined
     offer: Offered
@@ -96,7 +96,7 @@ en:
         - referee_mailer-reference_request_chaser_email
         - referee_mailer-reference_request_chase_again_email
 
-    rejected_at_end_of_cycle:
+    application_not_sent:
       name: Reject at the end of the cycle
       description: Application choices that are awaiting references are automatically rejected at the end of the cycle
 

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -5,5 +5,14 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
     it "renders with a #{state_name} application choice" do
       render_inline CandidateInterface::ApplicationStatusTagComponent.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))
     end
+
+    context 'when the application choice is in the application_not_sent state' do
+      it 'tells the candidate why their application was not sent to their provider(s)' do
+        application_choice = build_stubbed(:application_choice, :application_not_sent)
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text).to include('Your application was not sent for this course because references were not given before the deadline.')
+      end
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -419,6 +419,10 @@ FactoryBot.define do
       status { :application_complete }
     end
 
+    trait :withdrawn do
+      status { :withdrawn }
+    end
+
     trait :withdrawn_with_survey_completed do
       association :application_form, factory: %i[completed_application_form with_completed_references ready_to_send_to_provider]
       status { :withdrawn }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -444,6 +444,12 @@ FactoryBot.define do
       rejected_by_default { true }
     end
 
+    trait :application_not_sent do
+      status { 'application_not_sent' }
+      rejected_at { Time.zone.now }
+      rejection_reason { 'Awaiting references when the recruitment cycle closed.' }
+    end
+
     trait :with_offer do
       association :application_form, factory: %i[completed_application_form with_completed_references]
       status { 'offer' }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -385,20 +385,20 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#application_not_sent?' do
+  describe '#all_applications_not_sent?' do
     let(:application_form) { build(:application_form) }
 
-    it 'returns true if all application choices are in the application_not_sent_state' do
+    it 'returns true if all application choices are in the application_not_sent or withdrawn state' do
       create(:application_choice, :application_not_sent, application_form: application_form)
-      create(:application_choice, :application_not_sent, application_form: application_form)
+      create(:application_choice, :withdrawn, application_form: application_form)
 
-      expect(application_form.application_not_sent?).to eq true
+      expect(application_form.all_applications_not_sent?).to eq true
     end
 
     it 'returns false if application choices are in any other state' do
-      create(:awaiting_references_application_choice, application_form: application_form)
+      create(:application_choice, :withdrawn, application_form: application_form)
 
-      expect(application_form.application_not_sent?).to eq false
+      expect(application_form.all_applications_not_sent?).to eq false
     end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -384,4 +384,21 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#application_not_sent?' do
+    let(:application_form) { build(:application_form) }
+
+    it 'returns true if all application choices are in the application_not_sent_state' do
+      create(:application_choice, :application_not_sent, application_form: application_form)
+      create(:application_choice, :application_not_sent, application_form: application_form)
+
+      expect(application_form.application_not_sent?).to eq true
+    end
+
+    it 'returns false if application choices are in any other state' do
+      create(:awaiting_references_application_choice, application_form: application_form)
+
+      expect(application_form.application_not_sent?).to eq false
+    end
+  end
 end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ApplicationStateChange do
     it 'has corresponding entries in the OpenAPI spec' do
       valid_states_in_openapi = VendorAPISpecification.as_hash['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
-      expect(ApplicationStateChange.states_visible_to_provider_without_deferred - %i[offer_withdrawn rejected_at_end_of_cycle])
+      expect(ApplicationStateChange.states_visible_to_provider_without_deferred - %i[offer_withdrawn application_not_sent])
         .to match_array(valid_states_in_openapi.map(&:to_sym))
     end
   end

--- a/spec/services/candidate_interface/reject_awaiting_references_application_spec.rb
+++ b/spec/services/candidate_interface/reject_awaiting_references_application_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CandidateInterface::RejectAwaitingReferencesApplication do
       Timecop.freeze do
         described_class.call(application_choice)
 
-        expect(application_choice.status).to eq 'rejected_at_end_of_cycle'
+        expect(application_choice.status).to eq 'application_not_sent'
         expect(application_choice.rejection_reason).to eq 'Awaiting references when the recruitment cycle closed.'
         expect(application_choice.rejected_at).to eq Time.zone.now
       end

--- a/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Candidates awaiting references application choices are rejected w
   end
 
   def then_the_candidates_application_choices_should_be_rejected
-    expect(@application.application_choices.reload.first.status).to eq 'rejected_at_end_of_cycle'
+    expect(@application.application_choices.reload.first.status).to eq 'application_not_sent'
     expect(@application.application_choices.reload.first.rejection_reason).to eq 'Awaiting references when the recruitment cycle closed.'
   end
 end


### PR DESCRIPTION
## Context

The state for application choices being rejected at the end of a cycle should be called application_not_sent rather than rejected at the end of the cycle. There are also a few minor UI tweaks on the application dashboard

## Changes proposed in this pull request

- Refactor rejected_at_end_of_cycle to application_not_sent
- Add a description underneath the status informing candidates why their choice was rejected
- Make the status pink

| Before | After |
|-----------|-----------|
| ![image](https://user-images.githubusercontent.com/42515961/92378014-f9b47700-f0fc-11ea-8885-f29c189bd934.png) | ![image](https://user-images.githubusercontent.com/42515961/92377741-86ab0080-f0fc-11ea-8188-b594e2225fe2.png)|

## Link to Trello card

https://trello.com/c/51nJicmW/2080-%F0%9F%9A%B2%F0%9F%94%9A-dev-add-new-application-not-sent-status

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
