### PR TITLE
Add new submit application behaviour for decoupled references

### DIFF
--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -41,7 +41,13 @@ module CandidateInterface
       @further_information_form = FurtherInformationForm.new(further_information_params)
 
       if @further_information_form.save(current_application)
-        SubmitApplication.new(current_application).call
+        if FeatureFlag.active?(:decoupled_references)
+          # TODO: rename this to SubmitApplication when removing the
+          # decoupled_references feature flag
+          SubmitApplicationWithDecoupledReferences.new(current_application).call
+        else
+          SubmitApplication.new(current_application).call
+        end
 
         redirect_to candidate_interface_application_submit_success_path
       else

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -3,6 +3,10 @@ class SendApplicationToProvider
 
   attr_accessor :application_choice
 
+  def self.call(application_choice)
+    new(application_choice: application_choice).call
+  end
+
   def initialize(application_choice:)
     self.application_choice = application_choice
   end

--- a/app/services/submit_application_with_decoupled_references.rb
+++ b/app/services/submit_application_with_decoupled_references.rb
@@ -1,0 +1,28 @@
+class SubmitApplicationWithDecoupledReferences
+  attr_reader :application_form, :application_choices
+
+  def initialize(application_form)
+    @application_form = application_form
+    @application_choices = application_form.application_choices
+  end
+
+  def call
+    # TODO: the decoupled_references feature makes the edit window redundant.
+    # Drop the ApplicationForm#edit_by column when removing the
+    # decoupled_references feature flag.
+    application_form.update!(
+      submitted_at: Time.zone.now,
+      edit_by: Time.zone.now,
+    )
+
+    application_choices.each do |application_choice|
+      SendApplicationToProvider.call(application_choice)
+    end
+
+    if application_form.apply_2?
+      CandidateMailer.application_submitted_apply_again(application_form).deliver_later
+    else
+      CandidateMailer.application_submitted(application_form).deliver_later
+    end
+  end
+end

--- a/spec/services/submit_application_with_decoupled_references_spec.rb
+++ b/spec/services/submit_application_with_decoupled_references_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe SubmitApplicationWithDecoupledReferences do
+  describe '#call' do
+    it 'updates timestamps relevant to submitting an application' do
+      Timecop.freeze(Time.zone.local(0)) do
+        application_form = create(:application_form)
+
+        described_class.new(application_form).call
+
+        expect(application_form.submitted_at).to eq Time.zone.local(0)
+        expect(application_form.edit_by).to eq Time.zone.local(0)
+      end
+    end
+
+    it 'sends application choices to providers' do
+      application_choice_one = create(:application_choice)
+      application_choice_two = create(:application_choice)
+      application_form = create(
+        :application_form,
+        application_choices: [application_choice_one, application_choice_two],
+      )
+      provider_service_double = class_double('SendApplicationToProvider', call: true).as_stubbed_const
+
+      described_class.new(application_form).call
+
+      expect(provider_service_double).to have_received(:call).with(application_choice_one)
+      expect(provider_service_double).to have_received(:call).with(application_choice_two)
+    end
+
+    it 'sends the candidate an email' do
+      application_form = create(:application_form)
+      action_mailer_double = instance_double('ActionMailer::MessageDelivery', deliver_later: true)
+      candidate_mailer_double = class_double('CandidateMailer', application_submitted: action_mailer_double).as_stubbed_const
+
+      described_class.new(application_form).call
+
+      expect(candidate_mailer_double).to have_received(:application_submitted).with(application_form)
+      expect(action_mailer_double).to have_received(:deliver_later)
+    end
+
+    context 'when the application is apply_2' do
+      let(:application_form) { create(:application_form, phase: :apply_2) }
+
+      it 'sends the candidate an apply_2 email' do
+        action_mailer_double = instance_double('ActionMailer::MessageDelivery', deliver_later: true)
+        candidate_mailer_double = class_double('CandidateMailer', application_submitted_apply_again: action_mailer_double).as_stubbed_const
+
+        described_class.new(application_form).call
+
+        expect(candidate_mailer_double).to have_received(:application_submitted_apply_again).with(application_form)
+        expect(action_mailer_double).to have_received(:deliver_later)
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def and_i_receive_an_email_that_my_application_has_been_sent
     open_email(@candidate.email_address)
