### PR TITLE
Show how org/org permissions affect user permissions in the Invitation wizard

### DIFF
--- a/app/components/associated_providers_permissions_list_component.rb
+++ b/app/components/associated_providers_permissions_list_component.rb
@@ -1,8 +1,8 @@
 class AssociatedProvidersPermissionsListComponent < ViewComponent::Base
   attr_reader :permission_name
 
-  def initialize(permission_model, permission_name:)
-    @permission_model = permission_model
+  def initialize(provider:, permission_name:)
+    @provider = provider
     @permission_name = permission_name
   end
 
@@ -21,10 +21,10 @@ class AssociatedProvidersPermissionsListComponent < ViewComponent::Base
 private
 
   def permissions_as_ratifying_provider
-    @permissions_as_ratifying_provider ||= ProviderRelationshipPermissions.where(ratifying_provider_id: @permission_model.provider.id)
+    @permissions_as_ratifying_provider ||= ProviderRelationshipPermissions.where(ratifying_provider_id: @provider.id)
   end
 
   def permissions_as_training_provider
-    @permissions_as_training_provider ||= ProviderRelationshipPermissions.where(training_provider_id: @permission_model.provider.id)
+    @permissions_as_training_provider ||= ProviderRelationshipPermissions.where(training_provider_id: @provider.id)
   end
 end

--- a/app/components/permissions_list_component.html.erb
+++ b/app/components/permissions_list_component.html.erb
@@ -10,21 +10,21 @@
   <% if permission_model.make_decisions? %>
     <li>
       <%= render CheckIcon.new %><span class="govuk-!-font-weight-bold">Make decisions</span>
-      <%= render AssociatedProvidersPermissionsListComponent.new(permission_model, permission_name: 'make_decisions') %>
+      <%= render AssociatedProvidersPermissionsListComponent.new(provider: permission_model.provider, permission_name: 'make_decisions') %>
     </li>
   <% end %>
 
   <% if permission_model.view_safeguarding_information? %>
     <li>
       <%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">Access safeguarding information</span>
-      <%= render AssociatedProvidersPermissionsListComponent.new(permission_model, permission_name: 'view_safeguarding_information') %>
+      <%= render AssociatedProvidersPermissionsListComponent.new(provider: permission_model.provider, permission_name: 'view_safeguarding_information') %>
     </li>
   <% end %>
 
   <% if permission_model.view_diversity_information? %>
     <li>
       <%= render CheckIcon.new %> <span class="govuk-!-font-weight-bold">Access diversity information</span>
-      <%= render AssociatedProvidersPermissionsListComponent.new(permission_model, permission_name: 'view_diversity_information') %>
+      <%= render AssociatedProvidersPermissionsListComponent.new(provider: permission_model.provider, permission_name: 'view_diversity_information') %>
     </li>
   <% end %>
 

--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -27,20 +27,21 @@
                           label: { text: 'Make decisions' },
                           hint_text: 'Make offers, amend offers and reject applications' %>
     <div class="govuk-body govuk-!-margin-left-6">
-      <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'make_decisions') %>
+      <%= render AssociatedProvidersPermissionsListComponent.new(provider: permissions_form.provider, permission_name: 'make_decisions') %>
     </div>
+
     <%= f.govuk_check_box :view_safeguarding_information, true, multiple: false,
                           label: { text: 'Access safeguarding information' },
                           hint_text: 'View sensitive material about the candidate' %>
     <div class="govuk-body govuk-!-margin-left-6">
-      <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'view_safeguarding_information') %>
+      <%= render AssociatedProvidersPermissionsListComponent.new(provider: permissions_form.provider, permission_name: 'view_safeguarding_information') %>
     </div>
 
     <%= f.govuk_check_box :view_diversity_information, true, multiple: false,
                           label: { text: 'Access diversity information' },
                           hint_text: 'View diversity information about the candidate' %>
     <div class="govuk-body govuk-!-margin-left-6">
