### PR TITLE
Smol support IA changes

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -21,7 +21,7 @@ class NavigationItems
     def for_support_interface(current_support_user, current_controller)
       if current_support_user
         [
-          NavigationItem.new('Candidates', support_interface_candidates_path, is_active(current_controller, %w[candidates import_references application_forms])),
+          NavigationItem.new('Candidates', support_interface_applications_path, is_active(current_controller, %w[candidates import_references application_forms ucas_matches])),
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses provider_users api_tokens])),
           NavigationItem.new('Features', support_interface_feature_flags_path, is_active(current_controller, 'feature_flags')),
           NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance course_options email_log])),

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -23,7 +23,7 @@ class NavigationItems
         [
           NavigationItem.new('Candidates', support_interface_applications_path, is_active(current_controller, %w[candidates import_references application_forms ucas_matches])),
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses provider_users api_tokens])),
-          NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance course_options email_log])),
+          NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance performance_data course_options email_log])),
           NavigationItem.new('Service settings', support_interface_feature_flags_path, is_active(current_controller, %w[feature_flags cycles support_users tasks])),
           NavigationItem.new('Docs', support_interface_guidance_path, is_active(current_controller, %w[docs guidance mailer_previews])),
           NavigationItem.new(current_support_user.email_address, nil, false),

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -23,10 +23,9 @@ class NavigationItems
         [
           NavigationItem.new('Candidates', support_interface_applications_path, is_active(current_controller, %w[candidates import_references application_forms ucas_matches])),
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses provider_users api_tokens])),
-          NavigationItem.new('Features', support_interface_feature_flags_path, is_active(current_controller, 'feature_flags')),
           NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance course_options email_log])),
-          NavigationItem.new('Docs', support_interface_guidance_path, is_active(current_controller, %w[docs guidance mailer_previews cycles])),
-          NavigationItem.new('Tasks', support_interface_tasks_path, is_active(current_controller, %w[tasks support_users])),
+          NavigationItem.new('Service settings', support_interface_feature_flags_path, is_active(current_controller, %w[feature_flags cycles support_users tasks])),
+          NavigationItem.new('Docs', support_interface_guidance_path, is_active(current_controller, %w[docs guidance mailer_previews])),
           NavigationItem.new(current_support_user.email_address, nil, false),
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),
         ]

--- a/app/views/support_interface/candidates/_candidates_navigation.html.erb
+++ b/app/views/support_interface/candidates/_candidates_navigation.html.erb
@@ -1,6 +1,7 @@
 <% content_for :navigation do %>
   <%= render SubNavigationComponent.new(items: [
-    { name: 'Candidates', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
     { name: 'Applications', url: support_interface_applications_path, current: local_assigns[:current] == 'Applications' },
+    { name: 'Candidates', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
+    { name: 'UCAS matches', url: support_interface_ucas_matches_path, current: local_assigns[:current] == 'UCAS matches' },
   ]) %>
 <% end %>

--- a/app/views/support_interface/course_options/index.html.erb
+++ b/app/views/support_interface/course_options/index.html.erb
@@ -1,3 +1,8 @@
 <% content_for :title, 'Course options without vacancies' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_performance_path) %>
+
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation', current: 'Dashboards' %>
+<% end %>
 
 <%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>

--- a/app/views/support_interface/cycles/index.html.erb
+++ b/app/views/support_interface/cycles/index.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :title, 'Recruitment cycles' %>
 
-<%= render 'support_interface/docs/docs_navigation' %>
+<% content_for :navigation do %>
+  <%= render 'support_interface/settings/settings_navigation' %>
+<% end %>
 
 <% unless HostingEnvironment.production? %>
   <%= form_with model: SupportInterface::ChangeCycleForm.new, url: support_interface_switch_cycle_schedule_path, method: :post do |f| %>

--- a/app/views/support_interface/docs/_docs_navigation.html.erb
+++ b/app/views/support_interface/docs/_docs_navigation.html.erb
@@ -4,9 +4,7 @@
     { name: 'Flow for candidates', url: support_interface_candidate_flow_path },
     { name: 'Flow for providers', url: support_interface_provider_flow_path },
     { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path },
-    { name: 'Cycles', url: support_interface_cycles_path },
   ] %>