-    expect(current_email.subject).to have_content t('candidate_mailer.application_sent_to_provider.subject')
+    expect(current_email.subject).to have_content t('candidate_mailer.application_submitted.subject')
   end
 
   def and_i_do_not_see_referee_related_guidance

--- a/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.feature 'Submitting an application' do
+  include CandidateHelper
+
+  scenario 'Candidate submits complete application' do
+    given_i_am_signed_in
+    and_the_decoupled_references_flag_is_on
+    and_i_have_completed_my_application
+
+    when_i_have_added_references
+    and_i_submit_the_application
+    then_i_get_an_error_about_my_references
+    when_my_references_have_been_provided
+    and_i_submit_the_application
+
+    then_i_can_see_my_application_has_been_successfully_submitted
+    and_its_in_the_right_state
+    and_i_receive_an_email_about_my_submitted_application
+    and_a_slack_notification_is_sent
+    and_i_can_review_my_application
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_decoupled_references_flag_is_on
+    FeatureFlag.activate('decoupled_references')
+  end
+
+  def and_i_have_completed_my_application
+    candidate_completes_application_form
+  end
+
+  def when_i_have_added_references
+    create(:reference, :unsubmitted, application_form: current_candidate.current_application)
+    create(:reference, :unsubmitted, application_form: current_candidate.current_application)
+  end
+
+  def and_i_submit_the_application
+    visit candidate_interface_application_form_path
+    click_link 'Check and submit your application'
+    click_link 'Continue'
+  end
+
+  def then_i_get_an_error_about_my_references
+    within '.govuk-error-summary' do
+      expect(page).to have_content 'You need 2 references before you can submit your application'
+    end
+  end
+
+  def when_my_references_have_been_provided
+    application.application_references.each do |reference|
+      SubmitReference.new(reference: reference).save!
+    end
+  end
+
+  def then_i_can_see_my_application_has_been_successfully_submitted
+    click_link 'Continue without completing questionnaire'
+    choose 'No'
+    click_button 'Send application'
+  end
+
+  def and_its_in_the_right_state
+    expect(application.application_choices).to all(be_awaiting_provider_decision)
+  end
+
+  def and_i_receive_an_email_about_my_submitted_application
+    open_email(current_candidate.email_address)
+
+    expect(current_email.subject).to include 'You’ve submitted your teacher training application'
+    expect(current_email.text).to include application.support_reference
+  end
+
+  def and_a_slack_notification_is_sent
+    expect_slack_message_with_text "#{application.first_name}’s application is ready to be reviewed by #{provider.name}"
+  end
+
+  def and_i_can_review_my_application
+    visit candidate_interface_application_form_path
+    expect(page).to have_content 'Application dashboard'
+    expect(page).to have_content 'Application submitted'
+    expect(page).to have_link 'View application'
+  end
+
+private
+
+  def application
+    current_candidate.current_application
+  end
+
+  def provider
+    application.application_choices.first.provider
+  end
+end


### PR DESCRIPTION
## Context
With decoupled references active, applications can't be submitted until references are received. As such, once the application is submitted it should go immediately to the provider with no edit window.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Add a `SubmitApplicationWithDecoupledReferences` (temporary name) to handle the different submit behaviour.
- Invoke this service from `UnsubmittedApplicationFormController` when the `decoupled_references` flag is active.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Manual testing - submitting an application and then checking the appropriate candidate/provider emails have been sent ought to do it.
- Does the new service object cover everything it needs to? Has anything been missed from the existing `SubmitApplication` that should also be copied over?
- This card https://trello.com/c/oUQxxBUp will remove the bit about references in `CandidateMailer.application_submitted`

## Link to Trello card
https://trello.com/c/0hOHcSaf
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
