### PR TITLE
Add data migration to update legacy degree grade values 

### DIFF
--- a/db/migrate/20200924121000_migrate_old_degree_grade_values_to_hesa_descriptions.rb
+++ b/db/migrate/20200924121000_migrate_old_degree_grade_values_to_hesa_descriptions.rb
@@ -1,0 +1,15 @@
+class MigrateOldDegreeGradeValuesToHesaDescriptions < ActiveRecord::Migration[6.0]
+  def change
+    first = ApplicationQualification.degrees.where(grade: %w[first First])
+    first.update_all(grade: 'First class honours', grade_hesa_code: 1)
+
+    upper_second = ApplicationQualification.degrees.where(grade: %w[upper_second 2:1])
+    upper_second.update_all(grade: 'Upper second-class honours (2:1)', grade_hesa_code: 2)
+
+    lower_second = ApplicationQualification.degrees.where(grade: %w[lower_second 2:2])
+    lower_second.update_all(grade: 'Lower second-class honours (2:2)', grade_hesa_code: 3)
+
+    third = ApplicationQualification.degrees.where(grade: %w[third Third])
+    third.update_all(grade: 'Third-class honours', grade_hesa_code: 5)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_081721) do
+ActiveRecord::Schema.define(version: 2020_09_24_121000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -219,10 +219,10 @@ FactoryBot.define do
 
   factory :application_qualification do
     application_form
-    level { %w[gcse other].sample }
+    level { %w[degree gcse other].sample }
     qualification_type { %w[BA Masters A-Level gcse].sample }
     subject { Faker::Educator.subject }
-    grade { %w[first upper_second A B].sample }
+    grade { %w[A B].sample }
     predicted_grade { %w[true false].sample }
     start_year { Date.today.year }
     award_year { Faker::Date.between(from: 60.years.ago, to: 3.years.from_now).year }
@@ -261,6 +261,13 @@ FactoryBot.define do
       subject { Hesa::Subject.all.sample.name }
       institution_name { Hesa::Institution.all.sample.name }
       grade { Hesa::Grade.all.sample.description }
+
+      after(:build) do |degree, _evaluator|
+        degree.qualification_type_hesa_code = Hesa::DegreeType.find_by_name(degree.qualification_type)&.hesa_code
+        degree.subject_hesa_code = Hesa::Subject.find_by_name(degree.subject)&.hesa_code
+        degree.institution_hesa_code = Hesa::Institution.find_by_name(degree.institution_name)&.hesa_code
+        degree.grade_hesa_code = Hesa::Grade.find_by_description(degree.grade)&.hesa_code
+      end
     end
 
     factory :other_qualification do


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
When entering a degree grade, in addition to allowing free text input we
also offer the candidate a selection of radio buttons mapped to one of
several common values. We've provided radio buttons historically,
however the actual stored database value for these standard options
changed when we added structured HESA data to degrees. Rather than
saving a short string such as `upper_second`, we now simply persist the
HESA description (`Upper second-class honours (2:1)`).

This prompted a change to how we display these grades on the frontend. Instead
of translating database values such as `upper_second` to a presentable
form via I18n, we now simply show the database value. This works fine
for anything with a standard HESA grade or a free-text input, but
doesn't look so great for older degree records that simply display
`upper_second` on the frontend.
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
We can easily map those older values to the current HESA descriptions.
This commit adds a migration which applies that mapping and also adds
the corresponding HESA code to the degree record.

### Before migration
![Screenshot_20200924_203241](https://user-images.githubusercontent.com/519250/94191421-6376a400-fea5-11ea-93f7-8eff99361a8e.png)

### After migration
![Screenshot_20200924_203538](https://user-images.githubusercontent.com/519250/94191553-915be880-fea5-11ea-9015-49d48b9f2900.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/kRTjP8aV
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
