### PR TITLE
Add I18n fallback when showing GCSE qualifications

### DIFF
--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -35,7 +35,7 @@ class GcseQualificationCardsComponent < ViewComponent::Base
     elsif qualification.non_uk_qualification_type.present?
       qualification.non_uk_qualification_type
     else
-      I18n.t!("application_form.gcse.qualification_types.#{qualification.qualification_type}")
+      I18n.t("application_form.gcse.qualification_types.#{qualification.qualification_type}", default: qualification.qualification_type)
     end
   end
 


### PR DESCRIPTION
This fixes a bug in QA where some records in the scope
`ApplicationQualification.gcse` have a `qualification_type` of "GCSE"
(in caps). This isn't an expected state of the system, temporarily fix it
until the QA data task has been debugged.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
