### PR TITLE
Remove permissions-related feature flags

### DIFF
--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -1,6 +1,5 @@
 module ProviderInterface
   class ProviderRelationshipPermissionsSetupController < ProviderInterfaceController
-    before_action :require_feature_flag!
     before_action :require_manage_organisations_permission!
     before_action :require_access_to_manage_provider_relationship_permissions!, only: %i[setup_permissions save_permissions]
     before_action :redirect_unless_permissions_to_setup, except: %i[success]
@@ -113,10 +112,6 @@ module ProviderInterface
         WizardStateStores::RedisStore.new(key: persistence_key_for_current_user),
         options,
       )
-    end
-
-    def require_feature_flag!
-      render_404 unless FeatureFlag.active?(:enforce_provider_to_provider_permissions)
     end
 
     def require_manage_organisations_permission!

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -1,6 +1,5 @@
 module ProviderInterface
   class ProviderUsersController < ProviderInterfaceController
-    before_action :require_feature_flag!
     before_action :require_manage_users_permission!
     before_action :find_provider_user, except: %i[index]
 
@@ -82,10 +81,6 @@ module ProviderInterface
     def provider_update_permissions_params
       params.require(:provider_interface_provider_user_permissions_form)
             .permit(*ProviderPermissions::VALID_PERMISSIONS)
-    end
-
-    def require_feature_flag!
-      render_404 unless FeatureFlag.active?(:providers_can_manage_users_and_permissions)
     end
 
     def require_manage_users_permission!

--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -1,6 +1,5 @@
 module ProviderInterface
   class ProviderUsersInvitationsController < ProviderInterfaceController
-    before_action :require_feature_flag!
     before_action :require_manage_user_permission!
 
     def edit_details
@@ -143,10 +142,6 @@ module ProviderInterface
     def permissions_params
       params.require(:provider_interface_provider_user_invitation_wizard)
         .permit(provider_permissions: {})
-    end
-
-    def require_feature_flag!
-      render_404 unless FeatureFlag.active?(:providers_can_manage_users_and_permissions)
     end
 
     def require_manage_user_permission!

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -48,12 +48,11 @@ class NavigationItems
       items = []
 
       unless performing_setup
-        if FeatureFlag.active?('enforce_provider_to_provider_permissions') &&
-            current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
+        if current_provider_user.authorisation.can_manage_organisations_for_at_least_one_provider?
           items << NavigationItem.new('Organisations', provider_interface_organisations_path, is_active(current_controller, %w[organisations provider_relationship_permissions]))
         end
 
-        if FeatureFlag.active?(:providers_can_manage_users_and_permissions) && current_provider_user.authorisation.can_manage_users_for_at_least_one_provider?
+        if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider?
           items << NavigationItem.new('Users', provider_interface_provider_users_path, is_active(current_controller, 'provider_users'))
         end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,8 +23,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:providers_can_manage_users_and_permissions, 'Allows provider users to invite other provider users, and allows providers to manage other users permissions to do make decisions, view safeguarding, and add other users', 'Tijmen Brommet'],
