### PR TITLE
Remove "Safe to work with children" from referee survey export

### DIFF
--- a/app/models/referee_questionnaire.rb
+++ b/app/models/referee_questionnaire.rb
@@ -2,7 +2,4 @@ class RefereeQuestionnaire
   EXPERIENCE_QUESTION = 'Please rate your experience of giving a reference'.freeze
   GUIDANCE_QUESTION = 'Please rate how useful our guidance was'.freeze
   CONSENT_TO_BE_CONTACTED_QUESTION = 'Can we contact you about your experience of giving a reference?'.freeze
-
-  # This question is no longer asked
-  SAFE_TO_WORK_WITH_CHILDREN_QUESTION = 'If we asked whether a candidate was safe to work with children, would you feel able to answer?'.freeze
 end

--- a/app/services/support_interface/referee_survey_export.rb
+++ b/app/services/support_interface/referee_survey_export.rb
@@ -17,8 +17,6 @@ module SupportInterface
           'Experience explanation' => extract_explanation(reference, RefereeQuestionnaire::EXPERIENCE_QUESTION),
           'Consent to be contacted' => extract_rating(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
           'Contact details' => extract_explanation(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
-          'Safe to work with children?' => extract_rating(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
-          'Safe to work with children explanation' => extract_explanation(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
         }
 
         output << hash

--- a/spec/services/support_interface/referee_survey_export_spec.rb
+++ b/spec/services/support_interface/referee_survey_export_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe SupportInterface::RefereeSurveyExport do
         RefereeQuestionnaire::GUIDANCE_QUESTION => 'very_poor | I could not read it.',
         RefereeQuestionnaire::EXPERIENCE_QUESTION => 'very_good | I could read it.',
         RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => 'yes | 02113131',
-        RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION => 'yes | ',
+
+        # Legacy question that is no longer asked.
+        'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => 'yes | ',
       }
     end
 
@@ -16,7 +18,6 @@ RSpec.describe SupportInterface::RefereeSurveyExport do
         RefereeQuestionnaire::GUIDANCE_QUESTION => 'good | ',
         RefereeQuestionnaire::EXPERIENCE_QUESTION => 'poor | ',
         RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => ' | ',
-        RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION => ' | ',
       }
     end
 
@@ -25,7 +26,6 @@ RSpec.describe SupportInterface::RefereeSurveyExport do
         RefereeQuestionnaire::GUIDANCE_QUESTION => ' | ',
         RefereeQuestionnaire::EXPERIENCE_QUESTION => ' | ',
         RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => ' | ',
-        RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION => ' | ',
       }
     end
 
@@ -62,8 +62,6 @@ private
       'Experience explanation' => extract_explanation(reference, RefereeQuestionnaire::EXPERIENCE_QUESTION),
       'Consent to be contacted' => extract_rating(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
       'Contact details' => extract_explanation(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
-      'Safe to work with children?' => extract_rating(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
-      'Safe to work with children explanation' => extract_explanation(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
     }
   end
 end


### PR DESCRIPTION
## Context

This question was removed from the form, but not from the export. Trying to extract it results in calling `.split` on nil, which breaks in production/staging.

## Changes proposed in this pull request

Remove the extraction logic, update tests.

## Guidance to review

An alternative approach is we could attempt to export this info anyway, but not break on nil.

Test it on the review app by submitting a referee feedback form and then attempting an export.

Should we also add a data migration to clean the existing/orphaned data in the database?

Should we update the referee survey feedback form system spec to also test that the referee survey doesn't break, to catch these kinds of issues in the future?

## Link to Trello card

https://trello.com/c/fdRBkTms

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)