### PR TITLE
Add validation method for Becoming a Teacher section to application presenter

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -205,6 +205,10 @@ module CandidateInterface
       @application_form.becoming_a_teacher_completed
     end
 
+    def becoming_a_teacher_valid?
+      BecomingATeacherForm.build_from_application(@application_form).valid?
+    end
+
     def subject_knowledge_completed?
       @application_form.subject_knowledge_completed
     end

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -178,7 +178,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.becoming_a_teacher'),
             completed: @application_form_presenter.becoming_a_teacher_completed?,
-            path: @application_form_presenter.becoming_a_teacher_completed? ? candidate_interface_becoming_a_teacher_show_path : candidate_interface_becoming_a_teacher_edit_path
+            path: @application_form_presenter.becoming_a_teacher_valid? ? candidate_interface_becoming_a_teacher_show_path : candidate_interface_becoming_a_teacher_edit_path
           )
         ) %>
       </li>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -554,6 +554,22 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#becoming_a_teacher_valid?' do
+    it 'returns true if the becoming a teacher section is completed' do
+      application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_becoming_a_teacher_valid
+    end
+
+    it 'returns false if the becoming a teacher section is invalid' do
+      application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_becoming_a_teacher_valid
+    end
+  end
+
   describe '#subject_knowledge_completed?' do
     it 'returns true if the interview prefrences section is completed' do
       application_form = FactoryBot.build(:application_form, subject_knowledge_completed: true)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -555,8 +555,8 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#becoming_a_teacher_valid?' do
-    it 'returns true if the becoming a teacher section is completed' do
-      application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: true)
+    it 'returns true if the becoming a teacher section is valid' do
+      application_form = FactoryBot.build(:completed_application_form, becoming_a_teacher_completed: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_becoming_a_teacher_valid


### PR DESCRIPTION
## Context

When Becoming a Teacher section has been filled out but section is not marked as complete the Application presenter should route the candidate to the review page rather than to the edit path.

## Changes proposed in this pull request

Tweaks to the Application Form presenter and show view.

## Guidance to review

Check that behaviour is now as required and that test coverage is sufficient.

## Link to Trello card

https://trello.com/c/t98DVkIA/2059-returning-to-some-completed-sections-not-marked-as-complete-takes-you-to-the-wrong-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
