### PR TITLE
Render error page if candidate selects unavailable course

### DIFF
--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -30,7 +30,7 @@ module CandidateInterface
 
         if !@pick_course.open_on_apply?
           redirect_to candidate_interface_course_choices_ucas_with_course_path(@pick_course.provider_id, @pick_course.course_id)
-        elsif @pick_course.full?
+        elsif !@pick_course.available?
           redirect_to candidate_interface_course_choices_full_path(
             @pick_course.provider_id,
             @pick_course.course_id,

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -59,6 +59,8 @@ module CandidateInterface
 
     delegate :full?, to: :course
 
+    delegate :available?, to: :course
+
     def course
       @course ||= provider.courses.find(course_id)
     end

--- a/app/forms/candidate_interface/pick_site_form.rb
+++ b/app/forms/candidate_interface/pick_site_form.rb
@@ -8,11 +8,10 @@ module CandidateInterface
 
     def available_sites
       CourseOption
-        .selectable
+        .available
         .includes(:site)
         .where(course_id: course.id)
         .where(study_mode: study_mode)
-        .reject(&:no_vacancies?)
         .sort_by { |course_option| course_option.site.name }
     end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -102,6 +102,10 @@ class Course < ApplicationRecord
     course_options.all?(&:no_vacancies?)
   end
 
+  def available?
+    course_options.available.present?
+  end
+
   def find_url
     "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{code}"
   end

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -10,6 +10,7 @@ class CourseOption < ApplicationRecord
   validate :validate_providers
 
   scope :selectable, -> { where(site_still_valid: true) }
+  scope :available, -> { selectable.where(vacancy_status: 'vacancies') }
 
   enum study_mode: {
     full_time: 'full_time',

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Selecting a full course' do
     @course = create(:course, :open_on_apply)
 
     create(:course_option, course: @course, vacancy_status: 'no_vacancies')
+    create(:course_option, course: @course, vacancy_status: 'vacancies', site_still_valid: false)
   end
 
   def when_i_select_the_full_course


### PR DESCRIPTION
## Context

When selecting a course it's possible to find an empty list of locations to pick from after picking a course that has at least one course option that has vacancies but for which the site is no longer valid. This PR attempts to fix this by rendering the existing error page if a candidate picks a course that has no course options that both have vacancies and a valid site.

## Changes proposed in this pull request

- [x] Render the existing course has no vacancies error page (below) if the candidate selects an 'unavailable' course. Unavailable means that there are no locations for which there are vacancies and the site is still valid rather than just considering vancancy status. This makes the flow more consistent with the filtering of locations on the _Choose location_ page and should avoid ending up with an empty list of locations to choose from.
- [x] Attempt to keep things consistent by introducing a `CourseOption.available` scope that can be used for filtering locations and the page flow rule that renders the error page.
- [x] Adjust existing system spec to cover this.

<img width="619" alt="image" src="https://user-images.githubusercontent.com/450843/93115825-53e0a980-f6b4-11ea-83ac-c5523ea717d7.png">

## Guidance to review

- Do we need to change the wording on the above page?
- Is `CourseOption.available` the right name for the scope I've added?

## Link to Trello card

https://trello.com/c/jii8lEfX/2037-empty-location-page-when-choosing-a-course

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
