### PR TITLE
Create an offer accepted email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -306,6 +306,22 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def offer_accepted(application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course_option.course.name_and_code
+    @provider_name = application_choice.course_option.provider.name
+    @start_date = application_choice.course_option.course.start_date.to_s(:month_and_year)
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.offer_accepted.subject', {
+        course_name_and_code: @course_name_and_code,
+        provider_name: @provider_name,
+        start_date: @start_date,
+      }),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -21,6 +21,8 @@ class AcceptOffer
       ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
     end
 
+    CandidateMailer.offer_accepted(@application_choice).deliver_later
+
     StateChangeNotifier.call(:offer_accepted, application_choice: @application_choice)
   end
 

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @application_form.first_name %>,
+
+#You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>
+
+If everything goes well with meeting your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
+
+You can check your conditions anytime by signing in to your account: 
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+#What to do if you’re unable to start training in <%= @start_date %>
+
+Some providers allow you to defer your offer. This means that you could start your course a year later. 
+
+Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>. 
+
+Asking if it’s possible to defer will not affect your existing offer.

--- a/app/views/candidate_mailer/offer_accepted.text.erb
+++ b/app/views/candidate_mailer/offer_accepted.text.erb
@@ -4,14 +4,14 @@ Dear <%= @application_form.first_name %>,
 
 If everything goes well with meeting your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
 
-You can check your conditions anytime by signing in to your account: 
+You can check your conditions anytime by signing in to your account:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
 #What to do if you’re unable to start training in <%= @start_date %>
 
-Some providers allow you to defer your offer. This means that you could start your course a year later. 
+Some providers allow you to defer your offer. This means that you could start your course a year later.
 
-Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>. 
+Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
 
 Asking if it’s possible to defer will not affect your existing offer.

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -327,6 +327,7 @@ en:
       description: The candidate can accept the offer. All other application choices will be withdrawn.
       emails:
         - provider_mailer-offer_accepted
+        - candidate_mailer-offer_accepted
 
     offer-decline:
       name: Candidate declines offer

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -24,6 +24,8 @@ en:
       subject: "Give new referee as soon as possible: %{referee_name} has not responded"
     find_another_course:
       subject: "Find another course - %{course_name_and_code} at %{provider_name} is not available"
+    offer_accepted:
+      subject: "You’ve accepted %{provider_name}’s offer to study %{course_name_and_code}"
     new_referee_request:
       not_responded:
         subject: "Give details of a new referee: %{referee_name} has not responded"

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -673,4 +673,55 @@ RSpec.describe CandidateMailer, type: :mailer do
       )
     end
   end
+
+  describe '#offer_accepted' do
+    def build_stubbed_application_form
+      build_stubbed(
+        :application_form,
+        first_name: 'Bob',
+        candidate: @candidate,
+        application_choices: [
+          build_stubbed(
+            :application_choice,
+            status: 'pending_conditions',
+            course_option: build_stubbed(
+              :course_option,
+              site: build_stubbed(
+                :site,
+                name: 'West Wilford School',
+              ),
+              course: build_stubbed(
+                :course,
+                name: 'Mathematics',
+                code: 'M101',
+                start_date: Time.zone.local(2021, 9, 6),
+                provider: build_stubbed(
+                  :provider,
+                  name: 'Arithmetic College',
+                ),
+              ),
+            ),
+          ),
+        ],
+      )
+    end
+
+    def send_email
+      application_form = build_stubbed_application_form
+      application_choice = application_form.application_choices.first
+      described_class.offer_accepted(application_choice)
+    end
+
+    it 'has the correct subject and content' do
+      email = send_email
+
+      expect(email.subject).to eq(
+        'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
+      )
+      expect(email.body).to include('Dear Bob,')
+      expect(email.body).to include(
+        'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
+      )
+    end
+  end
 end

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -10,4 +10,25 @@ RSpec.describe AcceptOffer do
       }.to change { application_choice.accepted_at }.to(Time.zone.now)
     end
   end
+
+  describe 'emails' do
+    around { |example| perform_enqueued_jobs(&example) }
+
+    it 'sends a notification email to the provider' do
+      application_choice = create(:application_choice, status: :offer)
+      provider_user = create :provider_user, providers: [application_choice.provider]
+
+      expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
+      expect(ActionMailer::Base.deliveries.first.to).to eq [provider_user.email_address]
+      expect(ActionMailer::Base.deliveries.first.subject).to match(/has accepted your offer/)
+    end
+
+    it 'sends a confirmation email to the candidate' do
+      application_choice = create(:application_choice, status: :offer)
+
+      expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.candidate.email_address]
+      expect(ActionMailer::Base.deliveries.first.subject).to match(/You’ve accepted/)
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Candidate accepts an offer' do
     and_i_see_that_i_declined_the_other_offer
     and_i_see_that_i_withdrawn_from_the_third_choice
     and_the_provider_has_received_an_email
+    and_the_candidate_has_received_an_email
 
     when_i_visit_the_offer_page_of_the_declined_offer
     then_i_see_the_page_not_found
@@ -117,6 +118,11 @@ RSpec.feature 'Candidate accepts an offer' do
   def and_the_provider_has_received_an_email
     open_email(@provider_user.email_address)
     expect(current_email.subject).to have_content 'Harry Potter (123A) has accepted your offer'
+  end
+
+  def and_the_candidate_has_received_an_email
+    open_email(@candidate.email_address)
+    expect(current_email.subject).to have_content "You’ve accepted #{@course_option.course.provider.name}’s offer to study #{@course_option.course.name_and_code}"
   end
 
   def when_i_visit_the_offer_page_of_the_declined_offer


### PR DESCRIPTION
## Context

We do not have an email to reassure candidates that they successfully accepted their offer.

We should have one - not only for reassurance, but also because this is an opportune time in the user journey to inform candidates about deferrals.

## Changes proposed in this pull request

- [x] Add `CandidateMailer#offer_accepted`
- [x] Call `CandidateMailer#offer_accepted` from the `AcceptOffer` service
- [x] Update system spec and others 
- [ ] Update docs

## Guidance to review

- Per commit

## Link to Trello card

https://trello.com/c/WNUMspIi/2140-dev-create-an-offer-accepted-email

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
