### PR TITLE
Prevent submit without two references provided

### DIFF
--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -32,5 +32,11 @@
 <% end %>
 
 <% if show_references_not_provided? %>
-  <%= render(SectionMissingBannerComponent.new(section: :references, section_path: candidate_interface_referees_path, text: t('review_application.references_provided.incomplete', minimum_references: minimum_references), error: @missing_error)) %>
+  <%= render(SectionMissingBannerComponent.new(
+    section: :references,
+    section_path: candidate_interface_referees_path,
+    text: t('review_application.references_provided.incomplete', minimum_references: minimum_references),
+    link_text: t('review_application.references_provided.complete_section'),
+    error: @missing_error),
+  ) %>
 <% end %>

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -30,3 +30,7 @@
 <% if show_missing_banner? %>
   <%= render(SectionMissingBannerComponent.new(section: :references, section_path: candidate_interface_referees_path, text: t('review_application.references.incomplete', minimum_references: minimum_references), error: @missing_error)) %>
 <% end %>
+
+<% if show_references_not_provided? %>
+  <%= render(SectionMissingBannerComponent.new(section: :references, section_path: candidate_interface_referees_path, text: t('review_application.references_provided.incomplete', minimum_references: minimum_references), error: @missing_error)) %>
+<% end %>

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -26,7 +26,13 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      !@application_form.references_completed && @editable if @submitting_application
+      !@application_form.references_completed && @editable && @submitting_application
+    end
+
+    def show_references_not_provided?
+      return false unless FeatureFlag.active?(:decoupled_references)
+
+      !@application_form.enough_references_have_been_provided? && @editable && @submitting_application
     end
 
   private

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -26,6 +26,8 @@ module CandidateInterface
     end
 
     def show_missing_banner?
+      return false if FeatureFlag.active?(:decoupled_references)
+
       !@application_form.references_completed && @editable && @submitting_application
     end
 

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-banner<% if @error %> app-banner--warning<% end %> app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
     <p class="govuk-body"><%= @text %></p>
-    <%= link_to t("review_application.#{section}.complete_section"), @section_path, class: 'govuk-link govuk-link--no-visited-state', 'data-qa': "missing-#{section}" %>
+    <%= link_to @link_text, @section_path, class: 'govuk-link govuk-link--no-visited-state', 'data-qa': "missing-#{section}" %>
   </div>
 </div>

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-banner<% if @error %> app-banner--warning<% end %> app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
     <p class="govuk-body"><%= @text %></p>
-    <%= link_to @link_text, @section_path, class: 'govuk-link govuk-link--no-visited-state', 'data-qa': "missing-#{section}" %>
+    <%= link_to link_text, @section_path, class: 'govuk-link govuk-link--no-visited-state', 'data-qa': "missing-#{section}" %>
   </div>
 </div>

--- a/app/components/section_missing_banner_component.rb
+++ b/app/components/section_missing_banner_component.rb
@@ -1,12 +1,19 @@
 class SectionMissingBannerComponent < ViewComponent::Base
   validates :section, :section_path, presence: true
 
-  def initialize(section:, section_path:, text: t("review_application.#{section}.incomplete"), error: false)
+  def initialize(
+    section:,
+    section_path:,
+    text: t("review_application.#{section}.incomplete"),
+    link_text: t("review_application.#{section}.complete_section"),
+    error: false
+  )
     @section = section
     @section_path = section_path
     @text = text
     @error = error
+    @link_text = link_text
   end
 
-  attr_reader :section, :section_path, :text
+  attr_reader :section, :section_path, :text, :link_text
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -249,11 +249,11 @@ class ApplicationForm < ApplicationRecord
     application_references.any?(&:cancelled_at_end_of_cycle?)
   end
 
-private
-
   def enough_references_have_been_provided?
     application_references.feedback_provided.count >= MINIMUM_COMPLETE_REFERENCES
   end
+
+private
 
   def withdrawn_course_choices
     application_choices.includes(%i[provider course]).select { |choice| choice.course.withdrawn == true }

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -253,6 +253,8 @@ module CandidateInterface
     end
 
     def all_referees_provided_by_candidate?
