### PR TITLE
Clarify API’s HESA data available once offer accepted

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,11 @@
+### 5th October 2020
+
+Changes to existing attributes:
+
+- clarify that `hesa_itt_data` will be populated once an offer has been
+  accepted. (Previously it was following enrolment, but enrolment has been
+  removed).
+
 ### 29th September 2020
 
 New attributes:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -466,6 +466,8 @@ components:
           anyOf:
           - "$ref": "#/components/schemas/HESAITTData"
           nullable: true
+          description: Values to populate this candidate’s HESA Initial Teacher
+            Training data return.  Available once an offer has been accepted.
         further_information:
           type: string
           maxLength: 10240


### PR DESCRIPTION
## Context

We used to expose this on enrolment, but we don't have enrolment any more.

## Changes proposed in this pull request

Add it to the docs.

## Guidance to review

Does it read ok? Anywhere else need updating?

## Link to Trello card

https://trello.com/c/CgRrFaDA/2728-clarify-in-api-docs-that-the-hesa-itt-data-will-be-made-available-to-providers-once-a-candidate-has-accepted-an-application

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
