### PR TITLE
Only reject choices awaiting references at eoc

### DIFF
--- a/app/workers/reject_awaiting_references_course_choices_worker.rb
+++ b/app/workers/reject_awaiting_references_course_choices_worker.rb
@@ -3,7 +3,7 @@ class RejectAwaitingReferencesCourseChoicesWorker
 
   def perform
     CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications.call.each do |application_form|
-      application_form.application_choices.each do |application_choice|
+      application_form.application_choices.awaiting_references.each do |application_choice|
         CandidateInterface::RejectAwaitingReferencesApplication.call(application_choice)
       end
       CandidateMailer.application_on_pause(application_form).deliver_later

--- a/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
+++ b/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
@@ -4,12 +4,18 @@ RSpec.describe RejectAwaitingReferencesCourseChoicesWorker do
   describe '#perform' do
     it 'calls the appropriate services' do
       application_choice = create(:application_choice, :awaiting_references)
+      application_form = application_choice.application_form
+      application_choice_withdrawn = create(:application_choice, :withdrawn, application_form: application_form)
+
       allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to receive(:call).and_return([application_choice.application_form])
       allow(CandidateMailer).to receive(:application_on_pause).and_call_original
+      allow(CandidateInterface::RejectAwaitingReferencesApplication).to receive(:call).and_call_original
       RejectAwaitingReferencesCourseChoicesWorker.new.perform
 
       expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to have_received(:call)
       expect(CandidateMailer).to have_received(:application_on_pause).with(application_choice.application_form)
+      expect(CandidateInterface::RejectAwaitingReferencesApplication).to have_received(:call).with(application_choice)
+      expect(CandidateInterface::RejectAwaitingReferencesApplication).not_to have_received(:call).with(application_choice_withdrawn)
     end
   end
 end


### PR DESCRIPTION
## Context

I previously refactored `GetPreviousCyclesAwaitingReferencesApplication` to return application forms instead of individual choices. I didn't realise that this would lead to us calling `RejectAwaitingReferencesApplication` on all its choices, not just `awaiting_references` ones, including cancelled or withdrawn ones.

## Changes proposed in this pull request

Filter out for `.awaiting_references` course choices before calling `RejectAwaitingReferencesApplication`. Update tests.

## Guidance to review

Makes sense? Tested this locally.

## Link to Trello card

https://trello.com/c/nGoLoCQa

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)