### PR TITLE
Render 404 when an application is not visible to user or does not exist

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -93,6 +93,8 @@ module ProviderInterface
       GetApplicationChoicesForProviders.call(
         providers: available_providers,
       ).find(params[:application_choice_id])
+    rescue ActiveRecord::RecordNotFound
+      render_404
     end
 
     def get_sub_navigation_items

--- a/spec/requests/provider_interface/viewing_applications_spec.rb
+++ b/spec/requests/provider_interface/viewing_applications_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'Viewing applications', type: :request do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  describe 'GET show with application_choice_id for an application to my provider' do
+    it 'responds with 200' do
+      application_choice = create(
+        :submitted_application_choice,
+        course_option: create(:course_option, course: create(:course, provider: provider)),
+      )
+      get provider_interface_application_choice_path(application_choice_id: application_choice.id)
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe 'GET show with invalid application_choice_id param' do
+    it 'responds with 404' do
+      get provider_interface_application_choice_path(application_choice_id: 666)
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe 'GET show with application_choice_id param for an application to another provider' do
+    it 'responds with 404' do
+      application_choice = create(:application_choice)
+      get provider_interface_application_choice_path(application_choice_id: application_choice.id)
+
+      expect(response.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
## Context

If a provider user attempts to view an application which either does not exist or is not visible (eg. belongs to a different provider org) we currently get a 500 error.
 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Render 404 when attempting to access an inaccessible application or a non-existent application.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Amend the URL of application_choices#show to  use an ID of an application which doesn't exist or you don't have access to.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/SovfXd3q/2685-we-get-500-not-if-trying-to-access-an-application-we-cant-see-via-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
