### PR TITLE
Increase debuggability of provider interface problems

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
-    before_action :set_application_choice_and_sub_navigation_items, except: %i[index]
+    before_action :set_application_choice, except: %i[index]
+    before_action :set_sub_navigation_items, except: %i[index]
 
     def index
       @filter = ProviderApplicationsFilter.new(
@@ -91,19 +92,12 @@ module ProviderInterface
       current_provider_user.providers
     end
 
-    def set_application_choice_and_sub_navigation_items
-      @application_choice = get_application_choice
+    def set_sub_navigation_items
       @provider_can_respond = get_provider_can_respond
       @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
       @sub_navigation_items = get_sub_navigation_items
     rescue ActiveRecord::RecordNotFound
       render_404
-    end
-
-    def get_application_choice
-      GetApplicationChoicesForProviders.call(
-        providers: available_providers,
-      ).find(params[:application_choice_id])
     end
 
     def get_sub_navigation_items

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -96,8 +96,6 @@ module ProviderInterface
       @provider_can_respond = get_provider_can_respond
       @offer_present = ApplicationStateChange::OFFERED_STATES.include?(@application_choice.status.to_sym)
       @sub_navigation_items = get_sub_navigation_items
-    rescue ActiveRecord::RecordNotFound
-      render_404
     end
 
     def get_sub_navigation_items

--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -40,12 +40,5 @@ module ProviderInterface
 
       redirect_to provider_interface_application_choice_path(@application_choice.id)
     end
-
-  private
-
-    def set_application_choice
-      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
-        .find(params[:application_choice_id])
-    end
   end
 end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -159,11 +159,6 @@ module ProviderInterface
 
   private
 
-    def set_application_choice
-      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
-        .find(params[:application_choice_id])
-    end
-
     def make_an_offer_params
       params.require(:make_an_offer)
     end

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -24,7 +24,7 @@ module ProviderInterface
 
       @change_offer_component = ProviderInterface::ChangeOfferComponent.new(
         change_offer_form: change_offer_form,
-        providers: available_providers,
+        providers: current_provider_user.providers,
         completion_url: {
           action: :update_offer,
           application_choice_id: @application_choice.id,
@@ -49,16 +49,6 @@ module ProviderInterface
     end
 
   private
-
-    def available_providers
-      current_provider_user.providers
-    end
-
-    def set_application_choice
-      @application_choice = GetApplicationChoicesForProviders.call(
-        providers: available_providers,
-      ).find(params[:application_choice_id])
-    end
 
     def change_offer_form_from_params
       ProviderInterface::ChangeOfferForm.new(

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -71,6 +71,13 @@ module ProviderInterface
       @application_choice = GetApplicationChoicesForProviders.call(
         providers: current_provider_user.providers,
       ).find(params[:application_choice_id])
+
+      debugging_info = {
+        application_support_url: support_interface_application_form_url(@application_choice.application_form),
+      }
+
+      Raven.extra_context(debugging_info)
+      RequestLocals.store[:debugging_info] = debugging_info
     rescue ActiveRecord::RecordNotFound
       render_404
     end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -71,6 +71,8 @@ module ProviderInterface
       @application_choice = GetApplicationChoicesForProviders.call(
         providers: current_provider_user.providers,
       ).find(params[:application_choice_id])
+    rescue ActiveRecord::RecordNotFound
+      render_404
     end
 
     def redirect_if_setup_required

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -66,6 +66,13 @@ module ProviderInterface
       Raven.user_context(useful_debugging_info)
     end
 
+    # Set the `@application_choice` instance variable for use in views.
+    def set_application_choice
+      @application_choice = GetApplicationChoicesForProviders.call(
+        providers: current_provider_user.providers,
+      ).find(params[:application_choice_id])
+    end
+
     def redirect_if_setup_required
       return unless current_provider_user
 

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -57,8 +57,13 @@ module ProviderInterface
     def add_identity_to_log
       return unless current_provider_user
 
-      RequestLocals.store[:identity] = { dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid }
-      Raven.user_context(dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid)
+      useful_debugging_info = {
+        dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid,
+        provider_user_admin_url: support_interface_provider_user_url(current_provider_user),
+      }
+
+      RequestLocals.store[:identity] = useful_debugging_info
+      Raven.user_context(useful_debugging_info)
     end
 
     def redirect_if_setup_required

--- a/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
+++ b/app/controllers/provider_interface/reconfirm_deferred_offers_controller.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class ReconfirmDeferredOffersController < ProviderInterfaceController
-    before_action :find_application_choice
+    before_action :set_application_choice
     before_action :require_deferred_offer_from_previous_cycle
 
     def start
@@ -77,10 +77,6 @@ module ProviderInterface
     helper_method :previous_path
 
   private
-
-    def find_application_choice
-      @application_choice = ApplicationChoice.find(params[:application_choice_id])
-    end
 
     def require_deferred_offer_from_previous_cycle
       unless @application_choice.status == 'offer_deferred' &&

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -12,6 +12,10 @@ module SupportInterface
       @filter = SupportInterface::ProviderUsersFilter.new(params: params)
     end
 
+    def show
+      redirect_to edit_support_interface_provider_user_path(params[:id])
+    end
+
     def new
       @form = ProviderUserForm.new
     end

--- a/app/lib/logstash_logging.rb
+++ b/app/lib/logstash_logging.rb
@@ -15,7 +15,7 @@ class LogstashLogging
         if params
           event['params'] = params # add query params to the logs, if available
         end
-        add_identity_fields(event)
+        add_debugging_fields(event)
         add_sidekiq_fields(event)
       end
     end
@@ -63,9 +63,12 @@ class LogstashLogging
     rails_config.lograge.formatter = Lograge::Formatters::Logstash.new
   end
 
-  def self.add_identity_fields(event)
+  def self.add_debugging_fields(event)
     identity_hash = RequestLocals.fetch(:identity) {} # block is required
     identity_hash.each { |key, val| event[key] = val } if identity_hash
+
+    debugging_info = RequestLocals.fetch(:debugging_info) {} # block is required
+    debugging_info.each { |key, val| event[key] = val } if debugging_info
   end
 
   def self.add_sidekiq_fields(event)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -781,7 +781,7 @@ Rails.application.routes.draw do
 
       resources :support_users, only: %i[index new create show], path: :support
 
-      resources :provider_users, only: %i[index new create edit update], path: :provider do
+      resources :provider_users, only: %i[show index new create edit update], path: :provider do
         get '/audits' => 'provider_users#audits'
       end
     end

--- a/spec/requests/provider_interface/account_creation_in_progress_spec.rb
+++ b/spec/requests/provider_interface/account_creation_in_progress_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe 'GET /provider/applications' do
     before do
       allow(ProviderUser).to receive(:load_from_session)
         .and_return(
-          ProviderUser.new(
+          FactoryBot.build_stubbed(
+            :provider_user,
+            id: 12345,
             email_address: 'email@example.com',
             dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
           ),
@@ -27,7 +29,11 @@ RSpec.describe 'GET /provider/applications' do
 
       get '/provider/applications'
 
-      expect(Raven).to have_received(:user_context).with(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+      expect(Raven).to have_received(:user_context).with(
+        dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+        provider_user_admin_url: 'http://www.example.com/support/users/provider/12345',
+      )
+
       expect(Raven).to have_received(:capture_exception)
     end
   end

--- a/spec/requests/provider_interface/landing_page_redirect_spec.rb
+++ b/spec/requests/provider_interface/landing_page_redirect_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe 'GET /provider' do
     before do
       allow(ProviderUser).to receive(:load_from_session)
         .and_return(
-          ProviderUser.new(
+          build_stubbed(
+            :provider_user,
             email_address: 'email@example.com',
             dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
           ),


### PR DESCRIPTION
## Context

This PR addresses a couple of issues that would have made debugging https://github.com/DFE-Digital/apply-for-teacher-training/pull/3010 easier.

## Changes proposed in this pull request

- In Sentry and Logit, add a support UI link to the provider user that made the request (currently we only log the DSI UUID, which you then have to look up)
- If the request relates to an application choice, add a link to the Support UI in Sentry and Logit. Currently we only have the `application_choice_id`, which is tricky to quickly match to a application form
- The issue solved in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3010 was masked by the fact that we rescue `ActiveRecord::RecordNotFound` errors, regardless of where they occur. This PR makes the rescuing more specific so that we would have been notified via Sentry of the problem.

To do this, I've extracted a common `set_application_choice` method that also sets the debugging info. This solves a data scoping issue as well (https://github.com/DFE-Digital/apply-for-teacher-training/commit/12fd12aab5c7742ece8e2e561a65420ad902a276).

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5YqXBdtK/2817-fix-possible-bug-that-prevents-providers-from-seeing-certain-courses

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
