### PR TITLE
Remove covid_19 feature flag & guidance

### DIFF
--- a/app/components/candidate_interface/referee_guidance_component.html.erb
+++ b/app/components/candidate_interface/referee_guidance_component.html.erb
@@ -10,6 +10,4 @@
   <p class="govuk-body">Courses can become full at any time. Keep in touch with your referees to ensure they’re planning on giving a reference as soon as possible.</p>
 <% end %>
 
-<% unless FeatureFlag.active?('covid_19') %>
-  <p class="govuk-body">Training providers then have <%= reject_by_default_days %> working days to respond to your application.</p>
-<% end %>
+<p class="govuk-body">Training providers then have <%= reject_by_default_days %> working days to respond to your application.</p>

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -23,10 +23,6 @@ module ProviderInterface
       render_content_page :service_guidance_provider
     end
 
-    def covid_19_guidance
-      render_content_page :covid_19_guidance
-    end
-
     def getting_ready_for_next_cycle
       render_content_page :getting_ready_for_next_cycle
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -14,7 +14,6 @@ class FeatureFlag
   PERMANENT_SETTINGS = [
     [:banner_about_problems_with_dfe_sign_in, 'Displays a banner to notify users that DfE-Sign is having problems', 'Jake Benilov'],
     [:banner_for_ucas_downtime, 'Displays a banner to notify users that UCAS is having problems', 'Theodor Vararu'],
-    [:covid_19, 'Alters deadlines and displays an information banner related to our response to Covid-19', 'Theodor Vararu'],
     [:dfe_sign_in_fallback, 'Use this when DfE Sign-in is down', 'Tijmen Brommet'],
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -19,12 +19,6 @@
       <%= render CandidateInterface::RefereeGuidanceComponent.new(application_form: @application_form, editable_days: TimeLimitConfig.edit_by) %>
     <% end %>
 
-    <% if FeatureFlag.active?('covid_19') %>
-      <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
-      <p class="govuk-body">We’ve made some changes to response deadlines to give providers more time to make decisions. This may affect your response deadlines too.</p>
-      <p class="govuk-body"><%= govuk_link_to 'We’ll keep deadlines up to date on your application dashboard.', candidate_interface_application_complete_path %></p>
-    <% end %>
-
     <h2 class="govuk-heading-m">Interview</h2>
     <p class="govuk-body">Your training provider will be in touch with you if they want to arrange an interview.</p>
 

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -1,13 +1,5 @@
 <% content_for :title, t('page_titles.application_form') %>
 
-<% if FeatureFlag.active?('covid_19') && flash.empty? %>
-  <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
-    <div class="app-banner__message">
-      <h2 class="govuk-heading-m" id="success-message">There might be a delay in processing your application due to the impact of coronavirus (COVID-19)</h2>
-    </div>
-  </div>
-<% end %>
-
 <%= render(CandidateInterface::DeadlineBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
 <%= render(CandidateInterface::ReopenBannerComponent.new(phase: @application_form.phase, flash_empty: flash.empty?)) %>
 

--- a/app/views/candidate_mailer/application_rejected_offers_made.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_made.erb
@@ -9,20 +9,11 @@ You’ve received the following offers:
   - <%= "#{offered_application_choice.course_option.course.name_and_code} at #{offered_application_choice.course_option.course.provider.name}"%>
 <% end %>
 
-<% if FeatureFlag.active?('covid_19') %>
-If you do not reply by <%= @decline_by_default_at %> your application will be withdrawn.
-<% else %>
 If you do not reply within <%= @dbd_days %> working days, your applications will be withdrawn.
-<% end %>
 
 <% else %>
 
-<% if FeatureFlag.active?('covid_19') %>
-You’ve received an offer for a place on <%= @offers.first.course_option.course.name_and_code %> at <%= @offers.first.course_option.course.provider.name%>.
-If you do not reply by <%= @decline_by_default_at %> your application will be withdrawn.
-<% else %>
 You now have <%= @dbd_days %> working days to make a decision about your offer for a place on <%= @offers.first.course_option.course.name_and_code %> at <%= @offers.first.course_option.course.provider.name%>.
-<% end %>
 
 <% end %>
 

--- a/app/views/candidate_mailer/application_sent_to_provider.text.erb
+++ b/app/views/candidate_mailer/application_sent_to_provider.text.erb
@@ -4,15 +4,9 @@ Dear <%= @application_form.first_name %>,
 
 Your application is now with your teacher training <%= 'provider'.pluralize(@application_form.application_choices.count) %>.
 
-<% if FeatureFlag.active?('covid_19') %>
-They’ll be in touch with you if they want to arrange an interview.
-
-Due to the impact of coronavirus, this may take some time.
-<% else %>
 We’ve asked them to make a final decision within <%= @application_form.application_choices.first.reject_by_default_days %> working days.
 
 They’ll be in touch with you sooner if they want to arrange an interview.
-<% end %>
 
 Sign in to Apply for teacher training to review your application:
 

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -42,11 +42,7 @@ Your application will not be considered without references. Courses can become f
 
 If your training provider decides to progress your application, they’ll contact you directly to organise an interview date.
 
-<% if FeatureFlag.active?('covid_19') %>
-Due to the impact of coronavirus, it might take some time for providers to get back to you.
-<% else %>
 They should make a decision on whether to make an offer within <%= @respond_within_days %> working days of receiving your application.
-<% end %>
 
 # Need help?
 

--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -1,11 +1,8 @@
 Dear <%= @application_form.first_name %>
 
-<% if FeatureFlag.active?('covid_19') %>
-# Respond by <%= @dbd_date %>
-<% else %>
 If you do not reply within <%= @dbd_days %> working days, your applications will be withdrawn.
+
 # Respond within <%= @days_until_chaser %> working days
-<% end %>
 
 <% if @application_choices.count > 1 %>
 

--- a/app/views/candidate_mailer/declined_by_default.text.erb
+++ b/app/views/candidate_mailer/declined_by_default.text.erb
@@ -2,11 +2,7 @@ Dear <%= @application_form.first_name %>,
 
 # <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
 
-<% if FeatureFlag.active?('covid_19') %>
-We withdrew your application for <%= @declined_course_names.to_sentence %> because you did not respond in time.
-<% else %>
 We withdrew your application for <%= @declined_course_names.to_sentence %> because you did not respond to the <%= 'offer'.pluralize(@declined_course_names.size) %> within <%= @declined_courses.first.decline_by_default_days %> working days.
-<% end %>
 
 # Give feedback or report a problem
 

--- a/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_with_rejections.text.erb
@@ -2,11 +2,7 @@ Dear <%= @application_form.first_name %>,
 
 # <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
 
-<% if FeatureFlag.active?('covid_19') %>
-You did not respond in time so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.
-<% else %>
 You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>
-<% end %>
 
 <%= render 'interested_with_rejections' %>
 <%= render 'get_help' %>

--- a/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
+++ b/app/views/candidate_mailer/declined_by_default_without_rejections.text.erb
@@ -2,11 +2,7 @@ Dear <%= @application_form.first_name %>,
 
 # <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
 
-<% if FeatureFlag.active?('covid_19') %>
-You did not respond in time so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>.
-<% else %>
 You did not respond within <%= @declined_courses.first.decline_by_default_days %> working days so we declined your <%= 'offer'.pluralize(@declined_course_names.size) %> for <%= @declined_course_names.to_sentence %>
-<% end %>
 
 <%= render 'interested_without_rejections' %>
 <%= render 'get_help' %>

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -14,11 +14,7 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
-<% if FeatureFlag.active?('covid_19') %>
-If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
-<% else %>
 You have 10 working days to make a decision. If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
-<% end %>
 
 # Offers you’ve received
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -14,11 +14,7 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
-<% if FeatureFlag.active?('covid_19') %>
-If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
-<% else %>
 You have 10 working days to make a decision. If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
-<% end %>
 
 Sign in to your account to respond:
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,22 +1,5 @@
 <% content_for :browser_title, 'Applications' %>
 
-<% if FeatureFlag.active?('covid_19') %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="app-banner" aria-labelledby="covid-message" data-module="govuk-error-summary" role="alert">
-        <div class="app-banner__message">
-          <h2 class="govuk-heading-m" id="covid-message">
-            <%= link_to 'Coronavirus (COVID-19): check our guidance to see new deadlines for processing applications',
-              provider_interface_covid_19_guidance_path,
-              class: 'govuk-link'
-            %>
-          </h2>
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>
-
 <% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -25,16 +25,6 @@
   </div>
 </div>
 
-<% if FeatureFlag.active?('covid_19') %>
-  <div class="govuk-width-container">
-    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="covid-message" >
-      <div class="app-banner__message">
-        <h2 class="govuk-heading-m" id="covid-message">Coronavirus (COVID-19): <%= link_to 'find out how this service is changing', provider_interface_covid_19_guidance_path, class: 'govuk-link' %> to help you right now</h2>
-      </div>
-    </div>
-  </div>
-<% end %>
-
 <% if FeatureFlag.active?('getting_ready_for_next_cycle_banner') %>
   <div class="govuk-width-container">
     <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="getting-ready-for-next-cycle-message" >

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -4,14 +4,6 @@ Dear <%= @provider_user_name || 'colleague' %>
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
-<% if FeatureFlag.active?('covid_19') %>
-
-This application has been rejected automatically because you did not respond in time.
-
-<% else %>
-
 This application has been rejected automatically because you did not respond within <%= @application.rbd_days %> working days.
-
-<% end %>
 
 <%= provider_interface_application_choice_url(@application.application_choice_id) %>

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -10,12 +10,4 @@ Sign in to Manage teacher training applications to respond:
 
 <%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
 
-<% if FeatureFlag.active?('covid_19') %>
-
-You have <%= @application.rbd_date.to_s(:govuk_date).strip %> to respond. After that, the application will be automatically rejected.
-
-<% else %>
-
 We’ll reject the application on your behalf after <%= @application.rbd_days %> working days.
-
-<% end %>

--- a/app/views/provider_mailer/chase_provider_decision.text.erb
+++ b/app/views/provider_mailer/chase_provider_decision.text.erb
@@ -1,26 +1,10 @@
 Dear <%= @provider_user_name || 'colleague' %>
 
-<% if FeatureFlag.active?('covid_19') %>
-
-# Respond by <%= @application.rbd_date.to_s(:govuk_date).strip %>
-
-<% else %>
-
 # Only <%= @working_days_left %> working days left to respond
-
-<% end %>
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
-<% if FeatureFlag.active?('covid_19') %>
-
-Sign in to Manage teacher training applications to respond:
-
-<% else %>
-
 Sign in to Manage teacher training applications to respond within <%= @working_days_left %> working days:
-
-<% end %>
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,6 @@ en:
     provider:
       respond: Respond to application
       confirm: Confirm offer
-    covid_19_guidance: "Coronavirus (COVID-19): deadlines for processing applications extended to 31 May 2020"
     start_apply_again: Do you want to apply again?
     start_carry_over: Do you want to apply again?
     start_carry_over_between_cycles: "Get your application ready to submit from %{reopen_date}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -533,7 +533,7 @@ Rails.application.routes.draw do
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/cookies', to: 'content#cookies_provider', as: :cookies
     get '/service-guidance', to: 'content#service_guidance_provider', as: :service_guidance
-    get '/covid-19-guidance', to: 'content#covid_19_guidance', as: :covid_19_guidance
+    get '/covid-19-guidance', to: redirect('/')
     get '/getting-ready-for-next-cycle', to: 'content#getting_ready_for_next_cycle', as: :getting_ready_for_next_cycle
 
     get '/data-sharing-agreements/new', to: 'provider_agreements#new_data_sharing_agreement', as: :new_data_sharing_agreement

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe TimeLimitConfig do
   end
 
   describe '.edit_by' do
-    before { FeatureFlag.deactivate('covid_19') }
-
     it 'returns 5 days' do
       expect(TimeLimitConfig.edit_by.count).to eq(5)
     end

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -32,16 +32,6 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.new_offer_single_offer' do
-    context 'when the covid-19 feature flag is on' do
-      before { FeatureFlag.activate('covid_19') }
-
-      it_behaves_like(
-        'a mail with subject and content', :new_offer_single_offer,
-        'Offer received for Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
-        'Days to make an offer' => 'If you do not reply by 25 February 2020'
-      )
-    end
-
     it_behaves_like(
       'a mail with subject and content', :new_offer_single_offer,
       'Offer received for Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
@@ -148,54 +138,6 @@ RSpec.describe CandidateMailer, type: :mailer do
         'courses they are awaiting decisions' => 'Law (UFHG)',
         'providers they are awaiting decisions' => 'Vertapple University'
       )
-    end
-
-    describe '.application_rejected_offers_made' do
-      context 'one offer has been made' do
-        before do
-          FeatureFlag.activate('covid_19')
-          provider = build_stubbed(:provider, name: 'Vertapple University')
-          course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Law', code: 'UFHG', provider: provider))
-          @application_choice_with_offer = @application_form.application_choices.build(
-            application_form: @application_form,
-            course_option: course_option,
-            status: :offer,
-            decline_by_default_at: 10.business_days.from_now,
-            decline_by_default_days: 10,
-          )
-        end
-
-        it_behaves_like(
-          'a mail with subject and content', :application_rejected_offers_made,
-          I18n.t!('candidate_mailer.application_rejected.offers_made.subject', provider_name: 'Falconholt Technical College', dbd_days: 10),
-          'heading' => 'Dear Tyrell',
-          'course name and code' => 'Forensic Science (E0FO)',
-          'other course with an offer ' => 'Law (UFHG)',
-          'other provider they got an offer from' => 'Vertapple University',
-          'their DBD date' => 'Make a decision about your offer by 25 February 2020',
-          'prompt to reply with one offer' => 'You’ve received an offer for a place on',
-          'updated covid-19 prompt' => 'If you do not reply by 25 February 2020 your application will be withdrawn.'
-        )
-      end
-
-      context 'multiple offers have been made' do
-        before do
-          FeatureFlag.activate('covid_19')
-          setup_application_form_with_two_offers(@application_form)
-        end
-
-        it_behaves_like(
-          'a mail with subject and content', :application_rejected_offers_made,
-          I18n.t!('candidate_mailer.application_rejected.offers_made.subject', provider_name: 'Falconholt Technical College', dbd_days: 10),
-          'heading' => 'Dear Tyrell',
-          'course name and code' => 'MS Painting (P00)',
-          'first course with offer' => 'Code Refactoring (Z00)',
-          'first course provider with offer' => 'Wen University',
-          'their DBD date' => 'Make a decision about your offers by 25 February 2020',
-          'prompt to reply with multiple offers' => 'You’ve received the following offers:',
-          'updated covid-19 prompt' => 'If you do not reply by 25 February 2020 your application will be withdrawn.'
-        )
-      end
     end
   end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -38,17 +38,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       'RBD time limit' => -> { "to make an offer within #{TimeLimitCalculator.new(rule: :reject_by_default, effective_date: Time.zone.today).call.fetch(:days)} working days" },
       'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id',
     )
-
-    context 'when the covid-19 feature flag is on' do
-      before { FeatureFlag.activate('covid_19') }
-
-      it_behaves_like(
-        'a mail with subject and content',
-        :application_submitted,
-        I18n.t!('candidate_mailer.application_submitted.subject'),
-        'RBD time limit' => 'Due to the impact of coronavirus, it might take some time for providers to get back to you.',
-      )
-    end
   end
 
   describe 'Send survey email' do
@@ -77,29 +66,9 @@ RSpec.describe CandidateMailer, type: :mailer do
         'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id'
       )
     end
