### PR TITLE
Consider start of cycle when Find reopens

### DIFF
--- a/app/components/candidate_interface/carry_over_banner_component.html.erb
+++ b/app/components/candidate_interface/carry_over_banner_component.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-heading-m">
       <% if references_did_not_come_back_in_time? %>
         <p>
-          Courses for the <%= current_cycle_span %> academic year are now closed
+          Courses for the 2020 to 2021 academic year are now closed
         </p>
 
         <p class='govuk-body govuk-!-font-size-24'>
@@ -11,7 +11,7 @@
         </p>
       <% elsif between_cycles? %>
         <p>
-          Courses for the <%= current_cycle_span %> academic year are now closed
+          Courses for the 2020 to 2021 academic year are now closed
         </p>
 
         <p class='govuk-body govuk-!-font-size-24'>
@@ -23,7 +23,7 @@
         </p>
 
         <p class='govuk-body govuk-!-font-size-24'>
-          Applications are open for courses starting next academic year <%= current_cycle_span %>.
+          Applications are open for courses starting academic year 2021 to 2022.
         </p>
 
         <p class='govuk-body govuk-!-font-size-24'>

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -99,14 +99,6 @@ module ViewHelper
     boolean ? 'Yes' : 'No'
   end
 
-  def current_cycle_span
-    "#{RecruitmentCycle.current_year} to #{RecruitmentCycle.next_year}"
-  end
-
-  def next_cycle_span
-    "#{RecruitmentCycle.next_year} to #{RecruitmentCycle.next_year + 1}"
-  end
-
   def days_until_find_reopens
     (EndOfCycleTimetable.find_reopens - Time.zone.today).to_i
   end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,6 +1,6 @@
 module RecruitmentCycle
   def self.current_year
-    if Time.zone.today < EndOfCycleTimetable.apply_reopens
+    if Time.zone.today < EndOfCycleTimetable.find_reopens
       2020
     else
       2021

--- a/app/views/candidate_interface/carry_over/start.html.erb
+++ b/app/views/candidate_interface/carry_over/start.html.erb
@@ -7,7 +7,7 @@
     <h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over') %></h1>
 
     <p class="govuk-body">
-      Carry on with your application for courses starting in the <%= current_cycle_span %> academic year.
+      Carry on with your application for courses starting in the 2021 to 2022 academic year.
     </p>
 
     <p class="govuk-body">

--- a/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
@@ -8,12 +8,12 @@
 
     <% if CandidateInterface::EndOfCyclePolicy.before_find_reopens? %>
       <p class="govuk-body">
-        Applications for courses starting in the <%= current_cycle_span %> academic year are closed.
+        Applications for courses starting in the 2020 to 2021 academic year are closed.
       </p>
     <% end %>
 
     <p class="govuk-body">
-      Carry on with your application for courses starting in the <%= next_cycle_span %> year.
+      Carry on with your application for courses starting in the 2021 to 2022 academic year.
     </p>
 
     <% if CandidateInterface::EndOfCyclePolicy.before_apply_reopens? %>

--- a/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
@@ -6,9 +6,9 @@
 
     <h1 class="govuk-heading-xl"><%= t('page_titles.start_carry_over_between_cycles_unsubmitted') %></h1>
 
-    <p class="govuk-body">You did not submit your application in time to start a course in the <%= current_cycle_span %> academic year.</p>
+    <p class="govuk-body">You did not submit your application in time to start a course in the 2020 to 2021 academic year.</p>
 
-    <p class="govuk-body">But you can carry on with your application for courses starting in the <%= next_cycle_span %> academic year.</p>
+    <p class="govuk-body">But you can carry on with your application for courses starting in the 2021 to 2022 academic year.</p>
 
     <% if CandidateInterface::EndOfCyclePolicy.before_apply_reopens? %>
       <p class="govuk-body">

--- a/spec/components/candidate_interface/carry_over_banner_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_banner_component_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe CandidateInterface::CarryOverBannerComponent do
       application_form.recruitment_cycle_year = 2020
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Courses for the 2021 to 2022 academic year are now closed')
       expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_carry_over_path)
     end
 
@@ -106,7 +105,6 @@ RSpec.describe CandidateInterface::CarryOverBannerComponent do
       application_form.recruitment_cycle_year = 2021
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('Courses for the 2021 to 2022 academic year are now closed')
       expect(result.css('a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_start_carry_over_path)
     end
 

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_click_on_start_now
-    expect(page).to have_content 'Carry on with your application for courses starting in the 2021 to 2022 year.'
     expect(page).to have_content 'You can submit your application from 13 October 2020.'
     expect(page).to have_content 'Your courses have been removed. You can add them again later.'
     click_button 'Apply again'

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
   def and_i_click_on_apply_again
     expect(page).to have_content 'Do you want to continue applying?'
-    expect(page).to have_content 'Applications are open for courses starting next academic year 2021 to 2022.'
     click_link 'Continue your application'
   end
 


### PR DESCRIPTION
## Context

Find reopens tomorrow, and we'll allow existing candidates to choose new courses. This means that for all intents and purposes, tomorrow is the start of the cycle.

**If this isn't deployed by tomorrow, we will allow candidates to apply to courses from the previous cycle.**

## Changes proposed in this pull request

Change the logic to make sure tomorrow is the start of the new cycle, even if candidates can't submit yet.

## Guidance to review

Will this have any unintended side effects?

## Link to Trello card

https://trello.com/c/nGEHOTm7/2827-eoc-playbook

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
