### PR TITLE
API docs navigation

### DIFF
--- a/app/frontend/styles/api_docs/_all.scss
+++ b/app/frontend/styles/api_docs/_all.scss
@@ -1,2 +1,10 @@
 // API Docs components
+@import "~@ministryofjustice/frontend/moj/settings/assets";
+@import "~@ministryofjustice/frontend/moj/settings/measurements";
+@import "~@ministryofjustice/frontend/moj/helpers/all";
+@import "~@ministryofjustice/frontend/moj/objects/width-container";
+@import "~@ministryofjustice/frontend/moj/components/filter/filter";
+@import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
+@import "~@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
+@import "~@ministryofjustice/frontend/moj/utilities/all";
 @import "_syntax-highlighting";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,8 @@ module ApplicationHelper
       t('service_name.manage')
     when 'support_interface'
       t('service_name.support')
+    when 'api_docs'
+      t('service_name.api')
     else
       t('service_name.apply')
     end

--- a/app/views/api_docs/pages/lifecycle.html.erb
+++ b/app/views/api_docs/pages/lifecycle.html.erb
@@ -17,5 +17,4 @@
 
 <% ApplicationStateChange.workflow_spec.states.each do |_, state| %>
   <%= render StateExplanationComponent.new(machine: ApplicationStateChange, state: state) %>
-  <hr class='govuk-section-break govuk-section-break--xl govuk-section-break--visible'>
 <% end %>

--- a/app/views/api_docs/pages/lifecycle.html.erb
+++ b/app/views/api_docs/pages/lifecycle.html.erb
@@ -1,13 +1,11 @@
 <%= content_for :title, 'Application lifecycle' %>
 
-<% content_for :before_content do %>
-  <%= render TabNavigationComponent.new(items: [
-    { name: 'Application lifecycle', url: api_docs_lifecycle_path, current: true },
-    { name: 'When emails are sent', url: api_docs_when_emails_are_sent_path },
-  ]) %>
-<% end %>
+<h1 class="govuk-heading-xl">Lifecycle</h1>
 
-<h1 class="govuk-heading-xl">Application lifecycle</h1>
+<%= render TabNavigationComponent.new(items: [
+  { name: 'Application lifecycle', url: api_docs_lifecycle_path, current: true },
+  { name: 'When emails are sent', url: api_docs_when_emails_are_sent_path },
+]) %>
 
 <%= StateDiagram.svg(only_from_state: nil, machine: ApplicationStateChange) %>
 

--- a/app/views/api_docs/pages/when_emails_are_sent.html.erb
+++ b/app/views/api_docs/pages/when_emails_are_sent.html.erb
@@ -1,11 +1,11 @@
 <%= content_for :title, 'When emails are sent' %>
 
-<% content_for :before_content do %>
-  <%= render TabNavigationComponent.new(items: [
-    { name: 'Application lifecycle', url: api_docs_lifecycle_path },
-    { name: 'When emails are sent', url: api_docs_when_emails_are_sent_path, current: true },
-  ]) %>
-<% end %>
+<h1 class="govuk-heading-xl">Lifecycle</h1>
+
+<%= render TabNavigationComponent.new(items: [
+  { name: 'Application lifecycle', url: api_docs_lifecycle_path },
+  { name: 'When emails are sent', url: api_docs_when_emails_are_sent_path, current: true },
+]) %>
 
 <style>
   svg { max-width: 100%; }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -30,11 +30,13 @@
                                    navigation_items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, @provider_setup&.pending?))) %>
                                <% end %>
 <% when 'api_docs' %>
-  <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
-                                 service_name: service_name,
+  <%= render(ProductHeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
+                                 product_name: service_name,
                                  service_url: service_link,
+                                 phase_tag: true,
+                                 navigation_items: [])) %>
+                               <%= render(PrimaryNavigationComponent.new(
                                  navigation_items: NavigationItems.for_api_docs(controller))) %>
-                               <%= render PhaseBanner.new %>
 <% else %>
   <% components_url = '/rails/view_components' if request.path.match(/^\/rails\/view_components/) %>
   <% components_name = 'ViewComponent Previews' if request.path.match(/^\/rails\/view_components/) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     apply: Apply for teacher training
     manage: Manage teacher training applications
     support: Support for Apply
+    api: Apply for teacher training API
   page_titles:
     application: ""
     application_form: Your application


### PR DESCRIPTION
## Context

Update to follow same design used by Support and Provider interfaces.

Depends on #3060

## Changes proposed in this pull request

Before:

<img width="1048" alt="Screenshot 2020-10-05 at 18 31 43" src="https://user-images.githubusercontent.com/813383/95112792-51b0be80-0739-11eb-9896-e69eb2e9da47.png">

After:

<img width="1000" alt="Screenshot 2020-10-05 at 18 31 06" src="https://user-images.githubusercontent.com/813383/95112815-58d7cc80-0739-11eb-8d97-b1fbc2586b36.png">

## Guidance to review

I’m currently not showing the environment/phase in the header - on production this would mean showing ‘Apply for teacher training API BETA’. Is that a thing we want to call this? Is it strictly still Beta? @duncanjbrown 

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
