### PR TITLE
Update the application dashboards UI for deferred applications

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -6,6 +6,14 @@
   <p class="govuk-body">
     Your training provider will be in touch with you directly to explain what happens next.
   </p>
+<% elsif any_deferred? %>
+<h2 class="govuk-heading-m govuk-!-font-size-27">
+  <%= t('application_complete.dashboard.deferred') %>
+</h2>
+<p class="govuk-body">
+  We’ve sent you an email to confirm this. Your training provider will be in
+  touch with you directly to explain what happens next.
+</p>
 <% elsif any_accepted_offer? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.accepted_offer') %>

--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -14,6 +14,7 @@ module CandidateInterface
              :any_awaiting_provider_decision?,
              :all_choices_withdrawn?,
              :any_recruited?,
+             :any_deferred?,
              :any_offers?,
              :all_applications_not_sent?, to: :application_form
 

--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -4,4 +4,8 @@
   <p class="govuk-body govuk-body govuk-!-margin-top-2">
     Your application was not sent for this course because references were not given before the deadline.
   </p>
+<% elsif  @application_choice.offer_deferred? %>
+  <p class="govuk-body govuk-body govuk-!-margin-top-2">
+    Your training will now start in <%= (@application_choice.course.start_date + 1.year).strftime('%B %Y') %>.
+  </p>
 <% end %>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
         location_row(application_choice),
         type_row(application_choice.course),
         course_length_row(application_choice.course),
-        start_date_row(application_choice.course),
+        start_date_row(application_choice),
       ].compact
 
       rows.tap do |r|
@@ -142,11 +142,13 @@ module CandidateInterface
       }
     end
 
-    def start_date_row(course)
-      {
-        key: 'Date course starts',
-        value: course.start_date.strftime('%B %Y'),
-      }
+    def start_date_row(application_choice)
+      unless application_choice.offer_deferred?
+        {
+          key: 'Date course starts',
+          value: application_choice.course.start_date.to_s(:month_and_year),
+        }
+      end
     end
 
     def status_row(application_choice)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -100,6 +100,10 @@ class ApplicationForm < ApplicationRecord
     application_choices.map.any?(&:recruited?)
   end
 
+  def any_deferred?
+    application_choices.map.any?(&:offer_deferred?)
+  end
+
   def any_accepted_offer?
     application_choices.map.any?(&:pending_conditions?)
   end

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -14,3 +14,4 @@ en:
       all_withdrawn: You have withdrawn all your choices
       accepted_offer: You have accepted an offer
       recruited: You have met your conditions and are ready to be enrolled
+      deferred: Your original offer has been deferred 

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -140,6 +140,17 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
   end
 
+  context 'when the application is deferred' do
+    it 'renders with deferred content' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[offer_deferred declined])
+
+      render_result = render_inline(described_class.new(application_form: application_form))
+
+      expect(render_result.text).to include(t('application_complete.dashboard.deferred'))
+    end
+  end
+
   def stub_application_dates_with_form_uneditable
     application_dates = instance_double(
       ApplicationDates,

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -1,17 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
+  let(:course) { create(:course) }
+
   ApplicationStateChange.valid_states.each do |state_name|
     it "renders with a #{state_name} application choice" do
-      render_inline CandidateInterface::ApplicationStatusTagComponent.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))
+      render_inline CandidateInterface::ApplicationStatusTagComponent.new(application_choice: create(:application_choice, course: course, status: state_name))
     end
 
     context 'when the application choice is in the application_not_sent state' do
       it 'tells the candidate why their application was not sent to their provider(s)' do
-        application_choice = build_stubbed(:application_choice, :application_not_sent)
+        application_choice = create(:application_choice, :application_not_sent, course: course)
         result = render_inline(described_class.new(application_choice: application_choice))
 
         expect(result.text).to include('Your application was not sent for this course because references were not given before the deadline.')
+      end
+    end
+
+    context 'when the application choice is in the offer_deferred state' do
+      it 'tells the candidate when their course will start' do
+        application_choice = create(:application_choice, :offer_deferred, course: course)
+        result = render_inline(described_class.new(application_choice: application_choice))
+
+        expect(result.text).to include("Your training will now start in #{(application_choice.course.start_date + 1.year).strftime('%B %Y')}.")
       end
     end
   end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include("#{application_choice.course.name} (#{application_choice.course.code})")
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
       expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.start_date.strftime('%B %Y'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.start_date.to_s(:month_and_year))
       expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
     end
 


### PR DESCRIPTION
## Context

When an application choice has an offer which has been deferred the application dashboard should display offer_deferred specific content.
 
## Changes proposed in this pull request

Update the Application dashboard so deferred applications exhibit the following behaviour:

1. The title of the page should be 'Your original offer has been deferred'
2. The course choice review component should NOT show the course start date row  
3. Under the status tag, it should say  ‘Your training will now start in [original course start date + 1 year]’

## Guidance to review

I think this is everything on the candidate side. Did I miss anything?

## Link to Trello card

https://trello.com/c/WY1tmxt4/2081-%F0%9F%9A%B2%F0%9F%94%9A-dev-add-new-offer-deferred-status

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
