### PR TITLE
Don't show the referee banner at end of cycle

### DIFF
--- a/app/components/candidate_interface/new_references_needed_component.rb
+++ b/app/components/candidate_interface/new_references_needed_component.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     end
 
     def render?
-      reference_status.still_more_references_needed?
+      reference_status.still_more_references_needed? && EndOfCyclePolicy.can_add_course_choice?(application_form)
     end
 
     def pluralize_referee

--- a/spec/components/candidate_interface/new_references_needed_component_spec.rb
+++ b/spec/components/candidate_interface/new_references_needed_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::NewReferencesNeededComponent do
+  describe '#render?' do
+    let(:application_form) { create(:completed_application_form) }
+
+    context 'when an application form needs more references' do
+      it 'renders the component' do
+        allow(CandidateInterface::EndOfCyclePolicy).to receive(:can_add_course_choice?).and_return(true)
+        create(:reference, :requested, application_form: application_form, requested_at: Time.zone.now - 30.days)
+
+        expect(described_class.new(application_form: application_form).render?).to be_truthy
+      end
+    end
+
+    context "when we're at the end of the cycle" do
+      it 'does not render the component' do
+        allow(CandidateInterface::EndOfCyclePolicy).to receive(:can_add_course_choice?).and_return(false)
+        create(:reference, :requested, application_form: application_form, requested_at: Time.zone.now - 30.days)
+
+        expect(described_class.new(application_form: application_form).render?).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We shouldn't prompt candidates to add/replace referees at the end of the cycle.

## Changes proposed in this pull request

Don't `render?` when we're at the end of the cycle.

## Guidance to review

Makes sense?

### Before

<img width="1024" alt="Screenshot 2020-09-18 at 10 56 24" src="https://user-images.githubusercontent.com/1650875/93585456-c09ec100-f99e-11ea-889c-3e594f7285e7.png">

### After

<img width="1041" alt="Screenshot 2020-09-18 at 10 56 35" src="https://user-images.githubusercontent.com/1650875/93585460-c1375780-f99e-11ea-8dba-858d70ceba86.png">

## Link to Trello card

None.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)