### PR TITLE
Trace vendor api requests

### DIFF
--- a/app/controllers/support_interface/vendor_api_requests_controller.rb
+++ b/app/controllers/support_interface/vendor_api_requests_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class VendorAPIRequestsController < SupportInterfaceController
+    def index
+      @vendor_api_requests = VendorAPIRequest.all.order(created_at: :desc)
+    end
+  end
+end

--- a/app/controllers/support_interface/vendor_api_requests_controller.rb
+++ b/app/controllers/support_interface/vendor_api_requests_controller.rb
@@ -2,14 +2,18 @@ module SupportInterface
   class VendorAPIRequestsController < SupportInterfaceController
     def index
       @filter = SupportInterface::VendorAPIRequestsFilter.new(params: params)
-      @vendor_api_requests = VendorAPIRequest.order(created_at: :desc).page(params[:page] || 1).per(15)
+      @vendor_api_requests = VendorAPIRequest.includes(:provider).order(created_at: :desc).page(params[:page] || 1).per(15)
 
       if params[:q]
-        @vendor_api_requests = @vendor_api_requests.where("CONCAT(request_path, ' ', request_body, ' ', response_body, ' ', hashed_token) ILIKE ?", "%#{params[:q]}%")
+        @vendor_api_requests = @vendor_api_requests.where("CONCAT(request_path, ' ', request_body, ' ', response_body) ILIKE ?", "%#{params[:q]}%")
       end
 
       if params[:status_code]
         @vendor_api_requests = @vendor_api_requests.where('status_code IN (?)', params[:status_code])
+      end
+
+      if params[:provider_id]
+        @vendor_api_requests = @vendor_api_requests.where('provider_id IN (?)', params[:provider_id])
       end
 
       %w[created_at request_path].each do |column|

--- a/app/controllers/support_interface/vendor_api_requests_controller.rb
+++ b/app/controllers/support_interface/vendor_api_requests_controller.rb
@@ -1,7 +1,22 @@
 module SupportInterface
   class VendorAPIRequestsController < SupportInterfaceController
     def index
-      @vendor_api_requests = VendorAPIRequest.all.order(created_at: :desc)
+      @filter = SupportInterface::VendorAPIRequestsFilter.new(params: params)
+      @vendor_api_requests = VendorAPIRequest.order(created_at: :desc).page(params[:page] || 1).per(15)
+
+      if params[:q]
+        @vendor_api_requests = @vendor_api_requests.where("CONCAT(request_path, ' ', request_body, ' ', response_body, ' ', hashed_token) ILIKE ?", "%#{params[:q]}%")
+      end
+
+      if params[:status_code]
+        @vendor_api_requests = @vendor_api_requests.where('status_code IN (?)', params[:status_code])
+      end
+
+      %w[created_at request_path].each do |column|
+        next unless params[column]
+
+        @vendor_api_requests = @vendor_api_requests.where(column => params[column])
+      end
     end
   end
 end

--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -46,6 +46,10 @@ private
     @request.env.slice(*REQUEST_HEADER_KEYS)
   end
 
+  def trace_request?
+    FeatureFlag.active?('vendor_api_request_tracing') && vendor_api_path?
+  end
+
   def vendor_api_path?
     @request.path =~ /^\/api\/.*$/
   end

--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -1,0 +1,52 @@
+require 'redis'
+require './app/workers/vendor_api_request_worker'
+
+class VendorAPIRequestMiddleware
+  REQUEST_HEADER_KEYS = %w[
+    HTTP_VERSION
+    HTTP_HOST
+    HTTP_USER_AGENT
+    HTTP_ACCEPT
+    HTTP_ACCEPT_ENCODING
+    HTTP_AUTHORIZATION
+    HTTP_CONNECTION
+    HTTP_CACHE_CONTROL
+  ].freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @request = Rack::Request.new(env)
+    status, headers, response = @app.call(env)
+
+    begin
+      if trace_request?
+        VendorAPIRequestWorker.perform_async(request_data, response.body, status, Time.zone.now)
+      end
+    rescue Redis::BaseError => e
+      Rails.logger.warn e.message
+    end
+
+    [status, headers, response]
+  end
+
+private
+
+  def request_data
+    {
+      path: @request.path,
+      params: @request.params,
+      headers: request_headers,
+    }
+  end
+
+  def request_headers
+    @request.env.slice(*REQUEST_HEADER_KEYS)
+  end
+
+  def vendor_api_path?
+    @request.path =~ /^\/api\/.*$/
+  end
+end

