### PR TITLE
Support: Update design of pages in Tasks section

### DIFF
--- a/app/frontend/styles/_section.scss
+++ b/app/frontend/styles/_section.scss
@@ -1,4 +1,4 @@
-.app-product-section {
+.app-section {
   @include govuk-responsive-padding(6, "top");
   @include govuk-responsive-padding(4, "bottom");
 
@@ -7,11 +7,11 @@
   }
 }
 
-.app-product-section--with-top-border {
+.app-section--with-top-border {
   border-top: 1px solid $govuk-border-colour;
 }
 
-.app-product-section__title--with-top-border {
+.app-section__title--with-top-border {
   @include govuk-responsive-padding(4, "top");
   border-top: 1px solid $govuk-border-colour;
 }

--- a/app/frontend/styles/_styled-content.scss
+++ b/app/frontend/styles/_styled-content.scss
@@ -41,6 +41,12 @@
     @extend %govuk-link;
   }
 
+  code {
+    background-color: govuk-colour("light-grey");
+    font-family: monospace;
+    padding: 2px 5px;
+  }
+
   hr {
     @extend %govuk-section-break;
     @extend %govuk-section-break--visible;

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -36,6 +36,7 @@ $govuk-breakpoints: (
 @import "_contents-list";
 @import "_flex-grid";
 @import "_qualification";
+@import "_section";
 @import "_status-box";
 @import "_styled-content";
 @import "_summary-card";

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -10,6 +10,5 @@
 @import "_count";
 @import "_masthead";
 @import "_notes";
-@import "_product-section";
 @import "_timeline";
 @import "_offer";

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -42,7 +42,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <section class="app-product-section">
+  <section class="app-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m">View applications</h2>
@@ -58,7 +58,7 @@
     </div>
   </section>
 
-  <section class="app-product-section">
+  <section class="app-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m">Review applications</h2>
@@ -73,7 +73,7 @@
     </div>
   </section>
 
-  <section class="app-product-section">
+  <section class="app-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m">Respond to applications</h2>
@@ -87,7 +87,7 @@
     </div>
   </section>
 
-  <section class="app-product-section app-product-section--with-top-border">
+  <section class="app-section app-section--with-top-border">
     <h2 class="govuk-heading-m">Who’s using Apply?</h2>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
@@ -108,7 +108,7 @@
     </div>
   </section>
 
-  <section class="app-product-section app-product-section--with-top-border">
+  <section class="app-section app-section--with-top-border">
     <h2 class="govuk-heading-m">What providers say</h2>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
@@ -132,10 +132,10 @@
     </div>
   </section>
 
-  <section class="app-product-section">
+  <section class="app-section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <h2 class="govuk-heading-m app-product-section__title--with-top-border">The team</h2>
+        <h2 class="govuk-heading-m app-section__title--with-top-border">The team</h2>
         <p class="govuk-body">Our team is constantly making improvements based on feedback from users. To get involved so you can shape the service, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a></p>
       </div>
       <div class="govuk-grid-column-one-half">

--- a/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
@@ -5,16 +5,15 @@
     <%= form_with model: nil,
       url: support_interface_run_task_path('cancel_applications_at_end_of_cycle') do |f|
     %>
-      <h1 class="govuk-heading-xl">
-        Cancel unsubmitted applications that reach end-of-cycle
-      </h1>
+      <span class="govuk-caption-xl">End-of-cycle</span>
+      <h1 class="govuk-heading-xl">Are you sure you want to cancel all unsubmitted applications?</h1>
 
-      <p class="govuk-body">
-        Finds any unsubmitted applications from the recently closed recruitment cycle and moves them to the 'application_not_sent' status.
-        This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>
-      </p>
+      <div class="app-styled-content">
+        <p>This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
+        <p>This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+      </div>
 
-      <%= f.submit 'Yes, I\'m sure',
+      <%= f.submit 'Yes, I’m sure - cancel all unsubmitted applications',
         class: 'govuk-button govuk-button--warning',
         data: { module: 'govuk-button' }
       %>

--- a/app/views/support_interface/tasks/confirm_delete_test_applications.html.erb
+++ b/app/views/support_interface/tasks/confirm_delete_test_applications.html.erb
@@ -5,15 +5,13 @@
     <%= form_with model: nil,
       url: support_interface_run_task_path('delete_test_applications') do |f|
     %>
-      <h1 class="govuk-heading-xl">
-        Delete test applications
-      </h1>
+      <h1 class="govuk-heading-xl">Are you sure you want to delete all test applications?</h1>
 
-      <p class="govuk-body">
-        This will delete all candidates with emails that end in “@example.com”, their applications and associated data. Are you sure?
-      </p>
+      <div class="app-styled-content">
+        <p>This task deletes all candidates with emails that end in <code>@example.com</code>, their applications and associated data.</p>
+      </div>
 
-      <%= f.submit 'Yes, I\'m sure',
+      <%= f.submit 'Yes, I’m sure - delete all test applications',
         class: 'govuk-button govuk-button--warning',
         data: { module: 'govuk-button' }
       %>

--- a/app/views/support_interface/tasks/confirm_reject_applications_awaiting_references_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_reject_applications_awaiting_references_at_end_of_cycle.html.erb
@@ -5,16 +5,15 @@
     <%= form_with model: nil,
       url: support_interface_run_task_path('reject_applications_awaiting_references_at_end_of_cycle') do |f|
     %>
-      <h1 class="govuk-heading-xl">
-        Reject applications awaiting references at end-of-cycle
-      </h1>
+      <span class="govuk-caption-xl">End-of-cycle</span>
+      <h1 class="govuk-heading-xl">Are you sure you want to reject all applications awaiting references?</h1>
 
-      <p class="govuk-body">
-        Finds any applications that have been submitted but not sent to providers because they are awaiting references from the recently closed recruitment cycle and moves them to the 'application_not_sent' status.
-        This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>
-      </p>
+      <div class="app-styled-content">
+        <p>This task finds any applications that have been submitted but not sent to providers because they are awaiting references from the recently closed recruitment cycle, and moves them to the <code>application_not_sent</code> status.</p>
+        <p>This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+      </div>
 
-      <%= f.submit 'Yes, I\'m sure',
+      <%= f.submit 'Yes, I’m sure - reject all applications awaiting references',
         class: 'govuk-button govuk-button--warning',
         data: { module: 'govuk-button' }
       %>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -4,72 +4,104 @@
   <%= render 'support_interface/tasks/tasks_navigation' %>
 <% end %>
 
-<div>
-  <h2 class='govuk-heading-m'>Sync providers</h2>
-  <div class='govuk-body'>
-    Download providers from Find.
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Sync providers from Find</h2>
+      <p>This task downloads providers from Find.</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= button_to 'Sync providers', support_interface_run_task_path('sync_providers'), class: 'govuk-button govuk-button--secondary' %>
+    </div>
   </div>
-  <%= button_to 'Sync Providers from Find', support_interface_run_task_path('sync_providers'), class: 'govuk-button' %>
-</div>
+</section>
 
-<div>
-  <h2 class='govuk-heading-m'>Recalculate dates</h2>
-  <div class='govuk-body'>
-    Runs the RecalculateDates worker when we add or remove business time holidays in response to things like COVID-19.
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Recalculate dates</h3>
+      <p>This task runs the <code>RecalculateDates</code> worker when we add or remove business time holidays in response to things like COVID-19.</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= button_to 'Recalculate dates', support_interface_run_task_path('recalculate_dates'), class: 'govuk-button govuk-button--secondary' %>
+    </div>
   </div>
-  <%= button_to 'Recalculate dates', support_interface_run_task_path('recalculate_dates'), class: 'govuk-button' %>
-</div>
+</section>
 
-<div>
-  <h2 class='govuk-heading-m'>Cancel unsubmitted applications that reach end-of-cycle</h2>
-  <div class='govuk-body'>
-    Finds any unsubmitted applications from the recently closed recruitment cycle and moves them to the 'application_not_sent' status.
-    This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>End-of-cycle: Cancel unsubmitted applications</h3>
+      <p>This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
+      <p>It should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= govuk_button_link_to 'Cancel applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, class: 'govuk-button--warning' %>
+    </div>
   </div>
-  <%= govuk_button_link_to 'Cancel unsubmitted applications', support_interface_confirm_cancel_applications_at_end_of_cycle_path, class: 'govuk-button' %>
-</div>
+</section>
 
-<div>
-  <h2 class='govuk-heading-m'>Reject applications awaiting references at end-of-cycle</h2>
-  <div class='govuk-body'>
-    Finds any applications that have been submitted but not sent to providers because they are awaiting references from the recently closed recruitment cycle and moves them to the 'application_not_sent' status.
-    This should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>End-of-cycle: Reject applications awaiting references</h3>
+      <p>This task finds any applications that have been submitted but not sent to providers because they are awaiting references from the recently closed recruitment cycle, and moves them to the <code>application_not_sent</code> status.</p>
+      <p>It should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= govuk_button_link_to 'Reject applications', support_interface_confirm_reject_applications_awaiting_references_at_end_of_cycle_path, class: 'govuk-button--warning' %>
+    </div>
   </div>
-  <%= govuk_button_link_to 'Reject applications awaiting references', support_interface_confirm_reject_applications_awaiting_references_at_end_of_cycle_path, class: 'govuk-button' %>
-</div>
+</section>
 
 <% if DeleteTestApplications.can_run_in_this_environment? %>
-  <div>
-    <h2 class='govuk-heading-m'>Delete test applications</h2>
-    <div class='govuk-body'>
-      This will delete all candidates with emails that end in  “@example.com”, their applications and associated data.
+  <section class="app-section app-section--with-top-border">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds app-styled-content">
+        <h3>Delete test applications</h3>
+        <p>This task deletes all candidates with emails that end in <code>@example.com</code>, their applications and associated data.</p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= govuk_button_link_to 'Delete test applications', support_interface_confirm_delete_test_applications_path, class: 'govuk-button--warning' %>
+      </div>
     </div>
-    <%= govuk_button_link_to 'Delete test applications', support_interface_confirm_delete_test_applications_path, class: 'govuk-button--warning' %>
-  </div>
+  </section>
 <% end %>
 
 <% unless HostingEnvironment.production? %>
-  <div>
-    <h2 class='govuk-heading-m'>Test applications</h2>
-    <div class='govuk-body'>
-      This will generate ~10 mostly-random test applications in all of the states.
+  <section class="app-section app-section--with-top-border">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds app-styled-content">
+        <h3>Generate test applications</h3>
+        <p>This task generates ~10 mostly-random test applications in all of the states.</p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button govuk-button--secondary' %>
+      </div>
     </div>
-    <%= button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button' %>
-  </div>
+  </section>
 
-  <div>
-    <h2 class='govuk-heading-m'>Vendor providers</h2>
-    <div class='govuk-body'>
-      This will generate providers for providers to test with. It also generates 10 courses run by those providers and 3 courses ratified by them.
-    </div>
-    <%= button_to 'Generate providers for vendors', support_interface_run_task_path('create_vendor_providers'), class: 'govuk-button' %>
-  </div>
+  <section class="app-section app-section--with-top-border">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds app-styled-content">
+        <h3>Generate fake providers</h3>
+        <p>This task generates providers for vendors to test with. It also generates 10 courses run by those providers and 3 courses ratified by them.</p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= button_to 'Generate fake providers', support_interface_run_task_path('create_vendor_providers'), class: 'govuk-button govuk-button--secondary' %>
+      </div>
+    <div>
+  </section>
 
-  <div>
-    <h2 class='govuk-heading-m'>Fake provider for vendors</h2>
-    <div class='govuk-body'>
-      This will generate a fake provider with 10 courses and 3 ratified courses. You will be shown their name, code and vendor API token.
-    </div>
-    <%= button_to 'Generate a fake provider for a vendor', support_interface_tasks_create_fake_provider_path, class: 'govuk-button' %>
-  </div>
+  <section class="app-section app-section--with-top-border">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds app-styled-content">
+        <h3>Create a fake provider for vendors</h3>
+        <p>This task creates a fake provider with 10 courses and 3 ratified courses. You will be shown their name, code and vendor API token.</p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= button_to 'Create a fake provider', support_interface_tasks_create_fake_provider_path, class: 'govuk-button govuk-button--secondary' %>
+      </div>
+    <div>
+  </section>
 <% end %>

--- a/spec/system/support_interface/cancel_unsubmitted_at_eoc_task_spec.rb
+++ b/spec/system/support_interface/cancel_unsubmitted_at_eoc_task_spec.rb
@@ -39,11 +39,11 @@ RSpec.feature 'Cancel unsubmitted applications support task', sidekiq: true do
   end
 
   def and_i_click_on_cancel_unsubmitted_task
-    click_link 'Cancel unsubmitted applications'
+    click_link 'Cancel applications'
   end
 
   def and_i_click_the_i_am_sure_button
-    click_button 'Yes, I\'m sure'
+    click_button 'Yes, I’m sure - cancel all unsubmitted applications'
   end
 
   def then_i_see_that_the_job_has_been_scheduled

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature 'Providers and courses' do
     )
 
     Sidekiq::Testing.inline! do
-      click_button 'Sync Providers from Find'
+      click_button 'Sync providers'
     end
   end
 

--- a/spec/system/support_interface/purge_test_applications_spec.rb
+++ b/spec/system/support_interface/purge_test_applications_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Purge test applications' do
   end
 
   def and_i_click_the_i_am_sure_button
-    click_button 'Yes, I\'m sure'
+    click_button 'Yes, I’m sure - delete all test applications'
   end
 
   def then_i_see_a_message_telling_me_a_job_has_been_queued

--- a/spec/system/support_interface/reject_awaiting_references_at_eoc_task_spec.rb
+++ b/spec/system/support_interface/reject_awaiting_references_at_eoc_task_spec.rb
@@ -39,11 +39,11 @@ RSpec.feature 'Reject applications awaiting references suppor task', sidekiq: tr
   end
 
   def and_i_click_on_reject_awaiting_references_task
-    click_link 'Reject applications awaiting references'
+    click_link 'Reject applications'
   end
 
   def and_i_click_the_i_am_sure_button
-    click_button 'Yes, I\'m sure'
+    click_button 'Yes, I’m sure - reject all applications awaiting references'
   end
 
   def then_i_see_that_the_job_has_been_scheduled

--- a/spec/system/support_interface/tasks_spec.rb
+++ b/spec/system/support_interface/tasks_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Tasks', sidekiq: false do
   end
 
   def and_when_i_click_on_generate_fake_provider
-    click_button 'Generate a fake provider for a vendor'
+    click_button 'Create a fake provider'
   end
 
   def then_i_see_new_providers_details_and_api_token


### PR DESCRIPTION
## Context

There are a lot of important buttons on this page, so we should make sure its super clear what headings relate to which buttons, and that we use common conventions on confirmation pages that can have a destructive result.

## Changes proposed in this pull request

* Updates layout and tweak content/headings on ‘Tasks’ page
* Updated content for each task conformation pages that follows conventions for such pages
* Updates `app-product-section` to `app-section` to make it a common shared style
* Add styling for `code` in `app-styled-content`.

## Guidance to review

| Before | After |
| - | - |
| ![tasks-index](https://user-images.githubusercontent.com/813383/94055357-bfbdc300-fdd4-11ea-9044-513c988e6cb4.png) | ![tasks-index-redesigned](https://user-images.githubusercontent.com/813383/94066128-f18a5600-fde3-11ea-8976-1c0919c198bf.png) |
| ![tasks-confirmation](https://user-images.githubusercontent.com/813383/94055550-fc89ba00-fdd4-11ea-95c6-96a22931586a.png) | ![tasks-confirmation-redesigned](https://user-images.githubusercontent.com/813383/94055539-f98ec980-fdd4-11ea-9286-38ef32527694.png) |