### PR TITLE
Explain what NARIC means

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -93,9 +93,9 @@ module CandidateInterface
       return nil unless FeatureFlag.active?('international_gcses') && application_qualification.qualification_type == 'non_uk'
 
       {
-        key: 'Do you have a NARIC statement of comparability?',
+        key: t('application_form.gcse.naric_statement.review_label'),
         value: application_qualification.naric_reference ? 'Yes' : 'No',
-        action: 'Change the NARIC statement',
+        action: t('application_form.gcse.naric_statement.change_action'),
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }
     end
@@ -106,9 +106,9 @@ module CandidateInterface
         application_qualification.naric_reference
 
       {
-        key: 'NARIC reference number',
+        key: t('application_form.gcse.naric_reference.review_label'),
         value: application_qualification.naric_reference,
-        action: 'Change the NARIC reference number',
+        action: t('application_form.gcse.naric_reference.change_action'),
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }
     end
@@ -119,9 +119,9 @@ module CandidateInterface
         application_qualification.naric_reference
 
       {
-        key: 'Comparable UK qualification',
+        key: t('application_form.gcse.comparable_uk_qualification.review_label'),
         value: application_qualification.comparable_uk_qualification,
-        action: 'Change the comparable uk qualification',
+        action: t('application_form.gcse.comparable_uk_qualification.change_action'),
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }
     end

--- a/app/components/degree_qualification_cards_component.rb
+++ b/app/components/degree_qualification_cards_component.rb
@@ -40,7 +40,7 @@ class DegreeQualificationCardsComponent < ViewComponent::Base
   def naric_statement(degree)
     if degree.naric_reference.present? && degree.comparable_uk_degree.present?
       degree_name = I18n.t("application_form.degree.comparable_uk_degree.values.#{degree.comparable_uk_degree}")
-      "NARIC statement #{degree.naric_reference} says this is comparable to a #{degree_name}"
+      "UK NARIC statement #{degree.naric_reference} says this is comparable to a #{degree_name}"
     end
   end
 

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -41,7 +41,7 @@ class GcseQualificationCardsComponent < ViewComponent::Base
 
   def naric_statement(qualification)
     if qualification.naric_reference.present? && qualification.comparable_uk_qualification.present?
-      "NARIC statement #{qualification.naric_reference} says this is comparable to a #{qualification.comparable_uk_qualification}."
+      "UK NARIC statement #{qualification.naric_reference} says this is comparable to a #{qualification.comparable_uk_qualification}."
     end
   end
 end

--- a/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
@@ -1,5 +1,5 @@
-<p class="govuk-body">This shows how your qualifications compare to UK qualifications. Not all providers ask for a NARIC statement of comparability.</p>
-<%= f.govuk_radio_buttons_fieldset :have_naric_reference, legend: { tag: 'span' } do %>
+<p class="govuk-body">You can get a statement from The National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
+<%= f.govuk_radio_buttons_fieldset :have_naric_reference, legend: { text: t('application_form.degree.naric_statment.label'), tag: 'span' } do %>
   <%= f.govuk_radio_button :have_naric_reference, 'yes', label: { text: 'Yes' } do %>
     <%= f.govuk_text_field(
       :naric_reference,
@@ -21,10 +21,7 @@
     <% end %>
   <% end %>
   <%= f.govuk_radio_button :have_naric_reference, 'no', label: { text: 'No' } do %>
-    <p class="govuk-body">Ask your training provider if they need a NARIC statement of comparability.
-    Register with <%= govuk_link_to "Get Into Teaching", "https://register.getintoteaching.education.gov.uk/register" %>
-    for help if you need to get one.
-    </p>
+    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. Register with <%= govuk_link_to "Get Into Teaching", "https://register.getintoteaching.education.gov.uk/register" %> for help if you need to get one.</p>
   <% end %>
 <% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -7,23 +7,26 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        <%= t('page_titles.gcse_naric_reference') %>
+        <%= t("gcse_edit_naric_reference.page_title", subject: @subject.capitalize) %>
       </h1>
 
-      <p class='govuk-body'>This shows how your qualifications compare to UK qualifications. Not all providers ask for a NARIC statement of comparability.</p>
-
-      <%= f.govuk_radio_buttons_fieldset :naric_details do %>
+      <p class="govuk-body">You can get a statement from The National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
+      <%= f.govuk_radio_buttons_fieldset :naric_details, legend: { text: t('application_form.gcse.naric_statement.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :naric_reference_choice, 'Yes', label: { text: 'Yes' } do %>
-          <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint_text: 'For example ‘4000228363’', width: 20 %>
-          <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: 'Select the comparable UK qualification', size: 's'}, hint_text: 'As shown on your statement' do %>
-            <%= f.govuk_radio_button :comparable_uk_qualification, 'GCSE (grades A*-C / 9-4)', label: { text: 'GCSE (grades A*-C / 9-4)' } %>
-            <%= f.govuk_radio_button :comparable_uk_qualification, 'Between GCSE and GCE AS level', label: { text: 'Between GCSE and GCE AS level' } %>
-            <%= f.govuk_radio_button :comparable_uk_qualification, 'GCE Advanced Subsidiary (AS) level', label: { text: 'GCE Advanced Subsidiary (AS) level' } %>
-            <%= f.govuk_radio_button :comparable_uk_qualification, 'GCE Advanced (A) level', label: { text: 'GCE Advanced (A) level' } %>
+          <%= f.govuk_text_field(
+            :naric_reference,
+            label: { text: t('application_form.gcse.naric_reference.label'), size: 's' },
+            hint_text: t('application_form.gcse.naric_reference.hint_text'), width: 20
+          ) %>
+          <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('application_form.gcse.comparable_uk_qualification.label'), size: 's'}, hint_text: t('application_form.gcse.comparable_uk_qualification.hint_text') do %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') } %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel') } %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.aslevel_alevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.aslevel_alevel') } %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.alevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.alevel') } %>
           <% end %>
         <% end %>
         <%= f.govuk_radio_button :naric_reference_choice, 'No', label: { text: 'No' } do %>
