### PR TITLE
Show HESA codes for qualifications in support

### DIFF
--- a/app/components/degree_qualification_cards_component.html.erb
+++ b/app/components/degree_qualification_cards_component.html.erb
@@ -29,6 +29,15 @@
                 <dt class="app-qualification__key">Comparability</dt>
                 <dd class="app-qualification__value"><%= naric_statement(degree) %></dd>
               <% end %>
+
+              <% if show_hesa_codes? %>
+                <dt class="app-qualification__key">HESA codes</dt>
+                <dd class="app-qualification__value">
+                  <% hesa_code_values(degree).each do |key, value| %>
+                    <%= key %>: <%= value %><br/>
+                  <% end %>
+                </dd>
+              <% end %>
             </dl>
           </div>
         </div>

--- a/app/components/degree_qualification_cards_component.html.erb
+++ b/app/components/degree_qualification_cards_component.html.erb
@@ -32,11 +32,11 @@
 
               <% if show_hesa_codes? %>
                 <dt class="app-qualification__key">HESA codes</dt>
-                <dd class="app-qualification__value">
-                  <% hesa_code_values(degree).each do |key, value| %>
-                    <%= key %>: <%= value %><br/>
-                  <% end %>
-                </dd>
+                <% hesa_code_values(degree).each do |key, value| %>
+                  <dd class="app-qualification__value govuk-!-margin-bottom-0">
+                    <%= key %>: <%= value %>
+                  </dd>
+                <% end %>
               <% end %>
             </dl>
           </div>

--- a/app/components/degree_qualification_cards_component.rb
+++ b/app/components/degree_qualification_cards_component.rb
@@ -1,9 +1,12 @@
 class DegreeQualificationCardsComponent < ViewComponent::Base
-  attr_reader :degrees, :application_choice_state
+  attr_reader :degrees, :application_choice_state, :show_hesa_codes
 
-  def initialize(degrees, application_choice_state: nil)
+  alias_method :show_hesa_codes?, :show_hesa_codes
+
+  def initialize(degrees, application_choice_state: nil, show_hesa_codes: false)
     @degrees = degrees
     @application_choice_state = application_choice_state
+    @show_hesa_codes = show_hesa_codes
   end
 
   def section_title
@@ -39,6 +42,15 @@ class DegreeQualificationCardsComponent < ViewComponent::Base
       degree_name = I18n.t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}")
       "NARIC statement #{degree.naric_reference} says this is comparable to a #{degree_name}"
     end
+  end
+
+  def hesa_code_values(degree)
+    {
+      'Type' => degree.qualification_type_hesa_code,
+      'Subject' => degree.subject_hesa_code,
+      'Establishment' => degree.institution_hesa_code,
+      'Class' => degree.grade_hesa_code,
+    }
   end
 
 private

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -12,7 +12,7 @@
 </details>
 
 <div class="govuk-grid-row">
-  <%= render DegreeQualificationCardsComponent.new(application_form.application_qualifications.degrees, application_choice_state: application_choice_state) %>
+  <%= render DegreeQualificationCardsComponent.new(application_form.application_qualifications.degrees, application_choice_state: application_choice_state, show_hesa_codes: show_hesa_codes) %>
   <%= render GcseQualificationCardsComponent.new(application_form) %>
   <%= render QualificationsTableComponent.new(qualifications: application_form.application_qualifications.other, header: 'Other qualifications') %>
   <%= render EflQualificationCardComponent.new(application_form) %>

--- a/app/components/qualifications_component.rb
+++ b/app/components/qualifications_component.rb
@@ -1,8 +1,11 @@
 class QualificationsComponent < ViewComponent::Base
-  attr_reader :application_form, :application_choice_state
+  attr_reader :application_form, :application_choice_state, :show_hesa_codes
 
-  def initialize(application_form:, application_choice_state: nil)
+  alias_method :show_hesa_codes?, :show_hesa_codes
+
+  def initialize(application_form:, application_choice_state: nil, show_hesa_codes: false)
     @application_form = application_form
     @application_choice_state = application_choice_state
+    @show_hesa_codes = show_hesa_codes
   end
 end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -56,7 +56,7 @@
 <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-1" id="qualifications">Qualifications</h2>
 <p class='govuk-hint govuk-!-margin-top-0'>(HESA codes in brackets, where relevant)</p>
 
-<%= render QualificationsComponent.new(application_form: @application_form) %>
+<%= render QualificationsComponent.new(application_form: @application_form, show_hesa_codes: true) %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Work history</h2>
 

