### PR TITLE
Replace English foreign lang qual with English foreign lang assessment

### DIFF
--- a/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
+++ b/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
       def do_you_have_a_qualification_row(value:)
         {
-          key: 'Do you have an English as a foreign language qualification?',
+          key: 'Do you have an English as a foreign language assessment?',
           value: value,
           action: 'Change whether or not you have a qualification',
           change_path: candidate_interface_english_foreign_language_edit_start_path,

--- a/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
+++ b/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
       def do_you_have_a_qualification_row(value:)
         {
-          key: 'Do you have an English as a foreign language assessment?',
+          key: 'Have you done an English as a foreign language assessment?',
           value: value,
           action: 'Change whether or not you have a qualification',
           change_path: candidate_interface_english_foreign_language_edit_start_path,
@@ -14,9 +14,9 @@ module CandidateInterface
 
       def type_of_qualification_row(name:)
         {
-          key: 'Type of qualification',
+          key: 'Type of assessment',
           value: name,
-          action: 'Change type of qualification',
+          action: 'Change type of assessment',
           change_path: candidate_interface_english_foreign_language_type_path,
         }
       end

--- a/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
@@ -21,7 +21,7 @@ module CandidateInterface
         if english_proficiency.qualification_not_needed?
           'No, English is not a foreign language to me'
         else
-          tag.p('No, I do not have an English as a foreign language assessment', class: 'govuk-body') +
+          tag.p('No, I have not done an English as a foreign language assessment', class: 'govuk-body') +
             tag.p(english_proficiency.no_qualification_details, class: 'govuk-body')
         end
       end

--- a/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component.rb
@@ -21,7 +21,7 @@ module CandidateInterface
         if english_proficiency.qualification_not_needed?
           'No, English is not a foreign language to me'
         else
-          tag.p('No, I do not have an English as a foreign language qualification', class: 'govuk-body') +
+          tag.p('No, I do not have an English as a foreign language assessment', class: 'govuk-body') +
             tag.p(english_proficiency.no_qualification_details, class: 'govuk-body')
         end
       end

--- a/app/components/efl_qualification_card_component.rb
+++ b/app/components/efl_qualification_card_component.rb
@@ -19,9 +19,9 @@ class EflQualificationCardComponent < ViewComponent::Base
 
   def qualification_status
     if english_proficiency.has_qualification?
-      'Candidate has an English as a foreign language qualification.'
+      'Candidate has an English as a foreign language assessment.'
     elsif english_proficiency.no_qualification?
-      'Candidate does not have an English as a foreign language qualification yet.'
+      'Candidate does not have an English as a foreign language assessment yet.'
     else
       'Candidate said that English is not a foreign language to them.'
     end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -58,7 +58,7 @@
 <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
 <% if @application_form.efl_section_required? %>
-  <h3 class="govuk-heading-m">English as a foreign language qualification</h3>
+  <h3 class="govuk-heading-m">English as a foreign language assessment</h3>
   <% if @application_form.english_proficiency.present? %>
     <%= render(CandidateInterface::ChooseEflReviewComponent.call(@application_form.english_proficiency)) %>
   <% else %>

--- a/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
@@ -4,7 +4,7 @@
   <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I have not done an English as a foreign language assessment' } do %>
     <p class='govuk-hint'>If English is a foreign language to you, or if you do not have an English GCSE or equivalent, you may have to give evidence for your level of English.</p>
     <p class='govuk-hint'>Contact your provider for advice about showing your level of English.</p>
-    <%= f.govuk_text_area :no_qualification_details, max_words: 200, label: { text: "If you’re planning on doing an assessment, give details here ", size: 's'} %>
+    <%= f.govuk_text_area :no_qualification_details, max_words: 200, label: { text: "If you’re planning on doing an assessment, give details here", size: 's'} %>
   <% end %>
 <% end %>
 

--- a/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
@@ -1,10 +1,10 @@
-<%= f.govuk_radio_buttons_fieldset :qualification_status, legend: { size: 'm', text: 'Do you have an English as a foreign language assessment?', tag: 'span' } do %>
+<%= f.govuk_radio_buttons_fieldset :qualification_status, legend: { size: 'm', text: 'Have you done an English as a foreign language assessment?', tag: 'span' } do %>
   <%= f.govuk_radio_button :qualification_status, 'has_qualification', label: { text: 'Yes' } %>
   <%= f.govuk_radio_button :qualification_status, 'qualification_not_needed', label: { text: 'No, English is not a foreign language to me' } %>
-  <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I do not have an English as a foreign language assessment' } do %>
+  <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I have not done an English as a foreign language assessment' } do %>
     <p class='govuk-hint'>If English is a foreign language to you, or if you do not have an English GCSE or equivalent, you may have to give evidence for your level of English.</p>
     <p class='govuk-hint'>Contact your provider for advice about showing your level of English.</p>
-    <%= f.govuk_text_area :no_qualification_details, max_words: 200, label: { text: "If you’re working towards a qualification, give details here", size: 's'} %>
+    <%= f.govuk_text_area :no_qualification_details, max_words: 200, label: { text: "If you’re planning on doing an assessment, give details here ", size: 's'} %>
   <% end %>
 <% end %>
 

--- a/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
@@ -1,7 +1,7 @@
-<%= f.govuk_radio_buttons_fieldset :qualification_status, legend: { size: 'm', text: 'Do you have an English as a foreign language qualification?', tag: 'span' } do %>
+<%= f.govuk_radio_buttons_fieldset :qualification_status, legend: { size: 'm', text: 'Do you have an English as a foreign language assessment?', tag: 'span' } do %>
   <%= f.govuk_radio_button :qualification_status, 'has_qualification', label: { text: 'Yes' } %>
   <%= f.govuk_radio_button :qualification_status, 'qualification_not_needed', label: { text: 'No, English is not a foreign language to me' } %>
-  <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I do not have an English as a foreign language qualification' } do %>
+  <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I do not have an English as a foreign language assessment' } do %>
     <p class='govuk-hint'>If English is a foreign language to you, or if you do not have an English GCSE or equivalent, you may have to give evidence for your level of English.</p>
     <p class='govuk-hint'>Contact your provider for advice about showing your level of English.</p>
     <%= f.govuk_text_area :no_qualification_details, max_words: 200, label: { text: "If you’re working towards a qualification, give details here", size: 's'} %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -578,7 +578,7 @@ en:
         candidate_interface/english_foreign_language/start_form:
           attributes:
             qualification_status:
-              blank: Do you have an English as a foreign language qualification?
+              blank: Do you have an English as a foreign language assessment?
         candidate_interface/english_foreign_language/type_form:
           attributes:
             type:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -578,7 +578,7 @@ en:
         candidate_interface/english_foreign_language/start_form:
           attributes:
             qualification_status:
-              blank: Do you have an English as a foreign language assessment?
+              blank: Have you done an English as a foreign language assessment?
         candidate_interface/english_foreign_language/type_form:
           attributes:
             type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,12 +10,12 @@ en:
     application_edit: Editing your application
     eligibility: Check we’re ready for you to use this service
     efl:
-      ielts: Add IELTS qualification
-      other: Add English language qualification
+      ielts: Your IELTS result
+      other: Your English language assessment result
       review: English as a foreign language
       start: English as a foreign language
-      toefl: Add TOEFL qualification
-      type: What English language qualification do you have?
+      toefl: Your TOEFL result
+      type: What English language assessment did you do?
     error_prefix: "Error: "
     success_prefix: "Success: "
     not_eligible_yet: We’re sorry, but we’re not ready for you yet

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -41,7 +41,7 @@ en:
       complete_section: Complete your academic and other relevant qualifications
     efl:
       incomplete: English as a foreign language not marked as complete
-      complete_section: Do you have an English as a foreign language assessment?
+      complete_section: Have you done an English as a foreign language assessment?
     becoming_a_teacher:
       incomplete: Personal statement not entered
       complete_section: Why do you want to be a teacher?

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -41,7 +41,7 @@ en:
       complete_section: Complete your academic and other relevant qualifications
     efl:
       incomplete: English as a foreign language not marked as complete
-      complete_section: Do you have an English as a foreign language qualification?
+      complete_section: Do you have an English as a foreign language assessment?
     becoming_a_teacher:
       incomplete: Personal statement not entered
       complete_section: Why do you want to be a teacher?

--- a/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
     result = render_inline(described_class.new(ielts_qualification))
 
     [
-      { position: 0, title: 'Do you have an English as a foreign language qualification?', value: 'Yes' },
+      { position: 0, title: 'Do you have an English as a foreign language assessment?', value: 'Yes' },
       { position: 1, title: 'Type of qualification', value: 'IELTS' },
       { position: 2, title: 'Test report form (TRF) number', value: '111111' },
       { position: 3, title: 'Year awarded', value: '2001' },

--- a/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/ielts_review_component_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsReviewComponent,
     result = render_inline(described_class.new(ielts_qualification))
 
     [
-      { position: 0, title: 'Do you have an English as a foreign language assessment?', value: 'Yes' },
-      { position: 1, title: 'Type of qualification', value: 'IELTS' },
+      { position: 0, title: 'Have you done an English as a foreign language assessment?', value: 'Yes' },
+      { position: 1, title: 'Type of assessment', value: 'IELTS' },
       { position: 2, title: 'Test report form (TRF) number', value: '111111' },
       { position: 3, title: 'Year awarded', value: '2001' },
       { position: 4, title: 'Overall band score', value: '8' },

--- a/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
 
     row = {
       position: 0,
-      title: 'Do you have an English as a foreign language qualification?',
-      answer: 'No, I do not have an English as a foreign language qualification',
+      title: 'Do you have an English as a foreign language assessment?',
+      answer: 'No, I do not have an English as a foreign language assessment',
       detail: "I'm working on it.",
     }
     expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
 
     row = {
       position: 0,
-      title: 'Do you have an English as a foreign language qualification?',
+      title: 'Do you have an English as a foreign language assessment?',
       answer: 'No, English is not a foreign language to me',
     }
     expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])

--- a/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/no_efl_qualification_review_component_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
 
     row = {
       position: 0,
-      title: 'Do you have an English as a foreign language assessment?',
-      answer: 'No, I do not have an English as a foreign language assessment',
+      title: 'Have you done an English as a foreign language assessment?',
+      answer: 'No, I have not done an English as a foreign language assessment',
       detail: "I'm working on it.",
     }
     expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::NoEflQualificationRev
 
     row = {
       position: 0,
-      title: 'Do you have an English as a foreign language assessment?',
+      title: 'Have you done an English as a foreign language assessment?',
       answer: 'No, English is not a foreign language to me',
     }
     expect(result.css('.govuk-summary-list__key')[row[:position]].text).to include(row[:title])

--- a/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
     result = render_inline(described_class.new(other_qualification))
 
     [
-      { position: 0, title: 'Do you have an English as a foreign language qualification?', value: 'Yes' },
+      { position: 0, title: 'Do you have an English as a foreign language assessment?', value: 'Yes' },
       { position: 1, title: 'Type of qualification', value: 'Some English Test' },
       { position: 2, title: 'Score or grade', value: '8' },
       { position: 3, title: 'Year awarded', value: '2001' },

--- a/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/other_efl_qualification_review_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualificationReviewComponent, type: :component do
-  it 'renders a review summary for the qualification' do
+  it 'renders a review summary for the assessment' do
     other_qualification = build(
       :other_efl_qualification,
       name: 'Some English Test',
@@ -11,8 +11,8 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
     result = render_inline(described_class.new(other_qualification))
 
     [
-      { position: 0, title: 'Do you have an English as a foreign language assessment?', value: 'Yes' },
-      { position: 1, title: 'Type of qualification', value: 'Some English Test' },
+      { position: 0, title: 'Have you done an English as a foreign language assessment?', value: 'Yes' },
+      { position: 1, title: 'Type of assessment', value: 'Some English Test' },
       { position: 2, title: 'Score or grade', value: '8' },
       { position: 3, title: 'Year awarded', value: '2001' },
     ].each do |row|

--- a/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflReviewComponent,
     result = render_inline(described_class.new(toefl_qualification))
 
     [
-      { position: 0, title: 'Do you have an English as a foreign language qualification?', value: 'Yes' },
+      { position: 0, title: 'Do you have an English as a foreign language assessment?', value: 'Yes' },
       { position: 1, title: 'Type of qualification', value: 'TOEFL' },
       { position: 2, title: 'TOEFL registration number', value: '222222 22222' },
       { position: 3, title: 'Year awarded', value: '2001' },

--- a/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
+++ b/spec/components/candidate_interface/english_foreign_language/toefl_review_component_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflReviewComponent,
     result = render_inline(described_class.new(toefl_qualification))
 
     [
-      { position: 0, title: 'Do you have an English as a foreign language assessment?', value: 'Yes' },
-      { position: 1, title: 'Type of qualification', value: 'TOEFL' },
+      { position: 0, title: 'Have you done an English as a foreign language assessment?', value: 'Yes' },
+      { position: 1, title: 'Type of assessment', value: 'TOEFL' },
       { position: 2, title: 'TOEFL registration number', value: '222222 22222' },
       { position: 3, title: 'Year awarded', value: '2001' },
       { position: 4, title: 'Total score', value: '80' },

--- a/spec/components/efl_qualification_card_component_spec.rb
+++ b/spec/components/efl_qualification_card_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
         it 'renders the expected output' do
           result = render_inline(described_class.new(application_form))
 
-          expect(result.text).to include 'Candidate has an English as a foreign language qualification'
+          expect(result.text).to include 'Candidate has an English as a foreign language assessment'
 
           details_card = result.css('#english-as-a-foreign-language .app-card--outline')
           expect(details_card.text).to include 'IELTS'
@@ -42,7 +42,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
         it 'renders the expected output' do
           result = render_inline(described_class.new(application_form))
 
-          expect(result.text).to include 'Candidate has an English as a foreign language qualification'
+          expect(result.text).to include 'Candidate has an English as a foreign language assessment'
 
           details_card = result.css('#english-as-a-foreign-language .app-card--outline')
           expect(details_card.text).to include 'TOEFL'
@@ -62,7 +62,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
         it 'renders the expected output' do
           result = render_inline(described_class.new(application_form))
 
-          expect(result.text).to include 'Candidate has an English as a foreign language qualification'
+          expect(result.text).to include 'Candidate has an English as a foreign language assessment'
 
           details_card = result.css('#english-as-a-foreign-language .app-card--outline')
           expect(details_card.text).to include 'Cockney Rhyming Slang Proficiency Test'
@@ -87,7 +87,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       it 'renders the expected output' do
         result = render_inline(described_class.new(application_form))
 
-        expect(result.text).to include 'Candidate does not have an English as a foreign language qualification yet'
+        expect(result.text).to include 'Candidate does not have an English as a foreign language assessment yet'
         expect(result.text).to include 'Waiting for results'
         details_card = result.css('#english-as-a-foreign-language .app-card--outline')
         expect(details_card).to be_blank

--- a/spec/system/candidate_interface/english_as_a_foreign_language/change_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/change_qualification_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Change qualification' do
   end
 
   def then_i_can_change_my_qualification
-    click_link 'Change type of qualification'
+    click_link 'Change type of assessment'
     choose 'Test of English as a Foreign Language (TOEFL)'
     click_button 'Continue'
 

--- a/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
@@ -20,9 +20,9 @@ RSpec.feature 'Declare no EFL qualification' do
   end
 
   def when_i_declare_i_have_no_qualification
-    choose 'No, I do not have an English as a foreign language assessment'
+    choose 'No, I have not done an English as a foreign language assessment'
     fill_in(
-      'If you’re working towards a qualification, give details here',
+      'If you’re planning on doing an assessment, give details here ',
       with: "I'm working towards an IELTS.",
     )
     click_button 'Continue'
@@ -30,7 +30,7 @@ RSpec.feature 'Declare no EFL qualification' do
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_foreign_language_review_path
-    expect(page).to have_content 'No, I do not have an English as a foreign language assessment'
+    expect(page).to have_content 'No, I have not done an English as a foreign language assessment'
     expect(page).to have_content "I'm working towards an IELTS."
   end
 

--- a/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Declare no EFL qualification' do
   end
 
   def when_i_declare_i_have_no_qualification
-    choose 'No, I do not have an English as a foreign language qualification'
+    choose 'No, I do not have an English as a foreign language assessment'
     fill_in(
       'If you’re working towards a qualification, give details here',
       with: "I'm working towards an IELTS.",
@@ -30,7 +30,7 @@ RSpec.feature 'Declare no EFL qualification' do
 
   def then_i_see_the_review_page
     expect(page).to have_current_path candidate_interface_english_foreign_language_review_path
-    expect(page).to have_content 'No, I do not have an English as a foreign language qualification'
+    expect(page).to have_content 'No, I do not have an English as a foreign language assessment'
     expect(page).to have_content "I'm working towards an IELTS."
   end
 

--- a/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/declare_no_qualification_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Declare no EFL qualification' do
   def when_i_declare_i_have_no_qualification
     choose 'No, I have not done an English as a foreign language assessment'
     fill_in(
-      'If you’re planning on doing an assessment, give details here ',
+      'If you’re planning on doing an assessment, give details here',
       with: "I'm working towards an IELTS.",
     )
     click_button 'Continue'

--- a/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
@@ -31,6 +31,6 @@ RSpec.feature 'View EFL form' do
   end
 
   def then_i_see_the_efl_form
-    expect(page).to have_content 'Do you have an English as a foreign language assessment?'
+    expect(page).to have_content 'Have you done an English as a foreign language assessment?'
   end
 end

--- a/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/view_efl_form_spec.rb
@@ -31,6 +31,6 @@ RSpec.feature 'View EFL form' do
   end
 
   def then_i_see_the_efl_form
-    expect(page).to have_content 'Do you have an English as a foreign language qualification?'
+    expect(page).to have_content 'Do you have an English as a foreign language assessment?'
   end
 end

--- a/spec/system/candidate_interface/english_as_a_foreign_language/your_ielts_results_spec.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/your_ielts_results_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Add IELTS qualification' do
+RSpec.feature 'Your IELTS result' do
   include CandidateHelper
   include EFLHelper
 

--- a/spec/system/candidate_interface/english_as_a_foreign_language/your_toefl_result.rb
+++ b/spec/system/candidate_interface/english_as_a_foreign_language/your_toefl_result.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Add TOEFL qualification' do
+RSpec.feature 'Your TOEFL result' do
   include CandidateHelper
   include EFLHelper
 

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature 'International candidate submits the application' do
 
   def when_i_complete_the_efl_section
     within '#missing-efl-error' do
-      click_link 'Do you have an English as a foreign language assessment?'
+      click_link 'Have you done an English as a foreign language assessment?'
     end
 
     choose 'No, English is not a foreign language to me'

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature 'International candidate submits the application' do
 
   def when_i_complete_the_efl_section
     within '#missing-efl-error' do
-      click_link 'Do you have an English as a foreign language qualification?'
+      click_link 'Do you have an English as a foreign language assessment?'
     end
 
     choose 'No, English is not a foreign language to me'


### PR DESCRIPTION
## Context

Changing text in the application to read English as a foreign language

## Changes proposed in this pull request

Text previously read "English as a foreign language qualification" now reads "English as a foreign language assessment". on the views in the files changed. let me know if a list of these would be more helpful.

## Guidance to review

Check that content change is consistently applied throughout the app 

## Link to Trello card

https://trello.com/c/Up35mAyz/2142-%F0%9F%8C%90-dev-change-all-refs-to-english-as-a-foreign-language-qual-to-assessment

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
