### PR TITLE
Change 'Your account is not ready yet' page to an email address focused one

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -86,7 +86,7 @@ private
     if target_path_is_support_path
       'support_interface/unauthorized'
     else
-      'provider_interface/account_creation_in_progress'
+      'provider_interface/email_address_not_recognised'
     end
   end
 

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -22,7 +22,7 @@ module ProviderInterface
     rescue_from MissingProvider, with: lambda { |e|
       Raven.capture_exception(e)
 
-      render template: 'provider_interface/account_creation_in_progress', status: :forbidden
+      render template: 'provider_interface/email_address_not_recognised', status: :forbidden
     }
 
     rescue_from ProviderInterface::AccessDenied, with: :permission_error

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -6,13 +6,24 @@
       Your account is not ready yet
     </h1>
     <p class="govuk-body">
-      You’re seeing this page because you’ve signed in
-      to the <%= t('service_name.apply') %> service but your account
-      is not ready to use yet.
+      You have signed in to DfE as
+      <span style="font-weight: bold; white-space: nowrap;">
+        <%= @dfe_sign_in_user.email_address %>
+      </span>
+      but we cannot find your
+      <span style="white-space: nowrap;">
+        <%= govuk_link_to t('service_name.apply'), provider_interface_applications_path %>
+      </span>
+      account.
     </p>
 
     <p class="govuk-body">
-      If you’ve registered to work with us and you think your account should be ready, contact
+      Is this the email address that has been invited to this service?
+    </p>
+
+    <p class="govuk-body">
+      If you’ve registered to work with us with this email address and you think your account should be ready, please contact:<br><br>
+
       <%= bat_contact_mail_to %>.
     </p>
   </div>

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -3,27 +3,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Your account is not ready yet
+      Your email address is not recognised
     </h1>
+
     <p class="govuk-body">
       You have signed in to DfE as
       <span style="font-weight: bold; white-space: nowrap;">
         <%= @dfe_sign_in_user.email_address %>
-      </span>
-      but we cannot find your
-      <span style="white-space: nowrap;">
-        <%= govuk_link_to t('service_name.apply'), provider_interface_applications_path %>
-      </span>
-      account.
+      </span>.
+
+      We can’t find an ‘<%= t('service_name.apply') %>’ account associated with that address.
+      Please <%= govuk_link_to 'sign in', provider_interface_applications_path %>
+      again, using the email address associated with your Apply account.
     </p>
 
     <p class="govuk-body">
-      Is this the email address that has been invited to this service?
-    </p>
-
-    <p class="govuk-body">
-      If you’ve registered to work with us with this email address and you think your account should be ready, please contact:<br><br>
-
+      If you are using the correct email address to sign in to Apply and you’re still receiving this message, please contact us at
       <%= bat_contact_mail_to %>.
     </p>
   </div>

--- a/app/views/provider_interface/email_address_not_recognised.html.erb
+++ b/app/views/provider_interface/email_address_not_recognised.html.erb
@@ -8,10 +8,12 @@
 
     <p class="govuk-body">
       You have signed in to DfE as
-      <span style="font-weight: bold; white-space: nowrap;">
-        <%= @dfe_sign_in_user.email_address %>
-      </span>.
+      <span style="white-space: nowrap;">
+        <%= @dfe_sign_in_user&.email_address %>
+      </span>
+    </p>
 
+    <p class="govuk-body">
       We can’t find an ‘<%= t('service_name.apply') %>’ account associated with that address.
       Please <%= govuk_link_to 'sign in', provider_interface_applications_path %>
       again, using the email address associated with your Apply account.

--- a/spec/requests/provider_interface/account_creation_in_progress_spec.rb
+++ b/spec/requests/provider_interface/account_creation_in_progress_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe 'GET /provider/applications' do
       # do not grant the user permission to view a provider's applications
     end
 
-    it 'returns 403 with the account-creation-in-progress page' do
+    it 'returns 403 with the email-address-not-recognised page' do
       get '/provider/applications'
 
       expect(response).to have_http_status 403
-      expect(response.body).to include('Your account is not ready yet')
+      expect(response.body).to include('Your email address is not recognised')
     end
 
     it 'reports the error to Sentry, appending the Sign-in UID' do

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'See applications' do
     and_my_organisation_has_applications
 
     and_i_sign_in_to_the_provider_interface
-    then_i_should_see_the_account_creation_in_progress_page
+    then_i_should_see_the_email_address_not_recognised_page
 
     when_my_apply_account_has_been_created
     and_i_sign_in_to_the_provider_interface
@@ -34,8 +34,8 @@ RSpec.feature 'See applications' do
     provider_signs_in_using_dfe_sign_in
   end
 
-  def then_i_should_see_the_account_creation_in_progress_page
-    expect(page).to have_content('Your account is not ready yet')
+  def then_i_should_see_the_email_address_not_recognised_page
+    expect(page).to have_content('Your email address is not recognised')
   end
 
   def when_i_have_been_assigned_to_my_training_provider


### PR DESCRIPTION
## Context

Sometimes newly invited provider users get stuck because they have previously signed up to DSI (e.g. for Publish) with a different email address and they end up using this other email address when signing into Apply. Our system does not recognise this other email address and they are shown the 'Your account is not ready' page. Unfortunately, this page is not very helpful. With more information, provider users may be able to resolve the issue themselves, instead of contacting support.

## Changes proposed in this pull request

Change the message of the page to hint the problem is the email address. The 'Your account is not ready yet' message dates back to a time when inviting users was a multi-step process. It is now fully automated/single-step. 

Before:

![image](https://user-images.githubusercontent.com/107591/95445953-9154f180-0957-11eb-9d78-44d1dc9eff87.png)

After:

![image](https://user-images.githubusercontent.com/107591/95452457-30cab200-0961-11eb-91a6-9cc940cb3d5f.png)

## Guidance to review

You can log in here: https://apply-for-te-improve-yo-p1s3dt.herokuapp.com/provider/sign-in

If you use random `uid` and `email` values you'll be able to see these changes.

Is the copy ok?

## Link to Trello card

No Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
