### PR TITLE
HESA codes (sex, disabilities & ethnicity) - write to and read from the database

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
@@ -34,17 +34,34 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
+      hesa_codes = hesa_disability_codes
+
       if disabilities.include?('Other') && other_disability.present?
         disabilities.delete('Other')
         disabilities << other_disability
       end
 
       if application_form.equality_and_diversity.nil?
-        application_form.update(equality_and_diversity: { 'disabilities' => disabilities })
+        application_form.update(
+          equality_and_diversity: {
+            'disabilities' => disabilities,
+            'hesa_disabilities' => hesa_codes,
+          },
+        )
       else
         application_form.equality_and_diversity['disabilities'] = disabilities
+        application_form.equality_and_diversity['hesa_disabilities'] = hesa_codes
         application_form.save
       end
+    end
+
+  private
+
+    def hesa_disability_codes
+      disabilities.map { |disability|
+        disability_type = Hesa::Disability.convert_to_hesa_type(disability)
+        Hesa::Disability.find_by_type(disability_type)&.hesa_code
+      }.compact
     end
   end
 end

--- a/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
@@ -59,8 +59,8 @@ module CandidateInterface
 
     def hesa_disability_codes
       disabilities.map { |disability|
-        disability_type = Hesa::Disability.convert_to_hesa_type(disability)
-        Hesa::Disability.find_by_type(disability_type)&.hesa_code
+        disability_type = Hesa::Disability.convert_to_hesa_value(disability)
+        Hesa::Disability.find_by_value(disability_type)&.hesa_code
       }.compact
     end
   end

--- a/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -19,7 +19,13 @@ module CandidateInterface
       return false unless valid?
 
       if application_form.equality_and_diversity.nil?
-        application_form.update(equality_and_diversity: { 'disabilities' => [] })
+        hesa_code = Hesa::Disability
+                      .find_by_type(HesaDisabilityTypes::NONE)
+                      .hesa_code
+        application_form.update(equality_and_diversity: {
+          'disabilities' => [],
+          'hesa_disabilities' => [hesa_code],
+        })
       elsif reset_disabilities?(application_form)
         application_form.equality_and_diversity['disabilities'] = []
         application_form.save

--- a/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -20,7 +20,7 @@ module CandidateInterface
 
       if application_form.equality_and_diversity.nil?
         hesa_code = Hesa::Disability
-                      .find_by_type(HesaDisabilityTypes::NONE)
+                      .find_by_value(HesaDisabilityValues::NONE)
                       .hesa_code
         application_form.update(equality_and_diversity: {
           'disabilities' => [],

--- a/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
@@ -30,18 +30,18 @@ module CandidateInterface
       other_background_present = ethnic_background == EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group].first && other_background.present?
 
       background = other_background_present ? other_background : ethnic_background
-      ethnicity_type = hesa_ethnicity_type(ethnic_background)
+      ethnicity_value = hesa_ethnicity_value(ethnic_background)
 
       if application_form.equality_and_diversity.nil?
         application_form.update(
           equality_and_diversity: {
             'ethnic_background' => background,
-            'hesa_ethnicity' => hesa_ethnicity_code(ethnicity_type),
+            'hesa_ethnicity' => hesa_ethnicity_code(ethnicity_value),
           },
         )
       else
         application_form.equality_and_diversity['ethnic_background'] = background
-        application_form.equality_and_diversity['hesa_ethnicity'] = hesa_ethnicity_code(ethnicity_type)
+        application_form.equality_and_diversity['hesa_ethnicity'] = hesa_ethnicity_code(ethnicity_value)
         application_form.save
       end
     end
@@ -52,13 +52,13 @@ module CandidateInterface
 
   private
 
-    def hesa_ethnicity_type(background)
-      Hesa::Ethnicity.convert_to_hesa_type(background)
+    def hesa_ethnicity_value(background)
+      Hesa::Ethnicity.convert_to_hesa_value(background)
     end
 
     def hesa_ethnicity_code(type)
       Hesa::Ethnicity
-        .find_by_type(type, RecruitmentCycle.current_year)
+        .find_by_value(type, RecruitmentCycle.current_year)
         &.hesa_code
     end
   end

--- a/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
@@ -30,17 +30,36 @@ module CandidateInterface
       other_background_present = ethnic_background == EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group].first && other_background.present?
 
       background = other_background_present ? other_background : ethnic_background
+      ethnicity_type = hesa_ethnicity_type(ethnic_background)
 
       if application_form.equality_and_diversity.nil?
-        application_form.update(equality_and_diversity: { 'ethnic_background' => background })
+        application_form.update(
+          equality_and_diversity: {
+            'ethnic_background' => background,
+            'hesa_ethnicity' => hesa_ethnicity_code(ethnicity_type),
+          },
+        )
       else
         application_form.equality_and_diversity['ethnic_background'] = background
+        application_form.equality_and_diversity['hesa_ethnicity'] = hesa_ethnicity_code(ethnicity_type)
         application_form.save
       end
     end
 
     def self.listed_ethnic_background?(group, background)
       EthnicBackgroundHelper::ETHNIC_BACKGROUNDS[group].include?(background) || EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group].include?(background)
+    end
+
+  private
+
+    def hesa_ethnicity_type(background)
+      Hesa::Ethnicity.convert_to_hesa_type(background)
+    end
+
+    def hesa_ethnicity_code(type)
+      Hesa::Ethnicity
+        .find_by_type(type, RecruitmentCycle.current_year)
+        &.hesa_code
     end
   end
 end

--- a/app/forms/candidate_interface/equality_and_diversity/sex_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/sex_form.rb
@@ -16,11 +16,27 @@ module CandidateInterface
       return false unless valid?
 
       if application_form.equality_and_diversity.nil?
-        application_form.update(equality_and_diversity: { 'sex' => sex })
+        application_form.update(
+          equality_and_diversity: {
+            'sex' => sex,
+            'hesa_sex' => hesa_sex_code,
+          },
+        )
       else
         application_form.equality_and_diversity['sex'] = sex
