### PR TITLE
Correct wording in "Guidance shown to candidate" for diversity

### DIFF
--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -13,7 +13,7 @@
       We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.
     </p>
     <p class="govuk-body">
-      Your data will only be shared with training providers when you are enrolled on a course.
+      Your data will only be shared with training providers when you have successfully completed your application.
     </p>
   </div>
 </details>

--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -10,7 +10,7 @@
     <p class="govuk-body-l">Your application is now ready to submit. Before you do so, will you complete a 3-minute questionnaire?</p>
     <p class="govuk-body">This questionnaire is optional and has no impact on the progress of your application.</p>
     <p class="govuk-body">We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.</p>
-    <p class="govuk-body">Your data will only be shared with training providers when you have succesfully completed your application.</p>
+    <p class="govuk-body">Your data will only be shared with training providers when you have successfully completed your application.</p>
 
     <%= govuk_button_link_to 'Continue', entrypoint_path %>
 


### PR DESCRIPTION
The "enrolled" state has been removed. Update the text we show providers under "Guidance shown to candidate"