-    [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
     [:providers_can_filter_by_recruitment_cycle, 'Allows provider users to filter applications by recruitment cycle', 'Michael Nacos'],
     [:international_addresses, 'Candidates who live outside the UK can enter their local address in free-text format', 'Steve Hook'],
     [:international_personal_details, 'Changes to the candidate personal details section to account for international applicants.', 'David Gisbey'],

--- a/app/services/make_decisions_authorisation.rb
+++ b/app/services/make_decisions_authorisation.rb
@@ -14,14 +14,12 @@ class MakeDecisionsAuthorisation
     related_providers = [training_provider, ratifying_provider].compact
     return false unless actor_has_permission_to_make_decisions?(providers: related_providers)
 
-    if FeatureFlag.active?(:enforce_provider_to_provider_permissions)
-      # enforce org-level 'make_decisions' restriction
-      if ratifying_provider
-        return false unless actor_has_permissions_via_provider_to_provider_permissions?(
-          training_provider: training_provider,
-          ratifying_provider: ratifying_provider,
-        )
-      end
+    # enforce org-level 'make_decisions' restriction
+    if ratifying_provider
+      return false unless actor_has_permissions_via_provider_to_provider_permissions?(
+        training_provider: training_provider,
+        ratifying_provider: ratifying_provider,
+      )
     end
 
     # check (indirect) relationship between course_option and @actor

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -59,29 +59,19 @@ class ProviderAuthorisation
   end
 
   def can_view_safeguarding_information?(course:)
-    if FeatureFlag.active?(:enforce_provider_to_provider_permissions)
-      @actor.provider_permissions.view_safeguarding_information
-        .exists?(provider: [course.provider, course.accredited_provider].compact) &&
-        (course.accredited_provider.blank? ||
-          ratifying_provider_can_view_safeguarding_information?(course: course) ||
-            training_provider_can_view_safeguarding_information?(course: course))
-    else
-      @actor.provider_permissions.view_safeguarding_information
-        .exists?(provider: [course.provider, course.accredited_provider].compact)
-    end
+    @actor.provider_permissions.view_safeguarding_information
+      .exists?(provider: [course.provider, course.accredited_provider].compact) &&
+      (course.accredited_provider.blank? ||
+        ratifying_provider_can_view_safeguarding_information?(course: course) ||
+          training_provider_can_view_safeguarding_information?(course: course))
   end
 
   def can_view_diversity_information?(course:)
-    if FeatureFlag.active?(:enforce_provider_to_provider_permissions)
-      @actor.provider_permissions.view_diversity_information
-        .exists?(provider: [course.provider, course.accredited_provider].compact) &&
-        (course.accredited_provider.blank? ||
-          ratifying_provider_can_view_diversity_information?(course: course) ||
-            training_provider_can_view_diversity_information?(course: course))
-    else
-      @actor.provider_permissions.view_diversity_information
-        .exists?(provider: [course.provider, course.accredited_provider].compact)
-    end
+    @actor.provider_permissions.view_diversity_information
+      .exists?(provider: [course.provider, course.accredited_provider].compact) &&
+      (course.accredited_provider.blank? ||
+        ratifying_provider_can_view_diversity_information?(course: course) ||
+          training_provider_can_view_diversity_information?(course: course))
   end
 
   def can_manage_organisation?(provider:)

--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -23,8 +23,6 @@ class ProviderSetup
   end
 
   def next_relationship_pending
-    return unless FeatureFlag.active?('enforce_provider_to_provider_permissions')
-
     permissions = ProviderRelationshipPermissions.find_by(
       setup_at: nil,
       training_provider: @provider_user.providers,

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -30,31 +30,25 @@
           <%= pf.govuk_check_box :permissions, 'make_decisions',
                                 label: { text: 'Make decisions' },
                                 hint_text: 'Make offers, amend offers and reject applications' %>
-          <% if FeatureFlag.active?(:enforce_provider_to_provider_permissions) %>
-            <div class="govuk-body govuk-!-margin-left-6">
-              <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'make_decisions') %>
-            </div>
-          <% end %>
+          <div class="govuk-body govuk-!-margin-left-6">
+            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'make_decisions') %>
+          </div>
 
           <%= pf.govuk_check_box :permissions, 'view_safeguarding_information',
                                 label: { text: 'Access safeguarding information' },
                                 hint_text: 'View sensitive material about the candidate' %>
 
-          <% if FeatureFlag.active?(:enforce_provider_to_provider_permissions) %>
-            <div class="govuk-body govuk-!-margin-left-6">
-              <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_safeguarding_information') %>
-            </div>
-          <% end %>
+          <div class="govuk-body govuk-!-margin-left-6">
+            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_safeguarding_information') %>
+          </div>
 
           <%= pf.govuk_check_box :permissions, 'view_diversity_information',
                                 label: { text: 'Access diversity information' },
                                 hint_text: 'View diversity information about the candidate' %>
 
-          <% if FeatureFlag.active?(:enforce_provider_to_provider_permissions) %>
-            <div class="govuk-body govuk-!-margin-left-6">
-              <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_diversity_information') %>
-            </div>
-          <% end %>
+          <div class="govuk-body govuk-!-margin-left-6">
+            <%= render AssociatedProvidersPermissionsListComponent.new(provider: @provider, permission_name: 'view_diversity_information') %>
+          </div>
         <% end %>
       <% end %>
 

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -48,9 +48,7 @@
         <h2 class="govuk-heading-m">View applications</h2>
         <p class="govuk-body">See newly submitted applications at a glance.</p>
         <p class="govuk-body">Filter by status, training provider, ratifying body – and soon, reject by default date.</p>
-      <% if FeatureFlag.active?(:providers_can_manage_users_and_permissions) %>
         <p class="govuk-body">Choose who in your organisation can make decisions and view sensitive info.</p>
-      <% end %>
       </div>
       <div class="govuk-grid-column-one-half">
         <img src="/provider/view.png" alt="A screenshot of the service showing a list of applications and their statuses.">

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
-  before { FeatureFlag.deactivate(:enforce_provider_to_provider_permissions) }
-
   let(:training_provider) { create(:provider) }
   let(:ratifying_provider) { create(:provider) }
   let(:course) { create(:course, provider: training_provider, accredited_provider: ratifying_provider) }
