### PR TITLE
Update to Back links on contact details section

### DIFF
--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -1,9 +1,30 @@
 module CandidateInterface
   class ContactDetails::AddressController < ContactDetails::BaseController
+    def new
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_application,
+      )
+    end
+
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
+    end
+
+    def create
+      @contact_details_form = ContactDetailsForm.new(
+        contact_details_params.merge(address_type: current_application.address_type),
+      )
+
+      if @contact_details_form.save_address(current_application)
+        current_application.update!(contact_details_completed: false)
+
+        redirect_to candidate_interface_contact_details_review_path
+      else
+        track_validation_error(@contact_details_form)
+        render :new
+      end
     end
 
     def update

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -8,7 +8,6 @@ module CandidateInterface
       )
     end
 
-
     def edit
       render_404 and return unless FeatureFlag.active?(:international_addresses)
 

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -1,11 +1,35 @@
 module CandidateInterface
   class ContactDetails::AddressTypeController < ContactDetails::BaseController
+    def new
+      render_404 and return unless FeatureFlag.active?(:international_addresses)
+
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_application,
+      )
+    end
+
+
     def edit
       render_404 and return unless FeatureFlag.active?(:international_addresses)
 
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
+    end
+
+    def update
+      render_404 and return unless FeatureFlag.active?(:international_addresses)
+
+      @contact_details_form = ContactDetailsForm.new(address_type_params)
+
+      if @contact_details_form.save_address_type(current_application)
+        current_application.update!(contact_details_completed: false)
+
+        redirect_to candidate_interface_contact_details_new_address_path
+      else
+        track_validation_error(@contact_details_form)
+        render :new
+      end
     end
 
     def update

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -17,7 +17,7 @@ module CandidateInterface
       )
     end
 
-    def update
+    def create
       render_404 and return unless FeatureFlag.active?(:international_addresses)
 
       @contact_details_form = ContactDetailsForm.new(address_type_params)

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -2,10 +2,40 @@ module CandidateInterface
   class ContactDetails::BaseController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
 
+    def new
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_application,
+      )
+    end
+
+
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
+    end
+
+    def create
+      @contact_details_form = ContactDetailsForm.new(contact_details_params)
+
+      if @contact_details_form.save_base(current_application)
+        updated_contact_details_form = ContactDetailsForm.build_from_application(
+          current_application,
+        )
+
+        if updated_contact_details_form.valid?(:address)
+          current_application.update!(contact_details_completed: false)
+
+          redirect_to candidate_interface_contact_details_review_path
+        elsif FeatureFlag.active?(:international_addresses)
+          redirect_to candidate_interface_contact_details_new_address_type_path
+        else
+          redirect_to candidate_interface_contact_details_new_address_path
+        end
+      else
+        track_validation_error(@contact_details_form)
+        render :new
+      end
     end
 
     def update

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -1,13 +1,11 @@
 module CandidateInterface
   class ContactDetails::BaseController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
-
     def new
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,
       )
     end
