### PR TITLE
Use FilterPagination component in provider UI

### DIFF
--- a/app/components/filter_component.rb
+++ b/app/components/filter_component.rb
@@ -1,11 +1,11 @@
 class FilterComponent < ViewComponent::Base
   include ViewHelper
 
-  attr_reader :page_state
-  delegate :filters, to: :page_state
+  attr_reader :filter
+  delegate :filters, to: :filter
 
-  def initialize(page_state:)
-    @page_state = page_state
+  def initialize(filter:)
+    @filter = filter
   end
 
   def tags_for_active_filter(filter)

--- a/app/components/paginated_filter_component.html.erb
+++ b/app/components/paginated_filter_component.html.erb
@@ -1,5 +1,5 @@
 <div class='moj-filter-layout'>
-  <%= render FilterComponent.new(page_state: filter) %>
+  <%= render FilterComponent.new(filter: filter) %>
 
   <div class='moj-filter-layout__content'>
     <%= content %>

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     before_action :set_application_choice_and_sub_navigation_items, except: %i[index]
 
     def index
-      @page_state = ProviderApplicationsPageState.new(
+      @filter = ProviderApplicationsFilter.new(
         params: params,
         provider_user: current_provider_user,
         state_store: session,
@@ -15,7 +15,7 @@ module ProviderInterface
 
       application_choices = FilterApplicationChoicesForProviders.call(
         application_choices: application_choices,
-        filters: @page_state.applied_filters,
+        filters: @filter.applied_filters,
       )
 
       # Eager load / prevent Bullet::Notification::UnoptimizedQueryError

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -1,5 +1,5 @@
 module ProviderInterface
-  class ProviderApplicationsPageState
+  class ProviderApplicationsFilter
     attr_accessor :available_filters, :filter_selections, :provider_user
     attr_reader :applied_filters
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -20,28 +20,24 @@
 
 <h1 class='govuk-heading-xl'>Applications</h1>
 
-<div class='moj-filter-layout'>
-  <%= render FilterComponent.new(page_state: @page_state) %>
-  <div class='moj-filter-layout__content'>
-    <% if @application_choices.any? %>
-      <div class="app-application-cards">
-        <% previous_header = '' %>
-        <% @application_choices.each do |choice| %>
-          <% group_header = task_view_header choice %>
-          <% if group_header != previous_header %>
-            <h2 class='govuk-heading-m task_view_group_header'>
-              <%= group_header %>
-            </h2>
-            <% previous_header = group_header %>
-          <% end %>
-          <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
+<%= render PaginatedFilterComponent.new(filter: @page_state, collection: @application_choices) do %>
+  <% if @application_choices.any? %>
+    <div class="app-application-cards">
+      <% previous_header = '' %>
+      <% @application_choices.each do |choice| %>
+        <% group_header = task_view_header choice %>
+        <% if group_header != previous_header %>
+          <h2 class='govuk-heading-m task_view_group_header'>
+            <%= group_header %>
+          </h2>
+          <% previous_header = group_header %>
         <% end %>
-      </div>
-    <% elsif @page_state.filtered? %>
-      <p class='govuk-body'>No applications for the selected filters.</p>
-    <% else %>
-      <p class='govuk-body'>You have not received any applications from <%= t('service_name.apply') %>.</p>
-    <% end %>
-    <%= render(PaginatorComponent.new(scope: @application_choices)) %>
-  </div>
-</div>
+        <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
+      <% end %>
+    </div>
+  <% elsif @page_state.filtered? %>
+    <p class='govuk-body'>No applications for the selected filters.</p>
+  <% else %>
+    <p class='govuk-body'>You have not received any applications from <%= t('service_name.apply') %>.</p>
+  <% end %>
+<% end %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -20,7 +20,7 @@
 
 <h1 class='govuk-heading-xl'>Applications</h1>
 
-<%= render PaginatedFilterComponent.new(filter: @page_state, collection: @application_choices) do %>
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_choices) do %>
   <% if @application_choices.any? %>
     <div class="app-application-cards">
       <% previous_header = '' %>
@@ -35,7 +35,7 @@
         <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
       <% end %>
     </div>
-  <% elsif @page_state.filtered? %>
+  <% elsif @filter.filtered? %>
     <p class='govuk-body'>No applications for the selected filters.</p>
   <% else %>
     <p class='govuk-body'>You have not received any applications from <%= t('service_name.apply') %>.</p>

--- a/spec/components/filter_component_spec.rb
+++ b/spec/components/filter_component_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe FilterComponent do
   let(:current_provider_user) { build_stubbed(:provider_user) }
 
   it 'marks checkboxes as checked if they have already been pre-selected' do
-    page_state = ProviderInterface::ProviderApplicationsPageState.new(
+    filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: applied_filters,
       provider_user: current_provider_user,
       state_store: {},
     )
 
-    result = render_inline described_class.new(page_state: page_state)
+    result = render_inline described_class.new(filter: filter)
 
     expect(result.css('#status-awaiting_provider_decision').attr('checked').value).to eq('checked')
     expect(result.css('#status-offer').attr('checked')).to eq(nil)
@@ -58,12 +58,12 @@ RSpec.describe FilterComponent do
   end
 
   it 'on initial load all of the checkboxes are unchecked' do
-    page_state = ProviderInterface::ProviderApplicationsPageState.new(
+    filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: ActionController::Parameters.new({}),
       provider_user: current_provider_user,
       state_store: {},
     )
-    result = render_inline described_class.new(page_state: page_state)
+    result = render_inline described_class.new(filter: filter)
 
     expect(result.css('#status-awaiting_provider_decision').attr('checked')).to eq(nil)
     expect(result.css('#status-offer').attr('checked')).to eq(nil)
@@ -77,25 +77,25 @@ RSpec.describe FilterComponent do
   end
 
   it 'when filters have been selected filters dialogue to appear' do
-    page_state = ProviderInterface::ProviderApplicationsPageState.new(
+    filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: applied_filters,
       provider_user: current_provider_user,
       state_store: {},
     )
 
-    result = render_inline described_class.new(page_state: page_state)
+    result = render_inline described_class.new(filter: filter)
 
     expect(result.text).to include('Selected filters')
   end
 
   it 'selected filters dialogue should not appear if is nothing filtered for' do
-    page_state = ProviderInterface::ProviderApplicationsPageState.new(
+    filter = ProviderInterface::ProviderApplicationsFilter.new(
       params: ActionController::Parameters.new({}),
       provider_user: current_provider_user,
       state_store: {},
     )
 
-    result = render_inline described_class.new(page_state: page_state)
+    result = render_inline described_class.new(filter: filter)
 
     expect(result.text).not_to include('Selected filters')
   end

--- a/spec/components/previews/provider_interface/filter_component_preview.rb
+++ b/spec/components/previews/provider_interface/filter_component_preview.rb
@@ -1,22 +1,22 @@
 module ProviderInterface
   class FilterComponentPreview < ViewComponent::Preview
     def default_view
-      render_component_for(page_state: page_state_mock(filters: with_name_status_provider_and_accredited_provider))
+      render_component_for(filter: filter_mock(filters: with_name_status_provider_and_accredited_provider))
     end
 
     def with_locations_view
-      render_component_for(page_state: page_state_mock(filters: with_name_status_provider_accredited_provider_and_locations))
+      render_component_for(filter: filter_mock(filters: with_name_status_provider_accredited_provider_and_locations))
     end
 
   private
 
-    def render_component_for(page_state:)
-      render FilterComponent.new(page_state: page_state)
+    def render_component_for(filter:)
+      render FilterComponent.new(filter: filter)
     end
 
-    def page_state_mock(filters:)
-      page_state = Struct.new(:filters)
-      page_state.new(filters)
+    def filter_mock(filters:)
+      filter = Struct.new(:filters)
+      filter.new(filters)
     end
 
     def with_name_status_provider_and_accredited_provider

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ProviderInterface::ProviderApplicationsPageState do
+RSpec.describe ProviderInterface::ProviderApplicationsFilter do
   let(:course1) { create(:course) }
   let(:course2) { create(:course) }
   let(:course3) { create(:course) }
@@ -19,7 +19,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     it 'calculates a correct list of possible filters' do
       FeatureFlag.deactivate(:providers_can_filter_by_recruitment_cycle)
 
-      page_state = described_class.new(
+      filter = described_class.new(
         params: ActionController::Parameters.new,
         provider_user: provider_user,
         state_store: {},
@@ -29,15 +29,15 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       providers_array_index = 2
       number_of_courses = 3
 
-      expect(page_state.filters).to be_a(Array)
-      expect(page_state.filters.size).to eq(expected_number_of_filters)
-      expect(page_state.filters[providers_array_index][:options].size).to eq(number_of_courses)
+      expect(filter.filters).to be_a(Array)
+      expect(filter.filters.size).to eq(expected_number_of_filters)
+      expect(filter.filters[providers_array_index][:options].size).to eq(number_of_courses)
     end
 
     it 'calculates a correct list of possible filters when filtering by recruitment cycle is allowed' do
       FeatureFlag.activate(:providers_can_filter_by_recruitment_cycle)
 
-      page_state = described_class.new(
+      filter = described_class.new(
         params: ActionController::Parameters.new,
         provider_user: provider_user,
         state_store: {},
@@ -48,16 +48,16 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       providers_array_index = 3
       number_of_courses = 3
 
-      expect(page_state.filters).to be_a(Array)
-      expect(page_state.filters.size).to eq(expected_number_of_filters)
-      expect(page_state.filters[recruitment_cycle_index][:options].size).to eq(2)
-      expect(page_state.filters[providers_array_index][:options].size).to eq(number_of_courses)
+      expect(filter.filters).to be_a(Array)
+      expect(filter.filters.size).to eq(expected_number_of_filters)
+      expect(filter.filters[recruitment_cycle_index][:options].size).to eq(2)
+      expect(filter.filters[providers_array_index][:options].size).to eq(number_of_courses)
     end
 
     it 'does not include providers if avaible providers is < 2' do
       FeatureFlag.deactivate(:providers_can_filter_by_recruitment_cycle)
 
-      page_state = described_class.new(
+      filter = described_class.new(
         params: ActionController::Parameters.new,
         provider_user: another_provider_user,
         state_store: {},
@@ -65,33 +65,33 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
       expected_number_of_filters = 2
 
-      headings = page_state.filters.map { |filter| filter[:heading] }
+      headings = filter.filters.map { |f| f[:heading] }
 
-      expect(page_state.filters.size).to eq(expected_number_of_filters)
+      expect(filter.filters.size).to eq(expected_number_of_filters)
       expect(headings).not_to include('Provider')
     end
 
     it 'can return filter config for a list of provider locations' do
       FeatureFlag.deactivate(:providers_can_filter_by_recruitment_cycle)
 
-      page_state = described_class.new(
+      filter = described_class.new(
         params: ActionController::Parameters.new({ provider: [provider1.id] }),
         provider_user: another_provider_user,
         state_store: {},
       )
 
-      headings = page_state.filters.map { |filter| filter[:heading] }
+      headings = filter.filters.map { |f| f[:heading] }
 
       expect(headings).to include("Locations for #{provider1.name}")
 
       relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
       relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
 
-      expect(relevant_provider_ids).to include(page_state.filters[2][:options][0][:value])
-      expect(relevant_provider_ids).to include(page_state.filters[2][:options][1][:value])
+      expect(relevant_provider_ids).to include(filter.filters[2][:options][0][:value])
+      expect(relevant_provider_ids).to include(filter.filters[2][:options][1][:value])
 
-      expect(relevant_provider_names).to include(page_state.filters[2][:options][0][:label])
-      expect(relevant_provider_names).to include(page_state.filters[2][:options][1][:label])
+      expect(relevant_provider_names).to include(filter.filters[2][:options][0][:label])
+      expect(relevant_provider_names).to include(filter.filters[2][:options][1][:label])
     end
   end
 
@@ -106,11 +106,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'returns a has of permitted parameters' do
-      page_state = described_class.new(params: params, provider_user: provider_user, state_store: {})
+      filter = described_class.new(params: params, provider_user: provider_user, state_store: {})
 
-      expect(page_state.applied_filters).to be_a(Hash)
-      expect(page_state.applied_filters.keys).to include('status')
-      expect(page_state.applied_filters.keys).not_to include('weekdays')
+      expect(filter.applied_filters).to be_a(Hash)
+      expect(filter.applied_filters.keys).to include('status')
+      expect(filter.applied_filters.keys).not_to include('weekdays')
     end
   end
 
@@ -124,13 +124,13 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     let(:empty_params) { ActionController::Parameters.new }
 
     it 'returns true if filters have been applied' do
-      page_state = described_class.new(params: params, provider_user: provider_user, state_store: {})
-      expect(page_state.filtered?).to eq(true)
+      filter = described_class.new(params: params, provider_user: provider_user, state_store: {})
+      expect(filter.filtered?).to eq(true)
     end
 
     it 'returns false if filters have not been applied' do
-      page_state = described_class.new(params: empty_params, provider_user: provider_user, state_store: {})
-      expect(page_state.filtered?).to eq(false)
+      filter = described_class.new(params: empty_params, provider_user: provider_user, state_store: {})
+      expect(filter.filtered?).to eq(false)
     end
   end
 


### PR DESCRIPTION
## Context

This component was extracted from the provider UI in https://github.com/DFE-Digital/apply-for-teacher-training/pull/2901, but not used yet.

## Changes proposed in this pull request

This uses it and renames "page state" to "filter", as it's more consistent.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZKW9EAs3

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
