### PR TITLE
Show summaries of UCAS matches

### DIFF
--- a/app/components/support_interface/application_card_component.html.erb
+++ b/app/components/support_interface/application_card_component.html.erb
@@ -11,7 +11,7 @@
   <ul class="app-application-card__list govuk-list govuk-list--bullet">
     <% application_form.application_choices.each do |application_choice| %>
       <li class="govuk-list__item govuk-body-s">
-        <%= render SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
+        <%= render SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status) %>
         <%= application_choice.course.name_and_code %> at <%= application_choice.provider.name %>
       </li>
     <% end %>

--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -31,7 +31,7 @@
   { key: 'Course', value: course_name_and_status },
   { key: 'Location', value: location_and_status },
   { key: 'Study mode', value: application_choice.offered_option.study_mode.humanize },
-  { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) },
+  { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)) },
 ] %>
 
 <% rows << { key: 'Feedback', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -1,18 +1,15 @@
 module SupportInterface
   class ApplicationStatusTagComponent < ViewComponent::Base
-    validates :application_choice, presence: true
-    delegate :status, to: :application_choice
-
-    def initialize(application_choice:)
-      @application_choice = application_choice
+    def initialize(status:)
+      @status = status
     end
 
     def text
-      I18n.t!("application_states.#{status}.name")
+      I18n.t!("application_states.#{@status}.name")
     end
 
     def type
-      case status
+      case @status
       when 'unsubmitted'
         :grey
       when 'application_complete', 'awaiting_references', 'awaiting_provider_decision', 'offer_deferred'
@@ -26,12 +23,8 @@ module SupportInterface
       when 'conditions_not_met', 'declined', 'rejected', 'offer_withdrawn', 'withdrawn', 'cancelled', 'application_not_sent'
         :red
       else
-        raise "You need to define a colour for the #{status} state"
+        raise "You need to define a colour for the #{@status} state"
       end
     end
-
-  private
-
-    attr_reader :application_choice
   end
 end

--- a/app/components/support_interface/ucas_match_table_component.html.erb
+++ b/app/components/support_interface/ucas_match_table_component.html.erb
@@ -17,3 +17,8 @@
     <% end %>
   </tbody>
 </table>
+
+<h2 class='govuk-heading-l'>Summary</h2>
+<p class="govuk-body">
+  <%= @summary %>
+</p>

--- a/app/components/support_interface/ucas_match_table_component.html.erb
+++ b/app/components/support_interface/ucas_match_table_component.html.erb
@@ -1,0 +1,19 @@
+<table class="govuk-table" data-qa="ucas-matched-courses">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Course choice</th>
+      <th scope="col" class="govuk-table__header">Status on UCAS</th>
+      <th scope="col" class="govuk-table__header">Status on Apply</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% table_rows.each do |table_row| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= table_row[:course_choice_details] %></td>
+        <td class="govuk-table__cell"><%= table_row[:status_on_ucas] || 'N/A' %></td>
+        <td class="govuk-table__cell"><%= table_row[:status_on_apply] || 'N/A' %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/components/support_interface/ucas_match_table_component.html.erb
+++ b/app/components/support_interface/ucas_match_table_component.html.erb
@@ -11,8 +11,20 @@
     <% table_rows.each do |table_row| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= table_row[:course_choice_details] %></td>
-        <td class="govuk-table__cell"><%= table_row[:status_on_ucas] %></td>
-        <td class="govuk-table__cell"><%= table_row[:status_on_apply] %></td>
+        <td class="govuk-table__cell">
+          <% if table_row[:status_on_ucas] == 'N/A' %>
+            N/A
+          <% else %>
+            <%= render SupportInterface::ApplicationStatusTagComponent.new(status: table_row[:status_on_ucas]) %>
+          <% end %>
+        </td>
+        <td class="govuk-table__cell">
+          <% if table_row[:status_on_apply] == 'N/A' %>
+            N/A
+          <% else %>
+            <%= render SupportInterface::ApplicationStatusTagComponent.new(status: table_row[:status_on_apply]) %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/support_interface/ucas_match_table_component.html.erb
+++ b/app/components/support_interface/ucas_match_table_component.html.erb
@@ -11,8 +11,8 @@
     <% table_rows.each do |table_row| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= table_row[:course_choice_details] %></td>
-        <td class="govuk-table__cell"><%= table_row[:status_on_ucas] || 'N/A' %></td>
-        <td class="govuk-table__cell"><%= table_row[:status_on_apply] || 'N/A' %></td>
+        <td class="govuk-table__cell"><%= table_row[:status_on_ucas] %></td>
+        <td class="govuk-table__cell"><%= table_row[:status_on_apply] %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -24,11 +24,16 @@ module SupportInterface
         row_data = { course_choice_details: course_choice_details(course) }
 
         matched_applications_for_course(course).each do |application|
-          status = displayed_status(application)
+          status = DISPLAYED_STATUSES[application.status]
           if application.ucas_scheme?
-            row_data.merge!(status_on_ucas: status)
+            row_data.merge!(status_on_ucas: status, status_on_apply: 'N/A')
           elsif application.dfe_scheme?
-            row_data.merge!(status_on_apply: status)
+            row_data.merge!(status_on_ucas: 'N/A', status_on_apply: status)
+          else
+            row_data.merge!(
+              status_on_ucas: DISPLAYED_STATUSES[application.mapped_ucas_status],
+              status_on_apply: status,
+            )
           end
         end
 
@@ -54,10 +59,6 @@ module SupportInterface
 
     def course_choice_details(course)
       "#{course.code} — #{course.name} — #{course.provider.name}"
-    end
-
-    def displayed_status(ucas_matched_application)
-      DISPLAYED_STATUSES[ucas_matched_application.status]
     end
   end
 end

--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -2,19 +2,6 @@ module SupportInterface
   class UCASMatchTableComponent < ViewComponent::Base
     include ViewHelper
 
-    DISPLAYED_STATUSES =
-      {
-        'awaiting_provider_decision' => 'Awaiting provider decision',
-        'offer' => 'Offer received',
-        'rejected' => 'Application rejected',
-        'declined' => 'Offer declined',
-        'withdrawn' => 'Withdrawn',
-        'offer_withdrawn' => 'Withdrawn',
-        'conditions_not_met' => 'Withdrawn',
-        'cancelled' => 'Withdrawn',
-        'pending_conditions' => 'Offer received',
-      }.freeze
-
     def initialize(match)
       @match = match
       @summary = applied_on_both_services? ? 'This applicant has applied to the same course on both services.' : 'This applicant has applied on both services but not for the same course.'
@@ -25,14 +12,14 @@ module SupportInterface
         row_data = { course_choice_details: course_choice_details(course) }
 
         matched_applications_for_course(course).each do |application|
-          status = DISPLAYED_STATUSES[application.status]
+          status = application.status
           if application.ucas_scheme?
             row_data.merge!(status_on_ucas: status, status_on_apply: 'N/A')
           elsif application.dfe_scheme?
             row_data.merge!(status_on_ucas: 'N/A', status_on_apply: status)
           else
             row_data.merge!(
-              status_on_ucas: DISPLAYED_STATUSES[application.mapped_ucas_status],
+              status_on_ucas: application.mapped_ucas_status,
               status_on_apply: status,
             )
           end

--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -1,0 +1,63 @@
+module SupportInterface
+  class UCASMatchTableComponent < ViewComponent::Base
+    include ViewHelper
+
+    DISPLAYED_STATUSES =
+      {
+        'awaiting_provider_decision' => 'Awaiting provider decision',
+        'offer' => 'Offer received',
+        'rejected' => 'Application rejected',
+        'declined' => 'Offer declined',
+        'withdrawn' => 'Withdrawn',
+        'offer_withdrawn' => 'Withdrawn',
+        'conditions_not_met' => 'Withdrawn',
+        'cancelled' => 'Withdrawn',
+        'pending_conditions' => 'Offer received',
+      }.freeze
+
+    def initialize(match)
+      @match = match
+    end
+
+    def table_rows
+      candidates_course_choices.map do |course|
+        row_data = { course_choice_details: course_choice_details(course) }
+
+        matched_applications_for_course(course).each do |application|
+          status = displayed_status(application)
+          if application.ucas_scheme?
+            row_data.merge!(status_on_ucas: status)
+          elsif application.dfe_scheme?
+            row_data.merge!(status_on_apply: status)
+          end
+        end
+
+        row_data
+      end
+    end
+
+  private
+
+    def candidates_course_choices
+      ucas_matched_applications.map(&:course).uniq
+    end
+
+    def ucas_matched_applications
+      @match.matching_data.map do |data|
+        UCASMatchedApplication.new(data)
+      end
+    end
+
+    def matched_applications_for_course(course)
+      ucas_matched_applications.select { |application| application.course == course }
+    end
+
+    def course_choice_details(course)
+      "#{course.code} — #{course.name} — #{course.provider.name}"
+    end
+
+    def displayed_status(ucas_matched_application)
+      DISPLAYED_STATUSES[ucas_matched_application.status]
+    end
+  end
+end

--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -17,6 +17,7 @@ module SupportInterface
 
     def initialize(match)
       @match = match
+      @summary = applied_on_both_services? ? 'This applicant has applied to the same course on both services.' : 'This applicant has applied on both services but not for the same course.'
     end
 
     def table_rows
@@ -55,6 +56,10 @@ module SupportInterface
 
     def matched_applications_for_course(course)
       ucas_matched_applications.select { |application| application.course == course }
+    end
+
+    def applied_on_both_services?
+      ucas_matched_applications.map(&:both_scheme?).any?
     end
 
     def course_choice_details(course)

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -1,0 +1,45 @@
+class UCASMatchedApplication
+  def initialize(matching_data)
+    @matching_data = matching_data
+  end
+
+  def course
+    Course.find_by(code: @matching_data['Course code'], provider: Provider.find_by(code: @matching_data['Provider code']))
+  end
+
+  def scheme
+    @matching_data['Scheme']
+  end
+
+  def ucas_scheme?
+    scheme == 'U'
+  end
+
+  def dfe_scheme?
+    scheme == 'D'
+  end
+
+  def status
+    if ucas_scheme?
+      mapped_ucas_status
+    else
+      ApplicationForm.find_by(candidate_id: @matching_data['Apply candidate ID'])
+        .application_choices.find_by(course_option: course.course_options)
+        .status
+    end
+  end
+
+  def mapped_ucas_status
+    if @matching_data['Rejects'] == '1'
+      'rejected'
+    elsif @matching_data['Withdrawns'] == '1'
+      'withdrawn'
+    elsif @matching_data['Declined offers'] == '1'
+      'declined'
+    elsif @matching_data['Offers'] == '1'
+      'offer'
+    else
+      'awaiting_provider_decision'
+    end
+  end
+end

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -19,6 +19,10 @@ class UCASMatchedApplication
     scheme == 'D'
   end
 
+  def both_scheme?
+    scheme == 'B'
+  end
+
   def status
     if ucas_scheme?
       mapped_ucas_status

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -12,6 +12,13 @@
     <% end %>
   <% end %>
 </p>
+<h2 class='govuk-heading-l'>UCAS match</h2>
+<% application = @match.candidate.application_forms.first %>
+<% candidate_details_row = { "Candidate name" => "#{application.first_name} #{application.last_name}",  "Candidate email" => @match.candidate.email_address.to_s } %>
+<%= render SummaryListComponent.new(rows: candidate_details_row) %>
+
+<h2 class='govuk-heading-l'>Course choices</h2>
+<%= render SupportInterface::UCASMatchTableComponent.new(@match) %>
 
 <h2 class='govuk-heading-l'>Matched courses</h2>
 

--- a/spec/components/previews/support_interface/application_status_tag_component_preview.rb
+++ b/spec/components/previews/support_interface/application_status_tag_component_preview.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ApplicationStatusTagComponentPreview < ViewComponent::Preview
     ApplicationStateChange.valid_states.each do |state_name|
       define_method state_name do
-        render SupportInterface::ApplicationStatusTagComponent.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))
+        render SupportInterface::ApplicationStatusTagComponent.new(status: state_name)
       end
     end
   end

