### PR TITLE
Support: Provider/Provider User page layout improvements

### DIFF
--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -66,7 +66,8 @@ module SupportInterface
     end
 
     def audits
-      @provider_user = ProviderUser.find(params[:provider_user_id])
+      provider_user = ProviderUser.find(params[:provider_user_id])
+      @form = ProviderUserForm.from_provider_user(provider_user)
     end
 
   private

--- a/app/frontend/styles/support/_checkboxes-scroll.scss
+++ b/app/frontend/styles/support/_checkboxes-scroll.scss
@@ -1,5 +1,17 @@
 .app-checkboxes-scroll {
-  max-height: 13.5em;
+  border: 1px solid $govuk-border-colour;
+  height: 75vh;
+  min-height: 13.5em;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
+  padding: govuk-spacing(2);
+}
+
+.app-checkboxes-scroll::-webkit-scrollbar {
+  width: 20px;
+}
+
+.app-checkboxes-scroll::-webkit-scrollbar-thumb {
+  background-color: govuk-colour("mid-grey");
+  border: $govuk-border-width solid govuk-colour("white");
 }

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,23 +1,25 @@
 <%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Edit providers and permissions', tag: 'h2' } do %>
-  <% f.object.forms_for_possible_permissions.each do |permission_form| %>
-    <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
-      <%= pf.govuk_check_box :active, true, multiple: false,
-                              label: { text: permission_form.provider.name_and_code } do %>
-        <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
-          <%= ppf.hidden_field :provider_id %>
-          <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-            <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
-            <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
-                                    label: { text: 'Manage organisations' } %>
-            <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
-                                    label: { text: 'Make decisions' } %>
-            <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
-                                    label: { text: 'Access safeguarding information' } %>
-            <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
-                                    label: { text: 'Access diversity information' } %>
+  <div class="app-checkboxes-scroll govuk-!-width-two-thirds">
+    <% f.object.forms_for_possible_permissions.each do |permission_form| %>
+      <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
+        <%= pf.govuk_check_box :active, true, multiple: false,
+                               label: { text: permission_form.provider.name_and_code } do %>
+          <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+            <%= ppf.hidden_field :provider_id %>
+            <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
+              <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+              <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
+                                      label: { text: 'Manage organisations' } %>
+              <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
+                                      label: { text: 'Make decisions' } %>
+              <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
+                                      label: { text: 'Access safeguarding information' } %>
+              <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
+                                      label: { text: 'Access diversity information' } %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>
     <% end %>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,25 +1,23 @@
-<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Providers and permissions', tag: 'h2' } do %>
-  <div class="app-checkboxes-scroll" %>
-    <% f.object.forms_for_possible_permissions.each do |permission_form| %>
-      <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
-        <%= pf.govuk_check_box :active, true, multiple: false,
-                               label: { text: permission_form.provider.name_and_code } do %>
-          <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
-            <%= ppf.hidden_field :provider_id %>
-            <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-              <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
-              <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
-                                      label: { text: 'Manage organisations' } %>
-              <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
-                                      label: { text: 'Make decisions' } %>
-              <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
-                                      label: { text: 'Access safeguarding information' } %>
-              <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
-                                      label: { text: 'Access diversity information' } %>
-            <% end %>
+<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Edit providers and permissions', tag: 'h2' } do %>
+  <% f.object.forms_for_possible_permissions.each do |permission_form| %>
+    <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
+      <%= pf.govuk_check_box :active, true, multiple: false,
+                              label: { text: permission_form.provider.name_and_code } do %>
+        <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+          <%= ppf.hidden_field :provider_id %>
+          <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
+            <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+            <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
+                                    label: { text: 'Manage organisations' } %>
+            <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
+                                    label: { text: 'Make decisions' } %>
+            <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
+                                    label: { text: 'Access safeguarding information' } %>
+            <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
+                                    label: { text: 'Access diversity information' } %>
           <% end %>
         <% end %>
       <% end %>
     <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+  <span class="govuk-caption-xl">Provider user</span>
+  <%= @form.provider_user.full_name %>
+<% end %>
+
+<%= render TabNavigationComponent.new(items: [
+  { name: 'Details', url: edit_support_interface_provider_user_path(@form.provider_user), current: local_assigns[:current] == 'Details' },
+  { name: 'History', url: support_interface_provider_user_audits_path(@form.provider_user), current: local_assigns[:current] == 'History' },
+]) %>

