### PR TITLE
Add a dashboard for course stats

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -4,6 +4,8 @@ module SupportInterface
   class PerformanceController < SupportInterfaceController
     def index; end
 
+    def course_stats; end
+
     def application_timings
       applications = SupportInterface::ApplicationsExport.new.applications
       csv = to_csv(applications)

--- a/app/views/support_interface/performance/course_stats.html.erb
+++ b/app/views/support_interface/performance/course_stats.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, 'Course stats' %>
+
+<% %w[2021 2020].each do |year| %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-4"><%= year %></h2>
+
+  <div id="headline-stat" class="govuk-!-margin-bottom-4">
+    <%= render SupportInterface::TileComponent.new(count: Course.in_cycle(year).open_on_apply.count, label: 'courses available on Apply', colour: :blue) %>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <%= render SupportInterface::TileComponent.new(count: Course.in_cycle(year).exposed_in_find.where(open_on_apply: false).count, label: 'courses only on UCAS', size: :reduced) %>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <%= render SupportInterface::TileComponent.new(count: Provider.where(id: Course.in_cycle(year).open_on_apply.select(:provider_id)).count, label: 'providers with open courses', size: :reduced) %>
+        </div>
+        <div class="govuk-grid-column-one-third">
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -4,6 +4,7 @@
 
 <ul class='govuk-body'>
   <li><%= govuk_link_to 'Performance dashboard', integrations_performance_path %> (public)</li>
+  <li><%= govuk_link_to 'Course stats', support_interface_course_stats_path %></li>
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
   <li><%= govuk_link_to 'Applications with unavailable choices', support_interface_unavailable_choices_path %></li>
   <li><%= govuk_link_to 'Validation errors', support_interface_validation_errors_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -730,6 +730,7 @@ Rails.application.routes.draw do
 
     get '/performance' => 'performance#index', as: :performance
     get '/performance/application-timings', to: 'performance#application_timings', as: :application_timings
+    get '/performance/course-stats', to: 'performance#course_stats', as: :course_stats
     get '/performance/submitted-application-choices', to: 'performance#submitted_application_choices', as: :submitted_application_choices
     get '/performance/referee-survey', to: 'performance#referee_survey', as: :referee_survey
     get '/performance/providers', to: 'performance#providers_export', as: :providers_export


### PR DESCRIPTION
## Context

We'd like to know how many courses we're currently syncing / have open on Apply.

## Changes proposed in this pull request

Add a small dashboard. I imagine this will be expanded over time.

## Guidance to review

Are the stats correct? I haven't added tests.

## Link to Trello card

https://trello.com/c/lMdqoepW/2069-make-sure-that-syncing-courses-from-the-new-cycle-works

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
