### PR TITLE
Bug fixes for international Degrees & GCSEs

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -92,14 +92,14 @@ module CandidateInterface
 
       {
         key: t('application_form.degree.naric_reference.review_label'),
-        value: degree.naric_reference,
+        value: degree.naric_reference.presence || 'Not provided',
         action: generate_action(degree: degree, attribute: t('application_form.degree.naric_reference.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree.id),
       }
     end
 
     def comparable_uk_degree_row(degree)
-      return nil unless international?(degree)
+      return nil unless international?(degree) && degree.naric_reference.present?
 
       {
         key: t('application_form.degree.comparable_uk_degree.review_label'),

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -16,6 +16,7 @@ module CandidateInterface
         degree_type_row(degree),
         subject_row(degree),
         institution_row(degree),
+        naric_statment_row(degree),
         naric_reference_row(degree),
         comparable_uk_degree_row(degree),
         start_year_row(degree),
@@ -87,12 +88,23 @@ module CandidateInterface
       degree.international? && FeatureFlag.active?(:international_degrees)
     end
 
-    def naric_reference_row(degree)
+    def naric_statment_row(degree)
       return nil unless international?(degree)
 
       {
+        key: t('application_form.degree.naric_statment.review_label'),
+        value: degree.naric_reference.present? ? 'Yes' : 'No',
+        action: generate_action(degree: degree, attribute: t('application_form.degree.naric_statment.change_action')),
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree.id),
+      }
+    end
+
+    def naric_reference_row(degree)
+      return nil unless international?(degree) && degree.naric_reference.present?
+
+      {
         key: t('application_form.degree.naric_reference.review_label'),
-        value: degree.naric_reference.presence || 'Not provided',
+        value: degree.naric_reference,
         action: generate_action(degree: degree, attribute: t('application_form.degree.naric_reference.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree.id),
       }
@@ -103,7 +115,7 @@ module CandidateInterface
 
       {
         key: t('application_form.degree.comparable_uk_degree.review_label'),
-        value: degree.comparable_uk_degree.present? ? t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}", default: '') : '',
+        value: t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}", default: ''),
         action: generate_action(degree: degree, attribute: t('application_form.degree.comparable_uk_degree.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree.id),
       }

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -17,7 +17,8 @@ module CandidateInterface
         [
           qualification_row,
           country_row,
-          naric_row,
+          naric_statment_row,
+          naric_reference_row,
           comparable_uk_qualification_row,
           grade_row,
           award_year_row,
@@ -88,12 +89,25 @@ module CandidateInterface
       }
     end
 
-    def naric_row
+    def naric_statment_row
       return nil unless FeatureFlag.active?('international_gcses') && application_qualification.qualification_type == 'non_uk'
 
       {
+        key: 'Do you have a NARIC statment of comparability?',
+        value: application_qualification.naric_reference ? 'Yes' : 'No',
+        action: 'Change the NARIC statement',
+        change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
+      }
+    end
+
+    def naric_reference_row
+      return nil unless FeatureFlag.active?('international_gcses') &&
+        application_qualification.qualification_type == 'non_uk' &&
+        application_qualification.naric_reference
+
+      {
         key: 'NARIC reference number',
-        value: application_qualification.naric_reference || 'Not provided',
+        value: application_qualification.naric_reference,
         action: 'Change the NARIC reference number',
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }
@@ -106,7 +120,7 @@ module CandidateInterface
 
       {
         key: 'Comparable UK qualification',
-        value: application_qualification.comparable_uk_qualification || 'Not provided',
+        value: application_qualification.comparable_uk_qualification,
         action: 'Change the comparable uk qualification',
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -93,7 +93,7 @@ module CandidateInterface
       return nil unless FeatureFlag.active?('international_gcses') && application_qualification.qualification_type == 'non_uk'
 
       {
-        key: 'Do you have a NARIC statment of comparability?',
+        key: 'Do you have a NARIC statement of comparability?',
         value: application_qualification.naric_reference ? 'Yes' : 'No',
         action: 'Change the NARIC statement',
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -13,7 +13,7 @@ module CandidateInterface
     def gcse_qualification_rows
       if application_qualification.missing_qualification?
         [missing_qualification_row]
-      elsif FeatureFlag.active?('international_gcses') && @application_qualification.qualification_type == 'non_uk'
+      else
         [
           qualification_row,
           country_row,
@@ -21,13 +21,7 @@ module CandidateInterface
           comparable_uk_qualification_row,
           grade_row,
           award_year_row,
-        ]
-      else
-        [
-          qualification_row,
-          grade_row,
-          award_year_row,
-        ]
+        ].compact
       end
     end
 
@@ -95,6 +89,8 @@ module CandidateInterface
     end
 
     def naric_row
+      return nil unless FeatureFlag.active?('international_gcses') && application_qualification.qualification_type == 'non_uk'
+
       {
         key: 'NARIC reference number',
         value: application_qualification.naric_reference || 'Not provided',
@@ -104,6 +100,10 @@ module CandidateInterface
     end
 
     def comparable_uk_qualification_row
+      return nil unless FeatureFlag.active?('international_gcses') &&
+        application_qualification.qualification_type == 'non_uk' &&
+        application_qualification.naric_reference
+
       {
         key: 'Comparable UK qualification',
         value: application_qualification.comparable_uk_qualification || 'Not provided',

--- a/app/forms/candidate_interface/degree_naric_statement_form.rb
+++ b/app/forms/candidate_interface/degree_naric_statement_form.rb
@@ -22,7 +22,7 @@ module CandidateInterface
     end
 
     def fill_form_values
-      degree.naric_reference.present? ? self.have_naric_reference = 'yes' : self.have_naric_reference = 'no'
+      self.have_naric_reference = (degree.naric_reference.present? ? 'yes' : 'no')
       self.naric_reference = degree.naric_reference
       self.comparable_uk_degree = degree.comparable_uk_degree
       self

--- a/app/forms/candidate_interface/degree_naric_statement_form.rb
+++ b/app/forms/candidate_interface/degree_naric_statement_form.rb
@@ -16,13 +16,13 @@ module CandidateInterface
       return false unless valid?
 
       degree.update!(
-        naric_reference: have_naric_reference? ? naric_reference : nil,
-        comparable_uk_degree: have_naric_reference? ? comparable_uk_degree : nil,
+        naric_reference: have_naric_reference? == 'yes' ? naric_reference : nil,
+        comparable_uk_degree: have_naric_reference? == 'yes' ? comparable_uk_degree : nil,
       )
     end
 
     def fill_form_values
-      self.have_naric_reference = 'yes' if degree.naric_reference.present?
+      degree.naric_reference.present? ? self.have_naric_reference = 'yes' : self.have_naric_reference = 'no'
       self.naric_reference = degree.naric_reference
       self.comparable_uk_degree = degree.comparable_uk_degree
       self

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -190,10 +190,14 @@ en:
         button: Add another degree
       delete: Delete degree
       confirm_delete: Yes I’m sure - delete this degree
+      naric_statment:
+        label: NARIC statment
+        review_label: Do you have a NARIC statement of comparability?
+        change_action: NARIC statement
       naric_reference:
-        label: UK NARIC reference number
+        label: NARIC reference number
         hint_text: For example ‘4000228363’
-        review_label: UK NARIC reference number
+        review_label: NARIC reference number
         change_action: NARIC statement
       comparable_uk_degree:
         label: Select the comparable UK degree

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -210,21 +210,50 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       )
     end
 
-    it 'renders component with correct values for NARIC statement' do
-      result = render_inline(described_class.new(application_form: application_form))
+    context 'when a NARIC reference number has been provided' do
+      it 'renders component with correct values for NARIC statement' do
+        result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.institution_name.review_label'))
-      expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('0123456789')
-      expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
-      )
-      expect(result.css('.govuk-summary-list__value')[4].text.strip).to eq('Bachelor (Honours) degree')
-      expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
-      )
-      expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",
-      )
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.institution_name.review_label'))
+        expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('0123456789')
+        expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
+          Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
+        )
+        expect(result.css('.govuk-summary-list__value')[4].text.strip).to eq('Bachelor (Honours) degree')
+        expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
+          Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
+        )
+        expect(result.css('.govuk-summary-list__actions').text).to include(
+          "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",
+        )
+      end
+    end
+
+    context 'when the candidate has not provided a NARIC reference number' do
+      let(:degree1) do
+        build_stubbed(
+          :degree_qualification,
+          qualification_type: 'BA',
+          subject: 'Woof',
+          institution_name: 'University of Doge',
+          institution_country: 'DE',
+          naric_reference: '',
+          comparable_uk_degree: nil,
+          grade: 'erste Klasse',
+          predicted_grade: false,
+          start_year: '2005',
+          award_year: '2008',
+          international: true,
+        )
+      end
+
+      it 'does not render a row for comparable UK degree and sets UK NARIC reference number to "Not provided"' do
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__key')[3].text).to include(t('application_form.degree.naric_reference.review_label'))
+        expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('Not provided')
+        expect(result.css('.govuk-summary-list__key').text).not_to include(t('application_form.degree.comparable_uk_degree.review_label'))
+      end
     end
   end
 

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -215,12 +215,16 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
         result = render_inline(described_class.new(application_form: application_form))
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.institution_name.review_label'))
-        expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('0123456789')
+        expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('Yes')
         expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
           Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
         )
