### PR TITLE
Show fewer page links when paginating above a threshold

### DIFF
--- a/app/components/paginator_component.html.erb
+++ b/app/components/paginator_component.html.erb
@@ -1,9 +1,13 @@
 <nav class="moj-pagination" role="navigation" aria-label="pager">
   <p class="govuk-visually-hidden" aria-labelledby="pagination-label">Pagination navigation</p>
 
-  <%= paginate @scope %>
+  <%= paginate @scope, paginate_configuration %>
 
   <p class="moj-pagination__results govuk-body">
-    Showing <b><%= page_start %></b> to <b><%= page_end %></b> of <b><%= total %></b> results
+  <% if current_page_exceeds_total_pages? %>
+    <b><%= total %></b> results
+  <% else %>
+    Showing <b><%= page_start %></b> to <b><%= page_end %></b> of <b><%= total %></b>
+  <% end %>
   </p>
 </nav>

--- a/app/components/paginator_component.rb
+++ b/app/components/paginator_component.rb
@@ -1,6 +1,12 @@
 class PaginatorComponent < ViewComponent::Base
   attr_reader :scope
 
+  # This constant limits the number of links to pages rendered by #paginate.
+  # In some cases, the number of links will be KAMINARI_LINKS_LIMIT + 1 because
+  # kaminari refuses to leave a gap of just one number e.g. 1 ... 345 ... 9
+  # so it renders 1 2 3 4 5 ... 9 instead.
+  KAMINARI_LINKS_LIMIT = 5
+
   def initialize(scope:)
     @scope = scope
   end
@@ -22,5 +28,53 @@ class PaginatorComponent < ViewComponent::Base
 
   def total
     @scope.total_count
+  end
+
+  def current_page_exceeds_total_pages?
+    @scope.current_page > @scope.total_pages
+  end
+
+  def total_pages_exceed_limit?
+    @scope.total_pages > KAMINARI_LINKS_LIMIT
+  end
+
+  def paginate_configuration
+    {
+      window: numbers_each_side,
+      left: numbers_left,
+      right: numbers_right,
+    }
+  end
+
+  def numbers_each_side
+    return 4 unless total_pages_exceed_limit?
+
+    if @scope.current_page >= (KAMINARI_LINKS_LIMIT - 1) &&
+        @scope.current_page <= @scope.total_pages - (KAMINARI_LINKS_LIMIT - 2)
+
+      ((KAMINARI_LINKS_LIMIT - 2).to_f / 2).floor
+    else
+      0
+    end
+  end
+
+  def numbers_left
+    return 0 unless total_pages_exceed_limit?
+
+    if @scope.current_page < (KAMINARI_LINKS_LIMIT - 1)
+      KAMINARI_LINKS_LIMIT - 1
+    else
+      1
+    end
+  end
+
+  def numbers_right
+    return 0 unless total_pages_exceed_limit?
+
+    if @scope.current_page > @scope.total_pages - (KAMINARI_LINKS_LIMIT - 2)
+      KAMINARI_LINKS_LIMIT - 1
+    else
+      1
+    end
   end
 end

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -18,3 +18,4 @@
 @import "_notes";
 @import "_product-section";
 @import "_timeline";
+@import "_pagination";

--- a/app/frontend/styles/provider/_pagination.scss
+++ b/app/frontend/styles/provider/_pagination.scss
@@ -1,0 +1,7 @@
+.moj-pagination__item--prev .moj-pagination__link:before {
+  margin-right: 1px;
+}
+
+.moj-pagination__item--next .moj-pagination__link:after {
+  margin-left: 1px;
+}

--- a/spec/components/paginator_component_spec.rb
+++ b/spec/components/paginator_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PaginatorComponent do
     render_inline(component)
   end
 
-  context 'pagination behaviour' do
+  describe 'pagination behaviour' do
     context 'when there is only one page' do
       it 'renders nothing' do
         expect(rendered_component.text).to eq ''
@@ -43,6 +43,106 @@ RSpec.describe PaginatorComponent do
     context 'when we are on the second of three pages' do
       it 'renders correct summary message' do
         expect(rendered_component(current_page: 2, total_count: 59).text).to include 'Showing 26 to 50 of 59'
