### PR TITLE
Return nationality and residency data in the API

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -45,7 +45,7 @@ class ApplicationForm < ApplicationRecord
     yes: 'yes',
     no: 'no',
     decide_later: 'decide_later',
-  }
+  }, _prefix: true
 
   enum address_type: {
     uk: 'uk',

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -95,7 +95,12 @@ module VendorAPI
       [
         application_form.first_nationality,
         application_form.second_nationality,
+        application_form.third_nationality,
+        application_form.fourth_nationality,
+        application_form.fifth_nationality,
       ].map { |n| NATIONALITIES_BY_NAME[n] }.compact.uniq
+        .sort.partition { |e| %w[GB IE].include? e }.flatten
+    end
     end
 
     def course_info_for(course_option)

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -26,7 +26,7 @@ module VendorAPI
             last_name: application_form.last_name,
             date_of_birth: application_form.date_of_birth,
             nationality: nationalities,
-            uk_residency_status: application_form.uk_residency_status,
+            uk_residency_status: uk_residency_status,
             english_main_language: application_form.english_main_language,
             english_language_qualifications: application_form.english_language_details,
             other_languages: application_form.other_language_details,
@@ -101,6 +101,17 @@ module VendorAPI
       ].map { |n| NATIONALITIES_BY_NAME[n] }.compact.uniq
         .sort.partition { |e| %w[GB IE].include? e }.flatten
     end
+
+    def uk_residency_status
+      return 'UK Citizen' if nationalities.include?('GB')
+
+      return 'Irish Citizen' if nationalities.include?('IE')
+
+      return application_form.right_to_work_or_study_details if application_form.right_to_work_or_study_yes?
+
+      return 'Candidate needs to apply for permission to work and study in the UK' if application_form.right_to_work_or_study_no?
+
+      'Candidate does not know'
     end
 
     def course_info_for(course_option)

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,6 +1,15 @@
+### 16th September 2020
+
+Changes to existing attributes:
+
+- Increase the limit of elements in the `nationality` array to 5. Nationalities are sorted so British or Irish are first.
+- `uk_residency_status` now returns strings indicating candidate's right to work and study in the UK
+
 ### 15th September 2020
 
-Maximum length of `address_line1` increased to 200 characters to account for international addresses.
+Changes to existing attributes:
+
+- Maximum length of `address_line1` increased to 200 characters to account for international addresses.
 
 ### 9th September 2020
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -532,7 +532,7 @@ components:
         uk_residency_status:
           type: string
           maxLength: 256
-          description: The candidate’s UK residency status, e.g. Citizen
+          description: The candidate’s UK residency status indicating their right to work and study in the UK
           example: UK Citizen
         english_main_language:
           type: boolean

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -527,7 +527,7 @@ components:
             type: string
             pattern: "^[A-Z]{2}$"
             example: NL
-          maxItems: 2
+          maxItems: 5
           description: One or more ISO 3166-2 country codes
         uk_residency_status:
           type: string

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,7 +26,6 @@ FactoryBot.define do
       english_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
       other_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
       further_information { Faker::Lorem.paragraph_by_chars(number: 300) }
-      uk_residency_status { 'I have the right to study and/or work in the UK' }
       disclose_disability { %w[true false].sample }
       disability_disclosure { Faker::Lorem.paragraph_by_chars(number: 300) }
       safeguarding_issues_status { 'no_safeguarding_issues_to_declare' }

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -136,9 +136,22 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response[:attributes][:candidate][:nationality]).to eq(%w[GB US])
     end
+
+    it 'returns sorted array of nationalties so British or Irish are first' do
+      application_form = create(:completed_application_form,
+                                first_nationality: 'Canadian',
+                                second_nationality: 'Spanish',
+                                third_nationality: 'Irish',
+                                fourth_nationality: 'Welsh')
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :candidate, :nationality)).to eq(%w[GB IE CA ES])
+    end
   end
 
-  describe 'attributes.candidate.contact_details' do
+  describe 'attributes.contact_details' do
     it 'returns contact details in correct format for UK addresses' do
       application_form_attributes = {
         phone_number: '07700 900 982',

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -98,7 +98,7 @@ RSpec.feature 'Vendor receives the application' do
           last_name: 'Calrissian',
           date_of_birth: '1937-04-06',
           nationality: %w[GB US],
-          uk_residency_status: nil,
+          uk_residency_status: 'UK Citizen',
           english_main_language: true,
           other_languages: "I'm great at Galactic Basic so English is a piece of cake",
           english_language_qualifications: nil,


### PR DESCRIPTION
## Context

We have five new fields in the db:
- `right_to_work_or_study` 
- `right_to_work_or_study_details` (textarea following "yes" to the above)
- `third_nationality`
- `fourth_nationality`
- `fifth_nationality`

We need to surface them in the API. 
The API already has attribute `uk_residency_status`, which is currently always nil.

## Changes proposed in this pull request

- Make nationality array return additional nationalities (up to 5) and sort them so British or Irish are first.
- Make uk_residency_status return values indicating right to work or study in the UK

## Guidance to review

Q: We don't seem to use `uk_residency_status` column in the database. Shall we remove it? 
I'm going to rebase before merging to update the release note depending if it's going to make todays deploy.

## Link to Trello card

https://trello.com/c/A53gI2OX/2595-%F0%9F%8C%90return-new-nationality-residency-data-in-the-api

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