--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -23,7 +23,7 @@ class VendorAPIRequestMiddleware
 
     begin
       if trace_request?
-        VendorAPIRequestWorker.perform_async(request_data, response.body, status, Time.zone.now)
+        VendorAPIRequestWorker.perform_async(request_data, body_from(response), status, Time.zone.now)
       end
     rescue Redis::BaseError => e
       Rails.logger.warn e.message
@@ -33,6 +33,12 @@ class VendorAPIRequestMiddleware
   end
 
 private
+
+  def body_from(response)
+    body = response.respond_to?(:body) ? response.body : response.join
+    body = body.join if body.is_a?(Array)
+    body
+  end
 
   def request_data
     {

--- a/app/models/support_interface/vendor_api_requests_filter.rb
+++ b/app/models/support_interface/vendor_api_requests_filter.rb
@@ -1,0 +1,41 @@
+module SupportInterface
+  class VendorAPIRequestsFilter
+    attr_reader :applied_filters
+
+    def initialize(params:)
+      @applied_filters = params
+    end
+
+    def filters
+      @filters ||= [free_text] + [status_code]
+    end
+
+  private
+
+    def free_text
+      {
+        type: :search,
+        heading: 'Search',
+        value: applied_filters[:q],
+        name: 'q',
+      }
+    end
+
+    def status_code
+      options = VendorAPIRequest.distinct(:status_code).pluck(:status_code).map do |status_code|
+        {
+          value: status_code,
+          label: status_code,
+          checked: applied_filters[:status_code]&.include?(status_code),
+        }
+      end
+
+      {
+        type: :checkboxes,
+        heading: 'Status code',
+        name: 'status_code',
+        options: options,
+      }
+    end
+  end
+end

--- a/app/models/support_interface/vendor_api_requests_filter.rb
+++ b/app/models/support_interface/vendor_api_requests_filter.rb
@@ -7,7 +7,7 @@ module SupportInterface
     end
 
     def filters
-      @filters ||= [free_text] + [status_code]
+      @filters ||= [free_text] + [status_code] + [provider]
     end
 
   private
@@ -34,6 +34,23 @@ module SupportInterface
         type: :checkboxes,
         heading: 'Status code',
         name: 'status_code',
+        options: options,
+      }
+    end
+
+    def provider
+      options = Provider.where(id: VendorAPIRequest.distinct(:provider_id).pluck(:provider_id).compact).map do |provider|
+        {
+          value: provider.id,
+          label: provider.name,
+          checked: applied_filters[:provider_id]&.include?(provider.id),
+        }
+      end
+
+      {
+        type: :checkboxes,
+        heading: 'Provider',
+        name: 'provider_id',
         options: options,
       }
     end

--- a/app/models/support_interface/vendor_api_requests_filter.rb
+++ b/app/models/support_interface/vendor_api_requests_filter.rb
@@ -39,7 +39,7 @@ module SupportInterface
     end
 
     def provider
-      options = Provider.where(id: VendorAPIRequest.distinct(:provider_id).pluck(:provider_id).compact).map do |provider|
+      options = Provider.where(id: VendorAPIRequest.distinct(:provider_id).select(:provider_id)).map do |provider|
         {
           value: provider.id,
           label: provider.name,

--- a/app/models/vendor_api_request.rb
+++ b/app/models/vendor_api_request.rb
@@ -1,2 +1,3 @@
 class VendorAPIRequest < ApplicationRecord
+  belongs_to :provider, optional: true
 end

--- a/app/models/vendor_api_request.rb
+++ b/app/models/vendor_api_request.rb
@@ -1,0 +1,2 @@
+class VendorAPIRequest < ApplicationRecord
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -20,6 +20,7 @@ class FeatureFlag
     [:getting_ready_for_next_cycle_banner, 'Displays an information banner related to the end-of-cycle with link to static page', 'Steve Hook'],
     [:deadline_notices, 'Show candidates copy related to end of cycle deadlines', 'Malcolm Baig'],
     [:hold_courses_open, 'Force all courses to appear to have vacancies. Do not enable in production!', 'Duncan Brown'],
+    [:vendor_api_request_tracing, 'Enable middleware which records vendor API requests', 'Steve Laing'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/views/support_interface/performance/_performance_navigation.html.erb
+++ b/app/views/support_interface/performance/_performance_navigation.html.erb
@@ -6,7 +6,7 @@
   { name: 'Export data', url: support_interface_performance_data_path },
   { name: 'Email log', url: support_interface_email_log_path },
   { name: 'Validation errors', url: support_interface_validation_errors_path, current: local_assigns[:current] == 'Validation errors' },
-  { name: 'Vendor API requests', url: support_interface_vendor_api_requests_path, current: local_assigns[:current] == 'Vendor API requests' },
+  { name: 'Vendor API requests', url: support_interface_vendor_api_requests_path },
 ]) %>
 
 <h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/performance/_performance_navigation.html.erb
