### PR TITLE
Change how we display degrees on the Manage application choice page 

### DIFF
--- a/app/components/degree_qualification_cards_component.html.erb
+++ b/app/components/degree_qualification_cards_component.html.erb
@@ -1,0 +1,38 @@
+<div id="degrees" class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-m"><%= section_title %></h2>
+
+  <div class="govuk-grid">
+    <div class="govuk-grid-row app-grid-row--flex">
+      <% degrees.each do |degree| %>
+        <div class="govuk-grid-column-one-third">
+          <div class="app-card app-card--outline">
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+              <%= degree_type_and_subject(degree) %>
+            </h3>
+            <dl class="app-qualification">
+              <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
+              <dd class="app-qualification__value app-qualification__value--caption">
+              <%= degree.start_year %> to <%= degree.award_year %>
+              </dd>
+
+              <dt class="app-qualification__key">Grade</dt>
+              <dd class="app-qualification__value"><%= formatted_grade(degree) %></dd>
+
+              <dt class="app-qualification__key">Institution</dt>
+              <% if show_institution? %>
+                <dd class="app-qualification__value"><%= formatted_institution(degree) %></dd>
+              <% else %>
+                <dd class="app-qualification__value app-qualification__value--caption">Only available once an offer has been accepted</dd>
+              <% end %>
+
+              <% if naric_statement(degree) %>
+                <dt class="app-qualification__key">Comparability</dt>
+                <dd class="app-qualification__value"><%= naric_statement(degree) %></dd>
+              <% end %>
+            </dl>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/degree_qualification_cards_component.html.erb
+++ b/app/components/degree_qualification_cards_component.html.erb
@@ -1,18 +1,18 @@
-<div id="degrees" class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-m"><%= section_title %></h2>
+<div class="govuk-grid-column-full">
+  <h3 class="govuk-heading-m" id="degrees"><%= section_title %></h3>
 
   <div class="govuk-grid">
     <div class="govuk-grid-row app-grid-row--flex">
       <% degrees.each do |degree| %>
         <div class="govuk-grid-column-one-third">
-          <div class="app-card app-card--outline">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+          <div class="app-card app-card--outline" data-qa="degree-qualification">
+            <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
               <%= degree_type_and_subject(degree) %>
-            </h3>
+            </h4>
             <dl class="app-qualification">
               <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
               <dd class="app-qualification__value app-qualification__value--caption">
-              <%= degree.start_year %> to <%= degree.award_year %>
+                <%= degree.start_year %> to <%= degree.award_year %>
               </dd>
 
               <dt class="app-qualification__key">Grade</dt>

--- a/app/components/degree_qualification_cards_component.rb
+++ b/app/components/degree_qualification_cards_component.rb
@@ -1,0 +1,65 @@
+class DegreeQualificationCardsComponent < ViewComponent::Base
+  attr_reader :degrees, :application_choice_state
+
+  def initialize(degrees, application_choice_state: nil)
+    @degrees = degrees
+    @application_choice_state = application_choice_state
+  end
+
+  def section_title
+    'Degree'.pluralize(degrees.count)
+  end
+
+  def degree_type_and_subject(degree)
+    "#{degree_type_with_honours(degree)} #{degree.subject}"
+  end
+
+  def formatted_grade(degree)
+    if degree.predicted_grade?
+      "Predicted: #{degree.grade}"
+    else
+      degree.grade
+    end
+  end
+
+  def show_institution?
+    # Always show the institution if the component has not been made aware of
+    # any application choice state
+    return true if application_choice_state.nil?
+
+    application_choice_state.to_sym.in? ApplicationStateChange::ACCEPTED_STATES
+  end
+
+  def formatted_institution(degree)
+    degree.international? ? institution_and_country(degree) : institution(degree)
+  end
+
+  def naric_statement(degree)
+    if degree.naric_reference.present? && degree.comparable_uk_degree.present?
+      degree_name = I18n.t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}")
+      "NARIC statement #{degree.naric_reference} says this is comparable to a #{degree_name}"
+    end
+  end
+
+private
+
+  def degree_type_with_honours(degree)
+    if degree.grade&.include? 'honours'
+      "#{abbreviate_degree(degree.qualification_type)} (Hons)"
+    else
+      abbreviate_degree(degree.qualification_type)
+    end
+  end
+
+  def abbreviate_degree(name)
+    Hesa::DegreeType.find_by_name(name)&.abbreviation || name
+  end
+
+  def institution_and_country(degree)
+    "#{institution(degree)}, #{COUNTRIES[degree.institution_country]}"
+  end
+
+  def institution(degree)
+    degree.institution_name
+  end
+end

