### PR TITLE
Revert changes on the 'Getting ready for the next cycle' content page

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -2,7 +2,6 @@ module ContentHelper
   def render_content_page(page_name)
     @converted_markdown = Govuk::MarkdownRenderer.render(File.read("app/views/content/#{page_name}.md")).html_safe
     @page_name = page_name
-    @recruitment_cycle_span = "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}"
     render 'rendered_markdown_template'
   end
 end

--- a/app/views/provider_interface/content/rendered_markdown_template.html.erb
+++ b/app/views/provider_interface/content/rendered_markdown_template.html.erb
@@ -1,8 +1,8 @@
-<%= content_for :title, t("page_titles.#{@page_name}", recruitment_cycle_span: @recruitment_cycle_span) %>
+<%= content_for :title, t("page_titles.#{@page_name}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t("page_titles.#{@page_name}", recruitment_cycle_span: @recruitment_cycle_span) %></h1>
+    <h1 class="govuk-heading-xl"><%= t("page_titles.#{@page_name}") %></h1>
     <div class="app-styled-content">
       <%= @converted_markdown %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     privacy_policy: How we look after your personal data
     terms_candidate: Terms of use
     service_guidance_provider: "Using the Manage teacher training applications service: guidance for teacher training providers"
-    getting_ready_for_next_cycle: "Getting ready for the next cycle (%{recruitment_cycle_span})"
+    getting_ready_for_next_cycle: Getting ready for the next cycle (2020 to 2021)"
     cookies_candidate: Cookies
     cookies_provider: Cookies
     contact_details: Contact details


### PR DESCRIPTION
## Context

This page does not need to be cycle aware as it will be heavily modified for the next cycle. 

## Changes proposed in this pull request

- Revert changes on the getting ready for the next cycle content page

## Link to Trello card

https://trello.com/c/FjlIAtIP/2025-dev-%F0%9F%9A%B2%F0%9F%94%9A-update-references-to-2020-cycle-in-code

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