+++ b/app/views/support_interface/performance/_performance_navigation.html.erb
@@ -6,6 +6,7 @@
   { name: 'Export data', url: support_interface_performance_data_path },
   { name: 'Email log', url: support_interface_email_log_path },
   { name: 'Validation errors', url: support_interface_validation_errors_path, current: local_assigns[:current] == 'Validation errors' },
+  { name: 'Vendor API requests', url: support_interface_vendor_api_requests_path, current: local_assigns[:current] == 'Vendor API requests' },
 ]) %>
 
 <h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -1,26 +1,43 @@
 <% content_for :title, 'Vendor API Requests' %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Status</th>
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Path</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @vendor_api_requests.each do |vendor_api_request| %>
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @vendor_api_requests) do %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          <%= vendor_api_request.created_at.to_s(:govuk_date_and_time) %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= vendor_api_request.status_code %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= vendor_api_request.request_path %>
-        </td>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Request</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @vendor_api_requests.each do |vendor_api_request| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= vendor_api_request.created_at.to_s(:govuk_date_and_time) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= render SummaryListComponent.new(rows: [
+              { key: 'Status', value: vendor_api_request.status_code },
+              { key: 'Path', value: vendor_api_request.request_path },
+              { key: 'Duration', value: "#{vendor_api_request.response_time} ms" },
+            ]) %>
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Details
+                </span>
+              </summary>
+              <div class="govuk-details__text govuk-body-xs">
+                <h3>Headers</h3>
+                <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_headers)) %>
+                <h3>Request params</h3>
+                <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_body)) %>
+                <h3>Response body</h3>
+                <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_body)) %>
+              </div>
+            </details>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, 'Vendor API Requests' %>
 
+<% content_for :navigation do %>
+  <%= render 'support_interface/performance/performance_navigation' %>
+<% end %>
+
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @vendor_api_requests) do %>
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -1,8 +1,4 @@
-<% content_for :title, 'Vendor API Requests' %>
-
-<% content_for :navigation do %>
-  <%= render 'support_interface/performance/performance_navigation' %>
-<% end %>
+<%= render 'support_interface/performance/performance_navigation', title: 'Vendor API Requests' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @vendor_api_requests) do %>
   <table class="govuk-table">

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, 'Vendor API Requests' %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Status</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">Path</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @vendor_api_requests.each do |vendor_api_request| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= vendor_api_request.created_at.to_s(:govuk_date_and_time) %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= vendor_api_request.status_code %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= vendor_api_request.request_path %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -22,7 +22,7 @@
             <%= render SummaryListComponent.new(rows: [
               { key: 'Status', value: vendor_api_request.status_code },
               { key: 'Path', value: vendor_api_request.request_path },
-              { key: 'Duration', value: "#{vendor_api_request.response_time} ms" },
+              { key: 'Provider', value: vendor_api_request.provider.present? ? vendor_api_request.provider.name : 'Unknown' },
             ]) %>
             <details class="govuk-details" data-module="govuk-details">
               <summary class="govuk-details__summary">

