### PR TITLE
Add provider satisfaction survey to footer and header

### DIFF
--- a/app/components/phase_banner.html.erb
+++ b/app/components/phase_banner.html.erb
@@ -4,7 +4,7 @@
       <%= HostingEnvironment.phase %>
     </strong>
     <span class="govuk-phase-banner__text">
-      <%= HostingEnvironment.phase_banner_text %>
+      <%= text %>
     </span>
     </p>
   </div>

--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -13,7 +13,7 @@ class PhaseBanner < ViewComponent::Base
 
     case HostingEnvironment.environment_name
     when 'production'
-      "This is a new service - <a href='#{@feedback_link || DEFAULT_FEEDBACK_LINK}' class='govuk-link'>give feedback or report a problem</a>".html_safe
+      "This is a new service - <a href='#{@feedback_link || DEFAULT_FEEDBACK_LINK}' class='govuk-link govuk-link--no-visited-state'>give feedback or report a problem</a>".html_safe
     when 'qa'
       'This is the QA version of the Apply service'
     when 'staging'

--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -1,5 +1,29 @@
 class PhaseBanner < ViewComponent::Base
-  def initialize(no_border: false)
+  DEFAULT_FEEDBACK_LINK = 'mailto:becomingateacher@digital.education.gov.uk?subject=Apply+feedback'.freeze
+
+  def initialize(no_border: false, feedback_link: nil)
     @no_border = no_border
+    @feedback_link = feedback_link
+  end
+
+  def text
+    if HostingEnvironment.sandbox_mode?
+      return 'This is a <a href="/" class="govuk-link">test version of Apply</a> for providers and software vendors'.html_safe
+    end
+
+    case HostingEnvironment.environment_name
+    when 'production'
+      "This is a new service - <a href='#{@feedback_link || DEFAULT_FEEDBACK_LINK}' class='govuk-link'>give feedback or report a problem</a>".html_safe
+    when 'qa'
+      'This is the QA version of the Apply service'
+    when 'staging'
+      'This is a internal environment used by DfE to test deploys'
+    when 'development'
+      'This is a development version of the Apply service'
+    when 'review'
+      'This is a review environment used to test a pull request'
+    when 'unknown-environment'
+      'This is a unknown version of the Apply service'
+    end
   end
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -27,27 +27,6 @@ module HostingEnvironment
     end
   end
 
-  def self.phase_banner_text
-    if sandbox_mode?
-      return 'This is a <a href="/" class="govuk-link">test version of Apply</a> for providers and software vendors'.html_safe
-    end
-
-    case environment_name
-    when 'production'
-      'This is a new service - <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Apply+feedback" class="govuk-link">give feedback or report a problem</a>'.html_safe
-    when 'qa'
-      'This is the QA version of the Apply service'
-    when 'staging'
-      'This is a internal environment used by DfE to test deploys'
-    when 'development'
-      'This is a development version of the Apply service'
-    when 'review'
-      'This is a review environment used to test a pull request'
-    when 'unknown-environment'
-      'This is a unknown version of the Apply service'
-    end
-  end
-
   def self.environment_name
     ENV.fetch('HOSTING_ENVIRONMENT_NAME', 'unknown-environment')
   end

--- a/app/lib/provider_interface.rb
+++ b/app/lib/provider_interface.rb
@@ -1,0 +1,3 @@
+module ProviderInterface
+  FEEDBACK_LINK = 'https://docs.google.com/forms/d/e/1FAIpQLSeJfcE9cITcICGIbwnBn-xYGT24bn_Us_AUYVuA2GtJOZmIoA/viewform?usp=sf_link'.freeze
+end

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -2,6 +2,7 @@
 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
   <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
   <li><%= t('layout.support.response_time') %></li>
+  <li>Alternatively, <%= link_to 'give feedback through our survey', ProviderInterface::FEEDBACK_LINK, class: 'govuk-footer__link' %></li>
 </ul>
 <p class="govuk-body govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
   <%= link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,11 +18,11 @@
                                  navigation_items: NavigationItems.for_provider_account_nav(try(:current_provider_user), controller, @provider_setup&.pending?))) %>
 
                                <% if controller.controller_name == 'start_page' %>
-                                 <%= render PhaseBanner.new(no_border: true) %>
+                                 <%= render PhaseBanner.new(no_border: true, feedback_link: ProviderInterface::FEEDBACK_LINK) %>
                                <% elsif controller.controller_name.in? %w[sessions content provider_agreements] %>
-                                 <%= render PhaseBanner.new %>
+                                 <%= render PhaseBanner.new(feedback_link: ProviderInterface::FEEDBACK_LINK) %>
                                <% else %>
-                                 <%= render PhaseBanner.new(no_border: true) %>
+                                 <%= render PhaseBanner.new(no_border: true, feedback_link: ProviderInterface::FEEDBACK_LINK) %>
                                  <%= render(ProviderInterface::PrimaryNavigation.new(
                                    navigation_items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, @provider_setup&.pending?))) %>
                                <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,7 +19,7 @@
 
                                <% if controller.controller_name == 'start_page' %>
                                  <%= render PhaseBanner.new(no_border: true) %>
-                               <% elsif controller.controller_name.in? %w[sessions content start_page provider_agreements] %>
+                               <% elsif controller.controller_name.in? %w[sessions content provider_agreements] %>
                                  <%= render PhaseBanner.new %>
                                <% else %>
                                  <%= render PhaseBanner.new(no_border: true) %>

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe PhaseBanner do
+  describe 'in production' do
+    around do |ex|
+      ClimateControl.modify(HOSTING_ENVIRONMENT_NAME: 'production') { ex.run }
+    end
+
+    it 'renders a feedback link' do
+      result = render_inline(PhaseBanner.new)
+
+      expect(result.css('.govuk-link').attribute('href').value).to eq('mailto:becomingateacher@digital.education.gov.uk?subject=Apply+feedback')
+    end
+
+    specify 'the feedback link can be overridden' do
+      result = render_inline(PhaseBanner.new(feedback_link: 'http://geocities.com'))
+
+      expect(result.css('.govuk-link').attribute('href').value).to eq('http://geocities.com')
+    end
+  end
+end


### PR DESCRIPTION
## Context

Providers get a link to a survey instead of an email address for giving feedback.

## Changes proposed in this pull request

- refactor the PhaseBanner so it, not HostingEnvironment (!), is responsible for rendering its contents
- let PhaseBanner take the feedback link as an optional param and test it
- pass in `ProviderInterface::FEEDBACK_LINK` when we're building provider headers
- add the days we offer support to both candidate and provider headers (it was missing before)

## Guidance to review

Hopefully straightforward 🤞

## Link to Trello card

https://trello.com/c/MfZeMRX8/2677-add-satisfaction-survey-into-footer-and-header-of-live-service

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
