### PR TITLE
Find or create candidates in process matching data spec

### DIFF
--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
   end
 
   def given_there_is_a_newly_matched_candidate
-    @not_previously_matched = create(:candidate, id: 213)
+    @not_previously_matched = Candidate.create_with(email_address: 'not_previously_matched@abc.com').find_or_create_by(id: 213)
     course = create(:course, code: 'XYZ', provider: create(:provider, code: 'XX'))
     course_option = create(:course_option, course: course)
     application_choice = create(:submitted_application_choice, course_option: course_option)
@@ -35,7 +35,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
   end
 
   def and_there_is_a_previously_matched_candidate_with_new_data
-    @previously_matched_changed = create(:candidate, id: 44)
+    @previously_matched_changed = Candidate.create_with(email_address: 'previously_matched_changed@abc.com').find_or_create_by(id: 44)
     course1 = create(:course, code: 'LMN', provider: create(:provider, code: '2FF'))
     course_option1 = create(:course_option, course: course1)
     application_choice1 = create(:submitted_application_choice, course_option: course_option1)
@@ -50,7 +50,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
   end
 
   def and_there_is_a_previously_matched_candidate_with_no_changes
-    @previously_matched_unchanged = create(:candidate, id: 57)
+    @previously_matched_unchanged = Candidate.create_with(email_address: 'previously_matched_unchanged@abc.com').find_or_create_by(id: 57)
     course = create(:course, code: 'UVW', provider: create(:provider, code: '1EP'))
     course_option = create(:course_option, course: course)
     application_choice = create(:submitted_application_choice, course_option: course_option)


### PR DESCRIPTION
## Context

We were intermittently getting the following error:

```
ActiveRecord::RecordNotUnique:
  PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "candidates_pkey"
  DETAIL:  Key (id)=(44) already exists.
```

See: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=118561&view=ms.vss-test-web.build-test-results-tab&runId=1433526&resultId=100039&paneView=debug

In this test we are creating Candidates with specific IDs, which
have to correspond to the data in matching_data_example.csv
Occasionally those IDs were already used causing the error.


## Changes proposed in this pull request

Use `find_or_create_by` instead of the factory.
Find the first user with a particular  id (we don't care about email address) but if there isn't one we need to create it and specify email_address.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
