### PR TITLE
overrideFullDeployment variable to control full ARM deployment

### DIFF
--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -185,7 +185,7 @@ jobs:
 
           - task: AzureResourceGroupDeployment@2
             displayName: 'ARM Deployment - Create Or Update Resource Group action on $(resourceGroupName)'
-            condition: and(eq(variables['buildCancelled'], false), eq(variables['fullDeployment'], true))
+            condition: and(eq(variables['buildCancelled'], false), or(eq(variables['fullDeployment'], true), eq(variables['overrideFullDeployment'], true) ))
             inputs:
               azureSubscription: '${{parameters.subscriptionName}}'
               resourceGroupName: '$(resourceGroupName)'


### PR DESCRIPTION
## Context

Currently the full ARM deployment from the pipeline happens only if there are changes to the ARM template or azure pipeline files.
it might be required to run a full ARM template deployment irrespective of code changes.


## Changes proposed in this pull request

introduce a `overrideFullDeployment` variable to force a full ARM template deployment irrespective of file changes.


## Link to Trello card


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
