### PR TITLE
Refactor QualificationsTableComponent

### DIFF
--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -14,6 +14,6 @@
 <div class="govuk-grid-row">
   <%= render DegreeQualificationCardsComponent.new(application_form.application_qualifications.degrees, application_choice_state: application_choice_state) %>
   <%= render GcseQualificationCardsComponent.new(application_form) %>
-  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, type_label: 'Academic or other qualification') %>
+  <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'Other qualifications') %>
   <%= render EflQualificationCardComponent.new(application_form) %>
 </div>

--- a/app/components/qualifications_table_component.html.erb
+++ b/app/components/qualifications_table_component.html.erb
@@ -1,7 +1,7 @@
 <% if qualifications.any? %>
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m govuk-!-margin-top-8" id="other-qualifications">Other qualifications</h3>
-    <table class="govuk-table" data-qa="qualifications-table-<%= type_label.parameterize %>">
+    <h3 class="govuk-heading-m govuk-!-margin-top-8" id="other-qualifications"><%= header %></h3>
+    <table class="govuk-table" data-qa="qualifications-table-<%= header.parameterize %>">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-table__header">Qualification</th>

--- a/app/components/qualifications_table_component.rb
+++ b/app/components/qualifications_table_component.rb
@@ -1,8 +1,8 @@
 class QualificationsTableComponent < ViewComponent::Base
-  attr_reader :qualifications, :type_label
+  attr_reader :qualifications, :header
 
-  def initialize(qualifications:, type_label:)
+  def initialize(qualifications:, header:)
     @qualifications = qualifications
-    @type_label = type_label
+    @header = header
   end
 end

--- a/spec/components/qualifications_table_component_spec.rb
+++ b/spec/components/qualifications_table_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe QualificationsTableComponent do
   it 'renders nothing when no qualifications present' do
-    result = render_inline(described_class.new(qualifications: [], type_label: 'My label'))
+    result = render_inline(described_class.new(qualifications: [], header: 'My header'))
 
     expect(result.css('table')).to be_blank
   end
@@ -11,8 +11,8 @@ RSpec.describe QualificationsTableComponent do
     qualifications = [
       build_stubbed(:application_qualification),
     ]
-    result = render_inline(described_class.new(qualifications: qualifications, type_label: 'My label'))
+    result = render_inline(described_class.new(qualifications: qualifications, header: 'My header'))
 
-    expect(result.css('table').first['data-qa']).to eq 'qualifications-table-my-label'
+    expect(result.css('table').first['data-qa']).to eq 'qualifications-table-my-header'
   end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   def and_i_should_see_the_candidates_other_qualifications
-    expect(page).to have_selector('[data-qa="qualifications-table-academic-or-other-qualification"] tbody tr', count: 3)
+    expect(page).to have_selector('[data-qa="qualifications-table-other-qualifications"] tbody tr', count: 3)
   end
 
   def and_i_should_see_the_candidates_work_history


### PR DESCRIPTION



## Context

<!-- Why are you making this change? What might surprise someone about it? -->
This component was previously used to render a generic table populated
with qualifications. Most qualifications are now displayed in cards
(see, for example - `EflQualificationCardComponent`). This table
component is now only used for rendering the 'other' qualification
type. It's also in a slightly odd state - it still accepts a
`type_label` argument while having a hard-coded 'Other qualifications'
header in its markup.
## Changes proposed in this pull request

There are a couple of options to deal with this inconsistency -

- make the component specific to 'other' qualifications, renaming it and
  removing the `type_label` argument
- leave it as a generic component and use the argument to populate the
  header

This commit opts for the latter. There isn't much of a gain in code clarity
by making the component more specific, and it can be used to render
similar tables if required later on.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
