### PR TITLE
Speed up provider user forms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,3 +162,6 @@ Layout/FirstMethodArgumentLineBreak:
 # 🤷‍♂️
 Style/AsciiComments:
   Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false


### PR DESCRIPTION
## Context

We currently make 1400 queries to build the new / edit provider user page, which is a looot. And that's with 350 providers! If we sync all 2000 providers, this would increase to 7,811.

## Changes proposed in this pull request

This fixes the N+1's by:

- Memoizing the possible_permissions, because we're calling this method twice.
- Fetching all the current user's permissions in one go, and doing a lookup in Ruby
- Populating the `provider` object in case we haven't found a `ProviderPermissions` record, so that we don't have to make a query for that again.

This reduces the number of queries to 3 or 4 

## Guidance to review

OK?

## Link to Trello card

https://trello.com/c/HwAFHcKS

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