--- a/spec/components/support_interface/application_status_tag_component_spec.rb
+++ b/spec/components/support_interface/application_status_tag_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ApplicationStatusTagComponent do
   ApplicationStateChange.valid_states.each do |state_name|
     it "renders with a #{state_name} application choice" do
-      render_inline SupportInterface::ApplicationStatusTagComponent.new(application_choice: FactoryBot.build_stubbed(:application_choice, status: state_name))
+      render_inline SupportInterface::ApplicationStatusTagComponent.new(status: state_name.to_s)
     end
   end
 end

--- a/spec/components/support_interface/ucas_match_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_table_component_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
     it 'renders correct statuses for both' do
       result = render_inline(described_class.new(ucas_match))
 
-      expect(result.css('td')[1].text).to include('Application rejected')
-      expect(result.css('td')[2].text).to include('Offer received')
+      expect(result.css('td')[1].text).to include('Rejected')
+      expect(result.css('td')[2].text).to include('Offer made')
     end
 
     it 'renders correct summary' do
@@ -36,7 +36,7 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
       result = render_inline(described_class.new(ucas_match_for_apply_application))
 
       expect(result.css('td')[1].text).to include('N/A')
-      expect(result.css('td')[2].text).to include('Offer received')
+      expect(result.css('td')[2].text).to include('Offer made')
     end
 
     it 'renders correct summary' do
