### PR TITLE
Parse since param with Time#iso8601

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -23,9 +23,10 @@ module VendorAPI
     end
 
     def since_param
-      params.fetch(:since).tap do |since|
-        raise ParameterInvalid, 'Parameter is invalid (date is nonsense): since' unless Date.parse(since).year.positive?
-      end
+      since = Time.zone.iso8601(params.fetch(:since))
+      raise ParameterInvalid, 'Parameter is invalid (date is nonsense): since' unless since.year.positive?
+
+      since
     rescue ArgumentError
       raise ParameterInvalid, 'Parameter is invalid (should be ISO8601): since'
     end

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   end
 
   it 'returns HTTP status 422 given an unparseable `since` date value' do
-    get_api_request '/api/v1/applications?since=bad-date'
+    get_api_request '/api/v1/applications?since=17/07/2020T12:00:42Z'
 
     expect(response).to have_http_status(422)
 


### PR DESCRIPTION
https://sentry.io/organizations/dfe-bat/issues/1939203076/?project=1765973&referrer=slack

## Context

Non iso-8601 dates in the 'since' parameter were not being caught by `Date.parse` and were being passed to ActiveRecord resulting in `PG::DatetimeFieldOverflow` as Postgresql is evidently configured with `datestyle='iso'`. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Ensure the `since` parameter is in iso-8601 format and responds with the appropriate JSON error if not.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/FBINxp0u/2862-bug-pgdatetimefieldoverflow-sentry-error-on-sandbox

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