+      end
+    end
+  end
+
+  describe '#paginate_configuration' do
+    def paginate_configuration(total_pages:, current_page: 1)
+      # rubocop:disable RSpec/VerifiedDoubles
+      scope = double(
+        total_count: total_pages * 25,
+        limit_value: 25,
+        current_page: current_page,
+        total_pages: total_pages,
+      )
+      # rubocop:enable RSpec/VerifiedDoubles
+
+      described_class.new(scope: scope).paginate_configuration
+    end
+
+    context 'when there are KAMINARI_LINKS_LIMIT or fewer pages (e.g. 5)' do
+      def verify_default_paginate_configuration(config)
+        expect(config).to eq(
+          {
+            window: 4,
+            left: 0,
+            right: 0,
+          },
+        )
+      end
+
+      it 'displays links for every page on every page' do
+        (1..5).each do |page|
+          config = paginate_configuration(total_pages: 5, current_page: page)
+          verify_default_paginate_configuration(config)
+        end
+      end
+    end
+
+    context 'when there are more than KAMINARI_LINKS_LIMIT pages (e.g. 9)' do
+      describe 'on page 1' do
+        let(:result) { paginate_configuration(total_pages: 9, current_page: 1) }
+
+        it 'displays 4 links on the left' do
+          expect(result[:left]).to eq(4)
+        end
+
+        it 'displays 1 link on the right' do
+          expect(result[:right]).to eq(1)
+        end
+
+        it 'no links in the middle' do
+          expect(result[:window]).to eq(0)
+        end
+      end
+
+      describe 'on page 4' do
+        let(:result) { paginate_configuration(total_pages: 9, current_page: 4) }
+
+        it 'displays 1 link on the left' do
+          expect(result[:left]).to eq(1)
+        end
+
+        it 'displays 1 link on the right' do
+          expect(result[:right]).to eq(1)
+        end
+
+        it 'displays 3 links in the middle' do
+          expect(result[:window]).to eq(1)
+        end
+      end
+
+      describe 'on page 6' do
+        let(:result) { paginate_configuration(total_pages: 9, current_page: 6) }
+
+        it 'displays 1 link on the left' do
+          expect(result[:left]).to eq(1)
+        end
+
+        it 'displays 1 link on the right' do
+          expect(result[:right]).to eq(1)
+        end
+
+        it 'displays 3 links in the middle' do
+          expect(result[:window]).to eq(1)
+        end
+      end
+
+      describe 'on page 9' do
+        let(:result) { paginate_configuration(total_pages: 9, current_page: 9) }
+
+        it 'displays 1 link on the left' do
+          expect(result[:left]).to eq(1)
+        end
+
+        it 'displays 4 links on the right' do
+          expect(result[:right]).to eq(4)
+        end
+
+        it 'displays no links in the middle' do
+          expect(result[:window]).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

As the number of applications on the system grows, we are generating too many page links at the bottom of the page, which do not add any value and force the paginator component to wrap lines.
![image](https://user-images.githubusercontent.com/107591/92463988-6b0b2d00-f1c4-11ea-8d5b-ae842da90738.png)

## Changes proposed in this pull request

Enforce a limit to the number of page links included at the bottom of the page (`KAMINARI_LINKS_LIMIT`). This is set to five page links, which means we will never display more than six (explanation below).

![image](https://user-images.githubusercontent.com/107591/92463324-8fb2d500-f1c3-11ea-9219-2033aa2f1a4b.png)
![image](https://user-images.githubusercontent.com/107591/92463349-98a3a680-f1c3-11ea-8906-544a205aacd0.png)
![image](https://user-images.githubusercontent.com/107591/92463414-b113c100-f1c3-11ea-9fb4-6c4a324e5837.png)
![image](https://user-images.githubusercontent.com/107591/92463433-b7a23880-f1c3-11ea-9bf2-cfeab0e05ade.png)
![image](https://user-images.githubusercontent.com/107591/92463455-be30b000-f1c3-11ea-926c-b6f840244432.png)
![image](https://user-images.githubusercontent.com/107591/92463470-c4269100-f1c3-11ea-8ff8-89d68f8b829f.png)
![image](https://user-images.githubusercontent.com/107591/92463495-cc7ecc00-f1c3-11ea-9ec5-f23910e2ee25.png)
![image](https://user-images.githubusercontent.com/107591/92463511-d274ad00-f1c3-11ea-9e51-86471dddad37.png)
![image](https://user-images.githubusercontent.com/107591/92463521-d7d1f780-f1c3-11ea-8016-5357534ea90d.png)
![image](https://user-images.githubusercontent.com/107591/92463539-ddc7d880-f1c3-11ea-860c-44cfb3d77960.png)
![image](https://user-images.githubusercontent.com/107591/92463564-e4565000-f1c3-11ea-8a55-efa564612d25.png)

## Guidance to review

The `kaminari` gem, which handles our pagination, supports configuring `window`, `left` and `right` parameters to control how page links are displayed at the bottom of the page. It is also a bit opinionated and refuses to leave a gap / show an ellipsis where a single number fits. Thus, at the transition points (pages 4 and 8 in the example above) we show an additional number compared to our spec (`1 2 3 4 5 ...` instead of `1 ... 3 4 5 ...`).

Inspect the automated tests. Increase the total number of pages available on your local environment by running `GenerateTestApplications.new.perform` or using the support console.

## Link to Trello card

https://trello.com/c/SowrrBPb/2398-pagination-behaviour

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
