### PR TITLE
Fix hidden text change link descriptions in the EFL review component

### DIFF
--- a/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
+++ b/app/components/candidate_interface/english_foreign_language/efl_review_helper.rb
@@ -7,7 +7,7 @@ module CandidateInterface
         {
           key: 'Have you done an English as a foreign language assessment?',
           value: value,
-          action: 'Change whether or not you have a qualification',
+          action: 'whether or not you have a qualification',
           change_path: candidate_interface_english_foreign_language_edit_start_path,
         }
       end
@@ -16,7 +16,7 @@ module CandidateInterface
         {
           key: 'Type of assessment',
           value: name,
-          action: 'Change type of assessment',
+          action: 'type of assessment',
           change_path: candidate_interface_english_foreign_language_type_path,
         }
       end

--- a/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
+++ b/app/components/candidate_interface/english_foreign_language/toefl_review_component.rb
@@ -16,19 +16,19 @@ module CandidateInterface
           {
             key: 'TOEFL registration number',
             value: toefl_qualification.registration_number,
-            action: 'Change registration number',
+            action: 'registration number',
             change_path: candidate_interface_edit_toefl_path,
           },
           {
             key: 'Year completed',
             value: toefl_qualification.award_year,
-            action: 'Change year completed',
+            action: 'year completed',
             change_path: candidate_interface_edit_toefl_path,
           },
           {
             key: 'Total score',
             value: toefl_qualification.total_score,
-            action: 'Change total score',
+            action: 'total score',
             change_path: candidate_interface_edit_toefl_path,
           },
         ]


### PR DESCRIPTION
## Context

Currently, change links in the EFL review component aren't working correctly for screen readers.

They currently say 'Change change x attribute'

## Changes proposed in this pull request

- Remove 'change' from the beginning of the change action

before 

![image](https://user-images.githubusercontent.com/42515961/94254901-539ba600-ff1f-11ea-8837-f0cd3ab59629.png)

after

![image](https://user-images.githubusercontent.com/42515961/94254852-3f57a900-ff1f-11ea-9fd0-448cbd945228.png)


## Link to Trello card

https://trello.com/c/sMedrnoJ/2182-change-text-repeated-twice-on-efl-review-page-visually-shown-and-in-hidden-text

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
