### PR TITLE
2135 - Application reference export amends

### DIFF
--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -1,18 +1,17 @@
 module SupportInterface
   class ApplicationReferencesExport
     def self.header_row
-      [
+      header_row = [
         'Support Ref Number',
-        'Phase',
-        'Ref 1 type',
-        'Ref 1 state',
-        'Ref 2 type',
-        'Ref 2 state',
-        'Ref 3 type',
-        'Ref 3 state',
-        'Ref 4 type',
-        'Ref 4 state',
+        'Phase'
       ]
+
+      ApplicationForm::MAXIMUM_REFERENCES.times do |i|
+        header_row << "Ref #{i + 1} type"
+        header_row << "Ref #{i + 1} state"
+      end
+
+      header_row
     end
 
     def self.call

--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -2,8 +2,9 @@ module SupportInterface
   class ApplicationReferencesExport
     def self.header_row
       header_row = [
-        'Support Ref Number',
-        'Phase'
+        'Support ref number',
+        'Phase',
+        'Application state',
       ]
 
       ApplicationForm::MAXIMUM_REFERENCES.times do |i|
@@ -19,8 +20,9 @@ module SupportInterface
 
       application_forms.map do |af|
         output = {
-          'Support Ref Number' => af.support_reference,
+          'Support ref number' => af.support_reference,
           'Phase' => af.phase,
+          'Application state' => ProcessState.new(af).state,
         }
 
         af.application_references.map.with_index(1) do |reference, index|

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
           'Ref 3 state',
           'Ref 4 type',
           'Ref 4 state',
+          'Ref 5 type',
+          'Ref 5 state',
+          'Ref 6 type',
+          'Ref 6 state',
+          'Ref 7 type',
+          'Ref 7 state',
+          'Ref 8 type',
+          'Ref 8 state',
+          'Ref 9 type',
+          'Ref 9 state',
+          'Ref 10 type',
+          'Ref 10 state',
         ],
       )
     end

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
     it 'returns an array containing column headings' do
       expect(described_class.header_row).to eq(
         [
-          'Support Ref Number',
+          'Support ref number',
           'Phase',
+          'Application state',
           'Ref 1 type',
           'Ref 1 state',
           'Ref 2 type',
@@ -51,8 +52,9 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
 
   def return_expected_hash(application_form)
     {
-      'Support Ref Number' => application_form.support_reference,
+      'Support ref number' => application_form.support_reference,
       'Phase' => application_form.phase,
+      'Application state' => ProcessState.new(application_form).state,
       'Ref 1 type' => application_form.application_references[0].referee_type,
       'Ref 1 state' => application_form.application_references[0].feedback_status,
       'Ref 2 type' => application_form.application_references[1].referee_type,

--- a/spec/system/support_interface/application_references_performance_spec.rb
+++ b/spec/system/support_interface/application_references_performance_spec.rb
@@ -36,6 +36,7 @@ RSpec.feature 'Application references performance CSV' do
     af = ApplicationForm.first
     expect(page).to have_content af.support_reference
     expect(page).to have_content af.phase
+    expect(page).to have_content ProcessState.new(af).state
     expect(page).to have_content af.application_references[0].referee_type
     expect(page).to have_content af.application_references[0].feedback_status
     expect(page).to have_content af.application_references[1].referee_type


### PR DESCRIPTION
## Context

Some additional info needs to be added to the application reference export.

## Changes proposed in this pull request

- Add the application state
- Add the max number of references allowed (up to 10)

## Guidance to review

- Go to `/support/performance` and click on the ‘Download application references (CSV)’

## Link to Trello card

https://trello.com/c/dnwl0nC9/2135-dev-data-extract-of-reference-types

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