-
 
   <% if Rails.application.config.action_mailer.show_previews %>
     <% items << { name: 'Emails', url: '/support/mailers' } %>

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, 'Email log' %>
 
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation' %>
+<% end %>
+
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @emails) do %>
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, 'Feature flags' %>
 
+<% content_for :navigation do %>
+  <%= render 'support_interface/settings/settings_navigation' %>
+<% end %>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/support_interface/performance/_performance_navigation.html.erb
+++ b/app/views/support_interface/performance/_performance_navigation.html.erb
@@ -1,0 +1,8 @@
+<% content_for :navigation do %>
+  <%= render SubNavigationComponent.new(items: [
+    { name: 'Dashboards', url: support_interface_performance_path, current: local_assigns[:current] == 'Dashboards' },
+    { name: 'Export data', url: support_interface_performance_data_path },
+    { name: 'Email log', url: support_interface_email_log_path },
+    { name: 'Validation errors', url: support_interface_validation_errors_path, current: local_assigns[:current] == 'Validation errors' },
+  ]) %>
+<% end %>

--- a/app/views/support_interface/performance/course_stats.html.erb
+++ b/app/views/support_interface/performance/course_stats.html.erb
@@ -1,4 +1,9 @@
 <% content_for :title, 'Course stats' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_performance_path) %>
+
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation', current: 'Dashboards' %>
+<% end %>
 
 <% RecruitmentCycle.years_visible_in_support.each do |year| %>
   <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-4"><%= year %></h2>

--- a/app/views/support_interface/performance/data.html.erb
+++ b/app/views/support_interface/performance/data.html.erb
@@ -1,0 +1,101 @@
+<% content_for :title, 'Export performance data' %>
+
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation' %>
+<% end %>
+
+<h3 class='govuk-heading-m'>Application timings</h3>
+
+<p class='govuk-body'>
+  The application timings provides data on when an application
+  form attribute was last updated by the candidate.
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download application timings (CSV)', support_interface_application_timings_path %>
+</p>
+
+<h3 class='govuk-heading-m'>Submitted application choices</h3>
+
+<p class='govuk-body'>
+  The submitted application choices export provides data about which courses candidates applied to,
+  as well as info about offers and candidate decisions.
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download submitted application choices (CSV)', support_interface_submitted_application_choices_path %>
+</p>
+
+<h3 class='govuk-heading-m'>Candidate journey tracking</h3>
+
+<p class='govuk-body'>
+  Candidate journey tracking provides data on when each application choice
+  progressed through the various steps in the candidate application journey.
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download candidate journey tracking (CSV)', support_interface_candidate_journey_tracking_path %>
+</p>
+
+<h3 class='govuk-heading-m'>Providers</h3>
+
+<p class='govuk-body'>
+  The list of providers that are being synced from the Find service, along
+  with when they signed the data sharing agreement.
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download providers (CSV)', support_interface_providers_export_path %>
+</p>
+
+<h3 class='govuk-heading-m'>Referee survey</h3>
+
+<p class='govuk-body'>
+  This provides the compiled results of all the referee surveys
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download referee survey results (CSV)', support_interface_referee_survey_path %>
+</p>
+
+<h3 class='govuk-heading-m'>Candidate survey</h3>
+
+<p class='govuk-body'>
+  This provides the compiled results of all the candidate satisfaction surveys
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download candidate survey results (CSV)', support_interface_candidate_survey_path %>
+</p>
+
+<h3 class="govuk-heading-m">Active provider users</h3>
+
+<p class="govuk-body">The list of provider users that have signed in to apply at least once</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %>
+</p>
+
+<h3 class="govuk-heading-m">Candidate course choice withdrawal survey</h3>
+
+<p class="govuk-body">A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download course choice withdrawal survey results (CSV)', support_interface_course_choice_withdrawal_survey_path %>
+</p>
+
+<h3 class="govuk-heading-m">Provider performance for TAD</h3>
+
+<p class="govuk-body">A list of all application/offered/accepted counts for all courses in Apply</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download provider performance for TAD (CSV)', support_interface_tad_provider_performance_path %>
+</p>
+
+<h3 class="govuk-heading-m">Application references</h3>
+
+<p class="govuk-body">A list of all application references which have been selected by candidates to date</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download application references (CSV)', support_interface_application_references_path %>
+</p>

