### PR TITLE
 Decoupled references review page (2/2)

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -1,5 +1,4 @@
 <% references.each do |reference| %>
-
   <%= render(SummaryCardComponent.new(rows: reference_rows(reference), editable: editable && reference.editable?)) do %>
     <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
 
@@ -22,16 +21,4 @@
       <% end %>
     <% end %>
   <% end %>
-
-<% end %>
-
-<% if show_missing_banner? %>
-  <%= render(
-    SectionMissingBannerComponent.new(
-      section: :references,
-      section_path: candidate_interface_referees_path,
-      text: t('review_application.references.incomplete', minimum_references: 2),
-      error: style_as_errored,
-    )
-  ) %>
 <% end %>

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -47,7 +47,7 @@ module CandidateInterface
 
     def relationship_row(reference)
       {
-        key: 'Relationship',
+        key: 'Relationship to referee',
         value: reference.relationship,
         action: "relationship for #{reference.name}",
         change_path: candidate_interface_edit_referee_path(reference.id),

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -1,19 +1,10 @@
 module CandidateInterface
   class DecoupledReferencesReviewComponent < ViewComponent::Base
-    attr_reader :references, :references_section_completed, :editable, :style_as_errored, :submitting_application
+    attr_reader :references, :editable
 
-    def initialize(
-      references:,
-      references_section_completed:,
-      editable: true,
-      style_as_errored: false,
-      submitting_application: false
-    )
+    def initialize(references:, editable: true)
       @references = references
-      @references_section_completed = references_section_completed
       @editable = editable
-      @style_as_errored = style_as_errored
-      @submitting_application = submitting_application
     end
 
     def card_title(reference)
@@ -28,10 +19,6 @@ module CandidateInterface
         relationship_row(reference),
         feedback_status_row(reference),
       ].compact
-    end
-
-    def show_missing_banner?
-      submitting_application && !references_section_completed && editable
     end
 
   private

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -30,13 +30,3 @@
 <% if show_missing_banner? %>
   <%= render(SectionMissingBannerComponent.new(section: :references, section_path: candidate_interface_referees_path, text: t('review_application.references.incomplete', minimum_references: minimum_references), error: @missing_error)) %>
 <% end %>
-
-<% if show_references_not_provided? %>
-  <%= render(SectionMissingBannerComponent.new(
-    section: :references,
-    section_path: candidate_interface_referees_path,
-    text: t('review_application.references_provided.incomplete', minimum_references: minimum_references),
-    link_text: t('review_application.references_provided.complete_section'),
-    error: @missing_error),
-  ) %>
-<% end %>

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -26,15 +26,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      return false if FeatureFlag.active?(:decoupled_references)
-
       !@application_form.references_completed && @editable && @submitting_application
-    end
-
-    def show_references_not_provided?
-      return false unless FeatureFlag.active?(:decoupled_references)
-
-      !@application_form.enough_references_have_been_provided? && @editable && @submitting_application
     end
 
   private

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -77,15 +77,18 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
 <% if FeatureFlag.active?(:decoupled_references) %>
-  <%= render(
-    CandidateInterface::DecoupledReferencesReviewComponent.new(
-      references: application_form.application_references.feedback_provided,
-      references_section_completed: application_form.references_completed,
-      editable: editable,
-      style_as_errored: missing_error,
-      submitting_application: true,
-    )
-  ) %>
+  <% if !application_form.references_completed && editable %>
+    <%= render(
+      SectionMissingBannerComponent.new(
+        section: :references,
+        section_path: candidate_interface_decoupled_references_start_path,
+        text: t('review_application.references.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
+        error: missing_error,
+      )
+    ) %>
+  <% else %>
+    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: application_form.application_references.feedback_provided, editable: editable)) %>
+  <% end %>
 <% else %>
   <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error, submitting_application: true)) %>
 <% end %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -81,7 +81,7 @@
     <%= render(
       SectionMissingBannerComponent.new(
         section: :references_provided,
-        section_path: candidate_interface_decoupled_references_start_path,
+        section_path: candidate_interface_decoupled_references_review_path,
         text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
         link_text: t('review_application.references_provided.complete_section'),
         error: missing_error

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -77,14 +77,15 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
 <% if FeatureFlag.active?(:decoupled_references) %>
-  <% if !application_form.references_completed && editable %>
+  <% if !application_form.enough_references_have_been_provided? && editable %>
     <%= render(
       SectionMissingBannerComponent.new(
-        section: :references,
+        section: :references_provided,
         section_path: candidate_interface_decoupled_references_start_path,
-        text: t('review_application.references.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
-        error: missing_error,
-      )
+        text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
+        link_text: t('review_application.references_provided.complete_section'),
+        error: missing_error
+      ),
     ) %>
   <% else %>
     <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: application_form.application_references.feedback_provided, editable: editable)) %>

