### PR TITLE
Add offer tab to applications

### DIFF
--- a/app/components/provider_interface/status_box_components/conditions_not_met_component.html.erb
+++ b/app/components/provider_interface/status_box_components/conditions_not_met_component.html.erb
@@ -1,3 +1,9 @@
-<h2 class="govuk-heading-l">Offer</h2>
-<%= render SummaryListComponent.new(rows: rows) %>
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+<div class="app-offer-panel">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
+
+  <h3 class="govuk-heading-m">Course details</h3>
+  <%= render SummaryListComponent.new(rows: rows) %>
+
+  <h3 class="govuk-heading-m">Conditions</h3>
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+</div>

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -12,12 +12,12 @@ module ProviderInterface
             value: course_option.course.name_and_code,
           },
           {
-            key: 'Full time or part time',
-            value: course_option.study_mode.humanize,
-          },
-          {
             key: 'Location',
             value: course_option.site.name_and_address,
+          },
+          {
+            key: 'Full time or part time',
+            value: course_option.study_mode.humanize,
           },
         ]
 

--- a/app/components/provider_interface/status_box_components/declined_component.html.erb
+++ b/app/components/provider_interface/status_box_components/declined_component.html.erb
@@ -1,3 +1,9 @@
-<h2 class="govuk-heading-l">Offer</h2>
-<%= render SummaryListComponent.new(rows: rows) %>
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+<div class="app-offer-panel">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
+
+  <h3 class="govuk-heading-m">Course details</h3>
+  <%= render SummaryListComponent.new(rows: rows) %>
+
+  <h3 class="govuk-heading-m">Conditions</h3>
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+</div>

--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -1,10 +1,15 @@
-<h2 class="govuk-heading-l">Offer</h2>
+<div class="app-offer-panel">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
 
-<%= render SummaryListComponent.new(rows: rows) %>
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+  <% if provider_can_respond %>
+  <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
+    <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(application_choice.id) %>
+  </p>
+  <% end %>
 
-<% if provider_can_respond %>
-<p class="govuk-body govuk-!-margin-bottom-0 govuk-!-display-none-print">
-  <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
-</p>
-<% end %>
+  <h3 class="govuk-heading-m">Course details</h3>
+  <%= render SummaryListComponent.new(rows: rows) %>
+
+  <h3 class="govuk-heading-m">Conditions</h3>
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+</div>

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -22,12 +22,7 @@ module ProviderInterface
       end
 
       def rows
-        [
-          {
-            key: 'Offer made',
-            value: application_choice.offered_at.to_s(:govuk_date),
-          },
-        ] + add_change_links_to(course_rows(course_option: application_choice.offered_option))
+        add_change_links_to(course_rows(course_option: application_choice.offered_option))
       end
 
       def add_change_links_to(rows)

--- a/app/components/provider_interface/status_box_components/offer_deferred_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_deferred_component.html.erb
@@ -1,10 +1,15 @@
-<h2 class="govuk-heading-l">Offer</h2>
+<div class="app-offer-panel">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
 
-<%= render SummaryListComponent.new(rows: rows) %>
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+  <% if provider_can_respond %>
+  <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-display-none-print">
+    <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(application_choice.id) %>
+  </p>
+  <% end %>
 
-<% if provider_can_respond %>
-<p class="govuk-body govuk-!-margin-bottom-0 govuk-!-display-none-print">
-  <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
-</p>
-<% end %>
+  <h3 class="govuk-heading-m">Course details</h3>
+  <%= render SummaryListComponent.new(rows: rows) %>
+
+  <h3 class="govuk-heading-m">Conditions</h3>
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+</div>