--- a/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
@@ -4,6 +4,6 @@
 <% end %>
 
 <%= render TabNavigationComponent.new(items: [
-  { name: 'Details', url: edit_support_interface_provider_user_path(@form.provider_user), current: local_assigns[:current] == 'Details' },
-  { name: 'History', url: support_interface_provider_user_audits_path(@form.provider_user), current: local_assigns[:current] == 'History' },
+  { name: 'Details', url: edit_support_interface_provider_user_path(@form.provider_user) },
+  { name: 'History', url: support_interface_provider_user_audits_path(@form.provider_user) },
 ]) %>

--- a/app/views/support_interface/provider_users/audits.html.erb
+++ b/app/views/support_interface/provider_users/audits.html.erb
@@ -1,20 +1,7 @@
-<% content_for :browser_title, "History for provider user #{@provider_user.full_name}" %>
+<% content_for :browser_title, "History - #{@form.provider_user.full_name}" %>
 
 <%= render 'support_interface/providers/providers_navigation', current: 'Provider users' %>
 
-<% content_for :before_content do %>
-  <%= render TabNavigationComponent.new(items: [
-    { name: 'Details', url: edit_support_interface_provider_user_path(@provider_user) },
-    { name: 'History', url: support_interface_provider_user_audits_path(@provider_user), current: true },
-  ]) %>
-<% end %>
+<%= render 'provider_user_navigation', current: 'History' %>
 
-<h1 class='govuk-heading-xl'>
-  History for provider user <%= @provider_user.full_name %>
-</h1>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider_user) %>
-  </div>
-</div>
+<%= render SupportInterface::AuditTrailComponent.new(audited_thing: @form.provider_user) %>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -1,35 +1,22 @@
-<% content_for :browser_title, title_with_error_prefix("Edit provider user #{@form.provider_user.full_name}", @form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix("Edit - #{@form.provider_user.full_name}", @form.errors.any?) %>
 
 <%= render 'support_interface/providers/providers_navigation', current: 'Provider users' %>
 
-<% content_for :before_content do %>
-  <%= render TabNavigationComponent.new(items: [
-    { name: 'Details', url: edit_support_interface_provider_user_path(@form.provider_user), current: true },
-    { name: 'Audit trail', url: support_interface_provider_user_audits_path(@form.provider_user) },
-  ]) %>
+<%= render 'provider_user_navigation', current: 'Details' %>
+
+<%= form_with model: @form, url: support_interface_provider_user_path(@form.provider_user) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= render SummaryListComponent.new(rows: {
+    'First name' => @form.provider_user.first_name,
+    'Last name' => @form.provider_user.last_name,
+    'Email address' => @form.provider_user.email_address,
+    'DfE Sign-in UID' => @form.provider_user.dfe_sign_in_uid,
+    'Account created at' => @form.provider_user.created_at.to_s(:govuk_date_and_time),
+    'Last sign in at' => @form.provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet',
+  }) %>
+
+  <%= render 'provider_options', f: f %>
+
+  <%= f.govuk_submit 'Update user' %>
 <% end %>
-
-<h1 class='govuk-heading-xl'>
-  Provider user <%= @form.provider_user.full_name %> - Edit
-</h1>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: support_interface_provider_user_path(@form.provider_user) do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= render SummaryListComponent.new(rows: {
-        'First name' => @form.provider_user.first_name,
-        'Last name' => @form.provider_user.last_name,
-        'Email address' => @form.provider_user.email_address,
-        'DfE Sign-in UID' => @form.provider_user.dfe_sign_in_uid,
-        'Account created at' => @form.provider_user.created_at.to_s(:govuk_date_and_time),
-        'Last sign in at' => @form.provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet',
-      }) %>
-
-      <%= render 'provider_options', f: f %>
-
-      <%= f.govuk_submit 'Update user' %>
-    <% end %>
-  </div>
-</div>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'support_interface/providers/providers_navigation', current: 'Provider users' %>
 
-<%= render 'provider_user_navigation', current: 'Details' %>
+<%= render 'provider_user_navigation' %>
 
 <%= form_with model: @form, url: support_interface_provider_user_path(@form.provider_user) do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@provider.name_and_code} - #{title}" %>
