### PR TITLE
Decoupled reference flow (part3)

### DIFF
--- a/app/controllers/candidate_interface/decoupled_references/description_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/description_controller.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  module DecoupledReferences
+    class DescriptionController < BaseController
+      before_action :set_reference
+
+      def new; end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -1,0 +1,26 @@
+module CandidateInterface
+  module DecoupledReferences
+    class EmailAddressController < BaseController
+      before_action :set_reference
+
+      def new
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.new
+      end
+
+      def create
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(email_address: referee_email_address_param)
+        return render :new unless @reference_email_address_form.valid?
+
+        @reference_email_address_form.save(@reference)
+
+        redirect_to candidate_interface_decoupled_references_new_description_path(@reference.id)
+      end
+
+    private
+
+      def referee_email_address_param
+        params.dig(:candidate_interface_reference_referee_email_address_form, :email_address)
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
       end
 
       def create
-        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(email_address: referee_email_address_param)
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
         return render :new unless @reference_email_address_form.valid?
 
         @reference_email_address_form.save(@reference)
@@ -19,7 +19,8 @@ module CandidateInterface
     private
 
       def referee_email_address_param
-        params.dig(:candidate_interface_reference_referee_email_address_form, :email_address)
+        params.require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
+        .merge!(application_form_id: current_application.id)
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/email_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_controller.rb
@@ -1,9 +1,0 @@
-module CandidateInterface
-  module DecoupledReferences
-    class EmailController < BaseController
-      before_action :set_reference
-
-      def new; end
-    end
-  end
-end

--- a/app/controllers/candidate_interface/decoupled_references/name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/name_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
         @reference_name_form.save(@reference)
 
-        redirect_to candidate_interface_decoupled_references_new_email_path(@reference.id)
+        redirect_to candidate_interface_decoupled_references_new_email_address_path(@reference.id)
       end
 
     private

--- a/app/controllers/candidate_interface/decoupled_references/name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/name_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
       end
 
       def create
-        @reference_name_form = Reference::RefereeNameForm.new(name: referee_name_param)
+        @reference_name_form = Reference::RefereeNameForm.new(referee_name_param)
         return render :new unless @reference_name_form.valid?
 
         @reference_name_form.save(@reference)
@@ -19,7 +19,7 @@ module CandidateInterface
     private
 
       def referee_name_param
-        params.dig(:candidate_interface_reference_referee_name_form, :name)
+        params.require(:candidate_interface_reference_referee_name_form).permit(:name)
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -6,7 +6,7 @@ module CandidateInterface
       end
 
       def create
-        @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
+        @reference_type_form = Reference::RefereeTypeForm.new(referee_type_param)
         return render :new unless @reference_type_form.valid?
 
         @reference_type_form.save(current_application)
@@ -24,7 +24,7 @@ module CandidateInterface
       end
 
       def referee_type_param
-        params.dig(:candidate_interface_reference_referee_type_form, :referee_type)
+        params.require(:candidate_interface_reference_referee_type_form).permit(:referee_type)
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -16,13 +16,6 @@ module CandidateInterface
 
     private
 
-      def set_reference
-        @reference = current_candidate.current_application
-                                      .application_references
-                                      .includes(:application_form)
-                                      .find_by(id: params[:id])
-      end
-
       def referee_type_param
         params.require(:candidate_interface_reference_referee_type_form).permit(:referee_type)
       end

--- a/app/controllers/candidate_interface/decoupled_references_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references_controller.rb
@@ -1,0 +1,40 @@
+module CandidateInterface
+  class DecoupledReferencesController < CandidateInterfaceController
+    before_action :redirect_to_application_form_if_flag_is_not_active
+    before_action :set_reference, only: %i[name]
+
+    def start; end
+
+    def type
+      @reference_type_form = Reference::RefereeTypeForm.new
+    end
+
+    def update_type
+      @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
+      return render :type unless @reference_type_form.valid?
+
+      @reference_type_form.save(current_application)
+
+      redirect_to candidate_interface_decoupled_references_name_path(current_application.application_references.last.id)
+    end
+
+    def name; end
+
+  private
+
+    def redirect_to_application_form_if_flag_is_not_active
+      redirect_to candidate_interface_application_form_path unless FeatureFlag.active?('decoupled_references')
+    end
+
+    def set_reference
+      @reference = current_candidate.current_application
+                                    .application_references
+                                    .includes(:application_form)
+                                    .find_by(id: params[:id])
+    end
+
+    def referee_type_param
+      params.dig(:candidate_interface_reference_referee_type_form, :referee_type)
+    end
+  end
+end

