### PR TITLE
Notify in Slack when the cycle is changed through support

### DIFF
--- a/app/controllers/support_interface/cycles_controller.rb
+++ b/app/controllers/support_interface/cycles_controller.rb
@@ -1,7 +1,13 @@
 module SupportInterface
   class CyclesController < SupportInterfaceController
     def switch_cycle_schedule
-      SiteSetting.set(name: 'cycle_schedule', value: params[:support_interface_change_cycle_form][:cycle_schedule_name])
+      new_cycle = params[:support_interface_change_cycle_form][:cycle_schedule_name]
+      SiteSetting.set(name: 'cycle_schedule', value: new_cycle)
+
+      message = ":old_timey_parrot: Cycle schedule updated to #{new_cycle}"
+      url = Rails.application.routes.url_helpers.support_interface_cycles_url
+      SlackNotificationWorker.perform_async(message, url)
+
       flash[:success] = 'Cycle schedule updated'
       redirect_to support_interface_cycles_path
     end


### PR DESCRIPTION
## Context

It would be nice to see when the cycle was updated as it could help us track down issues.

## Changes proposed in this pull request

Add a Slack ping to the controller.

## Guidance to review

Makes sense?

## Link to Trello card

None.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)