### PR TITLE
Tidy up error handling in DeferOffer

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -143,18 +143,13 @@ module ProviderInterface
     end
 
     def defer_offer
-      @defer_offer = DeferOffer.new(
+      DeferOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
-      )
-      if @defer_offer.save
-        flash[:success] = 'Offer successfully deferred'
-        redirect_to provider_interface_application_choice_path(
-          application_choice_id: @application_choice.id,
-        )
-      else
-        render action: :new_defer_offer
-      end
+      ).save!
+
+      flash[:success] = 'Offer successfully deferred'
+      redirect_to provider_interface_application_choice_path(@application_choice)
     end
 
   private

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -270,7 +270,7 @@ class TestApplications
     as_provider_user(choice) do
       fast_forward(1..3)
       confirm_offer_conditions(choice) if rand > 0.5 # 'recruited' can also be deferred
-      DeferOffer.new(actor: actor, application_choice: choice).save
+      DeferOffer.new(actor: actor, application_choice: choice).save!
       choice.update_columns(offer_deferred_at: time, updated_at: time)
     end
     # service generates two audit writes, one for status, one for timestamp

--- a/spec/services/defer_offer_spec.rb
+++ b/spec/services/defer_offer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DeferOffer do
       DeferOffer.new(
         actor: create(:support_user),
         application_choice: application_choice,
-      ).save
+      ).save!
 
       expect(application_choice.reload.status).to eq 'offer_deferred'
     end
@@ -19,7 +19,7 @@ RSpec.describe DeferOffer do
       DeferOffer.new(
         actor: create(:support_user),
         application_choice: application_choice,
-      ).save
+      ).save!
 
       expect(application_choice.reload.offer_deferred_at).not_to be_nil
     end
@@ -30,7 +30,7 @@ RSpec.describe DeferOffer do
       DeferOffer.new(
         actor: create(:support_user),
         application_choice: application_choice,
-      ).save
+      ).save!
 
       expect(application_choice.reload.status).to eq 'offer_deferred'
     end
@@ -47,7 +47,7 @@ RSpec.describe DeferOffer do
         application_choice: application_choice,
       )
 
-      expect { service.save }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+      expect { service.save! }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
 
       expect(application_choice.reload.status).to eq 'pending_conditions'
     end
@@ -57,7 +57,7 @@ RSpec.describe DeferOffer do
       deliverer = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
       allow(CandidateMailer).to receive(:deferred_offer).and_return(deliverer)
 
-      DeferOffer.new(actor: create(:support_user), application_choice: application_choice).save
+      DeferOffer.new(actor: create(:support_user), application_choice: application_choice).save!
 
       expect(CandidateMailer).to have_received(:deferred_offer).once.with(application_choice)
     end
@@ -66,7 +66,7 @@ RSpec.describe DeferOffer do
       application_choice = create(:application_choice, :with_recruited)
       allow(StateChangeNotifier).to receive(:call)
 
-      DeferOffer.new(actor: create(:support_user), application_choice: application_choice).save
+      DeferOffer.new(actor: create(:support_user), application_choice: application_choice).save!
 
       expect(StateChangeNotifier).to have_received(:call).with(:defer_offer, application_choice: application_choice)
     end


### PR DESCRIPTION
## Context & changes

The error handling here is not consistent.

- We return `false` and populate the `errors` if the state transition is illegal. This is something that shouldn't happen in the normal user flow, so it's legitimate to raise an error that will notify us. Currently the provider user would see a message "The application is not ready for that action", which isn't helpful
- We're using `update` to set `status_before_deferral` and `offer_deferred_at`, which will return false if the validation fails, which we ignore - because we just return true in the last line of the method. This makes sure that we fail if the update fails.
- Rename the `save` method to indicate that it'll raise an error if it fails.
- Remove the error checking in the controller because it will never be called anyway.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