-
-    context 'when the covid-19 feature flag is on' do
-      before { FeatureFlag.activate('covid_19') }
-
-      it_behaves_like(
-        'a mail with subject and content', :application_sent_to_provider,
-        'Your application is being considered',
-        'time frame provider has to respond' => "They’ll be in touch with you if they want to arrange an interview.\r\n\r\nDue to the impact of coronavirus, this may take some time."
-      )
-    end
   end
 
   describe 'Candidate decision chaser email' do
-    context 'when the covid-19 feature flag is on' do
-      before { FeatureFlag.activate('covid_19') }
-
-      it_behaves_like(
-        'a mail with subject and content', :chase_candidate_decision,
-        I18n.t!('chase_candidate_decision_email.subject_singular'),
-        'Date to respond by' => -> { "Respond by #{10.business_days.from_now.to_s(:govuk_date).strip}" }
-      )
-    end
-
     context 'when a candidate has one appication choice with offer' do
       it_behaves_like(
         'a mail with subject and content', :chase_candidate_decision,
@@ -129,24 +98,6 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.decline_by_default' do
-    context 'when the covid-19 feature flag is on' do
-      before do
-        FeatureFlag.activate('covid_19')
-        @application_form = build_stubbed(
-          :application_form,
-          candidate: @candidate,
-          first_name: 'Fred',
-          application_choices: [build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10)],
-        )
-      end
-
-      it_behaves_like(
-        'a mail with subject and content', :declined_by_default,
-        'You did not respond to your offer: next steps',
-        'Reason' => 'You did not respond in time so we declined your'
-      )
-    end
-
     context 'when a candidate has 1 offer that was declined' do
       before do
         @application_form = build_stubbed(

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -52,54 +52,25 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send application submitted email' do
-    context 'with the covid_19 feature flag off' do
-      it_behaves_like('a provider mail with subject and content', :application_submitted,
-                      I18n.t!('provider_mailer.application_submitted.subject',
-                              course_name_and_code: 'Computer Science (6IND)'),
-                      'provider name' => 'Dear Johny English',
-                      'candidate name' => 'Harry Potter',
-                      'course name and code' => 'Computer Science (6IND)',
-                      'reject by default days' => 'after 123 working days',
-                      'link to the application' => 'http://localhost:3000/provider/applications/')
-    end
-
-    context 'with the covid_19 feature flag on' do
-      before { FeatureFlag.activate('covid_19') }
-
-      it_behaves_like('a provider mail with subject and content', :application_submitted,
-                      I18n.t!('provider_mailer.application_submitted.subject',
-                              course_name_and_code: 'Computer Science (6IND)'),
-                      'provider name' => 'Dear Johny English',
-                      'candidate name' => 'Harry Potter',
-                      'course name and code' => 'Computer Science (6IND)',
-                      'reject by default at' => -> { (Time.zone.now + 40.days).to_s(:govuk_date).strip },
-                      'link to the application' => 'http://localhost:3000/provider/applications/')
-    end
+    it_behaves_like('a provider mail with subject and content', :application_submitted,
+                    I18n.t!('provider_mailer.application_submitted.subject',
+                            course_name_and_code: 'Computer Science (6IND)'),
+                    'provider name' => 'Dear Johny English',
+                    'candidate name' => 'Harry Potter',
+                    'course name and code' => 'Computer Science (6IND)',
+                    'reject by default days' => 'after 123 working days',
+                    'link to the application' => 'http://localhost:3000/provider/applications/')
   end
 
   describe 'Send application rejected by default email' do
-    context 'with the covid_19 feature flag off' do
-      it_behaves_like('a provider mail with subject and content', :application_rejected_by_default,
-                      I18n.t!('provider_mailer.application_rejected_by_default.subject',
-                              candidate_name: 'Harry Potter', support_reference: '123A'),
-                      'provider name' => 'Dear Johny English',
-                      'candidate name' => 'Harry Potter',
-                      'course name and code' => 'Computer Science (6IND)',
-                      'reject by default days' => 'within 123 working days',
-                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip })
-    end
-
-    context 'with the covid_19 feature flag on' do
-      before { FeatureFlag.activate('covid_19') }
-
-      it_behaves_like('a provider mail with subject and content', :application_rejected_by_default,
-                      I18n.t!('provider_mailer.application_rejected_by_default.subject',
-                              candidate_name: 'Harry Potter', support_reference: '123A'),
-                      'provider name' => 'Dear Johny English',
-                      'candidate name' => 'Harry Potter',
-                      'course name and code' => 'Computer Science (6IND)',
-                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip })
-    end
+    it_behaves_like('a provider mail with subject and content', :application_rejected_by_default,
+                    I18n.t!('provider_mailer.application_rejected_by_default.subject',
+                            candidate_name: 'Harry Potter', support_reference: '123A'),
+                    'provider name' => 'Dear Johny English',
+                    'candidate name' => 'Harry Potter',
+                    'course name and code' => 'Computer Science (6IND)',
+                    'reject by default days' => 'within 123 working days',
+                    'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip })
   end
 
   describe 'Send provider decision chaser email' do
@@ -107,32 +78,16 @@ RSpec.describe ProviderMailer, type: :mailer do
       @application_choice.update(reject_by_default_at: 20.business_days.from_now)
     end
 
-    context 'with the covid_19 feature flag off' do
-      it_behaves_like('a provider mail with subject and content', :chase_provider_decision,
-                      I18n.t!('provider_mailer.application_waiting_for_decision.subject',
-                              candidate_name: 'Harry Potter', support_reference: '123A'),
-                      'provider name' => 'Dear Johny English',
-                      'candidate name' => 'Harry Potter',
-                      'course name and code' => 'Computer Science (6IND)',
-                      'time to respond' => 'Only 20 working days left to respond',
-                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip },
-                      'reject by default at' => -> { 20.business_days.from_now.to_s(:govuk_date).strip },
-                      'link to the application' => 'http://localhost:3000/provider/applications/')
-    end
-
-    context 'with the covid_19 feature flag on' do
-      before { FeatureFlag.activate('covid_19') }
-
-      it_behaves_like('a provider mail with subject and content', :chase_provider_decision,
-                      I18n.t!('provider_mailer.application_waiting_for_decision.subject',
-                              candidate_name: 'Harry Potter', support_reference: '123A'),
-                      'provider name' => 'Dear Johny English',
-                      'candidate name' => 'Harry Potter',
-                      'course name and code' => 'Computer Science (6IND)',
-                      'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip },
-                      'reject by default at' => -> { 20.business_days.from_now.to_s(:govuk_date).strip },
-                      'link to the application' => 'http://localhost:3000/provider/applications/')
-    end
+    it_behaves_like('a provider mail with subject and content', :chase_provider_decision,
+                    I18n.t!('provider_mailer.application_waiting_for_decision.subject',
+                            candidate_name: 'Harry Potter', support_reference: '123A'),
+                    'provider name' => 'Dear Johny English',
+                    'candidate name' => 'Harry Potter',
+                    'course name and code' => 'Computer Science (6IND)',
+                    'time to respond' => 'Only 20 working days left to respond',
+                    'submission date' => -> { (Time.zone.now - 5.days).to_s(:govuk_date).strip },
+                    'reject by default at' => -> { 20.business_days.from_now.to_s(:govuk_date).strip },
+                    'link to the application' => 'http://localhost:3000/provider/applications/')
   end
 
   describe '.offer_accepted' do

