### PR TITLE
Add validation methods for subject knowledge and interview preferences

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -213,8 +213,16 @@ module CandidateInterface
       @application_form.subject_knowledge_completed
     end
 
+    def subject_knowledge_valid?
+      SubjectKnowledgeForm.build_from_application(@application_form).valid?
+    end
+
     def interview_preferences_completed?
       @application_form.interview_preferences_completed
+    end
+
+    def interview_preferences_valid?
+      InterviewPreferencesForm.build_from_application(@application_form).valid?
     end
 
     def training_with_a_disability_completed?

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -187,7 +187,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.subject_knowledge'),
             completed: @application_form_presenter.subject_knowledge_completed?,
-            path: @application_form_presenter.subject_knowledge_completed? ? candidate_interface_subject_knowledge_show_path : candidate_interface_subject_knowledge_edit_path
+            path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_subject_knowledge_edit_path
           )
         ) %>
       </li>
@@ -196,7 +196,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.interview_preferences'),
             completed: @application_form_presenter.interview_preferences_completed?,
-            path: @application_form_presenter.interview_preferences_completed? ? candidate_interface_interview_preferences_show_path : candidate_interface_interview_preferences_edit_path
+            path: @application_form_presenter.interview_preferences_valid? ? candidate_interface_interview_preferences_show_path : candidate_interface_interview_preferences_edit_path
           )
         ) %>
       </li>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -586,19 +586,51 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
-  describe '#intervew_preferences_completed?' do
-    it 'returns true if the interview prefrences section is completed' do
+  describe '#subject_knowledge_valid?' do
+    it 'returns true if the subject knowledge section is valid' do
+      application_form = FactoryBot.build(:completed_application_form, subject_knowledge_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_subject_knowledge_valid
+    end
+
+    it 'returns false if the subject knowledge section is invalid' do
+      application_form = FactoryBot.build(:application_form, subject_knowledge_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_subject_knowledge_valid
+    end
+  end
+
+  describe '#interview_preferences_completed?' do
+    it 'returns true if the interview preferences section is completed' do
       application_form = FactoryBot.build(:application_form, interview_preferences_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_interview_preferences_completed
     end
 
-    it 'returns false if the interview prefrences section is incomplete' do
+    it 'returns false if the interview preferences section is incomplete' do
       application_form = FactoryBot.build(:application_form, interview_preferences_completed: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).not_to be_interview_preferences_completed
+    end
+  end
+
+  describe '#interview_preferences_valid?' do
+    it 'returns true if the intervew preference section is valid' do
+      application_form = FactoryBot.build(:completed_application_form, interview_preferences_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_interview_preferences_valid
+    end
+
+    it 'returns false if the interview preferences section is invalid' do
+      application_form = FactoryBot.build(:application_form, interview_preferences_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_interview_preferences_valid
     end
   end
 


### PR DESCRIPTION
## Context

When Subject knowledge and Interview preferences sections have been filled out but section is not marked as complete the Application presenter should route the candidate to the review page rather than to the edit path.

## Changes proposed in this pull request

Tweaks to the Application Form presenter and show view.

## Guidance to review

Check that behaviour is now as required and that test coverage is sufficient.

## Link to Trello card

https://trello.com/c/t98DVkIA/2059-returning-to-some-completed-sections-not-marked-as-complete-takes-you-to-the-wrong-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
