### PR TITLE
Change SubmitReference behaviour for decoupled references

### DIFF
--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -8,7 +8,20 @@ class SubmitReference
 
   def save!
     if enough_references_have_been_submitted?
-      progress_applications
+      # With the decoupled_references feature active, we should be preventing
+      # submission of the application unless the MINIMUM_COMPLETE_REFERENCES
+      # have been provided. We also no longer allow the candidate to manually
+      # mark the section complete - it is considered complete when the minimum
+      # references are given. We check the references directly when attempting
+      # to submit the form, rather than inspecting the
+      # ApplicationForm#references_completed flag.
+      #
+      # As such, this method only needs to update the state of the reference,
+      # not the application form.
+      #
+      # TODO: drop the ApplicationForm#references_completed column when
+      # removing the decoupled_references feature flag.
+      FeatureFlag.active?(:decoupled_references) ? reference_feedback_provided! : progress_applications
     else
       reference_feedback_provided!
     end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe TestApplications do
   include DateComparisonHelper
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   it 'generates an application with choices in the given states' do
     create(:course_option, course: create(:course, :open_on_apply))
     create(:course_option, course: create(:course, :open_on_apply))

--- a/spec/requests/vendor_api/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_generate_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request do
   include VendorAPISpecHelpers
 
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   it 'generates test data' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe SubmitApplication do
   describe 'Submit an application', sandbox: false do
     let(:current_date) { Time.zone.local(2019, 11, 11, 15, 0, 0) }
 
+    before { FeatureFlag.deactivate(:decoupled_references) }
+
     def create_application_form
       application_form = create(:application_form, submitted_at: current_date)
       create(:application_choice, application_form: application_form, status: 'unsubmitted')

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -2,79 +2,101 @@ require 'rails_helper'
 
 RSpec.describe SubmitReference do
   describe '#save!' do
-    let(:application_form) { create(:completed_application_form) }
+    describe 'decoupled_references feature ON' do
+      before { FeatureFlag.activate(:decoupled_references) }
 
-    context 'minimum required references received' do
-      it 'progresses the application choices to the "application complete" status' do
-        application_form = create(:completed_application_form, edit_by: 1.day.from_now)
-        active_application_choice = create(:application_choice, application_form: application_form, status: 'awaiting_references')
-        cancelled_application_choice = create(:application_choice, application_form: application_form, status: 'cancelled')
+      it 'updates the reference state to "feedback_provided"' do
+        application_choice = create(:application_choice, status: :unsubmitted)
+        application_form = application_choice.application_form
+        reference_one = create(:reference, :requested)
+        reference_two = create(:reference, :requested, application_form: reference_one.application_form)
 
-        create(:reference, :complete, application_form: application_form)
-        reference = create(:reference, :unsubmitted, application_form: application_form)
+        SubmitReference.new(reference: reference_one).save!
+        SubmitReference.new(reference: reference_two).save!
 
-        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
-
-        SubmitReference.new(
-          reference: reference,
-        ).save!
-
-        expect(active_application_choice.reload).to be_application_complete
-        expect(cancelled_application_choice.reload).to be_cancelled
+        expect(reference_one).to be_feedback_provided
+        expect(reference_two).to be_feedback_provided
+        expect(application_form.reload.application_choices).to all(be_unsubmitted)
       end
+    end
 
-      it 'progresses the application choices to the "awaiting_provider_decision" if edit_by has elapsed' do
-        application_form = create(:completed_application_form, edit_by: 1.day.ago)
-        create(:application_choice, application_form: application_form, status: 'awaiting_references')
-        create(:reference, :complete, application_form: application_form)
-        reference = create(:reference, :unsubmitted, application_form: application_form)
+    describe 'decoupled_references feature OFF' do
+      before { FeatureFlag.deactivate(:decoupled_references) }
 
-        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+      let(:application_form) { create(:completed_application_form) }
 
-        SubmitReference.new(
-          reference: reference,
-        ).save!
+      context 'minimum required references received' do
+        it 'progresses the application choices to the "application complete" status' do
+          application_form = create(:completed_application_form, edit_by: 1.day.from_now)
+          active_application_choice = create(:application_choice, application_form: application_form, status: 'awaiting_references')
+          cancelled_application_choice = create(:application_choice, application_form: application_form, status: 'cancelled')
 