--- a/app/workers/vendor_api_request_worker.rb
+++ b/app/workers/vendor_api_request_worker.rb
@@ -1,0 +1,40 @@
+class VendorAPIRequestWorker
+  include Sidekiq::Worker
+  include ActionController::HttpAuthentication::Token
+
+  sidekiq_options retry: 3, queue: :low_priority
+
+  def perform(request_data, response_body, status_code, created_at)
+    request_headers = request_data['headers']
+    provider_id = provider_id_from_auth_token(request_headers.delete('HTTP_AUTHORIZATION'))
+
+    VendorAPIRequest.create!(
+      request_path: request_data['path'],
+      request_headers: request_headers,
+      request_body: request_data['params'],
+      response_body: response_hash(response_body, status_code),
+      status_code: status_code,
+      provider_id: provider_id,
+      created_at: created_at,
+    )
+  end
+
+private
+
+  AuthorizationStruct = Struct.new(:authorization)
+
+  def provider_id_from_auth_token(auth_header)
+    return if auth_header.blank?
+
+    token, _options = token_and_options(AuthorizationStruct.new(auth_header))
+    VendorAPIToken.find_by_unhashed_token(token)&.provider_id
+  end
+
+  def response_hash(response_body, status)
+    return {} unless status > 299
+
+    JSON.parse(response_body)
+  rescue JSON::ParserError
+    { body: "#{status} did not respond with JSON" }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ Bundler.require(*Rails.groups)
 
 require './app/lib/hosting_environment'
 require './app/middlewares/redirect_to_service_gov_uk_middleware'
+require './app/middlewares/vendor_api_request_middleware'
 
 require 'pdfkit'
 
@@ -53,6 +54,7 @@ module ApplyForPostgraduateTeacherTraining
     config.active_job.queue_adapter = :sidekiq
 
     config.middleware.insert_after ActionDispatch::HostAuthorization, RedirectToServiceGovUkMiddleware
+    config.middleware.use VendorAPIRequestMiddleware
     config.middleware.use PDFKit::Middleware, { print_media_type: true }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
     config.skylight.environments = ENV['SKYLIGHT_ENABLE'].to_s == 'true' ? [Rails.env] : []
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -677,6 +677,7 @@ Rails.application.routes.draw do
     end
 
     get '/email-log', to: 'email_log#index', as: :email_log
+    get '/vendor-api-requests', to: 'vendor_api_requests#index', as: :vendor_api_requests
 
     get '/applications' => 'application_forms#index'
     get '/applications/unavailable-choices' => 'application_forms#unavailable_choices', as: :unavailable_choices

--- a/spec/middlewares/vendor_api_request_middleware_spec.rb
+++ b/spec/middlewares/vendor_api_request_middleware_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPIRequestMiddleware, type: :request do
+  let(:status) { 200 }
+  let(:headers) { { 'HEADER' => 'Yeah!' } }
+  let(:mock_response) { ['Hellowwworlds!'] }
+
+  def mock_app
+    main_app = lambda { |env|
+      @env = env
+      [status, headers, @body || mock_response]
+    }
+
+    builder = Rack::Builder.new
+    builder.use VendorAPIRequestMiddleware
+    builder.run main_app
+    @app = builder.to_app
+  end
+
+  before do
+    FeatureFlag.activate(:vendor_api_request_tracing)
+    mock_app
+    allow(VendorAPIRequestWorker).to receive(:perform_async)
+  end
+
+  describe '#call on a non-API path' do
+    it 'does not enqueue a background job' do
+      get '/candidate'
+
+      expect(VendorAPIRequestWorker).not_to have_received(:perform_async)
+    end
+  end
+
+  describe '#call on an API path' do
+    it 'enqueues a worker job' do
+      get '/api/v1/applications/1'
+
+      expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
+        hash_including(path: '/api/v1/applications/1'), anything, 401, anything
+      )
+    end
+  end
+
+  describe '#call on an API path when Redis is unavailable' do
+    it 'logs the Redis exception and returns' do
+      allow(Rails.logger).to receive(:warn)
+      allow(VendorAPIRequestWorker).to receive(:perform_async).and_raise(Redis::BaseError.new('Oops no Redis'))
+
+      get '/api/v1/applications/1'
+
+      expect(Rails.logger).to have_received(:warn).with('Oops no Redis')
+    end
+  end
+end

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Vendor API Requests' do
   include DfESignInHelpers
 
-  scenario 'API requests are logged' do
+  scenario 'Listed requests are filtered' do
     FeatureFlag.activate(:vendor_api_request_tracing)
 
     given_i_am_a_support_user
