### PR TITLE
Remove open_on_apply constraint on broken view component

### DIFF
--- a/spec/components/previews/provider_interface/change_offer_preview.rb
+++ b/spec/components/previews/provider_interface/change_offer_preview.rb
@@ -145,7 +145,6 @@ module ProviderInterface
     def pick_different_option
       new_provider = available_providers.sample
       new_course = new_provider.courses.where(
-        open_on_apply: true,
         recruitment_cycle_year: @application_choice.offered_course.recruitment_cycle_year,
       ).sample
       new_course.course_options.sample


### PR DESCRIPTION
## Context

The ChangeOfferPreview view component is still borked 🤦 

Currently, the pick_different_option method is returning nil as it is scoped to only return courses that are open_on_apply which is returning an empty array. There is no need for the replacement course choice to be open_on_apply for a preview component.

![image](https://user-images.githubusercontent.com/42515961/94136755-4ddd8c00-fe5d-11ea-9a16-58b87d287afa.png)

## Changes proposed in this pull request

- Remove the constraint that courses need to be open on apply

## Guidance to review

Is my assumption that this is not necessary correct?

## Link to Trello card

https://trello.com/c/Ejg12FYm/1954-fix-component-previews-and-enable-automated-accessibility-tests

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
