### PR TITLE
Remove redundant feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -19,7 +19,6 @@ class FeatureFlag
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
     [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to the end-of-cycle with link to static page', 'Steve Hook'],
-    [:switch_to_next_recruitment_cycle, 'Sync and serve courses for the next recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
   ].freeze
 


### PR DESCRIPTION
This flag was originally removed but got merged in again accidentally in https://github.com/DFE-Digital/apply-for-teacher-training/pull/2830.