@@ -17,11 +17,14 @@ RSpec.feature 'Vendor API Requests' do
     when_i_click_on_details_of_the_request
     then_i_see_the_request_and_response_info
 
+    when_i_filter_by_status
+    then_i_only_see_api_requests_filtered_by_status
+
     when_i_search_for_a_specific_request_path
     then_i_only_see_api_requests_filtered_by_the_search
 
-    when_i_filter_by_status
-    then_i_only_see_api_requests_filtered_by_status
+    when_i_filter_by_provider
+    then_i_only_see_api_requests_filtered_by_provider
   end
 
   def given_i_am_a_support_user
@@ -74,7 +77,18 @@ RSpec.feature 'Vendor API Requests' do
     expect(page).to have_content('Unauthorized')
   end
 
+  def when_i_filter_by_status
+    check '200'
+    click_on 'Apply filters'
+  end
+
+  def then_i_only_see_api_requests_filtered_by_status
+    expect(page).not_to have_content(vendor_api_path(@first_application_choice))
+    expect(page).to have_content(vendor_api_path(@last_application_choice))
+  end
+
   def when_i_search_for_a_specific_request_path
+    uncheck '200'
     fill_in :q, with: "applications/#{@first_application_choice.id}"
     click_on 'Apply filters'
   end
@@ -84,13 +98,13 @@ RSpec.feature 'Vendor API Requests' do
     expect(page).not_to have_content(vendor_api_path(@last_application_choice))
   end
 
-  def when_i_filter_by_status
+  def when_i_filter_by_provider
     fill_in :q, with: ''
-    check '200'
+    check @last_application_choice.provider.name
     click_on 'Apply filters'
   end
 
-  def then_i_only_see_api_requests_filtered_by_status
+  def then_i_only_see_api_requests_filtered_by_provider
     expect(page).not_to have_content(vendor_api_path(@first_application_choice))
     expect(page).to have_content(vendor_api_path(@last_application_choice))
   end

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.feature 'Vendor API Requests' do
+  include DfESignInHelpers
+
+  scenario 'API requests are logged' do
+    given_i_am_a_support_user
+    and_some_applications_exist
+    and_vendor_api_requests_for_applications_have_been_made
+
+    when_i_visit_the_vendor_api_requests_page
+    then_i_see_the_api_request
+    and_i_see_the_status_of_the_request
+
+    when_i_click_on_details_of_the_request
+    then_i_see_the_request_and_response_info
+
+    when_i_search_for_a_specific_request_path
+    then_i_only_see_api_requests_filtered_by_the_search
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_some_applications_exist
+    applications = create_list(:application_choice, 2)
+    @first_application_choice = applications.first
+    @last_application_choice = applications.last
+  end
+
+  def and_vendor_api_requests_for_applications_have_been_made
+    visit vendor_api_path(@first_application_choice)
+    visit vendor_api_path(@last_application_choice)
+  end
+
+  def when_i_visit_the_vendor_api_requests_page
+    visit support_interface_vendor_api_requests_path
+  end
+
+  def then_i_see_the_api_request
+    expect(page).to have_content(vendor_api_path(@first_application_choice))
+    expect(page).to have_content(vendor_api_path(@last_application_choice))
+  end
+
+  def and_i_see_the_status_of_the_request
+    expect(page).to have_content('401')
+  end
+
+  def when_i_click_on_details_of_the_request
+    find('.govuk-details__summary-text', match: :first).click
+  end
+
+  def then_i_see_the_request_and_response_info
+    expect(page).to have_content('Headers')
+    expect(page).to have_content('HTTP_HOST')
+    expect(page).to have_content('Request params')
+    expect(page).to have_content('Response body')
+    expect(page).to have_content('Unauthorized')
+  end
+
+  def when_i_search_for_a_specific_request_path
+    fill_in :q, with: "applications/#{@first_application_choice.id}"
+    click_on 'Apply filters'
+  end
+
+  def then_i_only_see_api_requests_filtered_by_the_search
+    expect(page).to have_content(vendor_api_path(@first_application_choice))
+    expect(page).not_to have_content(vendor_api_path(@last_application_choice))
+  end
+end

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Vendor API Requests' do
   include DfESignInHelpers
 
   scenario 'API requests are logged' do
