### PR TITLE
Always enforce user-level make_decisions, even if flags are off

### DIFF
--- a/app/services/make_decisions_authorisation.rb
+++ b/app/services/make_decisions_authorisation.rb
@@ -10,19 +10,17 @@ class MakeDecisionsAuthorisation
     training_provider = course_option.provider
     ratifying_provider = course_option.course.accredited_provider
 
-    if FeatureFlag.active?(:providers_can_manage_users_and_permissions)
-      # enforce user-level 'make_decisions' restriction
-      related_providers = [training_provider, ratifying_provider].compact
-      return false if !actor_has_permission_to_make_decisions?(providers: related_providers)
+    # enforce user-level 'make_decisions' restriction
+    related_providers = [training_provider, ratifying_provider].compact
+    return false unless actor_has_permission_to_make_decisions?(providers: related_providers)
 
-      if FeatureFlag.active?(:enforce_provider_to_provider_permissions)
-        # enforce org-level 'make_decisions' restriction
-        if ratifying_provider
-          return false unless actor_has_permissions_via_provider_to_provider_permissions?(
-            training_provider: training_provider,
-            ratifying_provider: ratifying_provider,
-          )
-        end
+    if FeatureFlag.active?(:enforce_provider_to_provider_permissions)
+      # enforce org-level 'make_decisions' restriction
+      if ratifying_provider
+        return false unless actor_has_permissions_via_provider_to_provider_permissions?(
+          training_provider: training_provider,
+          ratifying_provider: ratifying_provider,
+        )
       end
     end
 