--- a/app/components/efl_qualification_card_component.html.erb
+++ b/app/components/efl_qualification_card_component.html.erb
@@ -1,12 +1,12 @@
-<div id="english-as-a-foreign-language">
-  <h2 class="govuk-heading-m">English as a foreign language</h2>
+<div class="govuk-grid-column-full">
+  <h2 class="govuk-heading-m govuk-!-margin-top-8" id="english-as-a-foreign-language">English as a foreign language</h2>
   <p class="govuk-body"><%= qualification_status %></p>
 
   <% if english_proficiency.has_qualification? %>
     <div class="govuk-grid">
       <div class="govuk-grid-row app-grid-row--flex">
         <div class="govuk-grid-column-one-third">
-          <div class="app-card app-card--outline">
+          <div class="app-card app-card--outline" data-qa="english-proficiency-qualification">
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><%= name %></h3>
             <dl class="app-qualification">
               <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>

--- a/app/components/gcse_qualification_cards_component.html.erb
+++ b/app/components/gcse_qualification_cards_component.html.erb
@@ -1,15 +1,15 @@
-<div id="gcses" class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-m">GCSEs or equivalent</h2>
+<div class="govuk-grid-column-full">
+  <h3 class="govuk-heading-m govuk-!-margin-top-8" id="gcses">GCSEs or equivalent</h3>
 
   <div class="govuk-grid">
     <div class="govuk-grid-row app-grid-row--flex">
       <% [maths, english, science].compact.each do |qualification| %>
         <div class="govuk-grid-column-one-third">
-          <div class="app-card app-card--outline">
+          <div class="app-card app-card--outline" data-qa="gcse-qualification">
 
             <% # Missing qualification %>
             <% if qualification.missing_qualification? %>
-              <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><%= subject(qualification) %></h3>
+              <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><%= subject(qualification) %></h4>
               <dl class="app-qualification">
                 <dd class="app-qualification__value"> <%= candidate_does_not_have %> </dd>
                 <dt class="app-qualification__key">Reason given</dt>
@@ -18,9 +18,9 @@
 
             <% # International qualification %>
             <% elsif qualification.non_uk_qualification_type.present? %>
-              <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+              <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
                 <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
-              </h3>
+              </h4>
               <dl class="app-qualification">
                 <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
                 <dd class="app-qualification__value app-qualification__value--caption">
@@ -34,20 +34,20 @@
                 <% end %>
               </dl>
 
-              <% # UK or UK Other qualification %>
-              <% else %>
-                <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-                  <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
-                </h3>
-                <dl class="app-qualification">
-                  <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
-                  <dd class="app-qualification__value app-qualification__value--caption">
-                  <%= qualification.award_year %>
-                  </dd>
-                  <dt class="app-qualification__key">Grade</dt>
-                  <dd class="app-qualification__value"><%= qualification.grade %></dd>
-                </dl>
-              <% end %>
+            <% # UK or UK Other qualification %>
+            <% else %>
+              <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
+                <%= subject(qualification) %> <span class="govuk-!-font-weight-regular"><%= presentable_qualification_type(qualification) %></span>
+              </h4>
+              <dl class="app-qualification">
+                <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
+                <dd class="app-qualification__value app-qualification__value--caption">
+                <%= qualification.award_year %>
+                </dd>
+                <dt class="app-qualification__key">Grade</dt>
+                <dd class="app-qualification__value"><%= qualification.grade %></dd>
+              </dl>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -12,8 +12,8 @@
   </div>
 </details>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.degrees, type_label: 'Degree') %>
