### PR TITLE
Allow filtering applications by phase (apply 1 or apply 2)

### DIFF
--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -11,6 +11,10 @@ module SupportInterface
         @application_forms = @application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address) ILIKE ?", "%#{params[:q]}%")
       end
 
+      if params[:phase]
+        @application_forms = @application_forms.where('phase IN (?)', params[:phase])
+      end
+
       @filter = SupportInterface::ApplicationsFilter.new(params: params)
     end
 

--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -8,7 +8,7 @@ module SupportInterface
         .page(params[:page] || 1).per(15)
 
       if params[:q]
-        @application_forms = @application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address) ILIKE ?", "%#{params[:q]}%")
+        @application_forms = @application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address, ' ', application_forms.support_reference) ILIKE ?", "%#{params[:q]}%")
       end
 
       if params[:phase]

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -10,7 +10,7 @@ module SupportInterface
       [
         {
           type: :search,
-          heading: 'Name or email',
+          heading: 'Name, email or reference',
           value: applied_filters[:q],
           name: 'q',
         },
@@ -20,17 +20,17 @@ module SupportInterface
           name: 'phase',
           options: [
             {
-              value: "apply_1",
-              label: "Apply 1",
-              checked: applied_filters[:phase]&.include?("apply_1"),
+              value: 'apply_1',
+              label: 'Apply 1',
+              checked: applied_filters[:phase]&.include?('apply_1'),
             },
             {
-              value: "apply_2",
-              label: "Apply 2",
-              checked: applied_filters[:phase]&.include?("apply_2"),
+              value: 'apply_2',
+              label: 'Apply 2',
+              checked: applied_filters[:phase]&.include?('apply_2'),
             },
           ],
-        }
+        },
       ]
     end
   end

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -14,6 +14,23 @@ module SupportInterface
           value: applied_filters[:q],
           name: 'q',
         },
+        {
+          type: :checkboxes,
+          heading: 'Phase',
+          name: 'phase',
+          options: [
+            {
+              value: "apply_1",
+              label: "Apply 1",
+              checked: applied_filters[:phase]&.include?("apply_1"),
+            },
+            {
+              value: "apply_2",
+              label: "Apply 2",
+              checked: applied_filters[:phase]&.include?("apply_2"),
+            },
+          ],
+        }
       ]
     end
   end


### PR DESCRIPTION
## Context

It can be useful to filter the applications in support by apply 1/apply 2.

## Changes proposed in this pull request

This does that. Also allows searching for applications by reference.

## Guidance to review

Does it work?

## Link to Trello card

https://trello.com/c/ZKW9EAs3/2138-add-filtering-and-pagination-to-slow-support-pages

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
