### PR TITLE
Change how we display GCSEs on the Manage application choice page 

### DIFF
--- a/app/components/gcse_qualification_cards_component.html.erb
+++ b/app/components/gcse_qualification_cards_component.html.erb
@@ -1,0 +1,56 @@
+<div id="gcses" class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-m">GCSEs or equivalent</h2>
+
+  <div class="govuk-grid">
+    <div class="govuk-grid-row app-grid-row--flex">
+      <% [maths, english, science].compact.each do |qualification| %>
+        <div class="govuk-grid-column-one-third">
+          <div class="app-card app-card--outline">
+
+            <% # Missing qualification %>
+            <% if qualification.missing_qualification? %>
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><%= subject(qualification) %></h3>
+              <dl class="app-qualification">
+                <dd class="app-qualification__value"> <%= candidate_does_not_have %> </dd>
+                <dt class="app-qualification__key">Reason given</dt>
+                <dd class="app-qualification__value"><%= qualification.missing_explanation %></dd>
+              </dl>
+
+            <% # International qualification %>
+            <% elsif qualification.non_uk_qualification_type.present? %>
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+                <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
+              </h3>
+              <dl class="app-qualification">
+                <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
+                <dd class="app-qualification__value app-qualification__value--caption">
+                  <%= qualification.award_year %>, <%= institution_country(qualification) %>
+                </dd>
+                <dt class="app-qualification__key">Grade</dt>
+                <dd class="app-qualification__value"><%= qualification.grade %></dd>
+                <% if naric_statement(qualification) %>
+                  <dt class="app-qualification__key">Comparability</dt>
+                  <dd class="app-qualification__value"><%= naric_statement(qualification) %></dd>
+                <% end %>
+              </dl>
+
+              <% # UK or UK Other qualification %>
+              <% else %>
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+                  <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
+                </h3>
+                <dl class="app-qualification">
+                  <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
+                  <dd class="app-qualification__value app-qualification__value--caption">
+                  <%= qualification.award_year %>
+                  </dd>
+                  <dt class="app-qualification__key">Grade</dt>
+                  <dd class="app-qualification__value"><%= qualification.grade %></dd>
+                </dl>
+              <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -1,0 +1,47 @@
+class GcseQualificationCardsComponent < ViewComponent::Base
+  attr_reader :application_form
+
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def maths
+    application_form.maths_gcse
+  end
+
+  def english
+    application_form.english_gcse
+  end
+
+  def science
+    application_form.science_gcse
+  end
+
+  def candidate_does_not_have
+    'Candidate does not have this qualification yet'
+  end
+
+  def subject(qualification)
+    qualification.subject.capitalize
+  end
+
+  def institution_country(qualification)
+    COUNTRIES[qualification.institution_country]
+  end
+
+  def presentable_qualification_type(qualification)
+    if qualification.other_uk_qualification_type.present?
+      qualification.other_uk_qualification_type
+    elsif qualification.non_uk_qualification_type.present?
+      qualification.non_uk_qualification_type
+    else
+      I18n.t!("application_form.gcse.qualification_types.#{qualification.qualification_type}")
+    end
+  end
+
+  def naric_statement(qualification)
+    if qualification.naric_reference.present? && qualification.comparable_uk_qualification.present?
+      "NARIC statement #{qualification.naric_reference} says this is comparable to a #{qualification.comparable_uk_qualification}."
+    end
+  end
+end

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -17,7 +17,7 @@
 </div>
 
 <div class="govuk-grid-column-full">
-  <%= render GcseQualificationCardComponent.new(application_form) %>
+  <%= render GcseQualificationCardsComponent.new(application_form) %>
 </div>
 
 <div class="govuk-grid-column-two-thirds">

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -12,7 +12,18 @@
   </div>
 </details>
 
-<%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.degrees, type_label: 'Degree') %>
-<%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.gcses, type_label: 'GCSE or equivalent') %>
-<%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, type_label: 'Academic or other qualification') %>
-<%= render EflQualificationCardComponent.new(application_form) %>
+<div class="govuk-grid-column-two-thirds">
+  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.degrees, type_label: 'Degree') %>
+</div>
+
+<div class="govuk-grid-column-full">
+  <%= render GcseQualificationCardComponent.new(application_form) %>
+</div>
+
+<div class="govuk-grid-column-two-thirds">
+  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, type_label: 'Academic or other qualification') %>
+</div>
+
+ <div class="govuk-grid-column-full">
+  <%= render EflQualificationCardComponent.new(application_form) %>
+</div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -33,11 +33,9 @@
     <% end %>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Course details</h2>
-
     <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice)%>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="disabilities">Disability, access and other needs</h2>