-          <p class='govuk-body'> Ask your training provider if they need a NARIC statement of comparability. Register with <%= govuk_link_to 'Get Into Teaching', 'https://register.getintoteaching.education.gov.uk/register' %> for help if you need to get one.</p>
+          <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. Register with <%= govuk_link_to 'Get Into Teaching', 'https://register.getintoteaching.education.gov.uk/register' %> for help if you need to get one.</p>
         <% end %>
       <% end %>
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -191,19 +191,19 @@ en:
       delete: Delete degree
       confirm_delete: Yes I’m sure - delete this degree
       naric_statment:
-        label: NARIC statment
-        review_label: Do you have a NARIC statement of comparability?
-        change_action: NARIC statement
+        label: Do you have a statement of comparability from The National Recognition Information Centre?
+        review_label: Do you have a UK NARIC statement of comparability?
+        change_action: UK NARIC statement
       naric_reference:
-        label: NARIC reference number
+        label: UK NARIC reference number
         hint_text: For example ‘4000228363’
-        review_label: NARIC reference number
-        change_action: NARIC statement
+        review_label: UK NARIC reference number
+        change_action: UK NARIC reference number
       comparable_uk_degree:
         label: Select the comparable UK degree
         hint_text: As shown on your statement
         review_label: Comparable UK degree
-        change_action: NARIC statement
+        change_action: Comparable UK degree
         values:
           bachelor_ordinary_degree: Bachelor (Ordinary) degree
           bachelor_honours_degree: Bachelor (Honours) degree

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -235,6 +235,25 @@ en:
       award_year:
         label: Enter year
         hint_text: For example, 1996
+      naric_statement:
+        label: Do you have a statement of comparability from The National Recognition Information Centre?
+        review_label: Do you have a UK NARIC statement of comparability?
+        change_action: UK NARIC statement
+      naric_reference:
+        label: UK NARIC reference number
+        hint_text: For example ‘4000228363’
+        review_label: UK NARIC reference number
+        change_action: UK NARIC reference number
+      comparable_uk_qualification:
+        label: Select the comparable UK qualification
+        hint_text: As shown on your statement
+        review_label: Comparable UK qualification
+        change_action: Comparable UK qualification
+        values:
+          gcse: GCSE (grades A*-C / 9-4)
+          gcse_aslevel: Between GCSE and GCE AS level
+          aslevel_alevel: GCE Advanced Subsidiary (AS) level
+          alevel: GCE Advanced (A) level
       complete_form_button: Save and continue
     other_qualification:
       qualification:
@@ -715,9 +734,9 @@ en:
         candidate_interface/naric_reference_form:
           attributes:
             naric_reference_choice:
-              blank: Select if you have a NARIC statement of comparability
+              blank: Select if you have a UK NARIC statement of comparability
             naric_reference:
