### PR TITLE
Fix error caused by validation error on completing personal details

### DIFF
--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -33,6 +33,9 @@ module CandidateInterface
           current_application.update!(application_form_params)
           redirect_to candidate_interface_application_form_path
         else
+          @personal_details_review = PersonalDetailsReviewComponent.new(
+            application_form: current_application,
+          )
           render :show
         end
       end


### PR DESCRIPTION
## Context

This PR is a fix for an issue picked up on production by Sentry: https://sentry.io/organizations/dfe-bat/issues/1885573463/?project=1765973&referrer=slack

## Changes proposed in this pull request

- [x] Set `@personal_details_review` before rendering the `show` view template following a validation error.

## Guidance to review

It's not clear to me how you can get to the personal details review page with invalid data. I couldn't reproduce the error without nulling out a field in the database or by navigating straight to the review page URL `/candidate/application/personal-details/review`. So I've not been able to write a system spec to cover this fix. Any suggestions on how to do this welcome.

## Link to Trello card

https://trello.com/c/PoOPIdAs/2120-error-triggered-by-validation-error-when-completing-personal-details

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