+        application_form.equality_and_diversity['hesa_sex'] = hesa_sex_code
         application_form.save
       end
+    end
+
+  private
+
+    def hesa_sex_code
+      Hesa::Sex.find_by_type(hesa_sex_type)&.hesa_code
+    end
+
+    def hesa_sex_type
+      sex == 'intersex' ? 'other' : sex
     end
   end
 end

--- a/app/lib/hesa/disability.rb
+++ b/app/lib/hesa/disability.rb
@@ -1,0 +1,28 @@
+module Hesa
+  class Disability
+    DisabilityStruct = Struct.new(:hesa_code, :type)
+
+    def self.all
+      HESA_DISABILITIES.map { |disability| DisabilityStruct.new(*disability) }
+    end
+
+    def self.find_by_type(disability_type)
+      all.find { |disability| disability.type == disability_type }
+    end
+
+    def self.convert_to_hesa_type(disability)
+      {
+        'None' => HesaDisabilityTypes::NONE,
+        'Multiple' => HesaDisabilityTypes::MULTIPLE,
+        'Learning difficulty' => HesaDisabilityTypes::LEARNING,
+        'Social or communication impairment' => HesaDisabilityTypes::SOCIAL_OR_COMMUNICATION,
+        'Long-standing illness' => HesaDisabilityTypes::LONGSTANDING_ILLNESS,
+        'Mental health condition' => HesaDisabilityTypes::MENTAL_HEALTH_CONDITION,
+        'Physical disability or mobility issue' => HesaDisabilityTypes::PHYSICAL_OR_MOBILITY,
+        'Deaf' => HesaDisabilityTypes::DEAF,
+        'Blind' => HesaDisabilityTypes::BLIND,
+        'Other' => HesaDisabilityTypes::OTHER,
+      }.freeze[disability]
+    end
+  end
+end

--- a/app/lib/hesa/disability.rb
+++ b/app/lib/hesa/disability.rb
@@ -1,27 +1,27 @@
 module Hesa
   class Disability
-    DisabilityStruct = Struct.new(:hesa_code, :type)
+    DisabilityStruct = Struct.new(:hesa_code, :value)
 
     def self.all
       HESA_DISABILITIES.map { |disability| DisabilityStruct.new(*disability) }
     end
 
-    def self.find_by_type(disability_type)
-      all.find { |disability| disability.type == disability_type }
+    def self.find_by_value(value)
+      all.find { |disability| disability.value == value }
     end
 
-    def self.convert_to_hesa_type(disability)
+    def self.convert_to_hesa_value(disability)
       {
-        'None' => HesaDisabilityTypes::NONE,
-        'Multiple' => HesaDisabilityTypes::MULTIPLE,
-        'Learning difficulty' => HesaDisabilityTypes::LEARNING,
-        'Social or communication impairment' => HesaDisabilityTypes::SOCIAL_OR_COMMUNICATION,
-        'Long-standing illness' => HesaDisabilityTypes::LONGSTANDING_ILLNESS,
-        'Mental health condition' => HesaDisabilityTypes::MENTAL_HEALTH_CONDITION,
-        'Physical disability or mobility issue' => HesaDisabilityTypes::PHYSICAL_OR_MOBILITY,
-        'Deaf' => HesaDisabilityTypes::DEAF,
-        'Blind' => HesaDisabilityTypes::BLIND,
-        'Other' => HesaDisabilityTypes::OTHER,
+        'None' => HesaDisabilityValues::NONE,
+        'Multiple' => HesaDisabilityValues::MULTIPLE,
+        'Learning difficulty' => HesaDisabilityValues::LEARNING,
+        'Social or communication impairment' => HesaDisabilityValues::SOCIAL_OR_COMMUNICATION,
+        'Long-standing illness' => HesaDisabilityValues::LONGSTANDING_ILLNESS,
+        'Mental health condition' => HesaDisabilityValues::MENTAL_HEALTH_CONDITION,
+        'Physical disability or mobility issue' => HesaDisabilityValues::PHYSICAL_OR_MOBILITY,
+        'Deaf' => HesaDisabilityValues::DEAF,
+        'Blind' => HesaDisabilityValues::BLIND,
+        'Other' => HesaDisabilityValues::OTHER,
       }.freeze[disability]
     end
   end

--- a/app/lib/hesa/ethnicity.rb
+++ b/app/lib/hesa/ethnicity.rb
@@ -1,6 +1,6 @@
 module Hesa
   class Ethnicity
-    EthnicityStruct = Struct.new(:hesa_code, :type)
+    EthnicityStruct = Struct.new(:hesa_code, :value)
 
     def self.all(cycle_year)
       if cycle_year == 2020
@@ -12,31 +12,31 @@ module Hesa
       end
     end
 
-    def self.find_by_type(ethnicity_type, cycle_year)
-      all(cycle_year).find { |ethnicity| ethnicity.type == ethnicity_type }
+    def self.find_by_value(value, cycle_year)
+      all(cycle_year).find { |ethnicity| ethnicity.value == value }
     end
 
