### PR TITLE
Fix data issue where courses are inadvertently accredited to self

### DIFF
--- a/app/services/find_sync/sync_courses_from_find.rb
+++ b/app/services/find_sync/sync_courses_from_find.rb
@@ -100,12 +100,14 @@ module FindSync
     end
 
     def add_accredited_provider(course, find_accredited_provider)
-      if find_accredited_provider.present?
+      if find_accredited_provider.present? && course.provider.code != find_accredited_provider[:provider_code]
         accredited_provider = Provider.find_or_initialize_by(code: find_accredited_provider[:provider_code])
         accredited_provider.name = find_accredited_provider[:provider_name]
         accredited_provider.save!
 
         course.accredited_provider = accredited_provider
+      else
+        course.accredited_provider = nil
       end
     end
 


### PR DESCRIPTION
## Context

Some courses have the training provider specified as the accredited provider. This is unexpected, and our code can't handle this. Hence some users are seeing a 404 hen clicking on an application (https://becomingateacher.zendesk.com/agent/tickets/9284).

## Changes proposed in this pull request

This PR makes sure that we set the `course.accredited_provider` to nil if it's the same as the original provider.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Fixes https://trello.com/c/5YqXBdtK.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