-        expect(result.css('.govuk-summary-list__value')[4].text.strip).to eq('Bachelor (Honours) degree')
+        expect(result.css('.govuk-summary-list__value')[4].text.strip).to eq('0123456789')
         expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
+          Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
+        )
+        expect(result.css('.govuk-summary-list__value')[5].text.strip).to eq('Bachelor (Honours) degree')
+        expect(result.css('.govuk-summary-list__actions a')[5].attr('href')).to include(
           Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
         )
         expect(result.css('.govuk-summary-list__actions').text).to include(
@@ -250,8 +254,9 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       it 'does not render a row for comparable UK degree and sets UK NARIC reference number to "Not provided"' do
         result = render_inline(described_class.new(application_form: application_form))
 
-        expect(result.css('.govuk-summary-list__key')[3].text).to include(t('application_form.degree.naric_reference.review_label'))
-        expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('Not provided')
+        expect(result.css('.govuk-summary-list__key')[3].text).to include(t('application_form.degree.naric_statment.review_label'))
+        expect(result.css('.govuk-summary-list__value')[3].text.strip).to eq('No')
+        expect(result.css('.govuk-summary-list__key').text).not_to include(t('application_form.degree.naric_reference.review_label'))
         expect(result.css('.govuk-summary-list__key').text).not_to include(t('application_form.degree.comparable_uk_degree.review_label'))
       end
     end

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.css('.govuk-summary-list__value')[0].text).to include('High school diploma')
       expect(result.css('.govuk-summary-list__key')[1].text).to include('Country')
       expect(result.css('.govuk-summary-list__value')[1].text).to include('United States')
