### PR TITLE
Add application_not_sent in GenerateTestApplications & Fix bug in the service

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -40,7 +40,7 @@ class TestApplications
       )
     end
 
-    courses_to_apply_to ||= Course.includes(:course_options).joins(:course_options).distinct.open_on_apply
+    courses_to_apply_to = courses_to_apply_to.presence || Course.includes(:course_options).joins(:course_options).distinct.open_on_apply
     courses_to_apply_to =
       if course_full
         # Always use the first n courses, so that we can reliably generate
@@ -119,6 +119,8 @@ class TestApplications
         @application_form.update_columns(submitted_at: time, edit_by: Time.zone.now + 7.days, updated_at: time)
 
         return if states.include? :awaiting_references
+
+        @application_form.application_choices.each(&:application_not_sent!) and return if states.include? :application_not_sent
 
         @application_form.application_references.each do |reference|
           reference.relationship_correction = ['', Faker::Lorem.sentence].sample

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -23,6 +23,7 @@ class GenerateTestApplications
     create states: [:awaiting_references]
     create states: [:unsubmitted], course_full: true
     create states: [:awaiting_references], course_full: true
+    create states: [:application_not_sent]
     create states: [:application_complete]
     create states: [:awaiting_provider_decision] * 3
     create states: [:offer] * 2

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe GenerateTestApplications do
       'unsubmitted',
       'awaiting_provider_decision',
       'awaiting_references',
+      'application_not_sent',
       'offer',
       'rejected',
       'declined',


### PR DESCRIPTION
## Context

I wanted to reset my data and when i ran the dev_setup task from the readme the service was not working.

The service is currently broken as this line of code 
`courses_to_apply_to ||= Course.includes(:course_options).joins(:course_options).distinct.open_on_apply`
worked when nil or a course was being passed in. It now can return [] due to changes for the` generate_for_provider` method
`
There should be test applications for application_not_sent.

## Changes proposed in this pull request

- Add test application for :application_not_sent
- Fix a bug in the service 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
