### PR TITLE
Create Application Reference CSV report

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -81,6 +81,14 @@ module SupportInterface
       end
     end
 
+    def application_references
+      references = SupportInterface::ApplicationReferencesExport.call
+      header_row = SupportInterface::ApplicationReferencesExport.header_row
+      csv = to_csv(references, header_row)
+
+      send_data csv, filename: "application-references-#{Time.zone.today}.csv", disposition: :attachment
+    end
+
   private
 
     def to_csv(objects, header_row = nil)

--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -1,0 +1,36 @@
+module SupportInterface
+  class ApplicationReferencesExport
+    def self.header_row
+      [
+        'Support Ref Number',
+        'Phase',
+        'Ref 1 type',
+        'Ref 1 state',
+        'Ref 2 type',
+        'Ref 2 state',
+        'Ref 3 type',
+        'Ref 3 state',
+        'Ref 4 type',
+        'Ref 4 state',
+      ]
+    end
+
+    def self.call
+      application_forms = ApplicationForm.includes(:application_references)
+
+      application_forms.map do |af|
+        output = {
+          'Support Ref Number' => af.support_reference,
+          'Phase' => af.phase,
+        }
+
+        af.application_references.map.with_index(1) do |reference, index|
+          output["Ref #{index} type"] = reference.referee_type
+          output["Ref #{index} state"] = reference.feedback_status
+        end
+
+        output
+      end
+    end
+  end
+end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -102,3 +102,11 @@
 <p class='govuk-body'>
   <%= govuk_link_to 'Download provider performance for TAD (CSV)', support_interface_tad_provider_performance_path %>
 </p>
+
+<h3 class="govuk-heading-m">Application references</h3>
+
+<p class="govuk-body">A list of all application references which have been selected by candidates to date</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download application references (CSV)', support_interface_application_references_path %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -742,6 +742,7 @@ Rails.application.routes.draw do
     get '/performance/tad-provider-performance', to: 'performance#tad_provider_performance', as: :tad_provider_performance
     get '/performance/course-choice-withdrawal', to: 'performance#course_choice_withdrawal', as: :course_choice_withdrawal_survey
     get '/performance/candidate-journey-tracking', to: 'performance#candidate_journey_tracking', as: :candidate_journey_tracking
+    get 'performance/reference-types', to: 'performance#application_references', as: :application_references
 
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/create-fake-provider' => 'tasks#create_fake_provider'

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationReferencesExport do
+  describe '#call' do
+    it 'returns an array of hashes containing reference types' do
+      application_form = create(:application_form)
+
+      create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form)
+      create(:reference, feedback_status: 'feedback_refused', referee_type: 'professional', application_form: application_form)
+      create(:reference, feedback_status: 'feedback_requested', referee_type: 'school-based', application_form: application_form)
+      create(:reference, feedback_status: 'feedback_requested', referee_type: 'character', application_form: application_form)
+
+      expect(described_class.call).to match_array(
+        [
+          return_expected_hash(application_form),
+        ],
+      )
+    end
+  end
+
+  describe '#header_row' do
+    it 'returns an array containing column headings' do
+      expect(described_class.header_row).to eq(
+        [
+          'Support Ref Number',
+          'Phase',
+          'Ref 1 type',
+          'Ref 1 state',
+          'Ref 2 type',
+          'Ref 2 state',
+          'Ref 3 type',
+          'Ref 3 state',
+          'Ref 4 type',
+          'Ref 4 state',
+        ],
+      )
+    end
+  end
+
+  def return_expected_hash(application_form)
+    {
+      'Support Ref Number' => application_form.support_reference,
+      'Phase' => application_form.phase,
+      'Ref 1 type' => application_form.application_references[0].referee_type,
+      'Ref 1 state' => application_form.application_references[0].feedback_status,
+      'Ref 2 type' => application_form.application_references[1].referee_type,
+      'Ref 2 state' => application_form.application_references[1].feedback_status,
+      'Ref 3 type' => application_form.application_references[2].referee_type,
+      'Ref 3 state' => application_form.application_references[2].feedback_status,
+      'Ref 4 type' => application_form.application_references[3].referee_type,
+      'Ref 4 state' => application_form.application_references[3].feedback_status,
+    }
+  end
+end

--- a/spec/system/support_interface/application_references_performance_spec.rb
+++ b/spec/system/support_interface/application_references_performance_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Application references performance CSV' do
+  include DfESignInHelpers
+
+  scenario 'support user can download a CSV with the application references performance report' do
+    given_i_am_a_support_user
+    and_there_is_an_application_with_references_in_the_system
+
+    when_i_visit_the_service_performance_page
+    and_i_click_on_download_reference_types_performance_report
+
+    then_i_should_be_able_to_download_a_csv
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_with_references_in_the_system
+    application_form = create(:application_form)
+
+    create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form)
+    create(:reference, feedback_status: 'feedback_refused', referee_type: 'professional', application_form: application_form)
+  end
+
+  def when_i_visit_the_service_performance_page
+    visit support_interface_performance_path
+  end
+
+  def and_i_click_on_download_reference_types_performance_report
+    click_link 'Download application references (CSV)'
+  end
+
+  def then_i_should_be_able_to_download_a_csv
+    af = ApplicationForm.first
+    expect(page).to have_content af.support_reference
+    expect(page).to have_content af.phase
+    expect(page).to have_content af.application_references[0].referee_type
+    expect(page).to have_content af.application_references[0].feedback_status
+    expect(page).to have_content af.application_references[1].referee_type
+    expect(page).to have_content af.application_references[1].feedback_status
+  end
+end


### PR DESCRIPTION
### Context
To further inform our work around References we need an extract to see the proportion and volumes of different types of Reference, which have been selected by Candidates to date.

## Changes proposed in this pull request
- Add download link to ‘application references’ CSV to `/support/performance`

<img width="1241" alt="application_references_report" src="https://user-images.githubusercontent.com/5256922/93219204-feafa100-f762-11ea-92fe-f037841a1eac.png">

## Link to Trello card

https://trello.com/c/dnwl0nC9/2135-dev-extract-reference-types

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
