### PR TITLE
Allow providers to defer offers

### DIFF
--- a/app/components/provider_interface/status_box_components/offer_deferred_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_deferred_component.rb
@@ -24,8 +24,8 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Offer made',
-            value: application_choice.offered_at.to_s(:govuk_date),
+            key: 'Offer deferred',
+            value: application_choice.offer_deferred_at.to_s(:govuk_date),
           },
         ] + add_change_links_to(course_rows(course_option: application_choice.offered_option))
       end

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -3,5 +3,6 @@
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
 <% if provider_can_respond %>
-<%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0  govuk-!-display-none-print' %>
+  <%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print' %>
+  <%= govuk_button_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice.id), class: 'govuk-!-margin-bottom-0 govuk-!-margin-left-2 govuk-!-display-none-print' %>
 <% end %>

--- a/app/components/provider_interface/status_box_components/recruited_component.html.erb
+++ b/app/components/provider_interface/status_box_components/recruited_component.html.erb
@@ -1,3 +1,7 @@
 <h2 class="govuk-heading-l">Offer</h2>
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+
+<% if provider_can_respond %>
+  <%= govuk_button_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice.id), class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print'  %>
+<% end %>

--- a/app/components/provider_interface/status_box_components/recruited_component.rb
+++ b/app/components/provider_interface/status_box_components/recruited_component.rb
@@ -4,10 +4,11 @@ module ProviderInterface
       include ViewHelper
       include StatusBoxComponents::CourseRows
 
-      attr_reader :application_choice
+      attr_reader :application_choice, :provider_can_respond
 
       def initialize(application_choice:, options: {})
         @application_choice = application_choice
+        @provider_can_respond = options[:provider_can_respond]
         @options = options
       end
 

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -135,6 +135,28 @@ module ProviderInterface
       end
     end
 
+    def new_defer_offer
+      @defer_offer = DeferOffer.new(
+        actor: current_provider_user,
+        application_choice: @application_choice,
+      )
+    end
+
+    def defer_offer
+      @defer_offer = DeferOffer.new(
+        actor: current_provider_user,
+        application_choice: @application_choice,
+      )
+      if @defer_offer.save
+        flash[:success] = 'Offer successfully deferred'
+        redirect_to provider_interface_application_choice_path(
+          application_choice_id: @application_choice.id,
+        )
+      else
+        render action: :new_defer_offer
+      end
+    end
+
   private
 
     def set_application_choice

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -58,6 +58,9 @@ class StateChangeNotifier
     when :withdraw_offer
       text = ":no_good: #{provider_name} has just withdrawn #{applicant}’s offer"
       url = helpers.support_interface_application_form_url(application_form_id)
+    when :defer_offer
+      text = ":double_vertical_bar: #{provider_name} has just deferred #{applicant}’s offer"
+      url = helpers.support_interface_application_form_url(application_form_id)
     else
       raise 'StateChangeNotifier: unsupported state transition event'
     end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -213,6 +213,16 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def deferred_offer(application_choice)
+    @application_choice = application_choice
+    @course_option = @application_choice.offered_option
+
+    email_for_candidate(
+      @application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.deferred_offer.subject', provider_name: @course_option.course.provider.name),
+    )
+  end
+
   def withdraw_last_application_choice(application_form)
     @withdrawn_courses = application_form.application_choices.select(&:withdrawn?)
     @withdrawn_course_names = @withdrawn_courses.map { |application_choice| "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}" }

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -22,4 +22,8 @@ module RecruitmentCycle
   def self.years_visible_in_support
     [2021, 2020, 2019]
   end
+
+  def self.next_cycle_name
+    "#{next_year} to #{next_year + 1}"
+  end
 end

--- a/app/services/defer_offer.rb
+++ b/app/services/defer_offer.rb
@@ -13,6 +13,11 @@ class DeferOffer
       ApplicationStateChange.new(@application_choice).defer_offer!
       @application_choice.update(offer_deferred_at: Time.zone.now)
     end
+
+    CandidateMailer.deferred_offer(@application_choice).deliver_later
+    StateChangeNotifier.call(:defer_offer, application_choice: @application_choice)
+
+    true
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/views/candidate_mailer/deferred_offer.text.erb
+++ b/app/views/candidate_mailer/deferred_offer.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @application_form.first_name %>,
+
+<%= @course_option.course.provider.name %> has deferred your offer.
+
+Contact <%= @course_option.course.provider.name %> directly if you have any questions about this.
+
+You can sign in to Apply for teacher training to check the status of your application(s):
+
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/provider_interface/decisions/new_defer_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_defer_offer.html.erb
@@ -1,0 +1,23 @@
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @defer_offer, url: provider_interface_application_choice_defer_offer_path(@application_choice) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-xl">
+        <%= @application_choice.application_form.full_name %>
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        Check and confirm offer deferral
+      </h1>
+
+      <p class="govuk-body">This application will be marked as deferred.</p>
+      <p class="govuk-body">You must review and confirm your offer again at the start of the next cycle (2021 to 2022).</p>
+      <p class="govuk-body">We’ll email the candidate notifying them of the deferral after you confirm below.</p>
+
+      <%= f.button 'Confirm offer deferral', class: 'govuk-button', data: { module: 'govuk-button' } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/decisions/new_defer_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_defer_offer.html.erb
@@ -14,7 +14,7 @@
       </h1>
 
       <p class="govuk-body">This application will be marked as deferred.</p>
