### PR TITLE
Link to edit provider user view in the support interface

### DIFF
--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -46,7 +46,7 @@ private
   def send_slack_notification
     providers = @provider_user.providers.map(&:name).to_sentence
     message = "#{@provider_user.first_name} has been invited to join #{providers}"
-    url = Rails.application.routes.url_helpers.support_interface_provider_user_url(@provider_user)
+    url = Rails.application.routes.url_helpers.edit_support_interface_provider_user_url(@provider_user)
 
     SlackNotificationWorker.perform_async(message, url)
   end

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe InviteProviderUser, sidekiq: true do
     end
 
     it 'sends a slack message' do
-      url = Rails.application.routes.url_helpers.support_interface_provider_user_url(provider_user)
+      url = Rails.application.routes.url_helpers.edit_support_interface_provider_user_url(provider_user)
 
       expect(SlackNotificationWorker).to have_received(:perform_async)
         .with("Firstname has been invited to join #{provider.name}", url)


### PR DESCRIPTION
There isn't a show page for provider users in the support interface so make Slack notifications link to the edit page.

## Context

https://github.com/DFE-Digital/apply-for-teacher-training/pull/2822 added a Slack message when a new provider user is invited, this should link to the provider user but there is no support interface _show_ page for a provider user.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Amend link sent to Slack to support interface edit provider user view.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