-    def self.convert_to_hesa_type(background)
+    def self.convert_to_hesa_value(background)
       {
-        'British, English, Northern Irish, Scottish, or Welsh' => HesaEthnicityTypes::WHITE,
-        'Irish' => HesaEthnicityTypes::WHITE,
-        'Irish Traveller or Gypsy' => HesaEthnicityTypes::GYPSY_OR_TRAVELLER,
-        'Another White background' => HesaEthnicityTypes::WHITE,
-        'Prefer not to say' => HesaEthnicityTypes::INFORMATION_REFUSED,
-        'Bangladeshi' => HesaEthnicityTypes::BANGLADESHI,
-        'Chinese' => HesaEthnicityTypes::CHINESE,
-        'Indian' => HesaEthnicityTypes::INDIAN,
-        'Pakistani' => HesaEthnicityTypes::PAKISTANI,
-        'Another Asian background' => HesaEthnicityTypes::OTHER_ASIAN,
-        'African' => HesaEthnicityTypes::AFRICAN,
-        'Caribbean' => HesaEthnicityTypes::CARIBBEAN,
-        'Another Black background' => HesaEthnicityTypes::OTHER_BLACK,
-        'Asian and White' => HesaEthnicityTypes::WHITE_AND_ASIAN,
-        'Black African and White' => HesaEthnicityTypes::WHITE_AND_BLACK_AFRICAN,
-        'Black Caribbean and White' => HesaEthnicityTypes::WHITE_AND_BLACK_CARIBBEAN,
-        'Another Mixed background' => HesaEthnicityTypes::OTHER_MIXED,
-        'Arab' => HesaEthnicityTypes::ARAB,
-        'Another ethnic background' => HesaEthnicityTypes::OTHER_ETHNIC,
+        'British, English, Northern Irish, Scottish, or Welsh' => HesaEthnicityValues::WHITE,
+        'Irish' => HesaEthnicityValues::WHITE,
+        'Irish Traveller or Gypsy' => HesaEthnicityValues::GYPSY_OR_TRAVELLER,
+        'Another White background' => HesaEthnicityValues::WHITE,
+        'Prefer not to say' => HesaEthnicityValues::INFORMATION_REFUSED,
+        'Bangladeshi' => HesaEthnicityValues::BANGLADESHI,
+        'Chinese' => HesaEthnicityValues::CHINESE,
+        'Indian' => HesaEthnicityValues::INDIAN,
+        'Pakistani' => HesaEthnicityValues::PAKISTANI,
+        'Another Asian background' => HesaEthnicityValues::OTHER_ASIAN,
+        'African' => HesaEthnicityValues::AFRICAN,
+        'Caribbean' => HesaEthnicityValues::CARIBBEAN,
+        'Another Black background' => HesaEthnicityValues::OTHER_BLACK,
+        'Asian and White' => HesaEthnicityValues::WHITE_AND_ASIAN,
+        'Black African and White' => HesaEthnicityValues::WHITE_AND_BLACK_AFRICAN,
+        'Black Caribbean and White' => HesaEthnicityValues::WHITE_AND_BLACK_CARIBBEAN,
+        'Another Mixed background' => HesaEthnicityValues::OTHER_MIXED,
+        'Arab' => HesaEthnicityValues::ARAB,
+        'Another ethnic background' => HesaEthnicityValues::OTHER_ETHNIC,
       }.freeze[background]
     end
   end

--- a/app/lib/hesa/ethnicity.rb
+++ b/app/lib/hesa/ethnicity.rb
@@ -1,0 +1,43 @@
+module Hesa
+  class Ethnicity
+    EthnicityStruct = Struct.new(:hesa_code, :type)
+
+    def self.all(cycle_year)
+      if cycle_year == 2020
+        HESA_ETHNICITIES_2019_2020.map { |ethnicity| EthnicityStruct.new(*ethnicity) }
+      elsif cycle_year == 2021
+        HESA_ETHNICITIES_2020_2021.map { |ethnicity| EthnicityStruct.new(*ethnicity) }
+      else
+        raise ArgumentError, "Do not know Hesa Ethnicities codes for #{recruitment_cycle_year}"
+      end
+    end
+
+    def self.find_by_type(ethnicity_type, cycle_year)
+      all(cycle_year).find { |ethnicity| ethnicity.type == ethnicity_type }
+    end
+
+    def self.convert_to_hesa_type(background)
+      {
+        'British, English, Northern Irish, Scottish, or Welsh' => HesaEthnicityTypes::WHITE,
+        'Irish' => HesaEthnicityTypes::WHITE,
+        'Irish Traveller or Gypsy' => HesaEthnicityTypes::GYPSY_OR_TRAVELLER,
+        'Another White background' => HesaEthnicityTypes::WHITE,
+        'Prefer not to say' => HesaEthnicityTypes::INFORMATION_REFUSED,
+        'Bangladeshi' => HesaEthnicityTypes::BANGLADESHI,
+        'Chinese' => HesaEthnicityTypes::CHINESE,
+        'Indian' => HesaEthnicityTypes::INDIAN,
+        'Pakistani' => HesaEthnicityTypes::PAKISTANI,
+        'Another Asian background' => HesaEthnicityTypes::OTHER_ASIAN,
+        'African' => HesaEthnicityTypes::AFRICAN,
+        'Caribbean' => HesaEthnicityTypes::CARIBBEAN,
+        'Another Black background' => HesaEthnicityTypes::OTHER_BLACK,
+        'Asian and White' => HesaEthnicityTypes::WHITE_AND_ASIAN,
+        'Black African and White' => HesaEthnicityTypes::WHITE_AND_BLACK_AFRICAN,
+        'Black Caribbean and White' => HesaEthnicityTypes::WHITE_AND_BLACK_CARIBBEAN,
+        'Another Mixed background' => HesaEthnicityTypes::OTHER_MIXED,
+        'Arab' => HesaEthnicityTypes::ARAB,
+        'Another ethnic background' => HesaEthnicityTypes::OTHER_ETHNIC,
+      }.freeze[background]
+    end
+  end
+end

--- a/app/lib/hesa/sex.rb
+++ b/app/lib/hesa/sex.rb
@@ -1,0 +1,13 @@
+module Hesa
+  class Sex
+    SexStruct = Struct.new(:hesa_code, :type)
+
+    def self.all
+      HESA_SEX.map { |sex| SexStruct.new(*sex) }
+    end
+
+    def self.find_by_type(sex_type)
+      all.find { |sex| sex.type == sex_type }
+    end
+  end
+end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -42,6 +42,7 @@ module VendorAPI
             work_history_break_explanation: work_history_breaks,
           },
           offer: offer,
+          hesa_itt_data: hesa_itt_data,
           rejection: get_rejection,
           withdrawal: withdrawal,
           further_information: application_form.further_information,
