### PR TITLE
Use the courses start date for the deferral guidance in the offer emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -332,6 +332,7 @@ private
     @offers = @application_choice.application_form.application_choices.select(&:offer?).map do |offer|
       "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
     end
+    @start_date = @application_choice.course_option.course.start_date.to_s(:month_and_year)
 
     email_for_candidate(
       application_choice.application_form,

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -22,7 +22,7 @@ Contact <%= @provider_name %> if you have any questions about this.
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
-# What to do if you’re unable to start training this year
+# What to do if you’re unable to start training in <%= @start_date %>
 
 Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -26,7 +26,7 @@ Sign in to your account to respond:
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
-# What to do if you’re unable to start training this year
+# What to do if you’re unable to start training in <%= @start_date %>
 
 Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -20,7 +20,7 @@ Sign in to your account to respond:
 
 <%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
-# What to do if you’re unable to start training this year
+# What to do if you’re unable to start training in <%= @start_date %>
 
 Some teacher training providers allow you to defer your offer. This means that you could start your course a year later.
 


### PR DESCRIPTION
## Context

Using the start date in the deferral guidance in the offer emails makes it clearer to the candidate that they can defer into the next recruitment cycle rather than calendar year.

## Changes proposed in this pull request

- Use start date in the offer emails

Before 

![image](https://user-images.githubusercontent.com/42515961/93328192-54438680-f813-11ea-81b3-479c65446b35.png)


After

![image](https://user-images.githubusercontent.com/42515961/93328165-4988f180-f813-11ea-98e9-694d2e3dc85c.png)


## Link to Trello card

https://trello.com/c/v529AOd6/2141-dev-edit-offer-emails-to-include-deferrals-guidance

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