--- a/app/components/provider_interface/status_box_components/offer_withdrawn_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_withdrawn_component.html.erb
@@ -1,3 +1,9 @@
-<h2 class="govuk-heading-l">Offer</h2>
-<%= render SummaryListComponent.new(rows: offer_withdrawn_rows) %>
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+<div class="app-offer-panel">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
+
+  <h3 class="govuk-heading-m">Course details</h3>
+  <%= render SummaryListComponent.new(rows: offer_withdrawn_rows) %>
+
+  <h3 class="govuk-heading-m">Conditions</h3>
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+</div>

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -20,5 +20,5 @@
   </p>
   <% end %>
 
-  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice, show_header: false) %>
 </div>

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -16,7 +16,7 @@
 
   <% if provider_can_respond %>
   <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
-    <%= govuk_link_to 'Mark all conditions as met', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
+    <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
   </p>
   <% end %>
 

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -1,8 +1,24 @@
-<h2 class="govuk-heading-l">Offer</h2>
-<%= render SummaryListComponent.new(rows: rows) %>
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+<div class="app-offer-panel">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
 
-<% if provider_can_respond %>
-  <%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print' %>
-  <%= govuk_button_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice.id), class: 'govuk-!-margin-bottom-0 govuk-!-margin-left-2 govuk-!-display-none-print' %>
-<% end %>
+  <% if provider_can_respond %>
+  <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
+    <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(application_choice.id) %>
+    or
+    <%= govuk_link_to 'defer offer', provider_interface_application_choice_new_defer_offer_path(application_choice.id) %>
+  </p>
+  <% end %>
+
+  <h3 class="govuk-heading-m">Course details</h3>
+  <%= render SummaryListComponent.new(rows: rows) %>
+
+  <h3 class="govuk-heading-m">Conditions</h3>
+
+  <% if provider_can_respond %>
+  <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
+    <%= govuk_link_to 'Mark all conditions as met', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
+  </p>
+  <% end %>
+
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+</div>

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.rb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.rb
@@ -18,12 +18,7 @@ module ProviderInterface
       end
 
       def rows
-        [
-          {
-            key: 'Offer accepted',
-            value: application_choice.accepted_at.to_s(:govuk_date),
-          },
-        ] + course_rows(course_option: application_choice.offered_option)
+        course_rows(course_option: application_choice.offered_option)
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/recruited_component.html.erb
+++ b/app/components/provider_interface/status_box_components/recruited_component.html.erb
@@ -1,7 +1,24 @@
-<h2 class="govuk-heading-l">Offer</h2>
-<%= render SummaryListComponent.new(rows: rows) %>
-<%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+<div class="app-offer-panel">
+  <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
 
-<% if provider_can_respond %>
-  <%= govuk_button_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(@application_choice.id), class: 'govuk-!-margin-bottom-0 govuk-!-display-none-print'  %>
-<% end %>
+  <% if provider_can_respond %>
+  <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
+    <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(application_choice.id) %>
+    or
+    <%= govuk_link_to 'defer offer', provider_interface_application_choice_new_defer_offer_path(application_choice.id) %>
+  </p>
+  <% end %>
+
+  <h3 class="govuk-heading-m">Course details</h3>
+  <%= render SummaryListComponent.new(rows: rows) %>
+
+  <h3 class="govuk-heading-m">Conditions</h3>
+
+  <% if provider_can_respond %>
+  <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
+    <%= govuk_link_to 'Mark all conditions as met', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
+  </p>
+  <% end %>
+
+  <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+</div>

--- a/app/components/provider_interface/status_box_components/recruited_component.html.erb
+++ b/app/components/provider_interface/status_box_components/recruited_component.html.erb
@@ -16,7 +16,7 @@
 
   <% if provider_can_respond %>
   <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
-    <%= govuk_link_to 'Mark all conditions as met', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
+    <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
   </p>
   <% end %>
 

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -96,14 +96,14 @@ module ProviderInterface
       @provider_can_respond = get_provider_can_respond
       @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
       @sub_navigation_items = get_sub_navigation_items