--- a/app/forms/candidate_interface/reference/referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/referee_email_address_form.rb
@@ -2,9 +2,15 @@ module CandidateInterface
   class Reference::RefereeEmailAddressForm
     include ActiveModel::Model
 
-    attr_accessor :email_address
+    attr_accessor :email_address, :application_form_id
 
-    validates :email_address, presence: true
+    validates :email_address, presence: true,
+                              email_address: true,
+                              length: { maximum: 100 }
+
+    validates :application_form_id, presence: true
+
+    validate :email_address_unique?
 
     def self.build_from_reference(reference)
       new(email_address: reference.email_address)
@@ -14,6 +20,16 @@ module CandidateInterface
       return false unless valid?
 
       reference.update!(email_address: email_address)
+    end
+
+  private
+
+    def email_address_unique?
+      application_form = ApplicationForm.find(application_form_id)
+      current_email_addresses = application_form.application_references.map(&:email_address).compact
+      return true if current_email_addresses.blank?
+
+      errors.add(:email_address, :duplicate) if current_email_addresses.map(&:downcase).include?(email_address)
     end
   end
 end

--- a/app/forms/candidate_interface/reference/referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/referee_email_address_form.rb
@@ -1,0 +1,19 @@
+module CandidateInterface
+  class Reference::RefereeEmailAddressForm
+    include ActiveModel::Model
+
+    attr_accessor :email_address
+
+    validates :email_address, presence: true
+
+    def self.build_from_reference(reference)
+      new(email_address: reference.email_address)
+    end
+
+    def save(reference)
+      return false unless valid?
+
+      reference.update!(email_address: email_address)
+    end
+  end
+end

--- a/app/views/candidate_interface/decoupled_references/email/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email/new.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, t('page_titles.references_email_address') %>
+<% content_for :before_content, govuk_back_link_to %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_create_email_path(@reference.id) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">
+          <%= @reference.name %>
+        </span>
+        <%= t('page_titles.references_email_address') %>
+      </h1>
+
+      <% if HostingEnvironment.sandbox_mode? %>
+        <div class="app-status-box app-status-box--sandbox govuk-!-margin-bottom-4">
+          <p class="govuk-body">
+            <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag govuk-tag--purple">
+              sandbox feature
+            </strong>
+          </p>
+          <p class="govuk-body govuk-!-margin-bottom-0">
+            Enter <code>refbot1@example.com</code> and <code>refbot2@example.com</code> as your referee email addresses to have the references automatically completed
+          </p>
+        </div>
+      <% end %>
+      <%= f.govuk_text_field :email_address, type: 'email', label: { text: '' }, hint_text: 'In most cases, this should be a work address.' %>
+
+      <%= f.govuk_submit 'Save and continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/decoupled_references/email_address/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_create_email_path(@reference.id) do |f| %>
+    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_create_email_address_path(@reference.id) do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/decoupled_references/email_address/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/new.html.erb
@@ -7,13 +7,6 @@
     <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_create_email_address_path(@reference.id) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">
-          <%= @reference.name %>
-        </span>
-        <%= t('page_titles.references_email_address') %>
-      </h1>
-
       <% if HostingEnvironment.sandbox_mode? %>
         <div class="app-status-box app-status-box--sandbox govuk-!-margin-bottom-4">
           <p class="govuk-body">
@@ -26,7 +19,12 @@
           </p>
         </div>
       <% end %>
-      <%= f.govuk_text_field :email_address, type: 'email', label: { text: '' }, hint_text: 'In most cases, this should be a work address.' %>
+
+      <span class="govuk-caption-xl">
+        <%= @reference.name %>
+      </span>
+
+      <%= f.govuk_text_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-!-margin-top-0'), size: 'm' }, hint_text: 'In most cases, this should be a work address.' %>
 
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>

--- a/app/views/candidate_interface/decoupled_references/name/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/name/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references_name') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_referees_type_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -814,6 +814,7 @@ en:
             email_address:
               blank: Enter your referees email address
               invalid: Enter an email address in the correct format, like name@example.com
+              duplicate: Please give a different email address for each referee
         referee_interface/reference_relationship_form:
           attributes:
             relationship_confirmation:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -809,6 +809,11 @@ en:
           attributes:
             name:
               blank: Enter your referees name
+        candidate_interface/reference/referee_email_address_form:
+          attributes:
+            email_address:
+              blank: Enter your referees email address
+              invalid: Enter an email address in the correct format, like name@example.com
         referee_interface/reference_relationship_form:
           attributes:
             relationship_confirmation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
       finish: Thank you
     references_start: Choose your referees
     references_name: What is the referee’s name?
