### PR TITLE
Include reference ids in API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -163,6 +163,7 @@ module VendorAPI
 
     def reference_to_hash(reference)
       {
+        id: reference.id,
         name: reference.name,
         email: reference.email_address,
         relationship: reference.relationship,

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 29th September 2020
+
+New attributes:
+
+- `Reference` now has a unique `id` attribute of type integer to assist with tracking of reference changes.
+
 ### 16th September 2020
 
 Changes to existing attributes:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -757,11 +757,16 @@ components:
       type: object
       additionalProperties: false
       required:
+      - id
       - name
       - email
       - relationship
       - reference
       properties:
+        id:
+          type: integer
+          description: A unique reference id
+          example: 4321
         name:
           type: string
           description: The referee’s name

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -315,4 +315,18 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
   end
+
+  describe 'attributes.references' do
+    let(:application_choice) { create(:application_choice, :with_offer) }
+
+    it 'returns application references with their respective ids' do
+      reference = create(
+        :reference,
+        :complete,
+        application_form: application_choice.application_form,
+      )
+      presenter = VendorAPI::SingleApplicationPresenter.new(application_choice)
+      expect(presenter.as_json[:attributes][:references].first[:id]).to eq(reference.id)
+    end
+  end
 end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -159,12 +159,14 @@ RSpec.feature 'Vendor receives the application' do
         },
         references: [
           {
+            id: @application.application_references.first.id,
             name: 'Terri Tudor',
             email: 'terri@example.com',
             relationship: 'Tutor',
             reference: 'My ideal person',
           },
           {
+            id: @application.application_references.last.id,
             name: 'Anne Other',
             email: 'anne@other.com',
             relationship: 'First boss',


### PR DESCRIPTION
## Context

A reference id would be helpful for vendors to know whether reference details had been changed or updated.

## Changes proposed in this pull request

Return the `id` of each application reference in API responses

## Guidance to review

Is there more documentation to be updated?

## Link to Trello card

https://trello.com/c/kZ5SakwU/2793-add-an-id-to-the-references-object-of-the-apply-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