+<% content_for :title, "#{@provider.name_and_code}" %>
 
 <% content_for :before_content, govuk_back_link_to(support_interface_providers_path, 'Back to providers') %>
 
@@ -13,4 +13,4 @@
   { name: 'History', url: support_interface_provider_history_path },
 ]) %>
 
-<h2 class='govuk-heading-l'><%= title %></h2>
+<h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -3,9 +3,7 @@
 <% if @provider.sync_courses? %>
   <% unless @courses[RecruitmentCycle.current_year].to_a.all?(&:open_on_apply?) %>
     <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>
-      <h3 class="govuk-heading-m">
-        Open all courses
-      </h3>
+      <h3 class="govuk-heading-m">Open all courses</h3>
 
       <p class="govuk-body">This will toggle every course on this provider to be available through Apply.</p>
 
@@ -24,17 +22,13 @@
 
       <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @courses[year])) %>
     <% else %>
-      <h3 class='govuk-heading-m'><%= year %>: No courses</h3>
+      <h3 class="govuk-heading-m"><%= year %>: No courses</h3>
 
-      <p class='govuk-body'>
-        There aren't any courses for <%= year %>.
-      </p>
+      <p class="govuk-body">There aren’t any courses for <%= year %>.</p>
     <% end %>
   <% end %>
 <% else %>
-  <p class='govuk-body'>
-    There aren't any courses for this provider because the courses aren't synced yet.
-  </p>
+  <p class="govuk-body">There aren’t any courses for this provider because the courses aren’t synced yet.</p>
 
   <%= form_with model: @provider, url: support_interface_enable_provider_course_syncing_path(@provider), method: :post do |f| %>
     <%= f.govuk_submit 'Enable course syncing from Find' %>

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -3,30 +3,30 @@
 <%= render 'providers_navigation' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @providers) do %>
-  <table class='govuk-table'>
-    <thead class='govuk-table__head'>
-      <tr class='govuk-table__row'>
-        <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Provider Name</th>
-        <th scope='col' class='govuk-table__header'>Courses</th>
-        <th scope='col' class='govuk-table__header'>Sites</th>
-        <th scope='col' class='govuk-table__header'>DSA signed date</th>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
+        <th scope="col" class="govuk-table__header">Courses</th>
+        <th scope="col" class="govuk-table__header">Sites</th>
+        <th scope="col" class="govuk-table__header">DSA signed date</th>
       </tr>
     </thead>
 
-    <tbody class='govuk-table__body'>
+    <tbody class="govuk-table__body">
       <% @providers.each do |provider| %>
-        <tr class='govuk-table__row'>
-          <td class='govuk-table__cell'>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
             <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
           </td>
-          <td class='govuk-table__cell'>
+          <td class="govuk-table__cell">
             <%= pluralize provider.courses.size, 'course' %><br/>
             <%= provider.courses.open_on_apply.size %> on DfE Apply
           </td>
-          <td class='govuk-table__cell'>
+          <td class="govuk-table__cell">
             <%= provider.sites.size %>
           </td>
-          <td class='govuk-table__cell'>
+          <td class="govuk-table__cell">
             <% if provider.provider_agreements.data_sharing_agreements.any? %>
               <%= provider.provider_agreements.data_sharing_agreements.first.accepted_at.to_s(:govuk_date) %>
             <% else %>

--- a/app/views/support_interface/providers/other_providers.html.erb
+++ b/app/views/support_interface/providers/other_providers.html.erb
@@ -3,17 +3,17 @@
 <%= render 'providers_navigation' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @providers) do %>
-  <table class='govuk-table'>
-    <thead class='govuk-table__head'>
-      <tr class='govuk-table__row'>
-        <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Provider Name</th>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
       </tr>
     </thead>
 
-    <tbody class='govuk-table__body'>
+    <tbody class="govuk-table__body">
       <% @providers.each do |provider| %>
-        <tr class='govuk-table__row'>
-          <td class='govuk-table__cell'>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
             <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
           </td>
         </tr>

