### PR TITLE
Use the offered_course_choice in the offer emails if one is present

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -325,20 +325,21 @@ private
 
   def new_offer(application_choice, template_name)
     @application_choice = application_choice
-    @provider_name = @application_choice.course_option.course.provider.name
-    @course_name = @application_choice.course_option.course.name_and_code
+    course_option = CourseOption.find_by(id: @application_choice.offered_course_option_id) || @application_choice.course_option
+    @provider_name = course_option.course.provider.name
+    @course_name = course_option.course.name_and_code
     @conditions = @application_choice.offer&.dig('conditions') || []
     @offers = @application_choice.application_form.application_choices.select(&:offer?).map do |offer|
       "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
     end
-    @start_date = @application_choice.course_option.course.start_date.to_s(:month_and_year)
+    @start_date = course_option.course.start_date.to_s(:month_and_year)
 
     email_for_candidate(
       application_choice.application_form,
       subject: I18n.t!(
         "candidate_offer.#{template_name}.subject",
-        course_name: application_choice.course_option.course.name_and_code,
-        provider_name: application_choice.course_option.course.provider.name,
+        course_name: course_option.course.name_and_code,
+        provider_name: course_option.course.provider.name,
       ),
       template_path: 'candidate_mailer/new_offer',
       template_name: template_name,

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe CandidateMailer, type: :mailer do
       'Days to make an offer' => 'If you do not reply by 25 February 2020',
       'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
     )
+
+    context 'when the provider offers the candidate a different course option' do
+      before do
+        provider = build_stubbed(:provider, name: 'Falconholt Technical College')
+        new_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
+
+        @application_choice.offered_course_option_id = new_course_option.id
+
+        allow(CourseOption).to receive(:find_by).and_return new_course_option
+      end
+
+      it_behaves_like(
+        'a mail with subject and content', :new_offer_single_offer,
+        'Offer received for Forensic Science (E0FO) at Falconholt Technical College',
+        'heading' => 'Dear Bob',
+        'decline by default date' => 'Make a decision by 25 February 2020',
+        'first_condition' => 'DBS check',
+        'second_condition' => 'Pass exams',
+        'Days to make an offer' => 'If you do not reply by 25 February 2020',
+        'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
+      )
+    end
   end
 
   describe '.new_offer_multiple_offers' do


### PR DESCRIPTION
## Context

At the moment, a provider can offer a candidate a different course to the one they submitted. However, the offer email the candidate receives uses the course option they submitted to populate the email.

This whole process seems broken as they should probably getting an email which lets them know that the offer they submitted has been changed, but for now, I've changed the offer emails to use the correct (new) course options provider/course

## Changes proposed in this pull request

- Use the application choices `offered_course_option_id` to get the provider and course details contained in the email.

## Guidance to review

Does my assumption that a candidate should be explicitly told that they are being offered a different course option seem right? If they, for example, have just offered a new location the candidate might not spot it.

chats that have gone on in slack

https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1600947884011600

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1601033094026300

## Link to Trello card

https://trello.com/c/Ejkvl5nl/2206-alternative-courses-offer-emails-contain-old-course-info

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
