### PR TITLE
Add details component

### DIFF
--- a/app/components/candidate_interface/application_status_tag_component.html.erb
+++ b/app/components/candidate_interface/application_status_tag_component.html.erb
@@ -9,31 +9,33 @@
     Your training will now start in <%= (@application_choice.course_option.course.start_date + 1.year).to_s(:month_and_year) %>.
   </p>
 <% elsif @application_choice.pending_conditions? || @application_choice.recruited? || @application_choice.offer? %>
-    <details class="govuk-details govuk-!-margin-bottom-0 govuk-!-margin-top-2" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          What to do if you’re unable to start training in <%= @application_choice.course_option.course.start_date.to_s(:month_and_year) %>
-        </span>
-      </summary>
-      <div class="govuk-details__text govuk-!-padding-bottom-0">
-        <p>
-          Some providers allow you to defer your offer. This means that you could start your course a year later.
-        </p>
+  <% details_body = capture do %>
+    <div class="govuk-details__text govuk-!-padding-bottom-0">
+      <p>
+        Some providers allow you to defer your offer. This means that you could start your course a year later.
+      </p>
 
-        <p>
-          Every provider is different, so it may or may not be possible to do this.
-          Find out by contacting <%= @application_choice.course_option.course.provider.name %>.
-        </p>
+      <p>
+        Every provider is different, so it may or may not be possible to do this.
+        Find out by contacting <%= @application_choice.course_option.course.provider.name %>.
+      </p>
 
-        <p>
-          Asking if it’s possible to defer will not affect your existing offer.
-        </p>
+      <p>
+        Asking if it’s possible to defer will not affect your existing offer.
+      </p>
 
-        <% if @application_choice.offer? %>
-          <p>
-            If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.
-          </p>
-        <% end %>
-      </div>
-    </details>
+      <% if @application_choice.offer? %>
+        <p>
+          If your provider agrees to defer your offer, you’ll need to accept the offer on your account first.
+        </p>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= render DetailsComponent.new(
+    summary_text: "What to do if you’re unable to start training in #{@application_choice.course_option.course.start_date.to_s(:month_and_year)}",
+    details_body: details_body,
+    additional_css_classes: 'govuk-!-margin-bottom-0 govuk-!-margin-top-2',
+    )
+  %>
 <% end %>

--- a/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
+++ b/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
@@ -13,26 +13,18 @@
 <% end %>
 
 <% if english? && (gcse? || gce_o_level?) %>
-  <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        <% type = gcse? ? 'a GCSE' : 'an O level' %>
-        <%= t('gcse_edit_grade.guidance.english_literature_only.summary', type: type) %>
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <%= t('gcse_edit_grade.guidance.english_literature_only.details') %>
-    </div>
-  </details>
+  <% type = gcse? ? 'a GCSE' : 'an O level' %>
+  <%= render DetailsComponent.new(
+    summary_text: t('gcse_edit_grade.guidance.english_literature_only.summary', type: type),
+    details_body: t('gcse_edit_grade.guidance.english_literature_only.details'),
+    additional_css_classes: 'govuk-!-margin-bottom-2',
+    )
+  %>
 
-  <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        <%= t('gcse_edit_grade.guidance.multiple_english_qualifications.summary') %>
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <%= t('gcse_edit_grade.guidance.multiple_english_qualifications.details') %>
-    </div>
-  </details>
+  <%= render DetailsComponent.new(
+    summary_text: t('gcse_edit_grade.guidance.multiple_english_qualifications.summary'),
+    details_body: t('gcse_edit_grade.guidance.multiple_english_qualifications.details'),
+    additional_css_classes: 'govuk-!-margin-bottom-6',
+    )
+  %>
 <% end %>

--- a/app/components/candidate_interface/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons_component.html.erb
@@ -1,15 +1,14 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      See feedback from your previous application
-    </span>
-  </summary>
-
-  <div class="govuk-details__text govuk-!-padding-bottom-0">
-    <% @application_form.application_choices.includes(:course, :provider, [:offered_course_option]).rejected.each do |application_choice| %>
-      <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
-        <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>
-      <% end %>
+<% details_body = capture do %>
+  <% @application_form.application_choices.includes(:course, :provider, [:offered_course_option]).rejected.each do |application_choice| %>
+    <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
+      <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>
     <% end %>
