### PR TITLE
Check if find is down only once on providers page

### DIFF
--- a/app/components/grouped_provider_courses_component.html.erb
+++ b/app/components/grouped_provider_courses_component.html.erb
@@ -1,3 +1,5 @@
+<% find_down = EndOfCycleTimetable.find_down? %>
+
 <% courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= label_for(region_code) %></h2>
   <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
@@ -10,7 +12,7 @@
         </header>
         <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
           <ul class="govuk-list govuk-list--bullet">
-            <% if EndOfCycleTimetable.find_down? %>
+            <% if find_down %>
              <% provider.courses.sort_by(&:name).each do |course| %>
                <li><%= course.name_and_code %></li>
              <% end %>


### PR DESCRIPTION
## Context

The list of available courses on Apply (https://www.apply-for-teacher-training.service.gov.uk/candidate/providers) is a bit slow according to Skylight:

https://www.skylight.io/app/applications/t8bEzG0cuIkd/recent/6h/endpoints/CandidateInterface::ContentController%23providers?responseType=html

## Changes proposed in this pull request

Query is find is down only once. This saves a lot of `SiteSetting` queries and calculation, and might solve the performance issues with this page.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/x0OxYLae/2143-speed-up-the-providers-page-in-the-candidate-ui

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
