### PR TITLE
Display recruitment cycle year in support

### DIFF
--- a/app/components/support_interface/application_card_component.html.erb
+++ b/app/components/support_interface/application_card_component.html.erb
@@ -2,7 +2,7 @@
   <header class="app-application-card__header">
     <h3 class="govuk-heading-s">
       <%= govuk_link_to candidate_name, support_interface_application_form_path(application_form) %>
-      <span class="govuk-body-s"><%= support_reference %> <%= application_form.apply_2? ? '(Apply again)' : '' %></span>
+      <span class="govuk-body-s"><%= support_reference %> <%= apply_again_context %></span>
     </h3>
     <p class="govuk-body-s govuk-!-margin-bottom-2"><strong><%= overall_status %></strong></p>
   </header>

--- a/app/components/support_interface/application_card_component.rb
+++ b/app/components/support_interface/application_card_component.rb
@@ -21,9 +21,11 @@ module SupportInterface
 
     def apply_again_context
       if application_form.apply_2?
-        '(Apply again)'
+        "(#{application_form.recruitment_cycle_year}, apply again)"
       elsif application_form.candidate_has_previously_applied?
-        '(Carried over)'
+        "(#{application_form.recruitment_cycle_year}, carried over)"
+      else
+        "(#{application_form.recruitment_cycle_year})"
       end
     end
   end

--- a/app/components/support_interface/application_card_component.rb
+++ b/app/components/support_interface/application_card_component.rb
@@ -18,5 +18,13 @@ module SupportInterface
       process_state = ProcessState.new(application_form).state
       I18n.t!("candidate_flow_application_states.#{process_state}.name")
     end
+
+    def apply_again_context
+      if application_form.apply_2?
+        '(Apply again)'
+      elsif application_form.candidate_has_previously_applied?
+        '(Carried over)'
+      end
+    end
   end
 end

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -15,6 +15,7 @@ module SupportInterface
 
     def rows
       [
+        recruitment_cycle_year,
         support_reference_row,
         submitted_row,
         edit_by_row,
@@ -27,6 +28,13 @@ module SupportInterface
     end
 
   private
+
+    def recruitment_cycle_year
+      {
+        key: 'Recruitment cycle year',
+        value: application_form.recruitment_cycle_year,
+      }
+    end
 
     def last_updated_row
       {

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -21,14 +21,38 @@ module SupportInterface
         application_forms = application_forms.where('phase IN (?)', applied_filters[:phase])
       end
 
+      if applied_filters[:year]
+        application_forms = application_forms.where('recruitment_cycle_year IN (?)', applied_filters[:year])
+      end
+
       application_forms
     end
 
     def filters
-      @filters ||= [search_filter] + [phase_filter]
+      @filters ||= [search_filter] + [year_filter] + [phase_filter]
     end
 
 private
+
+    def year_filter
+      {
+        type: :checkboxes,
+        heading: 'Recruitment cycle year',
+        name: 'year',
+        options: [
+          {
+            value: '2020',
+            label: '2020 to 2021',
+            checked: applied_filters[:year]&.include?('2020'),
+          },
+          {
+            value: '2021',
+            label: '2021 to 2022',
+            checked: applied_filters[:year]&.include?('2021'),
+          },
+        ],
+      }
+    end
 
     def search_filter
       {

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -25,31 +25,38 @@ module SupportInterface
     end
 
     def filters
-      [
-        {
-          type: :search,
-          heading: 'Name, email or reference',
-          value: applied_filters[:q],
-          name: 'q',
-        },
-        {
-          type: :checkboxes,
-          heading: 'Phase',
-          name: 'phase',
-          options: [
-            {
-              value: 'apply_1',
-              label: 'Apply 1',
-              checked: applied_filters[:phase]&.include?('apply_1'),
-            },
-            {
-              value: 'apply_2',
-              label: 'Apply 2',
-              checked: applied_filters[:phase]&.include?('apply_2'),
-            },
-          ],
-        },
-      ]
+      @filters ||= [search_filter] + [phase_filter]
+    end
+
+private
+
+    def search_filter
+      {
+        type: :search,
+        heading: 'Name, email or reference',
+        value: applied_filters[:q],
+        name: 'q',
+      }
+    end
+
+    def phase_filter
+      {
+        type: :checkboxes,
+        heading: 'Phase',
+        name: 'phase',
+        options: [
+          {
+            value: 'apply_1',
+            label: 'Apply 1',
+            checked: applied_filters[:phase]&.include?('apply_1'),
+          },
+          {
+            value: 'apply_2',
+            label: 'Apply 2',
+            checked: applied_filters[:phase]&.include?('apply_2'),
+          },
+        ],
+      }
     end
   end
 end

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -32,7 +32,7 @@ module SupportInterface
       @filters ||= [search_filter] + [year_filter] + [phase_filter]
     end
 
-private
+  private
 
     def year_filter
       {

--- a/spec/components/support_interface/applications_table_component_spec.rb
+++ b/spec/components/support_interface/applications_table_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupportInterface::ApplicationsTableComponent do
   let(:application_forms) { [application_form_apply_again] + create_list(:application_form, 3, updated_at: 1.day.ago) }
 
   it 'renders the apply again text for the first application' do
-    expect(render_result.text).to include('Apply again')
+    expect(render_result.text).to include('(2020, apply again)')
   end
 
   def render_result


### PR DESCRIPTION
## Context

Application forms relate to specific recruitment cycles. 

## Changes proposed in this pull request

This adds the cycle in the applications list and adds filtering.

![image](https://user-images.githubusercontent.com/233676/95181791-a137ce80-07bb-11eb-8330-379cd50d0ea2.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/fbxCHROO/2293-prevent-candidates-from-accidentally-creating-multiple-carry-over-applications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
