### PR TITLE
Only show courses for current cycle on course page

### DIFF
--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -30,6 +30,7 @@ module CandidateInterface
     def courses_grouped_by_provider_and_region
       Course
         .open_on_apply
+        .current_cycle
         .includes(:provider)
         .order('providers.region_code', 'providers.name')
         .group_by { |course| [course.provider.region_code, course.provider.name] }


### PR DESCRIPTION
## Context

We currently show courses from all cycles on the [list of courses that Apply offers](https://www.apply-for-teacher-training.service.gov.uk/candidate/providers) (you can't see that at the moment because we don't sync 2021 courses yet).

## Changes proposed in this pull request

Scope it to the current year.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/okgNMrpY/2123-only-show-the-current-cycles-courses-on-the-courses-page

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