--- a/app/views/support_interface/performance/data.html.erb
+++ b/app/views/support_interface/performance/data.html.erb
@@ -4,98 +4,102 @@
   <%= render 'support_interface/performance/performance_navigation' %>
 <% end %>
 
-<h3 class='govuk-heading-m'>Application timings</h3>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Application timings</h3>
+      <p>The application timings provides data on when an application form attribute was last updated by the candidate.</p>
+      <p><%= govuk_link_to 'Download application timings (CSV)', support_interface_application_timings_path %></p>
+    </div>
+  </div>
+</section>
 
-<p class='govuk-body'>
-  The application timings provides data on when an application
-  form attribute was last updated by the candidate.
-</p>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Submitted application choices</h3>
+      <p>The submitted application choices export provides data about which courses candidates applied to, as well as info about offers and candidate decisions.</p>
+      <p><%= govuk_link_to 'Download submitted application choices (CSV)', support_interface_submitted_application_choices_path %></p>
+    </div>
+  </div>
+</section>
 
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download application timings (CSV)', support_interface_application_timings_path %>
-</p>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Candidate journey tracking</h3>
+      <p>Candidate journey tracking provides data on when each application choice progressed through the various steps in the candidate application journey.</p>
+      <p><%= govuk_link_to 'Download candidate journey tracking (CSV)', support_interface_candidate_journey_tracking_path %></p>
+    </div>
+  </div>
+</section>
 
-<h3 class='govuk-heading-m'>Submitted application choices</h3>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Providers</h3>
+      <p>The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.</p>
+      <p><%= govuk_link_to 'Download providers (CSV)', support_interface_providers_export_path %></p>
+    </div>
+  </div>
+</section>
 
-<p class='govuk-body'>
-  The submitted application choices export provides data about which courses candidates applied to,
-  as well as info about offers and candidate decisions.
-</p>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Referee survey</h3>
+      <p>This provides the compiled results of all the referee surveys.</p>
+      <p><%= govuk_link_to 'Download referee survey results (CSV)', support_interface_referee_survey_path %></p>
+    </div>
+  </div>
+</section>
 
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download submitted application choices (CSV)', support_interface_submitted_application_choices_path %>
-</p>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Candidate survey</h3>
+      <p>This provides the compiled results of all the candidate satisfaction surveys.</p>
+      <p><%= govuk_link_to 'Download candidate survey results (CSV)', support_interface_candidate_survey_path %></p>
+    </div>
+  </div>
+</section>
 
-<h3 class='govuk-heading-m'>Candidate journey tracking</h3>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Active provider users</h3>
+      <p>The list of provider users that have signed in to apply at least once.</p>
+      <p><%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %></p>
+    </div>
+  </div>
+</section>
 
-<p class='govuk-body'>
-  Candidate journey tracking provides data on when each application choice
-  progressed through the various steps in the candidate application journey.
-</p>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Candidate course choice withdrawal survey</h3>
+      <p>A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.</p>
+      <p><%= govuk_link_to 'Download course choice withdrawal survey results (CSV)', support_interface_course_choice_withdrawal_survey_path %></p>
+    </div>
+  </div>
+</section>
 
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download candidate journey tracking (CSV)', support_interface_candidate_journey_tracking_path %>
-</p>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Provider performance for TAD</h3>
+      <p>A list of all application/offered/accepted counts for all courses in Apply.</p>
+      <p><%= govuk_link_to 'Download provider performance for TAD (CSV)', support_interface_tad_provider_performance_path %></p>
+    </div>
+  </div>
+</section>
 