@@ -255,11 +256,15 @@ module VendorAPI
     end
 
     def hesa_itt_data
-      {
-        sex: '2',
-        disability: '00',
-        ethnicity: '10',
-      }
+      equality_and_diversity_data = application_form&.equality_and_diversity
+
+      if equality_and_diversity_data
+        {
+          sex: equality_and_diversity_data['hesa_sex'],
+          disability: equality_and_diversity_data['hesa_disabilities'],
+          ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+        }
+      end
     end
 
     def work_history_breaks

--- a/config/initializers/hesa_disabilities.rb
+++ b/config/initializers/hesa_disabilities.rb
@@ -1,12 +1,26 @@
+module HesaDisabilityTypes
+  NONE = 'No known disability'.freeze
+  MULTIPLE = 'Multiple disabilities'.freeze
+  LEARNING = 'A specific learning difficulty such as dyslexia, dyspraxia or AD(H)D'.freeze
+  SOCIAL_OR_COMMUNICATION = "A social/communication impairment such as Asperger's syndrome/other autistic spectrum disorder".freeze
+  LONGSTANDING_ILLNESS = 'A long standing illness or health condition such as cancer, HIV, diabetes, chronic heart disease, or epilepsy'.freeze
+  MENTAL_HEALTH_CONDITION = 'A mental health condition, such as depression, schizophrenia or anxiety disorder'.freeze
+  PHYSICAL_OR_MOBILITY = 'A physical impairment or mobility issues, such as difficulty using arms or using a wheelchair or crutches'.freeze
+  DEAF = 'Deaf or a serious hearing impairment'.freeze
+  BLIND = 'Blind or a serious visual impairment uncorrected by glasses'.freeze
+  OTHER = 'A disability, impairment or medical condition that is not listed above'.freeze
+end
+
+# https://www.hesa.ac.uk/collection/c20053/e/disable
 HESA_DISABILITIES = [
-  ['00', 'No known disability'],
-  ['08', 'Multiple disabilities'],
-  ['51', 'A specific learning difficulty such as dyslexia, dyspraxia or AD(H)D'],
-  ['53', "A social/communication impairment such as Asperger's syndrome/other autistic spectrum disorder"],
-  ['54', 'A long standing illness or health condition such as cancer, HIV, diabetes, chronic heart disease, or epilepsy'],
-  ['55', 'A mental health condition, such as depression, schizophrenia or anxiety disorder'],
-  ['56', 'A physical impairment or mobility issues, such as difficulty using arms or using a wheelchair or crutches'],
-  ['57', 'Deaf or a serious hearing impairment'],
-  ['58', 'Blind or a serious visual impairment uncorrected by glasses'],
-  ['96', 'A disability, impairment or medical condition that is not listed above'],
+  ['00', HesaDisabilityTypes::NONE],
+  ['08', HesaDisabilityTypes::MULTIPLE],
+  ['51', HesaDisabilityTypes::LEARNING],
+  ['53', HesaDisabilityTypes::SOCIAL_OR_COMMUNICATION],
+  ['54', HesaDisabilityTypes::LONGSTANDING_ILLNESS],
+  ['55', HesaDisabilityTypes::MENTAL_HEALTH_CONDITION],
+  ['56', HesaDisabilityTypes::PHYSICAL_OR_MOBILITY],
+  ['57', HesaDisabilityTypes::DEAF],
+  ['58', HesaDisabilityTypes::BLIND],
+  ['96', HesaDisabilityTypes::OTHER],
 ].freeze

--- a/config/initializers/hesa_disabilities.rb
+++ b/config/initializers/hesa_disabilities.rb
@@ -1,4 +1,4 @@
-module HesaDisabilityTypes
+module HesaDisabilityValues
   NONE = 'No known disability'.freeze
   MULTIPLE = 'Multiple disabilities'.freeze
   LEARNING = 'A specific learning difficulty such as dyslexia, dyspraxia or AD(H)D'.freeze
@@ -13,14 +13,14 @@ end
 
 # https://www.hesa.ac.uk/collection/c20053/e/disable
 HESA_DISABILITIES = [
-  ['00', HesaDisabilityTypes::NONE],
-  ['08', HesaDisabilityTypes::MULTIPLE],
-  ['51', HesaDisabilityTypes::LEARNING],
-  ['53', HesaDisabilityTypes::SOCIAL_OR_COMMUNICATION],
-  ['54', HesaDisabilityTypes::LONGSTANDING_ILLNESS],
-  ['55', HesaDisabilityTypes::MENTAL_HEALTH_CONDITION],
-  ['56', HesaDisabilityTypes::PHYSICAL_OR_MOBILITY],
-  ['57', HesaDisabilityTypes::DEAF],
-  ['58', HesaDisabilityTypes::BLIND],
-  ['96', HesaDisabilityTypes::OTHER],
+  ['00', HesaDisabilityValues::NONE],
+  ['08', HesaDisabilityValues::MULTIPLE],
+  ['51', HesaDisabilityValues::LEARNING],
+  ['53', HesaDisabilityValues::SOCIAL_OR_COMMUNICATION],
+  ['54', HesaDisabilityValues::LONGSTANDING_ILLNESS],
+  ['55', HesaDisabilityValues::MENTAL_HEALTH_CONDITION],
+  ['56', HesaDisabilityValues::PHYSICAL_OR_MOBILITY],
+  ['57', HesaDisabilityValues::DEAF],
+  ['58', HesaDisabilityValues::BLIND],
+  ['96', HesaDisabilityValues::OTHER],
 ].freeze

