### PR TITLE
Fix Application form presenter safeguarding section to route to review

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -229,6 +229,10 @@ module CandidateInterface
       @application_form.safeguarding_issues_completed
     end
 
+    def safeguarding_valid?
+      SafeguardingIssuesDeclarationForm.build_from_application(@application_form).valid?
+    end
+
     def no_incomplete_qualifications?
       @application_form.application_qualifications.other.select(&:incomplete_other_qualification?).blank?
     end

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -97,7 +97,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.suitability_to_work_with_children'),
             completed: @application_form_presenter.safeguarding_completed?,
-            path: @application_form_presenter.safeguarding_completed? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path
+            path: @application_form_presenter.safeguarding_valid? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path
           )
         ) %>
       </li>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -294,10 +294,10 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
 
     it 'returns true if safeguarding section is incomplete' do
-      application_form = FactoryBot.build(:completed_application_form, :with_safeguarding_issues_disclosed, safeguarding_issues_completed: false)
+      application_form = FactoryBot.build(:application_form)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-      expect(presenter).to be_safeguarding_valid
+      expect(presenter).not_to be_safeguarding_valid
     end
   end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
-  describe 'training_with_a_disability_valid?' do
+  describe '#training_with_a_disability_valid?' do
     it 'returns true if training with a disability section is completed' do
       application_form = FactoryBot.build(:completed_application_form)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
@@ -282,6 +282,22 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).not_to be_safeguarding_completed
+    end
+  end
+
+  describe '#safeguarding_valid?' do
+    it 'returns true if safeguarding section is completed' do
+      application_form = FactoryBot.build(:completed_application_form, :with_safeguarding_issues_disclosed)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_safeguarding_valid
+    end
+
+    it 'returns true if safeguarding section is incomplete' do
+      application_form = FactoryBot.build(:completed_application_form, :with_safeguarding_issues_disclosed, safeguarding_issues_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_safeguarding_valid
     end
   end
 


### PR DESCRIPTION
## Context

When Safeguarding section has been filled out but section is not marked as complete the Application presenter should route the candidate to the review page rather than to the edit path.

## Changes proposed in this pull request

Tweaks to the Application Form presenter and Training with a Disability show view. New method added and test file updated.

## Guidance to review

Check that behaviour is now as required.

## Link to Trello card

https://trello.com/c/t98DVkIA/2059-returning-to-some-completed-sections-not-marked-as-complete-takes-you-to-the-wrong-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
