### PR TITLE
Use greater or equal than in query to fix 'Less than 1 day to respond'

### DIFF
--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -115,7 +115,7 @@ module ProviderInterface
       <<~PG_DAYS_LEFT_TO_RESPOND.squish
         CASE
           WHEN status = 'awaiting_provider_decision'
-          AND (DATE(reject_by_default_at) > DATE('#{Time.zone.now.iso8601}'))
+          AND (DATE(reject_by_default_at) >= DATE('#{Time.zone.now.iso8601}'))
           THEN (DATE(reject_by_default_at) - DATE('#{Time.zone.now.iso8601}'))
           ELSE NULL END
       PG_DAYS_LEFT_TO_RESPOND

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -20,6 +20,27 @@ RSpec.describe ProviderInterface::SortApplicationChoices do
     end
   end
 
+  describe 'pg_days_left_to_respond' do
+    let(:pg_days_left_to_respond) do
+      described_class.call(application_choices: ApplicationChoice.all).first.pg_days_left_to_respond
+    end
+
+    it 'is nil when reject_by_default_at is in the past' do
+      create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 1.day.ago)
+      expect(pg_days_left_to_respond).to be_nil
+    end
+
+    it 'is zero when reject_by_default_at is tonight' do
+      create(:application_choice, :awaiting_provider_decision, reject_by_default_at: Time.zone.now.end_of_day)
+      expect(pg_days_left_to_respond).to eq(0)
+    end
+
+    it 'is the correct number of days when reject_by_default_at is in the future' do
+      create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 3.days.from_now.end_of_day)
+      expect(pg_days_left_to_respond).to eq(3)
+    end
+  end
+
   describe 'task view groups' do
     let(:application_choice) do
       described_class.call(application_choices: ApplicationChoice.all).first


### PR DESCRIPTION
## Context

When there's less than one day to respond, the 'days to respond' label does not appear in the applications list.

![image](https://user-images.githubusercontent.com/107591/92383873-fde59200-f106-11ea-993b-d30649d4fc70.png)

## Changes proposed in this pull request

Fix it.

![image](https://user-images.githubusercontent.com/107591/92383977-31282100-f107-11ea-9bc2-f57e71681aa2.png)

## Guidance to review

Inspect changes.

## Link to Trello card

No card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
