### PR TITLE
Re-enable auditing during setup_local_dev_data

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -1,7 +1,5 @@
 desc 'Set up your local development environment with data from Find'
 task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses] do
-  Audited.auditing_enabled = false
-
   puts 'Creating a provider-only user with DfE Sign-in UID `dev-provider` and email `provider@example.com`...'
   ProviderUser.create!(
     dfe_sign_in_uid: 'dev-provider',


### PR DESCRIPTION
## Context

Now that Heroku review apps can cope with 10k+ rows, re-enable the auditing.

## Changes proposed in this pull request

Re-enable auditing.

## Guidance to review

LGTY?

## Link to Trello card

None.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)