### PR TITLE
Speed up the list of provider users in support

### DIFF
--- a/app/components/associated_providers_permissions_list_component.rb
+++ b/app/components/associated_providers_permissions_list_component.rb
@@ -7,24 +7,14 @@ class AssociatedProvidersPermissionsListComponent < ViewComponent::Base
   end
 
   def training_providers_that_can(permission_name)
-    permissions_as_ratifying_provider.map { |permission_relationship|
+    @provider.ratifying_provider_permissions.map { |permission_relationship|
       permission_relationship.training_provider if permission_relationship.send("training_provider_can_#{permission_name}?")
     }.compact
   end
 
   def ratifying_providers_that_can(permission_name)
-    permissions_as_training_provider.map { |permission_relationship|
+    @provider.training_provider_permissions.map { |permission_relationship|
       permission_relationship.ratifying_provider if permission_relationship.send("ratifying_provider_can_#{permission_name}?")
     }.compact
-  end
-
-private
-
-  def permissions_as_ratifying_provider
-    @permissions_as_ratifying_provider ||= ProviderRelationshipPermissions.where(ratifying_provider_id: @provider.id)
-  end
-
-  def permissions_as_training_provider
-    @permissions_as_training_provider ||= ProviderRelationshipPermissions.where(training_provider_id: @provider.id)
   end
 end

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -1,7 +1,15 @@
 module SupportInterface
   class ProviderUsersController < SupportInterfaceController
     def index
-      @provider_users = ProviderUser.includes(:providers).all
+      @provider_users = ProviderUser
+        .includes(:providers)
+        .page(params[:page] || 1).per(15)
+
+      if params[:q]
+        @provider_users = @provider_users.where("CONCAT(first_name, ' ', last_name, ' ', email_address) ILIKE ?", "%#{params[:q]}%")
+      end
+
+      @filter = SupportInterface::ProviderUsersFilter.new(params: params)
     end
 
     def new

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ProviderUsersController < SupportInterfaceController
     def index
       @provider_users = ProviderUser
-        .includes(:providers)
+        .includes(providers: %i[training_provider_permissions ratifying_provider_permissions])
         .page(params[:page] || 1).per(15)
 
       if params[:q]

--- a/app/models/support_interface/provider_users_filter.rb
+++ b/app/models/support_interface/provider_users_filter.rb
@@ -1,0 +1,20 @@
+module SupportInterface
+  class ProviderUsersFilter
+    attr_reader :applied_filters
+
+    def initialize(params:)
+      @applied_filters = params
+    end
+
+    def filters
+      [
+        {
+          type: :search,
+          heading: 'Name or email',
+          value: applied_filters[:q],
+          name: 'q',
+        },
+      ]
+    end
+  end
+end

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -6,4 +6,6 @@
 
 <%= govuk_button_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %>
 
-<%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider_users)) %>
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @provider_users) do %>
+  <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider_users)) %>
+<% end %>

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature 'Managing provider users' do
     and_i_click_add_user
 
     then_i_should_see_the_list_of_provider_users
+    when_i_filter_the_list_of_provider_users
     and_i_should_see_the_user_i_created
     and_the_user_should_be_sent_a_welcome_email
 
@@ -147,6 +148,11 @@ RSpec.feature 'Managing provider users' do
 
   def then_i_should_see_the_list_of_provider_users
     expect(page).to have_title('Provider users')
+  end
+
+  def when_i_filter_the_list_of_provider_users
+    fill_in :q, with: 'harrison'
+    click_on 'Apply filters'
   end
 
   def and_i_should_see_the_user_i_created


### PR DESCRIPTION
## Context

The [list of provider users in support](https://www.apply-for-teacher-training.service.gov.uk/support/users/provider) is very slow, because 1) we display all users, 2) there are repeated database calls.

https://www.skylight.io/app/applications/t8bEzG0cuIkd/1600161240/1d/endpoints/SupportInterface::ProviderUsersController%23index?responseType=html

## Changes proposed in this pull request

Add pagination and filtering and fix a N+1 query.

## Guidance to review

Ok?

## Link to Trello card

https://trello.com/c/ZKW9EAs3/2138-add-filtering-and-pagination-to-slow-support-pages

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
