### PR TITLE
Fix A11y issues in components

### DIFF
--- a/app/components/filter_component.html.erb
+++ b/app/components/filter_component.html.erb
@@ -46,11 +46,11 @@
 
             <div class="govuk-form-group">
               <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                <legend id="filter-legend-<%= filter[:name] %>" class="govuk-fieldset__legend govuk-fieldset__legend--s">
                   <%= filter[:heading] %>
                 </legend>
                 <% if filter[:type] == :search %>
-                  <input class="govuk-input" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" >
+                  <input class="govuk-input" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" aria-labelledby="filter-legend-<%= filter[:name] %>" >
 
                 <% elsif filter[:type] == :checkboxes %>
                     <% filter[:options].each do |option| %>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -27,7 +27,7 @@
           <%= link_to row[:action], row[:action_path], class: 'govuk-link govuk-!-display-none-print' %>
         </dd>
       <% elsif any_row_has_action_span? %>
-        <span class="govuk-summary-list__actions"></span>
+        <dd class="govuk-summary-list__actions"></dd>
       <% end %>
     </div>
   <% end %>

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SummaryListComponent do
     expect(result.css('.govuk-summary-list__value p').to_html).to eq('<p class="govuk-body">Unsafe</p>')
   end
 
-  it 'does not render a span if no row has an action' do
+  it 'does not render an extra dd if no row has an action' do
     rows = [{ key: 'Job',
               value: ['Teacher', 'Clearcourt High'] },
             { key: 'Working pattern',
@@ -75,10 +75,10 @@ RSpec.describe SummaryListComponent do
 
     result = render_inline(SummaryListComponent.new(rows: rows))
 
-    expect(result.to_html).not_to include('<span class="govuk-summary-list__actions"></span>')
+    expect(result.to_html).not_to include('<dd class="govuk-summary-list__actions"></dd>')
   end
 
-  it 'does render a span if any row as an action' do
+  it 'does render an extra dd if any row as an action' do
     rows = [{ key: 'Job',
               value: ['Teacher', 'Clearcourt High'] },
             { key: 'Working pattern',
@@ -91,6 +91,6 @@ RSpec.describe SummaryListComponent do
 
     result = render_inline(SummaryListComponent.new(rows: rows))
 
-    expect(result.to_html).to include('<span class="govuk-summary-list__actions"></span>')
+    expect(result.to_html).to include('<dd class="govuk-summary-list__actions"></dd>')
   end
 end


### PR DESCRIPTION
## Context

This PR fixes two _serious_ accessibility issues (flagged by Axe) in UI components. It should allow us to switch accessibility testing on as part of our smoke tests (Cypress).

## Changes proposed in this pull request

- [x] Add `aria-labelledby` attribute to Candidate name input in the application list filter in Provider interface.
- [x] Change `span`s that are direct children of `dl` elements in `SummaryComponent` to `dd`.

There should be no visible changes resulting from this PR.

## Guidance to review

- One commit at a time.

## Link to Trello card

https://trello.com/c/ALvwnGc6/1844-include-serious-accessibility-issues-in-axe-tests

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