--- a/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
   let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
 
   before do
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     allow(DfESignInUser).to receive(:load_from_session)
       .and_return(
         DfESignInUser.new(

--- a/spec/services/conditions_not_met_spec.rb
+++ b/spec/services/conditions_not_met_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe ConditionsNotMet do
     provider_user = create(:provider_user)
     provider_user.providers << application_choice.offered_course.provider
 
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     service = ConditionsNotMet.new(
       actor: provider_user,
       application_choice: application_choice,

--- a/spec/services/confirm_offer_conditions_spec.rb
+++ b/spec/services/confirm_offer_conditions_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe ConfirmOfferConditions do
     provider_user = create(:provider_user)
     provider_user.providers << application_choice.offered_course.provider
 
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     service = ConfirmOfferConditions.new(
       actor: provider_user,
       application_choice: application_choice,

--- a/spec/services/defer_offer_spec.rb
+++ b/spec/services/defer_offer_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe DeferOffer do
       provider_user = create(:provider_user)
       provider_user.providers << application_choice.offered_course.provider
 
-      FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
       service = DeferOffer.new(
         actor: provider_user,
         application_choice: application_choice,

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -106,8 +106,6 @@ RSpec.describe MakeAnOffer, sidekiq: true do
     end
 
     it 'raises error if actor does not have make_decisions permission' do
-      FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
       unauthorised_user = create(:provider_user, :with_provider)
       course = create(:course, :open_on_apply, provider: unauthorised_user.providers.first)
       course_option = create(:course_option, course: course)

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe ProviderAuthorisation do
     context 'actor: provider user (org-level permissions)' do
       before do
         FeatureFlag.activate(:enforce_provider_to_provider_permissions)
-        FeatureFlag.activate(:providers_can_manage_users_and_permissions)
       end
 
       it 'training_provider without make_decisions' do
@@ -114,8 +113,6 @@ RSpec.describe ProviderAuthorisation do
     end
 
     context 'actor: provider user (user-level permissions)' do
-      before { FeatureFlag.activate(:providers_can_manage_users_and_permissions) }
-
       it 'training_provider_user without make_decisions' do
         training_provider_user.provider_permissions.update_all(make_decisions: false)
 
@@ -173,7 +170,6 @@ RSpec.describe ProviderAuthorisation do
     context 'actor: api user (org-level permissions)' do
       before do
         FeatureFlag.activate(:enforce_provider_to_provider_permissions)
-        FeatureFlag.activate(:providers_can_manage_users_and_permissions)
       end
 
       it 'is false for training_provider without make_decisions' do

--- a/spec/services/withdraw_offer_spec.rb
+++ b/spec/services/withdraw_offer_spec.rb
@@ -33,8 +33,6 @@ RSpec.describe WithdrawOffer do
       provider_user = create(:provider_user)
       provider_user.providers << application_choice.offered_course.provider
 
-      FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
       service = WithdrawOffer.new(
         actor: provider_user,
         application_choice: application_choice,

--- a/spec/support/test_helpers/provider_user_permissions_helper.rb
+++ b/spec/support/test_helpers/provider_user_permissions_helper.rb
@@ -1,7 +1,5 @@
 module ProviderUserPermissionsHelper
   def permit_make_decisions!(dfe_sign_in_uid: 'DFE_SIGN_IN_UID', provider: nil)
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     provider_user = ProviderUser.find_by_dfe_sign_in_uid dfe_sign_in_uid
     permissions = if provider
                     provider_user.provider_permissions.where(provider: provider)
@@ -13,8 +11,6 @@ module ProviderUserPermissionsHelper
   end
 
   def deny_make_decisions!(dfe_sign_in_uid: 'DFE_SIGN_IN_UID', provider: nil)
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     provider_user = ProviderUser.find_by_dfe_sign_in_uid dfe_sign_in_uid
     permissions = if provider
                     provider_user.provider_permissions.where(provider: provider)

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -3,10 +3,9 @@ require 'rails_helper'
 RSpec.feature 'Confirm conditions met' do
   include CourseOptionHelpers
   include DfESignInHelpers
+  include ProviderUserPermissionsHelper
 
   scenario 'Provider user confirms offer conditions have been met by the candidate' do
-    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
@@ -30,6 +29,7 @@ RSpec.feature 'Confirm conditions met' do
   def and_i_am_an_authorised_provider_user
     @provider = create(:provider, :with_signed_agreement)
     create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    permit_make_decisions!
   end
 
   def and_i_can_access_the_provider_interface

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -3,10 +3,9 @@ require 'rails_helper'
 RSpec.feature 'Confirm conditions not met' do
   include CourseOptionHelpers
   include DfESignInHelpers
+  include ProviderUserPermissionsHelper
 
   scenario 'Provider user confirms offer conditions have not been met by the candidate' do
-    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
@@ -30,6 +29,7 @@ RSpec.feature 'Confirm conditions not met' do
   def and_i_am_an_authorised_provider_user
     @provider = create(:provider, :with_signed_agreement)
     create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    permit_make_decisions!
   end
 
   def and_i_can_access_the_provider_interface

--- a/spec/system/provider_interface/provider_defers_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_defers_an_offer_spec.rb
@@ -3,10 +3,9 @@ require 'rails_helper'
 RSpec.feature 'Provider defers an offer' do
   include CourseOptionHelpers
   include DfESignInHelpers
+  include ProviderUserPermissionsHelper
 
   scenario 'Provider defers an offer' do
-    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_an_offered_application_choice_exists_for_my_provider
     and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
@@ -33,6 +32,7 @@ RSpec.feature 'Provider defers an offer' do
 
   def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
     provider_user_exists_in_apply_database
+    permit_make_decisions!
   end
 
   def and_i_view_an_offered_application

--- a/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
+++ b/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.feature 'Provider makes an offer' do
   include CourseOptionHelpers
   include DfESignInHelpers
+  include ProviderUserPermissionsHelper
 
   scenario 'Provider fails to select a response (offer/reject)' do
-    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_application_choices_exist_for_my_provider
     and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+
     and_i_sign_in_to_the_provider_interface
 
     when_i_respond_to_an_application
@@ -28,6 +29,10 @@ RSpec.feature 'Provider makes an offer' do
 
   def and_i_am_permitted_to_see_applications_for_my_provider
     provider_user_exists_in_apply_database
+  end
+
+  def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    permit_make_decisions!
   end
 
   def when_i_respond_to_an_application

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Provider rejects application' do
   include CourseOptionHelpers
   include DfESignInHelpers
+  include ProviderUserPermissionsHelper
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
   let(:application_awaiting_provider_decision) do
@@ -10,10 +11,9 @@ RSpec.feature 'Provider rejects application' do
   end
 
   scenario 'Provider rejects application' do
-    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
     when_i_respond_to_an_application
@@ -33,6 +33,10 @@ RSpec.feature 'Provider rejects application' do
 
   def and_i_am_permitted_to_see_applications_for_my_provider
     provider_user_exists_in_apply_database
+  end
+
+  def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    permit_make_decisions!
   end
 
   def when_i_respond_to_an_application

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -16,10 +16,9 @@ RSpec.feature 'Provider responds to application' do
   end
 
   scenario 'Provider can respond to an application' do
-    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_a_application_with_status_awaiting_provider_decision
@@ -47,6 +46,10 @@ RSpec.feature 'Provider responds to application' do
 
   def and_i_am_permitted_to_see_applications_for_my_provider
     provider_user_exists_in_apply_database
+  end
+
+  def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    permit_make_decisions!
   end
 
   def when_i_visit_a_application_with_status_awaiting_provider_decision

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.feature 'Provider withdraws an offer' do
   include CourseOptionHelpers
   include DfESignInHelpers
+  include ProviderUserPermissionsHelper
 
   scenario 'Provider withdraws an offer' do
-    FeatureFlag.deactivate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_an_offered_application_choice_exists_for_my_provider
     and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+
     and_i_sign_in_to_the_provider_interface
     and_i_view_an_offered_application
     and_i_navigate_to_the_offer_tab
@@ -37,6 +38,10 @@ RSpec.feature 'Provider withdraws an offer' do
 
   def and_i_am_permitted_to_see_applications_for_my_provider
     provider_user_exists_in_apply_database
+  end
+
+  def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
+    permit_make_decisions!
   end
 
   def and_i_view_an_offered_application


### PR DESCRIPTION
## Context

For historical reasons, our `:providers_can_manage_users_and_permissions` feature flag also controls whether the `:make_decisions` permission is enforced. If we were to turn off this flag on production, e.g. to stop providers from inviting users temporarily, then all users would effectively acquire permission to reject applications, make offers etc., regardless of their `:make_decisions` status. This is far from ideal and not what you would expect when reading the feature flag description.

## Changes proposed in this pull request

Change the authorisation code so that `:make_decisions` is always enforced and independent of any feature flags.

## Guidance to review

Inspect the code, read the specs. You shouldn't be able to notice anything different, as the `:providers_can_manage_users_and_permissions` flag has been on for a while.

## Link to Trello card

https://trello.com/c/l4vzf43X

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