-<h3 class='govuk-heading-m'>Providers</h3>
-
-<p class='govuk-body'>
-  The list of providers that are being synced from the Find service, along
-  with when they signed the data sharing agreement.
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download providers (CSV)', support_interface_providers_export_path %>
-</p>
-
-<h3 class='govuk-heading-m'>Referee survey</h3>
-
-<p class='govuk-body'>
-  This provides the compiled results of all the referee surveys
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download referee survey results (CSV)', support_interface_referee_survey_path %>
-</p>
-
-<h3 class='govuk-heading-m'>Candidate survey</h3>
-
-<p class='govuk-body'>
-  This provides the compiled results of all the candidate satisfaction surveys
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download candidate survey results (CSV)', support_interface_candidate_survey_path %>
-</p>
-
-<h3 class="govuk-heading-m">Active provider users</h3>
-
-<p class="govuk-body">The list of provider users that have signed in to apply at least once</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %>
-</p>
-
-<h3 class="govuk-heading-m">Candidate course choice withdrawal survey</h3>
-
-<p class="govuk-body">A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download course choice withdrawal survey results (CSV)', support_interface_course_choice_withdrawal_survey_path %>
-</p>
-
-<h3 class="govuk-heading-m">Provider performance for TAD</h3>
-
-<p class="govuk-body">A list of all application/offered/accepted counts for all courses in Apply</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download provider performance for TAD (CSV)', support_interface_tad_provider_performance_path %>
-</p>
-
-<h3 class="govuk-heading-m">Application references</h3>
-
-<p class="govuk-body">A list of all application references which have been selected by candidates to date</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download application references (CSV)', support_interface_application_references_path %>
-</p>
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Application references</h3>
+      <p>A list of all application references which have been selected by candidates to date.</p>
+      <p><%= govuk_link_to 'Download application references (CSV)', support_interface_application_references_path %></p>
+    </div>
+  </div>
+</section>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -9,7 +9,6 @@
   <li><%= govuk_link_to 'Applications with unavailable choices', support_interface_unavailable_choices_path %></li>
   <li><%= govuk_link_to 'Validation errors', support_interface_validation_errors_path %></li>
   <li><%= govuk_link_to 'Validation error summary', support_interface_validation_error_summary_path %></li>
-  <li><%= govuk_link_to 'UCAS Matches', support_interface_ucas_matches_path %></li>
   <li><%= govuk_link_to 'Email log', support_interface_email_log_path %></li>
 </ul>
 

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,111 +1,12 @@
-<% content_for :title, 'Service performance' %>
+<% content_for :title, 'Dashboards' %>
 
-<h2 class='govuk-heading-l'>Dashboards</h2>
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation' %>
+<% end %>
 
-<ul class='govuk-body'>
-  <li><%= govuk_link_to 'Performance dashboard', integrations_performance_path %> (public)</li>
+<ul class="govuk-list govuk-list--bullet">
+  <li><%= govuk_link_to 'Service performance', integrations_performance_path %> (public)</li>
   <li><%= govuk_link_to 'Course stats', support_interface_course_stats_path %></li>
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
   <li><%= govuk_link_to 'Applications with unavailable choices', support_interface_unavailable_choices_path %></li>
-  <li><%= govuk_link_to 'Validation errors', support_interface_validation_errors_path %></li>
-  <li><%= govuk_link_to 'Validation error summary', support_interface_validation_error_summary_path %></li>
-  <li><%= govuk_link_to 'Email log', support_interface_email_log_path %></li>
 </ul>
-
-<h2 class='govuk-heading-l'>Downloads for analysis</h2>
-
-<h3 class='govuk-heading-m'>Application timings</h3>
-
-<p class='govuk-body'>
-  The application timings provides data on when an application
-  form attribute was last updated by the candidate.
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download application timings (CSV)', support_interface_application_timings_path %>
-</p>
-
-<h3 class='govuk-heading-m'>Submitted application choices</h3>
-
-<p class='govuk-body'>
-  The submitted application choices export provides data about which courses candidates applied to,
-  as well as info about offers and candidate decisions.
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download submitted application choices (CSV)', support_interface_submitted_application_choices_path %>
-</p>
-
-<h3 class='govuk-heading-m'>Candidate journey tracking</h3>
-
-<p class='govuk-body'>
-  Candidate journey tracking provides data on when each application choice
-  progressed through the various steps in the candidate application journey.
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download candidate journey tracking (CSV)', support_interface_candidate_journey_tracking_path %>
-</p>
-
-<h3 class='govuk-heading-m'>Providers</h3>
-
-<p class='govuk-body'>
-  The list of providers that are being synced from the Find service, along
-  with when they signed the data sharing agreement.
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download providers (CSV)', support_interface_providers_export_path %>
-</p>
-
-<h3 class='govuk-heading-m'>Referee survey</h3>
-
-<p class='govuk-body'>
-  This provides the compiled results of all the referee surveys
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download referee survey results (CSV)', support_interface_referee_survey_path %>
-</p>
-
-<h3 class='govuk-heading-m'>Candidate survey</h3>
-
-<p class='govuk-body'>
-  This provides the compiled results of all the candidate satisfaction surveys
-</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download candidate survey results (CSV)', support_interface_candidate_survey_path %>
-</p>
-
-<h3 class="govuk-heading-m">Active provider users</h3>
-
-<p class="govuk-body">The list of provider users that have signed in to apply at least once</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %>
-</p>
-
-<h3 class="govuk-heading-m">Candidate course choice withdrawal survey</h3>
-
-<p class="govuk-body">A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download course choice withdrawal survey results (CSV)', support_interface_course_choice_withdrawal_survey_path %>
-</p>
-
-<h3 class="govuk-heading-m">Provider performance for TAD</h3>
-
-<p class="govuk-body">A list of all application/offered/accepted counts for all courses in Apply</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download provider performance for TAD (CSV)', support_interface_tad_provider_performance_path %>
-</p>
-
-<h3 class="govuk-heading-m">Application references</h3>
-
-<p class="govuk-body">A list of all application references which have been selected by candidates to date</p>
-
-<p class='govuk-body'>
-  <%= govuk_link_to 'Download application references (CSV)', support_interface_application_references_path %>
-</p>