-
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
@@ -45,21 +43,19 @@
 
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Interview</h2>
-
     <%= render InterviewPreferencesComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
 
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
     <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="work-history">Work history</h2>
 
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="work-history">Work history</h2>
     <div data-qa="work-history">
       <%= render ProviderInterface::WorkHistoryComponent.new(application_form: @application_choice.application_form) %>
     </div>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="volunteering">Unpaid experience and volunteering</h2>
-
     <div data-qa="volunteering">
       <%= render ProviderInterface::VolunteeringHistoryComponent.new(application_form: @application_choice.application_form) %>
     </div>
@@ -71,12 +67,10 @@
     <% end %>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="personal-statement">Personal statement</h2>
-
     <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
 
     <% if @application_choice.application_form.application_references.any? %>
       <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="references">References</h2>
-
       <%= render 'references_context' %>
 
       <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>
@@ -86,7 +80,6 @@
     <% end %>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Diversity information</h2>
-
     <%= render ProviderInterface::DiversityInformationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
   </div>
 </div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -44,12 +44,17 @@
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Interview</h2>
     <%= render InterviewPreferencesComponent.new(application_form: @application_choice.application_form) %>
+  </div>
+</div>
 
-
+<div class="govuk-grid-row">
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
     <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>
+</div>
 
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="work-history">Work history</h2>
     <div data-qa="work-history">
       <%= render ProviderInterface::WorkHistoryComponent.new(application_form: @application_choice.application_form) %>

--- a/spec/components/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/gcse_qualification_cards_component_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe GcseQualificationCardsComponent, type: :component do
+  describe 'rendering maths' do
+    context 'when it\'s a standard UK qualification' do
+      let(:application_form) do
+        create(
+          :application_form,
+          application_qualifications: [create(:gcse_qualification, subject: 'maths', grade: 'C', award_year: 2006)],
+        )
+      end
+
+      it 'renders all expected detail' do
+        result = render_inline(described_class.new(application_form))
+
+        expect(result.text).to include 'GCSEs or equivalent'
+        expect(result.text).to include 'Maths GCSE'
+        expect(result.text).to include '2006'
+        expect(result.text).to include 'C'
+      end
+    end
+
+    context 'when it\'s a uk_other qualification' do
+      let(:application_form) do
+        create(
+          :application_form,
+          application_qualifications: [
+            create(
+              :gcse_qualification,
+              qualification_type: 'other_uk',
+              other_uk_qualification_type: 'Standard Grade',
+              subject: 'maths',
+              grade: 'C',
+              award_year: 2006,
+            ),
+          ],
+        )
+      end
+
+      it 'renders all expected detail' do
+        result = render_inline(described_class.new(application_form))
+
+        expect(result.text).to include 'GCSEs or equivalent'
+        expect(result.text).to include 'Maths Standard Grade'
+        expect(result.text).to include '2006'
+        expect(result.text).to include 'C'
+      end
+    end
+
+    context 'when it\'s a non_uk qualification' do
+      let(:application_form) do
+        create(
+          :application_form,
+          application_qualifications: [
+            create(
+              :gcse_qualification,
+              :non_uk,
+              subject: 'maths',
+              grade: 'C',
+              award_year: 2006,
+              non_uk_qualification_type: 'Diploma',
+              institution_country: 'FR',
+            ),
+          ],
+        )
+      end
+
+      it 'renders all expected detail' do
+        result = render_inline(described_class.new(application_form))
+
+        expect(result.text).to include 'GCSEs or equivalent'
+        expect(result.text).to include 'Maths Diploma'
+        expect(result.text).to include '2006, France'
+        expect(result.text).to include 'C'
+        expect(result.text).to include 'NARIC statement 4000123456 says this is comparable to a Between GCSE and GCSE AS Level.'
+      end
+
+      context 'when the NARIC reference is not provided' do
+        before { application_form.maths_gcse.update(naric_reference: nil) }
+
+        it 'does not show a NARIC statement' do
+          result = render_inline(described_class.new(application_form))
+          expect(result.text).not_to include 'NARIC'
+        end
+      end
+    end
+
+    context 'when it\'s of type "missing"' do
+      let(:application_form) do
+        create(
+          :application_form,
+          application_qualifications: [create(:gcse_qualification, :missing)],
+        )
+      end
+
+      it 'renders details about the lack of this qualification' do
+        result = render_inline(described_class.new(application_form))
+
+        expect(result.text).to include 'GCSEs or equivalent'
+        expect(result.text).to include 'Candidate does not have this qualification yet'
+        expect(result.text).to include 'I will be taking an equivalency test in a few weeks'
+      end
+    end
+  end
+
+  describe 'rendering english' do
+    let(:application_form) do
+      create(
+        :application_form,
+        application_qualifications: [create(:gcse_qualification, subject: 'english', grade: 'C', award_year: 2006)],
+      )
+    end
+
+    it 'renders all expected detail' do
+      result = render_inline(described_class.new(application_form))
+
+      expect(result.text).to include 'GCSEs or equivalent'
+      expect(result.text).to include 'English GCSE'
+      expect(result.text).to include '2006'
+      expect(result.text).to include 'C'
+    end
+  end
+
+  describe 'rendering science' do
+    let(:application_form) do
+      create(
+        :application_form,
+        application_qualifications: [create(:gcse_qualification, subject: 'science', grade: 'C', award_year: 2006)],
+      )
+    end
+
+    it 'renders all expected detail' do
+      result = render_inline(described_class.new(application_form))
+
+      expect(result.text).to include 'GCSEs or equivalent'
+      expect(result.text).to include 'Science GCSE'
+      expect(result.text).to include '2006'
+      expect(result.text).to include 'C'
+    end
+  end
+
+  describe 'rendering a set of three cards' do
+    let(:application_form) do
+      create(
+        :application_form,
+        application_qualifications: [
+          create(:gcse_qualification, subject: 'maths', grade: 'C', award_year: 2006),
+          create(:gcse_qualification, subject: 'english', grade: 'C', award_year: 2006),
+          create(:gcse_qualification, subject: 'science', grade: 'C', award_year: 2006),
+        ],
+      )
+    end
+
+    it 'renders cards for maths, english, and science' do
+      result = render_inline(described_class.new(application_form))
+
+      cards = result.css('.app-card--outline').each
+      expect(cards.next.text).to include 'Maths'
+      expect(cards.next.text).to include 'English'
+      expect(cards.next.text).to include 'Science'
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -237,6 +237,22 @@ FactoryBot.define do
       subject { %w[maths english science].sample }
       grade { %w[A B C].sample }
       awarding_body { Faker::Educator.secondary_school }