--- a/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Candidate needs to provide a new referee' do
 
   scenario 'Candidate provides a new referee because one did not respond' do
     FeatureFlag.activate('pilot_open')
-    FeatureFlag.activate('covid_19')
 
     given_i_am_signed_in_as_a_candidate
     and_i_have_submitted_my_application
@@ -16,7 +15,6 @@ RSpec.describe 'Candidate needs to provide a new referee' do
 
     when_i_choose_to_continue_without_adding_a_new_referee
     then_i_see_that_i_need_a_new_reference_on_the_dashboard
-    and_i_do_not_see_the_covid_19_guidance
 
     when_i_sign_in_again
     then_i_see_the_interstitial_page_to_add_new_referee
@@ -72,10 +70,6 @@ RSpec.describe 'Candidate needs to provide a new referee' do
 
   def then_i_see_that_i_need_a_new_reference_on_the_dashboard
     expect(page).to have_content 'You need to give details of a new referee'
-  end
-
-  def and_i_do_not_see_the_covid_19_guidance
-    expect(page).not_to have_content 'Coronavirus (COVID-19)'
   end
 
   def then_i_see_the_interstitial_page_to_add_new_referee

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -5,8 +5,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_the_pilot_is_open
-    and_the_covid_19_feature_flag_is_active
-
     given_i_am_a_candidate_without_an_account
 
     when_i_go_to_sign_up
