### PR TITLE
Add missing method call to degree factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -244,7 +244,7 @@ FactoryBot.define do
       level { 'degree' }
       qualification_type { Hesa::DegreeType.all.sample.name }
       subject { Hesa::Subject.all.sample.name }
-      institution_name { Hesa::Institution.all.sample }
+      institution_name { Hesa::Institution.all.sample.name }
       grade { Hesa::Grade.all.sample.description }
     end
 


### PR DESCRIPTION
Ensure we call `name` after sampling a HESA institution, otherwise the
factory sets `institution_name` to a struct object rather than a string.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