--- a/spec/components/degree_qualification_cards_component_spec.rb
+++ b/spec/components/degree_qualification_cards_component_spec.rb
@@ -6,21 +6,17 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       create(
         :degree_qualification,
         qualification_type: 'Bachelor of Arts',
-        subject: 'Computer Science',
+        subject: 'Computer science',
         institution_name: 'The University of Oxford',
         grade: 'First class honours',
         predicted_grade: false,
-        qualification_type_hesa_code: 1234,
-        subject_hesa_code: 4567,
-        institution_hesa_code: 9876,
-        grade_hesa_code: 4321,
       )
     end
 
     it 'renders all expected detail' do
       result = render_inline described_class.new([degree])
 
-      expect(result.text).to include 'BA (Hons) Computer Science'
+      expect(result.text).to include 'BA (Hons) Computer science'
       expect(result.text).to include degree.start_year
       expect(result.text).to include degree.award_year
       expect(result.text).to include 'Grade'
@@ -33,7 +29,7 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
     it 'renders all expected detail including HESA codes' do
       result = render_inline described_class.new([degree], show_hesa_codes: true)
 
-      expect(result.text).to include 'BA (Hons) Computer Science'
+      expect(result.text).to include 'BA (Hons) Computer science'
       expect(result.text).to include degree.start_year
       expect(result.text).to include degree.award_year
       expect(result.text).to include 'Grade'
@@ -41,10 +37,10 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       expect(result.text).to include 'Institution'
       expect(result.text).to include 'The University of Oxford'
       expect(result.text).to include 'HESA codes'
-      expect(result.text).to include 'Type: 1234'
-      expect(result.text).to include 'Subject: 4567'
-      expect(result.text).to include 'Establishment: 9876'
-      expect(result.text).to include 'Class: 4321'
+      expect(result.text).to include "Type: #{Hesa::DegreeType.find_by_name(degree.qualification_type)&.hesa_code}"
+      expect(result.text).to include "Subject: #{Hesa::Subject.find_by_name(degree.subject)&.hesa_code}"
+      expect(result.text).to include "Establishment: #{Hesa::Institution.find_by_name(degree.institution_name)&.hesa_code}"
+      expect(result.text).to include "Class: #{Hesa::Grade.find_by_description(degree.grade)&.hesa_code}"
     end
 
     context 'when it is an international degree' do
@@ -81,7 +77,7 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
 
       it 'does not display (Hons) after the degree type' do
         result = render_inline described_class.new([degree])
-        expect(result.text).to include 'BA Computer Science'
+        expect(result.text).to include 'BA Computer science'
       end
     end
 

--- a/spec/components/degree_qualification_cards_component_spec.rb
+++ b/spec/components/degree_qualification_cards_component_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
         institution_name: 'The University of Oxford',
         grade: 'First class honours',
         predicted_grade: false,
+        qualification_type_hesa_code: 1234,
+        subject_hesa_code: 4567,
+        institution_hesa_code: 9876,
+        grade_hesa_code: 4321,
       )
     end
 
@@ -23,6 +27,24 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       expect(result.text).to include 'First class honours'
       expect(result.text).to include 'Institution'
       expect(result.text).to include 'The University of Oxford'
+      expect(result.text).not_to include 'HESA codes'
+    end
+
+    it 'renders all expected detail including HESA codes' do
+      result = render_inline described_class.new([degree], show_hesa_codes: true)
+
+      expect(result.text).to include 'BA (Hons) Computer Science'
+      expect(result.text).to include degree.start_year
+      expect(result.text).to include degree.award_year
+      expect(result.text).to include 'Grade'
+      expect(result.text).to include 'First class honours'
+      expect(result.text).to include 'Institution'
+      expect(result.text).to include 'The University of Oxford'
+      expect(result.text).to include 'HESA codes'
+      expect(result.text).to include 'Type: 1234'
+      expect(result.text).to include 'Subject: 4567'
+      expect(result.text).to include 'Establishment: 9876'
+      expect(result.text).to include 'Class: 4321'
     end
 
     context 'when it is an international degree' do


### PR DESCRIPTION
## Context

We updated the display of Degree qualifications in the provider UI. As this used a shared component, this also meant updating the same information in the support UI. Yet, in the support UI we also need to show HESA codes, which are now missing.

## Changes proposed in this pull request

- [x] Add markup for HESA codes to `DegreeQualificationCardsComponent` when new `show_hesa_codes` option is true.
- [x] Apply the new option only in the Support interface
- [x] Update `degree_qualification` factory so that HESA codes are populated by default so that sample data will be a fully populated.

<img width="335" alt="image" src="https://user-images.githubusercontent.com/450843/94279976-c66b4800-ff44-11ea-97c8-6d0035d9b8dc.png">

## Guidance to review

- I think that previously generated sample data doesn't include the codes, but if you re-run `rails setup_local_dev_data` they should be populated going forward.

## Link to Trello card

https://trello.com/c/TtA6Bu47/2208-📐-show-hesa-codes-for-qualifications-in-support

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