--- a/config/initializers/hesa_ethnicities.rb
+++ b/config/initializers/hesa_ethnicities.rb
@@ -1,23 +1,44 @@
+module HesaEthnicityTypes
+  WHITE = 'White'.freeze
+  GYPSY_OR_TRAVELLER = 'Gypsy or Traveller'.freeze
+  CARIBBEAN = 'Black or Black British - Caribbean'.freeze
+  AFRICAN = 'Black or Black British - African'.freeze
+  OTHER_BLACK = 'Other Black background'.freeze
+  BANGLADESHI = 'Asian or Asian British - Bangladeshi'.freeze
+  INDIAN = 'Asian or Asian British - Indian'.freeze
+  PAKISTANI = 'Asian or Asian British - Pakistani'.freeze
+  CHINESE = 'Chinese'.freeze
+  OTHER_ASIAN = 'Other Asian background'.freeze
+  WHITE_AND_BLACK_CARIBBEAN = 'Mixed - White and Black Caribbean'.freeze
+  WHITE_AND_BLACK_AFRICAN = 'Mixed - White and Black African'.freeze
+  WHITE_AND_ASIAN = 'Mixed - White and Asian'.freeze
+  OTHER_MIXED = 'Other Mixed background'.freeze
+  ARAB = 'Arab'.freeze
+  OTHER_ETHNIC = 'Other Ethnic background'.freeze
+  NOT_KNOWN = 'Not known'.freeze
+  INFORMATION_REFUSED = 'Information refused'.freeze
+end
+
 # https://www.hesa.ac.uk/collection/c19053/e/ethnic
 HESA_ETHNICITIES_2019_2020 = [
-  [10, 'White'],
-  [15, 'Gypsy or Traveller'],
-  [21, 'Black or Black British - Caribbean'],
-  [22, 'Black or Black British - African'],
-  [29, 'Other Black background'],
-  [31, 'Asian or Asian British - Indian'],
-  [32, 'Asian or Asian British - Pakistani'],
-  [33, 'Asian or Asian British - Bangladeshi'],
-  [34, 'Chinese'],
-  [39, 'Other Asian background'],
-  [41, 'Mixed - White and Black Caribbean'],
-  [42, 'Mixed - White and Black African'],
-  [43, 'Mixed - White and Asian'],
-  [49, 'Other Mixed background'],
-  [50, 'Arab'],
-  [80, 'Other Ethnic background'],
-  [90, 'Not known'],
-  [98, 'Information refused'],
+  [10, HesaEthnicityTypes::WHITE],
+  [15, HesaEthnicityTypes::GYPSY_OR_TRAVELLER],
+  [21, HesaEthnicityTypes::CARIBBEAN],
+  [22, HesaEthnicityTypes::AFRICAN],
+  [29, HesaEthnicityTypes::OTHER_BLACK],
+  [31, HesaEthnicityTypes::INDIAN],
+  [32, HesaEthnicityTypes::PAKISTANI],
+  [33, HesaEthnicityTypes::BANGLADESHI],
+  [34, HesaEthnicityTypes::CHINESE],
+  [39, HesaEthnicityTypes::OTHER_ASIAN],
+  [41, HesaEthnicityTypes::WHITE_AND_BLACK_CARIBBEAN],
+  [42, HesaEthnicityTypes::WHITE_AND_BLACK_AFRICAN],
+  [43, HesaEthnicityTypes::WHITE_AND_ASIAN],
+  [49, HesaEthnicityTypes::OTHER_MIXED],
+  [50, HesaEthnicityTypes::ARAB],
+  [80, HesaEthnicityTypes::OTHER_ETHNIC],
+  [90, HesaEthnicityTypes::NOT_KNOWN],
+  [98, HesaEthnicityTypes::INFORMATION_REFUSED],
 ].freeze
 
 # Two codes have been dropped in 2020/21

--- a/config/initializers/hesa_ethnicities.rb
+++ b/config/initializers/hesa_ethnicities.rb
@@ -1,4 +1,4 @@
-module HesaEthnicityTypes
+module HesaEthnicityValues
   WHITE = 'White'.freeze
   GYPSY_OR_TRAVELLER = 'Gypsy or Traveller'.freeze
   CARIBBEAN = 'Black or Black British - Caribbean'.freeze
@@ -21,24 +21,24 @@ end
 
 # https://www.hesa.ac.uk/collection/c19053/e/ethnic
 HESA_ETHNICITIES_2019_2020 = [
-  [10, HesaEthnicityTypes::WHITE],
-  [15, HesaEthnicityTypes::GYPSY_OR_TRAVELLER],
-  [21, HesaEthnicityTypes::CARIBBEAN],
-  [22, HesaEthnicityTypes::AFRICAN],
-  [29, HesaEthnicityTypes::OTHER_BLACK],
-  [31, HesaEthnicityTypes::INDIAN],
-  [32, HesaEthnicityTypes::PAKISTANI],
-  [33, HesaEthnicityTypes::BANGLADESHI],
-  [34, HesaEthnicityTypes::CHINESE],
-  [39, HesaEthnicityTypes::OTHER_ASIAN],
-  [41, HesaEthnicityTypes::WHITE_AND_BLACK_CARIBBEAN],
-  [42, HesaEthnicityTypes::WHITE_AND_BLACK_AFRICAN],
-  [43, HesaEthnicityTypes::WHITE_AND_ASIAN],
-  [49, HesaEthnicityTypes::OTHER_MIXED],
-  [50, HesaEthnicityTypes::ARAB],
-  [80, HesaEthnicityTypes::OTHER_ETHNIC],
-  [90, HesaEthnicityTypes::NOT_KNOWN],
-  [98, HesaEthnicityTypes::INFORMATION_REFUSED],
+  [10, HesaEthnicityValues::WHITE],
+  [15, HesaEthnicityValues::GYPSY_OR_TRAVELLER],
+  [21, HesaEthnicityValues::CARIBBEAN],
+  [22, HesaEthnicityValues::AFRICAN],
+  [29, HesaEthnicityValues::OTHER_BLACK],
+  [31, HesaEthnicityValues::INDIAN],
+  [32, HesaEthnicityValues::PAKISTANI],
+  [33, HesaEthnicityValues::BANGLADESHI],
+  [34, HesaEthnicityValues::CHINESE],
+  [39, HesaEthnicityValues::OTHER_ASIAN],
+  [41, HesaEthnicityValues::WHITE_AND_BLACK_CARIBBEAN],
+  [42, HesaEthnicityValues::WHITE_AND_BLACK_AFRICAN],
+  [43, HesaEthnicityValues::WHITE_AND_ASIAN],
+  [49, HesaEthnicityValues::OTHER_MIXED],
+  [50, HesaEthnicityValues::ARAB],
+  [80, HesaEthnicityValues::OTHER_ETHNIC],
+  [90, HesaEthnicityValues::NOT_KNOWN],
+  [98, HesaEthnicityValues::INFORMATION_REFUSED],
 ].freeze
 
 # Two codes have been dropped in 2020/21