@@ -50,7 +50,7 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
     it 'renders correct statuses' do
       result = render_inline(described_class.new(ucas_match_for_ucas_application))
 
-      expect(result.css('td')[1].text).to include('Application rejected')
+      expect(result.css('td')[1].text).to include('Rejected')
       expect(result.css('td')[2].text).to include('N/A')
     end
 

--- a/spec/components/support_interface/ucas_match_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_table_component_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
       expect(result.css('td')[1].text).to include('Application rejected')
       expect(result.css('td')[2].text).to include('Offer received')
     end
+
+    it 'renders correct summary' do
+      result = render_inline(described_class.new(ucas_match))
+
+      expect(result.text).to include('This applicant has applied to the same course on both services.')
+    end
   end
 
   context 'when application is only on Apply' do
@@ -32,6 +38,12 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
       expect(result.css('td')[1].text).to include('N/A')
       expect(result.css('td')[2].text).to include('Offer received')
     end
+
+    it 'renders correct summary' do
+      result = render_inline(described_class.new(ucas_match_for_apply_application))
+
+      expect(result.text).to include('This applicant has applied on both services but not for the same course.')
+    end
   end
 
   context 'when application is only on UCAS' do
@@ -40,6 +52,12 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
 
       expect(result.css('td')[1].text).to include('Application rejected')
       expect(result.css('td')[2].text).to include('N/A')
