### PR TITLE
Remove eligibility screen when international feature is active

### DIFF
--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -16,6 +16,8 @@ module CandidateInterface
 
       if @create_account_or_sign_in_form.existing_account?
         SignInCandidate.new(@create_account_or_sign_in_form.email, self).call
+      elsif FeatureFlag.active?(:international_personal_details)
+        redirect_to candidate_interface_sign_up_path(providerCode: params[:providerCode], courseCode: params[:courseCode])
       else
         redirect_to candidate_interface_eligibility_path(
           providerCode: params[:providerCode],

--- a/spec/system/candidate_interface/candidate_eligibility_spec.rb
+++ b/spec/system/candidate_interface/candidate_eligibility_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
+# TODO: remove this entire system spec when removing International feature flags
 RSpec.feature 'Candidate eligibility' do
   scenario 'Candidate confirms that they are eligible' do
     given_the_pilot_is_open
+    and_the_international_personal_details_feature_is_inactive
 
     when_i_click_start_on_the_start_page
     and_i_confirm_i_am_not_already_signed_up
@@ -15,10 +17,23 @@ RSpec.feature 'Candidate eligibility' do
     and_i_confirm_i_am_not_already_signed_up
     when_i_answer_yes_to_all_questions
     then_should_be_redirected_to_the_signup_page
+
+    given_the_international_personal_details_feature_is_active
+    when_i_click_start_on_the_start_page
+    and_i_confirm_i_am_not_already_signed_up
+    then_should_be_redirected_to_the_signup_page
   end
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_international_personal_details_feature_is_inactive
+    FeatureFlag.deactivate('international_personal_details')
+  end
+
+  def given_the_international_personal_details_feature_is_active
+    FeatureFlag.activate('international_personal_details')
   end
 
   def when_i_click_start_on_the_start_page

--- a/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -5,11 +5,11 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
 
   scenario 'Candidate is redirected to the before you start page on their first sign in' do
     given_the_pilot_is_open
+    and_the_international_personal_details_feature_is_active
 
     when_i_visit_apply
     and_i_click_start_now
     and_i_confirm_i_am_not_already_signed_up
-    and_i_fill_in_the_eligiblity_form_with_yes
     and_i_submit_my_email_address
     and_click_on_the_magic_link
     then_i_should_see_the_before_you_start_page
@@ -21,7 +21,6 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     when_i_visit_apply
     and_i_click_start_now
     and_i_confirm_i_am_not_already_signed_up
-    and_i_fill_in_the_eligiblity_form_with_yes
     and_i_submit_my_email_address
     and_click_on_the_magic_link
     then_i_should_see_the_before_you_start_page
@@ -37,7 +36,6 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     when_i_visit_apply
     and_i_click_start_now
     and_i_confirm_i_am_not_already_signed_up
-    and_i_fill_in_the_eligiblity_form_with_yes
     and_i_submit_my_email_address
     and_click_on_the_magic_link
     then_i_should_see_the_application_page
@@ -46,6 +44,10 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_international_personal_details_feature_is_active
+    FeatureFlag.activate('international_personal_details')
   end
 
   def when_i_visit_apply
@@ -59,18 +61,6 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
   def and_i_confirm_i_am_not_already_signed_up
     choose 'No, I need to create an account'
     click_button 'Continue'
-  end
-
-  def and_i_fill_in_the_eligiblity_form_with_yes
-    within_fieldset('Are you a citizen of the UK or the EU?') do
-      choose 'Yes'
-    end
-
-    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
-      choose 'Yes'
-    end
-
-    click_on 'Continue'
   end
 
   def and_i_submit_my_email_address

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -5,10 +5,10 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_the_pilot_is_open
+    and_the_international_personal_details_feature_is_active
     given_i_am_a_candidate_without_an_account
 
     when_i_go_to_sign_up
-    and_i_fill_in_the_eligiblity_form_with_yes
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
 
@@ -32,6 +32,10 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     FeatureFlag.activate('pilot_open')
   end
 
+  def and_the_international_personal_details_feature_is_active
+    FeatureFlag.activate('international_personal_details')
+  end
+
   def given_i_am_a_candidate_without_an_account
     @email = "#{SecureRandom.hex}@example.com"
   end
@@ -42,18 +46,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
     choose 'No, I need to create an account'
     click_button 'Continue'
-  end
-
-  def and_i_fill_in_the_eligiblity_form_with_yes
-    within_fieldset('Are you a citizen of the UK or the EU?') do
-      choose 'Yes'
-    end
-
-    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
-      choose 'Yes'
-    end
-
-    click_on 'Continue'
   end
 
   def and_i_submit_my_email_address

--- a/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   scenario 'seeing their course information on the landing page' do
     given_the_pilot_is_open
+    and_the_international_personal_details_feature_is_active
 
     when_i_arrive_from_find_with_invalid_course_parameters
     then_i_should_see_an_error_page
@@ -30,7 +31,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
     when_i_choose_to_apply_through_apply
     and_i_confirm_i_am_not_already_signed_up
-    then_i_see_the_eligibility_page
+    then_i_see_the_sign_up_page
 
     given_the_pilot_is_not_open
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
@@ -43,6 +44,10 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_international_personal_details_feature_is_active
+    FeatureFlag.activate('international_personal_details')
   end
 
   def when_i_arrive_from_find_with_invalid_course_parameters
@@ -123,7 +128,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
     click_button 'Continue'
   end
 
-  def then_i_see_the_eligibility_page
-    expect(page).to have_content('Check we’re ready for you to use this service')
+  def then_i_see_the_sign_up_page
+    expect(page).to have_content 'Create an Apply for teacher training account'
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
 
   scenario 'Candidate signs in and recieves an email inviting them to sign up and is prompted to select the course' do
     given_the_pilot_is_open
+    and_the_international_personal_details_feature_is_active
 
     given_i_am_a_candidate_without_an_account
     and_there_is_a_course_with_multiple_sites
@@ -12,7 +13,6 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
     when_i_follow_a_link_from_find
     and_i_choose_to_use_apply
     and_i_confirm_i_am_not_already_signed_up
-    and_i_answer_eligibility_questions
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
 
@@ -25,6 +25,10 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_international_personal_details_feature_is_active
+    FeatureFlag.activate('international_personal_details')
   end
 
   def given_i_am_a_candidate_without_an_account
@@ -49,18 +53,6 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
   def and_i_confirm_i_am_not_already_signed_up
     choose 'No, I need to create an account'
     click_button 'Continue'
-  end
-
-  def and_i_answer_eligibility_questions
-    within_fieldset('Are you a citizen of the UK or the EU?') do
-      choose 'Yes'
-    end
-
-    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
-      choose 'Yes'
-    end
-
-    click_on 'Continue'
   end
 
   def and_i_submit_my_email_address

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
 
   scenario 'retaining their course selection through the sign up process' do
     given_the_pilot_is_open
+    and_the_international_personal_details_feature_is_active
     and_the_course_i_selected_only_has_one_site
 
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
     and_i_choose_to_apply_on_apply
     and_i_choose_i_need_an_account
-    when_i_fill_in_the_eligiblity_form_with_yes
     when_i_submit_my_email_address
     and_click_on_the_magic_link
     then_i_should_see_the_course_selection_page
@@ -38,6 +38,10 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_international_personal_details_feature_is_active
+    FeatureFlag.activate('international_personal_details')
   end
 
   def and_the_course_i_selected_only_has_one_site
@@ -71,18 +75,6 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
 
   def and_i_choose_i_need_an_account
     choose 'No, I need to create an account'
-    click_on 'Continue'
-  end
-
-  def when_i_fill_in_the_eligiblity_form_with_yes
-    within_fieldset('Are you a citizen of the UK or the EU?') do
-      choose 'Yes'
-    end
-
-    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
-      choose 'Yes'
-    end
-
     click_on 'Continue'
   end
 


### PR DESCRIPTION


## Context
The eligibility screen asks questions about citizenship and whether
qualifications were obtained at a UK-based institution. Once the
International features are active, this screen becomes redundant.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->


Check against the `international_personal_details` feature flag and
disable the eligibility screen if the feature is active.
## Guidance to review
- In the review app, switch on the `international_personal_details` feature and click through the start pages.
- The eligibility screen should not appear.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/b/aRIgjf0y/candidate-team-board
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
