### PR TITLE
Fix HESA disabilities migration

### DIFF
--- a/app/services/candidate_interface/hesa_code_backfill.rb
+++ b/app/services/candidate_interface/hesa_code_backfill.rb
@@ -44,7 +44,7 @@ module CandidateInterface
 
     def hesa_disability_codes(application_form)
       disabilities = application_form.equality_and_diversity['disabilities']
-      return if disabilities.empty?
+      return if disabilities.blank?
 
       codes = disabilities.map do |disability|
         break if disability == 'Prefer not to say'

--- a/spec/services/candidate_interface/hesa_code_backfill_spec.rb
+++ b/spec/services/candidate_interface/hesa_code_backfill_spec.rb
@@ -46,6 +46,26 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
         )
       end
 
+      it "does not populate 'hesa_disabilities' if disabilities is nil" do
+        application_form = create(:application_form,
+                                  equality_and_diversity: {
+                                    disabilities: nil,
+                                  })
+
+        cycle_year = 2020
+
+        described_class.call(cycle_year)
+
+        application_form.reload
+
+        expect(application_form.equality_and_diversity).to eq(
+          'disabilities' => nil,
+          'hesa_disabilities' => nil,
+          'hesa_ethnicity' => nil,
+          'hesa_sex' => nil,
+        )
+      end
+
       it "populates 'hesa_disabilities' with hesa_code '96' for unknown disabilities" do
         application_form = create(:application_form,
                                   equality_and_diversity: {


### PR DESCRIPTION
## Context
The HESA disabilities backfill migration is failing because a course(s) have `nil` disabilities.
See Sentry error - https://sentry.io/organizations/dfe-bat/issues/1941601701/?project=1765973&referrer=slack

## Changes proposed in this pull request
Handle `nil`

## Link to Trello card
https://trello.com/c/mxKdgR5L/2178-dev-collect-hesa-codes-at-source-in-ed-qs

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
