### PR TITLE
EOC: References did not come back in time - copy changes

### DIFF
--- a/app/components/candidate_interface/carry_over_banner_component.html.erb
+++ b/app/components/candidate_interface/carry_over_banner_component.html.erb
@@ -3,17 +3,13 @@
     <div class="govuk-heading-m">
       <% if EndOfCycleTimetable.between_cycles_apply_2? %>
         <p>
-          Do you want to continue applying?
+          Courses for the <%= current_cycle_span %> academic year are now closed
         </p>
 
         <p class='govuk-body govuk-!-font-size-24'>
-          Applications for this academic year <%= current_cycle_span %> are now closed.
+          Your references did not come back in time, but you can <%= govuk_link_to 'apply again', start_path %>
         </p>
-
-        <p class='govuk-body govuk-!-font-size-24'>
-          You can still <%= govuk_link_to 'continue with your application', start_path %> so it’s ready to submit for courses starting next academic year <%= next_cycle_span %>.
-        </p>
-      <% else %> 
+      <% else %>
         <p>
           Do you want to continue applying?
         </p>

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -95,11 +95,11 @@ module ViewHelper
   end
 
   def current_cycle_span
-    "(#{RecruitmentCycle.current_year} - #{RecruitmentCycle.next_year})"
+    "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}"
   end
 
   def next_cycle_span
-    "(#{RecruitmentCycle.next_year} - #{RecruitmentCycle.next_year + 1})"
+    "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}"
   end
 
 private

--- a/app/views/candidate_interface/submitted_application_form/start_carry_over.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/start_carry_over.html.erb
@@ -5,21 +5,20 @@
 <div class="govuk-grid-row">
 
   <div class="govuk-grid-column-two-thirds">
+
     <p class="govuk-body">
-      Applications are open for courses starting next academic year <%= current_cycle_span %>.
-    </p>
-    <p class="govuk-body">
-      The application you started has been saved.
-    </p>
-    <p class="govuk-body">
-      You'll have 3 course choices.
+      Carry on with your application for courses starting in the <%= current_cycle_span %> academic year.
     </p>
 
-    <%= button_to 'Start now', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+    <p class="govuk-body">
+      Your courses have been removed. You can add them again now.
+    </p>
+
+    <%= button_to 'Apply again', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
 
     <p class="govuk-body">or</p>
 
-    <%= govuk_link_to 'Go to your dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
+    <%= govuk_link_to 'Go to dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
   </div>
 </div>
 

--- a/app/views/candidate_interface/submitted_application_form/start_carry_over_between_cycles.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/start_carry_over_between_cycles.html.erb
@@ -5,16 +5,36 @@
 <div class="govuk-grid-row">
 
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Your last application has been saved, so you do not need to start again.</p>
-    <p class="govuk-body">You can make changes to your application whenever you like.</p>
-    <p class="govuk-body">You will be able to choose courses from <%= EndOfCycleTimetable.find_reopens.to_s(:govuk_date) %> and submit from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>. </p>
-    <p class="govuk-body">You'll have 3 course choices.</p>
 
-    <%= button_to 'Start now', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+    <% if EndOfCycleTimetable.find_down? %>
+      <p class="govuk-body">
+        Applications for courses starting in the <%= current_cycle_span %> academic year are closed.
+      </p>
+    <% end %>
+
+    <p class="govuk-body">
+      Carry on with your application for courses starting in the <%= next_cycle_span %> year.
+    </p>
+
+    <p class="govuk-body">
+      You can submit your application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)%>
+    </p>
+
+    <p class="govuk-body">
+      Your courses have been removed.
+      <% if EndOfCycleTimetable.find_down? %>
+        You can add them again later.
+      <% else %>
+        You can add them now.
+      <% end %>
+    </p>
+
+    <%= button_to 'Apply again', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
 
     <p class="govuk-body">or</p>
 
-    <%= govuk_link_to 'Go to your dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
+    <%= govuk_link_to 'Go to dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
+
   </div>
 </div>
 

--- a/app/views/candidate_interface/submitted_application_form/start_carry_over_between_cycles.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/start_carry_over_between_cycles.html.erb
@@ -6,27 +6,20 @@
 
   <div class="govuk-grid-column-two-thirds">
 
-    <% if EndOfCycleTimetable.find_down? %>
-      <p class="govuk-body">
-        Applications for courses starting in the <%= current_cycle_span %> academic year are closed.
-      </p>
-    <% end %>
+    <p class="govuk-body">
+      Applications for courses starting in the <%= current_cycle_span %> academic year are closed.
+    </p>
 
     <p class="govuk-body">
       Carry on with your application for courses starting in the <%= next_cycle_span %> year.
     </p>
 
     <p class="govuk-body">
-      You can submit your application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)%>
+      You can submit your application from <%= EndOfCycleTimetable.apply_reopens.to_s(:govuk_date) %>
     </p>
 
     <p class="govuk-body">
