### PR TITLE
HESA code backfill - handle 'intersex'

### DIFF
--- a/app/services/candidate_interface/hesa_code_backfill.rb
+++ b/app/services/candidate_interface/hesa_code_backfill.rb
@@ -3,6 +3,8 @@ module CandidateInterface
     HESA_DISABILITY_CODE_OTHER = '96'.freeze
     HESA_ETHNICITY_CODE_REFUSED = '98'.freeze
     HESA_ETHNICITY_CODE_UNKNOWN = '80'.freeze
+    HESA_SEX_CODE_OTHER = 3
+
 
     def self.call(cycle_year)
       new(cycle_year).call
@@ -60,6 +62,7 @@ module CandidateInterface
 
     def hesa_sex_code(application_form)
       sex = application_form.equality_and_diversity['sex']
+      return HESA_SEX_CODE_OTHER if sex == 'intersex'
       Hesa::Sex.find_by_type(sex)&.hesa_code
     end
   end

--- a/app/services/candidate_interface/hesa_code_backfill.rb
+++ b/app/services/candidate_interface/hesa_code_backfill.rb
@@ -1,10 +1,9 @@
 module CandidateInterface
   class HesaCodeBackfill
     HESA_DISABILITY_CODE_OTHER = '96'.freeze
-    HESA_ETHNICITY_CODE_REFUSED = '98'.freeze
-    HESA_ETHNICITY_CODE_UNKNOWN = '80'.freeze
+    HESA_ETHNICITY_CODE_REFUSED = 98
+    HESA_ETHNICITY_CODE_UNKNOWN = 80
     HESA_SEX_CODE_OTHER = 3
-
 
     def self.call(cycle_year)
       new(cycle_year).call
@@ -63,6 +62,7 @@ module CandidateInterface
     def hesa_sex_code(application_form)
       sex = application_form.equality_and_diversity['sex']
       return HESA_SEX_CODE_OTHER if sex == 'intersex'
+
       Hesa::Sex.find_by_type(sex)&.hesa_code
     end
   end

--- a/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
         )
       end
     end
+
+    context "sex is 'intersex'" do
+      it 'updates equality and diversity information with the correct HESA code' do
+        form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'intersex')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('sex' => 'intersex', 'hesa_sex' => 3)
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/services/candidate_interface/hesa_code_backfill_spec.rb
+++ b/spec/services/candidate_interface/hesa_code_backfill_spec.rb
@@ -159,5 +159,28 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
         end
       end
     end
+
+    context 'sex' do
+      it "populates 'hesa_sex' with hesa_code '3' when candidate is 'intersex'" do
+        application_form = create(:application_form,
+                                  equality_and_diversity: {
+                                    sex: 'intersex',
+                                  },
+                                  recruitment_cycle_year: 2021)
+
+        cycle_year = 2021
+
+        described_class.call(cycle_year)
+
+        application_form.reload
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'intersex',
+          'hesa_sex' => described_class::HESA_SEX_CODE_OTHER,
+          'hesa_disabilities' => nil,
+          'hesa_ethnicity' => nil,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

```
As a Provendor team
I need application HESA data codes for Sex, Ethnicity, Disability to be collected at source
So that I can supply Providers with a download they can share with HESA/DfE
```

## Changes proposed in this pull request

- Make sure the backfill populates `hesa_sex` with a HESA code `3` when a candidate's sex is ‘intersex’. HESA code 3 is ‘other’
- Corrected types for some HESA codes

## Link to Trello card
https://trello.com/c/mxKdgR5L/2178-dev-collect-hesa-codes-at-source-in-ed-qs

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
