### PR TITLE
Add offer conditions CSV report to performance data page

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -89,6 +89,13 @@ module SupportInterface
       send_data csv, filename: "application-references-#{Time.zone.today}.csv", disposition: :attachment
     end
 
+    def offer_conditions
+      offers = SupportInterface::OfferConditionsExport.new.offers
+      csv = to_csv(offers)
+
+      send_data csv, filename: "offer-conditions-#{Time.zone.today}.csv", disposition: :attachment
+    end
+
   private
 
     def to_csv(objects, header_row = nil)

--- a/app/services/support_interface/offer_conditions_export.rb
+++ b/app/services/support_interface/offer_conditions_export.rb
@@ -1,0 +1,61 @@
+module SupportInterface
+  class OfferConditionsExport
+    def offers
+      relevant_choices.flat_map do |choice|
+        {
+          support_reference: choice.application_form.support_reference,
+          phase: choice.application_form.phase,
+          recruitment_cycle: choice.recruitment_cycle,
+          qualification_type: qualification_type(choice.application_form),
+          qualification_subject: qualification_subject(choice.application_form),
+          qualification_grade: qualification_grade(choice.application_form),
+          start_year: start_year(choice.application_form),
+          award_year: award_year(choice.application_form),
+          provider_code: choice.provider.code,
+          provider: choice.provider.name,
+          course_offered_provider_name: choice.offered_option.provider.name,
+          course_offered_course_name: choice.offered_course.name,
+          offer_made_at: choice.offered_at.to_s(:govuk_date),
+          application_status: choice.status,
+          conditions: conditions(choice),
+        }
+      end
+    end
+
+  private
+
+    def qualification_type(form)
+      qualifications(form).map(&:level).join(',')
+    end
+
+    def qualification_subject(form)
+      qualifications(form).map(&:subject).join(',')
+    end
+
+    def qualification_grade(form)
+      qualifications(form).map(&:grade).join(',')
+    end
+
+    def start_year(form)
+      qualifications(form).map(&:start_year).join(',')
+    end
+
+    def award_year(form)
+      qualifications(form).map(&:award_year).join(',')
+    end
+
+    def qualifications(form)
+      form.application_qualifications.order(:created_at)
+    end
+
+    def conditions(choice)
+      choice.offer['conditions'].join(',')
+    end
+
+    def relevant_choices
+      ApplicationChoice
+        .where('offer IS NOT NULL')
+        .order('offered_at asc')
+    end
+  end
+end

--- a/app/views/support_interface/performance/data.html.erb
+++ b/app/views/support_interface/performance/data.html.erb
@@ -103,3 +103,13 @@
     </div>
   </div>
 </section>
+
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Offer conditions</h3>
+      <p>A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.</p>
+      <p><%= govuk_link_to 'Download offer conditions (CSV)', support_interface_offer_conditions_path %></p>
+    </div>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -756,6 +756,7 @@ Rails.application.routes.draw do
     get '/performance/course-choice-withdrawal', to: 'performance#course_choice_withdrawal', as: :course_choice_withdrawal_survey
     get '/performance/candidate-journey-tracking', to: 'performance#candidate_journey_tracking', as: :candidate_journey_tracking
     get 'performance/reference-types', to: 'performance#application_references', as: :application_references
+    get 'performance/offer-conditions', to: 'performance#offer_conditions', as: :offer_conditions
 
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/create-fake-provider' => 'tasks#create_fake_provider'

