### PR TITLE
Use an autocomplete for the API token dropdown

### DIFF
--- a/app/frontend/packs/api-token-autocomplete.js
+++ b/app/frontend/packs/api-token-autocomplete.js
@@ -1,0 +1,20 @@
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const initApiTokenProviderAutocomplete = () => {
+  try {
+    const id = "#vendor-api-token-provider-id-field.govuk-select";
+    const apiTokenProviderSelect = document.querySelector(id);
+
+    if (!apiTokenProviderSelect) return;
+
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: apiTokenProviderSelect,
+      showAllValues: true,
+      confirmOnBlur: false
+    });
+  } catch (err) {
+    console.error("Could not enhance API token select:", err);
+  }
+};
+
+export default initApiTokenProviderAutocomplete;

--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -1,6 +1,9 @@
 require.context("govuk-frontend/govuk/assets");
 
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
+import initApiTokenProviderAutocomplete from "./api-token-autocomplete";
 import "../styles/application-support.scss";
+import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 
 govUKFrontendInitAll();
+initApiTokenProviderAutocomplete();

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'API tokens' %>
 
 <%= form_with model: VendorAPIToken.new, url: support_interface_api_tokens_path do |f| %>
-  <%= f.govuk_collection_select :provider_id, Provider.all, :id, :name, label: { text: 'Provider' } %>
+  <%= f.govuk_collection_select :provider_id, Provider.all, :id, :name, label: { text: 'Select a provider to generate a token for' }, options: { include_blank: true } %>
   <%= f.govuk_submit 'Create new token' %>
 <% end %>
 


### PR DESCRIPTION
## Context

The list is incredibly long and the ordering is arbitrary, so it’s often hard to find the provider you want. Autocomplete makes this better.

## Changes proposed in this pull request

### Before

<img width="872" alt="Screenshot 2020-09-07 at 21 42 03" src="https://user-images.githubusercontent.com/642279/92415935-fea41580-f152-11ea-8da8-3c7d610bff14.png">

### After 

<img width="1060" alt="Screenshot 2020-09-07 at 21 41 01" src="https://user-images.githubusercontent.com/642279/92415895-d87e7580-f152-11ea-820f-258b214dbc9c.png">

## Guidance to review

I hacked up some JavaScript from `course-autocomplete`. Might have missed something.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
