### PR TITLE
Fix UCAS matches summary in support

### DIFF
--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -37,7 +37,7 @@ module SupportInterface
 
     def ucas_matched_applications
       @match.matching_data.map do |data|
-        UCASMatchedApplication.new(data)
+        UCASMatchedApplication.new(data, @match.created_at.year)
       end
     end
 

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -1,5 +1,4 @@
 class UCASMatchedApplication
-
   def initialize(matching_data, recruitment_cycle_year)
     @matching_data = matching_data
     @recruitment_cycle_year = recruitment_cycle_year
@@ -33,8 +32,9 @@ class UCASMatchedApplication
     if ucas_scheme?
       mapped_ucas_status
     else
-      ApplicationForm.find_by(candidate_id: @matching_data['Apply candidate ID'])
-        .application_choices.find_by(course_option: course.course_options)
+      ApplicationChoice.includes(:application_form)
+        .where('application_forms.candidate_id = ?', @matching_data['Apply candidate ID']).references(:application_forms)
+        .find_by(course_option: course.course_options)
         .status
     end
   end

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -1,10 +1,16 @@
 class UCASMatchedApplication
-  def initialize(matching_data)
+
+  def initialize(matching_data, recruitment_cycle_year)
     @matching_data = matching_data
+    @recruitment_cycle_year = recruitment_cycle_year
   end
 
   def course
-    Course.find_by(code: @matching_data['Course code'], provider: Provider.find_by(code: @matching_data['Provider code']))
+    Course.find_by(
+      code: @matching_data['Course code'],
+      provider: Provider.find_by(code: @matching_data['Provider code']),
+      recruitment_cycle_year: @recruitment_cycle_year,
+    )
   end
 
   def scheme

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -1,23 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe UCASMatchedApplication do
-  let(:course) { create(:course) }
+  let(:course) { create(:course, recruitment_cycle_year: 2020) }
   let(:candidate) { create(:candidate) }
   let(:course_option) { create(:course_option, course: course) }
   let(:application_choice) { create(:application_choice, course_option: course_option) }
   let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+  let(:recruitment_cycle_year) { 2020 }
 
   before do
     application_form
+    create(:course, code: course.code, provider: course.provider, recruitment_cycle_year: 2021)
   end
 
   describe '#course' do
-    it 'returns the course' do
+    it 'returns the course for the correct recruitment cycle' do
       ucas_matching_data =
         { 'Course code' => course.code.to_s,
           'Provider code' => course.provider.code.to_s,
           'Apply candidate ID' => candidate.id.to_s }
-      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data)
+      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
       expect(ucas_matching_application.course).to eq(course)
     end
@@ -31,7 +33,7 @@ RSpec.describe UCASMatchedApplication do
             'Course code' => course.code.to_s,
             'Provider code' => course.provider.code.to_s,
             'Apply candidate ID' => candidate.id.to_s }
-        ucas_matching_application = UCASMatchedApplication.new(dfe_matching_data)
+        ucas_matching_application = UCASMatchedApplication.new(dfe_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.status).to eq(application_choice.status)
       end
@@ -50,7 +52,7 @@ RSpec.describe UCASMatchedApplication do
             'Applicant withdrawn from scheme while offer awaiting applicant reply' => '.',
             'Applicant withdrawn from scheme after firmly accepting a conditional offer' => '.',
             'Applicant withdrawn from scheme after firmly accepting an unconditional offer' => '.' }
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data)
+        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.status).to eq('rejected')
         expect(ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.map(&:to_s)).to include(ucas_matching_application.status)
@@ -73,7 +75,7 @@ RSpec.describe UCASMatchedApplication do
             'Applicant withdrawn from scheme while offer awaiting applicant reply' => '.',
             'Applicant withdrawn from scheme after firmly accepting a conditional offer' => '.',
             'Applicant withdrawn from scheme after firmly accepting an unconditional offer' => '.' }
-        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data)
+        ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
         expect(ucas_matching_application.status).to eq(application_choice.status)
       end

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe UCASMatchedApplication do
   let(:course_option) { create(:course_option, course: course) }
   let(:application_choice) { create(:application_choice, course_option: course_option) }
   let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+  let(:apply_again_application_form) { create(:application_form, candidate_id: candidate.id) }
   let(:recruitment_cycle_year) { 2020 }
 
   before do
+    apply_again_application_form
     application_form
     create(:course, code: course.code, provider: course.provider, recruitment_cycle_year: 2021)
   end


### PR DESCRIPTION
## Context

We are getting errors for individual UCAS match pages: 
https://sentry.io/organizations/dfe-bat/issues/1936503787/?project=1765973

<img width="809" alt="Screenshot 2020-10-06 at 09 03 28" src="https://user-images.githubusercontent.com/38078064/95175113-e73c6480-07b2-11eb-9574-c44b41544b25.png">


## Changes proposed in this pull request

**- Consider recruitment cycle when looking up course for UCAS matches**
Now that we are approaching the next recruitment cycle we have two courses with the same code and provider. One for each recruitment cycle year. Decided to hardcore it instead of using `RecruitmentCycle.current_year`, `RecruitmentCycle.previous_year` as it’s going to change soon but we still want to compare courses in 2020 recruitment cycle. 

**- Fix UCAS matches summary for apply again candidates**
When a candidate applied again they would have two application forms. `find_by` was returning the latest application form, which in most cases was incomplete and not sent to providers and therefore had no application choices. Candidate’s ids for which this was the case: 96, 471, 3410, 1030, 2485, 2850, 3327, 3616.

## Guidance to review

Review questions:
- thought on hardcoding recruitment cycle year
- is there a fancy join I can do to avoid 2 queries in the 2nd commit?

Don't think we can reproduce the same issue locally. We can get the same error by running `GenerateTestData.new(10).generate` a few times but this is because some test application forms are generated without application choices, _I think._

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
