### PR TITLE
Sort candidates in support by last activity

### DIFF
--- a/app/components/support_interface/candidates_table_component.html.erb
+++ b/app/components/support_interface/candidates_table_component.html.erb
@@ -3,7 +3,7 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Candidate</th>
       <th scope="col" class="govuk-table__header">Status of latest application</th>
-      <th scope="col" class="govuk-table__header">Last sign in</th>
+      <th scope="col" class="govuk-table__header">Last updated</th>
     </tr>
   </thead>
 
@@ -14,7 +14,7 @@
           <%= table_row[:candidate_link] %> <%= table_row[:apply_again] ? '(Apply again)' : '' %>
         </td>
         <td class="govuk-table__cell"><%= t "candidate_flow_application_states.#{table_row[:process_state]}.name" %></td>
-        <td class="govuk-table__cell"><%= table_row[:last_signed_in_at] %></td>
+        <td class="govuk-table__cell"><%= table_row[:updated_at] %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/support_interface/candidates_table_component.rb
+++ b/app/components/support_interface/candidates_table_component.rb
@@ -12,7 +12,7 @@ module SupportInterface
           candidate_id: candidate.id,
           process_state: process_state(candidate),
           candidate_link: govuk_link_to(candidate.email_address, support_interface_candidate_path(candidate)),
-          last_signed_in_at: candidate.last_signed_in_at&.to_s(:govuk_date_and_time),
+          updated_at: candidate.updated_at&.to_s(:govuk_date_and_time),
           apply_again: candidate.last_updated_application&.apply_2?,
         }
       end

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -5,7 +5,7 @@ module SupportInterface
     def index
       @candidates = Candidate
         .includes(application_forms: :application_choices)
-        .order(last_signed_in_at: :desc)
+        .order(updated_at: :desc)
         .page(params[:page] || 1).per(15)
 
       if params[:q]

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -5,7 +5,7 @@ class ApplicationForm < ApplicationRecord
 
   include Chased
 
-  belongs_to :candidate
+  belongs_to :candidate, touch: true
   has_many :application_choices
   has_many :application_work_experiences
   has_many :application_volunteering_experiences


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-teacher-training/pull/2901 we changed the sorting of the /support/candidates page to be by last signin. This doesn't work in practice because not everyone has signed in, so those who haven't are bubbling to the top.

## Changes proposed in this pull request

Change the sorting back to the original. However, use `updated_at` on the candidates table to do it, and add the `touch` so that the candidates is updated whenever one of their application forms is.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/ZKW9EAs3/2138-add-filtering-and-pagination-to-slow-support-pages

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