+
+      trait :non_uk do
+        qualification_type { 'non_uk' }
+        non_uk_qualification_type { 'High School Diploma' }
+        grade { %w[pass merit distinction].sample }
+        institution_country { Faker::Address.country_code }
+        naric_reference { '4000123456' }
+        comparable_uk_qualification { 'Between GCSE and GCSE AS Level' }
+      end
+
+      trait :missing do
+        qualification_type { 'missing' }
+        grade { nil }
+        awarding_body { nil }
+        missing_explanation { 'I will be taking an equivalency test in a few weeks' }
+      end
     end
 
     factory :degree_qualification do

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     )
 
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)
-    create_list(:application_qualification, 2, application_form: application_form, level: :gcse)
+    create(:gcse_qualification, subject: 'maths', application_form: application_form)
+    create(:gcse_qualification, subject: 'english', application_form: application_form)
     create_list(:application_qualification, 3, application_form: application_form, level: :other)
 
     create(:application_work_experience,
@@ -172,7 +173,9 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   def and_i_should_see_the_candidates_gcses
-    expect(page).to have_selector('[data-qa="qualifications-table-gcse-or-equivalent"] tbody tr', count: 2)
+    within '#gcses' do
+      expect(page).to have_selector('.app-card--outline', count: 2)
+    end
   end
 
   def and_i_should_see_the_candidates_other_qualifications


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Providers need to be able to see an international candidate's GCSE-level qualifications. We want to display these (and all other GCSE variants) in a new qualifications card component.

## Changes proposed in this pull request
Introduce a GcseQualificationCardsComponent that renders a set of
three cards, one each for Maths, English, and Science.

Each qualification card can render in one of four states:

- A 'missing' qualification, ie - the candidate has declared that they
  don't have the qualification.
- An international qualification
- A UK qualification, picked from one of the standard types we list
  (GCSE, O Level, and Scottish National 5).
- An 'other' UK qualification, specified by the candidate.

International cards display a NARIC statement of comparability if the
candidate has provided a NARIC reference.

### Before

![Screenshot_20200916_094543](https://user-images.githubusercontent.com/519250/93314214-61577a00-f801-11ea-9c24-5c3b10e47752.png)


### After
![Screenshot_20200916_093836](https://user-images.githubusercontent.com/519250/93313592-97482e80-f800-11ea-8500-dd98fa8bd4e8.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Should be possible to submit different applications on the review app to then view in Manage. May need to switch the app to 'Mid-cycle' in support.
- An outline of the `GcseQualificationCardsComponent` behaviour from the spec output:

![Screenshot_20200916_094436](https://user-images.githubusercontent.com/519250/93314096-3bca7080-f801-11ea-88c2-67f41246c2bc.png)


## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/Kc48lCfJ
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