+      return true if FeatureFlag.active?(:decoupled_references)
+
       @application_form.references_completed
     end
 

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -35,7 +35,7 @@ module CandidateInterface
         [:interview_preferences, interview_preferences_completed?],
 
         # "References" section
-        [:references, all_referees_provided_by_candidate?],
+        [:references, enough_references_provided?],
       ].compact
     end
 
@@ -246,6 +246,8 @@ module CandidateInterface
     end
 
     def enough_references_provided?
+      return all_referees_provided_by_candidate? unless FeatureFlag.active?(:decoupled_references)
+
       @application_form.enough_references_have_been_provided?
     end
 

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -36,7 +36,7 @@ module CandidateInterface
 
         # "References" section
         [:references, all_referees_provided_by_candidate?],
-        [:references_provider, enough_references_provided?],
+        [:references_provided, enough_references_provided?],
       ].compact
     end
 

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -35,7 +35,8 @@ module CandidateInterface
         [:interview_preferences, interview_preferences_completed?],
 
         # "References" section
-        [:references, enough_references_provided?],
+        [:references, all_referees_provided_by_candidate?],
+        [:references_provider, enough_references_provided?],
       ].compact
     end
 
@@ -246,7 +247,7 @@ module CandidateInterface
     end
 
     def enough_references_provided?
-      return all_referees_provided_by_candidate? unless FeatureFlag.active?(:decoupled_references)
+      return true unless FeatureFlag.active?(:decoupled_references)
 
       @application_form.enough_references_have_been_provided?
     end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -245,6 +245,10 @@ module CandidateInterface
       @application_form.application_volunteering_experiences.any?
     end
 
+    def enough_references_provided?
+      @application_form.enough_references_have_been_provided?
+    end
+
     def all_referees_provided_by_candidate?
       @application_form.references_completed
     end

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -54,3 +54,6 @@ en:
     references:
       incomplete: Add %{minimum_references} referees to your application
       complete_section: Add your references
+    references_provided:
+      incomplete: You need %{minimum_references} references before you can submit your application
+      complete_section: Manage your references

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -173,6 +173,8 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
     end
 
     it 'renders an error when references are marked incomplete' do
+      FeatureFlag.deactivate(:decoupled_references)
+
       application_form.update!(references_completed: false)
 
       result = render_inline(described_class.new(application_form: application_form, submitting_application: true))

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -171,6 +171,20 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(change_reference_type).to eq("Change reference type for #{first_referee.name}")
     end
+
+    it 'renders an error when references are marked incomplete' do
+      application_form.update!(references_completed: false)
+
+      result = render_inline(described_class.new(application_form: application_form, submitting_application: true))
+      expect(result.text).to include('Add 2 referees to your application')
+    end
+
+    it 'renders an error when references have not come back from referees' do
+      FeatureFlag.activate(:decoupled_references)
+
+      result = render_inline(described_class.new(application_form: application_form, submitting_application: true))
+      expect(result.text).to include('You need 2 references before you can submit your application')
+    end
   end
 
   context 'when referees are not editable' do

--- a/spec/components/section_missing_banner_component_spec.rb
+++ b/spec/components/section_missing_banner_component_spec.rb
@@ -5,5 +5,13 @@ RSpec.describe SectionMissingBannerComponent do
     result = render_inline(described_class.new(section: 'degrees', section_path: '#'))
     expect(result.css('.app-banner__message .govuk-body').text).to include('Degree(s) section not marked as completed')
     expect(result.css('.app-banner__message .govuk-link')).to be_present
+    expect(result.css('.app-banner__message .govuk-link').text).to include('Enter your degree(s)')
+  end
+
+  it 'renders custom link text if given' do
+    result = render_inline(described_class.new(section: 'degrees', section_path: '#', link_text: 'Click here to win'))
+    expect(result.css('.app-banner__message .govuk-body').text).to include('Degree(s) section not marked as completed')
+    expect(result.css('.app-banner__message .govuk-link')).to be_present
+    expect(result.css('.app-banner__message .govuk-link').text).to include('Click here to win')
   end
 end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -302,6 +302,8 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#enough_references_provided?' do
+    before { FeatureFlag.activate(:decoupled_references) }
+
     it 'returns true if the referees section has been created and two references have been provided' do
       application_form = create(:application_form, references_completed: true)
       create_list(:reference, 2, application_form: application_form, feedback_status: :feedback_provided)
