### PR TITLE
Manage org/org relationships in support

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -51,6 +51,39 @@ module SupportInterface
       @relationship_diagram = SupportInterface::ProviderRelationshipsDiagram.new(provider: @provider)
     end
 
+    def relationships
+      @provider = Provider.find(params[:provider_id])
+      relationships = ProviderRelationshipPermissions.where(
+        training_provider: @provider,
+      ).or(
+        ProviderRelationshipPermissions.where(
+          ratifying_provider: @provider,
+        ),
+      )
+
+      @relationships_form = SupportInterface::ProviderRelationshipsForm.from_models(relationships)
+    end
+
+    def update_relationships
+      @provider = Provider.find(params[:provider_id])
+      @relationships_form = SupportInterface::ProviderRelationshipsForm.from_params(
+        relationships_params[:relationships],
+      )
+
+      if @relationships_form.valid?
+        @relationships_form.save!
+        flash[:success] = 'Relationships updated'
+        redirect_to support_interface_provider_relationships_path
+      else
+        render :relationships
+      end
+    end
+
+    def relationships_params
+      params.require(:support_interface_provider_relationships_form)
+        .permit(relationships: {})
+    end
+
     def applications
       @provider = Provider.find(params[:provider_id])
       @filter = SupportInterface::ApplicationsFilter.new(params: params)

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -61,7 +61,11 @@ module SupportInterface
         ),
       )
 
-      @relationships_form = SupportInterface::ProviderRelationshipsForm.from_models(relationships)
+      if relationships.empty?
+        render 'no_relationships'
+      else
+        @relationships_form = SupportInterface::ProviderRelationshipsForm.from_models(relationships)
+      end
     end
 
     def update_relationships

--- a/app/forms/support_interface/provider_relationships_form.rb
+++ b/app/forms/support_interface/provider_relationships_form.rb
@@ -1,0 +1,55 @@
+module SupportInterface
+  class ProviderRelationshipsForm
+    include ActiveModel::Model
+
+    POSSIBLE_ATTRIBUTES = %w[
+      training_provider_can_make_decisions
+      ratifying_provider_can_make_decisions
+      training_provider_can_view_safeguarding_information
+      ratifying_provider_can_view_safeguarding_information
+      training_provider_can_view_diversity_information
+      ratifying_provider_can_view_diversity_information
+    ].freeze
+
+    attr_accessor :relationships
+    validate :all_relationships_valid?
+
+    def self.from_models(models)
+      new(relationships: models)
+    end
+
+    def self.from_params(params)
+      # fill the hash with "false" values
+      default_values = POSSIBLE_ATTRIBUTES.zip([false].cycle).to_h
+
+      relationships = params.to_h.map do |id, p|
+        relationship = ProviderRelationshipPermissions.find(id)
+        relationship.assign_attributes(default_values.merge(p))
+        if !relationship.setup_at
+          relationship.setup_at = Time.zone.now
+        end
+
+        relationship
+      end
+
+      new(relationships: relationships)
+    end
+
+    def save!
+      ActiveRecord::Base.transaction do
+        @relationships.each(&:save!)
+      end
+    end
+
+  private
+
+    def all_relationships_valid?
+      @relationships.each do |relationship|
+        relationship.valid?
+        relationship.errors.map do |key, message|
+          errors.add("relationships[#{relationship.id}][#{key}]", message)
+        end
+      end
+    end
+  end
+end

--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -18,6 +18,7 @@
   { name: 'Applications', url: support_interface_provider_applications_path },
   { name: 'Provider users', url: support_interface_provider_user_list_path },
   { name: 'Courses', url: support_interface_provider_courses_path },
+  { name: 'Relationships', url: support_interface_provider_relationships_path },
   { name: 'Ratified courses', url: support_interface_provider_ratified_courses_path },
   { name: 'Vacancies', url: support_interface_provider_vacancies_path },
   { name: 'Sites', url: support_interface_provider_sites_path },

--- a/app/views/support_interface/providers/no_relationships.html.erb
+++ b/app/views/support_interface/providers/no_relationships.html.erb
@@ -1,0 +1,5 @@
+<%= render 'no_admin_users_warning' %>
+
+<%= render 'provider_navigation', title: 'Details' %>
+
+<p class="govuk-body">This provider has no relationships to manage.</p>