-  </div>
-</details>
+  <% end %>
+<% end %>
+
+<%= render DetailsComponent.new(
+  summary_text: 'See feedback from your previous application',
+  details_body: details_body,
+  additional_css_classes: 'govuk-!-padding-bottom-0',
+  )
+%>

--- a/app/components/details_component.html.erb
+++ b/app/components/details_component.html.erb
@@ -1,0 +1,10 @@
+<details class="<%= css_classes %>" data-module="govuk-details" <%= open %> >
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= summary_text %>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= details_body %>
+  </div>
+</details>

--- a/app/components/details_component.rb
+++ b/app/components/details_component.rb
@@ -1,0 +1,15 @@
+class DetailsComponent < ViewComponent::Base
+  include ViewHelper
+  attr_reader :summary_text, :details_body, :open
+
+  def initialize(summary_text:, details_body:, additional_css_classes: nil, open: false)
+    @summary_text = summary_text
+    @details_body = details_body.html_safe
+    @additional_css_classes = additional_css_classes
+    @open = open ? 'open' : nil
+  end
+
+  def css_classes
+    @additional_css_classes.nil? ? 'govuk-details' : 'govuk-details ' + @additional_css_classes
+  end
+end

--- a/app/components/interview_preferences_component.html.erb
+++ b/app/components/interview_preferences_component.html.erb
@@ -1,21 +1,20 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Interview needs</h2>
-    <p class="govuk-body">Interviews usually take place over the course of a day. You'll need to attend in person.</p>
-    <p class="govuk-body">Training providers might not have much flexibility when setting a date and time for interview.</p>
-    <p class="govuk-body">If there's a reason why you need some flexibility you can tell us about it here.</p>
-    <p class="govuk-body">For example:</p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-      <li>you have commitments such as employment or caring responsibilities</li>
-      <li>you'll be travelling a long way to get to the interview</li>
-      <li>you'll need some adjustments because you're disabled</li>
-    </ul>
-  </div>
-</details>
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Interview needs</h2>
+  <p class="govuk-body">Interviews usually take place over the course of a day. You'll need to attend in person.</p>
+  <p class="govuk-body">Training providers might not have much flexibility when setting a date and time for interview.</p>
+  <p class="govuk-body">If there's a reason why you need some flexibility you can tell us about it here.</p>
+  <p class="govuk-body">For example:</p>
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+    <li>you have commitments such as employment or caring responsibilities</li>
+    <li>you'll be travelling a long way to get to the interview</li>
+    <li>you'll need some adjustments because you're disabled</li>
+  </ul>
+<% end %>
+
+<%= render DetailsComponent.new(
+  summary_text: 'View guidance given to candidate',
+  details_body: details_body,
+  )
+%>
 
 <%= simple_format interview_preferences, class: 'govuk-body' %>

--- a/app/components/personal_statement_component.html.erb
+++ b/app/components/personal_statement_component.html.erb
@@ -1,36 +1,35 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
-    <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
-    <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
-    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <a href="https://getintoteaching.education.gov.uk/" class="govuk-body">Get into Teaching</a> for help from a teacher training adviser.</p>
-    <p class="govuk-body govuk-!-font-weight-bold">Suggested topics to cover include:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>why you want to be a teacher</li>
-      <li>your passion for your subject and the age group you’ve chosen to teach</li>
-      <li>the welfare and education of children and/or young people</li>
-      <li>the demands and rewards of the profession</li>
-      <li>personal qualities that will make you a good teacher</li>
-      <li>your contribution to the life of the school outside the classroom – for example, running extra-curricular activities and clubs</li>
-      <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
-    </ul>
-    <h2 class="govuk-heading-m">What do you know about the subject you want to teach?</h2>
-    <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to your course choice.</p>
-    <p class="govuk-body">Evidence can include:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the subject of your undergraduate degree</li>
-      <li>modules you studied as part of your degree</li>
-      <li>postgraduate degrees (for example, a Masters or PhD)</li>
-      <li>your A level subjects</li>
-      <li>expertise you’ve gained at work</li>
-    </ul>
-  </div>
-</details>
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
+  <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
+  <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
+  <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <a href="https://getintoteaching.education.gov.uk/" class="govuk-body">Get into Teaching</a> for help from a teacher training adviser.</p>
+  <p class="govuk-body govuk-!-font-weight-bold">Suggested topics to cover include:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>why you want to be a teacher</li>
+    <li>your passion for your subject and the age group you’ve chosen to teach</li>
+    <li>the welfare and education of children and/or young people</li>
+    <li>the demands and rewards of the profession</li>
+    <li>personal qualities that will make you a good teacher</li>
+    <li>your contribution to the life of the school outside the classroom – for example, running extra-curricular activities and clubs</li>
+    <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
+  </ul>
+  <h2 class="govuk-heading-m">What do you know about the subject you want to teach?</h2>
+  <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to your course choice.</p>
+  <p class="govuk-body">Evidence can include:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>the subject of your undergraduate degree</li>
+    <li>modules you studied as part of your degree</li>
+    <li>postgraduate degrees (for example, a Masters or PhD)</li>
+    <li>your A level subjects</li>
+    <li>expertise you’ve gained at work</li>
+  </ul>
+<% end %>
+
+<%= render DetailsComponent.new(
+  summary_text: 'View guidance given to candidate',
+  details_body: details_body,
+  )
+%>
 
 <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Vocation</h3>
 <%= simple_format becoming_a_teacher, class: 'govuk-body' %></p>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,22 +1,17 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Equality and diversity</h2>