+<div class="govuk-grid-column-full">
+  <%= render DegreeQualificationCardsComponent.new(application_form.application_qualifications.degrees, application_choice_state: application_choice_state) %>
 </div>
 
 <div class="govuk-grid-column-full">

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -1,8 +1,7 @@
+<h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
+    <span class="govuk-details__summary-text">View guidance given to candidate</span>
   </summary>
   <div class="govuk-details__text">
     <h2 class="govuk-heading-m">Academic and other relevant qualifications</h2>
@@ -12,18 +11,9 @@
   </div>
 </details>
 
-<div class="govuk-grid-column-full">
+<div class="govuk-grid-row">
   <%= render DegreeQualificationCardsComponent.new(application_form.application_qualifications.degrees, application_choice_state: application_choice_state) %>
-</div>
-
-<div class="govuk-grid-column-full">
   <%= render GcseQualificationCardsComponent.new(application_form) %>
-</div>
-
-<div class="govuk-grid-column-two-thirds">
   <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, type_label: 'Academic or other qualification') %>
-</div>
-
- <div class="govuk-grid-column-full">
   <%= render EflQualificationCardComponent.new(application_form) %>
 </div>

--- a/app/components/qualifications_component.rb
+++ b/app/components/qualifications_component.rb
@@ -1,7 +1,8 @@
 class QualificationsComponent < ViewComponent::Base
-  attr_reader :application_form
+  attr_reader :application_form, :application_choice_state
 
-  def initialize(application_form:)
+  def initialize(application_form:, application_choice_state: nil)
     @application_form = application_form
+    @application_choice_state = application_choice_state
   end
 end

--- a/app/components/qualifications_table_component.html.erb
+++ b/app/components/qualifications_table_component.html.erb
@@ -1,5 +1,6 @@
 <% if qualifications.any? %>
   <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m govuk-!-margin-top-8" id="other-qualifications">Other qualifications</h3>
     <table class="govuk-table" data-qa="qualifications-table-<%= type_label.parameterize %>">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/components/qualifications_table_component.html.erb
+++ b/app/components/qualifications_table_component.html.erb
@@ -3,7 +3,7 @@
     <table class="govuk-table" data-qa="qualifications-table-<%= type_label.parameterize %>">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header govuk-table__header"><%= type_label %></th>
+          <th class="govuk-table__header govuk-table__header">Qualification</th>
           <th class="govuk-table__header govuk-table__header">Subject</th>
           <th class="govuk-table__header govuk-table__header">Started</th>
           <th class="govuk-table__header govuk-table__header">Awarded</th>

--- a/app/components/qualifications_table_component.html.erb
+++ b/app/components/qualifications_table_component.html.erb
@@ -1,18 +1,20 @@
 <% if qualifications.any? %>
-  <table class="govuk-table" data-qa="qualifications-table-<%= type_label.parameterize %>">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header govuk-table__header"><%= type_label %></th>
-        <th class="govuk-table__header govuk-table__header">Subject</th>
-        <th class="govuk-table__header govuk-table__header">Started</th>
-        <th class="govuk-table__header govuk-table__header">Awarded</th>
-        <th class="govuk-table__header govuk-table__header">Grade</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% qualifications.each do |qualification| %>
-        <%= render QualificationRowComponent.new(qualification: qualification) %>
-      <% end %>
-    </tbody>
-  </table>
+  <div class="govuk-grid-column-two-thirds">
+    <table class="govuk-table" data-qa="qualifications-table-<%= type_label.parameterize %>">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header govuk-table__header"><%= type_label %></th>
+          <th class="govuk-table__header govuk-table__header">Subject</th>
+          <th class="govuk-table__header govuk-table__header">Started</th>
+          <th class="govuk-table__header govuk-table__header">Awarded</th>
+          <th class="govuk-table__header govuk-table__header">Grade</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% qualifications.each do |qualification| %>
+          <%= render QualificationRowComponent.new(qualification: qualification) %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>