@@ -325,21 +327,23 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
       expect(presenter).not_to be_enough_references_provided
     end
-  end
 
-  describe '#all_referees_provided_by_candidate?' do
-    it 'returns true if the referees section has been completed' do
-      application_form = build(:application_form, references_completed: true)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+    context 'when the `decoupled_references` feature flag is NOT active (REMOVE CONTEXT WHEN DROPPING FEATURE FLAG)' do
+      before { FeatureFlag.deactivate(:decoupled_references) }
 
-      expect(presenter).to be_all_referees_provided_by_candidate
-    end
+      it 'returns true if the referees section has been completed' do
+        application_form = build(:application_form, references_completed: true)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-    it 'returns false if the referees section is incomplete' do
-      application_form = build(:application_form, references_completed: false)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+        expect(presenter).to be_enough_references_provided
+      end
 
-      expect(presenter).not_to be_all_referees_provided_by_candidate
+      it 'returns false if the referees section is incomplete' do
+        application_form = build(:application_form, references_completed: false)
+        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+        expect(presenter).not_to be_enough_references_provided
+      end
     end
   end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -331,19 +331,28 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     context 'when the `decoupled_references` feature flag is NOT active (REMOVE CONTEXT WHEN DROPPING FEATURE FLAG)' do
       before { FeatureFlag.deactivate(:decoupled_references) }
 
-      it 'returns true if the referees section has been completed' do
-        application_form = build(:application_form, references_completed: true)
+      it 'returns true even if the referees section is incomplete' do
+        application_form = build(:application_form, references_completed: false)
         presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
         expect(presenter).to be_enough_references_provided
       end
+    end
+  end
 