-      <%= render AssociatedProvidersPermissionsListComponent.new(permissions_form, permission_name: 'view_diversity_information') %>
+      <%= render AssociatedProvidersPermissionsListComponent.new(provider: permissions_form.provider, permission_name: 'view_diversity_information') %>
     </div>
   <% end %>
 

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -18,35 +18,6 @@ module ProviderInterface
       validates :providers, presence: true
     end
 
-    PermissionOption = Struct.new(:slug, :name, :hint)
-    AVAILABLE_PERMISSIONS = [
-      PermissionOption.new(
-        'manage_organisations',
-        'Manage organisations',
-        'Change permissions between organisations',
-      ),
-      PermissionOption.new(
-        'manage_users',
-        'Manage users',
-        'Invite or delete users and set their permissions',
-      ),
-      PermissionOption.new(
-        'make_decisions',
-        'Make decisions',
-        'Make offers, amend offers and reject applications',
-      ),
-      PermissionOption.new(
-        'view_safeguarding_information',
-        'Access safeguarding information',
-        'View sensitive material about the candidate',
-      ),
-      PermissionOption.new(
-        'view_diversity_information',
-        'Access diversity information',
-        'View diversity information about the candidate',
-      ),
-    ].freeze
-
     class PermissionsForm
       include ActiveModel::Model
 

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -12,18 +12,41 @@
           fieldset_legend_text = 'Select permissions'
           fieldset_legend_text += ": #{@provider.name}" unless @wizard.single_provider
         -%>
-        <%= pf.govuk_collection_check_boxes(
-          :permissions,
-          ProviderInterface::ProviderUserInvitationWizard::AVAILABLE_PERMISSIONS,
-          :slug,
-          :name,
-          :hint,
-          legend: { text: fieldset_legend_text, size: "xl" },
-          caption: { text: "Invite user", size: "xl" },
-        ) do %>
+        <%= pf.govuk_check_boxes_fieldset(:permissions,
+                legend: { text: fieldset_legend_text, size: "xl" },
+                caption: { text: 'Invite user', size: "xl" }) do %>
           <span id="permissions-hint" class="govuk-hint">
             The user will be able to view all applications made to courses at these organisations. You do not need to set permissions for this.
           </span>
+
+          <%= pf.govuk_check_box :permissions, 'manage_organisations',
+                                label: { text: 'Manage organisations' },
+                                hint_text: 'Change permissions between organisations' %>
+
+          <%= pf.govuk_check_box :permissions, 'manage_users',
+                                label: { text: 'Manage users' },
+                                hint_text: 'Invite or delete users and set their permissions' %>
+
+          <%= pf.govuk_check_box :permissions, 'make_decisions',
+                                label: { text: 'Make decisions' },
+                                hint_text: 'Make offers, amend offers and reject applications' %>
+          <div class="govuk-body govuk-!-margin-left-6">
+            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'make_decisions') %>
+          </div>
+
+          <%= pf.govuk_check_box :permissions, 'view_safeguarding_information',
+                                label: { text: 'Access safeguarding information' },
+                                hint_text: 'View sensitive material about the candidate' %>
+          <div class="govuk-body govuk-!-margin-left-6">
+            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_safeguarding_information') %>
+          </div>
+
+          <%= pf.govuk_check_box :permissions, 'view_diversity_information',
+                                label: { text: 'Access diversity information' },
+                                hint_text: 'View diversity information about the candidate' %>
+          <div class="govuk-body govuk-!-margin-left-6">
+            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_diversity_information') %>
+          </div>
         <% end %>
       <% end %>
 

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -30,23 +30,31 @@
           <%= pf.govuk_check_box :permissions, 'make_decisions',
                                 label: { text: 'Make decisions' },
                                 hint_text: 'Make offers, amend offers and reject applications' %>
