### PR TITLE
Add missing support translation string for cancelled at eoc references

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -127,7 +127,7 @@ module SupportInterface
         :green
       when 'feedback_overdue'
         :yellow
-      when 'cancelled'
+      when 'cancelled', 'cancelled_at_end_of_cycle'
         :orange
       when 'feedback_refused', 'email_bounced'
         :red

--- a/config/locales/reference.yml
+++ b/config/locales/reference.yml
@@ -1,6 +1,7 @@
 en:
   reference_status:
     cancelled: Cancelled
+    cancelled_at_end_of_cycle: Cancelled at end of cycle
     not_requested_yet: Not requested yet
     feedback_requested: Requested
     feedback_provided: Feedback provided


### PR DESCRIPTION
## Context

:bug:

## Changes proposed in this pull request

:wrench:

## Guidance to review

:thinking:

![Screenshot 2020-09-18 at 15 23 41](https://user-images.githubusercontent.com/1650875/93608813-f9e92800-f9c2-11ea-91e0-5cb6900a83b1.png)

## Link to Trello card

:speak_no_evil:

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)