+    FeatureFlag.activate(:vendor_api_request_tracing)
+
     given_i_am_a_support_user
     and_some_applications_exist
     and_vendor_api_requests_for_applications_have_been_made
@@ -17,6 +19,9 @@ RSpec.feature 'Vendor API Requests' do
 
     when_i_search_for_a_specific_request_path
     then_i_only_see_api_requests_filtered_by_the_search
+
+    when_i_filter_by_status
+    then_i_only_see_api_requests_filtered_by_status
   end
 
   def given_i_am_a_support_user
@@ -24,14 +29,23 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def and_some_applications_exist
-    applications = create_list(:application_choice, 2)
+    applications = create_list(:submitted_application_choice, 2)
     @first_application_choice = applications.first
     @last_application_choice = applications.last
   end
 
   def and_vendor_api_requests_for_applications_have_been_made
     visit vendor_api_path(@first_application_choice)
+
+    provider = @last_application_choice.provider
+    unhashed_token, hashed_token = Devise.token_generator.generate(VendorAPIToken, :hashed_token)
+    create(:vendor_api_token, hashed_token: hashed_token, provider_id: provider.id)
+
+    Capybara.current_session.driver.header('Authorization', "Bearer #{unhashed_token}")
+
     visit vendor_api_path(@last_application_choice)
+
+    Capybara.current_session.driver.header('Authorization', nil)
   end
 
   def when_i_visit_the_vendor_api_requests_page
@@ -45,6 +59,7 @@ RSpec.feature 'Vendor API Requests' do
 
   def and_i_see_the_status_of_the_request
     expect(page).to have_content('401')
+    expect(page).to have_content('200')
   end
 
   def when_i_click_on_details_of_the_request
@@ -67,5 +82,16 @@ RSpec.feature 'Vendor API Requests' do
   def then_i_only_see_api_requests_filtered_by_the_search
     expect(page).to have_content(vendor_api_path(@first_application_choice))
     expect(page).not_to have_content(vendor_api_path(@last_application_choice))
+  end
+
+  def when_i_filter_by_status
+    fill_in :q, with: ''
+    check '200'
+    click_on 'Apply filters'
+  end
+
+  def then_i_only_see_api_requests_filtered_by_status
+    expect(page).not_to have_content(vendor_api_path(@first_application_choice))
+    expect(page).to have_content(vendor_api_path(@last_application_choice))
   end
 end

--- a/spec/workers/vendor_api_request_worker_spec.rb
+++ b/spec/workers/vendor_api_request_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe VendorAPIRequestWorker do
+  describe '#perform' do
+    it 'creates a VendorAPIRequest record' do
+      expect {
+        described_class.new.perform({ 'headers' => [] }, {}.to_json, 401, Time.zone.now)
+      }.to change(VendorAPIRequest, :count).by(1)
+    end
+
+    it 'detects the provider making the request from the authorization header' do
+      provider = create(:provider)
+      unhashed_token, hashed_token = Devise.token_generator.generate(VendorAPIToken, :hashed_token)
+      create(:vendor_api_token, hashed_token: hashed_token, provider_id: provider.id)
+
+      headers = { 'HTTP_AUTHORIZATION' => "Bearer #{unhashed_token}" }
+      described_class.new.perform({ 'headers' => headers }, {}.to_json, 500, Time.zone.now)
+
+      expect(VendorAPIRequest.find_by(provider_id: provider.id)).not_to be nil
+    end
+  end
+end


### PR DESCRIPTION
## Context

We'd like to trace Vendor API usage.
[See spike here for preliminary work and discussion](https://github.com/DFE-Digital/apply-for-teacher-training/pull/2973)
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/93511/95074535-a2f38a80-0706-11eb-8987-7809bd016411.png)

- Adds the model `VendorAPIRequest` where request and response info lives. (See https://github.com/DFE-Digital/apply-for-teacher-training/pull/2999) for migration
- Adds middleware to intercept vendor API requests and enqueue them for processing by a Sidekiq worker.
- Provides support users with a basic UI to list and filter logged API requests

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

It would be good to componentise some of the view here. This might be simpler once we have a `DetailsComponent`.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/LsxYKL3n/2815-build-vendor-api-request-tracing
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