--- a/app/views/candidate_interface/decoupled_references/review/show.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/show.html.erb
@@ -14,18 +14,24 @@
 <% end %>
 
 <% if @references_given.present? %>
-  <h2 class="govuk-heading-m">References that have been given</h2>
-  <%= render(
-    CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_given, editable: false)
-  ) %>
+  <div id='references_given'>
+    <h2 class="govuk-heading-m">References that have been given</h2>
+    <%= render(
+      CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_given, editable: false)
+    ) %>
+  </div>
 <% end %>
 
 <% if @references_waiting_to_be_sent.present? %>
-  <h2 class="govuk-heading-m">Requests that have not been sent</h2>
-  <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_waiting_to_be_sent)) %>
+  <div id='references_waiting_to_be_sent'>
+    <h2 class="govuk-heading-m">Requests that have not been sent</h2>
+    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_waiting_to_be_sent)) %>
+  </div>
 <% end %>
 
 <% if @references_sent.present? %>
-  <h2 class="govuk-heading-m">Reference requests</h2>
-  <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_sent)) %>
+  <div id='references_sent'>
+    <h2 class="govuk-heading-m">Reference requests</h2>
+    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_sent, editable: false)) %>
+  </div>
 <% end %>

--- a/app/views/candidate_interface/decoupled_references/review/show.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/show.html.erb
@@ -16,30 +16,16 @@
 <% if @references_given.present? %>
   <h2 class="govuk-heading-m">References that have been given</h2>
   <%= render(
-    CandidateInterface::DecoupledReferencesReviewComponent.new(
-      references: @references_given,
-      references_section_completed: @application_form.references_completed,
-      editable: false
-    )
+    CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_given, editable: false)
   ) %>
 <% end %>
 
 <% if @references_waiting_to_be_sent.present? %>
   <h2 class="govuk-heading-m">Requests that have not been sent</h2>
-  <%= render(
-    CandidateInterface::DecoupledReferencesReviewComponent.new(
-      references: @references_waiting_to_be_sent,
-      references_section_completed: @application_form.references_completed,
-    )
-  ) %>
+  <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_waiting_to_be_sent)) %>
 <% end %>
 
 <% if @references_sent.present? %>
   <h2 class="govuk-heading-m">Reference requests</h2>
-  <%= render(
-    CandidateInterface::DecoupledReferencesReviewComponent.new(
-      references: @references_sent,
-      references_section_completed: @application_form.references_completed,
-    )
-  ) %>
+  <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_sent)) %>
 <% end %>

--- a/app/views/candidate_interface/decoupled_references/review/show.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/show.html.erb
@@ -35,3 +35,5 @@
     <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_sent, editable: false)) %>
   </div>
 <% end %>
+
+<%= govuk_link_to 'Continue', candidate_interface_application_form_path, class: 'govuk-button' %>

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -110,6 +110,8 @@ private
     sent_more_than_5_days_ago = create(:reference, :sent_more_than_5_days_ago, application_form: af)
     feedback_provided = create(:reference, :complete, application_form: af)
 
+    status_struct = Struct.new(:reference, :colour, :status_identifier, :info_identifier)
+    stub_const('Status', status_struct)
     [
       Status.new(not_requested_yet, :grey, 'not_requested_yet', 'not_requested_yet'),
       Status.new(feedback_refused, :red, 'feedback_refused', 'declined'),
@@ -122,7 +124,4 @@ private
       Status.new(feedback_provided, :green, 'feedback_provided', ''),
     ]
   end
-  # rubocop:disable RSpec/LeakyConstantDeclaration
-  Status = Struct.new(:reference, :colour, :status_identifier, :info_identifier)
-  # rubocop:enable RSpec/LeakyConstantDeclaration
 end

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -1,5 +1,128 @@
 require 'rails_helper'
 
