### PR TITLE
Ensure presence of equivalency_details in API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -207,8 +207,18 @@ module VendorAPI
         award_year: qualification.award_year,
         institution_details: institution_details(qualification),
         awarding_body: qualification.awarding_body,
-        equivalency_details: qualification.equivalency_details,
+        equivalency_details: composite_equivalency_details(qualification),
       }.merge HesaQualificationFieldsPresenter.new(qualification).to_hash
+    end
+
+    def composite_equivalency_details(qualification)
+      details = [
+        ("Naric: #{qualification.naric_reference}" if qualification.naric_reference),
+        qualification.comparable_uk_qualification,
+        qualification.equivalency_details,
+      ].compact.join(' - ')
+
+      details.strip if details.present? # return nil instead of empty string
     end
 
     def institution_details(qualification)

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,9 +1,13 @@
-### 6th October 2020
+### 8th October 2020
 
 New attributes:
 
 - `Candidate` now has a `domicile` attribute of type string, returning a two-letter country code (ISO 3166-2). Its value is derived from the candidate's address.
 - `Qualification` now includes attributes for HESA qualification codes, if the qualification is degree-level. The attributes are: `hesa_degtype`, `hesa_degsbj`, `hesa_degclss`, `hesa_degest`, `hesa_degctry`, `hesa_degstdt`, `hesa_degenddt`.
+
+Changes to existing attributes:
+
+- The `equivalency_details` attribute of `Qualification` will now contain a NARIC code and its description, if these are avalailable. Example: 'Naric: 4000123456 - Between GCSE and GCSE AS Level - Equivalent to GCSE C'
 
 ### 5th October 2020
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -759,7 +759,7 @@ components:
         equivalency_details:
           type: string
           description: Details of equivalency, if this qualification was awarded overseas
-          example: Equivalent to GCSE C
+          example: 'Naric: 4000123456 - Between GCSE and GCSE AS Level - Equivalent to GCSE C'
           maxLength: 256
           nullable: true
         awarding_body:

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -368,5 +368,43 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       expect(qualification_hash).to have_key(:hesa_degstdt)
     end
+
+    it 'contains equivalency_details' do
+      qualification = create(
+        :other_qualification,
+        :non_uk,
+        application_form: application_choice.application_form,
+      )
+
+      equivalency_details = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :other_qualifications,
+      ).first[:equivalency_details]
+
+      expect(equivalency_details).to eq(qualification.equivalency_details)
+    end
+
+    it 'adds NARIC information, if present, to equivalency_details' do
+      qualification = create(
+        :gcse_qualification,
+        :non_uk,
+        application_form: application_choice.application_form,
+      )
+
+      equivalency_details = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :gcses,
+      ).first[:equivalency_details]
+
+      composite_equivalency_details = [
+        "Naric: #{qualification.naric_reference}",
+        qualification.comparable_uk_qualification,
+        qualification.equivalency_details,
+      ].join(' - ')
+
+      expect(equivalency_details).to eq(composite_equivalency_details)
+    end
   end
 end


### PR DESCRIPTION
## Context

Trivial PR, as `equivalency_details` is already included in API responses.

## Changes proposed in this pull request

Add spec verifying `equivalency_details` is part of the API responses.

## Guidance to review

Easiest review ever.

## Link to Trello card

https://trello.com/c/bOYfMiKj

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
