### PR TITLE
Fix ended without success count in performance statistics

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -1,45 +1,58 @@
 class PerformanceStatistics
-  CANDIDATE_QUERY = "
-  WITH raw_data AS (
+  def candidate_query
+    <<-SQL
+      WITH raw_data AS (
+          SELECT
+              c.id,
+              f.id,
+              COUNT(f.id) FILTER (WHERE f.id IS NOT NULL) application_forms,
+              COUNT(ch.id) FILTER (WHERE f.id IS NOT NULL) application_choices,
+              CASE
+                WHEN f.id IS NULL THEN ARRAY['-1', 'never_signed_in']
+                WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND DATE_TRUNC('second', f.updated_at) = DATE_TRUNC('second', f.created_at) THEN ARRAY['0', 'unsubmitted_not_started_form']
+                WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND DATE_TRUNC('second', f.updated_at) <> DATE_TRUNC('second', f.created_at) THEN ARRAY['1', 'unsubmitted_in_progress']
+                WHEN 'awaiting_references' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['2', 'awaiting_references']
+                WHEN 'application_complete' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['3', 'waiting_to_be_sent']
+                WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['4', 'awaiting_provider_decisions']
+                WHEN 'offer' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['6', 'awaiting_candidate_response']
+                WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['8', 'recruited']
+                WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'pending_conditions']
+                WHEN 'offer_deferred' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['10', 'offer_deferred']
+                WHEN #{ended_without_success_sql} = '{}' THEN ARRAY['5', 'ended_without_success']
+                ELSE ARRAY['10', 'unknown_state']
+              END status
+          FROM
+              application_forms f
+          FULL OUTER JOIN
+              candidates c ON f.candidate_id = c.id
+          LEFT JOIN
+              application_choices ch ON ch.application_form_id = f.id
+          WHERE
+              NOT c.hide_in_reporting
+          GROUP BY
+              c.id, f.id
+      )
       SELECT
-          c.id,
-          f.id,
-          COUNT(f.id) FILTER (WHERE f.id IS NOT NULL) application_forms,
-          COUNT(ch.id) FILTER (WHERE f.id IS NOT NULL) application_choices,
-          CASE
-            WHEN f.id IS NULL THEN ARRAY['-1', 'never_signed_in']
-            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND DATE_TRUNC('second', f.updated_at) = DATE_TRUNC('second', f.created_at) THEN ARRAY['0', 'unsubmitted_not_started_form']
-            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND DATE_TRUNC('second', f.updated_at) <> DATE_TRUNC('second', f.created_at) THEN ARRAY['1', 'unsubmitted_in_progress']
-            WHEN 'awaiting_references' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['2', 'awaiting_references']
-            WHEN 'application_complete' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['3', 'waiting_to_be_sent']
-            WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['4', 'awaiting_provider_decisions']
-            WHEN 'offer' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['6', 'awaiting_candidate_response']
-            WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['8', 'recruited']
-            WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'pending_conditions']
-            WHEN 'offer_deferred' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['10', 'offer_deferred']
-            WHEN ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_AGG(DISTINCT ch.status), 'cancelled'), 'withdrawn'), 'offer_withdrawn'), 'rejected'), 'declined'), 'conditions_not_met') = '{}' THEN ARRAY['5', 'ended_without_success']
-            ELSE ARRAY['10', 'unknown_state']
-          END status
+          raw_data.status[2],
+          COUNT(*)
       FROM
-          application_forms f
-      FULL OUTER JOIN
-          candidates c ON f.candidate_id = c.id
-      LEFT JOIN
-          application_choices ch ON ch.application_form_id = f.id
-      WHERE
-          NOT c.hide_in_reporting
+          raw_data
       GROUP BY
-          c.id, f.id
-  )
-  SELECT
-      raw_data.status[2],
-      COUNT(*)
-  FROM
-      raw_data
-  GROUP BY
-      raw_data.status
-  ORDER BY
-      raw_data.status[1]".freeze
+          raw_data.status
+      ORDER BY
+          raw_data.status[1]
+    SQL
+  end
+
+  def ended_without_success_sql
+    sql = 'ARRAY_AGG(DISTINCT ch.status)'
+
+    ApplicationStateChange::UNSUCCESSFUL_END_STATES.each do |state|
+      sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
+    end
+
+    sql
+  end
 
   def [](key)
     candidate_status_counts.find { |x| x['status'] == key.to_s }&.[]('count')
@@ -56,7 +69,7 @@ class PerformanceStatistics
   def candidate_status_counts
     @candidate_status_counts ||= ActiveRecord::Base
       .connection
-      .execute(CANDIDATE_QUERY)
+      .execute(candidate_query)
       .to_a
   end
 


### PR DESCRIPTION
## Context

This is a new status (https://github.com/DFE-Digital/apply-for-teacher-training/pull/2840), but it hadn't been added to the performance statistics, which means applications like this aren't correctly counted.

## Changes proposed in this pull request

This changes the way we construct the SQL to make this automatically.

## Guidance to review

Trust that it works, because the existing spec still works.

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1600940768005500

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