--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -1,13 +1,9 @@
 .app-card {
+  @include govuk-responsive-padding(4);
+  @include govuk-font($size: 19);
   background-color: govuk-colour("light-grey");
   display: block;
-  padding: govuk-spacing(2);
   text-decoration: none;
-  @include govuk-font($size: 19);
-
-  @include govuk-media-query($from: desktop) {
-    padding: govuk-spacing(4);
-  }
 }
 
 .app-card--blue {

--- a/app/frontend/styles/_flex-grid.scss
+++ b/app/frontend/styles/_flex-grid.scss
@@ -1,6 +1,13 @@
+@include govuk-media-query($until: tablet) {
+  .app-grid-row--flex > * {
+    margin-top: govuk-spacing(4);
+  }
+}
+
 @include govuk-media-query($from: tablet) {
   .app-grid-row--flex {
     display: flex;
+    flex-wrap: wrap;
 
     @each $width in map-keys($govuk-grid-widths) {
       .govuk-grid-column-#{$width} {

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -49,7 +49,7 @@
 
 <div class="govuk-grid-row">
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
-    <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>
+    <%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
 </div>
 
 

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'application_choice_header' %>
 
-<p class="govuk-body govuk-!-margin-bottom-9 govuk-!-display-none-print">
+<p class="govuk-body govuk-!-margin-bottom-8 govuk-!-display-none-print">
   <%= govuk_link_to(
     'Download application (PDF)',
     provider_interface_application_choice_path(@application_choice.id, format: :pdf),
@@ -12,18 +12,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
     <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) %>
 
-    <h2 class="govuk-heading-l" id="course-info">Application</h2>
+    <h2 class="govuk-heading-l" id="application">Application</h2>
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>
 
     <% unless HostingEnvironment.production? %>
       <div class="app-status-box app-status-box--sandbox govuk-!-display-none-print">
         <p class="govuk-body">
-          <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--sandbox">
-            sandbox feature
-          </strong>
+          <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--sandbox">Sandbox feature</strong>
         </p>
         <p class="govuk-body">
           See what this application looks like from the candidate side by signing in as <%= @application_choice.application_form.full_name %>:
@@ -32,26 +29,21 @@
       </div>
     <% end %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Course details</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-details">Course details</h2>
     <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice)%>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="disabilities">Disability, access and other needs</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="disability-access-and-other-needs">Disability, access and other needs</h2>
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
     <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user)%>
 
-
-    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Interview</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="interview">Interview</h2>
     <%= render InterviewPreferencesComponent.new(application_form: @application_choice.application_form) %>
   </div>
 </div>
 
-<div class="govuk-grid-row">
-    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
-    <%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
-</div>
-
+<%= render QualificationsComponent.new(application_form: @application_choice.application_form, application_choice_state: @application_choice.status) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -60,7 +52,7 @@
       <%= render ProviderInterface::WorkHistoryComponent.new(application_form: @application_choice.application_form) %>
     </div>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="volunteering">Unpaid experience and volunteering</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="unpaid-experience-and-volunteering">Unpaid experience and volunteering</h2>
     <div data-qa="volunteering">
       <%= render ProviderInterface::VolunteeringHistoryComponent.new(application_form: @application_choice.application_form) %>
     </div>
@@ -79,12 +71,12 @@
       <%= render 'references_context' %>
 
       <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>
-        <h2 class="govuk-heading-m govuk-!-margin-top-8"><%= "#{TextOrdinalizer.call((i + 1)).capitalize} referee" %></h2>
+        <h3 class="govuk-heading-m govuk-!-margin-top-8"><%= "#{TextOrdinalizer.call((i + 1)).capitalize} referee" %></h3>
         <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference) %>
       <% end %>
     <% end %>
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2">Diversity information</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="diversity-information">Diversity information</h2>
     <%= render ProviderInterface::DiversityInformationComponent.new(application_choice: @application_choice, current_provider_user: current_provider_user) %>
   </div>
 </div>

--- a/spec/components/degree_qualification_cards_component_spec.rb
+++ b/spec/components/degree_qualification_cards_component_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe DegreeQualificationCardsComponent, type: :component do
+  describe 'rendering a degree' do
+    let(:degree) do
+      create(
+        :degree_qualification,
+        qualification_type: 'Bachelor of Arts',
+        subject: 'Computer Science',
+        institution_name: 'The University of Oxford',
+        grade: 'First class honours',
+        predicted_grade: false,
+      )
+    end
+
+    it 'renders all expected detail' do
+      result = render_inline described_class.new([degree])
+
+      expect(result.text).to include 'BA (Hons) Computer Science'
+      expect(result.text).to include degree.start_year
+      expect(result.text).to include degree.award_year
+      expect(result.text).to include 'Grade'
+      expect(result.text).to include 'First class honours'
+      expect(result.text).to include 'Institution'
+      expect(result.text).to include 'The University of Oxford'
+    end
+
+    context 'when it is an international degree' do
+      before { degree.update(international: true, institution_country: 'AF') }
+
+      it 'renders the institution country' do
+        result = render_inline described_class.new([degree])
+        expect(result.text).to include 'The University of Oxford, Afghanistan'
+      end
+    end
+
+    context 'when the grade is predicted' do
+      before { degree.update(predicted_grade: true) }
+
+      it 'renders a prefix when displaying the grade' do
+        result = render_inline described_class.new([degree])
+        expect(result.text).to include 'Predicted: First class honours'
+      end
+    end
+
+    context 'when NARIC details are provided' do
+      before { degree.update(naric_reference: '1234', comparable_uk_degree: 'masters_degree') }
+
+      it 'renders a NARIC statement' do
+        result = render_inline described_class.new([degree])
+        expect(result.text).to include(
+          'NARIC statement 1234 says this is comparable to a Master’s degree / Integrated Master’s degree',
+        )
+      end
+    end
+
+    context 'when the grade is not honours' do
+      before { degree.update(grade: 'Pass') }
+
+      it 'does not display (Hons) after the degree type' do
+        result = render_inline described_class.new([degree])
+        expect(result.text).to include 'BA Computer Science'
+      end
+    end
+
+    describe 'deciding on displaying the institution' do
+      it 'is visible when no application_choice state is specified' do
+        result = render_inline described_class.new([degree])
+        expect(result.text).to include 'Institution'
+        expect(result.text).to include 'The University of Oxford'
+      end
+
+      it 'is visible when the application_choice state is in one of the ACCEPTED_STATES' do
+        ApplicationStateChange::ACCEPTED_STATES.each do |accepted_state|
+          result = render_inline described_class.new([degree], application_choice_state: accepted_state)
+          expect(result.text).to include 'Institution'
+          expect(result.text).to include 'The University of Oxford'
+        end
+      end
+
+      it 'is not visible when the application_choice state is not one of the ACCEPTED_STATES' do
+        (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange::ACCEPTED_STATES).each do |state|
+          result = render_inline described_class.new([degree], application_choice_state: state)
+          expect(result.text).to include 'Institution'
+          expect(result.text).not_to include 'The University of Oxford'
+          expect(result.text).to include 'Only available once an offer has been accepted'
+        end
+      end
+    end
+  end
+
+  describe 'rendering multiple degrees' do
+    let(:degree_1) { create(:degree_qualification) }
+    let(:degree_2) { create(:degree_qualification) }
+
+    it 'renders multiple cards containing degree details' do
+      result = render_inline described_class.new([degree_1, degree_2])
+
+      cards = result.css('.app-card--outline').each
+      first_card = cards.next
+      second_card = cards.next
+      expect(first_card.text).to include degree_1.subject
+      expect(first_card.text).to include degree_1.grade
+      expect(second_card.text).to include degree_2.subject
+      expect(second_card.text).to include degree_2.grade
+    end
+  end
+end

--- a/spec/components/efl_qualification_card_component_spec.rb
+++ b/spec/components/efl_qualification_card_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
           expect(result.text).to include 'Candidate has an English as a foreign language qualification'
 
-          details_card = result.css('#english-as-a-foreign-language .app-card--outline')
+          details_card = result.css('[data-qa="english-proficiency-qualification"]')
           expect(details_card.text).to include 'IELTS'
           expect(details_card.text).to include '1999'
           expect(details_card.text).to include 'Overall band score'
@@ -44,7 +44,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
           expect(result.text).to include 'Candidate has an English as a foreign language qualification'
 
-          details_card = result.css('#english-as-a-foreign-language .app-card--outline')
+          details_card = result.css('[data-qa="english-proficiency-qualification"]')
           expect(details_card.text).to include 'TOEFL'
           expect(details_card.text).to include '1999'
           expect(details_card.text).to include 'Total score'
@@ -64,7 +64,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
 
           expect(result.text).to include 'Candidate has an English as a foreign language qualification'
 
-          details_card = result.css('#english-as-a-foreign-language .app-card--outline')
+          details_card = result.css('[data-qa="english-proficiency-qualification"]')
           expect(details_card.text).to include 'Cockney Rhyming Slang Proficiency Test'
           expect(details_card.text).to include '2001'
           expect(details_card.text).to include 'Score or grade'

--- a/spec/components/qualifications_table_component_spec.rb
+++ b/spec/components/qualifications_table_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe QualificationsTableComponent do
   it 'renders nothing when no qualifications present' do
     result = render_inline(described_class.new(qualifications: [], type_label: 'My label'))
 
-    expect(result.to_s).to be_blank
+    expect(result.css('table')).to be_blank
   end
 
   it 'renders a qualifications table' do
@@ -13,6 +13,6 @@ RSpec.describe QualificationsTableComponent do
     ]
     result = render_inline(described_class.new(qualifications: qualifications, type_label: 'My label'))
 