-      Your courses have been removed.
-      <% if EndOfCycleTimetable.find_down? %>
-        You can add them again later.
-      <% else %>
-        You can add them now.
-      <% end %>
+      Your courses have been removed. You can add them again later.
     </p>
 
     <%= button_to 'Apply again', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
       confirm: Confirm offer
     start_apply_again: Do you want to apply again?
     start_carry_over: Do you want to continue applying?
-    start_carry_over_between_cycles: "Get your application ready to submit from %{reopen_date}"
+    start_carry_over_between_cycles: You can apply again
     pick_choice_to_replace: Some of your choices are not available anymore
     pick_replacement_action: Update course choice
     confirm_replacement_course_choice: Your updated course choice

--- a/spec/components/candidate_interface/carry_over_banner_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_banner_component_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe CandidateInterface::CarryOverBannerComponent do
       application_form.recruitment_cycle_year = 2020
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Courses for the (2021 - 2022) academic year are now closed')
+      expect(result.text).to include('Courses for the 2021 to 2022 academic year are now closed')
       expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_carry_over_path)
     end
 
@@ -106,7 +106,7 @@ RSpec.describe CandidateInterface::CarryOverBannerComponent do
       application_form.recruitment_cycle_year = 2021
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Courses for the (2021 - 2022) academic year are now closed')
+      expect(result.text).to include('Courses for the 2021 to 2022 academic year are now closed')
       expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_carry_over_path)
     end
   end

--- a/spec/components/candidate_interface/carry_over_banner_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_banner_component_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe CandidateInterface::CarryOverBannerComponent do
       application_form.recruitment_cycle_year = 2020
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Do you want to continue applying?')
+      expect(result.text).to include('Courses for the (2021 - 2022) academic year are now closed')
       expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_carry_over_path)
     end
 
@@ -106,7 +106,7 @@ RSpec.describe CandidateInterface::CarryOverBannerComponent do
       application_form.recruitment_cycle_year = 2021
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Do you want to continue applying?')
+      expect(result.text).to include('Courses for the (2021 - 2022) academic year are now closed')
       expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_carry_over_path)
     end
   end

--- a/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Candidate vists their applicatin form after the cycle has ended'
 
   def then_there_is_a_link_to_the_carry_over_journey
     expect(page).to have_content('Do you want to continue applying?')
-    expect(page).to have_button('Start now')
+    expect(page).to have_button('Apply again')
   end
 
   def given_it_is_the_day_after_the_apply1_deadline

--- a/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -90,12 +90,12 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
 
   def then_i_am_redirected_to_the_carry_over_interstitial
     expect(page).not_to have_link 'Continue your application'
-    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 academic year.'
     expect(page).to have_content 'Your courses have been removed. You can add them again now.'
   end
 
   def when_i_click_on_start_now
-    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 academic year.'
     expect(page).to have_content 'Your courses have been removed. You can add them again now.'
     click_button 'Apply again'
   end

--- a/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -90,14 +90,14 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
 
   def then_i_am_redirected_to_the_carry_over_interstitial
     expect(page).not_to have_link 'Continue your application'
-    expect(page).to have_content 'Applications are open for courses starting next academic year (2021 - 2022).'
-    expect(page).to have_content 'You\'ll have 3 course choices.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Your courses have been removed. You can add them again now.'
   end
 
   def when_i_click_on_start_now
-    expect(page).to have_content 'Applications are open for courses starting next academic year (2021 - 2022).'
-    expect(page).to have_content 'You\'ll have 3 course choices.'
-    click_button 'Start now'
+    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Your courses have been removed. You can add them again now.'
+    click_button 'Apply again'
   end
 
   def and_i_click_go_to_my_application_form

--- a/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -85,14 +85,14 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
 
   def and_i_am_redirected_to_the_carry_over_interstitial
     expect(page).not_to have_link 'Continue your application'
-    expect(page).to have_content 'Applications are open for courses starting next academic year (2021 - 2022).'
-    expect(page).to have_content 'You\'ll have 3 course choices.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Your courses have been removed. You can add them again now.'
   end
 
   def when_i_click_on_start_now
-    expect(page).to have_content 'Applications are open for courses starting next academic year (2021 - 2022).'
-    expect(page).to have_content 'You\'ll have 3 course choices.'
-    click_button 'Start now'
+    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Your courses have been removed. You can add them again now.'
+    click_button 'Apply again'
   end
 
   def and_i_click_go_to_my_application_form

--- a/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -85,12 +85,12 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
 
   def and_i_am_redirected_to_the_carry_over_interstitial
     expect(page).not_to have_link 'Continue your application'
-    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 academic year.'
     expect(page).to have_content 'Your courses have been removed. You can add them again now.'
   end
 
   def when_i_click_on_start_now
-    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 academic year.'
     expect(page).to have_content 'Your courses have been removed. You can add them again now.'
     click_button 'Apply again'
   end

--- a/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
@@ -43,6 +43,6 @@ RSpec.feature 'Candidate with unsuccessful application' do
   end
 
   def and_i_do_see_a_carry_over_application_banner
-    expect(page).to have_content('Do you want to continue applying?')
+    expect(page).to have_content('Courses for the (2020 - 2021) academic year are now closed')
   end
 end

