### PR TITLE
Handle when permissions are empty in save provider user service

### DIFF
--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -55,7 +55,7 @@ module ProviderInterface
           provider_id: provider_id,
           provider_user_id: user.id,
         )
-        permission['permissions'].reject(&:blank?).each do |permission_name|
+        permission.fetch('permissions', []).reject(&:blank?).each do |permission_name|
           provider_permission.send("#{permission_name}=".to_sym, true)
         end
         provider_permission.save!

--- a/spec/services/provider_interface/save_provider_user_service_spec.rb
+++ b/spec/services/provider_interface/save_provider_user_service_spec.rb
@@ -78,4 +78,31 @@ RSpec.describe ProviderInterface::SaveProviderUserService do
     actor.provider_permissions.find_by(provider: @providers[1]).update(manage_users: false)
     expect { described_class.new(actor: actor, wizard: wizard).call! }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
   end
+
+  context 'when no permissions are granted' do
+    it 'invokes a service to persist a new ProviderUser for a new user' do
+      @providers = create_list(:provider, 3)
+      wizard = instance_double(
+        ProviderInterface::ProviderUserInvitationWizard,
+        first_name: 'Ed',
+        last_name: 'Yewcater',
+        email_address: 'ed@example.com',
+        provider_permissions: {
+          @providers[0].id.to_s => { 'provider_id' => @providers[0].id.to_s },
+          @providers[1].id.to_s => { 'provider_id' => @providers[1].id.to_s },
+        },
+      )
+      actor = setup_actor
+      expect { described_class.new(actor: actor, wizard: wizard).call! }.to change { ProviderUser.count }.by(1)
+      new_provider_user = ProviderUser.last
+      expect(new_provider_user.provider_permissions.count).to eq 2
+
+      first_permission = new_provider_user.provider_permissions.find { |permission| permission.provider_id == @providers[0].id }
+      second_permission = new_provider_user.provider_permissions.find { |permission| permission.provider_id == @providers[1].id }
+      expect(first_permission.manage_users).to be false
+      expect(first_permission.make_decisions).to be false
+      expect(second_permission.manage_users).to be false
+      expect(second_permission.make_decisions).to be false
+    end
+  end
 end


### PR DESCRIPTION
## Context

When the user decides not to give any permissions to the new user (view applications only) permissions array doesn't exists. This causes the following error https://sentry.io/organizations/dfe-bat/issues/1906888247/?project=1765973

<img width="775" alt="Screenshot 2020-09-23 at 16 41 45" src="https://user-images.githubusercontent.com/38078064/94035962-afe5b500-fdbb-11ea-9732-00baefdd5f68.png">


## Changes proposed in this pull request

Call `fetch` on permissions data so when it is nil, we can return an empty array.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