@@ -25,7 +23,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     and_i_confirm_the_sign_in
     then_i_see_the_before_you_start_page
     and_i_should_see_an_account_created_flash_message
-    and_i_should_not_see_the_covid19_banner
 
     when_click_on_the_apply_for_teacher_training_link_in_the_header
     then_i_should_see_the_application_page
@@ -33,10 +30,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_covid_19_feature_flag_is_active
-    FeatureFlag.activate('covid_19')
   end
 
   def given_i_am_a_candidate_without_an_account
@@ -105,10 +98,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def and_i_should_see_an_account_created_flash_message
     expect(page).to have_content(t('apply_from_find.account_created_message'))
-  end
-
-  def and_i_should_not_see_the_covid19_banner
-    expect(page).not_to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
   end
 
   def when_click_on_the_apply_for_teacher_training_link_in_the_header

--- a/spec/system/candidate_interface/candidate_submits_application_with_full_course_location_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_with_full_course_location_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application' do
+RSpec.feature 'Candidate submits the application with full course choice location' do
   include CandidateHelper
 
   scenario 'The location that the candidate picked is full but others have vacancies' do

--- a/spec/system/candidate_interface/candidate_submits_application_with_full_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_submits_application_with_full_course_study_mode_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application' do
+RSpec.feature 'Candidate submits the application with full course study mode' do
   include CandidateHelper
 
   scenario 'The location that the candidate picked has no full-time vacancies but does have part-time vacancies' do

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate submits the application' do
 
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in
-    and_the_covid_19_feature_flag_is_on
 
     when_i_have_completed_my_application
 
