### PR TITLE
Don’t capitalise ‘The’ when expanding NARIC acronym

### DIFF
--- a/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body">You can get a statement from The National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
+<p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
 <%= f.govuk_radio_buttons_fieldset :have_naric_reference, legend: { text: t('application_form.degree.naric_statment.label'), tag: 'span' } do %>
   <%= f.govuk_radio_button :have_naric_reference, 'yes', label: { text: 'Yes' } do %>
     <%= f.govuk_text_field(

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -10,7 +10,7 @@
         <%= t("gcse_edit_naric_reference.page_title", subject: @subject.capitalize) %>
       </h1>
 
-      <p class="govuk-body">You can get a statement from The National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
+      <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
       <%= f.govuk_radio_buttons_fieldset :naric_details, legend: { text: t('application_form.gcse.naric_statement.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :naric_reference_choice, 'Yes', label: { text: 'Yes' } do %>
           <%= f.govuk_text_field(

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -191,7 +191,7 @@ en:
       delete: Delete degree
       confirm_delete: Yes I’m sure - delete this degree
       naric_statment:
-        label: Do you have a statement of comparability from The National Recognition Information Centre?
+        label: Do you have a statement of comparability from the National Recognition Information Centre?
         review_label: Do you have a UK NARIC statement of comparability?
         change_action: UK NARIC statement
       naric_reference:
@@ -236,7 +236,7 @@ en:
         label: Enter year
         hint_text: For example, 1996
       naric_statement:
-        label: Do you have a statement of comparability from The National Recognition Information Centre?
+        label: Do you have a statement of comparability from the National Recognition Information Centre?
         review_label: Do you have a UK NARIC statement of comparability?
         change_action: UK NARIC statement
       naric_reference:

--- a/spec/system/candidate_interface/international/candidate_entering_international_degrees_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_international_degrees_spec.rb
@@ -163,7 +163,7 @@ RSpec.feature 'Entering their degrees' do
   end
 
   def then_i_can_see_the_naric_page
-    expect(page).to have_content 'Do you have a statement of comparability from The National Recognition Information Centre?'
+    expect(page).to have_content 'Do you have a statement of comparability from the National Recognition Information Centre?'
   end
 
   def then_i_see_validation_errors_for_naric_question


### PR DESCRIPTION
## Context

Use `blah blah the National Recognition Information Centre` not Use `blah blah The National Recognition Information Centre` (lowercase ‘the’).