### PR TITLE
Simplify query necessary to check permissions  on application

### DIFF
--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -1,20 +1,18 @@
 class GetApplicationChoicesForProviders
-  def self.call(providers:, vendor_api: false)
+  DEFAULT_INCLUDES = [
+    :accredited_provider,
+    :offered_course_option,
+    :provider,
+    :site,
+    application_form: %i[candidate application_references application_work_experiences application_volunteering_experiences application_qualifications],
+    course: %i[provider],
+    course_option: [{ course: %i[provider] }, :site],
+  ].freeze
+
+  def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES)
     providers = Array.wrap(providers).select(&:present?)
 
     raise MissingProvider if providers.none?
-
-    includes = [
-      :course,
-      :course_option,
-      :offered_course_option,
-      :application_form,
-      :provider,
-      :site,
-      application_form: %i[candidate application_references application_work_experiences application_volunteering_experiences application_qualifications],
-      course: %i[provider],
-      course_option: [{ course: %i[provider] }, :site],
-    ]
 
     statuses = vendor_api ? ApplicationStateChange.states_visible_to_provider_without_deferred : ApplicationStateChange.states_visible_to_provider
 
@@ -22,6 +20,6 @@ class GetApplicationChoicesForProviders
       .where('courses.provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.visible_years)
       .or(ApplicationChoice.includes(*includes)
         .where('courses.accredited_provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.visible_years))
-      .where('status IN (?)', statuses).includes([:accredited_provider])
+      .where('status IN (?)', statuses)
   end
 end

--- a/app/services/make_decisions_authorisation.rb
+++ b/app/services/make_decisions_authorisation.rb
@@ -42,7 +42,7 @@ private
   end
 
   def application_choice_visible_to_user?(application_choice:)
-    GetApplicationChoicesForProviders.call(providers: @actor.providers).include?(application_choice)
+    GetApplicationChoicesForProviders.call(providers: @actor.providers, includes: [course_option: :course]).include?(application_choice)
   end
 
   def actor_has_permissions_via_provider_to_provider_permissions?(training_provider:, ratifying_provider:)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

[We have Sentry errors for query timeouts coming from the same authorisation check](https://sentry.io/organizations/dfe-bat/issues/1882290403/?project=1765973&referrer=slack)

The underlying SQL performs a lot of LEFT OUTER JOIN statements, more than necessary to check whether an actor is eligible to make decisions for a given application.

## Changes proposed in this pull request

Simplify the underlying authorisation method to use a simplified version of the application check. This uses minimal joins to courses.

<!-- If there are UI changes, please include Before and After screenshots. -->

### Before (dev environment)

![image](https://user-images.githubusercontent.com/93511/92407826-a1e53280-f133-11ea-9ef9-bcd2ded5d149.png)

### After (dev environment)

![image](https://user-images.githubusercontent.com/93511/92451636-ea910000-f1b4-11ea-8f03-107d7c14e10e.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5ARv2hji/2727-investigate-potential-slow-query-performance-issue-with-getapplicationchoicesforproviders
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