-              blank: Enter your NARIC reference number
+              blank: Enter your UK NARIC reference number
             comparable_uk_qualification:
               blank: Choose a comparable UK qualification
         candidate_interface/volunteering_experience_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,6 @@ en:
     confirm_replacement_course_choice: Your updated course choice
     remove_course_choice: Remove your course choice
     withdraw_application: Are you sure you want to withdraw your application?
-    gcse_naric_reference: Do you have a NARIC statement of comparability for your maths qualification?
     guidance: User guidance
     applications_closed: Create an Apply for teacher training account
   layout:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
     degree_grade: What grade is your degree?
     degree_institution: Which institution did you study at?
     degree_subject: What subject is your degree?
-    degree_naric_statement: Do you have a NARIC statement of comparability for your degree?
+    degree_naric_statement: How your degree compares to a UK degree
     add_undergraduate_degree: Add undergraduate degree
     when_did_you_study_for_your_degree: When did you study for your degree?
     what_year_did_you_graduate: What year did you graduate?

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -33,7 +33,7 @@ en:
   gcse_edit_institution_country:
     page_title: In which country did you study for your %{subject} qualification?
   gcse_edit_naric_reference:
-    page_title: Do you have a NARIC statement of comparability for your %{subject} qualification?
+    page_title: How your %{subject} qualification compares to a UK qualification
   gcse_summary:
     page_titles:
       maths: Maths GCSE or equivalent

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -210,8 +210,8 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       )
     end
 
-    context 'when a NARIC reference number has been provided' do
-      it 'renders component with correct values for NARIC statement' do
+    context 'when a UK NARIC reference number has been provided' do
+      it 'renders component with correct values for UK NARIC statement' do
         result = render_inline(described_class.new(application_form: application_form))
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.institution_name.review_label'))
@@ -233,7 +233,7 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       end
     end
 
-    context 'when the candidate has not provided a NARIC reference number' do
+    context 'when the candidate has not provided a UK NARIC reference number' do
       let(:degree1) do
         build_stubbed(
           :degree_qualification,

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.css('.govuk-summary-list__value')[0].text).to include('High school diploma')
       expect(result.css('.govuk-summary-list__key')[1].text).to include('Country')
       expect(result.css('.govuk-summary-list__value')[1].text).to include('United States')
-      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statement of comparability?')
+      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a UK NARIC statement of comparability?')
       expect(result.css('.govuk-summary-list__value')[2].text).to include('Yes')
-      expect(result.css('.govuk-summary-list__key')[3].text).to include('NARIC reference number')
+      expect(result.css('.govuk-summary-list__key')[3].text).to include('UK NARIC reference number')
       expect(result.css('.govuk-summary-list__value')[3].text).to include('12345')
       expect(result.css('.govuk-summary-list__key')[4].text).to include('Comparable UK qualification')
       expect(result.css('.govuk-summary-list__value')[4].text).to include('Between GCSE and GCE AS level')
@@ -57,9 +57,9 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
       )
 
-      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a NARIC statement of comparability?')
+      expect(result.css('.govuk-summary-list__key')[2].text).to include('Do you have a UK NARIC statement of comparability?')
       expect(result.css('.govuk-summary-list__value')[2].text).to include('No')
-      expect(result.css('.govuk-summary-list__key').text).not_to include('NARIC reference number')
+      expect(result.css('.govuk-summary-list__key').text).not_to include('UK NARIC reference number')
       expect(result.css('.govuk-summary-list__key').text).not_to include('Comparable UK qualification')
     end
   end

--- a/spec/components/degree_qualification_cards_component_spec.rb
+++ b/spec/components/degree_qualification_cards_component_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
       end
     end
 
-    context 'when NARIC details are provided' do
+    context 'when UK NARIC details are provided' do
       before { degree.update(naric_reference: '1234', comparable_uk_degree: 'masters_degree') }
 
-      it 'renders a NARIC statement' do
+      it 'renders a UK NARIC statement' do
         result = render_inline described_class.new([degree])
         expect(result.text).to include(
-          'NARIC statement 1234 says this is comparable to a Master’s degree / Integrated Master’s degree',
+          'UK NARIC statement 1234 says this is comparable to a Master’s degree / Integrated Master’s degree',
         )
       end
     end

--- a/spec/components/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/gcse_qualification_cards_component_spec.rb
@@ -72,15 +72,15 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
         expect(result.text).to include 'Maths Diploma'
         expect(result.text).to include '2006, France'
         expect(result.text).to include 'C'