@@ -38,7 +37,6 @@ RSpec.feature 'Candidate submits the application' do
     then_i_can_see_my_application_has_been_successfully_submitted
 
     and_i_can_see_my_support_ref
-    and_that_covid_19_may_affect_my_application
     and_i_receive_an_email_with_my_support_ref
     and_my_referees_receive_a_request_for_a_reference_by_email
     and_a_slack_notification_is_sent
@@ -52,14 +50,6 @@ RSpec.feature 'Candidate submits the application' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_covid_19_feature_flag_is_on
-    FeatureFlag.activate('covid_19')
-  end
-
-  def and_the_covid_19_feature_flag_is_on
-    FeatureFlag.activate('covid_19')
   end
 
   def when_i_have_completed_my_application
@@ -192,10 +182,6 @@ RSpec.feature 'Candidate submits the application' do
   def and_i_can_see_my_support_ref
     support_ref = page.find('span#application-ref').text
     expect(support_ref).not_to be_empty
-  end
-
-  def and_that_covid_19_may_affect_my_application
-    expect(page).to have_content 'Coronavirus (COVID-19)'
   end
 
   def and_i_receive_an_email_with_my_support_ref

--- a/spec/system/candidate_interface/candidate_viewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_application_spec.rb
@@ -7,13 +7,7 @@ RSpec.feature 'Viewing their new application' do
     given_i_am_signed_in
     when_i_visit_the_site
     then_i_should_see_that_i_have_made_no_choices