--- a/app/views/support_interface/providers/ratified_courses.html.erb
+++ b/app/views/support_interface/providers/ratified_courses.html.erb
@@ -2,14 +2,12 @@
 
 <% RecruitmentCycle.years_visible_in_support.each do |year| %>
   <% if @ratified_courses[year] %>
-    <h3 class='govuk-heading-m'><%= year %>: ratifies <%= pluralize(@ratified_courses[year].size, 'course') %> (<%= @ratified_courses[year].count(&:open_on_apply?) %> on DfE Apply)</h3>
+    <h3 class="govuk-heading-m"><%= year %>: ratifies <%= pluralize(@ratified_courses[year].size, 'course') %> (<%= @ratified_courses[year].count(&:open_on_apply?) %> on DfE Apply)</h3>
 
     <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @ratified_courses[year])) %>
   <% else %>
-    <h3 class='govuk-heading-m'><%= year %>: No courses</h3>
+    <h3 class="govuk-heading-m"><%= year %>: No courses</h3>
 
-    <p class='govuk-body'>
-      There aren't any courses for <%= year %>.
-    </p>
+    <p class="govuk-body">There aren’t any courses for <%= year %>.</p>
   <% end %>
 <% end %>

--- a/app/views/support_interface/providers/sites.html.erb
+++ b/app/views/support_interface/providers/sites.html.erb
@@ -1,18 +1,18 @@
 <%= render 'provider_navigation', title: 'Sites' %>
 
-<table class='govuk-table'>
-  <thead class='govuk-table__head'>
-    <tr class='govuk-table__row'>
-      <th scope='col' class='govuk-table__header'>Name</th>
-      <th scope='col' class='govuk-table__header'>Address</th>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Address</th>
     </tr>
   </thead>
 
-  <tbody class='govuk-table__body'>
+  <tbody class="govuk-table__body">
     <% @provider.sites.each do |site| %>
-      <tr class='govuk-table__row'>
-        <td class='govuk-table__cell'><%= site.name_and_code %></td>
-        <td class='govuk-table__cell'><%= site.full_address %></td>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= site.name_and_code %></td>
+        <td class="govuk-table__cell"><%= site.full_address %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature 'Managing provider users' do
   end
 
   def when_i_click_the_audit_trail_tab
-    click_on 'Audit trail'
+    click_on 'History'
   end
 
   def then_i_should_see_the_audit_trail_for_that_user_record

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'See provider course syncing' do
   end
 
   def then_i_see_that_course_syncing_is_off
-    expect(page).to have_content('There aren\'t any courses for this provider because the courses aren\'t synced yet')
+    expect(page).to have_content('There aren’t any courses for this provider because the courses aren’t synced yet')
   end
 
   def when_i_click_on_the_enable_course_syncing_button
@@ -55,7 +55,7 @@ RSpec.feature 'See provider course syncing' do
   end
 
   def then_i_see_that_course_syncing_is_on
-    expect(page).not_to have_content('There aren\'t any courses for this provider because the courses aren\'t synced yet')
+    expect(page).not_to have_content('There aren’t any courses for this provider because the courses aren’t synced yet')
   end
 
   def when_provider_syncing_runs


### PR DESCRIPTION
## Context

Tidy up of navigation and layout for provider and provider user views, including removing repetition of page titles three times 😮

(Was there any reason why we show provider user permissions within a scrollable `div`? Doing this creates two scroll separate vertical scrollbars on the page, making this more difficult to use.)

## Changes proposed in this pull request

| Before | After |
| - | - |
| ![provider-details-before](https://user-images.githubusercontent.com/813383/94720395-54cc3900-034c-11eb-8b3f-caef904a8d6f.png) | ![provider-details-after](https://user-images.githubusercontent.com/813383/94720374-4ed65800-034c-11eb-959e-4cb5c2e3ab79.png) |
| ![provider-user-before](https://user-images.githubusercontent.com/813383/94720423-5c8bdd80-034c-11eb-8e47-b35a40632d63.png) | ![provider-user-after](https://user-images.githubusercontent.com/813383/94721011-2307a200-034d-11eb-9d80-c36de89d214b.png) |

## Guidance to review

Updated `ProviderUsersController` to provide same page variables for `edit` and `audits`; are my changes correct?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
