### PR TITLE
Mailer copy update  - References did not come back in time

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,6 +1,8 @@
 class CandidateMailer < ApplicationMailer
   def application_on_pause(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
+    @current_cycle_name = RecruitmentCycle.current_cycle_name
+    @next_cycle_name = RecruitmentCycle.next_cycle_name
 
     email_for_candidate(
       application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,5 +1,5 @@
 class CandidateMailer < ApplicationMailer
-  def application_on_pause(application_form)
+  def referees_did_not_respond_before_end_of_cycle(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
     @current_cycle_name = RecruitmentCycle.current_cycle_name
     @next_cycle_name = RecruitmentCycle.next_cycle_name

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -23,6 +23,10 @@ module RecruitmentCycle
     [2021, 2020, 2019]
   end
 
+  def self.current_cycle_name
+    "#{current_year} to #{next_year}"
+  end
+
   def self.next_cycle_name
     "#{next_year} to #{next_year + 1}"
   end

--- a/app/views/candidate_mailer/application_on_pause.erb
+++ b/app/views/candidate_mailer/application_on_pause.erb
@@ -1,20 +1,14 @@
 Dear <%= @application_form.first_name %>,
 
-# Your application is on pause
+# Your references did not come back in time
 
-Your referees did not respond by the time courses closed.
+Your referees did not respond in time for courses starting in the <%= @current_cycle_name %> academic year.
 
-This means that your application cannot be considered for courses starting this academic year.
-
-# Resubmit in October for courses starting next academic year
-
-We’ll send you an email when courses reopen.
-
-Your last application has been saved, so all you have to do is sign in, choose your courses and resubmit.
-
-In the meantime, you can sign in anytime to make changes to your application:
+You can update your referees and apply again for courses starting in the <%= @next_cycle_name %> academic year.
 
 <%= @candidate_magic_link %>
+
+We’ll send you an email when courses reopen.
 
 # Get help from a teacher training adviser
 

--- a/app/views/candidate_mailer/referees_did_not_respond_before_end_of_cycle.erb
+++ b/app/views/candidate_mailer/referees_did_not_respond_before_end_of_cycle.erb
@@ -6,6 +6,8 @@ Your referees did not respond in time for courses starting in the <%= @current_c
 
 You can update your referees and apply again for courses starting in the <%= @next_cycle_name %> academic year.
 
+Apply again:
+
 <%= @candidate_magic_link %>
 
 We’ll send you an email when courses reopen.

--- a/app/workers/reject_awaiting_references_course_choices_worker.rb
+++ b/app/workers/reject_awaiting_references_course_choices_worker.rb
@@ -6,7 +6,7 @@ class RejectAwaitingReferencesCourseChoicesWorker
       application_form.application_choices.awaiting_references.each do |application_choice|
         CandidateInterface::RejectAwaitingReferencesApplication.call(application_choice)
       end
-      CandidateMailer.application_on_pause(application_form).deliver_later
+      CandidateMailer.referees_did_not_respond_before_end_of_cycle(application_form).deliver_later
     end
   end
 end

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -229,7 +229,7 @@ en:
       by: system
       description: Application choices that are awaiting references are automatically rejected at the end of the cycle
       emails:
-        - candidate_mailer-application_on_pause
+        - candidate_mailer-referees_did_not_respond_before_end_of_cycle
 
     application_complete-cancel:
       name: Candidate cancels

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -1,7 +1,7 @@
 en:
   candidate_mailer:
     application_on_pause:
-      subject: "Your application is on pause: resubmit in October for courses starting next academic year"
+      subject: "Your references did not come back in time"
     eoc_choice_unavailable_no_other_choices:
       subject: Find a different course and re-submit your application
     eoc_choice_unavailable_has_other_choices:

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -1,6 +1,6 @@
 en:
   candidate_mailer:
-    application_on_pause:
+    referees_did_not_respond_before_end_of_cycle:
       subject: "Your references did not come back in time"
     eoc_choice_unavailable_no_other_choices:
       subject: Find a different course and re-submit your application

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -1,6 +1,6 @@
 class CandidateMailerPreview < ActionMailer::Preview
   def application_on_pause
-    CandidateMailer.application_on_pause(application_form)
+    CandidateMailer.referees_did_not_respond_before_end_of_cycle(application_form)
   end
 
   def application_submitted

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe RecruitmentCycle do
     end
   end
 
+  describe '.current_cycle_name' do
+    it 'is current year to the following year' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
+        expect(RecruitmentCycle.current_cycle_name).to eq('2020 to 2021')
+      end
+    end
+  end
+
   describe '.next_cycle_name' do
     it 'is next year to the following year' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do

--- a/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
+++ b/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe RejectAwaitingReferencesCourseChoicesWorker do
       application_choice_withdrawn = create(:application_choice, :withdrawn, application_form: application_form)
 
       allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to receive(:call).and_return([application_choice.application_form])
-      allow(CandidateMailer).to receive(:application_on_pause).and_call_original
+      allow(CandidateMailer).to receive(:referees_did_not_respond_before_end_of_cycle).and_call_original
       allow(CandidateInterface::RejectAwaitingReferencesApplication).to receive(:call).and_call_original
       RejectAwaitingReferencesCourseChoicesWorker.new.perform
 
       expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to have_received(:call)
-      expect(CandidateMailer).to have_received(:application_on_pause).with(application_choice.application_form)
+      expect(CandidateMailer).to have_received(:referees_did_not_respond_before_end_of_cycle).with(application_choice.application_form)
       expect(CandidateInterface::RejectAwaitingReferencesApplication).to have_received(:call).with(application_choice)
       expect(CandidateInterface::RejectAwaitingReferencesApplication).not_to have_received(:call).with(application_choice_withdrawn)
     end


### PR DESCRIPTION
## Context

If references haven't come back by 18 Sep the candidate gets an email 18 Sep at 11:59pm.

## Changes proposed in this pull request

- Update copy in mailer
- Rename references => ‘application_on_pause’ is now ‘referees_did_not_respond_before_end_of_cycle’. This is a better description in light of the copy changes

## Guidance to review

[Example of updated notification](https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534/notification/11d651c1-0875-4ea8-946f-84696846167b)

Note that subject has since been updated to correct wording.

## Link to Trello card

https://trello.com/c/KUyyYMxJ/2132-%F0%9F%9A%B2%F0%9F%94%9A-references-didnt-come-back-in-time-%F0%9F%8F%88

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
