### PR TITLE
Remove course names from referee emails

### DIFF
--- a/app/views/referee_mailer/reference_request_chase_again_email.text.erb
+++ b/app/views/referee_mailer/reference_request_chase_again_email.text.erb
@@ -10,12 +10,6 @@ Otherwise, give a reference as soon as possible:
 
 <%= referee_interface_reference_relationship_url(token: @token) %>
 
-<%= @candidate_name %> applied to:
-
-<% @application_form.application_choices.each do |application_choice| %>
-* <%= application_choice.course_option.provider.name %> - <%= application_choice.course_option.course.name %>
-<% end %>
-
 # Your data
 
 We’ll only use your data to process the candidate’s application, unless you agree to be contacted by us about your experience of giving a reference. We’ll ask about this before you submit any information.

--- a/app/views/referee_mailer/reference_request_chaser_email.text.erb
+++ b/app/views/referee_mailer/reference_request_chaser_email.text.erb
@@ -2,11 +2,7 @@ Dear <%= @reference.name %>,
 
 # Give a reference for <%= @candidate_name %> as soon as possible
 
-We have not had your reference for <%= @candidate_name %>. They put us in touch with you to get a reference for their teacher training application. They applied to:
-
-<% @application_form.application_choices.each do |application_choice| %>
-* <%= application_choice.course_option.provider.name %> - <%= application_choice.course_option.course.name %>
-<% end %>
+We have not had your reference for <%= @candidate_name %>. They put us in touch with you to get a reference for their teacher training application.
 
 Give a reference as soon as possible by filling in this short form (it does not take long):
 

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -2,11 +2,7 @@ Dear <%= @reference.name %>,
 
 # Give a reference for <%= @candidate_name %> as soon as possible
 
-<%= @candidate_name %> put us in touch with you to get a reference for their teacher training application. They applied to:
-
-<% @application_form.application_choices.each do |application_choice| %>
-* <%= application_choice.course_option.provider.name %> - <%= application_choice.course_option.course.name %>
-<% end %>
+<%= @candidate_name %> put us in touch with you to get a reference for their teacher training application.
 
 Give a reference as soon as possible by filling in this short form (it does not take long):
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -134,11 +134,8 @@ RSpec.describe RefereeMailer, type: :mailer do
         :application_form,
         first_name: 'Elliot',
         last_name: 'Alderson',
-        application_choices: [build_stubbed(:application_choice, course_option: course_option)],
       )
     end
-    let(:course) { build_stubbed(:course) }
-    let(:course_option) { build_stubbed(:course_option, course: course) }
     let(:reference) { build_stubbed(:reference, application_form: application_form) }
     let(:mail) { mailer.reference_request_chase_again_email(reference) }
 
@@ -161,10 +158,6 @@ RSpec.describe RefereeMailer, type: :mailer do
 
     it 'sends an email with a link to the reference form' do
       expect(mail.body.encoded).to include(referee_interface_reference_relationship_url(token: ''))
-    end
-
-    it 'sends an email with the candidates course choice' do
-      expect(mail.body.encoded).to include(course.name)
     end
   end
 end


### PR DESCRIPTION

## Context

<!-- Why are you making this change? What might surprise someone about it? -->
A content update across three reference request emails. Removes the list
of courses the candidate applied to.

## Changes proposed in this pull request
See diff.

Also, mailer previews:

https://apply-for-te-2230-updat-ux3g8r.herokuapp.com/rails/mailers/referee_mailer/reference_request_chase_again_email
https://apply-for-te-2230-updat-ux3g8r.herokuapp.com/rails/mailers/referee_mailer/reference_request_chaser_email
https://apply-for-te-2230-updat-ux3g8r.herokuapp.com/rails/mailers/referee_mailer/reference_request_email

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
These aren't directly tied to the `decoupled_references` feature, so I haven't put these behind a flag.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
