### PR TITLE
Update config for GCSE grade autocomplete

### DIFF
--- a/app/frontend/packs/gcse-grade-autocomplete.js
+++ b/app/frontend/packs/gcse-grade-autocomplete.js
@@ -12,11 +12,12 @@ const initGcseGradeAutocomplete = () => {
       if (!gradeSelect) return;
 
       accessibleAutocomplete.enhanceSelectElement({
+        autoselect: false,
         defaultValue: '',
         selectElement: gradeSelect,
         showAllValues: true,
         showNoOptionsFound: true,
-        confirmOnBlur: true,
+        confirmOnBlur: false,
       });
     });
   } catch (err) {


### PR DESCRIPTION

## Context
Some strange behaviour occurring with the grade select drop down.

_The drop down arrow when I try and select a qualification grade only shows 3 grade options and won't change unless I physically type out my grade in the box._

## Changes proposed in this pull request

- set `autoselect` to `false` so that the first option is no longer selected before blur.
- set `confirmOnBlur` to `false` to keep behaviour consistent with other autocompletes.

![autoselect_fix](https://user-images.githubusercontent.com/5256922/93090141-3ac80080-f694-11ea-9f2c-0393e0179f90.gif)

## Link to Trello card
https://trello.com/c/0GhLI2EE/2053-drop-down-arrow-not-working-and-grade-pre-filled-for-gcse

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