-        expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
-      end
+          create(:reference, :complete, application_form: application_form)
+          reference = create(:reference, :unsubmitted, application_form: application_form)
 
-      it 'sets edit_by to current time if the candidate is applying again' do
-        application_form = create(:completed_application_form, previous_application_form: create(:application_form), edit_by: 2.days.from_now)
-        create(:application_choice, application_form: application_form, status: 'awaiting_references')
-        create(:reference, :complete, application_form: application_form)
-        reference = create(:reference, :unsubmitted, application_form: application_form)
+          reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
-        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
-
-        Timecop.freeze(Time.utc(2020)) do
           SubmitReference.new(
             reference: reference,
           ).save!
 
-          expect(application_form.edit_by).to eq Time.utc(2020)
+          expect(active_application_choice.reload).to be_application_complete
+          expect(cancelled_application_choice.reload).to be_cancelled
         end
-      end
 
-      it 'is okay with a 3rd reference being provided' do
-        application_form = create(:completed_application_form, edit_by: 1.day.ago)
+        it 'progresses the application choices to the "awaiting_provider_decision" if edit_by has elapsed' do
+          application_form = create(:completed_application_form, edit_by: 1.day.ago)
+          create(:application_choice, application_form: application_form, status: 'awaiting_references')
+          create(:reference, :complete, application_form: application_form)
+          reference = create(:reference, :unsubmitted, application_form: application_form)
 
-        create(:application_choice, application_form: application_form, status: 'awaiting_references')
-        create(:reference, :complete, application_form: application_form)
-        reference = create(:reference, :unsubmitted, application_form: application_form)
+          reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
-        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+          SubmitReference.new(
+            reference: reference,
+          ).save!
 
-        SubmitReference.new(
-          reference: reference,
-        ).save!
+          expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
+        end
 
-        another_reference = create(:reference, :unsubmitted, application_form: application_form)
+        it 'sets edit_by to current time if the candidate is applying again' do
+          application_form = create(:completed_application_form, previous_application_form: create(:application_form), edit_by: 2.days.from_now)
+          create(:application_choice, application_form: application_form, status: 'awaiting_references')
+          create(:reference, :complete, application_form: application_form)
+          reference = create(:reference, :unsubmitted, application_form: application_form)
 
-        another_reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+          reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
-        SubmitReference.new(
-          reference: another_reference,
-        ).save!
+          Timecop.freeze(Time.utc(2020)) do
+            SubmitReference.new(
+              reference: reference,
+            ).save!
+
+            expect(application_form.edit_by).to eq Time.utc(2020)
+          end
+        end
+
+        it 'is okay with a 3rd reference being provided' do
+          application_form = create(:completed_application_form, edit_by: 1.day.ago)
+
+          create(:application_choice, application_form: application_form, status: 'awaiting_references')
+          create(:reference, :complete, application_form: application_form)
+          reference = create(:reference, :unsubmitted, application_form: application_form)
+
+          reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+
+          SubmitReference.new(
+            reference: reference,
+          ).save!
+
+          another_reference = create(:reference, :unsubmitted, application_form: application_form)
+
+          another_reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+
+          SubmitReference.new(
+            reference: another_reference,
+          ).save!
+        end
       end
     end
   end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe GenerateTestApplications do
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
   it 'generates test candidates with applications in various states', sidekiq: true do
     create(:course_option, course: create(:course, :open_on_apply))
     create(:course_option, course: create(:course, :open_on_apply))


### PR DESCRIPTION


## Context

With `decoupled_references` active, when a referee submits a reference
we only want to update the reference state. None of the
`progress_applications` logic is relevant or desirable, as the
application will be sent to providers on submit.


Arose out of the work on https://github.com/DFE-Digital/apply-for-teacher-training/pull/3083 . It's not obviously related, but this change was prompted by the requirement that we no longer allow the candidate to mark the section complete manually. Instead, the section is considered complete as soon as two references are provided.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
See diff.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/7autFjC7
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
