### PR TITLE
Only send completed references over the API

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -156,7 +156,7 @@ module VendorAPI
     end
 
     def references
-      application_form.application_references.map do |reference|
+      application_form.application_references.feedback_provided.map do |reference|
         reference_to_hash(reference)
       end
     end


### PR DESCRIPTION
We were sending all references, including ones that had been cancelled
or had no feedback.

## Context

Pointed out by an HEI 😬

## Changes proposed in this pull request

Put a scope on the application_references in the API