+    references_email_address: What is the referee’s email address?
     providers: Courses on this service
     view_and_respond_to_offer: Details of offer
     api_docs:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,7 @@ Rails.application.routes.draw do
         post '/name/:id' => 'decoupled_references/name#create', as: :decoupled_references_create_name
 
         get '/email/:id' => 'decoupled_references/email#new', as: :decoupled_references_new_email
+        post '/email/:id' => 'decoupled_references/email#create', as: :decoupled_references_create_email
 
         get '/review' => 'decoupled_references/review#show', as: :decoupled_references_review
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,8 +400,10 @@ Rails.application.routes.draw do
         get '/name/:id' => 'decoupled_references/name#new', as: :decoupled_references_new_name
         post '/name/:id' => 'decoupled_references/name#create', as: :decoupled_references_create_name
 
-        get '/email/:id' => 'decoupled_references/email#new', as: :decoupled_references_new_email
-        post '/email/:id' => 'decoupled_references/email#create', as: :decoupled_references_create_email
+        get '/email/:id' => 'decoupled_references/email_address#new', as: :decoupled_references_new_email_address
+        post '/email/:id' => 'decoupled_references/email_address#create', as: :decoupled_references_create_email_address
+
+        get '/description/:id' => 'decoupled_references/description#new', as: :decoupled_references_new_description
 
         get '/review' => 'decoupled_references/review#show', as: :decoupled_references_review
       end

--- a/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
@@ -1,8 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :model do
+  before do
+    FeatureFlag.activate('decoupled_references')
+  end
+
   describe 'validations' do
+    let(:form) { subject }
+
+    before do
+      allow(form).to receive(:email_address_unique?).and_return true
+    end
+
     it { is_expected.to validate_presence_of(:email_address) }
+    it { is_expected.to validate_presence_of(:application_form_id) }
+
+    one_hundred_character_email = "#{SecureRandom.hex(44)}@example.com"
+    one_hundred_and_two_character_email = "#{SecureRandom.hex(45)}@example.com"
+
+    it { is_expected.to allow_value(one_hundred_character_email).for(:email_address) }
+    it { is_expected.not_to allow_value(one_hundred_and_two_character_email).for(:email_address) }
+
+    context 'when a duplicate email is given' do
+      it 'is not valid' do
+        application_form = create(:application_form)
+        create(:reference, email_address: 'iamtheone@whoknocks.com', application_form: application_form)
+        application_reference = create(:reference, email_address: nil)
+
+        form = described_class.new(email_address: 'iamtheone@whoknocks.com', application_form_id: application_form.id)
+        expect(form.save(application_reference)).to be(false)
+      end
+    end
   end
 
   describe '.build_from_reference' do
@@ -17,21 +45,9 @@ RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :mo
   describe '#save' do
     let(:application_reference) { create(:reference) }
 
-    before do
-      FeatureFlag.activate('decoupled_references')
-    end
-
-    context 'when email_address is blank' do
-      it 'returns false' do
-        form = described_class.new
-
-        expect(form.save(application_reference)).to be(false)
-      end
-    end
-
     context 'when email_address has a value' do
       it 'creates the referee' do
-        form = described_class.new(email_address: 'iamtheone@whoknocks.com')
+        form = described_class.new(email_address: 'iamtheone@whoknocks.com', application_form_id: application_reference.application_form.id)
         form.save(application_reference)
 
         expect(application_reference.email_address).to eq('iamtheone@whoknocks.com')

--- a/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:email_address) }
+  end
+
+  describe '.build_from_reference' do
+    it 'creates an object based on the reference' do
+      application_reference = build_stubbed(:reference, email_address: 'iamtheone@whoknocks.com')
+      form = described_class.build_from_reference(application_reference)
+
+      expect(form.email_address).to eq('iamtheone@whoknocks.com')
+    end
+  end
+
+  describe '#save' do
+    let(:application_reference) { create(:reference) }
+
+    before do
+      FeatureFlag.activate('decoupled_references')
+    end
+
+    context 'when email_address is blank' do
+      it 'returns false' do
+        form = described_class.new
+
+        expect(form.save(application_reference)).to be(false)
+      end
+    end
+
+    context 'when email_address has a value' do
+      it 'creates the referee' do
+        form = described_class.new(email_address: 'iamtheone@whoknocks.com')
+        form.save(application_reference)
+
+        expect(application_reference.email_address).to eq('iamtheone@whoknocks.com')
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_see_the_referee_email_page
-    expect(page).to have_current_path candidate_interface_decoupled_references_new_email_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_decoupled_references_new_email_address_path(@application.application_references.last.id)
   end
 
   def when_i_click_save_and_continue_without_providing_an_emailing