-    expect(result.css('th').text).to include('My label')
+    expect(result.css('table').first['data-qa']).to eq 'qualifications-table-my-label'
   end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -169,7 +169,9 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   )
 
   def then_i_should_see_the_candidates_degrees
-    expect(page).to have_selector('[data-qa="qualifications-table-degree"] tbody tr', count: 1)
+    within '#degrees' do
+      expect(page).to have_selector('.app-card--outline', count: 1)
+    end
   end
 
   def and_i_should_see_the_candidates_gcses

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -169,15 +169,11 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   )
 
   def then_i_should_see_the_candidates_degrees
-    within '#degrees' do
-      expect(page).to have_selector('.app-card--outline', count: 1)
-    end
+    expect(page).to have_selector('[data-qa="degree-qualification"]', count: 1)
   end
 
   def and_i_should_see_the_candidates_gcses
-    within '#gcses' do
-      expect(page).to have_selector('.app-card--outline', count: 2)
-    end
+    expect(page).to have_selector('[data-qa="gcse-qualification"]', count: 2)
   end
 
   def and_i_should_see_the_candidates_other_qualifications


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Providers need to be able to see an international candidate's degrees. We want to display these in a new qualifications card component.

## Changes proposed in this pull request
Introduce a `DegreeQualificationCardsComponent` that renders a card for
each degree held by a candidate.

