### PR TITLE
Disable auditing during setup_local_dev_data

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -1,5 +1,7 @@
 desc 'Set up your local development environment with data from Find'
 task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses] do
+  Audited.auditing_enabled = false
+
   puts 'Creating a provider-only user with DfE Sign-in UID `dev-provider` and email `provider@example.com`...'
   ProviderUser.create!(
     dfe_sign_in_uid: 'dev-provider',


### PR DESCRIPTION
## Context

Heroku is complaining about hitting the 10k row limit on review apps. This is a band-aid to hopefully fix it.

## Changes proposed in this pull request

Disable auditing while running `setup_local_dev_data`. This reduced the number of rows by about 1k on my local machine.

## Guidance to review

To verify, connect to the review app on this PR and run:

```bash
$ heroku psql -a name-of-this-review-app
> SELECT schemaname,relname,n_live_tup
  FROM pg_stat_user_tables
  ORDER BY n_live_tup DESC;
```

And compare to the current results:

```
 schemaname |              relname              | n_live_tup
------------+-----------------------------------+------------
 public     | audits                            |       4434
 public     | providers                         |       2020
 public     | course_options                    |        830
 public     | courses                           |        320
 public     | emails                            |        308
 public     | schema_migrations                 |        220
```

I got this locally:

```
 schemaname |              relname              | n_live_tup
------------+-----------------------------------+------------
 public     | audits                            |       3330
 public     | providers                         |       2016
 public     | course_options                    |        830
 public     | courses                           |        320
 public     | emails                            |        307
 public     | schema_migrations                 |        220
```
I might open some follow-up stories if we need more.

## Link to Trello card

None.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)