-        expect(result.text).to include 'NARIC statement 4000123456 says this is comparable to a Between GCSE and GCSE AS Level.'
+        expect(result.text).to include 'UK NARIC statement 4000123456 says this is comparable to a Between GCSE and GCSE AS Level.'
       end
 
-      context 'when the NARIC reference is not provided' do
+      context 'when the UK NARIC reference is not provided' do
         before { application_form.maths_gcse.update(naric_reference: nil) }
 
-        it 'does not show a NARIC statement' do
+        it 'does not show a UK NARIC statement' do
           result = render_inline(described_class.new(application_form))
-          expect(result.text).not_to include 'NARIC'
+          expect(result.text).not_to include 'UK NARIC'
         end
       end
     end

--- a/spec/system/candidate_interface/international/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_international_degrees_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Entering their degrees' do
     and_i_fill_in_the_country
     and_i_click_on_save_and_continue
 
-    # Add NARIC statement
+    # Add UK NARIC statement
     then_i_can_see_the_naric_page
     when_i_click_on_save_and_continue
     then_i_see_validation_errors_for_naric_question
@@ -163,7 +163,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def then_i_can_see_the_naric_page
-    expect(page).to have_content 'Do you have a NARIC statement of comparability for your degree?'
+    expect(page).to have_content 'Do you have a statement of comparability from The National Recognition Information Centre?'
   end
 
   def then_i_see_validation_errors_for_naric_question
@@ -180,7 +180,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def and_i_fill_in_naric_reference
-    fill_in 'NARIC reference number', with: '0123456789'
+    fill_in 'UK NARIC reference number', with: '0123456789'
   end
 
   def and_i_fill_in_comparable_uk_degree_type
@@ -258,7 +258,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def when_i_click_to_change_my_naric_details
-    page.all('.govuk-summary-list__actions').to_a.fourth.click_link 'Change NARIC statement'
+    page.all('.govuk-summary-list__actions').to_a.fourth.click_link 'Change UK NARIC statement'
   end
 
   def then_i_see_my_original_naric_details_filled_in
@@ -266,7 +266,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def when_i_change_my_reference_number_and_comparable_uk_degree_type
-    fill_in 'NARIC reference number', with: '9876543210'
+    fill_in 'UK NARIC reference number', with: '9876543210'
     choose 'Post Doctoral award'
   end
 

--- a/spec/system/candidate_interface/international/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_international_gcse_spec.rb
@@ -116,7 +116,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   def when_i_do_not_input_my_naric_reference_or_choose_an_equivalency; end
 
   def then_i_see_the_do_you_have_a_naric_reference_error
-    expect(page).to have_content 'Select if you have a NARIC statement of comparability'
+    expect(page).to have_content 'Select if you have a UK NARIC statement of comparability'
   end
 
   def when_i_choose_yes
@@ -124,7 +124,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def then_i_see_the_naric_reference_blank_error
-    expect(page).to have_content 'Enter your NARIC reference number'
+    expect(page).to have_content 'Enter your UK NARIC reference number'
   end
 
   def and_i_see_the_choose_a_equivalency_option_error


### PR DESCRIPTION
## Context

We need to update content around NARIC to:

- spell out this acronym on first mention
- not use this acronym in the main heading before explaining what it is
- consistently refer to the UK NARIC rather than just NARIC.

## Changes proposed in this pull request

* Updates content on degree and GCSE NARIC pages
* Updates all references to ‘NARIC’ to ‘UK NARIC’
* Fixes incorrect change link text for degree NARIC
* Fixes a bug where the title for each GCSE NARIC page always referred to maths, regardless of subject
* Uses translation strings for NARIC GCSE page like we do for degrees, and generally aligns the implementation where possible between GCSE and degree NARIC pages

| English NARIC GCSE page before | English NARIC GCSE page after |
| - | - |
| ![naric-english-gcse-before](https://user-images.githubusercontent.com/813383/94432251-62d45b00-018e-11eb-8adb-ffd46c7c2fcc.png) | ![naric-english-gcse-after](https://user-images.githubusercontent.com/813383/94432247-61a32e00-018e-11eb-9a11-59a202f56997.png) |

## Guidance to review

I avoided updating all the values for GCSE to use translation strings, meaning consistent implementation across NARIC pages, but inconsistent implementation within GCSE (some strings are use locale, some don’t). Is this okay?

## Link to Trello card

https://trello.com/c/ckHNxsZ1

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
