### PR TITLE
Update the change offer confirmation component to work on QA

### DIFF
--- a/spec/components/previews/provider_interface/change_offer_preview.rb
+++ b/spec/components/previews/provider_interface/change_offer_preview.rb
@@ -88,7 +88,7 @@ module ProviderInterface
     end
 
     def available_choices
-      available_providers.first.application_choices
+      available_providers.map(&:application_choices).flatten
     end
 
     def initial_step(step)
@@ -100,11 +100,11 @@ module ProviderInterface
     end
 
     def application_choice_awaiting_decision
-      available_choices.where(status: :awaiting_provider_decision).order('created_at').first
+      available_choices.select(&:awaiting_provider_decision?).min_by(&:created_at)
     end
 
     def application_choice_with_offer
-      available_choices.where(status: :offer).order('created_at').first
+      available_choices.select(&:offer?).min_by(&:created_at)
     end
 
     def submitted_form(hash)


### PR DESCRIPTION
## Context

The change offer confirmation component preview is returning a 500.
https://qa.apply-for-teacher-training.service.gov.uk/rails/view_components/provider_interface/change_offer/existing_offer_start_at_confirm_change

The `application_choice_with_offer` and `application_choice_awaiting_decision` methods currently return nil on QA

## Changes proposed in this pull request

- Return a random ApplicationChoice in the correct state for the `application_choice_with_offer` and `application_choice_awaiting_decision` methods.

## Guidance to review

I found this fairly hard to test. I accessed the QA DB and had a play around to see what was not working correctly. I think this fix should work 🤞 

## Link to Trello card

https://trello.com/c/Ejg12FYm/1954-fix-component-previews-and-enable-automated-accessibility-tests

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
