### PR TITLE
Support navigation (candidates and providers)

### DIFF
--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title, 'API tokens' %>
-
-<%= render 'support_interface/providers/providers_navigation' %>
+<%= render 'support_interface/providers/providers_navigation', title: 'API tokens' %>
 
 <%= form_with model: VendorAPIToken.new, url: support_interface_api_tokens_path do |f| %>
   <%= f.govuk_collection_select :provider_id, Provider.all, :id, :name, label: { text: 'Select a provider to generate a token for' }, options: { include_blank: true } %>

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,6 +1,5 @@
 <% content_for :browser_title, "Application history – Application ##{@application_form.id}" %>
-
-<%= render 'support_interface/candidates/candidates_navigation', current: 'Applications' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_applications_path) %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
   <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>

--- a/app/views/support_interface/application_forms/index.html.erb
+++ b/app/views/support_interface/application_forms/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title, 'Applications' %>
-
-<%= render 'support_interface/candidates/candidates_navigation' %>
+<%= render 'support_interface/candidates/candidates_navigation', title: 'Applications' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_forms) do %>
   <%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @application_forms) %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,6 +1,5 @@
 <% content_for :browser_title, title_with_success_prefix("Application details – Application ##{@application_form.id}", flash[:success].present?) %>
-
-<%= render 'support_interface/candidates/candidates_navigation', current: 'Applications' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_applications_path) %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
   <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>

--- a/app/views/support_interface/candidates/_candidates_navigation.html.erb
+++ b/app/views/support_interface/candidates/_candidates_navigation.html.erb
@@ -1,7 +1,10 @@
-<% content_for :navigation do %>
-  <%= render SubNavigationComponent.new(items: [
-    { name: 'Applications', url: support_interface_applications_path, current: local_assigns[:current] == 'Applications' },
-    { name: 'Candidates', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
-    { name: 'UCAS matches', url: support_interface_ucas_matches_path, current: local_assigns[:current] == 'UCAS matches' },
-  ]) %>
-<% end %>
+<% content_for :browser_title, "#{title} - Candidates" %>
+<% content_for :title, 'Candidates' %>
+
+<%= render TabNavigationComponent.new(items: [
+  { name: 'Applications', url: support_interface_applications_path, current: local_assigns[:current] == 'Applications' },
+  { name: 'Candidates', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
+  { name: 'UCAS matches', url: support_interface_ucas_matches_path, current: local_assigns[:current] == 'UCAS matches' },
+]) %>
+
+<h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/candidates/index.html.erb
+++ b/app/views/support_interface/candidates/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title, 'Candidates' %>
-
-<%= render 'support_interface/candidates/candidates_navigation' %>
+<%= render 'candidates_navigation', title: 'Candidates' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @candidates) do %>
   <%= render SupportInterface::CandidatesTableComponent.new(candidates: @candidates) %>

--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for :browser_title, "Candidate ##{@candidate.id}" %>
+<% content_for :before_content, govuk_back_link_to(support_interface_candidates_path) %>
+
 <% content_for :title do %>
   <span class="govuk-caption-xl">Candidate #<%= @candidate.id %></span>
   <%= @candidate.email_address %>
 <% end %>
-
-<%= render 'support_interface/candidates/candidates_navigation', current: 'Candidates' %>
 
 <% unless HostingEnvironment.production? %>
   <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@candidate), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>

--- a/app/views/support_interface/provider_users/audits.html.erb
+++ b/app/views/support_interface/provider_users/audits.html.erb
@@ -1,6 +1,5 @@
 <% content_for :browser_title, "History - #{@form.provider_user.full_name}" %>
