### PR TITLE
Cancel outstanding references at the end of cycle

### DIFF
--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -121,10 +121,8 @@ module CandidateInterface
         :green
       when 'feedback_overdue'
         :yellow
-      when 'cancelled'
+      when 'cancelled', 'cancelled_at_end_of_cycle'
         :orange
-      when 'cancelled_at_end_of_cycle'
-        :pink
       when 'feedback_refused', 'email_bounced'
         :red
       end

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -88,7 +88,7 @@ module CandidateInterface
     end
 
     def feedback_status_text(reference)
-      return t('candidate_reference_status.feedback_overdue') if reference.feedback_overdue?
+      return t('candidate_reference_status.feedback_overdue') if reference.feedback_overdue? && !reference.cancelled_at_end_of_cycle?
 
       t("candidate_reference_status.#{reference.feedback_status}")
     end
@@ -98,6 +98,8 @@ module CandidateInterface
         tag.p(t('application_form.referees.info.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.feedback_refused?
         tag.p(t('application_form.referees.info.declined'), class: 'govuk-body govuk-!-margin-top-2')
+      elsif referee.cancelled_at_end_of_cycle?
+        tag.p(t('application_form.referees.info.cancelled_at_end_of_cycle'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.feedback_overdue?
         tag.p(t('application_form.referees.info.feedback_overdue'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.feedback_requested? && referee.requested_at > Time.zone.now - 5.days
@@ -121,6 +123,8 @@ module CandidateInterface
         :yellow
       when 'cancelled'
         :orange
+      when 'cancelled_at_end_of_cycle'
+        :pink
       when 'feedback_refused', 'email_bounced'
         :red
       end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -83,7 +83,7 @@ class ApplicationReference < ApplicationRecord
 
   def feedback_overdue?
     return unless replace_referee_at
-    return unless feedback_requested?
+    return unless feedback_requested? || cancelled_at_end_of_cycle?
 
     replace_referee_at < Time.zone.now
   end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -19,6 +19,7 @@ class ApplicationReference < ApplicationRecord
 
   enum feedback_status: {
     cancelled: 'cancelled',
+    cancelled_at_end_of_cycle: 'cancelled_at_end_of_cycle',
     not_requested_yet: 'not_requested_yet',
     feedback_requested: 'feedback_requested',
     feedback_provided: 'feedback_provided',

--- a/app/services/candidate_interface/cancel_reference_at_end_of_cycle.rb
+++ b/app/services/candidate_interface/cancel_reference_at_end_of_cycle.rb
@@ -1,0 +1,10 @@
+module CandidateInterface
+  class CancelReferenceAtEndOfCycle
+    def self.call(application_reference)
+      ActiveRecord::Base.transaction do
+        application_reference.cancelled_at_end_of_cycle!
+        RefereeMailer.reference_cancelled_email(application_reference).deliver_later
+      end
+    end
+  end
+end

--- a/app/workers/reject_awaiting_references_course_choices_worker.rb
+++ b/app/workers/reject_awaiting_references_course_choices_worker.rb
@@ -6,6 +6,11 @@ class RejectAwaitingReferencesCourseChoicesWorker
       application_form.application_choices.awaiting_references.each do |application_choice|
         CandidateInterface::RejectAwaitingReferencesApplication.call(application_choice)
       end
+
+      application_form.application_references.each do |application_reference|
+        CandidateInterface::CancelReferenceAtEndOfCycle.call(application_reference)
+      end
+
       CandidateMailer.referees_did_not_respond_before_end_of_cycle(application_form).deliver_later
     end
   end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -377,7 +377,7 @@ en:
         awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
         awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
         cancelled: You cancelled your reference request.
-        cancelled_at_end_of_cycle: Your reference was cancelled at the end of the cycle.
+        cancelled_at_end_of_cycle: The referee did not respond before courses closed.
         feedback_overdue: Your referee has not responded yet. Keep chasing the referee or cancel the request in favour of another referee.
   activemodel:
     errors:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -377,6 +377,7 @@ en:
         awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
         awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
         cancelled: You cancelled your reference request.
+        cancelled_at_end_of_cycle: Your reference was cancelled at the end of the cycle.
         feedback_overdue: Your referee has not responded yet. Keep chasing the referee or cancel the request in favour of another referee.
   activemodel:
     errors:

--- a/config/locales/reference.yml
+++ b/config/locales/reference.yml
@@ -8,7 +8,7 @@ en:
     email_bounced: Email bounced
   candidate_reference_status:
     cancelled: Cancelled
-    cancelled_at_end_of_cycle: Cancelled at end of cycle
+    cancelled_at_end_of_cycle: Cancelled
     not_requested_yet: Not requested yet
     feedback_requested: Awaiting response
     feedback_provided: Reference given

--- a/config/locales/reference.yml
+++ b/config/locales/reference.yml
@@ -8,6 +8,7 @@ en:
     email_bounced: Email bounced
   candidate_reference_status:
     cancelled: Cancelled
+    cancelled_at_end_of_cycle: Cancelled at end of cycle
     not_requested_yet: Not requested yet
     feedback_requested: Awaiting response
     feedback_provided: Reference given

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -112,6 +112,18 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.cancelled'))
     end
 
+    it 'renders component with correct value for status for cancelled_at_end_of_cycle reference request' do
+      first_referee = application_form.application_references.first
+      first_referee.update_columns(
+        feedback_status: 'cancelled_at_end_of_cycle',
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-tag.govuk-tag--pink.app-tag').to_html).to include('Cancelled at end of cycle')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.cancelled_at_end_of_cycle'))
+    end
+
     it 'renders component along with a delete link for each referee' do
       referee_id = application_form.application_references.first.id
       result = render_inline(described_class.new(application_form: application_form))

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-tag.govuk-tag--pink.app-tag').to_html).to include('Cancelled at end of cycle')
+      expect(result.css('.govuk-tag.govuk-tag--orange.app-tag').to_html).to include('Cancelled')
       expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.cancelled_at_end_of_cycle'))
     end
 

--- a/spec/services/candidate_interface/cancel_reference_at_end_of_cycle_spec.rb
+++ b/spec/services/candidate_interface/cancel_reference_at_end_of_cycle_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::CancelReferenceAtEndOfCycle do
+  describe '#call' do
+    let(:application_reference) { create(:reference, :requested) }
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    before do
+      allow(RefereeMailer).to receive(:reference_cancelled_email).and_return(mail)
+    end
+
+    it 'cancels a reference at the end of the cycle' do
+      described_class.call(application_reference)
+
+      expect(application_reference.feedback_status).to eq 'cancelled_at_end_of_cycle'
+      expect(RefereeMailer).to have_received(:reference_cancelled_email).with(application_reference)
+      expect(mail).to have_received(:deliver_later)
+    end
+  end
+end

--- a/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
+++ b/spec/workers/reject_awaiting_references_course_choices_worker_spec.rb
@@ -4,18 +4,26 @@ RSpec.describe RejectAwaitingReferencesCourseChoicesWorker do
   describe '#perform' do
     it 'calls the appropriate services' do
       application_choice = create(:application_choice, :awaiting_references)
+      reference1 = create(:reference, :feedback_requested, application_form: application_choice.application_form)
+      reference2 = create(:reference, :feedback_requested, application_form: application_choice.application_form)
+
       application_form = application_choice.application_form
       application_choice_withdrawn = create(:application_choice, :withdrawn, application_form: application_form)
 
       allow(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to receive(:call).and_return([application_choice.application_form])
       allow(CandidateMailer).to receive(:referees_did_not_respond_before_end_of_cycle).and_call_original
       allow(CandidateInterface::RejectAwaitingReferencesApplication).to receive(:call).and_call_original
+      allow(CandidateInterface::CancelReferenceAtEndOfCycle).to receive(:call).and_return(true)
+
       RejectAwaitingReferencesCourseChoicesWorker.new.perform
 
       expect(CandidateInterface::GetPreviousCyclesAwaitingReferencesApplications).to have_received(:call)
       expect(CandidateMailer).to have_received(:referees_did_not_respond_before_end_of_cycle).with(application_choice.application_form)
       expect(CandidateInterface::RejectAwaitingReferencesApplication).to have_received(:call).with(application_choice)
       expect(CandidateInterface::RejectAwaitingReferencesApplication).not_to have_received(:call).with(application_choice_withdrawn)
+
+      expect(CandidateInterface::CancelReferenceAtEndOfCycle).to have_received(:call).with(reference1)
+      expect(CandidateInterface::CancelReferenceAtEndOfCycle).to have_received(:call).with(reference2)
     end
   end
 end


### PR DESCRIPTION
## Context

Any outstanding reference requests which have not been received by the 18th September should be cancelled.

## Changes proposed in this pull request

- Add a 'cancelled_at_end_of_cycle' state to ApplicationReference
- Set all references which have not been received by EOC to the 'cancelled_at_end_of_cycle' state
- Carry over non-overdue referees details in the DuplicateApplication service


![image](https://user-images.githubusercontent.com/42515961/93489235-2cc9e800-f8ff-11ea-8df5-784b29701f0a.png)

## Guidance to review

There might be a potential issue with this implementation. If a Candidate added a reference just before EoC say 16/09 then their reference will be cancelled on 19/09. If they then don't log in for a month then those references will not be carried over as the feedback will be overdue. 

Not a huge issue though as it's a pretty niche context.

This will need a design and content review.

## Link to Trello card

https://trello.com/c/L93EMrXk/2125-dev-%F0%9F%9A%B2%F0%9F%94%9A-cancel-outstanding-ref-requests-on-18th

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
