### PR TITLE
Exclude British and Irish sub-nationalities from ‘Other’ nationalities

### DIFF
--- a/app/helpers/select_options_helper.rb
+++ b/app/helpers/select_options_helper.rb
@@ -1,8 +1,8 @@
 module SelectOptionsHelper
-  def select_nationality_options
+  def select_nationality_options(include_british_and_irish: false)
     [
       OpenStruct.new(id: '', name: t('application_form.personal_details.nationality.default_option')),
-    ] + NATIONALITIES.map { |_, nationality| OpenStruct.new(id: nationality, name: nationality) }
+    ] + nationality_options(include_british_and_irish: include_british_and_irish).map { |_, nationality| OpenStruct.new(id: nationality, name: nationality) }
   end
 
   def select_country_options
@@ -21,5 +21,11 @@ module SelectOptionsHelper
     [
       OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_provider_form.attributes.provider_id.blank')),
     ] + providers.map { |provider| OpenStruct.new(id: provider.id, name: "#{provider.name} (#{provider.code})") }
+  end
+
+private
+
+  def nationality_options(include_british_and_irish:)
+    include_british_and_irish ? NATIONALITIES : NATIONALITIES.reject { |iso_code, _| %w[GB IE].include?(iso_code) }
   end
 end

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -2,9 +2,27 @@
 
 <% if FeatureFlag.active?('international_personal_details') %>
   <%= f.govuk_check_boxes_fieldset :nationalities, legend: { size: 'xl', text:  t('page_titles.nationalities') } do %>
-    <%= f.govuk_check_box :nationalities, 'British', link_errors: true, multiple: true, label: { text: 'British' } %>
-    <%= f.govuk_check_box :nationalities, 'Irish', multiple: true, label: { text: 'Irish' } %>
-    <%= f.govuk_check_box :nationalities, 'other', multiple: true, label: { text: 'Other' } do %>
+    <%= f.govuk_check_box(
+      :nationalities,
+      'British',
+      link_errors: true,
+      multiple: true,
+      label: { text: 'British' },
+      hint_text: 'including English, Scottish, Welsh or from Northern Ireland',
+    ) %>
+    <%= f.govuk_check_box(
+      :nationalities,
+      'Irish',
+      multiple: true,
+      label: { text: 'Irish' },
+      hint_text: 'including from Northern Ireland',
+    ) %>
+    <%= f.govuk_check_box(
+      :nationalities,
+      'other',
+      multiple: true,
+      label: { text: 'Citizen of a different country' },
+    ) do %>
       <%= f.govuk_collection_select :other_nationality1, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
       <%= f.govuk_collection_select :other_nationality2, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
       <%= f.govuk_collection_select :other_nationality3, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
@@ -16,7 +34,7 @@
     <%= t('page_titles.nationalities') %>
   </h1>
 
-  <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+  <%= f.govuk_collection_select :first_nationality, select_nationality_options(include_british_and_irish: true), :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
 
     <details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>>
     <summary class="govuk-details__summary">

--- a/spec/helpers/select_options_helper_spec.rb
+++ b/spec/helpers/select_options_helper_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SelectOptionsHelper, type: :helper do
   describe '#select_nationality_options' do
-    it 'returns a structured list of nationalities' do
-      _, nationality = NATIONALITIES.sample
+    it 'returns a structured list of all non-British and Irish nationalities' do
+      _, nationality = NATIONALITIES.reject { |code, _| %w[GB IE].include?(code) }.sample
 
       expect(select_nationality_options).to include(
         OpenStruct.new(
@@ -17,6 +17,28 @@ RSpec.describe SelectOptionsHelper, type: :helper do
           name: nationality,
         ),
       )
+    end
+
+    it 'excludes Irish and British nationalities by default' do
+      NATIONALITIES.select { |code, _| %w[GB IE].include?(code) }.each do |_, nationality|
+        expect(select_nationality_options).not_to include(
+          OpenStruct.new(
+            id: nationality,
+            name: nationality,
+          ),
+        )
+      end
+    end
+
+    it 'includes Irish and British nationalities when `include_british_and_irish` option is true' do
+      NATIONALITIES.select { |code, _| %w[GB IE].include?(code) }.each do |_, nationality|
+        expect(select_nationality_options(include_british_and_irish: true)).to include(
+          OpenStruct.new(
+            id: nationality,
+            name: nationality,
+          ),
+        )
+      end
     end
   end
 

--- a/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_when_languages_hidden_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Entering personal details' do
 
     # Go back and change nationality
     visit candidate_interface_nationalities_path
-    check 'Other'
+    check 'Citizen of a different country'
     within all('.govuk-form-group')[1] do
       select 'Pakistani'
     end

--- a/spec/system/candidate_interface/international/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_enters_their_personal_details_spec.rb
@@ -41,14 +41,16 @@ RSpec.feature 'Entering their personal details' do
 
     when_i_click_change_on_my_nationality
     and_i_uncheck_that_i_am_irish
+    and_i_check_that_i_am_british
     and_i_check_other
-    and_select_i_am_english
+    and_select_i_am_french
     and_i_submit_the_form
     then_i_see_the_personal_details_review_page
-    and_i_see_i_am_english
+    and_i_see_i_am_french
 
     when_i_click_change_on_my_nationality
     and_i_select_i_am_german_dutch_and_belgian
+    and_i_uncheck_that_i_am_british
     and_i_submit_the_form
     then_i_see_the_right_to_work_or_study_page
 
@@ -172,18 +174,22 @@ RSpec.feature 'Entering their personal details' do
     uncheck 'Irish'
   end
 
-  def and_i_check_other
-    check 'Other'
+  def and_i_check_that_i_am_british
+    check 'British'
   end
 
-  def and_select_i_am_english
+  def and_i_check_other
+    check 'Citizen of a different country'
+  end
+
+  def and_select_i_am_french
     within all('.govuk-form-group')[1] do
-      select 'English'
+      select 'French'
     end
   end
 
-  def and_i_see_i_am_english
-    expect(page).to have_content 'English'
+  def and_i_see_i_am_french
+    expect(page).to have_content 'French'
   end
 
   def and_i_select_i_am_german_dutch_and_belgian

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'International candidate submits the application' do
     click_button t('complete_form_button', scope: scope)
 
     # Nationality
-    check 'Other'
+    check 'Citizen of a different country'
     within all('.govuk-form-group')[1] do
       select 'Belgian'
     end


### PR DESCRIPTION
## Context

Norther Irish, Welsh, English and Scottish are listed as an 'other' nationality in the nationality drop down. This doesn't make sense as British and Irish are separate check boxes.

## Changes proposed in this pull request

- [x] Make `include_british_and_irish` an option to the `select_nationality_options` that's off by default.
- [x] Fix specs
- [x] Update content to include hints making it clear that 'British' includes Welsh, Scottish etc.

<img width="793" alt="image" src="https://user-images.githubusercontent.com/450843/94411652-ba63ce00-0170-11eb-8f52-ee1c7a14ed8d.png">

## Guidance to review

- Updated existing feature specs, do we need an other new tests?
- Does the helper option make sense?

## Link to Trello card

https://trello.com/c/LXwV4OPH/2205-norn-irish-incl-in-nationality-drop-down

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
