### PR TITLE
Remove content related to editing an application post submission

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -62,7 +62,7 @@
     <%= t('application_complete.dashboard.providers_respond_by', date: respond_by_date) %>
   </p>
 
-<% elsif editable? %>
+<% elsif editable? && !FeatureFlag.active?('decoupled_references') %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>
   </h2>

--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -35,7 +35,7 @@ module CandidateInterface
     end
 
     def edit
-      redirect_to candidate_interface_application_complete_path and return unless current_application.can_edit_after_submission?
+      redirect_to candidate_interface_application_complete_path and return unless current_application.can_edit_after_submission? || !FeatureFlag.active?('decoupled_references')
 
       @application_form = current_application
       render :edit_by_support

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],
     [:separate_additional_referees, 'Candidates can submit and confirm their referees independently of each other in the additional referees flow.', 'George Holborn'],
+    [:decoupled_references, 'Candidates now complete and request their references prior to submitting their application.', 'David Gisbey'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -22,7 +22,10 @@
     <h2 class="govuk-heading-m">Interview</h2>
     <p class="govuk-body">Your training provider will be in touch with you if they want to arrange an interview.</p>
 
-    <% if @application_form.can_edit_after_submission? %>
+    <% if FeatureFlag.active?('decoupled_references') %>
+      <h2 class="govuk-heading-m">Track your application</h2>
+      <p class="govuk-body"><%= govuk_link_to 'You can track the progress of your application on your dashboard', candidate_interface_application_complete_path %>.</p>
+    <% elsif @application_form.can_edit_after_submission? %>
       <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
       <p class="govuk-body">You have <%= @editable_days %> to edit your application. We’ll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>
       <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
   before do
     view_helper = instance_double(ViewHelper)
     allow(view_helper).to receive(:respond_by_date).and_return('1 January 2020')
+    FeatureFlag.activate('decoupled_references')
   end
 
   context 'when the application is editable' do
     it 'renders with edit content' do
+      FeatureFlag.deactivate('decoupled_references')
       stub_application_dates_with_form_editable
       application_form = create_application_form_with_course_choices(statuses: %w[awaiting_references])
 
@@ -26,8 +28,20 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
   end
 
+  context 'when the application is editable and the decoupled_references feature flag is on' do
+    it 'renders with edit content' do
+      stub_application_dates_with_form_editable
+      application_form = create_application_form_with_course_choices(statuses: %w[awaiting_references])
+
+      render_result = render_inline(described_class.new(application_form: application_form))
+
+      expect(render_result.text).not_to include(t('application_complete.dashboard.edit_link'))
+    end
+  end
+
   context 'when the application is not editable' do
     it 'renders without edit content' do
+      FeatureFlag.deactivate('decoupled_references')
       stub_application_dates_with_form_uneditable
       application_form = create_application_form_with_course_choices(statuses: %w[awaiting_references])
 

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SubmitApplication do
       application_form
     end
 
-    it 'sets application_form.submitted_at and edit_by on the application foorm and choices' do
+    it 'sets application_form.submitted_at and edit_by on the application form and choices' do
       application_form = create_application_form
       Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
         expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day # business days

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate submits the application' do
 
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in
+    and_the_decoupled_references_flag_is_on
 
     when_i_have_completed_my_application
 
@@ -50,6 +51,10 @@ RSpec.feature 'Candidate submits the application' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_decoupled_references_flag_is_on
+    FeatureFlag.activate('decoupled_references')
   end
 
   def when_i_have_completed_my_application
@@ -203,7 +208,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_click_on_track_your_application
-    click_link 'To edit your application, return to your application dashboard.', match: :first
+    click_link 'You can track the progress of your application on your dashboard'
   end
 
   def then_i_can_see_my_application_dashboard

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   scenario 'Can apply again' do
     given_the_pilot_is_open
+    and_the_decoupled_references_flag_is_on
     and_i_am_signed_in_as_a_candidate
 
     when_i_have_an_unsuccessful_application
@@ -40,6 +41,10 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_decoupled_references_flag_is_on
+    FeatureFlag.activate('decoupled_references')
   end
 
   def and_i_am_signed_in_as_a_candidate
@@ -156,7 +161,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
   end
 
   def when_i_click_view_my_application
-    click_link 'To view your application, return to your application dashboard'
+    click_link 'You can track the progress of your application on your dashboard'
   end
 
   def then_i_do_not_see_a_link_to_edit_my_application


### PR DESCRIPTION
## Context

Going forward we are going to be sending applications to providers as soon as a candidate submits. This PR removes all of the post submission references to editing the application.

## Changes proposed in this pull request

- Updates the guidance on the submit show button

|Before|After|
|------------|-----------|
|![image](https://user-images.githubusercontent.com/42515961/94440341-805af200-0199-11eb-9813-b4e7ddf9b5c9.png) |![image](https://user-images.githubusercontent.com/42515961/94440128-2eb26780-0199-11eb-9305-a17078cd26e5.png)| 


- Removes the edit by x date content on the application dashboard

|Before|After|
|------------|-----------|
|![image](https://user-images.githubusercontent.com/42515961/94441204-61a92b00-019a-11eb-945f-1da6bc72d2a5.png) |![image](https://user-images.githubusercontent.com/42515961/94440665-cfa12280-0199-11eb-8664-ece47f66c7f6.png)| 

## Guidance to review

The edit_by support page will need to be removed once the feature flag is removed.

This card is just about changing the content. Not about implementing changes to remove the 5-day delay in sending the application to the provider.

I discussed the line 'You can track the progress of your application by signing in to your account:' with Emma as it didn't make complete sense as they were already signed in. It was agreed it would be changed to 'You can track the progress of your application on your dashboard'.

https://docs.google.com/document/d/1Ob7NsAeBrktz7w5BO9oAzaagOWVGtqcnJIwD87qCqdo/edit#

## Link to Trello card


https://trello.com/c/pFks3rJp/2233-%F0%9F%9A%AE-dev-remove-5-day-edit-window

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
