### PR TITLE
Check provider association before allowing access to 'reconfirm offer' wizard

### DIFF
--- a/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
+++ b/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
@@ -79,7 +79,9 @@ module ProviderInterface
   private
 
     def find_application_choice
-      @application_choice = ApplicationChoice.find(params[:application_choice_id])
+      @application_choice = GetApplicationChoicesForProviders.call(
+        providers: current_provider_user.providers,
+      ).find(params[:application_choice_id])
     end
 
     def require_deferred_offer_from_previous_cycle


### PR DESCRIPTION
## Context

The controller does a straight `.find` on the application choice id, which means a provider could theoretically guess the url of a deferred offer that doesn't belong to them and attempt to reinstate it.

Back-end services already check the association via their authorisation calls, so the issue is limited to UI access.

## Changes proposed in this pull request

Fix this

## Guidance to review

Straightfoward

## Link to Trello card

No Trello card.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