--- a/config/initializers/hesa_sex.rb
+++ b/config/initializers/hesa_sex.rb
@@ -1,5 +1,5 @@
 HESA_SEX = [
-  [1, 'Male'],
-  [2, 'Female'],
-  [3, 'Other'],
+  [1, 'male'],
+  [2, 'female'],
+  [3, 'other'],
 ].freeze

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -120,11 +120,18 @@ FactoryBot.define do
           other_disability = 'Acquired brain injury'
           all_disabilities = CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.map(&:second) << other_disability
           disabilities = rand < 0.85 ? all_disabilities.sample([*0..3].sample) : ['Prefer not to say']
+          hesa_sex = [1, 2, 3].sample
+          hesa_disabilities = disabilities ? HESA_DISABILITIES.map(&:first).sample : %w[00]
+          hesa_ethnicity = HESA_ETHNICITIES_2020_2021.map(&:first).sample
+
           {
             sex: ['male', 'female', 'intersex', 'Prefer not to say'].sample,
             ethnic_group: ethnicity.first,
             ethnic_background: ethnicity.last,
             disabilities: disabilities,
+            hesa_sex: hesa_sex,
+            hesa_disabilities: hesa_disabilities,
+            hesa_ethnicity: hesa_ethnicity,
           }
         end
       end

--- a/spec/forms/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
@@ -55,14 +55,20 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
         form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind Other], other_disability: 'Other disability')
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('disabilities' => ['Blind', 'Other disability'])
+        expect(application_form.equality_and_diversity).to eq(
+          'disabilities' => ['Blind', 'Other disability'],
+          'hesa_disabilities' => %w[58 96],
+        )
       end
 
       it 'allows other_disability field to be optional' do
         form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind Other], other_disability: '')
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('disabilities' => %w[Blind Other])
+        expect(application_form.equality_and_diversity).to eq(
+          'disabilities' => %w[Blind Other],
+          'hesa_disabilities' => %w[58 96],
+        )
       end
 
       it 'updates the existing record of equality and diversity information' do
@@ -71,7 +77,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'disabilities' => %w[Blind],
+          'sex' => 'male', 'hesa_disabilities' => %w[58], 'disabilities' => %w[Blind],
         )
       end
 
@@ -81,7 +87,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'disabilities' => %w[Blind],
+          'sex' => 'male', 'hesa_disabilities' => %w[58], 'disabilities' => %w[Blind],
         )
       end
     end

--- a/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
@@ -66,7 +66,10 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('disabilities' => [])
+        expect(application_form.equality_and_diversity).to eq(
+          'disabilities' => [],
+          'hesa_disabilities' => %w[00],
+        )
       end
 
       it 'updates the existing record of equality and diversity information' do

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
@@ -72,7 +72,11 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Bangladeshi')
+        expect(application_form.equality_and_diversity).to eq(
+          'ethnic_group' => 'Asian or Asian British',
+          'ethnic_background' => 'Bangladeshi',
+          'hesa_ethnicity' => 33,
+        )
       end
 
       it 'updates the existing record of equality and diversity information' do
@@ -82,7 +86,10 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'male', 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Bangladeshi',
+          'sex' => 'male',
+          'ethnic_group' => 'Asian or Asian British',
+          'ethnic_background' => 'Bangladeshi',
+          'hesa_ethnicity' => 33,
         )
       end
     end
@@ -93,7 +100,11 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Unlisted ethnic background')
+        expect(application_form.equality_and_diversity).to eq(
+          'ethnic_group' => 'Asian or Asian British',
+          'ethnic_background' => 'Unlisted ethnic background',
+          'hesa_ethnicity' => 39,
+        )
       end
 
       it 'updates the application form with the ethnic background value if other background is not provided' do
@@ -101,7 +112,11 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian background')
+        expect(application_form.equality_and_diversity).to eq(
+          'ethnic_group' => 'Asian or Asian British',
+          'ethnic_background' => 'Another Asian background',
+          'hesa_ethnicity' => 39,
+        )
       end
     end
   end

--- a/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
         form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'male')
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('sex' => 'male')
+        expect(application_form.equality_and_diversity).to eq('sex' => 'male', 'hesa_sex' => 1)
       end
 
       it 'updates the existing record of equality and diversity information' do
@@ -48,7 +48,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(
-          'sex' => 'female', 'disabilities' => [],
+          'sex' => 'female', 'hesa_sex' => 2, 'disabilities' => [],
         )
       end
     end

--- a/spec/lib/hesa/disability_spec.rb
+++ b/spec/lib/hesa/disability_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Hesa::Disability do
+  describe '.all' do
+    it 'returns a list of HESA disability structs' do
+      disability_types = described_class.all
+
+      expect(disability_types.size).to eq 10
+
+      deaf = disability_types.find { |e| e.hesa_code == '57' }
+
+      expect(deaf.hesa_code).to eq '57'
+      expect(deaf.type).to eq HesaDisabilityTypes::DEAF
+    end
+  end
+
+  describe '.find_by_type' do
+    context 'given a valid type' do
+      it 'returns the matching struct' do
+        result = described_class.find_by_type('Deaf or a serious hearing impairment')
+
+        expect(result.type).to eq HesaDisabilityTypes::DEAF
+        expect(result.hesa_code).to eq '57'
+      end
+    end
+
+    context 'given an unrecognised type' do
+      it 'returns nil' do
+        result = described_class.find_by_type('Unrecognised disability')
+
+        expect(result).to eq nil
+      end
+    end
+  end
+
+  describe '.convert_to_hesa_type' do
+    context 'given a known disability' do
+      it 'returns the matching hesa type' do
+        result = described_class.convert_to_hesa_type('Social or communication impairment')
+
+        expect(result).to eq HesaDisabilityTypes::SOCIAL_OR_COMMUNICATION
+      end
+    end
+
+    context 'given an unknown disability' do
+      it 'returns nil' do
+        result = described_class.convert_to_hesa_type('unrecognised disability')
+
+        expect(result).to eq nil
+      end
+    end
+  end
+end