--- a/app/views/support_interface/settings/_settings_navigation.html.erb
+++ b/app/views/support_interface/settings/_settings_navigation.html.erb
@@ -1,5 +1,7 @@
 <% content_for :navigation do %>
   <%= render SubNavigationComponent.new(items: [
+    { name: 'Feature flags', url: support_interface_feature_flags_path },
+    { name: 'Recruitment cycles', url: support_interface_cycles_path },
     { name: 'Tasks', url: support_interface_tasks_path },
     { name: 'Support users', url: support_interface_support_users_path, current: local_assigns[:current] == 'Support users' },
   ]) %>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Support users' %>
 
 <% content_for :navigation do %>
-  <%= render 'support_interface/tasks/tasks_navigation' %>
+  <%= render 'support_interface/settings/settings_navigation' %>
 <% end %>
 
 <%= govuk_button_link_to 'Add support user', new_support_interface_support_user_path %>

--- a/app/views/support_interface/support_users/new.html.erb
+++ b/app/views/support_interface/support_users/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, title_with_error_prefix('Add support user', @support_user.errors.any?) %>
 
 <% content_for :navigation do %>
-  <%= render 'support_interface/tasks/tasks_navigation', current: 'Support users' %>
+  <%= render 'support_interface/settings/settings_navigation', current: 'Support users' %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/support_interface/support_users/show.html.erb
+++ b/app/views/support_interface/support_users/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, @support_user.display_name %>
 
 <% content_for :navigation do %>
-  <%= render 'support_interface/tasks/tasks_navigation', current: 'Support users' %>
+  <%= render 'support_interface/settings/settings_navigation', current: 'Support users' %>
 <% end %>
 
 <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @support_user) %>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -7,7 +7,7 @@
 <section class="app-section app-section--with-top-border">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds app-styled-content">
-      <h3>Sync providers from Find</h2>
+      <h3>Sync providers from Find</h3>
       <p>This task downloads providers from Find.</p>
     </div>
     <div class="govuk-grid-column-one-third">

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Tasks' %>
 
 <% content_for :navigation do %>
-  <%= render 'support_interface/tasks/tasks_navigation' %>
+  <%= render 'support_interface/settings/settings_navigation' %>
 <% end %>
 
 <section class="app-section app-section--with-top-border">

--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, 'UCAS matches' %>
 
+<%= render 'support_interface/candidates/candidates_navigation' %>
+
 <table class='govuk-table'>
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, "UCAS match: #{@match.candidate.email_address}" %>
 
+<%= render 'support_interface/candidates/candidates_navigation' %>
+
 <p class="govuk-body">
   <%= render TagComponent.new(text: @match.matching_state.humanize, type: @match.processed? ? :green : :default) %> Last updated <%= @match.updated_at.to_s(:govuk_date_and_time) %>
 </p>

