### PR TITLE
Add a rake task to create large numbers of test applications 

### DIFF
--- a/app/services/bulk_create_test_applications.rb
+++ b/app/services/bulk_create_test_applications.rb
@@ -8,6 +8,8 @@ class BulkCreateTestApplications
   end
 
   def call
+    error_if_application_choice_state_is_not_unsubmitted
+
     begin
       tries ||= 0
       sql = compose_insert_statements(unique_id: SecureRandom.hex(10))
@@ -15,6 +17,14 @@ class BulkCreateTestApplications
     rescue ActiveRecord::RecordNotUnique
       retry unless (tries += 1) > 3
       raise UniqueCandidateError, 'Failed to create a uniquely identifiable candidate, tried 3 times'
+    end
+  end
+
+private
+
+  def error_if_application_choice_state_is_not_unsubmitted
+    unless application_choice.unsubmitted?
+      raise UnsupportedApplicationStateError, 'This task currently only supports template applications that are unsubmitted'
     end
   end
 
@@ -75,4 +85,5 @@ class BulkCreateTestApplications
   end
 
   class UniqueCandidateError < StandardError; end
+  class UnsupportedApplicationStateError < StandardError; end
 end

--- a/app/services/bulk_create_test_applications.rb
+++ b/app/services/bulk_create_test_applications.rb
@@ -1,0 +1,69 @@
+class BulkCreateTestApplications
+  attr_reader :template_application_form, :candidate, :application_choice
+
+  def initialize(template_application_form)
+    @template_application_form = template_application_form
+    @candidate = template_application_form.candidate
+    @application_choice = template_application_form.application_choices.first
+  end
+
+  def call
+    random_id = SecureRandom.hex(10)
+
+    candidate_field_names_sql, candidate_values_to_persist = compose_sql_fragments(
+      candidate,
+      ignore_fields: %w[id magic_link_token magic_link_token_sent_at],
+      custom_fields: { 'email_address' => "#{random_id}@example.com" },
+    )
+    application_form_field_names_sql, application_form_values_to_persist = compose_sql_fragments(
+      template_application_form,
+      ignore_fields: %w[id candidate_id],
+      custom_fields: { 'last_name' => random_id },
+    )
+    application_choice_field_names_sql, application_choice_values_to_persist = compose_sql_fragments(
+      application_choice,
+      ignore_fields: %w[id application_form_id],
+    )
+
+    query = <<~SQL
+      WITH created_candidate AS (
+        INSERT INTO "candidates" ( #{candidate_field_names_sql})
+        VALUES ( #{candidate_values_to_persist})
+        RETURNING "id"
+      ),
+       created_application_form AS (
+        INSERT INTO "application_forms" ( #{application_form_field_names_sql}, candidate_id )
+        VALUES ( #{application_form_values_to_persist}, (SELECT id FROM created_candidate) )
+        RETURNING "id"
+      )
+
+      INSERT INTO "application_choices" ( #{application_choice_field_names_sql}, application_form_id )
+      VALUES ( #{application_choice_values_to_persist}, (SELECT id FROM created_application_form) )
+      RETURNING "id"
+    SQL
+
+    ActiveRecord::Base.connection.execute(query)
+  end
+
+  def compose_sql_fragments(model, ignore_fields: [], custom_fields: {})
+    attr = model.attributes
+    ignore_fields.each { |f| attr.delete(f) }
+    attr.merge!(custom_fields)
+    field_names = attr.keys
+
+    field_names_sql = field_names.join(', ')
+    values_to_persist = field_names.map { |f|
+      value = attr[f]
+      if value == '' || value.nil?
+        'NULL'
+      elsif value.class == Hash
+        # Gracefully switch from Hash syntax to JSON when dealing with json model fields
+        "'#{value.to_json}'"
+      else
+        "'#{value}'"
+      end
+    }.join(', ')
+
+    [field_names_sql, values_to_persist]
+  end
+end

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -23,6 +23,8 @@ end
 
 desc 'Generate a very large number of applications quickly, based on an example application form'
 task :bulk_create_test_applications, %i[application_form_id number_of_applications] => :environment do |_t, args|
+  raise 'You cannot do this anywhere but QA or development!' unless HostingEnvironment.qa? || Rails.env.development?
+
   template_application_form = ApplicationForm.find(args[:application_form_id])
   number_of_applications = args[:number_of_applications]
   raise 'Specify how many applications to create' unless number_of_applications

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -20,3 +20,20 @@ task generate_test_applications: :environment do
 
   GenerateTestApplications.new(for_year: :current_year).perform
 end
+
+desc 'Generate a very large number of applications quickly, based on an example application form'
+task :bulk_create_test_applications, %i[application_form_id number_of_applications] => :environment do |_t, args|
+  template_application_form = ApplicationForm.find(args[:application_form_id])
+  number_of_applications = args[:number_of_applications]
+  raise 'Specify how many applications to create' unless number_of_applications
+
+  bulk_creation = BulkCreateTestApplications.new(template_application_form)
+
+  benchmark = Benchmark.measure do
+    number_of_applications.to_i.times do
+      bulk_creation.call
+    end
+  end
+
+  puts benchmark
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We're testing some of the performance characteristics of the Apply
service in preparation for the larger number of candidates expected next
cycle. One of these tests involves seeing how the service handles
display and navigation across a much larger number of applications.

This is a first pass at writing a rake task that creates applications en masse, 
with a view to creating ~200K applications on the QA environment. It emphasizes 
speed over strict 'completeness' of the applications, the goal being a task that's 
relatively quick to run while providing a reasonable approximation of what a new 
application looks like in the system.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
The rake task added in this commit provides a mechanism to create a
(candidate > application_form > application_choice) set multiple times.

- It accepts the id of an example ApplicationForm record to derive its
  test data from.
- It accepts a number specifying how many distinct applications should be
  created.
- Most of the work is delegated to the `BulkCreateTestApplications` class.

Inside `BulkCreateTestApplications`, we compose some SQL to create the
three records in a single query. The logic here endeavours to create a
minimal representation of an application in the system, and
intentionally leaves out some of the related data that would typically be 
found (eg - english_proficiency, references, qualifications, etc).

### Provider interface
![provider-applications](https://user-images.githubusercontent.com/519250/94029214-7bbac600-fdb4-11ea-8021-e19bd0ae1594.png)



### Support interface (candidates)

![support-candidates](https://user-images.githubusercontent.com/519250/94029241-84130100-fdb4-11ea-975e-2d101b98c2c4.png)


### Support interface (applications)

![support-applications](https://user-images.githubusercontent.com/519250/94029252-870df180-fdb4-11ea-810a-eac663ceb458.png)



## Guidance to review

To test manually, get a copy of the branch locally, find an application form to replicate and then run 
```
bundle exec rails 'bulk_create_test_applications[x,y]'
```
Where `x` is the `application_form id` and `y` is the number of applications to create.

### Questions

- Is the data generated by the task a reasonable representation of a new set of application forms in the system?
- Are there any further changes that should be made to the generated data?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/tRweeqzJ
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