--- a/spec/lib/hesa/disability_spec.rb
+++ b/spec/lib/hesa/disability_spec.rb
@@ -3,48 +3,48 @@ require 'rails_helper'
 RSpec.describe Hesa::Disability do
   describe '.all' do
     it 'returns a list of HESA disability structs' do
-      disability_types = described_class.all
+      disability_values = described_class.all
 
-      expect(disability_types.size).to eq 10
+      expect(disability_values.size).to eq 10
 
-      deaf = disability_types.find { |e| e.hesa_code == '57' }
+      deaf = disability_values.find { |e| e.hesa_code == '57' }
 
       expect(deaf.hesa_code).to eq '57'
-      expect(deaf.type).to eq HesaDisabilityTypes::DEAF
+      expect(deaf.value).to eq HesaDisabilityValues::DEAF
     end
   end
 
-  describe '.find_by_type' do
-    context 'given a valid type' do
+  describe '.find_by_value' do
+    context 'given a valid value' do
       it 'returns the matching struct' do
-        result = described_class.find_by_type('Deaf or a serious hearing impairment')
+        result = described_class.find_by_value('Deaf or a serious hearing impairment')
 
-        expect(result.type).to eq HesaDisabilityTypes::DEAF
+        expect(result.value).to eq HesaDisabilityValues::DEAF
         expect(result.hesa_code).to eq '57'
       end
     end
 
-    context 'given an unrecognised type' do
+    context 'given an unrecognised value' do
       it 'returns nil' do
-        result = described_class.find_by_type('Unrecognised disability')
+        result = described_class.find_by_value('Unrecognised disability')
 
         expect(result).to eq nil
       end
     end
   end
 
-  describe '.convert_to_hesa_type' do
+  describe '.convert_to_hesa_value' do
     context 'given a known disability' do
-      it 'returns the matching hesa type' do
-        result = described_class.convert_to_hesa_type('Social or communication impairment')
+      it 'returns the matching hesa value' do
+        result = described_class.convert_to_hesa_value('Social or communication impairment')
 
-        expect(result).to eq HesaDisabilityTypes::SOCIAL_OR_COMMUNICATION
+        expect(result).to eq HesaDisabilityValues::SOCIAL_OR_COMMUNICATION
       end
     end
 
     context 'given an unknown disability' do
       it 'returns nil' do
-        result = described_class.convert_to_hesa_type('unrecognised disability')
+        result = described_class.convert_to_hesa_value('unrecognised disability')
 
         expect(result).to eq nil
       end

--- a/spec/lib/hesa/ethnicity_spec.rb
+++ b/spec/lib/hesa/ethnicity_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Hesa::Ethnicity do
+  describe '.all' do
+    context 'Recruitment cycle 2019 - 2020' do
+      it 'returns a list of HESA ethnicity structs' do
+        cycle_year = 2020
+        ethnicity_types = described_class.all(cycle_year)
+
+        expect(ethnicity_types.size).to eq 18
+
+        chinese = ethnicity_types.find { |e| e.hesa_code == 34 }
+
+        expect(chinese.hesa_code).to eq 34
+        expect(chinese.type).to eq HesaEthnicityTypes::CHINESE
+      end
+    end
+
+    context 'Recruitment cycle 2020 - 2021' do
+      it 'returns a list of HESA ethnicity structs' do
+        cycle_year = 2021
+        ethnicity_types = described_class.all(cycle_year)
+
+        expect(ethnicity_types.size).to eq 16
+
+        chinese = ethnicity_types.find { |e| e.hesa_code == 34 }
+
+        expect(chinese.hesa_code).to eq 34
+        expect(chinese.type).to eq HesaEthnicityTypes::CHINESE
+      end
+    end
+  end
+
+  describe '.find_by_type' do
+    context 'given a valid type' do
+      it 'returns the matching struct' do
+        cycle_year = 2021
+        result = described_class.find_by_type('Chinese', cycle_year)
+
+        expect(result.type).to eq HesaEthnicityTypes::CHINESE
+        expect(result.hesa_code).to eq 34
+      end
+    end
+
+    context 'given an unrecognised type' do
+      it 'returns nil' do
+        result = described_class.find_by_type('Information refused', 2021)
+
+        expect(result).to eq nil
+      end
+    end
+  end
+
+  describe '.convert_to_hesa_type' do
+    context 'given a known ethnicity' do
+      it 'returns the matching hesa type' do
+        result = described_class.convert_to_hesa_type('Irish')
+
+        expect(result).to eq HesaEthnicityTypes::WHITE
+      end
+    end
+
+    context 'given an unknown ethnicity' do
+      it 'returns nil' do
+        result = described_class.convert_to_hesa_type('unknown ethnicity')
+
+        expect(result).to eq nil
+      end
+    end
+  end
+end

--- a/spec/lib/hesa/ethnicity_spec.rb
+++ b/spec/lib/hesa/ethnicity_spec.rb
@@ -5,64 +5,64 @@ RSpec.describe Hesa::Ethnicity do
     context 'Recruitment cycle 2019 - 2020' do
       it 'returns a list of HESA ethnicity structs' do
         cycle_year = 2020
-        ethnicity_types = described_class.all(cycle_year)
+        ethnicity_values = described_class.all(cycle_year)
 