@@ -109,7 +109,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def when_i_provide_an_email_address_with_an_invalid_format
-    fill_in 'candidate-interface-reference-referee-email-form-email-field-error', with: 'invalid.email.address'
+    fill_in 'candidate-interface-reference-referee-email-address-form-email-address-field-error', with: 'invalid.email.address'
   end
 
   def then_i_am_told_my_email_address_needs_a_valid_format
@@ -117,7 +117,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def when_i_provide_a_valid_email_address
-    fill_in 'candidate-interface-reference-referee-email-form-email-field-error', with: 'iamtheone@whoknocks.com'
+    fill_in 'candidate-interface-reference-referee-email-address-form-email-address-field-error', with: 'iamtheone@whoknocks.com'
   end
 
   def then_i_see_the_description_page

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -20,11 +20,22 @@ RSpec.feature 'Decoupled references' do
     and_i_click_save_and_continue
     then_i_should_see_the_referee_name_page
 
-    when_i_click_save_and_continue_without_giving_a_name
-    then_i_should_see_an_error
+    when_i_click_save_and_continue_without_providing_a_name
+    then_i_should_be_told_to_provide_a_name
 
     when_i_fill_in_my_references_name
     and_i_click_save_and_continue
+
+    when_i_click_save_and_continue_without_providing_an_emailing
+    then_i_should_be_told_to_provide_an_email_address
+
+    when_i_provide_an_email_address_with_an_invalid_format
+    and_i_click_save_and_continue
+    then_i_am_told_my_email_address_needs_a_valid_format
+
+    when_i_provide_a_valid_email_address
+    and_i_click_save_and_continue
+    then_i_see_the_description_page
   end
 
   def given_i_am_signed_in
@@ -73,11 +84,11 @@ RSpec.feature 'Decoupled references' do
     expect(page).to have_current_path candidate_interface_decoupled_references_new_name_path(@application.application_references.last.id)
   end
 
-  def when_i_click_save_and_continue_without_giving_a_name
+  def when_i_click_save_and_continue_without_providing_a_name
     and_i_click_save_and_continue
   end
 
-  def then_i_should_see_an_error
+  def then_i_should_be_told_to_provide_a_name
     expect(page).to have_content 'Enter your referees name'
   end
 
@@ -87,5 +98,29 @@ RSpec.feature 'Decoupled references' do
 
   def then_i_see_the_referee_email_page
     expect(page).to have_current_path candidate_interface_decoupled_references_new_email_path(@application.application_references.last.id)
+  end
+
+  def when_i_click_save_and_continue_without_providing_an_emailing
+    and_i_click_save_and_continue
+  end
+
+  def then_i_should_be_told_to_provide_an_email_address
+    expect(page).to have_content 'Enter your referees email address'
+  end
+
+  def when_i_provide_an_email_address_with_an_invalid_format
+    fill_in 'candidate-interface-reference-referee-email-form-email-field-error', with: 'invalid.email.address'
+  end
+
+  def then_i_am_told_my_email_address_needs_a_valid_format
+    expect(page).to have_content 'Enter an email address in the correct format, like name@example.com'
+  end
+
+  def when_i_provide_a_valid_email_address
+    fill_in 'candidate-interface-reference-referee-email-form-email-field-error', with: 'iamtheone@whoknocks.com'
+  end
+
+  def then_i_see_the_description_page
+    expect(page).to have_current_path candidate_interface_decoupled_references_new_description_path(@application.application_references.last.id)
   end
 end


### PR DESCRIPTION
## Context

Previous PRs are:
#3013 - Adds the new start and type page
#3016 - Migration to allow the references email address column to be NULL
#3022 - Breaks the new flow into a separate controller
#3035 - Up to adding a referees email 


This PR adds the email address view, controller actions, form and routes. The description page onwards is out of scope.


## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/42515961/94812185-4d5d6c00-03ee-11eb-8c81-66cc4bc70b1d.png)

- With no value 

![image](https://user-images.githubusercontent.com/42515961/94812148-40407d00-03ee-11eb-908a-d4f4a55b8eaf.png)

- With the incorrect format 

![image](https://user-images.githubusercontent.com/42515961/94812083-2737cc00-03ee-11eb-8ae1-87e51b5e502c.png)

- With a duplicate email

![image](https://user-images.githubusercontent.com/42515961/94812118-33bc2480-03ee-11eb-8e2c-2e3db7ba3b9e.png)

## Guidance to review

I'm not overly happy with the validations. I'd love some input on them if anyone has any ideas.

## Link to Trello card

https://trello.com/c/npGvdYqK/2213-%F0%9F%92%94-dev-request-a-referee-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
