### PR TITLE
Support: Remove phase banner

### DIFF
--- a/app/components/phase_banner.html.erb
+++ b/app/components/phase_banner.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-width-container">
   <div class="govuk-phase-banner <%= @no_border ? 'app-phase-banner--no-border' : '' %> govuk-!-display-none-print">
     <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag <%= app_environment_css_class %>">
+      <strong class="govuk-tag govuk-phase-banner__content__tag <%= phase_tag_class %>">
         <%= HostingEnvironment.phase %>
       </strong>
       <span class="govuk-phase-banner__text">

--- a/app/components/phase_banner.html.erb
+++ b/app/components/phase_banner.html.erb
@@ -1,12 +1,12 @@
 <div class="govuk-width-container">
   <div class="govuk-phase-banner <%= @no_border ? 'app-phase-banner--no-border' : '' %> govuk-!-display-none-print">
     <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag <%= app_environment_css_class %>">
+      <strong class="govuk-tag govuk-phase-banner__content__tag <%= app_environment_css_class %>">
         <%= HostingEnvironment.phase %>
       </strong>
-    <span class="govuk-phase-banner__text">
-      <%= text %>
-    </span>
+      <span class="govuk-phase-banner__text">
+        <%= text %>
+      </span>
     </p>
   </div>
 </div>

--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -30,25 +30,6 @@ class PhaseBanner < ViewComponent::Base
   def app_environment_css_class
     return '' if HostingEnvironment.production?
 
-    "govuk-tag--#{css_colour}"
-  end
-
-private
-
-  def css_colour
-    return :purple if HostingEnvironment.sandbox_mode?
-
-    case HostingEnvironment.environment_name
-    when 'qa'
-      :orange
-    when 'staging'
-      :red
-    when 'development'
-      :grey
-    when 'review'
-      :purple
-    when 'unknown-environment'
-      :yellow
-    end
+    "govuk-tag--#{HostingEnvironment.phase_colour}"
   end
 end

--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -27,7 +27,7 @@ class PhaseBanner < ViewComponent::Base
     end
   end
 
-  def app_environment_css_class
+  def phase_tag_class
     return '' if HostingEnvironment.production?
 
     "govuk-tag--#{HostingEnvironment.phase_colour}"

--- a/app/components/product_header_component.html.erb
+++ b/app/components/product_header_component.html.erb
@@ -15,7 +15,7 @@
           <%= product_name %>
         </span>
         <% if phase_tag %>
-          <strong class="govuk-tag <%= app_environment_css_class %>">
+          <strong class="govuk-tag <%= phase_tag_class %>">
             <%= HostingEnvironment.phase %>
           </strong>
         <% end %>

--- a/app/components/product_header_component.html.erb
+++ b/app/components/product_header_component.html.erb
@@ -14,6 +14,11 @@
         <span class="govuk-header__product-name">
           <%= product_name %>
         </span>
+        <% if phase_tag %>
+          <strong class="govuk-tag <%= app_environment_css_class %>">
+            <%= HostingEnvironment.phase %>
+          </strong>
+        <% end %>
       <% end %>
     </div>
     <div class="govuk-header__content app-header__content--provider">

--- a/app/components/product_header_component.rb
+++ b/app/components/product_header_component.rb
@@ -10,7 +10,7 @@ class ProductHeaderComponent < ViewComponent::Base
     @classes          = classes
   end
 
-  def app_environment_css_class
+  def phase_tag_class
     return '' if HostingEnvironment.production?
 
     "govuk-tag--#{HostingEnvironment.phase_colour}"

--- a/app/components/product_header_component.rb
+++ b/app/components/product_header_component.rb
@@ -1,11 +1,18 @@
 class ProductHeaderComponent < ViewComponent::Base
-  attr_reader :navigation_items, :service_url, :product_name, :classes
+  attr_reader :navigation_items, :service_url, :product_name, :phase_tag, :classes
   include ViewHelper
 
-  def initialize(navigation_items:, product_name:, service_url:, classes: '')
+  def initialize(navigation_items:, service_url:, product_name:, phase_tag: false, classes: '')
     @navigation_items = navigation_items
-    @product_name     = product_name
     @service_url      = service_url
+    @product_name     = product_name
+    @phase_tag        = phase_tag
     @classes          = classes
+  end
+
+  def app_environment_css_class
+    return '' if HostingEnvironment.production?
+
+    "govuk-tag--#{HostingEnvironment.phase_colour}"
   end
 end

