### PR TITLE
When validating nationality, highlight inputs containing errors

### DIFF
--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
       def create
         @application_form = current_application
-        @nationalities_form = NationalitiesForm.new(nationalities_params)
+        @nationalities_form = NationalitiesForm.new(prepare_nationalities_params)
 
         if @nationalities_form.save(current_application)
           current_application.update!(personal_details_completed: false)
@@ -36,7 +36,7 @@ module CandidateInterface
 
       def update
         @application_form = current_application
-        @nationalities_form = NationalitiesForm.new(nationalities_params)
+        @nationalities_form = NationalitiesForm.new(prepare_nationalities_params)
 
         if @nationalities_form.save(current_application)
           current_application.update!(personal_details_completed: false)
@@ -53,9 +53,20 @@ module CandidateInterface
 
     private
 
+      def prepare_nationalities_params
+        nationalities_params
+          .tap { |np| np.delete(:nationalities) }
+          .merge(nationalities_hash)
+      end
+
+      def nationalities_hash
+        nationalities_options = nationalities_params[:nationalities]
+        nationalities_options ? nationalities_options.index_by(&:downcase) : {}
+      end
+
       def nationalities_params
         params.require(:candidate_interface_nationalities_form).permit(
-          :first_nationality, :second_nationality, :british, :irish, :other, :other_nationality1, :other_nationality2, :other_nationality3
+          :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3, nationalities: []
         )
       end
 

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -1,7 +1,4 @@
 const nationalitiesComponent = () => {
-  const pageHasErrors = document.querySelector(".govuk-error-summary");
-  if (pageHasErrors) return;
-
   const secondSelectEl = document.getElementById(
     "candidate-interface-nationalities-form-other-nationality2-field"
   );
@@ -25,7 +22,7 @@ const nationalitiesComponent = () => {
   addRemoveLink(thirdFormLabel, thirdSelectEl);
 
   addAddNationalityButton(
-    "#candidate-interface-nationalities-form-other-other-conditional"
+    "#candidate-interface-nationalities-form-nationalities-other-conditional"
   );
 
   hideSection(secondSelectEl, secondFormLabel);

--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -18,6 +18,10 @@ const initNationalityAutocomplete = () => {
 
       if (!nationalitySelect) return;
 
+      const nationalitySelectValue = nationalitySelect.querySelector("[value='']");
+
+      if(!nationalitySelectValue) return;
+
       // Replace "Select a nationality" with empty string
       nationalitySelect.querySelector("[value='']").innerHTML = "";
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -202,7 +202,7 @@ class ApplicationForm < ApplicationRecord
     nationalities.present? && !english_speaking_nationality? && FeatureFlag.active?(:efl_section)
   end
 
-  def build_nationalties_hash
+  def build_nationalities_hash
     CandidateInterface::GetNationalitiesFormHash.new(application_form: self).call
   end
 

--- a/app/services/candidate_interface/get_nationalities_form_hash.rb
+++ b/app/services/candidate_interface/get_nationalities_form_hash.rb
@@ -6,9 +6,10 @@ module CandidateInterface
 
     def call
       {
+        nationalities: [set_british_attribute, set_irish_attribute, set_other_attribute].compact,
         british: set_british_attribute,
         irish: set_irish_attribute,
-        other: other_nationalities.present? ? 'other' : nil,
+        other: set_other_attribute,
         other_nationality1: other_nationalities[0],
         other_nationality2: other_nationalities[1],
         other_nationality3: other_nationalities[2],
@@ -23,6 +24,10 @@ module CandidateInterface
 
     def set_irish_attribute
       'Irish' if @application_form.nationalities.include?('Irish')
+    end
+
+    def set_other_attribute
+      other_nationalities.present? ? 'other' : nil
     end
 
     def other_nationalities

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -2,9 +2,9 @@
 
 <% if FeatureFlag.active?('international_personal_details') %>
   <%= f.govuk_check_boxes_fieldset :nationalities, legend: { size: 'xl', text:  t('page_titles.nationalities') } do %>
-    <%= f.govuk_check_box 'british', 'British', multiple: false, label: { text: 'British' } %>
-    <%= f.govuk_check_box 'irish', 'Irish', multiple: false, label: { text: 'Irish' } %>
-    <%= f.govuk_check_box 'other', 'other', multiple: false, label: { text: 'Other' } do %>
+    <%= f.govuk_check_box :nationalities, 'British', link_errors: true, multiple: true, label: { text: 'British' } %>
+    <%= f.govuk_check_box :nationalities, 'Irish', multiple: true, label: { text: 'Irish' } %>
+    <%= f.govuk_check_box :nationalities, 'other', multiple: true, label: { text: 'Other' } do %>
       <%= f.govuk_collection_select :other_nationality1, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
       <%= f.govuk_collection_select :other_nationality2, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
       <%= f.govuk_collection_select :other_nationality3, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -433,19 +433,20 @@ en:
               below_lower_age_limit: Enter a date of birth before %{date} – you must be over 16 years old to Apply for teacher training
         candidate_interface/nationalities_form:
           attributes:
+            nationalities:
+              blank: Select your nationality
             first_nationality:
-              blank: Select your nationality from the list
+              blank: If you have more than one nationality, select at least one other nationality from the list
               inclusion: Select your nationality from the list
             second_nationality:
               inclusion: Select your second nationality from the list
             other_nationality1:
+              blank: If you have an additional nationality, select it from the list
               inclusion: Select your third nationality from the list
             other_nationality2:
               inclusion: Select your fourth nationality from the list
             other_nationality3:
               inclusion: Select your fifth nationality from the list
-            other:
-              blank: Select your nationality
         candidate_interface/languages_form:
           attributes:
             english_main_language:

--- a/spec/services/candidate_interface/get_nationalities_form_hash_spec.rb
+++ b/spec/services/candidate_interface/get_nationalities_form_hash_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe CandidateInterface::GetNationalitiesFormHash do
 
     let(:expected_hash) do
       {
+        nationalities: [
+          data[:first_nationality],
+          data[:second_nationality],
+          'other',
+        ],
         british: data[:first_nationality],
         irish: data[:second_nationality],
         other: 'other',


### PR DESCRIPTION
## Context

When validating the nationality section  of the form, it does not show which fields are causing an error. Also, `Select your nationality` doesn’t appear to link to an element on the page.

## Changes proposed in this pull request
- If a user does not select any of the main options on the page (‘British’, ‘Irish’ or ‘other’) the correct field error is now displayed and linked to from the error summary at the top of the page
- If a candidate selects the ‘other’ nationality option but does not select a nationality from the list, the correct field error is now displayed and linked to from the error summary at the top of the page. ‘Other nationality‘ fields now also appear as autocomplete fields, and the number of these fields has been reduced to one.

![nationality_validation_final](https://user-images.githubusercontent.com/5256922/93024028-00eeef80-f5eb-11ea-9852-5fae476103f3.gif)

## Guidance to review
- To test this out locally you will need to activate the feature flag `:international_personal_details`

## Link to Trello card
https://trello.com/c/ZrGlg3H2/2085-when-validating-nationality-inputs-with-errors-are-not-highlighted

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
