### PR TITLE
Remove feature flag for cycle syncing

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,7 +29,6 @@ class FeatureFlag
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],
-    [:start_syncing_2021_courses, 'Sync the courses for the 2021 recruitment cycle', 'Tijmen Brommet'],
     [:international_degrees, 'Changes to the model and forms for degree qualifications to cater for non-UK degrees.', 'Steve Hook'],
     [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],

--- a/app/services/find_sync/sync_all_providers_from_find.rb
+++ b/app/services/find_sync/sync_all_providers_from_find.rb
@@ -9,11 +9,9 @@ module FindSync
         FindAPI::Provider.recruitment_cycle(2020).all,
       )
 
-      if FeatureFlag.active?(:start_syncing_2021_courses)
-        sync_providers(
-          FindAPI::Provider.recruitment_cycle(2021).all,
-        )
-      end
+      sync_providers(
+        FindAPI::Provider.recruitment_cycle(2021).all,
+      )
 
       FindSyncCheck.set_last_sync(Time.zone.now)
     rescue JsonApiClient::Errors::ApiError


### PR DESCRIPTION
## Context

This feature flag has been on for a couple of weeks now, and everything is fine.

## Changes proposed in this pull request

Remove the flag to make sure we keep syncing the 2021 cycle as well.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/lMdqoepW/2725-sync-courses-from-2021-recruitment-cycle

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
