### PR TITLE
Update application submission confirmation page

### DIFF
--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -24,7 +24,8 @@
 
     <% if FeatureFlag.active?('decoupled_references') %>
       <h2 class="govuk-heading-m">Track your application</h2>
-      <p class="govuk-body"><%= govuk_link_to 'You can track the progress of your application on your dashboard', candidate_interface_application_complete_path %>.</p>
+      <p class="govuk-body">You can track or withdraw your application from your application dashboard.</p>
+      <p class="govuk-body"><%= govuk_link_to 'To view your application, return to your application dashboard', candidate_interface_application_complete_path %>.</p>
     <% elsif @application_form.can_edit_after_submission? %>
       <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
       <p class="govuk-body">You have <%= @editable_days %> to edit your application. We’ll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -208,7 +208,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_click_on_track_your_application
-    click_link 'You can track the progress of your application on your dashboard'
+    click_link 'To view your application, return to your application dashboard'
   end
 
   def then_i_can_see_my_application_dashboard

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
   end
 
   def when_i_click_view_my_application
-    click_link 'You can track the progress of your application on your dashboard'
+    click_link 'To view your application, return to your application dashboard'
   end
 
   def then_i_do_not_see_a_link_to_edit_my_application


### PR DESCRIPTION
## Context

We need to update the content of the submission confirmation page for decoupled references.

See design: https://apply-beta-prototype.herokuapp.com/application/12345/confirmation

## Changes proposed in this pull request

- [x] Copy change
- [x] Fix spec regressions

<img width="880" alt="image" src="https://user-images.githubusercontent.com/450843/94924647-da1f2d00-04b5-11eb-9c00-4d178712a14a.png">

## Guidance to review

- Does this match the new design?
- Note that this content was changed fairly recently by https://github.com/DFE-Digital/apply-for-teacher-training/pull/3002

## Link to Trello card

https://trello.com/c/tBa9MHBv/2218-💔-dev-update-application-submission-confirmation-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