-
 
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(

--- a/app/views/candidate_interface/contact_details/address/_form_fields.html.erb
+++ b/app/views/candidate_interface/contact_details/address/_form_fields.html.erb
@@ -1,0 +1,20 @@
+<%= f.govuk_error_summary %>
+
+<% if @contact_details_form.uk? %>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+      <h1 class="govuk-fieldset__heading">
+        <%= t('page_titles.address') %>
+      </h1>
+    </legend>
+    <%= f.govuk_text_field :address_line1, label: ->{ safe_join([t('application_form.contact_details.address_line1.label'), ' ', tag.span(t('application_form.contact_details.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
+    <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
+    <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
+    <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
+    <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
+  </fieldset>
+<% else %>
+  <%= f.govuk_text_area :international_address, label: { text: t('page_titles.address'), size: 'xl' }, autocomplete: 'address' %>
+<% end %>
+
+<%= f.govuk_submit t('application_form.contact_details.address.button') %>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -1,29 +1,10 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_address_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <% if @contact_details_form.uk? %>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-            <h1 class="govuk-fieldset__heading">
-              <%= t('page_titles.address') %>
-            </h1>
-          </legend>
-          <%= f.govuk_text_field :address_line1, label: ->{ safe_join([t('application_form.contact_details.address_line1.label'), ' ', tag.span(t('application_form.contact_details.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
-          <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
-          <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
-          <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
-          <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
-        </fieldset>
-      <% else %>
-        <%= f.govuk_text_area :international_address, label: { text: t('page_titles.address'), size: 'xl' }, autocomplete: 'address' %>
-      <% end %>
-
-      <%= f.govuk_submit t('application_form.contact_details.address.button') %>
+    <%= render partial: 'form_fields', locals: { f: f }  %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/address/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address/new.html.erb
@@ -1,29 +1,10 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_address_type_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_new_address_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_create_address_path do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <% if @contact_details_form.uk? %>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-            <h1 class="govuk-fieldset__heading">
-              <%= t('page_titles.address') %>
-            </h1>
-          </legend>
-          <%= f.govuk_text_field :address_line1, label: ->{ safe_join([t('application_form.contact_details.address_line1.label'), ' ', tag.span(t('application_form.contact_details.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
-          <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
-          <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
-          <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
-          <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
-        </fieldset>
-      <% else %>
-        <%= f.govuk_text_area :international_address, label: { text: t('page_titles.address'), size: 'xl' }, autocomplete: 'address' %>
-      <% end %>
-
-      <%= f.govuk_submit t('application_form.contact_details.address.button') %>
+    <%= render partial: 'form_fields', locals: { f: f }  %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/address/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address/new.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_address_type_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_create_address_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <% if @contact_details_form.uk? %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+            <h1 class="govuk-fieldset__heading">
+              <%= t('page_titles.address') %>
+            </h1>
+          </legend>
+          <%= f.govuk_text_field :address_line1, label: ->{ safe_join([t('application_form.contact_details.address_line1.label'), ' ', tag.span(t('application_form.contact_details.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
+          <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
+          <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
+          <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
+          <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
+        </fieldset>
+      <% else %>
+        <%= f.govuk_text_area :international_address, label: { text: t('page_titles.address'), size: 'xl' }, autocomplete: 'address' %>
+      <% end %>
+
+      <%= f.govuk_submit t('application_form.contact_details.address.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/contact_details/address_type/_form_fields.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/_form_fields.html.erb
@@ -1,0 +1,14 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.where_do_you_live') %>
+</h1>
+
+<%= f.govuk_radio_buttons_fieldset :address_types do %>
+  <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_details.address_type.values.uk') } %>
+  <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_details.address_type.values.international') }, link_errors: true do %>
+    <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_details.country.label') } %>
+  <% end %>
+<% end %>
+
+<%= f.govuk_submit t('application_form.contact_details.address_type.button') %>

--- a/app/views/candidate_interface/contact_details/address_type/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/edit.html.erb
@@ -1,23 +1,10 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.where_do_you_live'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_type_path do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.where_do_you_live') %>
-      </h1>
-
-      <%= f.govuk_radio_buttons_fieldset :address_types do %>
-        <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_details.address_type.values.uk') } %>
-        <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_details.address_type.values.international') }, link_errors: true do %>
-          <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_details.country.label') } %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit t('application_form.contact_details.address_type.button') %>
+    <%= render partial: 'form_fields', locals: { f: f }  %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/address_type/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/new.html.erb
@@ -4,20 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_create_address_type_path do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.where_do_you_live') %>
-      </h1>
-
-      <%= f.govuk_radio_buttons_fieldset :address_types do %>
-        <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_details.address_type.values.uk') } %>
-        <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_details.address_type.values.international') }, link_errors: true do %>
-          <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_details.country.label') } %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit t('application_form.contact_details.address_type.button') %>
+    <%= render partial: 'form_fields', locals: { f: f }  %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/address_type/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.where_do_you_live'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_base_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_new_base_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/contact_details/address_type/new.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/new.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.where_do_you_live'), @contact_details_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_base_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_create_address_type_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.where_do_you_live') %>
+      </h1>
+
+      <%= f.govuk_radio_buttons_fieldset :address_types do %>
+        <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_details.address_type.values.uk') } %>
+        <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_details.address_type.values.international') }, link_errors: true do %>
+          <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_details.country.label') } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit t('application_form.contact_details.address_type.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/contact_details/base/_form_fields.html.erb
+++ b/app/views/candidate_interface/contact_details/base/_form_fields.html.erb
@@ -1,0 +1,9 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.contact_details') %>
+</h1>
+
+<%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20, autocomplete: 'tel' %>
+
+<%= f.govuk_submit t('application_form.contact_details.base.button') %>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -1,18 +1,10 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.contact_details'), @contact_details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.contact_details') %>
-      </h1>
-
-      <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20, autocomplete: 'tel' %>
-
-      <%= f.govuk_submit t('application_form.contact_details.base.button') %>
+    <%= render partial: 'form_fields', locals: { f: f }  %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/base/new.html.erb
+++ b/app/views/candidate_interface/contact_details/base/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.contact_details'), @contact_details_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_create_base_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.contact_details') %>
+      </h1>
+
+      <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20, autocomplete: 'tel' %>
+
+      <%= f.govuk_submit t('application_form.contact_details.base.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/contact_details/base/new.html.erb
+++ b/app/views/candidate_interface/contact_details/base/new.html.erb
@@ -4,15 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_create_base_path do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.contact_details') %>
-      </h1>
-
-      <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20, autocomplete: 'tel' %>
-
-      <%= f.govuk_submit t('application_form.contact_details.base.button') %>
+    <%= render partial: 'form_fields', locals: { f: f }  %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -63,7 +63,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.contact_details'),
             completed: @application_form_presenter.contact_details_completed?,
-            path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_details_review_path : candidate_interface_contact_details_edit_base_path
+            path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_details_review_path : candidate_interface_contact_details_new_base_path
           )
         ) %>
       </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,14 +115,20 @@ Rails.application.routes.draw do
       end
 
       scope '/contact-details' do
-        get '/' => 'contact_details/base#edit', as: :contact_details_edit_base
-        post '/' => 'contact_details/base#update', as: :contact_details_update_base
+        get '/' => 'contact_details/base#new', as: :contact_details_new_base
+        post '/' => 'contact_details/base#create', as: :contact_details_create_base
+        get '/edit' => 'contact_details/base#edit', as: :contact_details_edit_base
+        post '/edit' => 'contact_details/base#update', as: :contact_details_update_base
 
-        get '/address_type' => 'contact_details/address_type#edit', as: :contact_details_edit_address_type
-        post '/address_type' => 'contact_details/address_type#update', as: :contact_details_update_address_type
+        get '/address_type' => 'contact_details/address_type#new', as: :contact_details_new_address_type
+        post '/address_type' => 'contact_details/address_type#create', as: :contact_details_create_address_type
+        get '/address_type/edit' => 'contact_details/address_type#edit', as: :contact_details_edit_address_type
+        post '/address_type/edit' => 'contact_details/address_type#update', as: :contact_details_update_address_type
 
-        get '/address' => 'contact_details/address#edit', as: :contact_details_edit_address
-        post '/address' => 'contact_details/address#update', as: :contact_details_update_address
+        get '/address' => 'contact_details/address#new', as: :contact_details_new_address
+        post '/address' => 'contact_details/address#create', as: :contact_details_create_address
+        get '/address/edit' => 'contact_details/address#edit', as: :contact_details_edit_address
+        post '/address/edit' => 'contact_details/address#update', as: :contact_details_update_address
 
         get '/review' => 'contact_details/review#show', as: :contact_details_review
         post '/complete' => 'contact_details/review#complete', as: :contact_details_complete

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature 'Entering their contact details' do
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('phone_number')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_contact_details_update_base_path)
+    expect(validation_error.request_path).to eq(candidate_interface_contact_details_create_base_path)
   end
 
   def when_i_fill_in_my_phone_number

--- a/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_contact_details_without_international_addresses_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'Entering their contact details' do
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('phone_number')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_contact_details_update_base_path)
+    expect(validation_error.request_path).to eq(candidate_interface_contact_details_create_base_path)
   end
 
   def when_i_fill_in_my_phone_number


### PR DESCRIPTION
## Context

Making this change to iron out bugs with previous back link solution for the contact details section.

## Changes proposed in this pull request

New route, controller actions have been defined to split the new and edit functions to allow specific paths for each.

## Guidance to review

Please check that behaviour of back links in this section is consistent with: https://trello-attachments.s3.amazonaws.com/5cb88ec4be601441218204a0/5f47f079f0272516088b14c8/44e05334bb9f28deee5fc24425b9d819/Back_link_journeys.pdf

## Link to Trello card

https://trello.com/c/nrMBwBLm/2188-%F0%9F%94%99-back-links-on-contact-details-flow-should-not-use-history-but-context-prevent-back-loops

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
