### PR TITLE
Fix ApplicationStatusTagComponent preview

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -6,14 +6,14 @@
   </p>
 <% elsif  @application_choice.offer_deferred? %>
   <p class="govuk-body govuk-body govuk-!-margin-top-2">
-  Your training will now start in <%= (@application_choice.course.start_date + 1.year).to_s(:month_and_year) %>.
+  Your training will now start in <%= (@application_choice.course_option.course.start_date + 1.year).to_s(:month_and_year) %>.
   </p>
 <% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
   <p class="govuk-body govuk-body govuk-!-margin-top-2">
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          What to do if you’re unable to start training in <%= (@application_choice.course.start_date + 1.year).to_s(:month_and_year) %>
+          What to do if you’re unable to start training in <%= (@application_choice.course_option.course.start_date + 1.year).to_s(:month_and_year) %>
         </span>
       </summary>
 
@@ -22,7 +22,7 @@
       </div>
 
       <div class="govuk-details__text govuk-!-padding-bottom-0">
-        Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @application_choice.provider.name %>.
+        Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @application_choice.course_option.course.provider.name %>.
       </div>
 
       <div class="govuk-details__text govuk-!-padding-bottom-0">

--- a/spec/components/previews/candidate_interface/application_status_tag_component_preview.rb
+++ b/spec/components/previews/candidate_interface/application_status_tag_component_preview.rb
@@ -2,7 +2,17 @@ module CandidateInterface
   class ApplicationStatusTagComponentPreview < ViewComponent::Preview
     ApplicationStateChange.valid_states.each do |state_name|
       define_method state_name do
-        render CandidateInterface::ApplicationStatusTagComponent.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))
+        provider = FactoryBot.build_stubbed(:provider)
+        course = FactoryBot.build_stubbed(:course, provider: provider)
+        application_choice = FactoryBot.build_stubbed(
+          :application_choice,
+          status: state_name,
+          course_option: FactoryBot.build_stubbed(
+            :course_option,
+            course: course,
+          ),
+        )
+        render CandidateInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)
       end
     end
   end


### PR DESCRIPTION

## Context

This started failing on `qa` because the stubbed application choice created doesn't include a course or provider and the component makes a couple of (reasonable) assumptions about these being present.

## Changes proposed in this pull request

This is a compromise solution, I've stubbed out the 'missing' models but this requires the code under test to be a bit more explicit. e.g. replacing application_choice.course with application_choice.course_option.course because FactoryBot.build_stubbed doesn't stub implied `through` associations.

## Guidance to review

- Is there a nicer way to stub out these models?
- Is this likely to happen elsewhere?

## Link to Trello card

No Trello card, just this Sentry error:

https://sentry.io/organizations/dfe-bat/issues/1895580018/?project=1765973&referrer=slack

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