-          <div class="govuk-body govuk-!-margin-left-6">
-            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'make_decisions') %>
-          </div>
+          <% if FeatureFlag.active?(:enforce_provider_to_provider_permissions) %>
+            <div class="govuk-body govuk-!-margin-left-6">
+              <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'make_decisions') %>
+            </div>
+          <% end %>
 
           <%= pf.govuk_check_box :permissions, 'view_safeguarding_information',
                                 label: { text: 'Access safeguarding information' },
                                 hint_text: 'View sensitive material about the candidate' %>
-          <div class="govuk-body govuk-!-margin-left-6">
-            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_safeguarding_information') %>
-          </div>
+
+          <% if FeatureFlag.active?(:enforce_provider_to_provider_permissions) %>
+            <div class="govuk-body govuk-!-margin-left-6">
+              <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_safeguarding_information') %>
+            </div>
+          <% end %>
 
           <%= pf.govuk_check_box :permissions, 'view_diversity_information',
                                 label: { text: 'Access diversity information' },
                                 hint_text: 'View diversity information about the candidate' %>
-          <div class="govuk-body govuk-!-margin-left-6">
-            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_diversity_information') %>
-          </div>
+
+          <% if FeatureFlag.active?(:enforce_provider_to_provider_permissions) %>
+            <div class="govuk-body govuk-!-margin-left-6">
+              <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_diversity_information') %>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/spec/components/associated_providers_permissions_list_component_spec.rb
+++ b/spec/components/associated_providers_permissions_list_component_spec.rb
@@ -12,43 +12,43 @@ RSpec.describe AssociatedProvidersPermissionsListComponent do
   end
 
   it 'renders ratifying providers the permission also applies to' do
-    permission_model = create(:provider_permissions,
-                              provider: training_provider,
-                              make_decisions: true)
+    create(:provider_permissions,
+           provider: training_provider,
+           make_decisions: true)
     provider_relationship_permissions
-    result = render_inline(described_class.new(permission_model, permission_name: 'make_decisions'))
+    result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
 
     expect(result.text).to include('Applies to courses ratified by:')
     expect(result.css('li').text).to include(ratifying_provider.name.to_s)
   end
 
   it 'renders training providers the permission also applies to' do
-    permission_model = create(:provider_permissions,
-                              provider: ratifying_provider,
-                              make_decisions: true)
+    create(:provider_permissions,
+           provider: ratifying_provider,
+           make_decisions: true)
     provider_relationship_permissions
-    result = render_inline(described_class.new(permission_model, permission_name: 'make_decisions'))
+    result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
 
     expect(result.text).to include('Applies to courses run by:')
     expect(result.css('li').text).to include(training_provider.name.to_s)
   end
 
   it 'does not render associated training providers permissions if there are not any' do
-    permission_model = create(:provider_permissions,
-                              provider: training_provider,
-                              make_decisions: false)
+    create(:provider_permissions,
+           provider: training_provider,
+           make_decisions: false)
     provider_relationship_permissions
-    result = render_inline(described_class.new(permission_model, permission_name: 'make_decisions'))
+    result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
 
     expect(result.text).not_to include('Applies to courses run by:')
   end
 
   it 'does not render associated ratifying providers permissions if there are not any' do
-    permission_model = create(:provider_permissions,
-                              provider: ratifying_provider,
-                              make_decisions: false)
+    create(:provider_permissions,
+           provider: ratifying_provider,
+           make_decisions: false)
     provider_relationship_permissions
-    result = render_inline(described_class.new(permission_model, permission_name: 'make_decisions'))
+    result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
 
     expect(result.text).not_to include('Applies to courses ratified by:')
   end


### PR DESCRIPTION
## Context

When inviting a user, you might not realise that org/org permissions affect the user's permissions.

This PR is @AgaDufrat's work — added final fix and raising in her absence.

## Changes proposed in this pull request

Add the org/org permissions under each checkbox.

## Guidance to review

Test manually through the UI.

## Link to Trello card

https://trello.com/c/OnfnXcmz/2709-when-inviting-a-user-show-how-org-org-permissions-will-affect-the-permissions-youre-giving-them

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
