### PR TITLE
Don't tell providers they have 0 days to respond to an application

### DIFF
--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -18,10 +18,7 @@ module ProviderInterface
 
     def days_to_respond_text
       if (days_left_to_respond = application_choice.days_left_to_respond)
-        return '1 day to respond' if days_left_to_respond == 1
-        return 'Less than 1 day to respond' if days_left_to_respond < 1
-
-        "#{days_left_to_respond} days to respond"
+        "#{days_until(Date.current + days_left_to_respond).capitalize} to respond"
       end
     end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -89,6 +89,22 @@ module ViewHelper
     end
   end
 
+  def time_is_today_or_tomorrow?(time)
+    time.between?(Time.zone.now.beginning_of_day, Time.zone.tomorrow.end_of_day)
+  end
+
+  def time_today_or_tomorrow(time)
+    unless time_is_today_or_tomorrow?(time)
+      raise "#{time} was expected to be today or tomorrow, but is not"
+    end
+
+    if time.to_date == Date.tomorrow
+      "#{time.to_s(:govuk_time)} tomorrow"
+    else
+      time.to_s(:govuk_time).to_s
+    end
+  end
+
   def days_until(date)
     days = (date - Date.current).to_i
     if days.zero?

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -89,8 +89,13 @@ module ViewHelper
     end
   end
 
-  def days_to_respond_to(application_choice)
-    (application_choice.reject_by_default_at.to_date - Date.current).to_i
+  def days_until(date)
+    days = (date - Date.current).to_i
+    if days.zero?
+      'less than 1 day'
+    else
+      pluralize(days, 'day')
+    end
   end
 
   def boolean_to_word(boolean)

--- a/app/views/provider_interface/application_choices/_application_choice_header.html.erb
+++ b/app/views/provider_interface/application_choices/_application_choice_header.html.erb
@@ -11,7 +11,12 @@
           Respond to application
         </h2>
         <p class="govuk-body">
-          <%= "You have #{days_until(@application_choice.reject_by_default_at.to_date)} to respond to this application. On #{@application_choice.reject_by_default_at.to_s(:govuk_date)} this application will be automatically rejected." %>
+          <% if time_is_today_or_tomorrow?(@application_choice.reject_by_default_at) %>
+            You have until <%= time_today_or_tomorrow(@application_choice.reject_by_default_at) %> to respond to this application, or it will be automatically rejected.
+          <% else %>
+            <%= "You have #{days_until(@application_choice.reject_by_default_at.to_date)} to respond to this application." %>
+            On <%= @application_choice.reject_by_default_at.to_s(:govuk_date) %> this application will be automatically rejected.
+          <% end %>
         </p>
         <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>
       </div>

--- a/app/views/provider_interface/application_choices/_application_choice_header.html.erb
+++ b/app/views/provider_interface/application_choices/_application_choice_header.html.erb
@@ -10,9 +10,8 @@
         <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
           Respond to application
         </h2>
-
         <p class="govuk-body">
-          <%= "You have #{days_to_respond_to(@application_choice)} days to respond to this application. On #{@application_choice.reject_by_default_at.to_s(:govuk_date)} this application will be automatically rejected." %>
+          <%= "You have #{days_until(@application_choice.reject_by_default_at.to_date)} to respond to this application. On #{@application_choice.reject_by_default_at.to_s(:govuk_date)} this application will be automatically rejected." %>
         </p>
         <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>
       </div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -6,3 +6,4 @@ Time::DATE_FORMATS[:month_and_year] = '%B %Y'
 Date::DATE_FORMATS[:month_and_year] = '%B %Y'
 
 Time::DATE_FORMATS[:govuk_date_and_time] = '%e %B %Y at %l:%M%P'
+Time::DATE_FORMATS[:govuk_time] = '%l:%M%P'

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -155,4 +155,41 @@ RSpec.describe ViewHelper, type: :helper do
       expect(helper.days_until(Date.current + 0.5)).to eq('less than 1 day')
     end
   end
+
+  describe '#time_is_today_or_tomorrow?' do
+    it 'is true for now' do
+      expect(helper.time_is_today_or_tomorrow?(Time.zone.now)).to be true
+    end
+
+    it 'is true for a time in an hour' do
+      expect(helper.time_is_today_or_tomorrow?(Time.zone.now + 1.hour)).to be true
+    end
+
+    it 'is not true for a time 24 hours ago' do
+      expect(helper.time_is_today_or_tomorrow?(Time.zone.now - 24.hours)).to be false
+    end
+
+    it 'is not true for a time in 49 hours' do
+      expect(helper.time_is_today_or_tomorrow?(Time.zone.now - 49.hours)).to be false
+    end
+  end
+
+  describe '#time_today_or_tomorrow' do
+    it 'returns the time tomorrow for a time tomorrow' do
+      time = Time.zone.tomorrow.midnight + 3.hours
+      expect(helper.time_today_or_tomorrow(time)).to eq ' 3:00am tomorrow'
+    end
+
+    it 'returns the bare time for a time today' do
+      Timecop.freeze(Time.zone.now.midnight) do
+        time = Time.zone.now + 6.hours
+        expect(helper.time_today_or_tomorrow(time)).to eq ' 6:00am'
+      end
+    end
+
+    it 'throws an exception when the time is not today or tomorrow' do
+      time = Time.zone.now + 2.days
+      expect { helper.time_today_or_tomorrow(time) }.to raise_error(/was expected to be today or tomorrow/)
+    end
+  end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -148,10 +148,11 @@ RSpec.describe ViewHelper, type: :helper do
     end
   end
 
-  describe '#days_to_respond_to' do
-    it 'returns the number of days before application is rejected' do
-      choice = build(:application_choice, reject_by_default_at: Date.current + 1.week)
-      expect(helper.days_to_respond_to(choice)).to eq(7)
+  describe '#days_until' do
+    it 'returns a phrase expressing the number of days' do
+      expect(helper.days_until(Date.current + 2)).to eq('2 days')
+      expect(helper.days_until(Date.current + 1)).to eq('1 day')
+      expect(helper.days_until(Date.current + 0.5)).to eq('less than 1 day')
     end
   end
 end


### PR DESCRIPTION
## Context

We showed UI saying a provider had 0 days to respond.

## Changes proposed in this pull request

- Add a `days_until` method to the `ViewHelper`, which takes a date and gives back `x days`, `1 day` or `less than 1 day`
- use it in two places including the "respond to this application" header
- when less than 24 hours remain, also show the time an application will be RBD'd.

**Before**

<img width="698" alt="Screenshot_2020-09-22_at_22 50 03" src="https://user-images.githubusercontent.com/642279/95266220-aaac4f80-082a-11eb-88b1-10053d5430f8.png">

**After**

<img width="650" alt="Screenshot 2020-10-06 at 23 13 40" src="https://user-images.githubusercontent.com/642279/95266237-b3048a80-082a-11eb-8468-d0ed5a342917.png">

## Link to Trello card

https://trello.com/c/WaYdTK9b/2799-prompt-to-respond-to-application-can-read-you-have-0-days-to-respond-to-this-application

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