-    and_i_should_not_see_the_covid19_banner
 
-    given_covid19_feature_flag_is_active
-    when_i_visit_the_site
-    then_i_should_see_the_covid19_banner
-
-    # while I have not submitted an application
     when_i_visit_the_review_page
     then_i_am_on_the_application_form_page
 
@@ -50,17 +44,5 @@ RSpec.feature 'Viewing their new application' do
 
   def then_i_am_on_the_application_form_page
     then_i_should_see_that_i_have_made_no_choices
-  end
-
-  def and_i_should_not_see_the_covid19_banner
-    expect(page).not_to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
-  end
-
-  def given_covid19_feature_flag_is_active
-    FeatureFlag.activate('covid_19')
-  end
-
-  def then_i_should_see_the_covid19_banner
-    expect(page).to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
   end
 end

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature 'A candidate withdraws her application' do
 
   scenario 'successful withdrawal' do
     given_i_am_signed_in_as_a_candidate
-    and_the_covid_19_feature_flag_is_on
     and_i_have_multiple_application_choice_awaiting_provider_decision
 
     when_i_visit_the_application_dashboard
@@ -34,7 +33,6 @@ RSpec.feature 'A candidate withdraws her application' do
     and_i_click_continue
     then_i_see_my_application_dashboard
     and_i_am_thanked_for_my_feedback
