### PR TITLE
Send DSI API errors to Sentry

### DIFF
--- a/app/services/save_and_invite_provider_user.rb
+++ b/app/services/save_and_invite_provider_user.rb
@@ -16,11 +16,13 @@ class SaveAndInviteProviderUser
         save_service.call!
         invite_service.call! if new_user
       end
-    rescue DfeSignInAPIError
+    rescue DfeSignInAPIError => e
       form.errors.add(
         :base,
         'A problem occurred inviting this user. Please try again. If problems persist, please contact support.',
       )
+      Raven.capture_exception(e)
+
       return false
     end
 

--- a/spec/services/save_and_invite_provider_user_spec.rb
+++ b/spec/services/save_and_invite_provider_user_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe SaveAndInviteProviderUser do
     )
   end
   let(:provider_user) { form.build }
-  let(:save_service) { instance_double(SaveProviderUser, call!: true) }
+  let(:save_service) do
+    SaveProviderUser.new(
+      provider_user: provider_user,
+      provider_permissions: [],
+      deselected_provider_permissions: [],
+    )
+  end
   let(:invite_service) { instance_double(InviteProviderUser, call!: true) }
 
   describe '#initialize' do
@@ -26,6 +32,10 @@ RSpec.describe SaveAndInviteProviderUser do
   describe '#call!' do
     subject(:service) do
       described_class.new(form: form, save_service: save_service, invite_service: invite_service)
+    end
+
+    it 'saves the user' do
+      expect { service.call }.to change { ProviderUser.count }.by(1)
     end
 
     context 'form is invalid' do

--- a/spec/services/save_and_invite_provider_user_spec.rb
+++ b/spec/services/save_and_invite_provider_user_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe SaveAndInviteProviderUser do
         expect { service.call }.not_to change(ProviderUser, :count)
       end
 
+      it 'notifies Sentry' do
+        allow(Raven).to receive(:capture_exception)
+        service.call
+        expect(Raven).to have_received(:capture_exception)
+      end
+
       it 'populates form errors' do
         service.call
 


### PR DESCRIPTION
## Context

From Slack thread where Bill found a user who was created in Manage but not in DSI. Need more information to understand what went on here, so this should help us in the future.

We currently swallow these exceptions and don't report them to sentry, preferring to show the user a flash in the form.

## Changes proposed in this pull request

Send them to Sentry so we know about them.

## Guidance to review

Sending them to Sentry right?

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1601469929065800

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
