### PR TITLE
Remove to work details when a candidate selects they are British or Irish

### DIFF
--- a/app/forms/candidate_interface/nationalities_form.rb
+++ b/app/forms/candidate_interface/nationalities_form.rb
@@ -33,13 +33,25 @@ module CandidateInterface
       if FeatureFlag.active?('international_personal_details')
         nationalities = candidates_nationalities
 
-        application_form.update!(
-          first_nationality: nationalities[0],
-          second_nationality: nationalities[1],
-          third_nationality: nationalities[2],
-          fourth_nationality: nationalities[3],
-          fifth_nationality: nationalities[4],
-        )
+        if british.present? || irish.present?
+          application_form.update!(
+            first_nationality: nationalities[0],
+            second_nationality: nationalities[1],
+            third_nationality: nationalities[2],
+            fourth_nationality: nationalities[3],
+            fifth_nationality: nationalities[4],
+            right_to_work_or_study: nil,
+            right_to_work_or_study_details: nil,
+          )
+        else
+          application_form.update!(
+            first_nationality: nationalities[0],
+            second_nationality: nationalities[1],
+            third_nationality: nationalities[2],
+            fourth_nationality: nationalities[3],
+            fifth_nationality: nationalities[4],
+          )
+        end
       else
         application_form.update!(
           first_nationality: first_nationality,

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -96,14 +96,18 @@ module CandidateInterface
     end
 
     def right_to_work_row
-      if NationalitiesForm::UK_AND_IRISH_NATIONALITIES.exclude?(@nationalities_form.first_nationality)
-        {
-          key: 'Residency status',
-          value: formatted_right_to_work_or_study,
-          action: ('Right to work or study' if @editable),
-          change_path: candidate_interface_edit_right_to_work_or_study_path,
-        }
-      end
+      return nil if british_or_irish?
+
+      {
+        key: 'Residency status',
+        value: formatted_right_to_work_or_study,
+        action: ('Right to work or study' if @editable),
+        change_path: candidate_interface_edit_right_to_work_or_study_path,
+      }
+    end
+
+    def british_or_irish?
+      @application_form.build_nationalities_hash[:irish] || @application_form.build_nationalities_hash[:british]
     end
 
     def formatted_nationalities

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -274,18 +274,24 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
   context 'when the international personal details flag is on and the candidate is British or Irish' do
     before { FeatureFlag.activate(:international_personal_details) }
 
-    it 'renders the right to work row' do
+    it 'does not render the right to work row' do
       nationalities_form = build(
         :nationalities_form,
         first_nationality: 'British',
+        second_nationality: 'Albanian',
       )
       right_to_work_form = build(
         :right_to_work_form,
         right_to_work_or_study: 'yes',
         right_to_work_or_study_details: 'I have the right.',
       )
+      application_form = build(
+        :application_form,
+        first_nationality: 'Albanian',
+        second_nationality: 'British',
+      )
 
-      expect(rows(nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).not_to include(
+      expect(rows(application_form: application_form, nationalities_form: nationalities_form, right_to_work_form: right_to_work_form)).not_to include(
         row_for(:right_to_work, "I have the right to work or study in the UK \b<br> <p>I have the right.</p>", candidate_interface_edit_right_to_work_or_study_path),
       )
     end


### PR DESCRIPTION
## Context

There is a bug that can be reproduced with the following steps on QA:

1. Complete the personal details section as an Albanian candidate
2. Edit nationality to British and Albanian
3. See the right to work row is there when it should not be

## Changes proposed in this pull request

- Reset the right_to_work_or_study and  right_to_work_or_study_details fields to nil when a candidate selects British or Irish as one of their nationalities
- Update the logic for rendering the right_to_work row to check for Britsh/Irish in all nationalities

## Guidance to review

Previously the logic for whether to render the right to work row only checked the first nationality. The nationalities are stored alphabetically so if someone has picked Austrian/Albanian etc. and British as nationalities it renders the row when it shouldn't.

## Link to Trello card

https://trello.com/c/V6N7Dv0K/2050-%F0%9F%8C%90-dont-show-or-save-residency-status-if-nationality-is-british-or-irish

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