-    and_i_do_not_see_the_covid_19_guidance
 
     when_i_try_to_visit_the_withdraw_page
     then_i_see_the_page_not_found
@@ -50,10 +48,6 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def given_i_am_signed_in_as_a_candidate
     create_and_sign_in_candidate
-  end
-
-  def and_the_covid_19_feature_flag_is_on
-    FeatureFlag.activate('covid_19')
   end
 
   def and_i_have_multiple_application_choice_awaiting_provider_decision
@@ -94,10 +88,6 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def then_my_application_should_be_withdrawn
     and_my_application_should_be_withdrawn
-  end
-
-  def and_i_do_not_see_the_covid_19_guidance
-    expect(page).not_to have_content('Coronavirus (COVID-19)')
   end
 
   def and_a_slack_notification_is_sent

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application' do
+RSpec.feature 'International candidate submits the application' do
   include CandidateHelper
   include EFLHelper
 

--- a/spec/system/provider_interface/first_login_spec.rb
+++ b/spec/system/provider_interface/first_login_spec.rb
@@ -10,15 +10,6 @@ RSpec.feature 'See applications' do
   end
 
   scenario 'Provider user can access interface immediately if pre-approved' do
-    when_the_covid_19_feature_is_active
-    and_i_visit_the_provider_page
-    then_i_expect_to_see_the_covid_19_message
-
-    when_i_click_the_covid_19_message_link_to_covid_19_guidance
-    then_i_expect_to_see_the_covid_19_guidance_page
-
-    then_the_covid_19_feature_is_deactivated
-
     when_i_visit_the_provider_page
     given_a_support_user_has_pre_approved_my_email_address
     and_i_am_a_new_provider_user_authenticated_with_dfe_sign_in