+    rescue ActiveRecord::RecordNotFound
+      render_404
     end
 
     def get_application_choice
       GetApplicationChoicesForProviders.call(
         providers: available_providers,
       ).find(params[:application_choice_id])
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def get_sub_navigation_items

--- a/app/frontend/styles/_status-box.scss
+++ b/app/frontend/styles/_status-box.scss
@@ -6,3 +6,9 @@
 .app-status-box--sandbox {
   border-left: $govuk-border-width solid govuk-colour("purple");
 }
+
+.app-offer-panel {
+  border: 5px solid #b1b4b6;
+  padding: 20px;
+  margin-bottom: 20px;
+}

--- a/app/views/provider_interface/application_choices/offer.html.erb
+++ b/app/views/provider_interface/application_choices/offer.html.erb
@@ -1,0 +1,7 @@
+<%= render 'application_choice_header' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) %>
+  </div>
+</div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -12,7 +12,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) %>
+    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) unless @offer_present %>
 
     <h2 class="govuk-heading-l" id="application">Application</h2>
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>

--- a/app/views/provider_interface/conditions/edit.html.erb
+++ b/app/views/provider_interface/conditions/edit.html.erb
@@ -24,7 +24,7 @@
         Conditions
       </h2>
 
-      <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice) %>
+      <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice, show_header: false) %>
 
       <%= f.govuk_radio_buttons_fieldset :conditions_met, legend: { size: 'm', text: 'Has the candidate met all of the conditions?', tag: 'span' } do %>
         <%= f.govuk_radio_button :conditions_met, 'yes', label: { text: 'Yes, they’ve met all of the conditions' }, link_errors: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -543,6 +543,7 @@ Rails.application.routes.draw do
 
     scope path: '/applications/:application_choice_id' do
       get '/' => 'application_choices#show', as: :application_choice
+      get '/offer' => 'application_choices#offer', as: :application_choice_offer
       get '/notes' => 'application_choices#notes', as: :application_choice_notes
       get '/notes/new' => 'application_choices#new_note', as: :application_choice_new_note
       post '/notes' => 'application_choices#create_note', as: :application_choice_create_note
@@ -550,7 +551,7 @@ Rails.application.routes.draw do
       get '/emails' => 'application_choices#emails', as: :application_choice_emails
       get '/respond' => 'decisions#respond', as: :application_choice_respond
       post '/respond' => 'decisions#submit_response', as: :application_choice_submit_response
-      get '/offer' => 'decisions#new_offer', as: :application_choice_new_offer
+      get '/offer/new' => 'decisions#new_offer', as: :application_choice_new_offer
       get '/reject' => 'decisions#new_reject', as: :application_choice_new_reject
       post '/reject/confirm' => 'decisions#confirm_reject', as: :application_choice_confirm_reject
       post '/reject' => 'decisions#create_reject', as: :application_choice_create_reject

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -82,6 +82,7 @@ RSpec.feature 'Provider changes an offer' do
 
   def when_i_click_on_change_provider
     visit provider_interface_application_choice_path(@application_offered.id)
+    click_on 'Offer'
     click_on 'Change training provider'
   end
 
@@ -136,6 +137,8 @@ RSpec.feature 'Provider changes an offer' do
   end
 
   def then_the_offer_has_new_course_study_mode_and_location_details
+    click_on 'Offer'
+
     expect(page).to have_content @course_option_three.course.name_and_code
     expect(page).to have_content @course_option_three.site.name_and_address
     expect(page).to have_content 'Part time'

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Confirm conditions met' do
     and_i_can_access_the_provider_interface
 
     when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_i_navigate_to_the_offer_tab
     and_click_on_confirm_conditions
     and_select_they_have_met_the_conditions
     and_confirm_my_selection_in_the_next_page
@@ -53,8 +54,12 @@ RSpec.feature 'Confirm conditions met' do
     visit provider_interface_application_choice_path(@application_choice.id)
   end
 
+  def and_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
   def and_click_on_confirm_conditions
