### PR TITLE
Update "institution withheld" copy; don't withhold international institutions

### DIFF
--- a/app/components/degree_qualification_cards_component.html.erb
+++ b/app/components/degree_qualification_cards_component.html.erb
@@ -19,7 +19,7 @@
               <dd class="app-qualification__value"><%= formatted_grade(degree) %></dd>
 
               <dt class="app-qualification__key">Institution</dt>
-              <% if show_institution? %>
+              <% if show_institution?(degree) %>
                 <dd class="app-qualification__value"><%= formatted_institution(degree) %></dd>
               <% else %>
                 <dd class="app-qualification__value app-qualification__value--caption">Institution name is withheld at this stage to avoid any unconscious bias in favour of certain institutions.</dd>

--- a/app/components/degree_qualification_cards_component.html.erb
+++ b/app/components/degree_qualification_cards_component.html.erb
@@ -22,7 +22,7 @@
               <% if show_institution? %>
                 <dd class="app-qualification__value"><%= formatted_institution(degree) %></dd>
               <% else %>
-                <dd class="app-qualification__value app-qualification__value--caption">Only available once an offer has been accepted</dd>
+                <dd class="app-qualification__value app-qualification__value--caption">Institution name is withheld at this stage to avoid any unconscious bias in favour of certain institutions.</dd>
               <% end %>
 
               <% if naric_statement(degree) %>

--- a/app/components/degree_qualification_cards_component.rb
+++ b/app/components/degree_qualification_cards_component.rb
@@ -25,10 +25,10 @@ class DegreeQualificationCardsComponent < ViewComponent::Base
     end
   end
 
-  def show_institution?
+  def show_institution?(degree)
     # Always show the institution if the component has not been made aware of
     # any application choice state
-    return true if application_choice_state.nil?
+    return true if application_choice_state.nil? || degree.international?
 
     application_choice_state.to_sym.in? ApplicationStateChange::ACCEPTED_STATES
   end

--- a/spec/components/degree_qualification_cards_component_spec.rb
+++ b/spec/components/degree_qualification_cards_component_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
           result = render_inline described_class.new([degree], application_choice_state: state)
           expect(result.text).to include 'Institution'
           expect(result.text).not_to include 'The University of Oxford'
-          expect(result.text).to include 'Only available once an offer has been accepted'
+          expect(result.text).to include 'Institution name is withheld at this stage to avoid any unconscious bias in favour of certain institutions.'
         end
       end
     end

--- a/spec/components/degree_qualification_cards_component_spec.rb
+++ b/spec/components/degree_qualification_cards_component_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe DegreeQualificationCardsComponent, type: :component do
         result = render_inline described_class.new([degree])
         expect(result.text).to include 'The University of Oxford, Afghanistan'
       end
+
+      it 'renders the institution even when the offer has not been accepted yet' do
+        (ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange::ACCEPTED_STATES).each do |state|
+          result = render_inline described_class.new([degree], application_choice_state: state)
+          expect(result.text).to include 'The University of Oxford'
+        end
+      end
     end
 
     context 'when the grade is predicted' do


### PR DESCRIPTION
## Context

- The existing copy was confusing users in research.
- We mistakenly hid the institution for international degrees

## Changes proposed in this pull request

**New copy under "Institution name"**

<img width="480" alt="Screenshot 2020-10-06 at 17 00 14" src="https://user-images.githubusercontent.com/642279/95226941-6c486d80-07f5-11eb-8b55-6ff776aa7f54.png">

## Guidance to review

2 separate commits

## Link to Trello card

https://trello.com/c/1zEiTlH2/2858-update-copy-to-explain-that-the-institution-name-is-withheld-to-avoid-any-unconscious-bias

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
