### PR TITLE
Add new flow for decoupled references (part 1)

### DIFF
--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -14,6 +14,8 @@ module CandidateInterface
       end
     end
 
+    def start; end
+
     def type
       if params[:id]
         set_referee_id

--- a/app/views/candidate_interface/referees/start.html.erb
+++ b/app/views/candidate_interface/referees/start.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t('page_titles.referees_start') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.referees_start') %>
+    </h1>
+
+    <p class="govuk-body">Referees should not be family members, partners or friends.</p>
+
+    <p class="govuk-body">Choose at least one academic referee if you graduated in the last 5 years or you do not have a grade for your degree yet.</p>
+
+    <p class="govuk-body">Training providers will only accept a character reference if there’s also an academic or professional reference.</p>
+
+    <p class="govuk-body">Contact your referees in advance to check they can submit a reference quickly online.</p>
+
+    <%= govuk_link_to 'Continue', candidate_interface_referees_type_path, class: 'govuk-button' %>
+  </div>
+</div>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -41,6 +41,27 @@
       ) %>
     <% end %>
 
+
+    <% if FeatureFlag.active?('decoupled_references') %>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
+
+      <p class="govuk-body">You have to get 2 references back before you can send your application to training providers.</p>
+
+      <p class="govuk-body">It takes 8 days to get a reference on average.</p>
+
+      <ul class="app-task-list govuk-!-margin-bottom-8">
+        <li class="app-task-list__item">
+          <%= render(
+            TaskListItemComponent.new(
+              text: 'Add your references',
+              completed: @application_form_presenter.all_referees_provided_by_candidate?,
+              path: candidate_interface_referees_start_path, submitted: false
+            )
+          ) %>
+        </li>
+      </ul>
+    <% end %>
+
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-4">
       About you
     </h2>
@@ -204,18 +225,20 @@
       </li>
     </ul>
 
-    <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
-    <ul class="app-task-list govuk-!-margin-bottom-8">
-      <li class="app-task-list__item">
-        <%= render(
-          TaskListItemComponent.new(
-            text: 'Referees',
-            completed: @application_form_presenter.all_referees_provided_by_candidate?,
-            path: candidate_interface_referees_path, submitted: false
-          )
-        ) %>
-      </li>
-    </ul>
+    <% unless FeatureFlag.active?('decoupled_references') %>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
+      <ul class="app-task-list govuk-!-margin-bottom-8">
+        <li class="app-task-list__item">
+          <%= render(
+            TaskListItemComponent.new(
+              text: 'Referees',
+              completed: @application_form_presenter.all_referees_provided_by_candidate?,
+              path: candidate_interface_referees_path, submitted: false
+            )
+          ) %>
+        </li>
+      </ul>
+    <% end %>
 
     <% if EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
       <h2 class="govuk-heading-m govuk-!-font-size-27">Review</h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
     referees_choosing: Choosing your referees
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?
+    referees_start: Choose your referees
     add_referee: Details of referee
     maximum_referees: You cannot add any more referees
     give_a_reference:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,6 +372,8 @@ Rails.application.routes.draw do
       scope '/referees' do
         get '/' => 'referees#index', as: :referees
 
+        get '/start' => 'referees#start', as: :referees_start
+
         get '/type/(:id)' => 'referees#type', as: :referees_type
         post '/update-type/(:id)' => 'referees#update_type', as: :update_referees_type
 

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate adding referees' do
 
   scenario 'Candidate adds references' do
     given_i_am_signed_in
+    and_the_decoupled_references_flag_is_off
     and_i_visit_the_application_form
 
     given_i_have_no_existing_references_on_the_form
@@ -77,6 +78,10 @@ RSpec.feature 'Candidate adding referees' do
 
   def and_i_visit_the_application_form
     visit candidate_interface_application_form_path
+  end
+
+  def and_the_decoupled_references_flag_is_off
+    FeatureFlag.deactivate('decoupled_references')
   end
 
   def when_i_click_on_referees

--- a/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_between_cycles_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
 
   scenario 'Carry over application and remove all application choices when new cycle opens' do
     given_i_am_signed_in_as_a_candidate
+    and_the_decoupled_references_flag_is_off
     and_i_am_in_the_2020_recruitment_cycle
     when_i_have_an_unsubmitted_application
     and_the_recruitment_cycle_ends
