### PR TITLE
Set references_completed correctly when carrying over application

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -45,6 +45,10 @@ class DuplicateApplication
       )
     end
 
+    if new_application_form.can_add_reference?
+      new_application_form.update! references_completed: false
+    end
+
     original_application_form.application_work_history_breaks.each do |w|
       new_application_form.application_work_history_breaks.create!(
         w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -22,6 +22,14 @@ RSpec.shared_examples 'duplicates application form' do |expected_phase, expected
     expect(duplicate_application_form.application_choices).to be_empty
   end
 
+  it 'sets references_completed correctly' do
+    if duplicate_application_form.can_add_reference?
+      expect(duplicate_application_form.references_completed).to be_falsey
+    else
+      expect(duplicate_application_form.references_completed).to be_truthy
+    end
+  end
+
   it 'resets the state to unsubmitted' do
     expect(duplicate_application_form.submitted_at).to be_nil
     expect(duplicate_application_form.course_choices_completed).to be false


### PR DESCRIPTION
## Context

If we change the number of references on the application when carrying it over, we should set it to false.

## Changes proposed in this pull request

Set `references_completed` correctly when carrying over application.

## Guidance to review

Does this make sense?

## Link to Trello card

None, spotted while working on other things.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)