-RSpec.describe DecoupledReferencesReviewComponent, type: :component do
-  pending
+RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :component do
+  it 'renders the referee name and email' do
+    reference = create(:reference, :unsubmitted)
+    result = render_inline(described_class.new(references: [reference]))
+
+    name_row = result.css('.govuk-summary-list__row')[0].text
+    email_row = result.css('.govuk-summary-list__row')[1].text
+    expect(name_row).to include 'Name'
+    expect(name_row).to include reference.name
+    expect(email_row).to include 'Email address'
+    expect(email_row).to include reference.email_address
+  end
+
+  it 'renders the reference type' do
+    reference = create(:reference, :unsubmitted, referee_type: :school_based)
+    result = render_inline(described_class.new(references: [reference]))
+
+    type_row = result.css('.govuk-summary-list__row')[2].text
+    expect(type_row).to include 'Reference type'
+    expect(type_row).to include 'School-based'
+  end
+
+  it 'renders the relationship' do
+    reference = create(:reference, :unsubmitted)
+    result = render_inline(described_class.new(references: [reference]))
+
+    relationship_row = result.css('.govuk-summary-list__row')[3].text
+    expect(relationship_row).to include 'Relationship to referee'
+    expect(relationship_row).to include reference.relationship
+  end
+
+  it 'renders the correct status' do
+    status_table.each do |row|
+      result = render_inline(described_class.new(references: [row.reference]))
+
+      expect(result.css(".govuk-tag.govuk-tag--#{row.colour}.app-tag").text).to(
+        include(t("candidate_reference_status.#{row.status_identifier}")),
+      )
+      next if row.info_identifier.blank?
+
+      expect(result.css('.govuk-summary-list__value')[4].text).to(
+        include(t("application_form.referees.info.#{row.info_identifier}")),
+      )
+    end
+  end
+
+  it 'renders all references passed in' do
+    reference_one = create(:reference)
+    reference_two = create(:reference)
+
+    result = render_inline(described_class.new(references: [reference_one, reference_two]))
+    expect(result.text).to include reference_one.email_address
+    expect(result.text).to include reference_two.email_address
+  end
+
+  context 'when editable is true' do
+    let(:reference) { create(:reference, :unsubmitted) }
+    let(:result) { render_inline(described_class.new(references: [reference], editable: true)) }
+
+    it 'fields can be changed' do
+      expect(result.css('.app-summary-card__body').text).to include 'Change'
+    end
+
+    it 'the reference can be deleted' do
+      expect(result.css('.app-summary-card__header').text).to include 'Delete referee'
+    end
+  end
+
+  context 'when editable is false' do
+    let(:reference) { create(:reference, :unsubmitted) }
+    let(:result) { render_inline(described_class.new(references: [reference], editable: false)) }
+
+    it 'fields cannot be changed' do
+      expect(result.css('.app-summary-card__body').text).not_to include 'Change'
+    end
+
+    it 'the reference cannot be deleted' do
+      expect(result.css('.app-summary-card__header').text).not_to include 'Delete referee'
+    end
+  end
+
+  context 'when reference state is "feedback_requested"' do
+    let(:feedback_requested) { create(:reference, :requested) }
+    let(:feedback_refused) { create(:reference, :refused) }
+
+    it 'a cancel link is available' do
+      result = render_inline(described_class.new(references: [feedback_requested, feedback_refused]))
+
+      feedback_requested_summary = result.css('.app-summary-card')[0]
+      feedback_refused_summary = result.css('.app-summary-card')[1]
+      expect(feedback_requested_summary.text).to include 'Cancel request'
+      expect(feedback_refused_summary.text).not_to include 'Cancel request'
+    end
+  end
+
+private
+
+  def status_table
+    af = create(:application_form)
+
+    not_requested_yet = create(:reference, :unsubmitted, application_form: af)
+    feedback_refused = create(:reference, :refused, application_form: af)
+    email_bounced = create(:reference, :email_bounced, application_form: af)
+    cancelled_at_end_of_cycle = create(:reference, :cancelled_at_end_of_cycle, application_form: af)
+    cancelled = create(:reference, :cancelled, application_form: af)
+    feedback_overdue = create(:reference, :feedback_overdue, application_form: af)
+    sent_less_than_5_days_ago = create(:reference, :sent_less_than_5_days_ago, application_form: af)
+    sent_more_than_5_days_ago = create(:reference, :sent_more_than_5_days_ago, application_form: af)
+    feedback_provided = create(:reference, :complete, application_form: af)
+
+    [
+      Status.new(not_requested_yet, :grey, 'not_requested_yet', 'not_requested_yet'),
+      Status.new(feedback_refused, :red, 'feedback_refused', 'declined'),
+      Status.new(email_bounced, :red, 'email_bounced', ''),
+      Status.new(cancelled_at_end_of_cycle, :orange, 'cancelled_at_end_of_cycle', 'cancelled_at_end_of_cycle'),
+      Status.new(cancelled, :orange, 'cancelled', 'cancelled'),
+      Status.new(feedback_overdue, :yellow, 'feedback_overdue', 'feedback_overdue'),
+      Status.new(sent_less_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_less_than_5_days_ago'),
+      Status.new(sent_more_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_more_than_5_days_ago'),
+      Status.new(feedback_provided, :green, 'feedback_provided', ''),
+    ]
+  end
+  # rubocop:disable RSpec/LeakyConstantDeclaration
+  Status = Struct.new(:reference, :colour, :status_identifier, :info_identifier)
+  # rubocop:enable RSpec/LeakyConstantDeclaration
 end

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -180,13 +180,6 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form, submitting_application: true))
       expect(result.text).to include('Add 2 referees to your application')
     end