-        expect(ethnicity_types.size).to eq 18
+        expect(ethnicity_values.size).to eq 18
 
-        chinese = ethnicity_types.find { |e| e.hesa_code == 34 }
+        chinese = ethnicity_values.find { |e| e.hesa_code == 34 }
 
         expect(chinese.hesa_code).to eq 34
-        expect(chinese.type).to eq HesaEthnicityTypes::CHINESE
+        expect(chinese.value).to eq HesaEthnicityValues::CHINESE
       end
     end
 
     context 'Recruitment cycle 2020 - 2021' do
       it 'returns a list of HESA ethnicity structs' do
         cycle_year = 2021
-        ethnicity_types = described_class.all(cycle_year)
+        ethnicity_values = described_class.all(cycle_year)
 
-        expect(ethnicity_types.size).to eq 16
+        expect(ethnicity_values.size).to eq 16
 
-        chinese = ethnicity_types.find { |e| e.hesa_code == 34 }
+        chinese = ethnicity_values.find { |e| e.hesa_code == 34 }
 
         expect(chinese.hesa_code).to eq 34
-        expect(chinese.type).to eq HesaEthnicityTypes::CHINESE
+        expect(chinese.value).to eq HesaEthnicityValues::CHINESE
       end
     end
   end
 
-  describe '.find_by_type' do
-    context 'given a valid type' do
+  describe '.find_by_value' do
+    context 'given a valid value' do
       it 'returns the matching struct' do
         cycle_year = 2021
-        result = described_class.find_by_type('Chinese', cycle_year)
+        result = described_class.find_by_value('Chinese', cycle_year)
 
-        expect(result.type).to eq HesaEthnicityTypes::CHINESE
+        expect(result.value).to eq HesaEthnicityValues::CHINESE
         expect(result.hesa_code).to eq 34
       end
     end
 
-    context 'given an unrecognised type' do
+    context 'given an unrecognised value' do
       it 'returns nil' do
-        result = described_class.find_by_type('Information refused', 2021)
+        result = described_class.find_by_value('Information refused', 2021)
 
         expect(result).to eq nil
       end
     end
   end
 
-  describe '.convert_to_hesa_type' do
+  describe '.convert_to_hesa_value' do
     context 'given a known ethnicity' do
-      it 'returns the matching hesa type' do
-        result = described_class.convert_to_hesa_type('Irish')
+      it 'returns the matching hesa value' do
+        result = described_class.convert_to_hesa_value('Irish')
 
-        expect(result).to eq HesaEthnicityTypes::WHITE
+        expect(result).to eq HesaEthnicityValues::WHITE
       end
     end
 
     context 'given an unknown ethnicity' do
       it 'returns nil' do
-        result = described_class.convert_to_hesa_type('unknown ethnicity')
+        result = described_class.convert_to_hesa_value('unknown ethnicity')
 
         expect(result).to eq nil
       end

--- a/spec/lib/hesa/sex_spec.rb
+++ b/spec/lib/hesa/sex_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Hesa::Sex do
+  describe '.all' do
+    it 'returns a list of HESA sex structs' do
+      sex_types = described_class.all
+
+      expect(sex_types.size).to eq 3
+
+      female = sex_types.find { |s| s.hesa_code == 2 }
+
+      expect(female.hesa_code).to eq 2
+      expect(female.type).to eq 'female'
+    end
+  end
+
+  describe '.find_by_type' do
+    context 'given a valid type' do
+      it 'returns the matching struct' do
+        result = described_class.find_by_type('female')
+
+        expect(result.type).to eq 'female'
+        expect(result.hesa_code).to eq 2
+      end
+    end
+
+    context 'given an unrecognised type' do
+      it 'returns nil' do
+        result = described_class.find_by_type('An unrecognised type')
+
+        expect(result).to eq nil
+      end
+    end
+  end
+end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -42,13 +42,18 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.hesa_itt_data' do
     let(:application_choice) do
-      application_form = create(:completed_application_form, :with_completed_references)
+      application_form = create(:completed_application_form, :with_completed_references, :with_equality_and_diversity_data)
       create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
     end
 
-    it 'is hidden by default' do
+    it 'returns the hesa_itt_data attribute of an application' do
+      equality_and_diversity_data = application_choice.application_form.equality_and_diversity
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
-      expect(response.dig(:attributes, :hesa_itt_data)).to be_nil
+      expect(response.dig(:attributes, :hesa_itt_data)).to eq(
+        disability: equality_and_diversity_data['hesa_disabilities'],
+        ethnicity: equality_and_diversity_data['hesa_ethnicity'],
+        sex: equality_and_diversity_data['hesa_sex'],
+      )
     end
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -74,6 +74,7 @@ RSpec.feature 'Vendor receives the application' do
         support_reference: @provider.application_forms.first.support_reference,
         personal_statement: "Why do you want to become a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
         interview_preferences: 'Not on a Wednesday',
+        hesa_itt_data: nil,
         offer: nil,
         contact_details: {
           phone_number: '07700 900 982',


### PR DESCRIPTION
## Context
```
As a Provendor team
I need application HESA data codes for Sex, Ethnicity, Disability to be collected at source
So that I can supply Providers with a download they can share with HESA/DfE
```

## Changes proposed in this pull request

- This PR takes the information inputted by the user in the equality and diversity survey, looks up the HESA codes for sex, disability and ethnicity and writes them to the database (stored in the `equalities_and_diversity` JSON blob in the application form.
- This information is now exposed in the Provender Application API

## Guidance to review

- Fill out the equality and diversity survey and you will see the values written to the db.
- One of the challenges has been how to deal with strings, strings, strings. Some complexity / indirection arises in cases where we need to convert a form value to a HESA value in order to get the HESA code (see ethnicity and disbabilities). Perhaps there is a better way to do this? 
- Note that backfilling values will be in a separate PR.

## Link to Trello card

https://trello.com/c/mxKdgR5L/2178-dev-collect-hesa-codes-at-source-in-ed-qs

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
