### PR TITLE
Capitalise environment name tag

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -21,9 +21,9 @@ module HostingEnvironment
 
   def self.phase
     if production?
-      'beta'
+      'Beta'
     else
-      environment_name
+      environment_name.capitalize
     end
   end
 

--- a/config/initializers/inflector.rb
+++ b/config/initializers/inflector.rb
@@ -4,6 +4,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym('UCAS')
   inflect.acronym('TAD')
   inflect.acronym('CSV')
+  inflect.acronym('QA')
   inflect.irregular 'chaser_sent', 'chasers_sent'
   inflect.irregular 'provider_permissions', 'provider_permissions'
 end


### PR DESCRIPTION
## Context

Just a smol thing…

## Changes proposed in this pull request

In the environment tag, capitalise the word. So `beta => Beta`, `sandbox => Sandbox` (but `qa => QA`) 