-    <p class="govuk-body">
-      The equality and diversity questionnaire is optional and has no impact on the progress of your application.
-    </p>
-    <p class="govuk-body">
-      We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.
-    </p>
-    <p class="govuk-body">
-      Your data will only be shared with training providers when you have successfully completed your application.
-    </p>
-  </div>
-</details>
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Equality and diversity</h2>
+  <p class="govuk-body">
+    The equality and diversity questionnaire is optional and has no impact on the progress of your application.
+  </p>
+  <p class="govuk-body">
+    We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.
+  </p>
+  <p class="govuk-body">
+    Your data will only be shared with training providers when you have successfully completed your application.
+  </p>
+<% end %>
+
+<%= render DetailsComponent.new(summary_text: 'View guidance given to candidate', details_body: details_body) %>
 
 <% if display_diversity_information? -%>
   <%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/email_log_row_component.html.erb
+++ b/app/components/provider_interface/email_log_row_component.html.erb
@@ -5,15 +5,6 @@
   <td class="govuk-table__cell">
     <%= render SummaryListComponent.new(rows: summary_list_rows) %>
 
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Email body
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <%= tag.pre(email.body) %>
-      </div>
-    </details>
+    <%= render DetailsComponent.new(summary_text: 'Email body', details_body: tag.pre(email.body)) %>
   </td>
 </tr>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,33 +1,8 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Declaring any safeguarding issues</h2>
