### PR TITLE
Support nav labels and heading sizes

### DIFF
--- a/app/components/state_explanation_component.html.erb
+++ b/app/components/state_explanation_component.html.erb
@@ -1,5 +1,5 @@
 <section class="app-section app-section--with-top-border">
-  <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2" id="<%= state_name %>"><%= human_state_name %></h3>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom-1" id="<%= state_name %>"><%= human_state_name %></h3>
   <% if development_details %>
     <p class="govuk-body-l"><%= govuk_link_to pluralize(machine.state_count(state_name), 'application'), support_interface_applications_path, class: 'govuk-link--no-visited-state' %> currently in this state</p>
   <% end %>

--- a/app/components/when_emails_are_sent_component.html.erb
+++ b/app/components/when_emails_are_sent_component.html.erb
@@ -3,7 +3,7 @@
   <% human_state_name = I18n.t!("application_states.#{state_name}.name") %>
   <% next unless state.events.any? %>
   <section class="app-section app-section--with-top-border">
-    <h2 class="govuk-heading-m govuk-!-font-size-27" id='<%= state_name %>'><%= human_state_name %></h2>
+    <h2 class="govuk-heading-m" id="<%= state_name %>"><%= human_state_name %></h2>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half app-styled-content">
         <% chaser_emails = I18n.exists?("application_states.#{state_name}.emails") ? I18n.t!("application_states.#{state_name}.emails") : [] %>

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -24,7 +24,7 @@ class NavigationItems
           NavigationItem.new('Candidates', support_interface_applications_path, is_active(current_controller, %w[candidates import_references application_forms ucas_matches])),
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses provider_users api_tokens])),
           NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance performance_data course_options email_log])),
-          NavigationItem.new('Service settings', support_interface_feature_flags_path, is_active(current_controller, %w[feature_flags cycles support_users tasks])),
+          NavigationItem.new('Settings', support_interface_feature_flags_path, is_active(current_controller, %w[feature_flags cycles support_users tasks])),
           NavigationItem.new('Docs', support_interface_guidance_path, is_active(current_controller, %w[docs guidance mailer_previews])),
         ]
       else

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -23,7 +23,7 @@ class NavigationItems
         [
           NavigationItem.new('Candidates', support_interface_applications_path, is_active(current_controller, %w[candidates import_references application_forms ucas_matches])),
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses provider_users api_tokens])),
-          NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance performance_data course_options email_log])),
+          NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance performance_data course_options email_log validation_errors])),
           NavigationItem.new('Settings', support_interface_feature_flags_path, is_active(current_controller, %w[feature_flags cycles support_users tasks])),
           NavigationItem.new('Documentation', support_interface_guidance_path, is_active(current_controller, %w[docs guidance mailer_previews])),
         ]

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -25,7 +25,7 @@ class NavigationItems
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses provider_users api_tokens])),
           NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance performance_data course_options email_log])),
           NavigationItem.new('Settings', support_interface_feature_flags_path, is_active(current_controller, %w[feature_flags cycles support_users tasks])),
-          NavigationItem.new('Docs', support_interface_guidance_path, is_active(current_controller, %w[docs guidance mailer_previews])),
+          NavigationItem.new('Documentation', support_interface_guidance_path, is_active(current_controller, %w[docs guidance mailer_previews])),
         ]
       else
         []

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% if yield(:title).present? && controller_name != 'errors' %>
-    <h1 class="govuk-heading-xl"><%= yield :title %></h1>
+    <h1 class="govuk-heading-l"><%= yield :title %></h1>
   <% end %>
 
   <%= yield %>

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, "Application history – Application ##{@application_form.id}" %>
 <% content_for :before_content, govuk_back_link_to(support_interface_applications_path) %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+<h1 class="govuk-heading-l govuk-!-margin-bottom-4">
   <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
   <%= break_email_address(@application_form.candidate.email_address) %>
 </h1>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :browser_title, title_with_success_prefix("Application details – Application ##{@application_form.id}", flash[:success].present?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_applications_path) %>
 
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+<h1 class="govuk-heading-l govuk-!-margin-bottom-4">
   <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
   <%= break_email_address(@application_form.candidate.email_address) %>
 </h1>

