### PR TITLE
Update EndOfCycleTimetable schedules

### DIFF
--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -76,8 +76,8 @@ class EndOfCycleTimetable
         apply_1_deadline: Date.new(2020, 8, 24),
         stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
         apply_2_deadline: Date.new(2020, 9, 18),
-        find_closes: Date.new(2020, 9, 19),
-        find_reopens: Date.new(2020, 10, 3),
+        find_closes: Date.new(2020, 10, 3),
+        find_reopens: Date.new(2020, 10, 6),
         apply_reopens: Date.new(2020, 10, 13),
       },
 

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Cycle switching' do
 
   def then_i_see_the_cycle_information
     expect(page).to have_title 'Recruitment cycles'
-    expect(page).to have_content("Find closes on\n19 September 2020")
+    expect(page).to have_content("Find closes on\n3 October 2020")
   end
 
   def when_i_click_to_choose_a_new_schedule


### PR DESCRIPTION
## Context

- values for `find_closes` and `find_reopens` are incorrect. 😱 

## Changes proposed in this pull request

- values for `find_closes` and `find_reopens` have been corrected.

## Link to Trello card

https://trello.com/c/SHFtsvzu/2154-fix-endofcycletimetable-schedules

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