@@ -27,26 +18,6 @@ RSpec.feature 'See applications' do
 
     then_i_should_be_on_the_applications_page
     and_my_dfe_sign_in_uid_has_been_stored
-  end
-
-  def when_i_click_the_covid_19_message_link_to_covid_19_guidance
-    click_link('find out how this service is changing')
-  end
-
-  def then_i_expect_to_see_the_covid_19_guidance_page
-    expect(page).to have_content('Coronavirus (COVID-19): deadlines for processing applications extended')
-  end
-
-  def then_i_expect_to_see_the_covid_19_message
-    expect(page).to have_content('Coronavirus (COVID-19): find out how this service is changing to help you right now')
-  end
-
-  def when_the_covid_19_feature_is_active
-    FeatureFlag.activate('covid_19')
-  end
-
-  def then_the_covid_19_feature_is_deactivated
-    FeatureFlag.deactivate('covid_19')
   end
 
   def given_a_support_user_has_pre_approved_my_email_address

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -19,10 +19,6 @@ RSpec.feature 'See applications' do
 
     when_i_click_on_an_application
     then_i_should_be_on_the_application_view_page
-
-    when_covid19_feature_flag_is_active
-    and_i_visit_the_provider_page
-    then_i_should_see_a_covid19_information_banner
   end
 
   def when_my_apply_account_has_been_created
@@ -81,13 +77,5 @@ RSpec.feature 'See applications' do
   def then_i_should_be_on_the_application_view_page
     expect(page).to have_content @my_provider_choice1.application_form.support_reference
     expect(page).to have_content @my_provider_choice1.application_form.full_name
-  end
-
-  def when_covid19_feature_flag_is_active
-    FeatureFlag.activate('covid_19')
-  end
-
-  def then_i_should_see_a_covid19_information_banner
-    expect(page).to have_content 'Coronavirus (COVID-19): check our guidance to see new deadlines for processing applications'
   end
 end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'See applications' do
     when_my_apply_account_has_been_created
     and_i_sign_in_to_the_provider_interface
     then_i_should_see_the_applications_from_my_organisation
-    and_i_should_not_see_a_covid19_information_banner
     and_i_should_see_the_applications_menu_item_highlighted
 
     when_i_click_on_an_application
@@ -59,10 +58,6 @@ RSpec.feature 'See applications' do
   def then_i_should_see_the_applications_from_my_organisation
     expect(page).to have_content @my_provider_choice1.application_form.full_name
     expect(page).to have_content @my_provider_choice2.application_form.full_name
-  end
-
-  def and_i_should_not_see_a_covid19_information_banner
-    expect(page).not_to have_content 'coronavirus'
   end
 
   def and_i_should_see_the_applications_menu_item_highlighted


### PR DESCRIPTION
## Context

This feature flag has been off in production for a while, and won't be turned on again. 

## Changes proposed in this pull request

See commits.

## Guidance to review

Per commit.

## Link to Trello card

https://trello.com/c/r1NgyH99/747-remove-covid-19-guidance-page-from-the-provider-interface

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
