### PR TITLE
Add pagination and filtering to providers application list

### DIFF
--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -1,21 +1,8 @@
 module SupportInterface
   class ApplicationFormsController < SupportInterfaceController
     def index
-      @application_forms = ApplicationForm
-        .joins(:candidate)
-        .includes(:candidate, application_choices: %i[course provider])
-        .order(updated_at: :desc)
-        .page(params[:page] || 1).per(15)
-
-      if params[:q]
-        @application_forms = @application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address, ' ', application_forms.support_reference) ILIKE ?", "%#{params[:q]}%")
-      end
-
-      if params[:phase]
-        @application_forms = @application_forms.where('phase IN (?)', params[:phase])
-      end
-
       @filter = SupportInterface::ApplicationsFilter.new(params: params)
+      @application_forms = @filter.filter_records(ApplicationForm)
     end
 
     def show

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -53,6 +53,8 @@ module SupportInterface
 
     def applications
       @provider = Provider.find(params[:provider_id])
+      @filter = SupportInterface::ApplicationsFilter.new(params: params)
+      @application_forms = @filter.filter_records(@provider.application_forms)
     end
 
     def sites

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -6,6 +6,24 @@ module SupportInterface
       @applied_filters = params
     end
 
+    def filter_records(application_forms)
+      application_forms = application_forms
+        .joins(:candidate)
+        .includes(:candidate, :application_choices)
+        .order(updated_at: :desc)
+        .page(applied_filters[:page] || 1).per(15)
+
+      if applied_filters[:q]
+        application_forms = application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address, ' ', application_forms.support_reference) ILIKE ?", "%#{applied_filters[:q]}%")
+      end
+
+      if applied_filters[:phase]
+        application_forms = application_forms.where('phase IN (?)', applied_filters[:phase])
+      end
+
+      application_forms
+    end
+
     def filters
       [
         {

--- a/app/views/support_interface/providers/applications.html.erb
+++ b/app/views/support_interface/providers/applications.html.erb
@@ -1,3 +1,5 @@
 <%= render 'provider_navigation', title: 'Applications' %>
 
-<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @provider.application_forms.includes(:candidate, :application_choices).order(updated_at: :desc)) %>
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_forms) do %>
+  <%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @application_forms) %>
+<% end %>


### PR DESCRIPTION
## Context

This adds pagination and filtering to the providers page (support/providers/1/applications).

## Changes proposed in this pull request

I've extracted the filtering logic out. I wasn't quite sure where to put it, so I decided the simplest thing was to move it into the Filter object, because it already knows about what filters are being applied.

![image](https://user-images.githubusercontent.com/233676/93777314-83476700-fc1c-11ea-885b-84e8e2e3f26f.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ZKW9EAs3/2138-add-filtering-and-pagination-to-slow-support-pages

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