-      <p class="govuk-body">You must review and confirm your offer again at the start of the next cycle (2021 to 2022).</p>
+      <p class="govuk-body">You must review and confirm your offer again at the start of the next cycle (<%= RecruitmentCycle.next_cycle_name %>).</p>
       <p class="govuk-body">We’ll email the candidate notifying them of the deferral after you confirm below.</p>
 
       <%= f.button 'Confirm offer deferral', class: 'govuk-button', data: { module: 'govuk-button' } %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -379,12 +379,16 @@ en:
     pending_conditions-defer_offer:
       name: Provider defers offer
       by: provider
-      description: ""
+      description: "A provider defers an offer with pending conditions until the next recruitment cycle"
+      emails:
+        - candidate_mailer-deferred_offer
 
     recruited-defer_offer:
       name: Provider defers offer
       by: provider
-      description: ""
+      description: "A provider defers an offer until the next recruitment cycle"
+      emails:
+        - candidate_mailer-deferred_offer
 
     offer_deferred-reinstate_conditions_met:
       name: Provider reinstates deferred offer and conditions are still valid

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -68,6 +68,8 @@ en:
       subject: "You have not met your conditions for %{course_name}: next steps"
     changed_offer:
       subject: "%{provider_name} changed the details of your offer"
+    deferred_offer:
+      subject: "%{provider_name} has deferred your offer"
     apply_again_call_to_action:
       subject: You can still apply for teacher training
     course_unavailable_notification:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -564,6 +564,8 @@ Rails.application.routes.draw do
       get '/offer/new_withdraw' => 'decisions#new_withdraw_offer', as: :application_choice_new_withdraw_offer
       post '/offer/confirm_withdraw' => 'decisions#confirm_withdraw_offer', as: :application_choice_confirm_withdraw_offer
       post '/offer/withdraw' => 'decisions#withdraw_offer', as: :application_choice_withdraw_offer
+      get '/offer/defer' => 'decisions#new_defer_offer', as: :application_choice_new_defer_offer
+      post '/offer/defer' => 'decisions#defer_offer', as: :application_choice_defer_offer
     end
 
     post '/candidates/:candidate_id/impersonate' => 'candidates#impersonate', as: :impersonate_candidate

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -416,6 +416,19 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.find_another_course(application_choice_awaiting_references)
   end
 
+  def deferred_offer
+    application_form = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Harry',
+      application_choices: [
+        FactoryBot.build_stubbed(:application_choice, status: 'pending_conditions', course_option: course_option),
+      ],
+      candidate: candidate,
+    )
+
+    CandidateMailer.deferred_offer(application_form.application_choices.first)
+  end
+
 private
 
   def candidate

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -14,4 +14,12 @@ RSpec.describe RecruitmentCycle do
       end
     end
   end
+
+  describe '.next_cycle_name' do
+    it 'is next year to the following year' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
+        expect(RecruitmentCycle.next_cycle_name).to eq('2021 to 2022')
+      end
+    end
+  end
 end

--- a/spec/system/provider_interface/provider_defers_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_defers_an_offer_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider defers an offer' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider defers an offer' do
+    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
+
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_an_offered_application_choice_exists_for_my_provider
+    and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_i_view_an_offered_application
+
+    when_i_click_on_defer_application
+    then_i_am_asked_to_confirm_deferral_of_the_offer
+
+    when_i_confirm_deferral_of_the_offer
+    then_i_am_back_to_the_application_page
+    and_i_can_see_the_application_offer_is_deferred
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_an_offered_application_choice_exists_for_my_provider
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    @application_offered = create(:application_choice, status: 'pending_conditions', accepted_at: 1.day.ago, course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
+  end
+
+  def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_i_view_an_offered_application
+    visit provider_interface_application_choice_path(
+      @application_offered.id,
+    )
+  end
+
+  def when_i_click_on_defer_application
+    click_on 'Defer offer'
+  end
+
+  def then_i_am_asked_to_confirm_deferral_of_the_offer
+    expect(page).to have_current_path(
+      provider_interface_application_choice_new_defer_offer_path(
+        @application_offered.id,
+      ),
+    )
+    expect(page).to have_content 'Confirm offer deferral'
+  end
+
+  def when_i_confirm_deferral_of_the_offer
+    click_on 'Confirm offer deferral'
+  end
+
+  def then_i_am_back_to_the_application_page
+    expect(page).to have_current_path(
+      provider_interface_application_choice_path(
+        @application_offered.id,
+      ),
+    )
+    expect(page).to have_content @application_offered.application_form.first_name
+    expect(page).to have_content @application_offered.application_form.last_name
+  end
+
+  def and_i_can_see_the_application_offer_is_deferred
+    expect(page).to have_content 'Offer successfully deferred'
+  end
+end


### PR DESCRIPTION
## Context

Providers need the ability to defer an offer until the next recruitment cycle.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds button links allowing a provider user to defer offers on applications which are _recruited_ or _pending conditions_.
- Adds a confirmation step before deferral state change.
- Calls `DeferOffer` service which triggers a candidate email and notifies the state change.

<!-- If there are UI changes, please include Before and After screenshots. -->

### Offer deferral button

![image](https://user-images.githubusercontent.com/93511/92716663-0502df00-f357-11ea-99ab-0cd2cfa24f15.png)

### Offer deferral confirmation

![image](https://user-images.githubusercontent.com/93511/92716729-1b109f80-f357-11ea-9168-a7fa6490b269.png)

## Guidance to review

I've deliberately omitted the Offer tab from this PR, will tackle this separately.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ouFrR3xE/2690-allow-providers-to-defer-offers
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