@@ -33,6 +34,10 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   def given_i_am_signed_in_as_a_candidate
     @candidate = create(:candidate)
     login_as(@candidate)
+  end
+
+  def and_the_decoupled_references_flag_is_off
+    FeatureFlag.deactivate('decoupled_references')
   end
 
   def and_i_am_in_the_2020_recruitment_cycle

--- a/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
 
   scenario 'Carry over application and remove all application choices when new cycle opens' do
     given_i_am_signed_in_as_a_candidate
+    and_the_decoupled_references_flag_is_off
     and_i_am_in_the_2020_recruitment_cycle
     when_i_have_an_unsubmitted_application
     and_the_recruitment_cycle_ends
@@ -40,6 +41,10 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   def given_i_am_signed_in_as_a_candidate
     @candidate = create(:candidate)
     login_as(@candidate)
+  end
+
+  def and_the_decoupled_references_flag_is_off
+    FeatureFlag.deactivate('decoupled_references')
   end
 
   def and_i_am_in_the_2020_recruitment_cycle

--- a/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
 
   scenario 'Carry over application when new cycle opens' do
     given_i_am_signed_in_as_a_candidate
+    and_the_decoupled_references_flag_is_off
     and_i_am_in_the_2020_recruitment_cycle
     when_i_have_an_unsubmitted_application_without_a_course
     and_the_recruitment_cycle_ends
@@ -40,6 +41,10 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
   def given_i_am_signed_in_as_a_candidate
     @candidate = create(:candidate)
     login_as(@candidate)
+  end
+
+  def and_the_decoupled_references_flag_is_off
+    FeatureFlag.deactivate('decoupled_references')
   end
 
   def and_i_am_in_the_2020_recruitment_cycle

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate applying again' do
 
   scenario 'Can replace a completed reference' do
     given_the_pilot_is_open
+    and_the_decoupled_references_flag_is_off
     and_i_am_signed_in_as_a_candidate
 
     when_i_have_an_unsuccessful_application_with_references
@@ -36,6 +37,10 @@ RSpec.feature 'Candidate applying again' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_decoupled_references_flag_is_off
+    FeatureFlag.deactivate('decoupled_references')
   end
 
   def and_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate application choices are delivered to providers' do
+  include CandidateHelper
+
+  scenario 'the candidate receives an email' do
+    given_i_am_signed_in
+    and_the_decoupled_references_flag_is_on
+
+    when_i_visit_the_site
+    then_i_should_see_the_decoupled_references_section
+
+    when_i_click_add_you_references
+    then_i_see_the_start_page
+
+    when_i_click_continue
+    then_i_see_the_type_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_decoupled_references_flag_is_on
+    FeatureFlag.activate('decoupled_references')
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_should_see_the_decoupled_references_section
+    expect(page).to have_content 'It takes 8 days to get a reference on average.'
+  end
+
+  def when_i_click_add_you_references
+    click_link 'Add your references'
+  end
+
+  def then_i_see_the_start_page
+    expect(page).to have_current_path candidate_interface_referees_start_path
+  end
+
+  def when_i_click_continue
+    click_link 'Continue'
+  end
+
+  def then_i_see_the_type_page
+    expect(page).to have_current_path candidate_interface_referees_type_path
+  end
+end


### PR DESCRIPTION
## Context

This is the initial flow for decoupling references. This PR covers changing the application form show page through to a candidate being asked to input the type of reference.

## Changes proposed in this pull request

- Update the application show page to use the new design

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/94557657-c45ffc80-0256-11eb-8508-62760bd37eef.png)|![image](https://user-images.githubusercontent.com/42515961/94557610-b3af8680-0256-11eb-88d0-323763857c21.png)|

- Add the start page 

![image](https://user-images.githubusercontent.com/42515961/94557337-561b3a00-0256-11eb-971b-e318bd5f4be0.png)

## Guidance to review

I'm going to keep these PRs small as I think it's going to end up being a fairly substantial piece of work.

Out of scope adding a type, name, email, description and review page

prototype - https://apply-beta-prototype.herokuapp.com/application/P3TB2

## Link to Trello card

https://trello.com/c/npGvdYqK/2213-%F0%9F%92%94-dev-request-a-referee-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