--- a/spec/services/support_interface/offer_conditions_export_spec.rb
+++ b/spec/services/support_interface/offer_conditions_export_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::OfferConditionsExport do
+  describe '#offers' do
+    it 'returns all application choices that have had an offer' do
+      # excluded
+      create(:completed_application_form, application_choices_count: 1)
+      create(:submitted_application_choice)
+      create(:application_choice, :with_rejection)
+      # included
+      create(:application_choice, :with_offer)
+      create(:application_choice, :with_modified_offer)
+      create(:application_choice, :with_accepted_offer)
+      create(:application_choice, :with_declined_offer)
+      create(:application_choice, :with_declined_by_default_offer)
+      create(:application_choice, :with_withdrawn_offer)
+      create(:application_choice, :with_recruited)
+      create(:application_choice, :with_deferred_offer)
+      create(:application_choice, :with_offer, :previous_year)
+
+      offers = described_class.new.offers
+      expect(offers.count).to eq(9)
+    end
+
+    it 'returns a support reference for each application choice with an offer' do
+      form = create(:completed_application_form)
+      create(:application_choice, :with_declined_offer, application_form: form)
+      create(:application_choice, :with_accepted_offer, application_form: form)
+      create(:application_choice, :withdrawn, application_form: form)
+
+      support_references = described_class.new.offers.map { |o| o[:support_reference] }
+      expect(support_references).to eq([form.support_reference] * 2)
+    end
+
+    it 'returns phase information for each offer' do
+      apply_1_form = create(:completed_application_form)
+      create(:application_choice, :with_declined_offer, application_form: apply_1_form)
+      create(:application_choice, :withdrawn, application_form: apply_1_form)
+      apply_2_form = ApplyAgain.new(apply_1_form).call
+      create(:application_choice, :with_offer, application_form: apply_2_form)
+
+      phases = described_class.new.offers.map { |o| o[:phase] }
+      expect(phases).to eq(%w[apply_1 apply_2])
+    end
+
+    it 'contains qualification information' do
+      form = create(:completed_application_form, with_gcses: true, with_degree: true)
+      create(:application_choice, :with_offer, application_form: form)
+      offers = described_class.new.offers
+
+      qualification_types = offers.map { |o| o[:qualification_type] }
+      expect(qualification_types.first).to include('gcse,gcse,gcse')
+      expect(qualification_types.first).to include('degree')
+
+      qualification_subjects = offers.map { |o| o[:qualification_subject] }
+      expect(qualification_subjects.first).to include('maths,english,science')
+
+      qualification_grades = offers.map { |o| o[:qualification_grade] }
+      expected_grades = form.application_qualifications.order(:created_at).map(&:grade).join(',')
+      expect(qualification_grades.first).to eq(expected_grades)
+
+      start_years = offers.map { |o| o[:start_year] }
+      expected_years = form.application_qualifications.order(:created_at).map(&:start_year).join(',')
+      expect(start_years.first).to eq(expected_years)
+
+      award_years = offers.map { |o| o[:award_year] }
+      expected_years = form.application_qualifications.order(:created_at).map(&:award_year).join(',')
+      expect(award_years.first).to eq(expected_years)
+    end
+
+    it 'returns provider information for each offer' do
+      choice = create(:application_choice, :with_modified_offer)
+
+      offers = described_class.new.offers
+      expect(offers.first[:provider_code]).to eq(choice.provider.code)
+      expect(offers.first[:provider]).to eq(choice.provider.name)
+    end
+
+    it 'returns offered course information' do
+      choice = create(:application_choice, :with_modified_offer)
+
+      offers = described_class.new.offers
+      expect(offers.first[:course_offered_provider_name]).to eq(choice.offered_course.provider.name)
+      expect(offers.first[:course_offered_course_name]).to eq(choice.offered_course.name)
+    end
+
+    it 'returns most recent offered_at' do
+      choice = create(:application_choice, :with_modified_offer)
+
+      offers = described_class.new.offers
+      expect(offers.first[:offer_made_at]).to eq(choice.offered_at.to_s(:govuk_date))
+    end
+
+    it 'includes offer conditions' do
+      choice = create(:application_choice, :with_modified_offer)
+      choice.update(offer: { 'conditions' => ['DBS Check', 'Be cool'] })
+
+      offers = described_class.new.offers
+      expect(offers.first[:conditions]).to eq('DBS Check,Be cool')
+    end
+  end
+end


### PR DESCRIPTION
## Context

There is an analysis requirement for offer conditions against candidate qualifications.

## Changes proposed in this pull request

Add an offer conditions report to the performance data support page.

## Guidance to review

See the spec. Download the report.

## Link to Trello card

https://trello.com/c/yyHtB54i

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
