### PR TITLE
Highlight providers with no users or no admin users in support console

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -4,7 +4,7 @@ module SupportInterface
       @filter = SupportInterface::ProvidersFilter.new(params: params)
 
       @providers = Provider.where(sync_courses: true)
-        .includes(:sites, :courses, :provider_agreements)
+        .includes(:sites, :courses, :provider_agreements, :provider_users)
         .order(:name)
         .page(params[:page] || 1).per(15)
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -58,4 +58,9 @@ class Provider < ApplicationRecord
     accredited_providers = courses.map(&:accredited_provider).uniq.compact
     accredited_providers.all?(&:onboarded?)
   end
+
+  def no_admin_users?
+    !(provider_permissions.exists?(manage_users: true) &&
+      provider_permissions.exists?(manage_organisations: true))
+  end
 end

--- a/app/views/support_interface/providers/_no_admin_users_warning.html.erb
+++ b/app/views/support_interface/providers/_no_admin_users_warning.html.erb
@@ -1,0 +1,6 @@
+<% if @provider.sync_courses? && @provider.no_admin_users? %>
+  <div class="govuk-inset-text govuk-!-margin-bottom-4">
+    <h2 class="govuk-heading-m">Needs attention</h2>
+    <p class="govuk-body">This provider has no users with the ability to manage organisations and users.</p>
+  </div>
+<% end %>

--- a/app/views/support_interface/providers/applications.html.erb
+++ b/app/views/support_interface/providers/applications.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'Applications' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_forms) do %>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'Courses' %>
 
 <% if @provider.sync_courses? %>

--- a/app/views/support_interface/providers/history.html.erb
+++ b/app/views/support_interface/providers/history.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'History' %>
 
 <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider) %>

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -15,7 +15,12 @@
       <% @providers.each do |provider| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
+            <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+              <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
+            </p>
+            <% if provider.no_admin_users? %>
+              <%= render TagComponent.new(text: 'Needs attention', type: :red) %>
+            <% end %>
           </td>
           <td class="govuk-table__cell">
             <%= pluralize provider.courses.size, 'course' %><br/>

--- a/app/views/support_interface/providers/ratified_courses.html.erb
+++ b/app/views/support_interface/providers/ratified_courses.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'Ratified courses' %>
 
 <% RecruitmentCycle.years_visible_in_support.each do |year| %>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'Details' %>
 
 <% dsa = capture do %>

--- a/app/views/support_interface/providers/sites.html.erb
+++ b/app/views/support_interface/providers/sites.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'Sites' %>
 
 <table class="govuk-table">

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'Users' %>
 
 <%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>

--- a/app/views/support_interface/providers/vacancies.html.erb
+++ b/app/views/support_interface/providers/vacancies.html.erb
@@ -1,3 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
 <%= render 'provider_navigation', title: 'Vacancies' %>
 
 <%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>


### PR DESCRIPTION
## Context

We are onboarding a large number of training providers and it would be super useful to be able to detect visually any providers with a. no users or b. no 'admin' users (able to manage users and relationships with ratifying providers).

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/107591/95321101-78ced380-0892-11eb-84d8-742fcab3ac37.png)
![image](https://user-images.githubusercontent.com/107591/95319399-bbdb7780-088f-11eb-9423-9b474ab9457d.png)

The inset text warning persists across tabs, e.g. Applications, Users, Courses etc.

## Guidance to review

Easy peasy.

## Link to Trello card

No Trello card.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
