### PR TITLE
Fix rescuing errors when syncing with Find

### DIFF
--- a/app/services/find_sync/find_sync_error.rb
+++ b/app/services/find_sync/find_sync_error.rb
@@ -1,0 +1,3 @@
+module FindSync
+  class SyncError < StandardError; end
+end

--- a/app/services/find_sync/sync_all_providers_from_find.rb
+++ b/app/services/find_sync/sync_all_providers_from_find.rb
@@ -17,7 +17,7 @@ module FindSync
 
       FindSyncCheck.set_last_sync(Time.zone.now)
     rescue JsonApiClient::Errors::ApiError
-      raise SyncFindApiError
+      raise FindSync::SyncError
     end
 
     def self.sync_providers(find_providers)
@@ -31,7 +31,5 @@ module FindSync
     end
 
     private_class_method :sync_providers
-
-    class SyncFindApiError < StandardError; end
   end
 end

--- a/app/services/find_sync/sync_courses_from_find.rb
+++ b/app/services/find_sync/sync_courses_from_find.rb
@@ -12,6 +12,8 @@ module FindSync
       find_provider.courses.each do |find_course|
         create_or_update_course(find_course)
       end
+    rescue JsonApiClient::Errors::ApiError
+      raise FindSync::SyncError
     end
 
   private

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -8,6 +8,6 @@ Raven.configure do |config|
     'ActionController::UnknownHttpMethod',
     'ActionDispatch::Http::Parameters::ParseError',
     'Redis::CannotConnectError',
-    'SyncAllProvidersFromFind::SyncFindApiError',
+    'FindSync::SyncError',
   ]
 end


### PR DESCRIPTION
## Context

The error is currently named `FindSync::SyncAllProvidersFromFind::SyncFindApiError` because it was moved into a namespace. This means we no longer ignore the error in Sentry.

## Changes proposed in this pull request

This updates the error to have a better name, rescue exceptions in the new worker as well, and make sure we ignore
this error in Sentry.

## Guidance to review

Ok?

## Link to Trello card

https://trello.com/c/HwAFHcKS/1965-tech-performance-sync-all-of-the-courses-from-find

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
