### PR TITLE
don't trigger build if another one is inprogress

### DIFF
--- a/azure/pipelines/build-gems-node-modules.yml
+++ b/azure/pipelines/build-gems-node-modules.yml
@@ -107,6 +107,13 @@ steps:
 
 - powershell: |
     $azureDevOpsAuthorizationHeader = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+    $getApplyTeacherTrainingInprogressBuildsApi = "$($env:COLLECTION_URL)$env:PROJECT_ID/_apis/build/builds?definitions=49&branchName=$($env:SOURCE_BRANCH)&sourceVersion=$($env:SOURCE_VERSION)&statusFilter=inProgress&api-version=5.1"
+    $applyTeacherTrainingInprogressBuilds = Invoke-RestMethod -Uri $getApplyTeacherTrainingInprogressBuildsApi -Headers $azureDevOpsAuthorizationHeader -Method Get -ErrorAction Stop -ErrorVariable $errorVariable
+    if($applyTeacherTrainingInprogressBuilds.count -gt 0){
+        # A build is already in progress for the same commit, no need to trigger a new build
+        Write-Host $applyTeacherTrainingInprogressBuilds | ConvertTo-Json
+        exit 0
+    }
     $newBuild = @{
       definition = @{
         id = 49

--- a/azure/pipelines/templates/swap-staging-production-slots.yml
+++ b/azure/pipelines/templates/swap-staging-production-slots.yml
@@ -34,7 +34,18 @@ steps:
       WebAppName: '${{ parameters.appService }}'
       ResourceGroupName: '${{ parameters.resourceGroup }}'
       SourceSlot: 'staging'
-  
+
+  - task: AzureAppServiceManage@0
+    condition: and(succeeded(), eq(variables.buildCancelled, false))
+    displayName: Start Production slot in ${{ parameters.appService }}
+    inputs:
+      azureSubscription: '${{ parameters.azureSubscription }}'
+      Action: 'Start Azure App Service'
+      WebAppName: '${{ parameters.appService }}'
+      SpecifySlotOrASE: true
+      ResourceGroupName: '${{ parameters.resourceGroup }}'
+      Slot: 'production'      
+
   - template: health-check.yml
     parameters:
       url: ${{ format('https://{0}.azurewebsites.net/check', parameters.appService) }}


### PR DESCRIPTION
## Context
Concurrent builds could cause the swap operation to be reversed and the production slot to be stopped.
This is a less probable risk when deploying to staging/production env as the release pipeline is triggered manually 
https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1599643603067100

## Changes proposed in this pull request

When a build is triggered from the `gems-node-packages` pipeline, only trigger the down stream pipeline if there isn't an inprogress build for the same commit.

Start the production slot after a swap operation as a fail-safe to prevent production slot to be stopped in the event of concurrent builds.

## Guidance to review

## Link to Trello card

https://trello.com/c/CQ77rcgp/2743-pipeline-improvement-start-production-slot-before-deployment

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
