### PR TITLE
Add caching for edit provider users page

### DIFF
--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,21 +1,23 @@
 <%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Edit providers and permissions', tag: 'h2' } do %>
   <div class="app-checkboxes-scroll govuk-!-width-two-thirds">
     <% f.object.forms_for_possible_permissions.each do |permission_form| %>
-      <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
-        <%= pf.govuk_check_box :active, true, multiple: false,
-                               label: { text: permission_form.provider.name_and_code } do %>
-          <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
-            <%= ppf.hidden_field :provider_id %>
-            <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-              <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
-              <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
-                                      label: { text: 'Manage organisations' } %>
-              <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
-                                      label: { text: 'Make decisions' } %>
-              <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
-                                      label: { text: 'Access safeguarding information' } %>
-              <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
-                                      label: { text: 'Access diversity information' } %>
+      <%= cache [permission_form.provider, permission_form.provider_permission] do %>
+        <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
+          <%= pf.govuk_check_box :active, true, multiple: false,
+                                 label: { text: permission_form.provider.name_and_code } do %>
+            <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+              <%= ppf.hidden_field :provider_id %>
+              <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
+                <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+                <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
+                                        label: { text: 'Manage organisations' } %>
+                <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
+                                        label: { text: 'Make decisions' } %>
+                <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
+                                        label: { text: 'Access safeguarding information' } %>
+                <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
+                                        label: { text: 'Access diversity information' } %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,9 @@ module ApplyForPostgraduateTeacherTraining
 
     config.active_job.queue_adapter = :sidekiq
 
+    config.action_controller.perform_caching = true
+    config.cache_store = :memory_store
+
     config.middleware.insert_after ActionDispatch::HostAuthorization, RedirectToServiceGovUkMiddleware
     config.middleware.use PDFKit::Middleware, { print_media_type: true }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
     config.skylight.environments = ENV['SKYLIGHT_ENABLE'].to_s == 'true' ? [Rails.env] : []

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,21 +12,7 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-    config.action_controller.enable_fragment_cache_logging = true
-
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  config.action_controller.enable_fragment_cache_logging = true
 
   # Do not care if the mailer cannot send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,9 +43,6 @@ Rails.application.configure do
     hsts: true,
   }
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "apply_for_postgraduate_teacher_training_production"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,8 +18,6 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
-  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
## Context

The new/edit provider user page is very slow, because we're generating a lot of checkboxes.

## Changes proposed in this pull request

First, configure caching in all environments. We use in-memory cache, which is not fantastic (it's per node, so users won't get a consistent caching experience) but better than nothing. I'll investigate using Redis for this later.

Use key-based cache expiration to cache the set of checkboxes for a single provider. The checkbox cache is invalidated when:

- the HTML changes
- the provider changes (the updated_at attribute)
- the provider permission changes (when a checkbox is changed)

## Guidance to review

Does this make sense? Any problems that we can anticipate with this caching strategy?

## Link to Trello card

https://trello.com/c/jpKDACFO/2285-make-sure-add-provider-user-page-in-support-can-deal-with-a-lot-of-providers

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
