### PR TITLE
Request a referee flow part5 - Review unsubmitted reference page

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -32,7 +32,7 @@ module CandidateInterface
         key: 'Name',
         value: reference.name,
         action: "name for #{reference.name}",
-        change_path: candidate_interface_edit_referee_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_name_path(reference.id),
       }
     end
 
@@ -41,7 +41,7 @@ module CandidateInterface
         key: 'Email address',
         value: reference.email_address,
         action: "email address for #{reference.name}",
-        change_path: candidate_interface_edit_referee_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_email_address_path(reference.id),
       }
     end
 
@@ -50,7 +50,7 @@ module CandidateInterface
         key: 'Relationship to referee',
         value: reference.relationship,
         action: "relationship for #{reference.name}",
-        change_path: candidate_interface_edit_referee_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_relationship_path(reference.id),
       }
     end
 
@@ -59,7 +59,7 @@ module CandidateInterface
         key: 'Reference type',
         value: formatted_reference_type(reference),
         action: "reference type for #{reference.name}",
-        change_path: candidate_interface_referees_type_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_type_path(reference.id),
       }
     end
 

--- a/app/components/candidate_interface/unsubmitted_reference_review_component.html.erb
+++ b/app/components/candidate_interface/unsubmitted_reference_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render SummaryListComponent.new(rows: reference_rows(@reference)) %>

--- a/app/components/candidate_interface/unsubmitted_reference_review_component.rb
+++ b/app/components/candidate_interface/unsubmitted_reference_review_component.rb
@@ -1,0 +1,58 @@
+module CandidateInterface
+  class UnsubmittedReferenceReviewComponent < ViewComponent::Base
+    validates :reference, presence: true
+
+    def initialize(reference:)
+      @reference = reference
+    end
+
+    def reference_rows(reference)
+      [
+        name_row(reference),
+        email_address_row(reference),
+        type_row(reference),
+        relationship_row(reference),
+      ]
+    end
+
+  private
+
+    attr_reader :reference
+
+    def name_row(reference)
+      {
+        key: 'Name',
+        value: reference.name,
+        action: "name for #{reference.name}",
+        change_path: candidate_interface_decoupled_references_edit_name_path(reference.id),
+      }
+    end
+
+    def email_address_row(reference)
+      {
+        key: 'Email address',
+        value: reference.email_address,
+        action: "email address for #{reference.name}",
+        change_path: candidate_interface_decoupled_references_edit_email_address_path(reference.id),
+      }
+    end
+
+    def type_row(reference)
+      {
+        key: 'Reference type',
+        value: reference.referee_type ? reference.referee_type.capitalize.dasherize : '',
+        action: "reference type for #{reference.name}",
+        change_path: candidate_interface_decoupled_references_edit_type_path(reference.id),
+      }
+    end
+
+    def relationship_row(reference)
+      {
+        key: 'Relationship to referee',
+        value: reference.relationship,
+        action: "relationship for #{reference.name}",
+        change_path: candidate_interface_decoupled_references_edit_relationship_path(reference.id),
+      }
+    end
+  end
+end

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
         @reference_email_address_form.save(@reference)
 
-        redirect_to candidate_interface_decoupled_references_new_relationship_path(@reference.id)
+        redirect_to candidate_interface_decoupled_references_relationship_path(@reference.id)
       end
 
     private

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -33,7 +33,7 @@ module CandidateInterface
 
       def referee_email_address_param
         params.require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
-        .merge!(application_form_id: current_application.id)
+        .merge!(reference_id: @reference.id)
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -16,6 +16,19 @@ module CandidateInterface
         redirect_to candidate_interface_decoupled_references_relationship_path(@reference.id)
       end
 
+      def edit
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.build_from_reference(@reference)
+      end
+
+      def update
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
+        return render :edit unless @reference_email_address_form.valid?
+
+        @reference_email_address_form.save(@reference)
+
+        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+      end
+
     private
 
       def referee_email_address_param

--- a/app/controllers/candidate_interface/decoupled_references/name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/name_controller.rb
@@ -16,6 +16,19 @@ module CandidateInterface
         redirect_to candidate_interface_decoupled_references_email_address_path(@reference.id)
       end
 
+      def edit
+        @reference_name_form = Reference::RefereeNameForm.build_from_reference(@reference)
+      end
+
+      def update
+        @reference_name_form = Reference::RefereeNameForm.new(referee_name_param)
+        return render :edit unless @reference_name_form.valid?
+
+        @reference_name_form.save(@reference)
+
+        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+      end
+
     private
 
       def referee_name_param

--- a/app/controllers/candidate_interface/decoupled_references/name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/name_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
         @reference_name_form.save(@reference)
 
-        redirect_to candidate_interface_decoupled_references_new_email_address_path(@reference.id)
+        redirect_to candidate_interface_decoupled_references_email_address_path(@reference.id)
       end
 
     private

--- a/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
@@ -16,6 +16,19 @@ module CandidateInterface
         redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
       end
 