-      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statment of comparability?')
+      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statement of comparability?')
       expect(result.css('.govuk-summary-list__value')[2].text).to include('Yes')
       expect(result.css('.govuk-summary-list__key')[3].text).to include('NARIC reference number')
       expect(result.css('.govuk-summary-list__value')[3].text).to include('12345')
@@ -57,7 +57,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
       )
 
-      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statment of comparability?')
+      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statement of comparability?')
       expect(result.css('.govuk-summary-list__value')[2].text).to include('No')
       expect(result.css('.govuk-summary-list__key').text).not_to include('NARIC reference number')
       expect(result.css('.govuk-summary-list__key').text).not_to include('Comparable UK qualification')

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         qualification_type: 'non_uk',
         non_uk_qualification_type: 'High school diploma',
         level: 'gcse',
-        grade: 'c',
+        grade: 'C',
+        award_year: '2020',
         institution_country: 'US',
         naric_reference: '12345',
         comparable_uk_qualification: 'Between GCSE and GCE AS level',
@@ -23,13 +24,23 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
       )
 
-      expect(result.text).to match(/Qualification\s+#{@qualification.non_uk_qualification_type}/)
-      expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
-      expect(result.text).to match(/Grade\s+#{@qualification.grade}/)
-      expect(result.text).to match(/Country\s+#{COUNTRIES[@qualification.institution_country]}/)
+      expect(result.css('.govuk-summary-list__key')[0].text).to include('Qualification')
+      expect(result.css('.govuk-summary-list__value')[0].text).to include('High school diploma')
+      expect(result.css('.govuk-summary-list__key')[1].text).to include('Country')
+      expect(result.css('.govuk-summary-list__value')[1].text).to include('United States')
+      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statment of comparability?')
+      expect(result.css('.govuk-summary-list__value')[2].text).to include('Yes')
+      expect(result.css('.govuk-summary-list__key')[3].text).to include('NARIC reference number')
+      expect(result.css('.govuk-summary-list__value')[3].text).to include('12345')
+      expect(result.css('.govuk-summary-list__key')[4].text).to include('Comparable UK qualification')
+      expect(result.css('.govuk-summary-list__value')[4].text).to include('Between GCSE and GCE AS level')
+      expect(result.css('.govuk-summary-list__key')[5].text).to include('Grade')
+      expect(result.css('.govuk-summary-list__value')[5].text).to include('C')
+      expect(result.css('.govuk-summary-list__key')[6].text).to include('Year')
+      expect(result.css('.govuk-summary-list__value')[6].text).to include('2020')
     end
 
-    it 'displays "Not provided" for naric_reference and hides comparable_uk_qualification when nil' do
+    it 'displays the naric_statment row and hides the naric_reference and comparable_uk_qualification when nil' do
       application_form = build :application_form
       @qualification = application_qualification = build(
         :application_qualification,
@@ -46,7 +57,9 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
       )
 
-      expect(result.text).to match(/NARIC reference number\s+Not provided/)
+      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statment of comparability?')
+      expect(result.css('.govuk-summary-list__value')[2].text).to include('No')
+      expect(result.css('.govuk-summary-list__key').text).not_to include('NARIC reference number')
       expect(result.css('.govuk-summary-list__key').text).not_to include('Comparable UK qualification')
     end
   end

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.text).to match(/Country\s+#{COUNTRIES[@qualification.institution_country]}/)
     end
 
-    it 'displays "Not provided" for naric_reference and comparable_uk_qualification when nil' do
+    it 'displays "Not provided" for naric_reference and hides comparable_uk_qualification when nil' do
       application_form = build :application_form
       @qualification = application_qualification = build(
         :application_qualification,
@@ -47,7 +47,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       )
 
       expect(result.text).to match(/NARIC reference number\s+Not provided/)
-      expect(result.text).to match(/Comparable UK qualification\s+Not provided/)
+      expect(result.css('.govuk-summary-list__key').text).not_to include('Comparable UK qualification')
     end
   end
 

--- a/spec/forms/candidate_interface/degree_naric_statement_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_naric_statement_form_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::DegreeNaricStatementForm do
     end
 
     context 'when `have_naric_reference` is "no"' do
-      it 'returns false if naric_reference and comparable_uk_degree are empty' do
+      it 'returns true and updated naric_reference and comparable_uk_degree to nil' do
         degree = create(
           :degree_qualification,
           international: true,
@@ -55,6 +55,8 @@ RSpec.describe CandidateInterface::DegreeNaricStatementForm do
         form = described_class.new(
           degree: degree,
           have_naric_reference: 'no',
+          naric_reference: '0123456789',
+          comparable_uk_degree: 'bachelor_ordinary_degree',
         )
 
         expect(form.save).to eq true

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -167,11 +167,11 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_click_to_change_year
-    page.all('.govuk-summary-list__actions').to_a.third.click_link 'Change'
+    page.all('.govuk-summary-list__actions').to_a.fourth.click_link 'Change'
   end
 
   def when_i_click_to_change_grade
-    page.all('.govuk-summary-list__actions').to_a.second.click_link 'Change'
+    page.all('.govuk-summary-list__actions').to_a.third.click_link 'Change'
   end
 
   def when_i_enter_a_different_qualification_grade

--- a/spec/system/candidate_interface/international/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_international_degrees_spec.rb
@@ -180,7 +180,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def and_i_fill_in_naric_reference
-    fill_in 'UK NARIC reference number', with: '0123456789'
+    fill_in 'NARIC reference number', with: '0123456789'
   end
 
   def and_i_fill_in_comparable_uk_degree_type
@@ -266,7 +266,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def when_i_change_my_reference_number_and_comparable_uk_degree_type
-    fill_in 'UK NARIC reference number', with: '9876543210'
+    fill_in 'NARIC reference number', with: '9876543210'
     choose 'Post Doctoral award'
   end
 


### PR DESCRIPTION
## Context

There are a few bugs at the moment in the international degrees section. This PR tackles two separate cards and two additional bugs that I noticed while fixing the first two.

## Changes proposed in this pull request

Both the degree and GCSE review component

1. The review components for international degrees/GCSEs should have a row showing stating if they have a NARIC statement. If no it should not  show the naric_reference or comparable UK qualification rows.

Degree review page  

NARIC ref provided 

![image](https://user-images.githubusercontent.com/42515961/94003100-b7449880-fd92-11ea-8f04-cbaadb87de3d.png)

NARIC ref not provided

![image](https://user-images.githubusercontent.com/42515961/94003193-d9d6b180-fd92-11ea-810e-31ef4e23ba35.png)

GCSE review page 

NARIC ref provided

![image](https://user-images.githubusercontent.com/42515961/94003267-ec50eb00-fd92-11ea-87a4-39efe9da06f5.png)

NARIC ref not provided 

![image](https://user-images.githubusercontent.com/42515961/94003316-fd99f780-fd92-11ea-8d20-0e592be6ef4c.png)


Degrees - NARIC page


Degree specific bugs

1. Prefill the form correctly so the 'No' radio button works correctly

Before 

![image](https://user-images.githubusercontent.com/42515961/93894455-a76f7a80-fce6-11ea-98cf-5c6a754cec64.png)

After

![image](https://user-images.githubusercontent.com/42515961/93894394-96266e00-fce6-11ea-9ef2-45fde12f0526.png)

2. If a candidate has added a NARIC reference number. Then chooses to change their response to 'No' it sets the naric_reference and comparable_uk_degree to nil (previously it retained their values)
 
## Guidance to review

Test it locally/on the review app 👍 

## Link to Trello card

https://trello.com/c/0QxX0k6r/2052-%F0%9F%8C%90-comparable-uk-degree-shown-in-summary-card-for-international-degree-if-answered-no-to-having-a-naric-statement
https://trello.com/c/ojQCw0IY/2056-%F0%9F%8C%90-empty-naric-ref-field-in-summary-when-no-naric-equivalent-for-degree

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
