### PR TITLE
Update 'application_submitted' email content

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -9,10 +9,6 @@ class CandidateMailer < ApplicationMailer
 
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
-    @respond_within_days = TimeLimitCalculator.new(
-      rule: :reject_by_default,
-      effective_date: application_form.application_choices.first&.sent_to_provider_at || Time.zone.now,
-    ).call[:days]
 
     email_for_candidate(
       application_form,

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -10,42 +10,23 @@ You have submitted an application for:
 
 Your application reference is <%= @application_form.support_reference %>.
 
-You can track the progress of your <%= 'application'.pluralize(@application_form.application_choices.count) %> here:
+Sign in to your account anytime to check the progress of your application:
 
 <%= @candidate_magic_link %>
 
-# Making changes to your application
+# What's next?
 
-Get in touch with us as soon as possible if you need to make any amends, as we only have <%= TimeLimitConfig.edit_by %> to make changes.
+If your training provider decides to progress your application, they’ll contact you to organise an interview.
 
-Once we’ve processed your request, you cannot make any more changes.
+# Get your references
 
-However, you can ask us to update your name or contact details at any point.
+Ask your referees to check their email and give a reference as soon as possible.
 
-Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) if you need to make changes.
+Courses can become full at any time and your application will not be considered without references.
 
-# Withdrawing your application
+# Get support
 
-You can withdraw your application to your <%= 'course'.pluralize(@application_form.application_choices.count) %> at any point, even after you’ve accepted an offer.
+Email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
 
-Sign in to your account and click ‘withdraw’ next to the course(s) you want to withdraw:
+We typically respond within one working day for urgent queries or 5 working days for less urgent queries.
 
-<%= @candidate_magic_link %>
-
-# References
-
-We’ve emailed your referees and will send them a reminder in <%= (TimeLimitConfig.chase_referee_by - 2) %> working days.
-
-Your application will not be considered without references. Courses can become full at any time - keep in touch with your referees to ensure they give a reference as soon as possible.
-
-# Application decision
-
-If your training provider decides to progress your application, they’ll contact you directly to organise an interview date.
-
-They should make a decision on whether to make an offer within <%= @respond_within_days %> working days of receiving your application.
-
-# Need help?
-
-Contact the team on [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
-
-We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We do not provide support over the weekend or on public holidays.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_submitted.subject'),
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
-      'RBD time limit' => -> { "to make an offer within #{TimeLimitCalculator.new(rule: :reject_by_default, effective_date: Time.zone.today).call.fetch(:days)} working days" },
       'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id',
     )
   end


### PR DESCRIPTION
## Context

We need to simplify our emails for consistency, style and accessibility reasons, recent UR, and technical complexity.

## Changes proposed in this pull request

'Application submitted' copy updated in line with https://docs.google.com/document/d/19kn6zJ8sSg7gS02tVMCfdfadTGPVaaiqzu4oCi3ViTw/edit#

<img width="703" alt="email_updated" src="https://user-images.githubusercontent.com/5256922/92446782-3b512a80-f1ae-11ea-9781-dcac261bb520.png">

## Guidance to review

- Locally, you can view the changes at http://localhost:3000/rails/mailers/candidate_mailer/application_submitted

## Link to Trello card

https://trello.com/c/Kaxo28mT/2000-dev-change-candidate-applicationsubmitted-email-content

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