@@ -10,6 +8,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
     create(
       :provider_relationship_permissions,
       training_provider: training_provider,
+      ratifying_provider: ratifying_provider,
       training_provider_can_view_safeguarding_information: true,
     )
   end
@@ -47,6 +46,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
     context 'when provider user can view safeguarding information' do
       it 'displays the correct text' do
         provider_relationship_permissions
+
         provider_user.provider_permissions.find_by(provider: training_provider)
           .update!(view_safeguarding_information: true)
         result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))

--- a/spec/models/navigation_items_spec.rb
+++ b/spec/models/navigation_items_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe NavigationItems do
       before do
         provider_user.provider_permissions.find_by(provider: provider).update!(manage_organisations: true)
         create(:provider_relationship_permissions, training_provider: provider)
-        FeatureFlag.activate('enforce_provider_to_provider_permissions')
       end
 
       it 'includes a link to Organisations' do

--- a/spec/requests/provider_interface/managing_provider_users_spec.rb
+++ b/spec/requests/provider_interface/managing_provider_users_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'ProviderUserController actions' do
   let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
 
   before do
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     allow(DfESignInUser).to receive(:load_from_session)
       .and_return(
         DfESignInUser.new(

--- a/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/setup_provider_relationship_permissions_request_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'Set up ProviderRelationshipPermissions', type: :request do
   let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
 
   before do
-    FeatureFlag.activate(:enforce_provider_to_provider_permissions)
-
     allow(DfESignInUser).to receive(:load_from_session)
       .and_return(
         DfESignInUser.new(

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -83,10 +83,6 @@ RSpec.describe ProviderAuthorisation do
     end
 
     context 'actor: provider user (org-level permissions)' do
-      before do
-        FeatureFlag.activate(:enforce_provider_to_provider_permissions)
-      end
-
       it 'training_provider without make_decisions' do
         provider_relationship_permissions.update(training_provider_can_make_decisions: false)
 
@@ -168,10 +164,6 @@ RSpec.describe ProviderAuthorisation do
     end
 
     context 'actor: api user (org-level permissions)' do
-      before do
-        FeatureFlag.activate(:enforce_provider_to_provider_permissions)
-      end
-
       it 'is false for training_provider without make_decisions' do
         provider_relationship_permissions.update(training_provider_can_make_decisions: false)
 
@@ -201,10 +193,6 @@ RSpec.describe ProviderAuthorisation do
         ratifying_provider: ratifying_provider,
         training_provider: training_provider,
       )
-    end
-
-    before do
-      FeatureFlag.activate(:enforce_provider_to_provider_permissions)
     end
 
     subject(:can_view_safeguarding_information) do
@@ -306,10 +294,6 @@ RSpec.describe ProviderAuthorisation do
         ratifying_provider: ratifying_provider,
         training_provider: training_provider,
       )
-    end
-
-    before do
-      FeatureFlag.activate(:enforce_provider_to_provider_permissions)
     end
 
     subject(:can_view_diversity_information) do

--- a/spec/services/provider_setup_spec.rb
+++ b/spec/services/provider_setup_spec.rb
@@ -54,8 +54,6 @@ RSpec.describe ProviderSetup do
     end
 
     it 'returns a ProviderRelationshipPermissions record in need of setup' do
-      FeatureFlag.activate('enforce_provider_to_provider_permissions')
-
       create(
         :provider_relationship_permissions,
         training_provider: training_provider,
@@ -67,8 +65,6 @@ RSpec.describe ProviderSetup do
     end
 
     it 'provides all relationships pending setup for the user when called multiple times' do
-      FeatureFlag.activate('enforce_provider_to_provider_permissions')
-
       relationships = 3.times.map do
         create(
           :provider_relationship_permissions,

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
 
   scenario 'Provider manages permissions for their organisation' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_provider_permissions_feature_is_enabled
     and_i_sign_in_to_the_provider_interface
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
@@ -44,10 +43,6 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_user_exists_in_apply_database
-  end
-
-  def and_the_provider_permissions_feature_is_enabled
-    FeatureFlag.activate('enforce_provider_to_provider_permissions')
   end
 
   def and_i_can_manage_organisations_for_a_provider

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Managing provider user permissions' do
   include DfESignInHelpers
 
   scenario 'Provider manages permissions for users' do
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider

--- a/spec/system/provider_interface/manage_provider_user_providers_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_providers_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Managing providers a user has access to' do
   include DfESignInHelpers
 
   scenario 'Provider adds and removes providers from a user' do
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_users_for_two_providers
     and_there_is_a_user_with_access_to_one_of_the_providers

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement_spec.rb
@@ -35,7 +35,6 @@ RSpec.feature 'Accept data sharing agreement' do
   scenario 'Provider user with an organisation to set up accepts the data sharing agreement' do
     given_i_am_an_authorised_provider_user
     and_no_data_sharing_agreement_for_my_provider_has_been_accepted
-    and_the_provider_permissions_feature_is_enabled
     and_i_need_to_set_up_organisation_permissions
     and_i_am_presented_with_a_data_sharing_agreement
     and_i_cannot_navigate_to_pages_i_do_not_have_access_to
@@ -62,10 +61,6 @@ RSpec.feature 'Accept data sharing agreement' do
     provider2.provider_users << provider_user
     ProviderAgreement.data_sharing_agreements.for_provider(provider1).destroy_all
     ProviderAgreement.data_sharing_agreements.for_provider(provider2).destroy_all
-  end
-
-  def and_the_provider_permissions_feature_is_enabled
-    FeatureFlag.activate('enforce_provider_to_provider_permissions')
   end
 
   def and_i_need_to_set_up_organisation_permissions

--- a/spec/system/provider_interface/provider_cannot_respond_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_cannot_respond_to_application_spec.rb
@@ -23,8 +23,6 @@ RSpec.feature 'Provider cannot respond to application' do
   end
 
   scenario 'Provider cannot respond to an application they cannot make offer on' do
-    FeatureFlag.activate('enforce_provider_to_provider_permissions')
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
     and_my_provider_relationship_permissions_have_been_set_up

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -5,8 +5,6 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   include DsiAPIHelper
 
   scenario 'Provider sends invite to user' do
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers
     and_i_sign_in_to_the_provider_interface

--- a/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
@@ -5,8 +5,6 @@ RSpec.feature 'Providers can view managed users' do
   include DsiAPIHelper
 
   scenario 'Provider use can see their individual users permissions' do
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider

--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe 'Removing a provider user' do
   include DfESignInHelpers
 
   scenario 'removing a user from all providers', with_audited: true do
-    FeatureFlag.activate(:providers_can_manage_users_and_permissions)
-
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   scenario 'the application data is visible' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_enforce_provider_to_provider_permissions_feature_flag_is_active
     and_my_organisation_has_received_an_application
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
@@ -46,10 +45,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def then_i_should_see_the_safeguarding_declaration_section
     expect(page).to have_content('Criminal convictions and professional misconduct')
     expect(page).to have_content(t('provider_interface.safeguarding_declaration_component.has_safeguarding_issues_to_declare'))
-  end
-
-  def and_the_enforce_provider_to_provider_permissions_feature_flag_is_active
-    FeatureFlag.activate('enforce_provider_to_provider_permissions')
   end
 
   def when_i_am_permitted_to_see_safeguarding_information

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'See organisation permissions' do
 
   scenario 'A provider user views the organisations they belong to' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_provider_permissions_feature_is_enabled
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
     and_the_ratifying_provider_has_courses_run_by_another_provider
@@ -27,10 +26,6 @@ RSpec.feature 'See organisation permissions' do
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_user_exists_in_apply_database
-  end
-
-  def and_the_provider_permissions_feature_is_enabled
-    FeatureFlag.activate('enforce_provider_to_provider_permissions')
   end
 
   def and_i_can_manage_organisations_for_a_provider

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Setting up provider relationship permissions' do
 
   scenario 'Provider user sets up permissions for their organisation' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_provider_permissions_feature_is_enabled
     and_i_can_manage_organisations
     and_my_organisations_have_not_had_permissions_setup
 
@@ -35,10 +34,6 @@ RSpec.feature 'Setting up provider relationship permissions' do
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_user_exists_in_apply_database
-  end
-
-  def and_the_provider_permissions_feature_is_enabled
-    FeatureFlag.activate('enforce_provider_to_provider_permissions')
   end
 
   def and_i_can_manage_organisations


### PR DESCRIPTION
## Context

`:providers_can_manage_users_and_permissions` and `:enforce_provider_to_provider_permissions` are feature flags which helped us launch the provider interface access control feature. Now that the feature is live, we don't need these flags, as permissions are already being used and there is no going back.

## Changes proposed in this pull request

Remove all instances of `:providers_can_manage_users_and_permissions` and `:enforce_provider_to_provider_permissions` from code and tests. Do so in a way that's equivalent to the flags being always on.

## Guidance to review

Inspect file changes, run the tests.

## Link to Trello card

https://trello.com/c/l4vzf43X

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
