### PR TITLE
Use hobby-basic for Heroku review apps dbs

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,7 @@
       "size": "hobby"
     }
   },
-  "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
+  "addons": ["heroku-postgresql:hobby-basic", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {
       "url": "heroku/ruby"


### PR DESCRIPTION
## Context

This will raise the row limit to 10 million, which should eliminate the row limit warnings we've been receiving.

## Changes proposed in this pull request

Change to the `hobby-basic` plan for review app databases.

## Guidance to review

We've previously tried doing the same in https://github.com/DFE-Digital/apply-for-teacher-training/pull/1817.

That didn't work, because Heroku has an ephemeral restriction to disallow certain add-ons on review apps. After contacting support, they've lifted the restriction for the `dfe-bat` team.

This can be checked by enumerating the add-ons using the Heroku CLI on the review app attached to this PR.

## Link to Trello card

None.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)