--- a/app/views/support_interface/validation_errors/index.html.erb
+++ b/app/views/support_interface/validation_errors/index.html.erb
@@ -1,5 +1,11 @@
 <% content_for :title, 'Validation errors' %>
 
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation' %>
+<% end %>
+
+<p class="govuk-body"><%= govuk_link_to 'Validation error summary', support_interface_validation_error_summary_path %></p>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/support_interface/validation_errors/search.html.erb
+++ b/app/views/support_interface/validation_errors/search.html.erb
@@ -1,6 +1,10 @@
 <% content_for :title, "Search validation errors" %>
 <% content_for :before_content, govuk_back_link_to(support_interface_validation_errors_path) %>
 
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation', current: 'Validation errors' %>
+<% end %>
+
 <p class='govuk-body'>
   <% if params[:id] %>
     Showing validation error #<%= params[:id] %>

--- a/app/views/support_interface/validation_errors/summary.html.erb
+++ b/app/views/support_interface/validation_errors/summary.html.erb
@@ -1,4 +1,9 @@
 <% content_for :title, 'Validation error summary' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_validation_errors_path) %>
+
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation', current: 'Validation errors' %>
+<% end %>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -743,6 +743,7 @@ Rails.application.routes.draw do
     post '/feature-flags/:feature_name/deactivate' => 'feature_flags#deactivate', as: :deactivate_feature_flag
 
     get '/performance' => 'performance#index', as: :performance
+    get '/performance/data' => 'performance#data', as: :performance_data
     get '/performance/application-timings', to: 'performance#application_timings', as: :application_timings
     get '/performance/course-stats', to: 'performance#course_stats', as: :course_stats
     get '/performance/submitted-application-choices', to: 'performance#submitted_application_choices', as: :submitted_application_choices

--- a/spec/system/support_interface/active_provider_users_csv_export_spec.rb
+++ b/spec/system/support_interface/active_provider_users_csv_export_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Active provider users CSV' do
   end
 
   def when_i_visit_the_provider_users_page
-    visit support_interface_performance_path
+    visit support_interface_provider_users_path
   end
 
   def and_i_click_on_download_active_provider_users

--- a/spec/system/support_interface/application_choices_performance_spec.rb
+++ b/spec/system/support_interface/application_choices_performance_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Candidate journey tracking CSV' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     then_i_should_be_able_to_download_a_csv
   end
 
@@ -19,8 +19,8 @@ RSpec.feature 'Candidate journey tracking CSV' do
     create(:application_choice, :awaiting_provider_decision)
   end
 
-  def when_i_visit_the_service_performance_page
-    visit support_interface_performance_path
+  def when_i_visit_the_service_performance_data_page
+    visit support_interface_performance_data_path
   end
 
   def then_i_should_be_able_to_download_a_csv

--- a/spec/system/support_interface/application_references_performance_spec.rb
+++ b/spec/system/support_interface/application_references_performance_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Application references performance CSV' do
     given_i_am_a_support_user
     and_there_is_an_application_with_references_in_the_system
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     and_i_click_on_download_reference_types_performance_report
 
     then_i_should_be_able_to_download_a_csv
@@ -24,8 +24,8 @@ RSpec.feature 'Application references performance CSV' do
     create(:reference, feedback_status: 'feedback_refused', referee_type: 'professional', application_form: application_form)
   end
 
-  def when_i_visit_the_service_performance_page
-    visit support_interface_performance_path
+  def when_i_visit_the_service_performance_data_page
+    visit support_interface_performance_data_path
   end
 
   def and_i_click_on_download_reference_types_performance_report

--- a/spec/system/support_interface/candidate_survey_csv_spec.rb
+++ b/spec/system/support_interface/candidate_survey_csv_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature 'Candidate survey CSV' do
   scenario 'support user can download a CSV with the candidate satisfaction survey results' do
     given_i_am_a_support_user
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     and_i_click_on_download_candidate_survey_results
     then_i_should_be_informed_there_are_no_survey_results
 
     given_there_are_candidate_survey_results
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     and_i_click_on_download_candidate_survey_results
     then_i_should_be_able_to_download_a_csv
   end
@@ -21,8 +21,8 @@ RSpec.feature 'Candidate survey CSV' do
     sign_in_as_support_user
   end
 