-    click_on 'Confirm conditions'
+    click_on 'Mark all conditions as met'
   end
 
   def and_select_they_have_met_the_conditions

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Confirm conditions met' do
   end
 
   def and_click_on_confirm_conditions
-    click_on 'Mark all conditions as met'
+    click_on 'Update status of conditions'
   end
 
   def and_select_they_have_met_the_conditions

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Confirm conditions not met' do
   end
 
   def and_click_on_confirm_conditions
-    click_on 'Mark all conditions as met'
+    click_on 'Update status of conditions'
   end
 
   def and_select_they_have_not_met_the_conditions

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Confirm conditions not met' do
     and_i_can_access_the_provider_interface
 
     when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_i_navigate_to_the_offer_tab
     and_click_on_confirm_conditions
     and_select_they_have_not_met_the_conditions
     and_confirm_my_selection_in_the_next_page
@@ -53,8 +54,12 @@ RSpec.feature 'Confirm conditions not met' do
     visit provider_interface_application_choice_path(@application_choice.id)
   end
 
+  def and_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
   def and_click_on_confirm_conditions
-    click_on 'Confirm conditions'
+    click_on 'Mark all conditions as met'
   end
 
   def and_select_they_have_not_met_the_conditions

--- a/spec/system/provider_interface/provider_defers_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_defers_an_offer_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature 'Provider defers an offer' do
     and_i_sign_in_to_the_provider_interface
     and_i_view_an_offered_application
 
-    when_i_click_on_defer_application
+    when_i_navigate_to_the_offer_tab
+    and_i_click_on_defer_offer
     then_i_am_asked_to_confirm_deferral_of_the_offer
 
     when_i_confirm_deferral_of_the_offer
@@ -40,8 +41,12 @@ RSpec.feature 'Provider defers an offer' do
     )
   end
 
-  def when_i_click_on_defer_application
-    click_on 'Defer offer'
+  def when_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
+  def and_i_click_on_defer_offer
+    click_on 'defer offer'
   end
 
   def then_i_am_asked_to_confirm_deferral_of_the_offer

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -155,6 +155,8 @@ RSpec.feature 'Provider makes changes before making an offer' do
   end
 
   def then_a_new_offer_has_new_course_and_location_details
+    click_on 'Offer'
+
     expect(page).to have_content @course_option_three.course.name_and_code
     expect(page).to have_content @course_option_three.site.name_and_address
     expect(@application.reload.offered_option).to eq(@course_option_three)

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Provider withdraws an offer' do
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
     and_i_view_an_offered_application
+    and_i_navigate_to_the_offer_tab
 
     when_i_click_on_withdraw_application
     then_i_see_a_form_prompting_for_reasons
@@ -44,10 +45,11 @@ RSpec.feature 'Provider withdraws an offer' do
     )
   end
 
+  def and_i_navigate_to_the_offer_tab
+    click_on 'Offer'
+  end
+
   def when_i_click_on_withdraw_application
-    visit provider_interface_application_choice_path(
-      @application_offered.id,
-    )
     click_on 'Withdraw offer'
   end
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Offer information has been relocated to a separate tab in recent designs.

## Changes proposed in this pull request

- Adds an Offer tab to the application sub-navigation, this only appears when an offer is present.
- Refactors offer related status components to match design.
- Adds deferral link where necessary and moves links to withdraw/defer/accept conditions to more prominent place.

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/93511/93198819-7242b580-f745-11ea-8999-7fdf3a8a0f8a.png)



## Guidance to review

There are a lot of different status box components affected by this change, it's a game of spot the difference with the design prototype. 
I've tried to follow the permitted state machine transitions when rendering _Withdraw or defer_ links.
Not 100% sure if the _Mark all conditions as met_ link should appear for all statuses, I've not added it to any components which didn't already have a _Confirm conditions_ link.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/L4Q2cjdD/2749-add-offer-tab-to-application
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
