### PR TITLE
Typecast @status to string in support ApplicationStatusTagComponent

### DIFF
--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -9,7 +9,7 @@ module SupportInterface
     end
 
     def type
-      case @status
+      case @status.to_s
       when 'unsubmitted'
         :grey
       when 'application_complete', 'awaiting_references', 'awaiting_provider_decision', 'offer_deferred'


### PR DESCRIPTION
## Context

https://sentry.io/organizations/dfe-bat/issues/1936326855/?project=1765973&referrer=slack

## Changes proposed in this pull request

`ApplicationStatusTagComponentPreview` iterates through `ApplicationStateChange.valid_states` which returns an array of symbols representing the various states, e.g. `:application_complete`.

For whatever reason, `'application_complete' != :application_complete` for the purposes of this function. `.to_s` seems to fix it.

## Guidance to review

🤔 

## Link to Trello card

https://trello.com/c/5AD4EMOa

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)