### PR TITLE
Update to other qualification and work history back links

### DIFF
--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -2,7 +2,7 @@
 <% if current_application.application_qualifications.other.blank? %>
   <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 <% else %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path, 'Back') %>
+  <% content_for :before_content, govuk_back_link_to %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_job'), @work_experience_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% if current_application.application_work_experiences.present? %>
+  <% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
+<% else %>
+  <% content_for :before_content, govuk_back_link_to %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

Last 2 comments based off of previous back links work. The work history back link on the new viewneeds to redirect to the review page if a job already exists. The other qualification view is hard coded to the review page and needs to be a general back link.

## Changes proposed in this pull request

Back link updated on both views. In the case of the work history conditional has been used to overwrite general back link if job already present. Other Qual back link has been changed to a generic one.

## Guidance to review

Test that desired behaviour now in review app. Or we can merge to test in QA.

## Link to Trello card

https://trello.com/c/GJnkuuBK/2193-%F0%9F%94%99-back-on-add-job-should-return-you-to-first-question-how-long-have-you-been-working-if-first-job-section-review-page-if-subsequ
https://trello.com/c/DNyWaZgN/2196-%F0%9F%94%99-back-link-when-adding-details-of-an-other-qualification-takes-you-to-review-page-should-take-you-to-previous-question-in-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