+      def edit
+        @references_relationship_form = Reference::RefereeRelationshipForm.build_from_reference(@reference)
+      end
+
+      def update
+        @references_relationship_form = Reference::RefereeRelationshipForm.new(references_relationship_params)
+        return render :edit unless @references_relationship_form.valid?
+
+        @references_relationship_form.save(@reference)
+
+        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+      end
+
     private
 
       def references_relationship_params

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -14,6 +14,17 @@ module CandidateInterface
         @submit_reference_form = Reference::RefereeSubmitForm.new
       end
 
+      def submit
+        @submit_reference_form = Reference::RefereeSubmitForm.new(submit: submit_param)
+        return render :unsubmitted unless @submit_reference_form.valid?
+
+        if @submit_reference_form.submit == 'yes'
+          # call the ref service and redirect to the ref revie page
+        else
+          redirect_to candidate_interface_decoupled_references_review_path
+        end
+      end
+
       def confirm_destroy
         @reference = ApplicationReference.find(params[:id])
       end
@@ -22,6 +33,12 @@ module CandidateInterface
         @reference = ApplicationReference.find(params[:id])
         @reference.destroy!
         redirect_to candidate_interface_decoupled_references_review_path
+      end
+
+    private
+
+      def submit_param
+        params.dig(:candidate_interface_reference_referee_submit_form, :submit)
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -18,8 +18,22 @@ module CandidateInterface
         @submit_reference_form = Reference::RefereeSubmitForm.new(submit: submit_param)
         return render :unsubmitted unless @submit_reference_form.valid?
 
+        # TODO: Refactor the below into one form object so we don't need 5 condtionals
+        # Will be done in a follow up PR
         if @submit_reference_form.submit == 'yes'
-          # call the ref service and redirect to the ref revie page
+          if Reference::RefereeTypeForm.build_from_reference(@reference).valid? &&
+              Reference::RefereeNameForm.build_from_reference(@reference).valid? &&
+              Reference::RefereeRelationshipForm.build_from_reference(@reference).valid? &&
+              Reference::RefereeEmailForm.build_from_reference(@reference).valid?
+
+            # TODO: Link up with Steve's work
+          else
+            # TODO: Once the forms are moved into objects this won't be necessary
+            # It can just call valid? and render the errors.
+            flash[:warning] = 'You must complete all of your referees details before your reference request can be submitted'
+
+            render :unsubmitted
+          end
         else
           redirect_to candidate_interface_decoupled_references_review_path
         end

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -10,7 +10,9 @@ module CandidateInterface
         @references_sent = current_application.application_references.pending_feedback_or_failed
       end
 
-      def unsubmitted; end
+      def unsubmitted
+        @submit_reference_form = Reference::RefereeSubmitForm.new
+      end
 
       def confirm_destroy
         @reference = ApplicationReference.find(params[:id])

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module DecoupledReferences
     class TypeController < BaseController
+      before_action :set_reference, only: %i[edit update]
+
       def new
         @reference_type_form = Reference::RefereeTypeForm.new
       end
@@ -12,6 +14,19 @@ module CandidateInterface
         @reference_type_form.save(current_application)
 
         redirect_to candidate_interface_decoupled_references_name_path(current_application.application_references.last.id)
+      end
+
+      def edit
+        @reference_type_form = Reference::RefereeTypeForm.build_from_reference(@reference)
+      end
+
+      def update
+        @reference_type_form = Reference::RefereeTypeForm.new(referee_type_param)
+        return render :edit unless @reference_type_form.valid?
+
+        @reference_type_form.update(@reference)
+
+        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
       end
 
     private

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
       end
 
       def create
-        @reference_type_form = Reference::RefereeTypeForm.new(referee_type_param)
+        @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
         return render :new unless @reference_type_form.valid?
 
         @reference_type_form.save(current_application)
@@ -21,7 +21,7 @@ module CandidateInterface
       end
 
       def update
-        @reference_type_form = Reference::RefereeTypeForm.new(referee_type_param)
+        @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
         return render :edit unless @reference_type_form.valid?
 
         @reference_type_form.update(@reference)
@@ -32,7 +32,7 @@ module CandidateInterface
     private
 
       def referee_type_param
-        params.require(:candidate_interface_reference_referee_type_form).permit(:referee_type)
+        params.dig(:candidate_interface_reference_referee_type_form, :referee_type)
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
         @reference_type_form.save(current_application)
 
-        redirect_to candidate_interface_decoupled_references_new_name_path(current_application.application_references.last.id)
+        redirect_to candidate_interface_decoupled_references_name_path(current_application.application_references.last.id)
       end
 
     private

--- a/app/forms/candidate_interface/reference/referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/referee_email_address_form.rb
@@ -2,13 +2,13 @@ module CandidateInterface
   class Reference::RefereeEmailAddressForm
     include ActiveModel::Model
 
-    attr_accessor :email_address, :application_form_id
+    attr_accessor :email_address, :reference_id
 
     validates :email_address, presence: true,
                               email_address: true,
                               length: { maximum: 100 }
 
-    validates :application_form_id, presence: true
+    validates :reference_id, presence: true
 
     validate :email_address_unique?
 
@@ -25,8 +25,8 @@ module CandidateInterface
   private
 
     def email_address_unique?