--- a/app/frontend/styles/_header.scss
+++ b/app/frontend/styles/_header.scss
@@ -1,32 +1,29 @@
-$app-colour-qa: govuk-colour("orange");
-$app-colour-sandbox: govuk-colour("purple");
-$app-colour-review: govuk-colour("purple");
-$app-colour-staging: govuk-colour("red");
-$app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
-
-.app-header--production .govuk-header__container {
-  // default blue styling
+.app-header--production.app-header--full-border {
+  border-bottom-color: govuk-colour("blue");
 }
 
-.app-header--qa .govuk-header__container {
-  border-bottom-color: $app-colour-qa;
+.app-header--qa .govuk-header__container,
+.app-header--qa.app-header--full-border {
+  border-bottom-color: govuk-colour("orange");
 }
 
-.app-header--staging .govuk-header__container {
-  border-bottom-color: $app-colour-staging;
+.app-header--staging .govuk-header__container,
+.app-header--staging.app-header--full-border {
+  border-bottom-color: govuk-colour("red");
 }
 
-.app-header--sandbox .govuk-header__container {
-  border-bottom-color: $app-colour-sandbox;
-}
-
-.app-header--review .govuk-header__container {
-  border-bottom-color: $app-colour-review;
+.app-header--review .govuk-header__container,
+.app-header--review.app-header--full-border,
+.app-header--sandbox .govuk-header__container,
+.app-header--sandbox.app-header--full-border {
+  border-bottom-color: govuk-colour("purple");
 }
 
 .app-header--development .govuk-header__container,
-.app-header--unknown-environment .govuk-header__container {
-  border-bottom-color: $app-colour-development;
+.app-header--development.app-header--full-border,
+.app-header--unknown-environment .govuk-header__container,
+.app-header--unknown-environment.app-header--full-border {
+  border-bottom-color: govuk-colour("dark-grey");
 }
 
 .app-header__logo--provider {

--- a/app/frontend/styles/_header.scss
+++ b/app/frontend/styles/_header.scss
@@ -1,3 +1,7 @@
+.govuk-header .govuk-tag {
+  vertical-align: middle;
+}
+
 .app-header--production.app-header--full-border {
   border-bottom-color: govuk-colour("blue");
 }

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -27,6 +27,23 @@ module HostingEnvironment
     end
   end
 
+  def self.phase_colour
+    return :purple if HostingEnvironment.sandbox_mode?
+
+    case HostingEnvironment.environment_name
+    when 'qa'
+      :orange
+    when 'staging'
+      :red
+    when 'development'
+      :grey
+    when 'review'
+      :purple
+    when 'unknown-environment'
+      :yellow
+    end
+  end
+
   def self.environment_name
     ENV.fetch('HOSTING_ENVIRONMENT_NAME', 'unknown-environment')
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,8 +9,8 @@
   <%= render(ProductHeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
                                  product_name: service_name,
                                  service_url: service_link,
+                                 phase_tag: true,
                                  navigation_items: NavigationItems.for_support_account_nav(try(:current_support_user)))) %>
-                               <%= render PhaseBanner.new(no_border: true) %>
                                <%= render(PrimaryNavigationComponent.new(
                                  navigation_items: NavigationItems.for_support_primary_nav(try(:current_support_user), controller))) %>
   <%= yield(:navigation) if content_for?(:navigation) %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,7 +6,7 @@
                                  navigation_items: NavigationItems.for_candidate_interface(try(:current_candidate), controller))) %>
                                <%= render PhaseBanner.new %>
 <% when 'support_interface' %>
-  <%= render(ProductHeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
+  <%= render(ProductHeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
                                  product_name: service_name,
                                  service_url: service_link,
                                  navigation_items: NavigationItems.for_support_account_nav(try(:current_support_user)))) %>


### PR DESCRIPTION
## Context

We don’t need to show any feedback links or other content in the support interface, though we still need to know what environment we are looking at. We can save some space by moving the phase tag into the header, next to the product name.

## Changes proposed in this pull request

Before:

<img width="1024" alt="Screenshot 2020-10-05 at 17 52 56" src="https://user-images.githubusercontent.com/813383/95108853-b8cb7480-0733-11eb-863e-91fb95ed429f.png">

After:

<img width="1024" alt="Screenshot 2020-10-05 at 17 51 56" src="https://user-images.githubusercontent.com/813383/95108886-bf59ec00-0733-11eb-9e2b-f78c0def4267.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
