### PR TITLE
Support: Application details and history page layout improvements

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -104,7 +104,7 @@ module SupportInterface
       process_state = ProcessState.new(application_form).state
       name = I18n.t!("candidate_flow_application_states.#{process_state}.name")
       desc = I18n.t!("candidate_flow_application_states.#{process_state}.description")
-      "#{name} – #{desc}"
+      "<strong>#{name}</strong><br>#{desc}".html_safe
     end
 
     def ucas_match

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -31,7 +31,7 @@ module SupportInterface
     def last_updated_row
       {
         key: 'Last updated',
-        value: "#{updated_at.to_s(:govuk_date_and_time)} (#{govuk_link_to('See history', support_interface_application_form_audit_path(application_form))}, #{govuk_link_to('Emails about application', support_interface_email_log_path(application_form_id: application_form.id))})".html_safe,
+        value: updated_at.to_s(:govuk_date_and_time),
       }
     end
 

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% if yield(:title).present? && controller_name != 'errors' %>
-    <h1 class='govuk-heading-xl'><%= yield :title %></h1>
+    <h1 class="govuk-heading-xl"><%= yield :title %></h1>
   <% end %>
 
   <%= yield %>

--- a/app/views/support_interface/application_forms/_application_navigation.html.erb
+++ b/app/views/support_interface/application_forms/_application_navigation.html.erb
@@ -1,6 +1,4 @@
-<% content_for :before_content do %>
-  <%= render TabNavigationComponent.new(items: [
-    { name: 'Details', url: support_interface_application_form_path(@application_form) },
-    { name: 'History', url: support_interface_application_form_audit_path(@application_form) },
-  ]) %>
-<% end %>
+<%= render TabNavigationComponent.new(items: [
+  { name: 'Details', url: support_interface_application_form_path(@application_form) },
+  { name: 'History', url: support_interface_application_form_audit_path(@application_form) },
+]) %>

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,17 +1,18 @@
 <% content_for :browser_title, "Application history – Application ##{@application_form.id}" %>
-<% content_for :title do %>
-  <span class="govuk-caption-xl"><%= break_email_address(@application_form.candidate.email_address) %></span>
-  Application history
-<% end %>
 
 <%= render 'support_interface/candidates/candidates_navigation', current: 'Applications' %>
+
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+  <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
+  <%= break_email_address(@application_form.candidate.email_address) %>
+</h1>
+
+<p class="govuk-body govuk-!-margin-bottom-6">
+  <%= govuk_link_to 'Emails about this application', support_interface_email_log_path(application_form_id: @application_form.id), class: 'govuk-link--no-visited-state' %>
+</p>
 
 <%= render 'application_navigation' %>
 
 <%= govuk_button_link_to 'Add comment', support_interface_application_form_new_comment_path %>
-
-<p class="govuk-body">
-  <%= govuk_link_to 'View all emails about this application', support_interface_email_log_path(application_form_id: @application_form.id) %>
-</p>
 
 <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @application_form) %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,10 +1,15 @@
-<% content_for :browser_title, title_with_success_prefix("Application ##{@application_form.id}", flash[:success].present?) %>
-<% content_for :title do %>
-  <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
-  <%= break_email_address(@application_form.candidate.email_address) %>
-<% end %>
+<% content_for :browser_title, title_with_success_prefix("Application details – Application ##{@application_form.id}", flash[:success].present?) %>
 
 <%= render 'support_interface/candidates/candidates_navigation', current: 'Applications' %>
+
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+  <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
+  <%= break_email_address(@application_form.candidate.email_address) %>
+</h1>
+
+<p class="govuk-body govuk-!-margin-bottom-6">
+  <%= govuk_link_to 'Emails about this application', support_interface_email_log_path(application_form_id: @application_form.id), class: 'govuk-link--no-visited-state' %>
+</p>
 
 <%= render 'application_navigation' %>
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -15,19 +15,19 @@
 
 <%= render SupportInterface::ApplicationSummaryComponent.new(application_form: @application_form) %>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-8">Personal details</h2>
-
-<%= render PersonalDetailsComponent.new(application_form: @application_form) %>
-
 <% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), class: 'govuk-button' %>
+  <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
 <% end %>
 
 <% if @application_form.candidate.hide_in_reporting? %>
-  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
 <% else %>
-  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
 <% end %>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-8">Personal details</h2>
+
+<%= render PersonalDetailsComponent.new(application_form: @application_form) %>
 
 <% if @application_form.application_choices.any? %>
   <h2 class="govuk-heading-l govuk-!-margin-top-8">Course choices</h2>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -58,9 +58,6 @@
   <% end %>
 <% end %>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-1" id="qualifications">Qualifications</h2>
-<p class='govuk-hint govuk-!-margin-top-0'>(HESA codes in brackets, where relevant)</p>
-
 <%= render QualificationsComponent.new(application_form: @application_form, show_hesa_codes: true) %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Work history</h2>

--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -7,13 +7,13 @@
 <%= render 'support_interface/candidates/candidates_navigation', current: 'Candidates' %>
 
 <% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@candidate), class: 'govuk-button' %>
+  <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@candidate), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
 <% end %>
 
 <% if @candidate.hide_in_reporting? %>
-  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
 <% else %>
-  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
 <% end %>
 
 <% unless @application_forms.empty? %>


### PR DESCRIPTION
## Context

Ensuring the navigation and information shown above it on the details and history pages is consistent. Also:

* Move email links from different locations on each page to below header
* Move ‘Sign in as this candidate’ and ‘Include/exclude’ buttons up to nearer top of details page
* Update display of application status in summary list
* Remove duplicated ‘Qualifications’ heading on details page

## Changes proposed in this pull request

| Before | After |
| - | - |
| ![application-details-before](https://user-images.githubusercontent.com/813383/94712185-06fe0380-0341-11eb-86af-459dd47a012b.png) | ![application-details-after](https://user-images.githubusercontent.com/813383/94709208-64905100-033d-11eb-8bc9-dd9a3f4dd954.png) |
| ![application-history-before](https://user-images.githubusercontent.com/813383/94712199-0b2a2100-0341-11eb-8aea-50c3c750b712.png) | ![application-history-after](https://user-images.githubusercontent.com/813383/94709233-6b1ec880-033d-11eb-98d3-07028473de48.png) |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
