### PR TITLE
Add filtering for the email log

### DIFF
--- a/app/models/support_interface/emails_filter.rb
+++ b/app/models/support_interface/emails_filter.rb
@@ -1,0 +1,58 @@
+module SupportInterface
+  class EmailsFilter
+    attr_reader :applied_filters
+
+    def initialize(params:)
+      @applied_filters = params
+    end
+
+    def filters
+      @filters ||= [free_text] + [delivery_status] + [mailer]
+    end
+
+  private
+
+    def free_text
+      {
+        type: :search,
+        heading: 'Search',
+        value: applied_filters[:q],
+        name: 'q',
+      }
+    end
+
+    def delivery_status
+      options = Email.distinct(:delivery_status).pluck(:delivery_status).map do |status|
+        {
+          value: status,
+          label: status.humanize,
+          checked: applied_filters[:delivery_status]&.include?(status),
+        }
+      end
+
+      {
+        type: :checkboxes,
+        heading: 'Delivery status',
+        name: 'delivery_status',
+        options: options,
+      }
+    end
+
+    def mailer
+      options = Email.distinct(:mailer).pluck(:mailer).map do |status|
+        {
+          value: status,
+          label: status.humanize,
+          checked: applied_filters[:mailer]&.include?(status),
+        }
+      end
+
+      {
+        type: :checkboxes,
+        heading: 'Mailer',
+        name: 'mailer',
+        options: options,
+      }
+    end
+  end
+end

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -1,18 +1,20 @@
 <% content_for :title, 'Email log' %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
-      <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Email</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-  <% @emails.each do |email| %>
-    <%= render SupportInterface::EmailLogRowComponent.new(email: email) %>
-  <% end %>
-  </tbody>
-</table>
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @emails) do %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Email</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    <% @emails.each do |email| %>
+      <%= render SupportInterface::EmailLogRowComponent.new(email: email) %>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
 
 <p class='govuk-body'>
   Note that only emails sent since <%= Email.order(:id).first&.created_at&.to_s(:govuk_date_and_time) %> have been logged.

--- a/spec/system/support_interface/email_log_spec.rb
+++ b/spec/system/support_interface/email_log_spec.rb
@@ -15,6 +15,9 @@ RSpec.feature 'Email log' do
 
     when_notify_tells_us_the_emails_have_not_been_delivered
     then_the_delivery_status_is_displayed_on_the_page
+
+    when_i_search_for_an_email
+    i_see_only_the_filtered_email
   end
 
   def given_i_am_a_support_user
@@ -80,9 +83,25 @@ RSpec.feature 'Email log' do
 
   def then_the_delivery_status_is_displayed_on_the_page
     visit support_interface_email_log_path(delivery_status: 'permanent_failure')
-    expect(page).to have_content 'Permanent failure'
+
+    within '.moj-filter-layout__content' do
+      expect(page).to have_content 'Permanent failure'
+    end
 
     visit support_interface_email_log_path(delivery_status: 'delivered')
-    expect(page).not_to have_content 'Permanent failure'
+
+    within '.moj-filter-layout__content' do
+      expect(page).not_to have_content 'Permanent failure'
+    end
+  end
+
+  def when_i_search_for_an_email
+    fill_in :q, with: 'harry'
+    click_on 'Apply filters'
+  end
+
+  def i_see_only_the_filtered_email
+    expect(page).to have_content 'Application submitted (Candidate mailer)'
+    expect(page).not_to have_content 'Sign up email (Authentication mailer)'
   end
 end


### PR DESCRIPTION
## Context

We currently only show the last 1000 emails in the log. This adds pagination and filtering so we can better interrogate it.

## Changes proposed in this pull request

It looks like this in dev:

![image](https://user-images.githubusercontent.com/233676/93331857-d71b1000-f818-11ea-90f3-8527c5f8828d.png)

But when there are more emails, the filters automatically reflect that.

## Guidance to review

Does it work?

## Link to Trello card

https://trello.com/c/ZKW9EAs3/2138-add-filtering-and-pagination-to-slow-support-pages

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
