### PR TITLE
Fix a webpacker deprecation warning

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,7 @@ default: &default
   webpack_compile_output: false
 
   # Additional paths webpack should lookup modules
-  resolved_paths: ['node_modules/govuk-frontend/govuk', 'node_modules/@ministryofjustice/frontend']
+  additional_paths: ['node_modules/govuk-frontend/govuk', 'node_modules/@ministryofjustice/frontend']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
`resolved_paths` in `webpacker.yml` was causing deprecation warnings in the logs

Before

<img width="981" alt="Screenshot 2020-09-28 at 09 40 44" src="https://user-images.githubusercontent.com/642279/94410087-dcf4e780-016e-11eb-9bd2-d3979811954d.png">



After

<img width="980" alt="Screenshot 2020-09-28 at 09 39 55" src="https://user-images.githubusercontent.com/642279/94410095-e0886e80-016e-11eb-97ad-0e8797557d00.png">

