### PR TITLE
Fix styling and remove erroneous divs from the deferral guidance

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -6,34 +6,34 @@
   </p>
 <% elsif  @application_choice.offer_deferred? %>
   <p class="govuk-body govuk-body govuk-!-margin-top-2">
-  Your training will now start in <%= (@application_choice.course_option.course.start_date + 1.year).to_s(:month_and_year) %>.
+    Your training will now start in <%= (@application_choice.course_option.course.start_date + 1.year).to_s(:month_and_year) %>.
   </p>
 <% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
-  <p class="govuk-body govuk-body govuk-!-margin-top-2">
-    <details class="govuk-details" data-module="govuk-details">
+    <details class="govuk-details govuk-!-margin-bottom-0 govuk-!-margin-top-2" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          What to do if you’re unable to start training in <%= (@application_choice.course_option.course.start_date + 1.year).to_s(:month_and_year) %>
+          What to do if you’re unable to start training in <%= @application_choice.course_option.course.start_date.to_s(:month_and_year) %>
         </span>
       </summary>
-
       <div class="govuk-details__text govuk-!-padding-bottom-0">
-        Some providers allow you to defer your offer. This means that you could start your course a year later.
-      </div>
+        <p>
+          Some providers allow you to defer your offer. This means that you could start your course a year later.
+        </p>
 
-      <div class="govuk-details__text govuk-!-padding-bottom-0">
-        Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @application_choice.course_option.course.provider.name %>.
-      </div>
+        <p>
+          Every provider is different, so it may or may not be possible to do this.
+          Find out by contacting <%= @application_choice.course_option.course.provider.name %>.
+        </p>
 
-      <div class="govuk-details__text govuk-!-padding-bottom-0">
-        Asking if it’s possible to defer will not affect your existing offer.
-      </div>
+        <p>
+          Asking if it’s possible to defer will not affect your existing offer.
+        </p>
 
-      <% if @application_choice.offer? %>
-        <div class="govuk-details__text govuk-!-padding-bottom-0">
-          If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.
-        </div>
-      <% end %>
+        <% if @application_choice.offer? %>
+          <p>
+            If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.
+          </p>
+        <% end %>
+      </div>
     </details>
-  </p>
 <% end %>


### PR DESCRIPTION
## Context

There are some styling issues with the deferral guidance on the application dashboard.

## Changes proposed in this pull request

- Use paras instead of divs
- Remove the extra para
- Add margin bottom 0 to the details tag

Before

![image](https://user-images.githubusercontent.com/42515961/93331053-9ff82f00-f817-11ea-884b-06033c9214f9.png)

After

![image](https://user-images.githubusercontent.com/42515961/93331013-9373d680-f817-11ea-9f3a-98afd34db93f.png)


## Link to Trello card

https://trello.com/c/UJQHdsvh/2139-dev-conditional-deferral-guidance-on-dashboard?menu=filter&filter=label:Dev
https://trello.com/c/m3Cd50Gv/2153-margin-around-deferral-guidance

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
