### PR TITLE
Update application submit page for decoupled references MVP

### DIFF
--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
         @errors = @application_form_presenter.section_errors
         @application_choice_errors = @application_form_presenter.application_choice_errors
 
-        render 'candidate_interface/unsubmitted_application_form/review'
+        render 'candidate_interface/unsubmitted_application_form/review' and return
       end
 
       # TODO: When dropping the decoupled_references feature flag delete the

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -28,6 +28,13 @@ module CandidateInterface
 
         render 'candidate_interface/unsubmitted_application_form/review'
       end
+
+      # TODO: When dropping the decoupled_references feature flag delete the
+      # following `unless` block, the submit_show_without_decoupled_references
+      # view template and the associated i18n strings in `submit_application.yml`
+      unless FeatureFlag.active?(:decoupled_references)
+        render 'candidate_interface/unsubmitted_application_form/submit_show_without_decoupled_references' and return
+      end
     end
 
     def submit

--- a/app/views/candidate_interface/unsubmitted_application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/submit_show.html.erb
@@ -42,8 +42,8 @@
       <% end %>
 
       <p class="govuk-body">
-        By submitting, I confirm that the information given is true, complete
-        and accurate.
+        By sending this application to providers,
+        I confirm that the information given is true, complete and accurate.
       </p>
 
       <%= f.govuk_submit t('submit_application.submit_button') %>

--- a/app/views/candidate_interface/unsubmitted_application_form/submit_show_without_decoupled_references.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/submit_show_without_decoupled_references.html.erb
@@ -1,0 +1,52 @@
+<% content_for :title, t('submit_application.without_decoupled_references.title') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_review_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @further_information_form, url: candidate_interface_application_submit_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('submit_application.without_decoupled_references.heading') %>
+      </h1>
+
+      <p class="govuk-body">
+        I understand I will have to undergo an enhanced
+        <%= govuk_link_to t('submit_application.without_decoupled_references.disclosure_link'), 'https://www.gov.uk/government/organisations/disclosure-and-barring-service' %>
+        as part of my application.
+      </p>
+
+      <div class="govuk-inset-text">
+        <p class="govuk-body">
+          As prospective teachers, all candidates must consent to an enhanced
+          DBS check. This will show up any past criminal convictions, both
+          spent and unspent. Some convictions, even if they are spent, will
+          disbar you from teaching.
+        </p>
+        <p class="govuk-body">
+          However, not all past convictions prevent you from training to be a
+          teacher. Talk to your provider about their policy on criminal
+          convictions.
+        </p>
+        <p class="govuk-body">
+          <%= govuk_link_to t('submit_application.without_decoupled_references.conviction_link'), 'https://www.gov.uk/exoffenders-and-employment' %>.
+        </p>
+      </div>
+
+      <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
+        <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>
+          <%= f.govuk_text_area :further_information_details, label: { text: t('application_form.further_information.further_information_details.label') }, max_words: 300 %>
+        <% end %>
+
+        <%= f.govuk_radio_button :further_information, false, label: { text: 'No' } %>
+      <% end %>
+
+      <p class="govuk-body">
+        By submitting, I confirm that the information given is true, complete
+        and accurate.
+      </p>
+
+      <%= f.govuk_submit t('submit_application.without_decoupled_references.submit_button') %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/submit_application.yml
+++ b/config/locales/submit_application.yml
@@ -1,7 +1,7 @@
 en:
   submit_application:
-    title: Submit application
-    heading: Submit application
+    title: Send application to training providers
+    heading: Send application to training providers
     disclosure_link: Disclosure and Barring Service (DBS) check
-    submit_button: Submit application
+    submit_button: Send application
     conviction_link: Learn more about telling an employer about your conviction

--- a/config/locales/submit_application.yml
+++ b/config/locales/submit_application.yml
@@ -5,3 +5,9 @@ en:
     disclosure_link: Disclosure and Barring Service (DBS) check
     submit_button: Send application
     conviction_link: Learn more about telling an employer about your conviction
+    without_decoupled_references:
+      title: Submit application
+      heading: Submit application
+      disclosure_link: Disclosure and Barring Service (DBS) check
+      submit_button: Submit application
+      conviction_link: Learn more about telling an employer about your conviction

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -87,7 +87,7 @@ module CandidateHelper
     click_link 'Continue without completing questionnaire'
     choose 'No' # "Is there anything else you would like to tell us?"
 
-    click_button 'Submit application'
+    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
 
     @application = ApplicationForm.last
   end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -87,7 +87,7 @@ module CandidateHelper
     click_link 'Continue without completing questionnaire'
     choose 'No' # "Is there anything else you would like to tell us?"
 
-    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
+    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application' : 'Submit application')
 
     @application = ApplicationForm.last
   end

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
   end
 
   def and_i_submit_the_application
-    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
+    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application' : 'Submit application')
   end
 
   def then_i_see_that_the_application_was_sent_to_provider

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
   end
 
   def and_i_submit_the_application
-    click_button 'Submit application'
+    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
   end
 
   def then_i_see_that_the_application_was_sent_to_provider

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_can_submit_my_application
-    expect(page).to have_content('Submit application')
+    expect(page).to have_content(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
   end
 
   def when_i_am_on_the_equality_and_diversity_page

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_can_submit_my_application
-    expect(page).to have_content(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
+    expect(page).to have_content(FeatureFlag.active?(:decoupled_references) ? 'Send application' : 'Submit application')
   end
 
   def when_i_am_on_the_equality_and_diversity_page

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -182,7 +182,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def and_i_can_submit_the_application
-    click_button 'Submit application'
+    click_button 'Send application'
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -181,7 +181,7 @@ RSpec.feature 'International candidate submits the application' do
   end
 
   def and_i_submit_the_application
-    click_button 'Submit application'
+    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -181,7 +181,7 @@ RSpec.feature 'International candidate submits the application' do
   end
 
   def and_i_submit_the_application
-    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application': 'Submit application')
+    click_button(FeatureFlag.active?(:decoupled_references) ? 'Send application' : 'Submit application')
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted


### PR DESCRIPTION
## Context

This PR updates the content of the submit page to reflect the decoupled references prototype, with content that talks about sending rather than submitting.

## Changes proposed in this pull request

- [x] Copy the old template `submit_show.html.erb` to `submit_show_without_decoupled_references.html.erb` and update the content for `submit_show.html.erb`.
- [x] Copy the old localised strings referenced by the template above to a new `without_decoupled_references` key and use those for `submit_show_without_decoupled_references.html.erb`. Update the original keys with new content.
- [x] Put `submit_show.html.erb` behind the existing `decoupled_references` feature flag.
- [x] Fix specs

<img width="497" alt="image" src="https://user-images.githubusercontent.com/450843/95306957-f5a48200-087f-11eb-8c78-045a78b8f25d.png">


## Guidance to review

- I've tried to make it as simple as possible to remove the feature flag by duplicating the view template etc. - is there a simpler way?

## Link to Trello card

https://trello.com/c/waoPgAbN/2243-💔-dev-update-application-submit-page-mvp

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