-
-    it 'renders an error when references have not come back from referees' do
-      FeatureFlag.activate(:decoupled_references)
-
-      result = render_inline(described_class.new(application_form: application_form, submitting_application: true))
-      expect(result.text).to include('You need 2 references before you can submit your application')
-    end
   end
 
   context 'when referees are not editable' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -677,10 +677,35 @@ FactoryBot.define do
       requested_at { Time.zone.now }
     end
 
+    trait :cancelled_at_end_of_cycle do
+      feedback_status { 'cancelled_at_end_of_cycle' }
+      feedback { nil }
+      requested_at { Time.zone.now }
+    end
+
     trait :requested do
       feedback_status { 'feedback_requested' }
       feedback { nil }
       requested_at { Time.zone.now }
+    end
+
+    trait :sent_less_than_5_days_ago do
+      feedback_status { 'feedback_requested' }
+      feedback { nil }
+      requested_at { Time.zone.now - 2.days }
+    end
+
+    trait :sent_more_than_5_days_ago do
+      feedback_status { 'feedback_requested' }
+      feedback { nil }
+      requested_at { Time.zone.now - 6.days }
+    end
+
+    trait :feedback_overdue do
+      feedback_status { 'feedback_requested' }
+      feedback { nil }
+      requested_at { 11.business_days.ago }
+      created_at { 11.business_days.ago }
     end
 
     trait :complete do

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Candidate reviewing an incomplete application' do
   include CandidateHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   scenario 'sees everything missing from the current state' do
     given_i_am_signed_in
 

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.feature 'Review references' do
+  include CandidateHelper
+
+  scenario 'the candidate has several references in different states' do
+    given_i_am_signed_in
+    and_the_decoupled_references_flag_is_on
+    and_i_have_added_references
+    then_i_can_review_my_references_before_submission
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_decoupled_references_flag_is_on
+    FeatureFlag.activate('decoupled_references')
+  end
+
+  def and_i_have_added_references
+    application_form = current_candidate.current_application
+    @complete_reference = create(:reference, :complete, application_form: application_form)
+    @not_sent_reference = create(:reference, :unsubmitted, application_form: application_form)
+    @requested_reference = create(:reference, :requested, application_form: application_form)
+    @refused_reference = create(:reference, :refused, application_form: application_form)
+  end
+
+  def then_i_can_review_my_references_before_submission
+    visit candidate_interface_decoupled_references_review_path
+
+    within '#references_given' do
+      expect(page).to have_content @complete_reference.email_address
+      expect(page).not_to have_link 'Change'
+      expect(page).not_to have_link 'Delete referee'
+      expect(page).not_to have_link 'Cancel request'
+    end
+
+    within '#references_waiting_to_be_sent' do
+      expect(page).to have_content @not_sent_reference.email_address
+      expect(page).to have_link 'Change'
+      expect(page).to have_link 'Delete referee'
+      expect(page).not_to have_link 'Cancel request'
+    end
+
+    within '#references_sent' do
+      expect(page).to have_content @requested_reference.email_address
+      expect(page).to have_content @refused_reference.email_address
+      expect(page).not_to have_link 'Change'
+      expect(page).not_to have_link 'Delete referee'
+      expect(page).to have_link 'Cancel request'
+    end
+  end
+end

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Review references' do
     and_the_decoupled_references_flag_is_on
     and_i_have_added_references
     then_i_can_review_my_references_before_submission
+    and_i_can_return_to_the_application_page
   end
 
   def given_i_am_signed_in
@@ -50,5 +51,10 @@ RSpec.feature 'Review references' do
       expect(page).not_to have_link 'Delete referee'
       expect(page).to have_link 'Cancel request'
     end
+  end
+
+  def and_i_can_return_to_the_application_page
+    click_link 'Continue'
+    expect(page).to have_current_path candidate_interface_application_form_path
   end
 end


### PR DESCRIPTION
## Context
Builds on code introduced by https://github.com/DFE-Digital/apply-for-teacher-training/pull/3081
<!-- Why are you making this change? What might surprise someone about it? -->
As a... candidate
I need to... see the status of my referees and reference requests
So that... I now what I need to do next to complete this section
## Changes proposed in this pull request
- Simplify the component implementation
- Move the app submit error messaging over from another location where it was previously implemented by @stevehook 
- Add component and system tests

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Path: `/candidate/application/references/review`
- Also worth checking the app submit error (if not enough references) and the post-submit application review.
- Delete, Cancel, and Change behaviour not implemented yet, will follow in another PR.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Probably best reviewed locally, might need to create some references via the existing references flow and modify state on the console until the decoupled references flow is ready.

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/7autFjC7
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
