### PR TITLE
Remove repetitive ‘Complete section’ links on application review page

### DIFF
--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-banner<% if @error %> app-banner--warning<% end %> app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
-    <p class="govuk-body" id="<%= "missing-#{section}" %>"><%= @text %></p>
-    <%= link_to t('review_application.complete_section'), @section_path, class: 'govuk-link govuk-link--no-visited-state', aria: { describedby: "missing-#{section}" } %>
+    <p class="govuk-body"><%= @text %></p>
+    <%= link_to t("review_application.#{section}.complete_section"), @section_path, class: 'govuk-link govuk-link--no-visited-state', 'data-qa': "missing-#{section}" %>
   </div>
 </div>

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -2,39 +2,55 @@ en:
   review_application:
     title: Review your application
     heading: Review your application
-    complete_section: Complete section
     button_continue: Continue
-    becoming_a_teacher:
-      incomplete: Tell us why you want to be a teacher
-    contact_details:
-      incomplete: Contact details not entered
     course_choices:
       incomplete: Course choices are not marked as completed
-    degrees:
-      incomplete: Degree(s) are not marked as completed
-    maths_gcse:
-      incomplete: Maths GCSE or equivalent not entered
-    english_gcse:
-      incomplete: English GCSE or equivalent not entered
-    science_gcse:
-      incomplete: Science GCSE or equivalent not entered
-    interview_preferences:
-      incomplete: Tell us your interview needs
+      complete_section: Complete your course choices
     personal_details:
       incomplete: Personal details not entered
-    references:
-      incomplete: Add %{minimum_references} referees to your application
-    subject_knowledge:
-      incomplete: Tell us about your knowledge about the subject you want to teach
+      complete_section: Enter your personal details
+    contact_details:
+      incomplete: Contact details not entered
+      complete_section: Enter your contact details
     training_with_a_disability:
-      incomplete: Training with a disability not entered
-    volunteering:
-      incomplete: Volunteering with children and young people is not marked as completed
-    work_experience:
-      incomplete: Work history is not marked as completed
+      incomplete: Any disability or other needs not entered
+      complete_section: Do you want to ask for help to become a teacher?
     safeguarding:
       incomplete: Safeguarding information not entered
+      complete_section: Do you need to declare any safeguarding issues?
+    work_experience:
+      incomplete: Work history is not marked as completed
+      complete_section: Complete your work history
+    volunteering:
+      incomplete: Volunteering with children and young people is not marked as completed
+      complete_section: Do you have any experience working with children and young people?
+    degrees:
+      incomplete: Degree(s) section not marked as completed
+      complete_section: Enter your degree(s)
+    maths_gcse:
+      incomplete: Maths GCSE or equivalent not entered
+      complete_section: Enter your Maths GCSE or equivalent
+    english_gcse:
+      incomplete: English GCSE or equivalent not entered
+      complete_section: Enter your English GCSE or equivalent
+    science_gcse:
+      incomplete: Science GCSE or equivalent not entered
+      complete_section: Enter your Science GCSE or equivalent
     other_qualifications:
-      incomplete: Your Other Qualifications section has an incomplete qualification
+      incomplete: The academic and other relevant qualifications section has an incomplete qualification
+      complete_section: Complete your academic and other relevant qualifications
     efl:
       incomplete: English as a foreign language not marked as complete
+      complete_section: Do you have an English as a foreign language qualification?
+    becoming_a_teacher:
+      incomplete: Personal statement not entered
+      complete_section: Why do you want to be a teacher?
+    subject_knowledge:
+      incomplete: Subject knowledge not entered
+      complete_section: What you know about the subject you want to teach?
+    interview_preferences:
+      incomplete: Interview needs not entered
+      complete_section: Do you have any interview needs?
+    references:
+      incomplete: Add %{minimum_references} referees to your application
+      complete_section: Add your references

--- a/spec/components/section_missing_banner_component_spec.rb
+++ b/spec/components/section_missing_banner_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SectionMissingBannerComponent do
   it 'renders a section missing banner component' do
     result = render_inline(described_class.new(section: 'degrees', section_path: '#'))
-    expect(result.css('.app-banner__message .govuk-body').text).to include('Degree(s) are not marked as completed')
+    expect(result.css('.app-banner__message .govuk-body').text).to include('Degree(s) section not marked as completed')
     expect(result.css('.app-banner__message .govuk-link')).to be_present
   end
 end

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
 
   def then_i_should_see_all_sections_are_complete
     CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
-      expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
+      expect(page).not_to have_selector "[data-qa='missing-#{section}']"
     end
   end
 

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -110,7 +110,7 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def when_i_have_an_application_form_that_is_ready_to_submit
     create_list :reference, 2, application_form: @application
-    click_link 'Complete section', match: :first
+    click_link 'Add your references', match: :first
     check t('application_form.completed_checkbox')
     click_button t('application_form.continue')
   end

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -24,9 +24,8 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   def then_i_should_be_able_to_click_through_and_complete_each_required_section
     (CandidateHelper::APPLICATION_FORM_SECTIONS - %i[science_gcse efl]).each do |section|
-      expect(page).to have_selector "[aria-describedby='missing-#{section}']"
       within "#missing-#{section}-error" do
-        expect(page).to have_link('Complete section')
+        expect(page).to have_selector("a[data-qa='missing-#{section}']")
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Candidate submits the application' do
 
   def then_i_should_see_all_sections_are_complete
     CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
-      expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
+      expect(page).not_to have_selector "[data-qa='missing-#{section}']"
     end
   end
 

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature 'International candidate submits the application' do
   end
 
   def then_i_should_see_the_efl_section_is_incomplete
-    expect(page).to have_selector "[aria-describedby='missing-efl']"
+    expect(page).to have_selector "[data-qa='missing-efl']"
   end
 
   def then_i_see_an_error_about_the_efl_section
@@ -136,7 +136,7 @@ RSpec.feature 'International candidate submits the application' do
 
   def when_i_complete_the_efl_section
     within '#missing-efl-error' do
-      click_link 'Complete section'
+      click_link 'Do you have an English as a foreign language qualification?'
     end
 
     choose 'No, English is not a foreign language to me'
@@ -147,7 +147,7 @@ RSpec.feature 'International candidate submits the application' do
 
   def then_i_should_see_all_sections_are_complete
     CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
-      expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
+      expect(page).not_to have_selector "[data-qa='missing-#{section}']"
     end
   end
 


### PR DESCRIPTION
## Context

Reviewing an application with multiple uncompleted sections shows repeated ‘Complete section’ links. As these are all audibly the same (despite using `aria-describedby`), it’s difficult for those using accessible technologies to know where each link will take them.

## Changes proposed in this pull request

Replaces ‘Complete section’ with unique link titles.

## Guidance to review

Added `data-qa` as a hook for tests, is this correct?

## Link to Trello card

https://trello.com/c/FQwJPRzA

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
