### PR TITLE
Fix broken error summary in the permissions wizard

### DIFF
--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
       )
       @wizard.save_state!
 
-      setup_permissions_form
+      @permissions_form = @wizard.current_permissions_form
     end
 
     def save_permissions
@@ -44,8 +44,7 @@ module ProviderInterface
         end
       else
         @permissions_model = ProviderRelationshipPermissions.find(params[:id])
-
-        setup_permissions_form
+        @permissions_form = @wizard.current_permissions_form
 
         render :setup_permissions
       end
@@ -141,12 +140,6 @@ module ProviderInterface
       params.require(:provider_interface_provider_relationship_permissions_setup_wizard)
         .permit(provider_relationship_permissions: {}).to_h
         .merge(current_provider_relationship_id: params[:id], checking_answers: params[:checking_answers])
-    end
-
-    def setup_permissions_form
-      @permissions_form = ProviderInterface::ProviderRelationshipPermissionsSetupWizard::PermissionsForm.new(
-        @wizard.permissions_for_relationship(@permissions_model.id).merge(id: @permissions_model.id),
-      )
     end
 
     def persistence_key_for_current_user

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -41,7 +41,7 @@
       <%= f.fields_for "provider_relationship_permissions[]", @permissions_form do |pf| %>
         <% ProviderRelationshipPermissions::PERMISSIONS.each do |permission_name| %>
           <div class="govuk-form-group <%= permission_name.to_s.dasherize %>" id="<%= permission_name %>">
-            <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: "Which organisations can #{permission_name.to_s.humanize.downcase}?" } do %>
+            <%= pf.govuk_check_boxes_fieldset permission_name, legend: { text: "Which organisations can #{permission_name.to_s.humanize.downcase}?" } do %>
               <%= hidden_field_tag "#{pf.object_name}[#{permission_name}][]", '' %>
               <%= pf.govuk_check_box permission_name, 'training', link_errors: true,
                                      label: { text: @permissions_model.training_provider.name } %>

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
         )
 
         expect(wizard.valid?(:permissions)).to be false
-        expect(wizard.errors.keys).to eq(%i[make_decisions])
+        expect(wizard.errors.keys).to eq([:'provider_relationship_permissions[123][make_decisions]'])
       end
     end
   end


### PR DESCRIPTION
## Context

Validation errors caused by not selecting at least one permission during the permission wizard flow would light up the fields but were not correctly linked from the error summary

## Changes proposed in this pull request

The links now work! See commit.

## Link to Trello card

https://trello.com/c/laVaKzET/2705-the-error-summary-links-in-the-permissions-wizard-do-not-link-to-the-checkboxes

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
