### PR TITLE
Fix incorrect role on navigation components

### DIFF
--- a/app/components/sub_navigation_component.html.erb
+++ b/app/components/sub_navigation_component.html.erb
@@ -6,11 +6,11 @@
           <% items.each do |item| %>
             <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>
               <li class="moj-primary-navigation__item">
-                <%= govuk_link_to item[:name], item[:url],  class: "moj-primary-navigation__link", aria: { current: "true" }, role:"tab" %>
+                <%= govuk_link_to item[:name], item[:url], class: "moj-primary-navigation__link", aria: { current: "page" } %>
               </li>
             <% else %>
               <li class="moj-primary-navigation__item">
-                <%= govuk_link_to item[:name], item[:url],  class: "moj-primary-navigation__link", role:"tab" %>
+                <%= govuk_link_to item[:name], item[:url], class: "moj-primary-navigation__link" %>
               </li>
             <% end %>
           <% end %>

--- a/app/components/tab_navigation_component.html.erb
+++ b/app/components/tab_navigation_component.html.erb
@@ -3,9 +3,9 @@
     <% items.each do |item| %>
       <li class="app-tab-navigation__item">
         <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>
-          <%= govuk_link_to item[:name], item[:url],  class: "app-tab-navigation__link", aria: { selected: "true" }, role:"tab" %>
+          <%= govuk_link_to item[:name], item[:url],  class: "app-tab-navigation__link", aria: { current: "page" } %>
         <% else %>
-          <%= govuk_link_to item[:name], item[:url],  class: "app-tab-navigation__link", role:"tab" %>
+          <%= govuk_link_to item[:name], item[:url],  class: "app-tab-navigation__link" %>
         <% end %>
       </li>
     <% end %>

--- a/app/frontend/styles/_tab-navigation.scss
+++ b/app/frontend/styles/_tab-navigation.scss
@@ -84,7 +84,7 @@
 }
 
 
-.app-tab-navigation__link[aria-selected="true"] {
+.app-tab-navigation__link[aria-current="page"] {
   color: $govuk-link-active-colour;
   position: relative;
   text-decoration: none;

--- a/spec/components/tab_navigation_component_spec.rb
+++ b/spec/components/tab_navigation_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TabNavigationComponent do
     it 'when the item is "current" then that tab is selected' do
       result = render_inline(described_class.new(items: items))
 
-      expect(result.css('.app-tab-navigation__link[aria-selected="true"]').text).to include('Application')
+      expect(result.css('.app-tab-navigation__link[aria-current="page"]').text).to include('Application')
     end
   end
 


### PR DESCRIPTION
## Context

We are using `role=tab` in our navigation components. We shouldn’t be doing this as links in these components do not behave like tabs (i.e. switching a view within a page). We can however [use `aria-current` to indicate which item in a set of items is currently selected](https://tink.uk/using-the-aria-current-attribute/).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

@adamsilver Value for `aria-current`: `page` or `true`? Can we have two navigation lists with the same `aria-current` value (I believe you can as current is relative to sibling links).

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