+    end
+
+    it 'renders correct summary' do
+      result = render_inline(described_class.new(ucas_match_for_ucas_application))
+
+      expect(result.text).to include('This applicant has applied on both services but not for the same course.')
     end
   end
 end

--- a/spec/components/support_interface/ucas_match_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_table_component_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::UCASMatchTableComponent do
+  let(:candidate) { create(:candidate) }
+  let(:course) { create(:course) }
+  let(:course_option) { create(:course_option, course: course) }
+  let(:application_choice) { create(:application_choice, :with_offer, course_option: course_option) }
+  let(:application_form) { create(:application_form, candidate: candidate, application_choices: [application_choice]) }
+  let(:ucas_match_for_apply_application) { create(:ucas_match, scheme: 'D', application_form: application_form) }
+  let(:ucas_match_for_ucas_application) { create(:ucas_match, scheme: 'U', ucas_status: :rejected, application_form: application_form) }
+  let(:ucas_match) { create(:ucas_match, scheme: 'B', ucas_status: :rejected, application_form: application_form) }
+
+  it 'renders course choice details' do
+    result = render_inline(described_class.new(ucas_match))
+
+    expect(result.css('td').first.text).to include("#{course.code} — #{course.name} — #{course.provider.name}")
+  end
+
+  context 'when application is in both Apply and UCAS' do
+    it 'renders correct statuses for both' do
+      result = render_inline(described_class.new(ucas_match))
+
+      expect(result.css('td')[1].text).to include('Application rejected')
+      expect(result.css('td')[2].text).to include('Offer received')
+    end
+  end
+
+  context 'when application is only on Apply' do
+    it 'renders correct statuses' do
+      result = render_inline(described_class.new(ucas_match_for_apply_application))
+
+      expect(result.css('td')[1].text).to include('N/A')
+      expect(result.css('td')[2].text).to include('Offer received')
+    end
+  end
+
+  context 'when application is only on UCAS' do
+    it 'renders correct statuses' do
+      result = render_inline(described_class.new(ucas_match_for_ucas_application))
+
+      expect(result.css('td')[1].text).to include('Application rejected')
+      expect(result.css('td')[2].text).to include('N/A')
+    end
+  end
+end

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe UCASMatchedApplication do
+  let(:course) { create(:course) }
+  let(:candidate) { create(:candidate) }
+  let(:course_option) { create(:course_option, course: course) }
+  let(:application_choice) { create(:application_choice, course_option: course_option) }
+  let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+
+  before do
+    application_form
+  end
+
+  describe '#course' do
+    it 'returns the course' do
+      ucas_matching_data =
+        { 'Course code' => course.code.to_s,
+          'Provider code' => course.provider.code.to_s,
+          'Apply candidate ID' => candidate.id.to_s }
+      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data)
+
+      expect(ucas_matching_application.course).to eq(course)
+    end
+  end
+
+  describe '#status' do
+    context 'when it is a DfE match' do
+      it 'returns the applications status' do
+        dfe_matching_data =
+          { 'Scheme' => 'D',
+            'Course code' => course.code.to_s,
+            'Provider code' => course.provider.code.to_s,
+            'Apply candidate ID' => candidate.id.to_s }
+        ucas_matching_application = UCASMatchedApplication.new(dfe_matching_data)
+
+        expect(ucas_matching_application.status).to eq(application_choice.status)
+      end
+    end
+
+    context 'when it is a UCAS match' do
+      it 'returns the applications status' do
+        ucas_matching_data =
+          { 'Scheme' => 'U',
+            'Offers' => '.',
+            'Rejects' => '1',
+            'Withdrawns' => '.',
+            'Applications' => '.',
+            'Unconditional firm' => '.',
+            'Applicant withdrawn entirely from scheme' => '.',
+            'Applicant withdrawn from scheme while offer awaiting applicant reply' => '.',
+            'Applicant withdrawn from scheme after firmly accepting a conditional offer' => '.',
+            'Applicant withdrawn from scheme after firmly accepting an unconditional offer' => '.' }
+        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data)
+
+        expect(ucas_matching_application.status).to eq('rejected')
+        expect(ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.map(&:to_s)).to include(ucas_matching_application.status)
+      end
+    end
+
+    context 'when it is a match on both systems' do
+      it 'returns the applications status on apply' do
+        ucas_matching_data =
+          { 'Scheme' => 'B',
+            'Course code' => course.code.to_s,
+            'Provider code' => course.provider.code.to_s,
+            'Apply candidate ID' => candidate.id.to_s,
+            'Offers' => '.',
+            'Rejects' => '1',
+            'Withdrawns' => '.',
+            'Applications' => '.',
+            'Unconditional firm' => '.',
+            'Applicant withdrawn entirely from scheme' => '.',
+            'Applicant withdrawn from scheme while offer awaiting applicant reply' => '.',
+            'Applicant withdrawn from scheme after firmly accepting a conditional offer' => '.',
+            'Applicant withdrawn from scheme after firmly accepting an unconditional offer' => '.' }
+        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data)
+
+        expect(ucas_matching_application.status).to eq(application_choice.status)
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.feature 'See UCAS matches' do
+  include DfESignInHelpers
+
+  scenario 'Support agent visits UCAS matches pages' do
+    given_i_am_a_support_user
+    and_there_are_applications_in_the_system
+    and_there_are_ucas_matches_in_the_system
+    and_i_visit_the_support_page
+
+    when_i_go_to_ucas_matches_page
+    then_i_should_see_list_of_ucas_matches
+
+    when_i_follow_the_link_to_ucas_match_for_a_candidate
+    then_i_should_see_ucas_match_summary
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_applications_in_the_system
+    @candidate = create(:candidate)
+    @course1 = create(:course)
+    course_option1 = create(:course_option, course: @course1)
+    application_choice1 = create(:application_choice, :with_offer, course_option: course_option1)
+    @course2 = create(:course)
+    course_option2 = create(:course_option, course: @course2)
+    application_choice2 = create(:submitted_application_choice, course_option: course_option2)
+    @application_form = create(:application_form, candidate: @candidate, application_choices: [application_choice1, application_choice2])
+  end
+
+  def and_there_are_ucas_matches_in_the_system
+    ucas_matching_data =
+      {
+        'Scheme' => 'B',
+        'Apply candidate ID' => @candidate.id.to_s,
+        'Course code' => @course1.code.to_s,
+        'Provider code' => @course1.provider.code.to_s,
+        'Withdrawns' => '1',
+      }
+    dfe_matching_data =
+      {
+        'Scheme' => 'D',
+        'Apply candidate ID' => @candidate.id.to_s,
+        'Course code' => @course2.code.to_s,
+        'Provider code' => @course2.provider.code.to_s,
+      }
+    create(:ucas_match, matching_state: 'new_match', application_form: @application_form, matching_data: [ucas_matching_data, dfe_matching_data])
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_go_to_ucas_matches_page
+    visit support_interface_ucas_matches_path
+  end
+
+  def then_i_should_see_list_of_ucas_matches
+    expect(page).to have_content 'New match'
+    expect(page).to have_content @candidate.email_address
+  end
+
+  def when_i_follow_the_link_to_ucas_match_for_a_candidate
+    click_link @candidate.email_address
+  end
+
+  def then_i_should_see_ucas_match_summary
+    expect(page).to have_content 'Matched courses'
+    within('tbody tr:eq(1)') do
+      expect(page).to have_content("#{@course1.code} — #{@course1.name} — #{@course1.provider.name}")
+      expect(page).to have_content('Withdrawn')
+      expect(page).to have_content('Offer made')
+    end
+    within('tbody tr:eq(2)') do
+      expect(page).to have_content("#{@course2.code} — #{@course2.name} — #{@course2.provider.name}")
+      expect(page).to have_content('N/A')
+      expect(page).to have_content('Awaiting provider decision')
+    end
+    expect(page).to have_content('This applicant has applied to the same course on both services.')
+  end
+end


### PR DESCRIPTION
## Context

We need to show a summary of UCAS matches

## Changes proposed in this pull request

See commit messages for details. 

<img width="657" alt="Screenshot 2020-09-24 at 16 37 02" src="https://user-images.githubusercontent.com/38078064/94244331-9f931e80-ff10-11ea-9eda-667448e819c2.png">


## Guidance to review
- run `GenerateTestData.new(10).generate` to generate some test application with UCAS matches
- visit http://localhost:3000/support/ucas-matches
- check individual matches

Need to add more details to the summary in the next PR.

## Link to Trello card

https://trello.com/c/daCqbLWQ/2751-show-summaries-of-ucas-matches-at-the-top-of-the-individual-match-page

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
