### PR TITLE
Prevent candidates from accidentally creating multiple carry-over applications

### DIFF
--- a/app/components/candidate_interface/carry_over_banner_component.rb
+++ b/app/components/candidate_interface/carry_over_banner_component.rb
@@ -8,13 +8,7 @@ module CandidateInterface
     end
 
     def render?
-      if @application_form.ended_without_success?
-        @application_form.recruitment_cycle_year < RecruitmentCycle.current_year ||
-          EndOfCycleTimetable.between_cycles_apply_2?
-      elsif !@application_form.submitted?
-        @application_form.recruitment_cycle_year < RecruitmentCycle.current_year &&
-          !EndOfCycleTimetable.between_cycles_apply_1?
-      end
+      @application_form.must_be_carried_over?
     end
 
     def references_did_not_come_back_in_time?

--- a/app/controllers/candidate_interface/carry_over_controller.rb
+++ b/app/controllers/candidate_interface/carry_over_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class CarryOverController < CandidateInterfaceController
+    before_action :redirect_if_already_carried_over
+
     def start
       if EndOfCycleTimetable.between_cycles_apply_2?
         render current_application.submitted? ? :start_between_cycles : :start_between_cycles_unsubmitted
@@ -12,6 +14,14 @@ module CandidateInterface
       CarryOverApplication.new(current_application).call
       flash[:success] = 'Your application is ready for editing'
       redirect_to candidate_interface_before_you_start_path
+    end
+
+  private
+
+    def redirect_if_already_carried_over
+      return if current_application.must_be_carried_over?
+
+      redirect_to candidate_interface_application_form_path
     end
   end
 end

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -75,15 +75,9 @@ module CandidateInterface
     end
 
     def redirect_to_carry_over_if_unsubmitted_previous_cycle
-      if !current_application.submitted? &&
-          (
-            current_application.recruitment_cycle_year < RecruitmentCycle.current_year ||
-            (current_application.recruitment_cycle_year == RecruitmentCycle.current_year && EndOfCycleTimetable.between_cycles_apply_2?)
-          )
-        redirect_to candidate_interface_start_carry_over_path and return false
-      end
+      return unless current_application.must_be_carried_over?
 
-      true
+      redirect_to candidate_interface_start_carry_over_path
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -154,6 +154,14 @@ class ApplicationForm < ApplicationRecord
     apply_2?
   end
 
+  def must_be_carried_over?
+    if ended_without_success?
+      recruitment_cycle_year < RecruitmentCycle.current_year || EndOfCycleTimetable.between_cycles_apply_2?
+    elsif !submitted?
+      recruitment_cycle_year < RecruitmentCycle.current_year && !EndOfCycleTimetable.between_cycles_apply_1?
+    end
+  end
+
   def choices_left_to_make
     number_of_choices_candidate_can_make - application_choices.size
   end

--- a/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -38,11 +38,6 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
 
     when_i_visit_the_site
     then_there_is_a_link_to_the_course_choices_section
-
-    given_it_is_the_day_after_the_apply2_deadline
-
-    when_i_visit_the_site
-    then_i_see_that_i_can_carry_over_my_application
   end
 
   def given_i_am_signed_in
@@ -103,13 +98,5 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
 
   def and_it_is_the_day_before_the_apply_2_deadline
     Timecop.travel(EndOfCycleTimetable.apply_2_deadline)
-  end
-
-  def given_it_is_the_day_after_the_apply2_deadline
-    Timecop.travel(EndOfCycleTimetable.apply_2_deadline + 1.day)
-  end
-
-  def then_i_see_that_i_can_carry_over_my_application
-    expect(page).to have_content('You did not submit your application in time')
   end
 end

--- a/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/carry_over_unsuccessful_application_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
 
     then_i_can_see_application_details
     and_i_can_see_that_no_courses_are_selected
+
+    when_i_visit_the_carry_over_page_again
+    then_i_am_redirected_to_my_existing_application
   end
 
   def given_i_am_signed_in
@@ -92,5 +95,13 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
     expect(page).to have_content('Course choice Incomplete')
     click_link 'Course choice'
     expect(page).to have_content 'You can apply for up to 3 courses'
+  end
+
+  def when_i_visit_the_carry_over_page_again
+    visit candidate_interface_start_carry_over_path
+  end
+
+  def then_i_am_redirected_to_my_existing_application
+    then_i_can_see_application_details
   end
 end


### PR DESCRIPTION
## Context

https://www.apply-for-teacher-training.service.gov.uk/support/applications/3701 carried over their application twice, probably by doing some kind of back-button thing (see https://kibana.logit.io/goto/fb8e25702d6f321da484fe0698e6883d).

## Changes proposed in this pull request

This disallows carry-over if the application form is not in a state that needs carrying over. Prevents candidates from accidentally making multiple applications by using the back button.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/fbxCHROO/2293-prevent-candidates-from-accidentally-creating-multiple-carry-over-applications

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
