### PR TITLE
Show right to work fields when viewing application in Provider interface

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -1,5 +1,10 @@
 class PersonalDetailsComponent < ViewComponent::Base
   MISSING = '<em>Not provided</em>'.html_safe
+  RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES = {
+    'yes' => 'Yes',
+    'no' => 'Not yet',
+    'decide_later' => 'Candidate does not know',
+  }.freeze
 
   include ViewHelper
 
@@ -24,6 +29,8 @@ class PersonalDetailsComponent < ViewComponent::Base
       name_row,
       date_of_birth_row,
       nationality_row,
+      right_to_work_or_study_row,
+      residency_details_row,
       phone_number_row,
       email_row,
       address_row,
@@ -79,6 +86,24 @@ private
     ]
     .reject(&:blank?)
     .to_sentence
+  end
+
+  def right_to_work_or_study_row
+    return if @application_form.right_to_work_or_study.blank?
+
+    {
+      key: 'Has the right to work or study in the UK?',
+      value: RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.fetch(@application_form.right_to_work_or_study),
+    }
+  end
+
+  def residency_details_row
+    return unless @application_form.right_to_work_or_study == 'yes'
+
+    {
+      key: 'Residency details',
+      value: @application_form.right_to_work_or_study_details,
+    }
   end
 
   def date_of_birth_row

--- a/spec/components/personal_details_component_spec.rb
+++ b/spec/components/personal_details_component_spec.rb
@@ -68,4 +68,59 @@ RSpec.describe PersonalDetailsComponent do
 
     expect(result.css('.govuk-summary-list__value').text).to include(international_address)
   end
+
+  it 'does not render right to work fields if nationality is British or Irish' do
+    expect(result.text).not_to include('Has the right to work or study in the UK?')
+    expect(result.text).not_to include('Residency details')
+  end
+
+  context 'a candidate whose nationality is neither British or Irish' do
+    let(:application_form) do
+      build_stubbed(
+        :completed_application_form,
+        first_nationality: 'Pakistani',
+        second_nationality: 'Singaporean',
+        third_nationality: 'Spanish',
+      )
+    end
+
+    it 'renders their right to work or study status' do
+      PersonalDetailsComponent::RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.each do |key, value|
+        application_form.right_to_work_or_study = key
+        result = render_inline(PersonalDetailsComponent.new(application_form: application_form))
+        row_title = result.css('.govuk-summary-list__row')[5].css('dt').text
+        row_value = result.css('.govuk-summary-list__row')[5].css('dd').text
+        expect(row_title).to include 'Has the right to work or study in the UK?'
+        expect(row_value).to include value
+      end
+    end
+
+    context 'the right to work or study status is "yes"' do
+      before do
+        application_form.right_to_work_or_study = 'yes'
+        application_form.right_to_work_or_study_details = 'I have settled status'
+      end
+
+      it 'renders the residency_details_row' do
+        expect(result.css('.govuk-summary-list__key').text).to include('Residency details')
+        expect(result.css('.govuk-summary-list__value').text).to include('I have settled status')
+      end
+    end
+
+    context 'the right to work or study status is "no"' do
+      before { application_form.right_to_work_or_study = 'no' }
+
+      it 'does not render the residency_details_row' do
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Residency details')
+      end
+    end
+
+    context 'the right to work or study status is "decide_later"' do
+      before { application_form.right_to_work_or_study = 'decide_later' }
+
+      it 'does not render the residency_details_row' do
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Residency details')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to open up the service to international applicants. Providers need to be able to make decisions based on the availability of this information.
## Changes proposed in this pull request

- Add right to work or study row if nationality is not British/Irish
- Add details row if right to work or study is 'yes'

![Screenshot_20200908_162524](https://user-images.githubusercontent.com/519250/92496382-f64de800-f1ef-11ea-9a30-0b39024fe78e.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Submitting an application as a non-British candidate in the review app is probably the most complete way. Changing nationality and right to work values on the console locally is an alternative.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/oj1jNqYY
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
