### PR TITLE
Support: Use summary card component for feature flags

### DIFF
--- a/app/components/support_interface/feature_audit_trail_component.html.erb
+++ b/app/components/support_interface/feature_audit_trail_component.html.erb
@@ -1,7 +1,8 @@
 <ul class="govuk-list govuk-list--bullet">
   <% audits.select { |audit| visible?(audit) }.each do |audit| %>
     <li>
-      <%= l(audit.created_at.to_date, format: :long) %> <%= l(audit.created_at, format: :time) %> - <%= action_label_for(audit) %> <%= active_value_for(audit) %><%= user_label_for(audit) %>
+      <%= action_label_for(audit) %> <%= active_value_for(audit).downcase %><%= user_label_for(audit) %>
+      <span class="govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16"><%= l(audit.created_at.to_date, format: :long) %> at <%= l(audit.created_at, format: :time) %></span>
     </li>
   <% end %>
 </ul>

--- a/app/frontend/styles/_summary-card.scss
+++ b/app/frontend/styles/_summary-card.scss
@@ -17,7 +17,7 @@
     @include govuk-media-query($from: desktop) {
       display: flex;
       justify-content: space-between;
-      align-items: start;
+      align-items: center;
     }
 
     @include govuk-media-query($media-type: print) {

--- a/app/frontend/styles/support/_all.scss
+++ b/app/frontend/styles/support/_all.scss
@@ -7,5 +7,6 @@
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
 @import "~@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
 @import "~@ministryofjustice/frontend/moj/utilities/all";
+@import "_button";
 @import "_checkboxes-scroll";
 @import "_relationship-diagram";

--- a/app/frontend/styles/support/_button.scss
+++ b/app/frontend/styles/support/_button.scss
@@ -1,0 +1,38 @@
+// Tertiary button variables
+$button-shadow-size: $govuk-border-width-form-element;
+$app-button-tertiary-button-colour: govuk-colour("blue");
+$app-button-tertiary-button-hover-colour: govuk-shade($app-button-tertiary-button-colour, 10%);
+$app-button-tertiary-button-shadow-colour: govuk-shade($app-button-tertiary-button-colour, 40%);
+$app-button-tertiary-button-text-colour: govuk-colour("white");
+
+.app-button--tertiary {
+  background-color: $app-button-tertiary-button-colour;
+  box-shadow: 0 $button-shadow-size 0 $app-button-tertiary-button-shadow-colour;
+
+  &,
+  &:link,
+  &:visited,
+  &:active,
+  &:hover {
+    color: $app-button-tertiary-button-text-colour;
+  }
+
+  // alphagov/govuk_template includes a specific a:link:focus selector
+  // designed to make unvisited links a slightly darker blue when focussed, so
+  // we need to override the text colour for that combination of selectors so
+  // so that unvisited links styled as buttons do not end up with dark blue
+  // text when focussed.
+  @include govuk-compatibility(govuk_template) {
+    &:link:focus {
+      color: $app-button-tertiary-button-text-colour;
+    }
+  }
+
+  &:hover {
+    background-color: $app-button-tertiary-button-hover-colour;
+
+    &[disabled] {
+      background-color: $app-button-tertiary-button-colour;
+    }
+  }
+}

--- a/app/views/support_interface/cycles/index.html.erb
+++ b/app/views/support_interface/cycles/index.html.erb
@@ -2,11 +2,7 @@
 
 <% unless HostingEnvironment.production? %>
   <%= form_with model: SupportInterface::ChangeCycleForm.new, url: support_interface_switch_cycle_schedule_path, method: :post do |f| %>
-    <%= f.govuk_radio_buttons_fieldset :cycle_schedule_name do %>
-
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h2 class='govuk-heading-m'>Current point in the recruitment cycle</h2>
-        </legend>
+    <%= f.govuk_radio_buttons_fieldset :cycle_schedule_name, legend: { text: 'Current point in the recruitment cycle', tag: 'span' } do %>
 
       <%= f.govuk_radio_button :cycle_schedule_name, 'real', label: { text: t('cycles.real.name') }, hint_text: t('cycles.real.description') %>
 
@@ -21,7 +17,9 @@
   <% end %>
 <% end %>
 
-<h2 class='govuk-heading-m'>Cycle years</h2>
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<h3 class="govuk-heading-m">Cycle years</h3>
 
 <%= render SummaryListComponent.new(rows: {
   'Previous cycle year' => RecruitmentCycle.previous_year,
@@ -30,11 +28,9 @@
   'Years visible to providers' => RecruitmentCycle.years_visible_to_providers.to_sentence,
 }) %>
 
-<h2 class='govuk-heading-m'>Deadlines</h2>
+<h3 class="govuk-heading-m">Deadlines</h2>
 
-<p class='govuk-body'>
-  (Today is <%= Date.today.to_s(:govuk_date) %>)
-</p>
+<p class="govuk-body">(Today is <%= Date.today.to_s(:govuk_date) %>)</p>
 
 <%= render SummaryListComponent.new(rows: {
   'Appy 1 deadline' => EndOfCycleTimetable.apply_1_deadline.to_s(:govuk_date),
@@ -45,7 +41,7 @@
   'Apply reopens on' => EndOfCycleTimetable.apply_reopens.to_s(:govuk_date),
 }) %>
 
-<h2 class='govuk-heading-m'>Flags</h2>
+<h3 class="govuk-heading-m">Flags</h3>
 
 <%= render SummaryListComponent.new(rows: {
   'Show Apply 1 deadline banner?' => boolean_to_word(EndOfCycleTimetable.show_apply_1_deadline_banner?),

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -1,42 +1,38 @@
 <%= render 'support_interface/settings/settings_navigation', title: 'Feature flags' %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header">Feature</th>
-      <th class="govuk-table__header">Activated?</th>
-      <th class="govuk-table__header">Action</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% FeatureFlag::FEATURES.each do |feature_name, feature_flag| %>
-      <tr class="govuk-table__row">
-
-        <td class="govuk-table__cell">
-          <h3 class="govuk-!-margin-top-0"><%= feature_name.humanize %></h3>
-          <p>Owner: <%= feature_flag.owner %></p>
-          <p><%= feature_flag.description %></p>
-          <p>
-            <%= render SupportInterface::FeatureAuditTrailComponent.new(feature: feature_flag.feature) %>
-          </p>
-        </td>
-
-        <td class="govuk-table__cell">
-          <% if FeatureFlag.active?(feature_name) %>
-            <strong class="govuk-tag govuk-tag--turquoise app-tag">Active</strong>
-          <% else %>
-            <strong class="govuk-tag govuk-tag--grey app-tag">Inactive</strong>
-          <% end %>
-        </td>
-
-        <td class="govuk-table__cell">
-          <% if FeatureFlag.active?(feature_name) %>
-            <%= button_to 'Deactivate', support_interface_deactivate_feature_flag_path(feature_name), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2' %>
-          <% else %>
-            <%= button_to 'Activate', support_interface_activate_feature_flag_path(feature_name), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2' %>
-          <% end %>
-        </td>
-      </tr>
+<% FeatureFlag::FEATURES.each do |feature_name, feature_flag| %>
+  <%= render SummaryCardComponent.new(editable: true, border: true, rows: [
+    {
+      key: 'Description',
+      value: feature_flag.description
+    },
+    {
+      key: 'Status',
+      value: render(
+        TagComponent.new(
+          text: FeatureFlag.active?(feature_name) ? 'Active' : 'Inactive',
+          type: FeatureFlag.active?(feature_name) ? 'green' : 'grey'
+        ),
+      )
+    },
+    {
+      key: 'Owner',
+      value: feature_flag.owner
+    },
+    {
+      key: 'History',
+      value: render(
+        SupportInterface::FeatureAuditTrailComponent.new(feature: feature_flag.feature)
+      )
+    }
+  ].compact
+  ) do %>
+    <%= render SummaryCardHeaderComponent.new(title: feature_name.humanize, heading_level: 3) do %>
+      <% if FeatureFlag.active?(feature_name) %>
+        <%= button_to 'Deactivate', support_interface_deactivate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' %>
+      <% else %>
+        <%= button_to 'Activate', support_interface_activate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' %>
+      <% end %>
     <% end %>
-  </tbody>
-</table>
+  <% end %>
+<% end %>

--- a/spec/components/support_interface/feature_audit_trail_component_spec.rb
+++ b/spec/components/support_interface/feature_audit_trail_component_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
     end
 
     it 'renders the create audit entry' do
-      expect(render_result.text).to include('1 May 2020 12:00 - Created Inactive by bob@example.com')
+      expect(render_result.text).to include('Created inactive by bob@example.com')
+      expect(render_result.text).to include('1 May 2020 at 12:00')
     end
   end
 
@@ -47,11 +48,13 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
     end
 
     it 'renders the create audit entry' do
-      expect(render_result.text).to include("1 May 2020 12:00 - Created Active\n")
+      expect(render_result.text).to include('Created active')
+      expect(render_result.text).to include('1 May 2020 at 12:00')
     end
 
     it 'renders the update audit entry' do
-      expect(render_result.text).to include("3 May 2020 15:30 - Changed to Inactive by alice@example.com\n")
+      expect(render_result.text).to include('Changed to inactive by alice@example.com')
+      expect(render_result.text).to include('3 May 2020 at 15:30')
     end
   end
 end

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -32,47 +32,39 @@ RSpec.feature 'Feature flags', with_audited: true do
   end
 
   def then_i_should_see_the_existing_feature_flags
-    expect(page).to have_content(
-      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}",
-    )
+    expect(page).to have_content('Pilot open')
+    expect(page).to have_content(pilot_open_feature.owner)
+    expect(page).to have_content(pilot_open_feature.description)
   end
 
   def when_i_activate_the_feature
-    within(pilot_open_row) { click_button 'Activate' }
+    within(pilot_open_summary_card) { click_button 'Activate' }
   end
 
   def then_the_feature_is_activated
-    expect(page).to have_content(
-      /Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\n.*\nActive/,
-    )
+    expect(page).to have_content('Active')
     expect(FeatureFlag.active?('pilot_open')).to be true
   end
 
   def and_i_can_see_the_activation_in_the_audit_trail
-    expect(page).to have_content(
-      'Changed to Active by user@apply-support.com',
-    )
+    expect(page).to have_content('Changed to active by user@apply-support.com')
   end
 
   def when_i_deactivate_the_feature
-    within(pilot_open_row) { click_button 'Deactivate' }
+    within(pilot_open_summary_card) { click_button 'Deactivate' }
   end
 
   def then_the_feature_is_deactivated
-    expect(page).to have_content(
-      /Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\n.*\nInactive/,
-    )
+    expect(page).to have_content('Inactive')
     expect(FeatureFlag.active?('pilot_open')).to be false
   end
 
   def and_i_can_see_the_deactivation_in_the_audit_trail
-    expect(page).to have_content(
-      'Changed to Inactive by user@apply-support.com',
-    )
+    expect(page).to have_content('Changed to inactive by user@apply-support.com')
   end
 
-  def pilot_open_row
-    find(:xpath, "//tr[td[contains(.,'Pilot open')]]")
+  def pilot_open_summary_card
+    find('.app-summary-card', text: 'Pilot open')
   end
 
   def pilot_open_feature


### PR DESCRIPTION
## Context

Use summary card for feature flags, use same design for reference request history for feature flag audit trail

## Changes proposed in this pull request

Before

<img width="980" alt="Screenshot 2020-10-05 at 20 21 47" src="https://user-images.githubusercontent.com/813383/95122668-c2aba280-0748-11eb-93ed-686cd4fd6d56.png">

After

<img width="981" alt="Screenshot 2020-10-05 at 20 20 42" src="https://user-images.githubusercontent.com/813383/95122663-c0e1df00-0748-11eb-8ed5-562777171963.png">

## Guidance to review

@adamsilver What colour the button? Previously was grey, but can’t use grey button on grey background. Can’t really use green, as that might suggest an active feature flag. So added a blue variant… I’m not sure this is right.

Are the updated tests correctly written?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
