### PR TITLE
Display conditional deferral guidance on the dashboard

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -6,6 +6,38 @@
   </p>
 <% elsif  @application_choice.offer_deferred? %>
   <p class="govuk-body govuk-body govuk-!-margin-top-2">
-    Your training will now start in <%= (@application_choice.course.start_date + 1.year).strftime('%B %Y') %>.
+  Your training will now start in <%= (@application_choice.course.start_date + 1.year).to_s(:month_and_year) %>.
+  </p>
+<% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
+  <p class="govuk-body govuk-body govuk-!-margin-top-2">
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          What to do if you’re unable to start training in <%= (@application_choice.course.start_date + 1.year).to_s(:month_and_year) %>
+        </span>
+      </summary>
+
+      <div class="govuk-details__text govuk-!-padding-bottom-0">
+        Some providers allow you to defer your offer. This means that you could start your course a year later.
+      </div>
+
+      <div class="govuk-details__text govuk-!-padding-bottom-0">
+        Every provider is different, so it may or may not be possible to do this.
+      </div>
+
+      <div class="govuk-details__text govuk-!-padding-bottom-0">
+        Find out by contacting <%= @application_choice.provider.name %>.
+      </div>
+
+      <div class="govuk-details__text govuk-!-padding-bottom-0">
+        Asking if it’s possible to defer will not affect your existing offer.
+      </div>
+
+      <% if @application_choice.offer? %>
+        <div class="govuk-details__text govuk-!-padding-bottom-0">
+          If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.
+        </div>
+      <% end %>
+    </details>
   </p>
 <% end %>

--- a/spec/components/candidate_interface/application_status_tag_component_spec.rb
+++ b/spec/components/candidate_interface/application_status_tag_component_spec.rb
@@ -22,7 +22,34 @@ RSpec.describe CandidateInterface::ApplicationStatusTagComponent do
         application_choice = create(:application_choice, :offer_deferred, course: course)
         result = render_inline(described_class.new(application_choice: application_choice))
 
-        expect(result.text).to include("Your training will now start in #{(application_choice.course.start_date + 1.year).strftime('%B %Y')}.")
+        expect(result.text).to include("Your training will now start in #{(application_choice.course.start_date + 1.year).to_s(:month_and_year)}.")
+      end
+
+      context 'when the application choice is in the pending_conditions state' do
+        it 'provides guidance on how to defer your application' do
+          application_choice = create(:application_choice, :pending_conditions, course: course)
+          result = render_inline(described_class.new(application_choice: application_choice))
+
+          expect(result.text).to include('Some providers allow you to defer your offer. This means that you could start your course a year later.')
+        end
+      end
+
+      context 'when the application choice is in the recruited state' do
+        it 'provides guidance on how to defer your application' do
+          application_choice = create(:application_choice, :recruited, course: course)
+          result = render_inline(described_class.new(application_choice: application_choice))
+
+          expect(result.text).to include('Some providers allow you to defer your offer. This means that you could start your course a year later.')
+        end
+      end
+
+      context 'when the application choice is in the offer state' do
+        it 'provides guidance on how to defer your application' do
+          application_choice = create(:application_choice, :offer, course: course)
+          result = render_inline(described_class.new(application_choice: application_choice))
+
+          expect(result.text).to include('If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.')
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

When a candidates application choice is in the recruited, pending conditions or offer state. They should be given guidance on how they can defer their application if needed.
 
## Changes proposed in this pull request

Before

![image](https://user-images.githubusercontent.com/42515961/93187197-736ce600-f737-11ea-997e-bd949f10f5ab.png)


Offer

![image](https://user-images.githubusercontent.com/42515961/93223891-73d1a500-f768-11ea-81b5-c2d9aa38a546.png)


Pending conditions and recruited

![image](https://user-images.githubusercontent.com/42515961/93223804-58669a00-f768-11ea-8e5d-8af75cc6a841.png)



## Link to Trello card

https://trello.com/c/UJQHdsvh/2139-dev-conditional-deferral-guidance-on-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