-  def when_i_visit_the_service_performance_page
-    visit support_interface_performance_path
+  def when_i_visit_the_service_performance_data_page
+    visit support_interface_performance_data_path
   end
 
   def and_i_click_on_download_candidate_survey_results

--- a/spec/system/support_interface/course_choice_withdrawal_survey_csv_spec.rb
+++ b/spec/system/support_interface/course_choice_withdrawal_survey_csv_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature 'Course choice withdrawal survey CSV' do
   scenario 'support user can download a CSV with the course choice withdrawal survey results' do
     given_i_am_a_support_user
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     and_i_click_on_download_course_choice_withdrawl_survey_results
     then_i_should_be_informed_there_are_no_survey_results
 
     given_there_are_candidate_survey_results
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     and_i_click_on_download_course_choice_withdrawl_survey_results
     then_i_should_be_able_to_download_a_csv
   end
@@ -21,8 +21,8 @@ RSpec.feature 'Course choice withdrawal survey CSV' do
     sign_in_as_support_user
   end
 
-  def when_i_visit_the_service_performance_page
-    visit support_interface_performance_path
+  def when_i_visit_the_service_performance_data_page
+    visit support_interface_performance_data_path
   end
 
   def and_i_click_on_download_course_choice_withdrawl_survey_results

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -17,8 +17,8 @@ RSpec.feature 'Cycle switching' do
   end
 
   def when_i_click_on_the_recruitment_cycle_link
-    click_on 'Docs'
-    click_on 'Cycles'
+    click_on 'Service settings'
+    click_on 'Recruitment cycles'
   end
 
   def then_i_see_the_cycle_information

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Managing support users' do
   end
 
   def and_i_click_the_manange_support_users_link
-    click_link 'Tasks'
+    click_link 'Service settings'
     click_link 'Support users'
   end
 

--- a/spec/system/support_interface/referee_survey_csv_spec.rb
+++ b/spec/system/support_interface/referee_survey_csv_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Referee survery CSV' do
     given_i_am_a_support_user
     and_there_are_referee_survey_results
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     and_i_click_on_download_referee_survey_results
     then_i_should_be_able_to_download_a_csv
   end
@@ -20,8 +20,8 @@ RSpec.feature 'Referee survery CSV' do
     create_list(:reference, 3, :complete)
   end
 
-  def when_i_visit_the_service_performance_page
-    visit support_interface_performance_path
+  def when_i_visit_the_service_performance_data_page
+    visit support_interface_performance_data_path
   end
 
   def and_i_click_on_download_referee_survey_results

--- a/spec/system/support_interface/tad_provider_performance_spec.rb
+++ b/spec/system/support_interface/tad_provider_performance_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'TAD provider performance CSV' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
 
-    when_i_visit_the_service_performance_page
+    when_i_visit_the_service_performance_data_page
     and_i_click_on_download_tad_performance_report
     then_i_should_be_able_to_download_a_csv
   end
@@ -20,8 +20,8 @@ RSpec.feature 'TAD provider performance CSV' do
     create(:application_choice, :awaiting_provider_decision)
   end
 
-  def when_i_visit_the_service_performance_page
-    visit support_interface_performance_path
+  def when_i_visit_the_service_performance_data_page
+    visit support_interface_performance_data_path
   end
 
   def and_i_click_on_download_tad_performance_report

--- a/spec/system/support_interface/validation_errors_summary_spec.rb
+++ b/spec/system/support_interface/validation_errors_summary_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Validation errors summary' do
   def when_i_navigate_to_the_validation_errors_summary_page
     visit support_interface_path
     click_link 'Performance'
+    click_link 'Validation errors'
     click_link 'Validation error summary'
   end
 


### PR DESCRIPTION
## Context

Small reorganisation given recent additions to support interface.

## Changes proposed in this pull request

* Moves ‘UCAS matches’ from ‘Performance’ into ‘Candidates’
* Makes ‘Applications’ first item in ‘Candidates’
* Merges ‘Features’ and ‘Tasks’ into ‘Service settings’.
* Moves ‘Recruitment cycles’ from ‘Docs’ into ‘Service settings’
* Reorganises ‘Performance’ section, ensuring most pages within it share its section navigation 
* Adds a new ‘Export performance data’ page inside ‘Performance’
* Updates tests
* Fixes small HTML bug on ‘Tasks’ page 
