### PR TITLE
Mitigate empty permissions for invited user

### DIFF
--- a/app/components/provider_interface/provider_user_invitation_details_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_details_component.rb
@@ -61,7 +61,7 @@ module ProviderInterface
           key: key,
           value: render(
             ProviderInterface::ProviderUserInvitationPermissionsComponent.new(
-              @wizard.provider_permissions[provider.id.to_s]['permissions'].reject(&:blank?),
+              @wizard.provider_permissions[provider.id.to_s].fetch('permissions', []).reject(&:blank?),
             ),
           ),
           change_path: provider_interface_update_invitation_provider_permissions_path(

--- a/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
+++ b/spec/components/provider_interface/provider_user_invitation_details_component_spec.rb
@@ -72,4 +72,27 @@ RSpec.describe ProviderInterface::ProviderUserInvitationDetailsComponent do
       expect(result.css('.govuk-summary-list__value')[3].text).to include('Manage users')
     end
   end
+
+  context 'when no permissions are granted' do
+    let(:provider) { create(:provider) }
+    let(:wizard) do
+      instance_double(
+        ProviderInterface::ProviderUserInvitationWizard,
+        first_name: 'Ed',
+        last_name: 'Yewcator',
+        email_address: 'ed@example.com',
+        providers: [provider.id.to_s],
+        provider_permissions: {
+          provider.id.to_s => { 'provider_id' => provider.id },
+        },
+        single_provider: 'true',
+      )
+    end
+
+    it 'presents the default view applications message' do
+      result = render_inline(described_class.new(wizard: wizard))
+
+      expect(result.css('.govuk-summary-list__value')[3].text).to include('The user will only be able to view applications')
+    end
+  end
 end


### PR DESCRIPTION
## Context

https://sentry.io/organizations/dfe-bat/issues/1897001575/?project=1765973

![image](https://user-images.githubusercontent.com/93511/93363191-cda49e80-f83e-11ea-830b-2b199c89f9f8.png)


When a provider user is invited and no permissions are granted in the invitation wizard the underlying data will not contain a permissions list. The details component which renders the granted permissions relied on the presence of this collection.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Calls `fetch` on permissions data saved in the wizard so that the collection of assigned permissions defaults to an empty array. This allows the details component to correctly render the _The user will only be able to view applications_ message. 

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/YLJ6awIP/2755-when-inviting-a-new-user-but-not-adding-any-permissions-i-see-a-sorry-there-is-a-problem-with-the-service-error-message

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
