### PR TITLE
Fix flaky change offer preview component

### DIFF
--- a/spec/components/previews/provider_interface/change_offer_preview.rb
+++ b/spec/components/previews/provider_interface/change_offer_preview.rb
@@ -143,11 +143,7 @@ module ProviderInterface
     end
 
     def pick_different_option
-      new_provider = available_providers.sample
-      new_course = new_provider.courses.where(
-        recruitment_cycle_year: @application_choice.offered_course.recruitment_cycle_year,
-      ).sample
-      new_course.course_options.sample
+      CourseOption.available.sample
     end
 
     def render_component(component_to_render, form:, completion_url:)


### PR DESCRIPTION
## Context

This preview now works some of the time. With the current implementation, the pick_different_option method sometimes returns an empty array.

![image](https://user-images.githubusercontent.com/42515961/94158913-dc143b00-fe7a-11ea-9c0f-a90db692a72d.png)


## Changes proposed in this pull request

- Use a random available course option instead of grabbing a random provider.


## Link to Trello card

https://trello.com/c/Ejg12FYm/1954-fix-component-previews-and-enable-automated-accessibility-tests

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