--- a/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_views_unsuccessful_application_between_cycles_spec.rb
@@ -43,6 +43,6 @@ RSpec.feature 'Candidate with unsuccessful application' do
   end
 
   def and_i_do_see_a_carry_over_application_banner
-    expect(page).to have_content('Courses for the (2020 - 2021) academic year are now closed')
+    expect(page).to have_content('Courses for the 2020 to 2021 academic year are now closed')
   end
 end

--- a/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
   end
 
   def then_i_am_redirected_to_the_carry_over_interstitial
-    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 academic year.'
     expect(page).to have_content 'Your courses have been removed. You can add them again now.'
     click_button 'Apply again'
   end

--- a/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsubmitted_application_between_cycles_spec.rb
@@ -74,8 +74,8 @@ RSpec.feature 'Candidate attempts to submit the application after the end-of-cyc
   end
 
   def then_i_am_redirected_to_the_carry_over_interstitial
-    expect(page).to have_content 'Applications are open for courses starting next academic year (2021 - 2022).'
-    expect(page).to have_content 'You\'ll have 3 course choices.'
-    expect(page).to have_button 'Start now'
+    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Your courses have been removed. You can add them again now.'
+    click_button 'Apply again'
   end
 end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -58,9 +58,10 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_start_now
-    expect(page).to have_content "Get your application ready to submit from #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}"
-    expect(page).to have_content 'You\'ll have 3 course choices.'
-    click_button 'Start now'
+    expect(page).to have_content 'You can apply again'
+    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) year.'
+    expect(page).to have_content 'Your courses have been removed.'
+    click_button 'Apply again'
   end
 
   def and_i_click_go_to_my_application_form

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_apply_again
-    expect(page).to have_content 'Courses for the (2020 - 2021) academic year are now closed'
+    expect(page).to have_content 'Courses for the 2020 to 2021 academic year are now closed'
     click_link 'apply again'
   end
 
   def and_i_click_on_start_now
     expect(page).to have_content 'You can apply again'
-    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) year.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 year.'
     expect(page).to have_content 'Your courses have been removed.'
     click_button 'Apply again'
   end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_apply_again
-    expect(page).to have_content 'Do you want to continue applying?'
-    click_link 'continue with your application'
+    expect(page).to have_content 'Courses for the (2020 - 2021) academic year are now closed'
+    click_link 'apply again'
   end
 
   def and_i_click_on_start_now

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_start_now
-    expect(page).to have_content 'Applications are open for courses starting next academic year (2021 - 2022).'
-    expect(page).to have_content 'You\'ll have 3 course choices.'
-    click_button 'Start now'
+    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Your courses have been removed. You can add them again now.'
+    click_button 'Apply again'
   end
 
   def and_i_click_go_to_my_application_form

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
   def and_i_click_on_apply_again
     expect(page).to have_content 'Do you want to continue applying?'
-    expect(page).to have_content 'Applications are open for courses starting next academic year (2021 - 2022).'
+    expect(page).to have_content 'Applications are open for courses starting next academic year 2021 to 2022.'
     click_link 'Continue your application'
   end
 
   def and_i_click_on_start_now
-    expect(page).to have_content 'Carry on with your application for courses starting in the (2021 - 2022) academic year.'
+    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 academic year.'
     expect(page).to have_content 'Your courses have been removed. You can add them again now.'
     click_button 'Apply again'
   end


### PR DESCRIPTION
## Context

From 19 September, when the candidate visits their dashboard, they see a banner if their references were not completed in time.

This banner remains until the user starts a new application (from the interstitial page).

When the candidate clicks ‘Apply again’ from the dashboard banner they see an interstitial page, the copy of which differs depending whether we are between cycles or not, and if Find is closed / open.

## Changes proposed in this pull request

### Update copy in the banner

<img width="1276" alt="carry_over_banner" src="https://user-images.githubusercontent.com/5256922/93488866-b927db00-f8fe-11ea-9b70-6a8e1bb0b58f.png">

### Update interstitial pages

#### Start carry over interstitial page (within cycle)

<img width="1341" alt="start_carry_over_within_cycle" src="https://user-images.githubusercontent.com/5256922/93471965-f20a8480-f8eb-11ea-8808-ce96bcfe64d9.png">

#### Start carry over page (between cycles)

<img width="1098" alt="start_carry_over_between_cycles" src="https://user-images.githubusercontent.com/5256922/93489117-07d57500-f8ff-11ea-9e0a-07770a83985d.png">

## Guidance to review

Give me a yell if you me want to walk through this. 

1. Fired up the app locally and changed cycle to ‘mid cycle’
2. Created a new application with two references
3. Change cycle to ‘Apply 2 deadline has passed’
4. Manually trigger the RejectAwaitingReferencesApplication email. 
5. Go back to application dashboard. A banner should appear. The link that is there (continue your application) should take you to /candidate/application/start-carry-over.

## Link to Trello card

https://trello.com/c/KUyyYMxJ/2132-%F0%9F%9A%B2%F0%9F%94%9A-references-didnt-come-back-in-time-%F0%9F%8F%88

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