-
-<%= render 'support_interface/providers/providers_navigation', current: 'Provider users' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_users_path) %>
 
 <%= render 'provider_user_navigation', current: 'History' %>
 

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -1,6 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix("Edit - #{@form.provider_user.full_name}", @form.errors.any?) %>
-
-<%= render 'support_interface/providers/providers_navigation', current: 'Provider users' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_users_path) %>
 
 <%= render 'provider_user_navigation' %>
 

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title, 'Provider users' %>
-
-<%= render 'support_interface/providers/providers_navigation' %>
+<%= render 'support_interface/providers/providers_navigation', title: 'Provider users' %>
 
 <%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
 

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -1,6 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix('Add provider user', @form.errors.any?) %>
-
-<%= render 'support_interface/providers/providers_navigation', current: 'Provider users' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_users_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support_interface/providers/_providers_navigation.html.erb
+++ b/app/views/support_interface/providers/_providers_navigation.html.erb
@@ -1,8 +1,11 @@
-<% content_for :navigation do %>
-  <%= render SubNavigationComponent.new(items: [
-    { name: 'Synced providers', url: support_interface_providers_path },
-    { name: 'Other providers', url: support_interface_other_providers_path },
-    { name: 'API tokens', url: support_interface_api_tokens_path },
-    { name: 'Provider users', url: support_interface_provider_users_path, current: local_assigns[:current] == 'Provider users' },
-  ]) %>
-<% end %>
+<% content_for :browser_title, "#{title} - Providers" %>
+<% content_for :title, 'Providers' %>
+
+<%= render TabNavigationComponent.new(items: [
+  { name: 'Synced providers', url: support_interface_providers_path },
+  { name: 'Other providers', url: support_interface_other_providers_path },
+  { name: 'API tokens', url: support_interface_api_tokens_path },
+  { name: 'Provider users', url: support_interface_provider_users_path, current: local_assigns[:current] == 'Provider users' },
+]) %>
+
+<h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title, 'Synced providers' %>
-
-<%= render 'providers_navigation' %>
+<%= render 'providers_navigation', title: 'Synced providers' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @providers) do %>
   <table class="govuk-table">

--- a/app/views/support_interface/providers/other_providers.html.erb
+++ b/app/views/support_interface/providers/other_providers.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title, 'Other providers' %>
-
-<%= render 'providers_navigation' %>
+<%= render 'providers_navigation', title: 'Other providers' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @providers) do %>
   <table class="govuk-table">

--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title, 'UCAS matches' %>
-
-<%= render 'support_interface/candidates/candidates_navigation' %>
+<%= render 'support_interface/candidates/candidates_navigation', title: 'UCAS matches' %>
 
 <table class='govuk-table'>
   <thead class='govuk-table__head'>

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, "UCAS match: #{@match.candidate.email_address}" %>
-
-<%= render 'support_interface/candidates/candidates_navigation' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_ucas_matches_path) %>
 
 <p class="govuk-body">
   <%= render TagComponent.new(text: @match.matching_state.humanize, type: @match.processed? ? :green : :default) %> Last updated <%= @match.updated_at.to_s(:govuk_date_and_time) %>

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'See an application' do
   end
 
   def when_i_return_to_the_support_page
-    click_on 'Applications'
+    click_on 'Back'
   end
 
   def and_i_click_on_an_unsubmitted_application


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Following on from #3037, plan is to use navigation below the header for primary navigation, but in order to do that, pages further down the navigation hierarchy need to be adapted first. These are the final two sections that need adjusting before we can do that.

## Guidance to review

| Before | After |
| - | - |
| <img width="1020" alt="candidates-before" src="https://user-images.githubusercontent.com/813383/94941304-97b51a80-04cc-11eb-9d60-1dbbaea247c5.png"> | <img width="1032" alt="candidates-after" src="https://user-images.githubusercontent.com/813383/94941059-47d65380-04cc-11eb-8014-7a82593eb498.png"> |
| <img width="1039" alt="providers-before" src="https://user-images.githubusercontent.com/813383/94941072-4c9b0780-04cc-11eb-96d0-bcc2caae174f.png"> | <img width="1045" alt="providers-after" src="https://user-images.githubusercontent.com/813383/94941069-4b69da80-04cc-11eb-9628-5c75238f5af7.png">

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
