### PR TITLE
Remove Oxford comma from nationalities list in Provider interface

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -78,7 +78,7 @@ private
       @application_form.fifth_nationality,
     ]
     .reject(&:blank?)
-    .to_sentence
+    .to_sentence(last_word_connector: ' and ')
   end
 
   def date_of_birth_row

--- a/spec/components/personal_details_component_spec.rb
+++ b/spec/components/personal_details_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe PersonalDetailsComponent do
   end
 
   it 'renders the candidates nationalities' do
-    expect(result.css('.govuk-summary-list__value').text).to include('British, Irish, and Spanish')
+    expect(result.css('.govuk-summary-list__value').text).to include('British, Irish and Spanish')
   end
 
   it 'renders the candidate phone number' do


### PR DESCRIPTION
Minor style change in how we list multiple nationalities in the personal
details section.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/COoRAFqS/2011-%F0%9F%8C%90-international-nationalitys

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
