### PR TITLE
Fix training with a disability section to route to review page

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -205,6 +205,10 @@ module CandidateInterface
       @application_form.training_with_a_disability_completed
     end
 
+    def training_with_a_disability_valid?
+      TrainingWithADisabilityForm.build_from_application(@application_form).valid?
+    end
+
     def course_choices_completed?
       @application_form.course_choices_completed
     end

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -88,7 +88,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.training_with_a_disability'),
             completed: @application_form_presenter.training_with_a_disability_completed?,
-            path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path
+            path: @application_form_presenter.training_with_a_disability_valid? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path
           )
         ) %>
       </li>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -191,14 +191,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#training_with_a_disability_completed?' do
     it 'returns true if training with a disabilitty section is completed' do
-      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: true)
+      application_form = FactoryBot.build(:completed_application_form)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_training_with_a_disability_completed
     end
 
     it 'returns false if maths training with a disabilitty section is incomplete' do
-      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: false)
+      application_form = FactoryBot.build(:application_form)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).not_to be_training_with_a_disability_completed
@@ -207,17 +207,17 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe 'training_with_a_disability_valid?' do
     it 'returns true if training with a disability section is completed' do
-      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: true, disclose_disability: true)
+      application_form = FactoryBot.build(:completed_application_form)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_training_with_a_disability_valid
     end
 
     it 'returns true if training with a disability section is incomplete' do
-      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: false, disclose_disability: true)
+      application_form = FactoryBot.build(:completed_application_form, disclose_disability: '')
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-      expect(presenter).to be_training_with_a_disability_valid
+      expect(presenter).not_to be_training_with_a_disability_valid
     end
   end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -205,6 +205,22 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe 'training_with_a_disability_valid?' do
+    it 'returns true if training with a disability section is completed' do
+      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: true, disclose_disability: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_training_with_a_disability_valid
+    end
+
+    it 'returns true if training with a disability section is incomplete' do
+      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: false, disclose_disability: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_training_with_a_disability_valid
+    end
+  end
+
   describe '#volunteering_completed?' do
     it 'returns true if volunteering section is completed' do
       application_form = build(:application_form, volunteering_completed: true)


### PR DESCRIPTION
## Context

When Training with a Disability have been filled out but section is not marked as complete the Application presenter should route the candidate to the review page rather than to the edit path.

## Changes proposed in this pull request

Tweaks to the Application Form presenter and Training with a Disability show view.

## Guidance to review

Check that behaviour is now as required.

## Link to Trello card

https://trello.com/c/t98DVkIA/2059-returning-to-some-completed-sections-not-marked-as-complete-takes-you-to-the-wrong-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
