### PR TITLE
Add deferral guidance to the offer emails

### DIFF
--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>,
 
 # You have an offer
 
-Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 The provider has set the following condition(s):
 
@@ -10,7 +10,7 @@ The provider has set the following condition(s):
   - <%= condition %>
 <% end %>
 
-Contact <%= @provider_name %> directly if you have any questions about this.
+Contact <%= @provider_name %> if you have any questions about this.
 
 # Next steps
 
@@ -26,9 +26,7 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this.
-
-Find out by contacting <%= @provider_name %>.
+Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
 
 Asking if it’s possible to defer will not affect your existing offer.
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -22,6 +22,18 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
+# What to do if you’re unable to start training this year
+
+Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
+
+Every provider is different, so it may or may not be possible to do this.
+
+Find out by contacting <%= @provider_name %>.
+
+Asking if it’s possible to defer will not affect your existing offer.
+
+If <%= @provider_name %> agrees to defer your offer, you’ll need to accept the offer on your account first.
+
 # Give feedback or report a problem
 
 Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>,
 
 # You have an offer
 
-Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 The provider has set the following condition(s):
 
@@ -10,11 +10,11 @@ The provider has set the following condition(s):
   - <%= condition %>
 <% end %>
 
-Contact <%= @provider_name %> directly if you have any questions about this.
+Contact <%= @provider_name %> if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
-You have 10 working days to make a decision. If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
+If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
 
 # Offers you’ve received
 
@@ -30,9 +30,7 @@ Sign in to your account to respond:
 
 Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this.
-
-Find out by contacting <%= @provider_name %>.
+Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
 
 Asking if it’s possible to defer will not affect your existing offer.
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -26,6 +26,18 @@ Sign in to your account to respond:
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
+# What to do if you’re unable to start training this year
+
+Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
+
+Every provider is different, so it may or may not be possible to do this.
+
+Find out by contacting <%= @provider_name %>.
+
+Asking if it’s possible to defer will not affect your existing offer.
+
+If <%= @provider_name %> agrees to defer your offer, you’ll need to accept the offer on your account first.
+
 # Give feedback or report a problem
 
 Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.first_name %>,
 
 # You have an offer
 
-Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
 The provider has set the following condition(s):
 
@@ -10,11 +10,11 @@ The provider has set the following condition(s):
   - <%= condition %>
 <% end %>
 
-Contact <%= @provider_name %> directly if you have any questions about this.
+Contact <%= @provider_name %> if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
-You have 10 working days to make a decision. If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
+If you do not reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
 
 Sign in to your account to respond:
 
@@ -24,9 +24,7 @@ Sign in to your account to respond:
 
 Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this.
-
-Find out by contacting <%= @provider_name %>.
+Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
 
 Asking if it’s possible to defer will not affect your existing offer.
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -20,6 +20,18 @@ Sign in to your account to respond:
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
+# What to do if you’re unable to start training this year
+
+Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
+
+Every provider is different, so it may or may not be possible to do this.
+
+Find out by contacting <%= @provider_name %>.
+
+Asking if it’s possible to defer will not affect your existing offer.
+
+If <%= @provider_name %> agrees to defer your offer, you’ll need to accept the offer on your account first.
+
 # Give feedback or report a problem
 
 Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       'decline by default date' => 'Make a decision by 25 February 2020',
       'first_condition' => 'DBS check',
       'second_condition' => 'Pass exams',
-      'Days to make an offer' => 'You have 10 working days to make a decision. If you do not reply by 25 February 2020'
+      'Days to make an offer' => 'You have 10 working days to make a decision. If you do not reply by 25 February 2020',
+      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
     )
   end
 
@@ -67,7 +68,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       'first_condition' => 'DBS check',
       'second_condition' => 'Pass exams',
       'first_offer' => 'Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
-      'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College'
+      'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College',
+      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
     )
   end
 
@@ -89,7 +91,8 @@ RSpec.describe CandidateMailer, type: :mailer do
       'heading' => 'Dear Bob',
       'first_condition' => 'DBS check',
       'second_condition' => 'Pass exams',
-      'instructions' => 'You can wait to hear back about your other application(s) before making a decision'
+      'instructions' => 'You can wait to hear back about your other application(s) before making a decision',
+      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
     )
   end
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'decline by default date' => 'Make a decision by 25 February 2020',
       'first_condition' => 'DBS check',
       'second_condition' => 'Pass exams',
-      'Days to make an offer' => 'You have 10 working days to make a decision. If you do not reply by 25 February 2020',
+      'Days to make an offer' => 'If you do not reply by 25 February 2020',
       'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
     )
   end


### PR DESCRIPTION
## Context

When a candidate gets an offer they should receive guidance on how to defer their application in the email they receive.

## Changes proposed in this pull request

Update the 3 offer received emails 

- New offer single offer email

| Before | After |
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/93199769-b5e9ef00-f746-11ea-9827-3dd00ccf18b9.png)|![image](https://user-images.githubusercontent.com/42515961/93238846-e303c500-f779-11ea-8590-0be4e68d5267.png)|

- New offer multiple offers email

| Before | After |
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/93199820-c7cb9200-f746-11ea-8abf-7277a103d7b2.png)|![image](https://user-images.githubusercontent.com/42515961/93238913-fca50c80-f779-11ea-9375-647a3185ba0f.png)|

- New offer decisions pending email

| Before | After |
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/93199962-0bbe9700-f747-11ea-824b-cea2d7628916.png)|![image](https://user-images.githubusercontent.com/42515961/93238989-147c9080-f77a-11ea-8f70-b4580df34b88.png)|
  
## Link to Trello card

https://trello.com/c/v529AOd6/2141-dev-edit-offer-emails-to-include-deferrals-guidance

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
