### PR TITLE
Remove flash message when a candidate carries over their application

### DIFF
--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -55,9 +55,9 @@ module CandidateInterface
 
     def redirect_to_application_if_between_cycles
       if EndOfCycleTimetable.between_cycles?(current_application.phase)
-        flash[:warning] = 'Applications for courses starting this academic year have now closed.'
         redirect_to candidate_interface_application_form_path and return false
       end
+
       true
     end
 


### PR DESCRIPTION
## Context

When a candidate carries over an application they see a flash message. They should be told that their application is ready for editing.

## Changes proposed in this pull request

Before 

![image](https://user-images.githubusercontent.com/42515961/94416508-d9655e80-0176-11eb-9f33-36d545298791.png)

After

![image](https://user-images.githubusercontent.com/42515961/94416417-be92ea00-0176-11eb-8b3d-f8aeb9bc7e5b.png)


## Link to Trello card

https://trello.com/c/HqHoLTQ9/2184-bug-%F0%9F%94%9A%F0%9F%9A%B2-incorrect-red-banner-showing-on-carried-over-applications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