--- a/app/views/support_interface/providers/relationships.html.erb
+++ b/app/views/support_interface/providers/relationships.html.erb
@@ -1,0 +1,57 @@
+<%= render 'no_admin_users_warning' %>
+
+<%= render 'provider_navigation', title: 'Details' %>
+
+<%= form_with model: @relationships_form, url: support_interface_update_provider_relationships_path do |f| %>
+
+  <%= f.govuk_error_summary %>
+
+  <% @relationships_form.relationships.each do |r| %>
+    <%= f.fields_for 'relationships[]', r do |rf| %>
+      <%= rf.hidden_field :id %>
+      <%= rf.hidden_field :training_provider_id %>
+      <%= rf.hidden_field :ratifying_provider_id %>
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half"></th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"><%= r.training_provider.name %><br />(training provider)</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"><%= r.ratifying_provider.name %><br />(ratifying provider)</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Can make decisions</th>
+            <td class="govuk-table__cell">
+              <%= rf.govuk_check_box :training_provider_can_make_decisions, true, multiple: false, label: { text: 'Permit' }, link_errors: true %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= rf.govuk_check_box "ratifying_provider_can_make_decisions", true, multiple: false, label: { text: 'Permit' } %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Can view safeguarding information</th>
+            <td class="govuk-table__cell">
+              <%= rf.govuk_check_box "training_provider_can_view_safeguarding_information", true, multiple: false, label: { text: 'Permit' } %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= rf.govuk_check_box "ratifying_provider_can_view_safeguarding_information", true, multiple: false, label: { text: 'Permit' } %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Can view diversity information</th>
+            <td class="govuk-table__cell">
+              <%= rf.govuk_check_box "training_provider_can_view_diversity_information", true, multiple: false, label: { text: 'Permit' } %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= rf.govuk_check_box "ratifying_provider_can_view_diversity_information", true, multiple: false, label: { text: 'Permit' } %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit 'Update relationships' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -771,6 +771,8 @@ Rails.application.routes.draw do
       get '/users' => 'providers#users', as: :provider_user_list
       get '/applications' => 'providers#applications', as: :provider_applications
       get '/history' => 'providers#history', as: :provider_history
+      get '/relationships' => 'providers#relationships', as: :provider_relationships
+      post '/relationships' => 'providers#update_relationships', as: :update_provider_relationships
 
       post '' => 'providers#open_all_courses'
       post '/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing

--- a/spec/system/support_interface/managing_provider_permissions_spec.rb
+++ b/spec/system/support_interface/managing_provider_permissions_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider-provider permissions via support' do
+  include DfESignInHelpers
+
+  scenario 'Support user changes provider permissions' do
+    given_i_am_a_support_user
+    and_there_are_two_providers_in_a_partnership
+
+    when_i_visit_the_first_provider
+    and_click_relationships
+    and_set_invalid_relationships
+    then_i_should_see_an_error
+
+    when_i_set_valid_relationships
+    then_the_relationships_should_be_updated
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_two_providers_in_a_partnership
+    training = create(:provider, sync_courses: true, name: 'Numan College')
+    ratifying = create(:provider, sync_courses: true, name: 'Oldman University')
+
+    create(:provider_relationship_permissions, :not_set_up_yet,
+           training_provider: training, ratifying_provider: ratifying)
+  end
+
+  def when_i_visit_the_first_provider
+    click_on 'Providers'
+    click_on 'Numan College'
+  end
+
+  def and_click_relationships
+    click_on 'Relationships'
+  end
+
+  def and_set_invalid_relationships
+    # check no checkboxes
+
+    click_on 'Update relationships'
+  end
+
+  def then_i_should_see_an_error
+    expect(page).to have_content 'Select which organisations can make decisions'
+  end
+
+  def when_i_set_valid_relationships
+    all('input[type=checkbox]').each do |checkbox|
+      if !checkbox.checked?
+        checkbox.click
+      end
+    end
+
+    click_on 'Update relationships'
+  end
+
+  def then_the_relationships_should_be_updated
+    expect(page).to have_content 'Relationships updated'
+
+    checkboxes = all('input[type=checkbox]')
+    expect(checkboxes.count).to eq 6
+    expect(checkboxes).to all be_checked
+  end
+end


### PR DESCRIPTION
An page which allows Support users to manage org/org relationshis

## Context

The support team are going to need this as masses of SDs come on along with their HEIs

## Changes proposed in this pull request

Introduce a page in support which allows these relationships to be managed all at the same time. 

Known defects

- the error summary does not link to the checkboxes

This is fiddly because the permissions are models nested in a form object. There is surely a way to fix this but I don't think it's worth holding up this feature for.

<img width="1066" alt="Screenshot 2020-10-07 at 23 54 55" src="https://user-images.githubusercontent.com/642279/95396594-2aa0eb00-08f9-11eb-806d-4244bb840352.png">

## Link to Trello card

https://trello.com/c/Ov5yNRrS/2870-allow-changing-org-permissions-via-the-support-console

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
