### PR TITLE
Set sync_courses: true for fake providers

### DIFF
--- a/app/services/generate_fake_provider.rb
+++ b/app/services/generate_fake_provider.rb
@@ -3,6 +3,10 @@ class GenerateFakeProvider
     raise 'You cannot generate test data in production' if HostingEnvironment.production?
 
     Provider.find_or_create_by(provider) do |new_provider|
+      # turn this on even though there's nothing to sync, because it enables
+      # courses to be opened and lets us assign users
+      new_provider.update!(sync_courses: true)
+
       generate_courses_for(new_provider)
       generate_ratified_courses_for(new_provider) unless new_provider.code == 'TEST'
     end

--- a/spec/services/generate_fake_provider_spec.rb
+++ b/spec/services/generate_fake_provider_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe GenerateFakeProvider do
         .to change { Provider.count }.by(2)
     end
 
+    it 'turns on syncing for the provider' do
+      new_provider = generate_provider_call
+
+      expect(new_provider.sync_courses).to be true
+    end
+
     describe 'courses and course options' do
       let(:fake_provider) { Provider.find_by(code: 'FAKE') }
 


### PR DESCRIPTION
## Context

When we create fake providers the courses are not automatically opened because the provider does not have `sync_courses` set to true. This means there's a manual step to open courses, and it's easy to forget.

## Changes proposed in this pull request

- always mark fake providers with `sync_courses` true

## Link to Trello card

Came up as part of https://trello.com/c/3iC0aiNg/741-investigate-bug-report-from-ucb and also https://ukgovernmentdfe.slack.com/archives/CTHFLRFHB/p1599573003004300

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
