### PR TITLE
Load test spike - Apache JMeter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :test do
   gem 'database_cleaner'
   gem 'clockwork-test'
   gem 'deepsort'
+  gem 'ruby-jmeter'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
@@ -236,12 +237,16 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     multipart-post (2.1.1)
     nenv (0.3.0)
+    netrc (0.11.0)
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -352,6 +357,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.4)
     rouge (3.23.0)
     rspec (3.9.0)
@@ -405,6 +415,9 @@ GEM
       i18n
     ruby-graphviz (1.2.5)
       rexml
+    ruby-jmeter (3.1.08)
+      nokogiri
+      rest-client
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
@@ -546,6 +559,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-govuk
   ruby-graphviz
+  ruby-jmeter
   selenium-webdriver
   sentry-raven
   shoulda-matchers (~> 4.4)

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -1,0 +1,26 @@
+# Load testing
+
+[Apache JMeter](https://jmeter.apache.org/) allows us to test our service with realistic loads. 
+
+## Instructions
+### 1. Install Apache JMeter
+```sh
+brew install jmeter
+```
+
+### 2. Grab an auth token
+- Check the app is running in mid-cycle mode.
+- Sign into you application as a user with an application that has been started but not completed.
+- Open up your browser dev console and grab the value of `_apply_for_postgraduate_teacher_training_session` from the cookies.
+
+### 3. Generate a test plan
+- Generate the test plan with the following command passing in the token you grabbed earlier. You can optionally set the host and thread count if you want to else it will revert to defaults.
+```sh
+bundle exec rake generate_jmeter_plan[HOST,THREAD_COUNT,TOKEN]
+```
+
+Note: you can also run your plan as part of the rake task in order to iron out bugs. Replace the call to `.jmx` with `.run` 
+
+### 4. Run your plan on your JMeter instance
+From here you can either choose to run your plan from the command line or the GUI if you want to configure bar charts and tables.
+

--- a/lib/tasks/jmeter.rake
+++ b/lib/tasks/jmeter.rake
@@ -1,0 +1,55 @@
+# Guidance for this task can be found at docs/load_testing.md
+
+desc 'Generates jmeter test plan'
+task :generate_jmeter_plan, [:host, :token, :thread_count] do |_t, args|
+  require 'ruby-jmeter'
+  generate_plan extract_options_from(args)
+end
+
+def extract_options_from(args)
+  defaults = {
+    host: 'http://localhost:3000',
+    thread_count: 10,
+    token: nil,
+  }
+
+  options = defaults.merge(args)
+
+  raise ArgumentError, 'Missing token!' if options[:token].nil?
+
+  puts("Generating jmeter plan with the following options:\n
+         host: #{options[:host]}\n
+         thread_count: #{options[:thread_count]}\n
+         token: #{options[:token]}\n")
+
+  options
+end
+
+def generate_plan(host:, thread_count:, token:)
+  test {
+    threads count: thread_count do
+      header name: 'COOKIE', value: "_apply_for_postgraduate_teacher_training_session=#{token}"
+
+      visit name: 'GET application', url: "#{host}/candidate/application" do
+        assert contains: 'Your application'
+      end
+
+      visit name: 'GET contact-details', url: "#{host}/candidate/application/contact-details" do
+        assert contains: 'Contact details'
+        extract name: 'csrf-token', xpath: "//meta[@name='csrf-token']/@content", tolerant: true
+      end
+
+      header name: 'X-CSRF-Token', value: '${csrf-token}'
+
+      submit name: 'POST contact-details',
+             url: "#{host}/candidate/application/contact-details",
+             fill_in: {
+               'candidate_interface_contact_details_form[phone_number]' => '07173 473748',
+             }
+    end
+    view_results_in_table
+    view_results_tree
+    graph_results
+    aggregate_graph
+  }.jmx
+end


### PR DESCRIPTION
## Context
- We'd like to test our service with realistic loads. 
- [View kickoff discussion document](https://docs.google.com/document/d/1JDgvBuXkdpWNDRHz8e_kmq50svSdi_wxajXxcgRF77c/edit) for more context

## Changes proposed in this PR
- Add [ruby-jmeter](https://github.com/flood-io/ruby-jmeter). Lets you write test plans for [Apache JMeter](https://jmeter.apache.org/). Plans can be tested locally before running on a JMeter instance on your environment of choice
- Create rake task to generate Apache JMeter plan
- Add documentation

## Guidance for review
- To test this out for yourself take a look at `docs/load_testing.md` included in this PR
- Noticed that `ruby-jmeter` has not had any new commits for 3 years 😱. Seems to work ok (so far), there are a few deprecation warnings appearing  in the logs but nothing to worry about?

## Sample results
Tested against `localhost` using 10 threads

<img width="1138" alt="candidate_aggregate_graph" src="https://user-images.githubusercontent.com/5256922/94021143-9a688f00-fdab-11ea-8c70-8aa49a4df85d.png">


## Link to Trello card

https://trello.com/c/S2NAdvH8/1968-%F0%9F%8F%88-tech-performance-spike-load-testing

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