- Each card contains the details expected by the provider (subject,
  grade, degree type, etc)
- A NARIC statement is displayed if the corresponding database fields
  contain values
- An '(Hons)' is appended to the degree type if the awarded grade is an
  honours
- Predicted grades are prefixed with 'Predicted:'
- The component can be initialised with an optional
  `application_choice_state` argument. If provided, we only show the
  institution name if the application is in an 'offer accepted' state.
  This was implemented as an optional argument because this component is
  also used in the Support interface, where hiding the institution isn't
  a requirement.
<!-- If there are UI changes, please include Before and After screenshots. -->

### Before
![Screenshot_20200917_115059](https://user-images.githubusercontent.com/519250/93461023-0ba3d000-f8dc-11ea-8b38-3a0167b10b1d.png)

### After
![Screenshot_20200917_115035](https://user-images.githubusercontent.com/519250/93460986-fcbd1d80-f8db-11ea-821d-3a72eda02c4b.png)




## Guidance to review

- Should be possible to submit different applications on the review app to then view in Manage. May need to switch the app to 'Mid-cycle' in support.
- An outline of the `DegreeQualificationCardsComponent` behaviour from the spec output:

![Screenshot_20200917_113800](https://user-images.githubusercontent.com/519250/93460939-e9aa4d80-f8db-11ea-9907-f331dd3684a6.png)
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/66hZWX9d
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