-      it 'returns false if the referees section is incomplete' do
-        application_form = build(:application_form, references_completed: false)
-        presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+  describe '#all_referees_provided_by_candidate?' do
+    it 'returns true if the referees section has been completed' do
+      application_form = build(:application_form, references_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-        expect(presenter).not_to be_enough_references_provided
-      end
+      expect(presenter).to be_all_referees_provided_by_candidate
+    end
+
+    it 'returns false if the referees section is incomplete' do
+      application_form = build(:application_form, references_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_all_referees_provided_by_candidate
     end
   end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -341,6 +341,8 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#all_referees_provided_by_candidate?' do
+    before { FeatureFlag.deactivate(:decoupled_references) }
+
     it 'returns true if the referees section has been completed' do
       application_form = build(:application_form, references_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -301,6 +301,32 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#enough_references_provided?' do
+    it 'returns true if the referees section has been created and two references have been provided' do
+      application_form = create(:application_form, references_completed: true)
+      create_list(:reference, 2, application_form: application_form, feedback_status: :feedback_provided)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_enough_references_provided
+    end
+
+    it 'returns false if the referees section has been created and only one reference has been provided' do
+      application_form = create(:application_form, references_completed: true)
+      create(:reference, application_form: application_form, feedback_status: :feedback_provided)
+      create(:reference, application_form: application_form, feedback_status: :feedback_requested)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_enough_references_provided
+    end
+
+    it 'returns false if the referees section is incomplete' do
+      application_form = build(:application_form, references_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_enough_references_provided
+    end
+  end
+
   describe '#all_referees_provided_by_candidate?' do
     it 'returns true if the referees section has been completed' do
       application_form = build(:application_form, references_completed: true)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       expect(presenter).to be_enough_references_provided
     end
 
-    it 'returns false if the referees section has been created and only one reference has been provided' do
+    it 'returns false if the referees section has been completed and only one reference has been provided' do
       application_form = create(:application_form, references_completed: true)
       create(:reference, application_form: application_form, feedback_status: :feedback_provided)
       create(:reference, application_form: application_form, feedback_status: :feedback_requested)

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   def candidate_provides_two_referees
     visit candidate_interface_referees_type_path
     choose 'Academic'

--- a/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
+++ b/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Cancelling a reference' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'candidate cancels a reference request after completing their application' do
     given_i_have_completed_and_submitted_my_application
 

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Candidate satisfaction survey' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'Candidate completes the survey' do
     given_the_candidate_completes_and_submits_their_application
     then_they_should_be_asked_to_give_feedback

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Entering their equality and diversity information' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'Candidate submits equality and diversity information' do
     given_i_am_signed_in
     and_i_have_an_application_form_that_is_not_ready_to_submit

--- a/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_awaiting_references_when_the_next_cycle_launches_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Candidates awaiting references application choices are rejected when the new cycle launches' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'An application is rejected when find opens for a new cycle' do
     given_i_have_submitted_my_application
 

--- a/spec/system/candidate_interface/candidate_removes_a_full_or_withdrawn_course_choice_post_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_removes_a_full_or_withdrawn_course_choice_post_submission_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'Both a candidates course choices have become full or been withdr
   include CandidateHelper
   include CourseOptionHelpers
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'when a candidate arrives at the dashboard they can follow the replace course flow' do
     given_i_have_submitted_my_application
     and_both_of_my_application_choices_have_become_full

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Candidate submits the application' do
     and_the_decoupled_references_flag_is_on
 
     when_i_have_completed_my_application
+    and_i_have_received_2_references
 
     and_i_review_my_application
 
@@ -39,7 +40,6 @@ RSpec.feature 'Candidate submits the application' do
 
     and_i_can_see_my_support_ref
     and_i_receive_an_email_with_my_support_ref
-    and_my_referees_receive_a_request_for_a_reference_by_email
     and_a_slack_notification_is_sent
 
     when_i_click_on_track_your_application
@@ -59,6 +59,12 @@ RSpec.feature 'Candidate submits the application' do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
+  end
+
+  def and_i_have_received_2_references
+    @current_candidate.current_application.application_references.each do |reference|
+      reference.update!(feedback_status: :feedback_provided)
+    end
   end
 
   def and_i_review_my_application
@@ -192,15 +198,6 @@ RSpec.feature 'Candidate submits the application' do
   def and_i_receive_an_email_with_my_support_ref
     open_email(current_candidate.email_address)
     expect(current_email).to have_content 'Application submitted'
-  end
-
-  def and_my_referees_receive_a_request_for_a_reference_by_email
-    current_application = current_candidate.current_application
-    current_application.application_references.each do |reference|
-      open_email(reference.email_address)
-      expect(current_email).to have_content "#{current_application.first_name} #{current_application.last_name} put us in touch with you to get a reference"
-      expect(current_email).to have_content reference.name
-    end
   end
 
   def and_a_slack_notification_is_sent

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   include CandidateHelper
   include CourseOptionHelpers
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'when a candidate arrives at the dashboard they can follow the replace course flow' do
     given_i_have_submitted_my_application
     and_my_course_is_only_available_on_ucas

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'International candidate submits the application' do
   include CandidateHelper
   include EFLHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'International candidate completes and submits an application' do
     FeatureFlag.deactivate(:international_addresses)
     FeatureFlag.deactivate(:international_degrees)

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Referee can submit reference', with_audited: true do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Referee does not respond in time' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'Emails are sent if a referee does not respond in time' do
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Refusing to give a reference' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'Referee refuses to give a reference' do
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Stop submission of incomplete references', with_audited: true do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'Referee tries to submit incomplete reference' do
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.feature 'Vendor receives the application' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'A completed application is submitted with references' do
     Timecop.freeze do # simplify date assertions in the response
       given_a_candidate_has_submitted_their_application


### PR DESCRIPTION
## Context

Candidates should not be able to submit an application until they have 2 references.

## Changes proposed in this pull request

- [x] Update `ApplicationFormPresenter` to include new ready for submission rule. (Behind `decoupled_references` feature flags).
- [x] Update `RefereesReviewComponent` to include new error message. (Behind `decoupled_references` feature flags).
- [x] Update `SectionMissingBannerComponent` to allow a non-standard link text to support above.

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/450843/94903781-32443800-0492-11eb-97a3-3736bd64923b.png">

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/450843/94903974-7f280e80-0492-11eb-8e27-5af27a1a266d.png">


## Guidance to review

- Have I missed anything?
- I've added some unit tests but not tried to alter the system specs here mainly because the other parts of the decoupled reference journey are not yet in place. We could modify one of the existing specs if needed.

## Link to Trello card

https://trello.com/c/tlQBYyRa/2216-💔-dev-prevent-submitting-application-without-2-references

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
