### PR TITLE
Add submitted_with_safeguarding email for providers

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -20,6 +20,16 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def application_submitted_with_safeguarding_issues(provider_user, application_choice)
+    @application = map_application_choice_params(application_choice)
+
+    email_for_provider(
+      provider_user,
+      application_choice.application_form,
+      subject: I18n.t!('provider_mailer.application_submitted_with_safeguarding_issues.subject', course_name_and_code: @application.course_name_and_code),
+    )
+  end
+
   def application_rejected_by_default(provider_user, application_choice)
     @application = map_application_choice_params(application_choice)
 

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -9,7 +9,11 @@ class SendNewApplicationEmailToProvider
     return false unless application_choice.awaiting_provider_decision?
 
     application_choice.provider.provider_users.each do |provider_user|
-      ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
+      if application_choice.application_form.has_safeguarding_issues_to_declare?
+        ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later
+      else
+        ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
+      end
     end
   end
 end

--- a/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
+++ b/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @provider_user_name || 'colleague' %>
+
+# Application submitted with safeguarding issues disclosed
+
+<%= @application.candidate_name %> has submitted an application for <%= @application.course_name_and_code %>.
+
+Their application contains information related to ‘Criminal convictions and professional misconduct’.
+
+The information can be viewed by users on your team with permission to read sensitive material.
+
+# Next steps
+
+Log in to Manage teacher training applications to respond:
+
+<%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
+
+We’ll reject the application on your behalf after <%= @application.rbd_days %> working days.

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -10,6 +10,8 @@ en:
       subject: Sign in to Manage teacher training applications
     application_submitted:
       subject: Application received for %{course_name_and_code}
+    application_submitted_with_safeguarding_issues:
+      subject: Application with safeguarding issues received for %{course_name_and_code}
     application_rejected_by_default:
       subject: "%{candidate_name}’s (%{support_reference}) application was rejected automatically"
     application_waiting_for_decision:

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -7,6 +7,10 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.application_submitted(provider_user, application_choice)
   end
 
+  def application_submitted_with_safeguarding_issues
+    ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice)
+  end
+
   def application_rejected_by_default
     ProviderMailer.application_rejected_by_default(provider_user, application_choice)
   end

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
+  include CourseOptionHelpers
+
+  it 'sends an email to the provider' do
+    provider = create(:provider)
+    create(:provider_user, providers: [provider])
+    option = course_option_for_provider(provider: provider)
+    choice = create(:application_choice, :awaiting_provider_decision, course_option: option)
+
+    SendNewApplicationEmailToProvider.new(application_choice: choice).call
+
+    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted' }
+
+    expect(email).to be_present
+  end
+
+  it 'sends a different email when the candidate supplied safeguarding information' do
+    provider = create(:provider)
+    create(:provider_user, providers: [provider])
+    option = course_option_for_provider(provider: provider)
+
+    form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
+    choice = create(:application_choice, :awaiting_provider_decision, course_option: option, application_form: form)
+
+    SendNewApplicationEmailToProvider.new(application_choice: choice).call
+
+    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted_with_safeguarding_issues' }
+
+    expect(email).to be_present
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification
       candidate_mailer-find_another_course
+      provider_mailer-application_submitted_with_safeguarding_issues
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
Send this email instead of `application_submitted` if the form has a safeguarding declaration

## Context

SITS-based HEIs need this so that they know which applications to check safeguarding information for, as SITS doesn't (yet) pull this information.

## Changes proposed in this pull request

Send a different email depending on whether safeguarding information was provided.

## Guidance to review

- email copy
- is the logic in the service correct?

## Link to Trello card

https://trello.com/c/41vpld5z/2838-implement-submitted-with-safeguarding-emails

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
