### PR TITLE
Change Unit 4's test provider code

### DIFF
--- a/app/services/generate_vendor_providers.rb
+++ b/app/services/generate_vendor_providers.rb
@@ -7,7 +7,7 @@ class GenerateVendorProviders
       { name: 'Ellucian Provider', code: 'ELLU' },
       { name: 'Oracle Provider', code: 'ORAC' },
       { name: 'NASBITT Provider', code: 'NASB' },
-      { name: 'Unit 4 Provider', code: 'UNIT' },
+      { name: 'Unit 4 Provider', code: 'Z88' },
       { name: 'Capita Provider', code: 'CAPI' },
       { name: 'Technology One Provider', code: 'TECH' },
       { name: 'Gordon Associates Provider', code: 'GORD' },


### PR DESCRIPTION
## Context

They already use 'Z88' as their test provider code with UCAS and it would help them to use the same on the sandbox environment.

## Changes proposed in this pull request

Change the provider code.

## Guidance to review

Easy peasy.

## Link to Trello card

No Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
