### PR TITLE
Manage: Use full-width header border

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,7 +15,7 @@
                                  navigation_items: NavigationItems.for_support_primary_nav(try(:current_support_user), controller))) %>
   <%= yield(:navigation) if content_for?(:navigation) %>
 <% when 'provider_interface' %>
-  <%= render(ProductHeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
+  <%= render(ProductHeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name} app-header--full-border",
                                  product_name: service_name,
                                  service_url: service_link,
                                  navigation_items: NavigationItems.for_provider_account_nav(try(:current_provider_user), controller, @provider_setup&.pending?))) %>


### PR DESCRIPTION
## Context

Use full-width border under header to match width of primary navigation (matching design in prototype)

## Changes proposed in this pull request

Before:
<img width="1018" alt="Screenshot 2020-10-06 at 16 11 39" src="https://user-images.githubusercontent.com/813383/95220950-e6c1bf00-07ee-11eb-88c4-9ec436b3d1b9.png">

After:

<img width="1040" alt="Screenshot 2020-10-06 at 16 12 45" src="https://user-images.githubusercontent.com/813383/95220962-e9241900-07ee-11eb-85d7-1148f517040d.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
