### PR TITLE
Fix CancelUnsubmittedApplicationsWorker

### DIFF
--- a/app/services/candidate_interface/cancel_unsubmitted_application_at_end_of_cycle.rb
+++ b/app/services/candidate_interface/cancel_unsubmitted_application_at_end_of_cycle.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     end
 
     def call
-      @application_form.application_choices.each do |application_choice|
+      @application_form.application_choices.unsubmitted.each do |application_choice|
         ApplicationStateChange.new(application_choice).reject_at_end_of_cycle!
       end
     end

--- a/app/workers/cancel_unsubmitted_applications_worker.rb
+++ b/app/workers/cancel_unsubmitted_applications_worker.rb
@@ -20,8 +20,8 @@ private
         hidden_candidates: Candidate.where(hide_in_reporting: true).select(:id),
       )
       .where(
-        'application_forms.id NOT IN (:duplicated_applications)',
-        duplicated_applications: ApplicationForm.where.not(previous_application_form_id: nil).select(:previous_application_form_id),
+        'application_forms.id IN (:unsubmitted_application_choices)',
+        unsubmitted_application_choices: ApplicationChoice.unsubmitted.select(:application_form_id),
       )
       .includes(:application_choices)
       .distinct

--- a/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
         course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
       )
 
+      unsubmitted_cancelled_application_from_this_year = create(
+        :completed_application_form,
+        submitted_at: nil,
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+      )
+      create(
+        :application_choice,
+        status: :application_not_sent,
+        application_form: unsubmitted_cancelled_application_from_this_year,
+        course_option: create(:course_option, course: create(:course, recruitment_cycle_year: RecruitmentCycle.current_year)),
+      )
+
       described_class.new.perform
 
       expect(unsubmitted_application_from_this_year.reload.application_choices.first).to be_application_not_sent
@@ -62,6 +74,7 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
       expect(unsubmitted_application_from_last_year.reload.application_choices.first).not_to be_application_not_sent
       expect(rejected_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
       expect(hidden_application_from_this_year.reload.application_choices.first).not_to be_application_not_sent
+      expect(unsubmitted_cancelled_application_from_this_year.reload.application_choices.first).to be_application_not_sent
     end
   end
 end


### PR DESCRIPTION
## Context

This worker was failing if run a second time, after having processed at least one un-submitted application on an earlier run. This is because the condition in the query that prevented it picking up previously processed applications had not been updated since we changed the way the processing itself worked. It should just check the status of the associated application choices.

This wasn't an issue on `production` (so far) because we've only run the task once but has spawned errors on `qa`. e.g. https://sentry.io/organizations/dfe-bat/issues/1901289529/?referrer=slack

## Changes proposed in this pull request

- Add condition to the query in `CancelUnsubmittedApplicationsWorker` to filter out application forms that are not associated with unsubmitted application choices. (Had to do this as a sub-query rather than JOIN because Postgres cannot do a DISTINCT over a json column like `application_choices.offer`.)
- Additional check in `CancelUnsubmittedApplicationAtEndOfCycle` to only process unsubmitted application choices.

## Guidance to review

- Does the query make sense?
- Does the task now run without error if you run it repeatedly?

## Link to Trello card

Original card - https://trello.com/c/DagOgy6H/2077-🚲🔚-unsubmitted-applications-should-be-carried-over-to-next-recruitment-cycle-manually

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