--- a/app/views/support_interface/change_course/select_course_to_add.html.erb
+++ b/app/views/support_interface/change_course/select_course_to_add.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @form, url: support_interface_add_course_to_application_path(@form.application_form), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class='govuk-heading-xl'>
+      <h1 class='govuk-heading-l'>
         Add a course to <%= @form.application_form.full_name %>’s application
       </h1>
 

--- a/app/views/support_interface/docs/_docs_navigation.html.erb
+++ b/app/views/support_interface/docs/_docs_navigation.html.erb
@@ -2,9 +2,9 @@
 <% content_for :title, 'Documentation' %>
 
 <% items = [
-  { name: 'Guidance', url: support_interface_guidance_path },
-  { name: 'Flow for candidates', url: support_interface_candidate_flow_path },
-  { name: 'Flow for providers', url: support_interface_provider_flow_path },
+  { name: 'User guidance', url: support_interface_guidance_path },
+  { name: 'Candidate flow', url: support_interface_candidate_flow_path },
+  { name: 'Provider flow', url: support_interface_provider_flow_path },
   { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path },
 ] %>
 
@@ -18,4 +18,4 @@
 
 <%= render TabNavigationComponent.new(items: items) %>
 
-<h2 class="govuk-heading-l"><%= title %></h2>
+<h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @form, url: support_interface_provider_users_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class='govuk-heading-xl'>Add provider user</h1>
+      <h1 class='govuk-heading-l'>Add provider user</h1>
 
       <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
       <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>

--- a/app/views/support_interface/references/cancel.html.erb
+++ b/app/views/support_interface/references/cancel.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Are you sure you want to cancel this reference?
     </h1>
 

--- a/app/views/support_interface/references/reinstate.html.erb
+++ b/app/views/support_interface/references/reinstate.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Are you sure you want to reinstate this reference?
     </h1>
 

