### PR TITLE
Add definitions for new HESA codes

### DIFF
--- a/config/initializers/hesa_disabilities.rb
+++ b/config/initializers/hesa_disabilities.rb
@@ -1,0 +1,12 @@
+HESA_DISABILITIES = [
+  ['00', 'No known disability'],
+  ['08', 'Multiple disabilities'],
+  ['51', 'A specific learning difficulty such as dyslexia, dyspraxia or AD(H)D'],
+  ['53', "A social/communication impairment such as Asperger's syndrome/other autistic spectrum disorder"],
+  ['54', 'A long standing illness or health condition such as cancer, HIV, diabetes, chronic heart disease, or epilepsy'],
+  ['55', 'A mental health condition, such as depression, schizophrenia or anxiety disorder'],
+  ['56', 'A physical impairment or mobility issues, such as difficulty using arms or using a wheelchair or crutches'],
+  ['57', 'Deaf or a serious hearing impairment'],
+  ['58', 'Blind or a serious visual impairment uncorrected by glasses'],
+  ['96', 'A disability, impairment or medical condition that is not listed above'],
+].freeze

--- a/config/initializers/hesa_ethnicities.rb
+++ b/config/initializers/hesa_ethnicities.rb
@@ -1,0 +1,26 @@
+# https://www.hesa.ac.uk/collection/c19053/e/ethnic
+HESA_ETHNICITIES_2019_2020 = [
+  [10, 'White'],
+  [15, 'Gypsy or Traveller'],
+  [21, 'Black or Black British - Caribbean'],
+  [22, 'Black or Black British - African'],
+  [29, 'Other Black background'],
+  [31, 'Asian or Asian British - Indian'],
+  [32, 'Asian or Asian British - Pakistani'],
+  [33, 'Asian or Asian British - Bangladeshi'],
+  [34, 'Chinese'],
+  [39, 'Other Asian background'],
+  [41, 'Mixed - White and Black Caribbean'],
+  [42, 'Mixed - White and Black African'],
+  [43, 'Mixed - White and Asian'],
+  [49, 'Other Mixed background'],
+  [50, 'Arab'],
+  [80, 'Other Ethnic background'],
+  [90, 'Not known'],
+  [98, 'Information refused'],
+].freeze
+
+# Two codes have been dropped in 2020/21
+# https://www.hesa.ac.uk/collection/c20053/e/ethnic
+HESA_ETHNICITIES_2020_2021 = HESA_ETHNICITIES_2019_2020
+                               .reject { |ethnicity| [90, 98].include?(ethnicity.first) }

--- a/config/initializers/hesa_sex.rb
+++ b/config/initializers/hesa_sex.rb
@@ -1,0 +1,5 @@
+HESA_SEX = [
+  [1, 'Male'],
+  [2, 'Female'],
+  [3, 'Other'],
+].freeze


### PR DESCRIPTION
## Context

```
As a Provendor team
I need application HESA data codes for Sex, Ethnicity, Disability to be collected at source
So that I can supply Providers with a download they can share with HESA/DfE
```

## Changes proposed in this pull request

- Definitions added for ethnicity, sex and disabilities.
- More PRs to follow!

## Guidance to review

Hesa code information taken from the following links:
- [Sex](https://www.hesa.ac.uk/collection/c19053/e/sexid)
- [Disabilities](https://www.hesa.ac.uk/collection/c19053/e/disable)
- [Ethnicity 2019 - 2020](https://www.hesa.ac.uk/collection/c19053/e/ethnic)
- [Ethnicity 2020 - 2021](https://www.hesa.ac.uk/collection/c20053/e/ethnic) - NB two codes are dropped in the new cycle

## Link to Trello card

https://trello.com/c/mxKdgR5L/2178-dev-collect-hesa-codes-at-source-in-ed-qs

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