-    <p class="govuk-body">Teacher training providers need to check that it’s safe for you to work with children and young people.</p>
-    <p class="govuk-body">As well as confirming your identity and your right to work in the UK, providers will check:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>your criminal record in the UK (they'll do an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks" class="govuk-link">DBS check)</a> and abroad where relevant</li>
-      <li>whether you’ve been banned from teaching or working with children</li>
-      <li>your professional behaviour, such as whether you’ve been removed from teacher training and what your referees say about you</li>
-    </ul>
-    <p class="govuk-body">Tell your provider about any potential safeguarding issues, such as offences, cautions, reprimands and final warnings. They can give advice about whether this will affect your application.</p>
-    <p class="govuk-body">It won’t necessarily stop you becoming a teacher.</p>
-  </div>
-</details>
-
 <p class="govuk-body"><%= message %></p>
 <% if display_safeguarding_issues_details? %>
-  <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        View information disclosed by the candidate
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <%= details %>
-    </div>
-  </details>
+  <%= render DetailsComponent.new(
+    summary_text: 'View information disclosed by the candidate',
+    details_body: details,
+    )
+  %>
 <% end %>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,26 +1,21 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Asking for support if you have a disability or other needs</h2>
-    <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
-    <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
-    <p class="govuk-body">Examples of support could be:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>organising equipment like a hearing loop or an adapted keyboard</li>
-      <li>putting you in touch with support staff if you have a mental health condition</li>
-      <li>making sure classrooms are wheelchair accessible</li>
-    </ul>
-    <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work" class="govuk-link">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
-    <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
-    <p class="govuk-body">If you’re disabled, <a href="/getintoteaching/train-to-teach-with-a-disability" class="govuk-link">it’s against the law to discriminate against you</a>. Training providers must not:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
-      <li>reject your application because you’re disabled</li>
-    </ul>
-  </div>
-</details>
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Asking for support if you have a disability or other needs</h2>
+  <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
+  <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
+  <p class="govuk-body">Examples of support could be:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>organising equipment like a hearing loop or an adapted keyboard</li>
+    <li>putting you in touch with support staff if you have a mental health condition</li>
+    <li>making sure classrooms are wheelchair accessible</li>
+  </ul>
+  <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work" class="govuk-link">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
+  <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
+  <p class="govuk-body">If you’re disabled, <a href="/getintoteaching/train-to-teach-with-a-disability" class="govuk-link">it’s against the law to discriminate against you</a>. Training providers must not:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
+    <li>reject your application because you’re disabled</li>
+  </ul>
+<% end %>
+<%= render DetailsComponent.new(summary_text: 'View guidance given to candidate', details_body: details_body) %>
+
 <p class="govuk-body"><%= disability_disclosure %></p>

--- a/app/components/provider_interface/volunteering_history_component.html.erb
+++ b/app/components/provider_interface/volunteering_history_component.html.erb
@@ -1,20 +1,14 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Unpaid experience working with children and other volunteering</h2>
-    <p class="govuk-body">Tell us about any unpaid experience you have working with children or in a school. For example:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>one-off observations in a school</li>
-      <li>volunteering at a children's club</li>
-      <li>being a governor</li>
-    </ul>
-    <p class="govuk-body">You can also tell us about any other volunteering you’ve done, and how this supports your application to become a teacher.</p>
-  </div>
-</details>
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Unpaid experience working with children and other volunteering</h2>
+  <p class="govuk-body">Tell us about any unpaid experience you have working with children or in a school. For example:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>one-off observations in a school</li>
+    <li>volunteering at a children's club</li>
+    <li>being a governor</li>
+  </ul>
+  <p class="govuk-body">You can also tell us about any other volunteering you’ve done, and how this supports your application to become a teacher.</p>
+<% end %>
+<%= render DetailsComponent.new(summary_text: 'View guidance given to candidate', details_body: details_body) %>
 
 <% history.each do |item| %>
   <%= render ProviderInterface::WorkHistoryItemComponent.new(item: item) %>

--- a/app/components/provider_interface/work_history_component.html.erb
+++ b/app/components/provider_interface/work_history_component.html.erb
@@ -1,15 +1,9 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-		<h2 class="govuk-heading-m">Work history</h2>
-		<p class="govuk-body">Training providers need a complete picture of the last 5 years of of your work history, including time out of the workplace, to safeguard children.</p>
-		<p class="govuk-body">Breaks in work history won’t impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
-  </div>
-</details>
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Work history</h2>
+  <p class="govuk-body">Training providers need a complete picture of the last 5 years of of your work history, including time out of the workplace, to safeguard children.</p>
+  <p class="govuk-body">Breaks in work history won’t impact your application if you have a reasonable explanation for them (for example, parenting responsibilities, redundancy, illness or personal reasons such as study or travel).</p>
+<% end %>
+<%= render DetailsComponent.new(summary_text: 'View guidance given to candidate', details_body: details_body) %>
 
 <% history.each do |item| %>
   <%= render ProviderInterface::WorkHistoryItemComponent.new(item: item) %>

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -1,15 +1,18 @@
 <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="qualifications">Qualifications</h2>
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">View guidance given to candidate</span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Academic and other relevant qualifications</h2>
-    <p class="govuk-body">Your undergraduate degree confirms your eligibility to teach. Enter the details of your degree as they appear on your certificate, translating them into English if necessary.</p>
-    <p class="govuk-body">You should also include any postgraduate degrees.</p>
-    <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>
-  </div>
-</details>
+
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Academic and other relevant qualifications</h2>
+  <p class="govuk-body">Your undergraduate degree confirms your eligibility to teach. Enter the details of your degree as they appear on your certificate, translating them into English if necessary.</p>
+  <p class="govuk-body">You should also include any postgraduate degrees.</p>
+  <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>
+<% end %>
+<%= render DetailsComponent.new(
+    summary_text: 'View guidance given to candidate',
+    details_body: details_body,
+    additional_css_classes: 'govuk-!-margin-top-8 govuk-!-margin-bottom-2',
+  )
+%>
+
 
 <div class="govuk-grid-row">
   <%= render DegreeQualificationCardsComponent.new(application_form.application_qualifications.degrees, application_choice_state: application_choice_state, show_hesa_codes: show_hesa_codes) %>

--- a/app/components/support_interface/email_log_row_component.html.erb
+++ b/app/components/support_interface/email_log_row_component.html.erb
@@ -5,15 +5,7 @@
   <td class="govuk-table__cell">
     <%= render SummaryListComponent.new(rows: summary_list_rows) %>
 
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Email body
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <%= tag.pre(email.body) %>
-      </div>
-    </details>
+    <%= render DetailsComponent.new(summary_text: 'Email body', details_body: tag.pre(email.body)) %>
+  
   </td>
 </tr>

--- a/app/views/api_docs/reference/_operation.html.erb
+++ b/app/views/api_docs/reference/_operation.html.erb
@@ -57,35 +57,20 @@
 
   <%= render 'properties_list', properties: operation.request_body.schema.properties %>
 
-  <details class="govuk-details" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        Example request body
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <%= json_code_sample(operation.request_body.example) %>
-    </div>
-  </details>
+  <%= render DetailsComponent.new(summary_text: 'Example request body', details_body: json_code_sample(operation.request_body.example)) %>
 <% end %>
 
 <% if operation.responses.any? %>
   <h4 class="govuk-heading-s">Possible reponses</h4>
 
   <% operation.responses.each do |response| %>
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          HTTP <%= response.code %> - <%= response.description %>
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        This request will return a <%= govuk_link_to response.schema_name, "##{response.schema_name.parameterize}-object" %> object.
+    <% details_body = capture do %>
+      This request will return a <%= govuk_link_to response.schema_name, "##{response.schema_name.parameterize}-object" %> object.
+      <% if response.example %>
+        <%= json_code_sample(response.example) %>
+      <% end %>
+    <% end %>
 
-        <% if response.example %>
-          <%= json_code_sample(response.example) %>
-        <% end %>
-      </div>
-    </details>
+    <%= render DetailsComponent.new(summary_text: "HTTP #{response.code} - #{response.description}", details_body: details_body) %>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -35,17 +35,16 @@
   </h1>
 
   <%= f.govuk_collection_select :first_nationality, select_nationality_options(include_british_and_irish: true), :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+  <% details_body = capture do %>
+    <%= f.govuk_collection_select :second_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.second_nationality.label') } %>
+  <% end %>
+  <%= render DetailsComponent.new(
+    summary_text: 'Add another nationality',
+    details_body: details_body,
+    open: @nationalities_form.second_nationality.present?,
+    )
+  %>
 
-    <details class="govuk-details" data-module="govuk-details" <%= 'open' if @nationalities_form.second_nationality.present? %>>
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        Add another nationality
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      <%= f.govuk_collection_select :second_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.second_nationality.label') } %>
-    </div>
-  </details>
 <% end %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/provider_interface/application_choices/_references_context.html.erb
+++ b/app/views/provider_interface/application_choices/_references_context.html.erb
@@ -1,19 +1,14 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View guidance given to candidate
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Choosing referees</h2>
-    <p class="govuk-body">Referees should not be family members, partners or friends.</p>
-    <p class="govuk-body">If you’re struggling to find a suitable referee, contact your provider to discuss this.</p>
-    <p class="govuk-body">Types of referee you can add:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>Academic (for example, your university tutor or supervisor – choose an academic referee if you graduated in the last 5 years or you have a predicted grade for your degree)</li>
-      <li>Professional (for example, your current line manager or a previous employer –&nbsp;if you’re self-employed, you could use a client or supplier)</li>
-      <li>School-based (for example, a teacher at a school where you’ve volunteered or gained experience)</li>
-      <li>Character (choose a responsible person who can confirm you’re suitable for teaching – for example, a sports coach –&nbsp;and remember that training providers will only accept character references if there’s also an academic or professional reference)</li>
-    </ul>
-  </div>
-</details>
+<% details_body = capture do %>
+  <h2 class="govuk-heading-m">Choosing referees</h2>
+  <p class="govuk-body">Referees should not be family members, partners or friends.</p>
+  <p class="govuk-body">If you’re struggling to find a suitable referee, contact your provider to discuss this.</p>
+  <p class="govuk-body">Types of referee you can add:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Academic (for example, your university tutor or supervisor – choose an academic referee if you graduated in the last 5 years or you have a predicted grade for your degree)</li>
+    <li>Professional (for example, your current line manager or a previous employer –&nbsp;if you’re self-employed, you could use a client or supplier)</li>
+    <li>School-based (for example, a teacher at a school where you’ve volunteered or gained experience)</li>
+    <li>Character (choose a responsible person who can confirm you’re suitable for teaching – for example, a sports coach –&nbsp;and remember that training providers will only accept character references if there’s also an academic or professional reference)</li>
+  </ul>
+<% end %>
+
+<%= render DetailsComponent.new(summary_text: "View guidance given to candidate", details_body: details_body) %>

--- a/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
@@ -17,26 +17,21 @@
     <div class="app-banner">
       <div class="app-banner__message">
         <p>All users at your organisation and ratifying organisation(s) will be able to view applications to these courses. You do not need to set permissions for this.</p>
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              More about permissions
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <h2 class="govuk-heading-m">Permission to make decisions</h2>
-            <p>You can allow an organisation to make offers, amend offers and reject applications.</p>
 
-            <h2 class="govuk-heading-m">Permission to view safeguarding information</h2>
-            <p>You can give an organisation access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
-            <p>This may include highly sensitive material about the candidate.</p>
+        <% details_body = capture do %>
+          <h2 class="govuk-heading-m">Permission to make decisions</h2>
+          <p>You can allow an organisation to make offers, amend offers and reject applications.</p>
 
-            <h2 class="govuk-heading-m">Permission to view diversity information</h2>
-            <p>You can give an organisation access to information disclosed by the candidate in the ‘equality and diversity’ section of the application. </p>
+          <h2 class="govuk-heading-m">Permission to view safeguarding information</h2>
+          <p>You can give an organisation access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
+          <p>This may include highly sensitive material about the candidate.</p>
 
-            <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted. </p>
-          </div>
-        </details>
+          <h2 class="govuk-heading-m">Permission to view diversity information</h2>
+          <p>You can give an organisation access to information disclosed by the candidate in the ‘equality and diversity’ section of the application. </p>
+
+          <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted. </p>
+        <% end %>
+        <%= render DetailsComponent.new(summary_text: "More about permissions", details_body: details_body) %>
       </div>
     </div>
 

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -16,25 +16,21 @@
       <div class="app-banner">
         <div class="app-banner__message">
           <p>All users at your organisation and ratifying organisation(s) will be able to view applications to these courses. You do not need to set permissions for this.</p>
-          <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text">
-                More about permissions
-              </span>
-            </summary>
-            <div class="govuk-details__text">
-              <h2 class="govuk-heading-m">Permission to make decisions</h2>
-              <p>You can allow an organisation to make offers, amend offers and reject applications.</p>
-              <h2 class="govuk-heading-m">Permission to view safeguarding information</h2>
-              <p>You can give an organisation access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
-              <p>This may include highly sensitive material about the candidate.</p>
 
-              <h2 class="govuk-heading-m">Permission to view diversity information</h2>
-              <p>You can give an organisation access to information disclosed by the candidate in the ‘equality and diversity’ section of the application.</p>
+          <% details_body = capture do %>
+            <h2 class="govuk-heading-m">Permission to make decisions</h2>
+            <p>You can allow an organisation to make offers, amend offers and reject applications.</p>
+            <h2 class="govuk-heading-m">Permission to view safeguarding information</h2>
+            <p>You can give an organisation access to information disclosed in the ‘criminal convictions and professional misconduct’ section of the application.</p>
+            <p>This may include highly sensitive material about the candidate.</p>
 
-              <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted.</p>
-            </div>
-          </details>
+            <h2 class="govuk-heading-m">Permission to view diversity information</h2>
+            <p>You can give an organisation access to information disclosed by the candidate in the ‘equality and diversity’ section of the application.</p>
+
+            <p>To avoid any unconscious bias in the selection process, this information only becomes available to training providers after an offer has been made and accepted.</p>
+          <% end %>
+          <%= render DetailsComponent.new(summary_text: "More about permissions", details_body: details_body) %>
+
         </div>
       </div>
 

--- a/app/views/provider_interface/reconfirm_deferred_offers/start.html.erb
+++ b/app/views/provider_interface/reconfirm_deferred_offers/start.html.erb
@@ -18,16 +18,12 @@
           The details of the course you offered previously are not available in the current cycle.
         </p>
        <% end %>
-      <details class="govuk-details govuk-!-margin-bottom-0 app-details--no-boder" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            Details of deferred offer
-          </span>
-        </summary>
-        <div class="govuk-details__text govuk-!-padding-bottom-0">
-          <%= render ProviderInterface::DeferredOfferDetailsComponent.new(application_choice: @wizard.modified_application_choice) %>
-        </div>
-      </details>
+      <%= render DetailsComponent.new(
+          summary_text: 'Details of deferred offer',
+          details_body: render(ProviderInterface::DeferredOfferDetailsComponent.new(application_choice: @wizard.modified_application_choice)),
+          additional_css_classes: 'govuk-!-margin-bottom-0 app-details--no-boder',
+        )
+      %>
 
       <% unless @wizard.applicable? %>
         <p class="govuk-body-m govuk-!-margin-top-5">

--- a/app/views/support_interface/docs/candidate_flow.html.erb
+++ b/app/views/support_interface/docs/candidate_flow.html.erb
@@ -6,16 +6,11 @@
   This page documents the states and transitions that make up the Apply service, from the perspective of the candidate.
 </p>
 
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View full diagram
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <%= StateDiagram.svg(only_from_state: nil, machine: ProcessState) %>
-  </div>
-</details>
+<%= render DetailsComponent.new(
+  summary_text: 'View full diagram',
+  details_body: StateDiagram.svg(only_from_state: nil, machine: ProcessState),
+  )
+%>
 
 <style>
   svg { max-width: 100%; }

--- a/app/views/support_interface/docs/provider_flow.html.erb
+++ b/app/views/support_interface/docs/provider_flow.html.erb
@@ -6,16 +6,7 @@
   This page documents the states and transitions that make up the Apply service, from the perspective of the provider.
 </p>
 
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View full diagram
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <%= StateDiagram.svg(only_from_state: nil, machine: ApplicationStateChange) %>
-  </div>
-</details>
+<%= render DetailsComponent.new(summary_text: 'View full diagram', details_body: StateDiagram.svg(only_from_state: nil, machine: ApplicationStateChange)) %>
 
 <style>
   svg { max-width: 100%; }

--- a/spec/components/details_component_spec.rb
+++ b/spec/components/details_component_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe DetailsComponent do
+  let(:summary_text) { 'This is a summary text' }
+  let(:details_text) { 'This is a details text which will be shown once summary text is clicked' }
+  let(:details_text_with_html) { "This is a <span class='safe-html'>details text</span> which will be shown once summary text is clicked" }
+
+  it 'renders summary text' do
+    result = render_inline(described_class.new(summary_text: summary_text, details_body: details_text))
+
+    expect(result.css('.govuk-details__summary-text').text).to include('This is a summary text')
+  end
+
+  it 'renders plain details text' do
+    result = render_inline(described_class.new(summary_text: summary_text, details_body: details_text))
+
+    expect(result.css('.govuk-details__text').text).to include('This is a details text which will be shown once summary text is clicked')
+  end
+
+  it 'renders details text with HTML tags correctly' do
+    result = render_inline(described_class.new(summary_text: summary_text, details_body: details_text_with_html))
+
+    expect(result.css('.govuk-details__text > .safe-html').text).to include('details text')
+  end
+
+  it 'ensures details are not visible by default' do
+    result = render_inline(described_class.new(summary_text: summary_text, details_body: details_text))
+
+    expect(result.to_html).to include('<details class="govuk-details" data-module="govuk-details">')
+  end
+
+  it 'adds open attribute when `open` argument is true' do
+    result = render_inline(described_class.new(summary_text: summary_text, details_body: details_text, open: true))
+
+    expect(result.to_html).to include('<details class="govuk-details" data-module="govuk-details" open>')
+  end
+
+  it 'applies additonal css classes' do
+    result = render_inline(described_class.new(summary_text: summary_text, details_body: details_text, additional_css_classes: 'govuk-!-margin-top-2'))
+
+    expect(result.to_html).to include('<details class="govuk-details govuk-!-margin-top-2" data-module="govuk-details">')
+  end
+end


### PR DESCRIPTION
## Context

We use `<details>` HTML tag multiple time in all interfaces. It should be a component
## Changes proposed in this pull request

See commits for details. No visual change.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Ci0WZjb2/353-low-add-details-component

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