--- a/app/views/support_interface/settings/_settings_navigation.html.erb
+++ b/app/views/support_interface/settings/_settings_navigation.html.erb
@@ -1,5 +1,5 @@
-<% content_for :browser_title, "#{title} - Service settings" %>
-<% content_for :title, 'Service settings' %>
+<% content_for :browser_title, "#{title} - Settings" %>
+<% content_for :title, 'Settings' %>
 
 <%= render TabNavigationComponent.new(items: [
   { name: 'Feature flags', url: support_interface_feature_flags_path },

--- a/app/views/support_interface/support_users/confirm_destroy.html.erb
+++ b/app/views/support_interface/support_users/confirm_destroy.html.erb
@@ -5,7 +5,7 @@
     <%= form_with model: @support_user,
       url: support_interface_destroy_support_user_path(@support_user.id),
       method: :delete do |f| %>
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         <span class="govuk-caption-xl">Support user</span>
         <%= t('support_interface.support_user.confirm_remove',
               email: @support_user.email_address) %>

--- a/app/views/support_interface/support_users/confirm_restore.html.erb
+++ b/app/views/support_interface/support_users/confirm_restore.html.erb
@@ -5,7 +5,7 @@
     <%= form_with model: @support_user,
       url: support_interface_restore_support_user_path(@support_user.id),
       method: :delete do |f| %>
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         <span class="govuk-caption-xl">Support user</span>
         <%= t('support_interface.support_user.confirm_restore',
               email: @support_user.email_address) %>

--- a/app/views/support_interface/support_users/new.html.erb
+++ b/app/views/support_interface/support_users/new.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @support_user, url: support_interface_support_users_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class='govuk-heading-xl'>Add support user</h1>
+      <h1 class="govuk-heading-l">Add support user</h1>
 
       <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
       <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID', size: 'm' } %>

--- a/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_cancel_applications_at_end_of_cycle.html.erb
@@ -5,8 +5,8 @@
     <%= form_with model: nil,
       url: support_interface_run_task_path('cancel_applications_at_end_of_cycle') do |f|
     %>
-      <span class="govuk-caption-xl">End-of-cycle</span>
-      <h1 class="govuk-heading-xl">Are you sure you want to cancel all unsubmitted applications?</h1>
+      <span class="govuk-caption-l">End-of-cycle</span>
+      <h1 class="govuk-heading-l">Are you sure you want to cancel all unsubmitted applications?</h1>
 
       <div class="app-styled-content">
         <p>This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>

--- a/app/views/support_interface/tasks/confirm_delete_test_applications.html.erb
+++ b/app/views/support_interface/tasks/confirm_delete_test_applications.html.erb
@@ -5,7 +5,7 @@
     <%= form_with model: nil,
       url: support_interface_run_task_path('delete_test_applications') do |f|
     %>
-      <h1 class="govuk-heading-xl">Are you sure you want to delete all test applications?</h1>
+      <h1 class="govuk-heading-l">Are you sure you want to delete all test applications?</h1>
 
       <div class="app-styled-content">
         <p>This task deletes all candidates with emails that end in <code>@example.com</code>, their applications and associated data.</p>

--- a/app/views/support_interface/tasks/confirm_reject_applications_awaiting_references_at_end_of_cycle.html.erb
+++ b/app/views/support_interface/tasks/confirm_reject_applications_awaiting_references_at_end_of_cycle.html.erb
@@ -5,8 +5,8 @@
     <%= form_with model: nil,
       url: support_interface_run_task_path('reject_applications_awaiting_references_at_end_of_cycle') do |f|
     %>
-      <span class="govuk-caption-xl">End-of-cycle</span>
-      <h1 class="govuk-heading-xl">Are you sure you want to reject all applications awaiting references?</h1>
+      <span class="govuk-caption-l">End-of-cycle</span>
+      <h1 class="govuk-heading-l">Are you sure you want to reject all applications awaiting references?</h1>
 
       <div class="app-styled-content">
         <p>This task finds any applications that have been submitted but not sent to providers because they are awaiting references from the recently closed recruitment cycle, and moves them to the <code>application_not_sent</code> status.</p>

--- a/app/views/support_interface/unauthorized.html.erb
+++ b/app/views/support_interface/unauthorized.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
+    <h1 class="govuk-heading-l">
       Your account is not authorized
     </h1>
     <p class="govuk-body">

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Cycle switching' do
   end
 
   def when_i_click_on_the_recruitment_cycle_link
-    click_on 'Service settings'
+    click_on 'Settings'
     click_on 'Recruitment cycles'
   end
 

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Docs' do
   end
 
   def when_i_click_on_candidate_flow_documentation
-    click_on 'Flow for candidates'
+    click_on 'Candidate flow'
   end
 
   def then_i_see_the_candidate_flow_documentation

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Managing support users' do
   end
 
   def and_i_click_the_manange_support_users_link
-    click_link 'Service settings'
+    click_link 'Settings'
     click_link 'Support users'
   end
 


### PR DESCRIPTION
## Context

* Rename ‘Service settings’ to ‘Settings’
* Rename ‘Docs’ label in primary navigation to ‘Documentation’
* Adjust heading sizes used throughout support to be one step smaller

## Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="1048" alt="Screenshot 2020-10-05 at 14 37 30" src="https://user-images.githubusercontent.com/813383/95087014-130b0c00-0719-11eb-8d24-85a6c4d0c7c5.png"> | <img width="1060" alt="Screenshot 2020-10-05 at 14 37 10" src="https://user-images.githubusercontent.com/813383/95087008-11414880-0719-11eb-841f-8b0fa9e2cc82.png"> |
| <img width="1033" alt="Screenshot 2020-10-05 at 14 38 38" src="https://user-images.githubusercontent.com/813383/95087023-156d6600-0719-11eb-9085-ae040cef67de.png"> | <img width="1024" alt="Screenshot 2020-10-05 at 14 38 50" src="https://user-images.githubusercontent.com/813383/95087027-169e9300-0719-11eb-9f3e-2331731b7d7b.png"> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