-      application_form = ApplicationForm.find(application_form_id)
-      current_email_addresses = application_form.application_references.map(&:email_address).compact
+      reference = ApplicationReference.find(reference_id)
+      current_email_addresses = (reference.application_form.application_references.map(&:email_address) - [reference.email_address]).compact
       return true if current_email_addresses.blank?
 
       errors.add(:email_address, :duplicate) if current_email_addresses.map(&:downcase).include?(email_address)

--- a/app/forms/candidate_interface/reference/referee_submit_form.rb
+++ b/app/forms/candidate_interface/reference/referee_submit_form.rb
@@ -1,0 +1,5 @@
+module CandidateInterface
+  class Reference::RefereeSubmitForm
+    include ActiveModel::Model
+  end
+end

--- a/app/forms/candidate_interface/reference/referee_submit_form.rb
+++ b/app/forms/candidate_interface/reference/referee_submit_form.rb
@@ -1,5 +1,9 @@
 module CandidateInterface
   class Reference::RefereeSubmitForm
     include ActiveModel::Model
+
+    attr_accessor :submit
+
+    validates :submit, presence: true
   end
 end

--- a/app/views/candidate_interface/decoupled_references/base/start.html.erb
+++ b/app/views/candidate_interface/decoupled_references/base/start.html.erb
@@ -17,6 +17,6 @@
 
     <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
 
-    <%= govuk_link_to 'Continue', candidate_interface_decoupled_references_new_type_path, class: 'govuk-button' %>
+    <%= govuk_link_to 'Continue', candidate_interface_decoupled_references_type_path, class: 'govuk-button' %>
   </div>
 </div>

--- a/app/views/candidate_interface/decoupled_references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/_shared_form.html.erb
@@ -17,6 +17,6 @@
   <%= @reference.name %>
 </span>
 
-<%= f.govuk_text_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-!-margin-top-0'), size: 'm' }, hint_text: 'In most cases, this should be a work address.' %>
+<%= f.govuk_text_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' }, hint_text: 'In most cases, this should be a work address.' %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/_shared_form.html.erb
@@ -1,0 +1,22 @@
+<%= f.govuk_error_summary %>
+
+<% if HostingEnvironment.sandbox_mode? %>
+  <div class="app-status-box app-status-box--sandbox govuk-!-margin-bottom-4">
+    <p class="govuk-body">
+      <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag govuk-tag--purple">
+        sandbox feature
+      </strong>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      Enter <code>refbot1@example.com</code> and <code>refbot2@example.com</code> as your referee email addresses to have the references automatically completed
+    </p>
+  </div>
+<% end %>
+
+<span class="govuk-caption-xl">
+  <%= @reference.name %>
+</span>
+
+<%= f.govuk_text_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-!-margin-top-0'), size: 'm' }, hint_text: 'In most cases, this should be a work address.' %>
+
+<%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/_shared_form.html.erb
@@ -4,7 +4,7 @@
   <div class="app-status-box app-status-box--sandbox govuk-!-margin-bottom-4">
     <p class="govuk-body">
       <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag govuk-tag--purple">
-        sandbox feature
+        Sandbox feature
       </strong>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-0">

--- a/app/views/candidate_interface/decoupled_references/email_address/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/edit.html.erb
@@ -3,8 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_email_address_path(@reference.id), method: :patch do |f| %>
-      <% render 'shared_form', f: f  %>
+    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_edit_email_address_path(@reference.id), method: :patch do |f| %>
+      <% render 'shared_form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/decoupled_references/email_address/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_create_email_address_path(@reference.id) do |f| %>
+    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_email_address_path(@reference.id), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if HostingEnvironment.sandbox_mode? %>

--- a/app/views/candidate_interface/decoupled_references/name/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/name/_shared_form.html.erb
@@ -1,0 +1,5 @@
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_text_field :name, label: { text: tag.h1(t('page_titles.references_name'), class: 'govuk-!-margin-top-0 govuk-!-margin-bottom-8'), size: 'm' } %>
+
+<%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/name/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/name/_shared_form.html.erb
@@ -1,5 +1,5 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_text_field :name, label: { text: tag.h1(t('page_titles.references_name'), class: 'govuk-!-margin-top-0 govuk-!-margin-bottom-8'), size: 'm' } %>
+<%= f.govuk_text_field :name, label: { text: tag.h1(t('page_titles.references_name'), class: 'govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-8'), size: 'm' } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/name/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/name/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_name_form, url: candidate_interface_decoupled_references_name_path(@reference.id), method: :patch do |f| %>
+    <%= form_with model: @reference_name_form, url: candidate_interface_decoupled_references_edit_name_path(@reference.id), method: :patch do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/decoupled_references/name/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/name/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_name_form, url: candidate_interface_decoupled_references_create_name_path(@reference.id) do |f| %>
+    <%= form_with model: @reference_name_form, url: candidate_interface_decoupled_references_name_path(@reference.id), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :name, label: { text: tag.h1(t('page_titles.references_name')), size: 'm' } %>

--- a/app/views/candidate_interface/decoupled_references/relationship/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/relationship/_shared_form.html.erb
@@ -1,7 +1,11 @@
 <%= f.govuk_error_summary %>
 
+<span class="govuk-caption-xl">
+  <%= @reference.name %>
+</span>
+
 <%= f.govuk_text_area :relationship,
