### PR TITLE
Increase the max length of `address_line1` to 200 chars in the API

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+### 15th September 2020
+
+Maximum length of `address_line1` increased to 200 characters to account for international addresses.
+
 ### 9th September 2020
 
 - fix a bug with test data generation where provider names in qualifications

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -574,7 +574,7 @@ components:
         address_line1:
           type: string
           description: The candidate’s address line 1
-          maxLength: 50
+          maxLength: 200
           example: 45 Dialstone Lane
         address_line2:
           type: string


### PR DESCRIPTION
## Context

We proposed to use this field for international addresses, which aren't structured. A vendor pointed out that 50 chars was unlikely to be long enough. We are increasing the limit to 200 chars.

## Changes proposed in this pull request

Increase the max length of `address_line1` to 200 chars in the API

## Guidance to review



## Link to Trello card

https://trello.com/c/6JtUGjCv/2744-api-addressline1-field-is-too-short-to-accommodate-international-addresses

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