-                        label: { text: tag.h1(t('page_titles.references_relationship'), class: 'govuk-!-margin-top-0'), size: 'm' },
+                        label: { text: tag.h1(t('page_titles.references_relationship'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' },
                         hint_text: t("application_form.references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50  %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/relationship/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/relationship/_shared_form.html.erb
@@ -1,0 +1,7 @@
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_text_area :relationship,
+                        label: { text: tag.h1(t('page_titles.references_relationship'), class: 'govuk-!-margin-top-0'), size: 'm' },
+                        hint_text: t("application_form.references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50  %>
+
+<%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/relationship/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/relationship/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @references_relationship_form, url: candidate_interface_decoupled_references_relationship_path(@reference.id), method: :patch do |f| %>
+    <%= form_with model: @references_relationship_form, url: candidate_interface_decoupled_references_edit_relationship_path(@reference.id), method: :patch do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/decoupled_references/relationship/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/relationship/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @references_relationship_form, url: candidate_interface_decoupled_references_create_relationship_path(@reference.id) do |f| %>
+    <%= form_with model: @references_relationship_form, url: candidate_interface_decoupled_references_relationship_path(@reference.id), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_area :relationship,

--- a/app/views/candidate_interface/decoupled_references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/unsubmitted.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, t('page_titles.references_unsubmitted_review') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">
+        <%= @reference.name %>
+      </span>
+      <%= t('page_titles.references_unsubmitted_review') %>
+    </h1>
+
+    <%= render CandidateInterface::UnsubmittedReferenceReviewComponent.new(reference: @reference) %>
+
+    <%= form_with model: @submit_reference_form, url: candidate_interface_decoupled_references_submit_path, class: 'govuk-!-margin-top-8' do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :submit_reference, legend: { text: "Are you ready to send a reference request to #{@reference.name}?", size: 'm' } do %>
+          <%= f.govuk_radio_button :submit, 'yes', label: { text: 'Yes, send a reference request now' } %>
+          <%= f.govuk_radio_button :submit, 'no', label: { text: 'No, not at the moment' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Save and continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/decoupled_references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/unsubmitted.html.erb
@@ -2,21 +2,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">
-        <%= @reference.name %>
-      </span>
-      <%= t('page_titles.references_unsubmitted_review') %>
-    </h1>
-
-    <%= render CandidateInterface::UnsubmittedReferenceReviewComponent.new(reference: @reference) %>
-
     <%= form_with model: @submit_reference_form, url: candidate_interface_decoupled_references_submit_path, class: 'govuk-!-margin-top-8' do |f| %>
       <%= f.govuk_error_summary %>
 
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">
+          <%= @reference.name %>
+        </span>
+        <%= t('page_titles.references_unsubmitted_review') %>
+      </h1>
+
+      <%= render CandidateInterface::UnsubmittedReferenceReviewComponent.new(reference: @reference) %>
+
+
       <%= f.govuk_radio_buttons_fieldset :submit_reference, legend: { text: "Are you ready to send a reference request to #{@reference.name}?", size: 'm' } do %>
-          <%= f.govuk_radio_button :submit, 'yes', label: { text: 'Yes, send a reference request now' } %>
-          <%= f.govuk_radio_button :submit, 'no', label: { text: 'No, not at the moment' } %>
+          <%= f.govuk_radio_button :submit, 'yes', link_errors: true,  label: { text: 'Yes, send a reference request now' } %>
+          <%= f.govuk_radio_button :submit, 'no', link_errors: true, label: { text: 'No, not at the moment' } %>
       <% end %>
 
       <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/decoupled_references/type/_shared_form.html.erb
@@ -1,0 +1,13 @@
+<%= f.govuk_error_summary %>
+
+<%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: t('page_titles.referee_type'), size: 'xl' } do %>
+  <div class="govuk-!-margin-top-7">
+    <%= f.govuk_radio_button :referee_type, 'academic', link_errors: true, label: { text: 'Academic' }, hint_text: t("application_form.references.referee_type.hint_text.academic") %>
+    <%= f.govuk_radio_button :referee_type, 'professional', label: { text: 'Professional' }, hint_text: t("application_form.references.referee_type.hint_text.professional") %>
+    <%= f.govuk_radio_button :referee_type, 'school-based', label: { text: 'School-based' }, hint_text: t("application_form.references.referee_type.hint_text.school_based") %>
+    <%= f.govuk_radio_divider %>
+    <%= f.govuk_radio_button :referee_type, 'character', label: { text: 'Character' }, hint_text: t("application_form.references.referee_type.hint_text.character") %>
+  </div>
+<% end %>
+
+<%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/decoupled_references/type/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/type/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_type_form, url: candidate_interface_decoupled_references_type_path, method: :post do |f| %>
+    <%= form_with model: @reference_type_form, url: candidate_interface_decoupled_references_edit_type_path(@reference.id), method: :patch do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/decoupled_references/type/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/type/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_type_form, url: candidate_interface_decoupled_references_create_type_path, method: :post do |f| %>
+    <%= form_with model: @reference_type_form, url: candidate_interface_decoupled_references_type_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: t('page_titles.referee_type'), size: 'xl' } do %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -818,21 +818,21 @@ en:
         candidate_interface/reference/referee_type_form:
           attributes:
             referee_type:
-              blank: Choose the type of your reference
+              blank: Choose a type of referee
         candidate_interface/reference/referee_name_form:
           attributes:
             name:
-              blank: Enter your referees name
+              blank: Enter your referee’s name
         candidate_interface/reference/referee_email_address_form:
           attributes:
             email_address:
-              blank: Enter your referees email address
+              blank: Enter your referee’s email address
               invalid: Enter an email address in the correct format, like name@example.com
               duplicate: Please give a different email address for each referee
         candidate_interface/reference/referee_relationship_form:
           attributes:
             relationship:
-              blank: Enter how you know this referee.
+              blank: Enter how you know this referee and for how long
         candidate_interface/reference/referee_submit_form:
           attributes:
             submit:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -833,6 +833,10 @@ en:
           attributes:
             relationship:
               blank: Enter how you know this referee.
+        candidate_interface/reference/referee_submit_form:
+          attributes:
+            submit:
+              blank: Choose whether to send your reference request now
         candidate_interface/reference/candidate_name_form:
           attributes:
             first_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,7 @@ en:
     references_name: What is the referee’s name?
     references_email_address: What is the referee’s email address?
     references_relationship: How do you know this referee and how long have you known them?
+    references_unsubmitted_review: Check your answers before sending your request
     references_candidate_name: Tell the referee your name
     providers: Courses on this service
     view_and_respond_to_offer: Details of offer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -419,7 +419,7 @@ Rails.application.routes.draw do
         patch '/relationship/edit/:id' => 'decoupled_references/relationship#update'
 
         get '/review-unsubmitted/:id' => 'decoupled_references/review#unsubmitted', as: :decoupled_references_review_unsubmitted
-        patch '/review-unsubmitted/:id' => 'decoupled_references/review#submit', as: :decoupled_references_submit
+        post '/review-unsubmitted/:id' => 'decoupled_references/review#submit', as: :decoupled_references_submit
 
         get '/review' => 'decoupled_references/review#show', as: :decoupled_references_review
         get '/review/delete/:id' => 'decoupled_references/review#confirm_destroy', as: :destroy_decoupled_reference

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -407,6 +407,7 @@ Rails.application.routes.draw do
         post '/relationship/:id' => 'decoupled_references/relationship#create', as: :decoupled_references_create_relationship
 
         get '/review-unsubmitted/:id' => 'decoupled_references/review#unsubmitted', as: :decoupled_references_review_unsubmitted
+        post '/review-unsubmitted/:id' => 'decoupled_references/review#submit', as: :decoupled_references_submit
 
         get '/review' => 'decoupled_references/review#show', as: :decoupled_references_review
         get '/review/delete/:id' => 'decoupled_references/review#confirm_destroy', as: :destroy_decoupled_reference

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,14 +397,26 @@ Rails.application.routes.draw do
         get '/type' => 'decoupled_references/type#new', as: :decoupled_references_type
         post '/type' => 'decoupled_references/type#create'
 
+        get '/type/edit/:id' => 'decoupled_references/type#edit', as: :decoupled_references_edit_type
+        patch '/type/edit/:id' => 'decoupled_references/type#update'
+
         get '/name/:id' => 'decoupled_references/name#new', as: :decoupled_references_name
         patch '/name/:id' => 'decoupled_references/name#create'
+
+        get '/name/edit/:id' => 'decoupled_references/name#edit', as: :decoupled_references_edit_name
+        patch '/name/edit/:id' => 'decoupled_references/name#update'
 
         get '/email/:id' => 'decoupled_references/email_address#new', as: :decoupled_references_email_address
         patch '/email/:id' => 'decoupled_references/email_address#create'
 
+        get '/email/edit/:id' => 'decoupled_references/email_address#edit', as: :decoupled_references_edit_email_address
+        patch '/email/edit/:id' => 'decoupled_references/email_address#update'
+
         get '/relationship/:id' => 'decoupled_references/relationship#new', as: :decoupled_references_relationship
         patch '/relationship/:id' => 'decoupled_references/relationship#create'
+
+        get '/relationship/edit/:id' => 'decoupled_references/relationship#edit', as: :decoupled_references_edit_relationship
+        patch '/relationship/edit/:id' => 'decoupled_references/relationship#update'
 
         get '/review-unsubmitted/:id' => 'decoupled_references/review#unsubmitted', as: :decoupled_references_review_unsubmitted
         patch '/review-unsubmitted/:id' => 'decoupled_references/review#submit', as: :decoupled_references_submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -394,20 +394,20 @@ Rails.application.routes.draw do
       scope '/references' do
         get '/start' => 'decoupled_references/base#start', as: :decoupled_references_start
 
-        get '/type' => 'decoupled_references/type#new', as: :decoupled_references_new_type
-        post '/update-type' => 'decoupled_references/type#create', as: :decoupled_references_create_type
+        get '/type' => 'decoupled_references/type#new', as: :decoupled_references_type
+        post '/type' => 'decoupled_references/type#create'
 
-        get '/name/:id' => 'decoupled_references/name#new', as: :decoupled_references_new_name
-        post '/name/:id' => 'decoupled_references/name#create', as: :decoupled_references_create_name
+        get '/name/:id' => 'decoupled_references/name#new', as: :decoupled_references_name
+        patch '/name/:id' => 'decoupled_references/name#create'
 
-        get '/email/:id' => 'decoupled_references/email_address#new', as: :decoupled_references_new_email_address
-        post '/email/:id' => 'decoupled_references/email_address#create', as: :decoupled_references_create_email_address
+        get '/email/:id' => 'decoupled_references/email_address#new', as: :decoupled_references_email_address
+        patch '/email/:id' => 'decoupled_references/email_address#create'
 
-        get '/relationship/:id' => 'decoupled_references/relationship#new', as: :decoupled_references_new_relationship
-        post '/relationship/:id' => 'decoupled_references/relationship#create', as: :decoupled_references_create_relationship
+        get '/relationship/:id' => 'decoupled_references/relationship#new', as: :decoupled_references_relationship
+        patch '/relationship/:id' => 'decoupled_references/relationship#create'
 
         get '/review-unsubmitted/:id' => 'decoupled_references/review#unsubmitted', as: :decoupled_references_review_unsubmitted
-        post '/review-unsubmitted/:id' => 'decoupled_references/review#submit', as: :decoupled_references_submit
+        patch '/review-unsubmitted/:id' => 'decoupled_references/review#submit', as: :decoupled_references_submit
 
         get '/review' => 'decoupled_references/review#show', as: :decoupled_references_review
         get '/review/delete/:id' => 'decoupled_references/review#confirm_destroy', as: :destroy_decoupled_reference

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -60,7 +60,11 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     let(:result) { render_inline(described_class.new(references: [reference], editable: true)) }
 
     it 'fields can be changed' do
-      expect(result.css('.app-summary-card__body').text).to include 'Change'
+      actions = result.css('.govuk-summary-list__actions')
+      ordered_edit_paths(reference).each_with_index do |path, index|
+        expect(actions[index].to_html).to include path
+        expect(actions[index].text).to include 'Change'
+      end
     end
 
     it 'the reference can be deleted' do
@@ -73,7 +77,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     let(:result) { render_inline(described_class.new(references: [reference], editable: false)) }
 
     it 'fields cannot be changed' do
-      expect(result.css('.app-summary-card__body').text).not_to include 'Change'
+      expect(result.text).not_to include 'Change'
     end
 
     it 'the reference cannot be deleted' do
@@ -123,6 +127,16 @@ private
       Status.new(sent_less_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_less_than_5_days_ago'),
       Status.new(sent_more_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_more_than_5_days_ago'),
       Status.new(feedback_provided, :green, 'feedback_provided', ''),
+    ]
+  end
+
+  def ordered_edit_paths(reference)
+    url_helpers = Rails.application.routes.url_helpers
+    [
+      url_helpers.candidate_interface_decoupled_references_edit_name_path(reference),
+      url_helpers.candidate_interface_decoupled_references_edit_email_address_path(reference),
+      url_helpers.candidate_interface_decoupled_references_edit_type_path(reference),
+      url_helpers.candidate_interface_decoupled_references_edit_relationship_path(reference),
     ]
   end
 end

--- a/spec/components/candidate_interface/unsubmitted_reference_review_component_spec.rb
+++ b/spec/components/candidate_interface/unsubmitted_reference_review_component_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::UnsubmittedReferenceReviewComponent do
+  let(:reference) { create(:reference) }
+
+  it 'renders component with correct values for a references name' do
+    result = render_inline(described_class.new(reference: reference))
+
+    expect(result.css('.govuk-summary-list__key')[0].text).to include('Name')
+    expect(result.css('.govuk-summary-list__value')[0].to_html).to include(reference.name)
+    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+      Rails.application.routes.url_helpers.candidate_interface_decoupled_references_edit_name_path(reference.id),
+    )
+    expect(result.css('.govuk-summary-list__actions')[0].text).to include("Change name for #{reference.name}")
+  end
+
+  it 'renders component with correct values for the references email address' do
+    result = render_inline(described_class.new(reference: reference))
+
+    expect(result.css('.govuk-summary-list__key')[1].text).to include('Email address')
+    expect(result.css('.govuk-summary-list__value')[1].to_html).to include(reference.email_address)
+    expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(
+      Rails.application.routes.url_helpers.candidate_interface_decoupled_references_edit_email_address_path(reference.id),
+    )
+    expect(result.css('.govuk-summary-list__actions')[1].text).to include("Change email address for #{reference.name}")
+  end
+
+  it 'renders component with correct values for the references type' do
+    result = render_inline(described_class.new(reference: reference))
+
+    expect(result.css('.govuk-summary-list__key')[2].text).to include('Reference type')
+    expect(result.css('.govuk-summary-list__value')[2].to_html).to include(reference.referee_type.capitalize.dasherize)
+    expect(result.css('.govuk-summary-list__actions a')[2].attr('href')).to include(
+      Rails.application.routes.url_helpers.candidate_interface_decoupled_references_edit_type_path(reference.id),
+    )
+    expect(result.css('.govuk-summary-list__actions')[2].text).to include("Change reference type for #{reference.name}")
+  end
+
+  it 'renders component with correct values for the references relationship' do
+    result = render_inline(described_class.new(reference: reference))
+
+    expect(result.css('.govuk-summary-list__key')[3].text).to include('Relationship to referee')
+    expect(result.css('.govuk-summary-list__value')[3].to_html).to include(reference.relationship)
+    expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
+      Rails.application.routes.url_helpers.candidate_interface_decoupled_references_edit_relationship_path(reference.id),
+    )
+    expect(result.css('.govuk-summary-list__actions')[3].text).to include("Change relationship for #{reference.name}")
+  end
+end

--- a/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :mo
     end
 
     it { is_expected.to validate_presence_of(:email_address) }
-    it { is_expected.to validate_presence_of(:application_form_id) }
 
     one_hundred_character_email = "#{SecureRandom.hex(44)}@example.com"
     one_hundred_and_two_character_email = "#{SecureRandom.hex(45)}@example.com"
@@ -25,9 +24,9 @@ RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :mo
       it 'is not valid' do
         application_form = create(:application_form)
         create(:reference, email_address: 'iamtheone@whoknocks.com', application_form: application_form)
-        application_reference = create(:reference, email_address: nil)
+        application_reference = create(:reference, email_address: nil, application_form: application_form)
 
-        form = described_class.new(email_address: 'iamtheone@whoknocks.com', application_form_id: application_form.id)
+        form = described_class.new(email_address: 'iamtheone@whoknocks.com', reference_id: application_reference.id)
         expect(form.save(application_reference)).to be(false)
       end
     end
@@ -47,7 +46,7 @@ RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :mo
 
     context 'when email_address has a value' do
       it 'creates the referee' do
-        form = described_class.new(email_address: 'iamtheone@whoknocks.com', application_form_id: application_reference.application_form.id)
+        form = described_class.new(email_address: 'iamtheone@whoknocks.com', reference_id: application_reference.id)
         form.save(application_reference)
 
         expect(application_reference.email_address).to eq('iamtheone@whoknocks.com')

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Candidate adding referees' do
   end
 
   def then_i_see_an_error_to_choose_the_type_of_my_first_reference
-    expect(page).to have_content('Choose the type of your reference')
+    expect(page).to have_content('Choose a type of referee')
   end
 
   def when_i_choose_academic_as_reference_type

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def then_i_see_an_error_to_choose_the_type_of_my_first_reference
-    expect(page).to have_content('Choose the type of your reference')
+    expect(page).to have_content('Choose a type of referee')
   end
 
   def when_i_choose_school_based_as_reference_type

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_with_separate_additional_referees_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_with_separate_additional_referees_flag_on_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def then_i_see_an_error_to_choose_the_type_of_my_first_reference
-    expect(page).to have_content('Choose the type of your reference')
+    expect(page).to have_content('Choose a type of referee')
   end
 
   def when_i_choose_school_based_as_reference_type

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -64,6 +64,11 @@ RSpec.feature 'Decoupled references' do
     and_i_input_my_relationship_to_the_referee
     and_i_click_save_and_continue
     then_i_see_the_updated_relationship
+
+    when_i_choose_that_im_not_ready_to_submit_my_reference
+    and_i_click_save_and_continue
+    then_i_see_the_review_references_page
+    and_i_should_see_my_reference
   end
 
   def given_i_am_signed_in
@@ -221,5 +226,17 @@ RSpec.feature 'Decoupled references' do
 
   def then_i_see_the_updated_relationship
     expect(page).to have_content 'I sold him a moterhome.'
+  end
+
+  def when_i_choose_that_im_not_ready_to_submit_my_reference
+    choose 'No, not at the moment'
+  end
+
+  def then_i_see_the_review_references_page
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
+  end
+
+  def and_i_should_see_my_reference
+    expect(page).to have_content 'Character reference from Jessie Pinkman'
   end
 end

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_should_be_told_to_provide_a_name
-    expect(page).to have_content 'Enter your referees name'
+    expect(page).to have_content 'Enter your referee’s name'
   end
 
   def when_i_fill_in_my_references_name
@@ -138,7 +138,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_should_be_told_to_provide_an_email_address
-    expect(page).to have_content 'Enter your referees email address'
+    expect(page).to have_content 'Enter your referee’s email address'
   end
 
   def when_i_provide_an_email_address_with_an_invalid_format
@@ -162,7 +162,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_should_be_told_to_provide_a_description
-    expect(page).to have_content 'Enter how you know this referee.'
+    expect(page).to have_content 'Enter how you know this referee and for how long'
   end
 
   def when_i_fill_in_my_references_description

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -43,6 +43,27 @@ RSpec.feature 'Decoupled references' do
     when_i_fill_in_my_references_description
     and_i_click_save_and_continue
     then_i_should_see_the_review_unsubmitted_page
+    and_i_should_see_my_references_details
+
+    when_i_click_change_on_the_references_name
+    and_i_input_a_new_name
+    and_i_click_save_and_continue
+    then_i_see_the_updated_name
+
+    when_i_click_change_on_email_address
+    and_i_input_a_new_email_address
+    and_i_click_save_and_continue
+    then_i_see_the_updated_email_address
+
+    when_i_click_change_on_the_reference_type
+    and_i_choose_professional
+    and_i_click_save_and_continue
+    then_i_see_the_updated_type
+
+    when_i_click_change_on_relationship
+    and_i_input_my_relationship_to_the_referee
+    and_i_click_save_and_continue
+    then_i_see_the_updated_relationship
   end
 
   def given_i_am_signed_in
@@ -145,5 +166,60 @@ RSpec.feature 'Decoupled references' do
 
   def then_i_should_see_the_review_unsubmitted_page
     expect(page).to have_current_path candidate_interface_decoupled_references_review_unsubmitted_path(@application.application_references.last.id)
+  end
+
+  def and_i_should_see_my_references_details
+    expect(page).to have_content 'Academic'
+    expect(page).to have_content 'Walter White'
+    expect(page).to have_content 'iamtheone@whoknocks.com'
+    expect(page).to have_content 'Through nefarious behaviour.'
+  end
+
+  def when_i_click_change_on_the_references_name
+    page.all('.govuk-summary-list__actions')[0].click_link
+  end
+
+  def and_i_input_a_new_name
+    fill_in 'candidate-interface-reference-referee-name-form-name-field', with: 'Jessie Pinkman'
+  end
+
+  def then_i_see_the_updated_name
+    expect(page).to have_content 'Jessie Pinkman'
+  end
+
+  def when_i_click_change_on_email_address
+    page.all('.govuk-summary-list__actions')[1].click_link
+  end
+
+  def and_i_input_a_new_email_address
+    fill_in 'candidate-interface-reference-referee-email-address-form-email-address-field', with: 'jessie@pinkman.com'
+  end
+
+  def then_i_see_the_updated_email_address
+    expect(page).to have_content 'jessie@pinkman.com'
+  end
+
+  def when_i_click_change_on_the_reference_type
+    page.all('.govuk-summary-list__actions')[2].click_link
+  end
+
+  def and_i_choose_professional
+    choose 'Character'
+  end
+
+  def then_i_see_the_updated_type
+    expect(page).to have_content 'Character'
+  end
+
+  def when_i_click_change_on_relationship
+    page.all('.govuk-summary-list__actions')[3].click_link
+  end
+
+  def and_i_input_my_relationship_to_the_referee
+    fill_in 'candidate-interface-reference-referee-relationship-form-relationship-field', with: 'I sold him a moterhome.'
+  end
+
+  def then_i_see_the_updated_relationship
+    expect(page).to have_content 'I sold him a moterhome.'
   end
 end

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_see_the_type_page
-    expect(page).to have_current_path candidate_interface_decoupled_references_new_type_path
+    expect(page).to have_current_path candidate_interface_decoupled_references_type_path
   end
 
   def when_i_select_academic
@@ -109,7 +109,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_should_see_the_referee_name_page
-    expect(page).to have_current_path candidate_interface_decoupled_references_new_name_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_decoupled_references_name_path(@application.application_references.last.id)
   end
 
   def when_i_click_save_and_continue_without_providing_a_name
@@ -125,7 +125,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_see_the_referee_email_page
-    expect(page).to have_current_path candidate_interface_decoupled_references_new_email_address_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_decoupled_references_email_address_path(@application.application_references.last.id)
   end
 
   def when_i_click_save_and_continue_without_providing_an_emailing
@@ -149,7 +149,7 @@ RSpec.feature 'Decoupled references' do
   end
 
   def then_i_see_the_description_page
-    expect(page).to have_current_path candidate_interface_decoupled_references_new_relationship_path(@application.application_references.last.id)
+    expect(page).to have_current_path candidate_interface_decoupled_references_relationship_path(@application.application_references.last.id)
   end
 
   def when_i_click_save_and_continue_without_providing_a_description


### PR DESCRIPTION
## Context

Previous PRs are:
#3013 - Adds the new start and type page
#3016 - Migration to allow the references email address column to be NULL
#3022 - Breaks the new flow into a separate controller
#3035 - Up to adding a referees name
#3040 - Add referees email
#3044 - Adds the relationship page 

This PR covers adding the unsubmitted review page which is the final part of the flow.

## Changes proposed in this pull request

- Adds the review unsubmitted page 

![image](https://user-images.githubusercontent.com/42515961/95504805-33e79180-09a5-11eb-804f-aad68dbc6330.png)

- Adds a the UnsubmittedReferenceReviewComponent which is called is the above view
- Adds edit functionality for name, email, type and relationship
- Adds the RefereeSubmitForm which deals with submitting a reference or redirecting to the review page (this still needs to be linked into Steves work.

## Guidance to review

Apologies for the size or the PR. I've tried to keep the commits logical so reviewing by commit is probs the way to go.

This isn't fully functional yet as it needs to be wired into the work Steve is doing around submitting a reference

Still TODO: 
1. The wiring in on the review controller
2. Malcolms review page and this need to link up properly (the change links)
3. Refactor all the Forms into one form (see the contact details form for an example 

## Link to Trello card

https://trello.com/c/7autFjC7/2214-%F0%9F%92%94-dev-references-review-page-mvp

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
