### PR TITLE
Update edit paths on decoupled references review page

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -32,7 +32,7 @@ module CandidateInterface
         key: 'Name',
         value: reference.name,
         action: "name for #{reference.name}",
-        change_path: candidate_interface_edit_referee_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_name_path(reference.id),
       }
     end
 
@@ -41,7 +41,7 @@ module CandidateInterface
         key: 'Email address',
         value: reference.email_address,
         action: "email address for #{reference.name}",
-        change_path: candidate_interface_edit_referee_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_email_address_path(reference.id),
       }
     end
 
@@ -50,7 +50,7 @@ module CandidateInterface
         key: 'Relationship to referee',
         value: reference.relationship,
         action: "relationship for #{reference.name}",
-        change_path: candidate_interface_edit_referee_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_relationship_path(reference.id),
       }
     end
 
@@ -59,7 +59,7 @@ module CandidateInterface
         key: 'Reference type',
         value: formatted_reference_type(reference),
         action: "reference type for #{reference.name}",
-        change_path: candidate_interface_referees_type_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_type_path(reference.id),
       }
     end
 

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -60,7 +60,11 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     let(:result) { render_inline(described_class.new(references: [reference], editable: true)) }
 
     it 'fields can be changed' do
-      expect(result.css('.app-summary-card__body').text).to include 'Change'
+      actions = result.css('.govuk-summary-list__actions')
+      ordered_edit_paths(reference).each_with_index do |path, index|
+        expect(actions[index].to_html).to include path
+        expect(actions[index].text).to include 'Change'
+      end
     end
 
     it 'the reference can be deleted' do
@@ -73,7 +77,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     let(:result) { render_inline(described_class.new(references: [reference], editable: false)) }
 
     it 'fields cannot be changed' do
-      expect(result.css('.app-summary-card__body').text).not_to include 'Change'
+      expect(result.text).not_to include 'Change'
     end
 
     it 'the reference cannot be deleted' do
@@ -122,6 +126,16 @@ private
       Status.new(sent_less_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_less_than_5_days_ago'),
       Status.new(sent_more_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_more_than_5_days_ago'),
       Status.new(feedback_provided, :green, 'feedback_provided', ''),
+    ]
+  end
+
+  def ordered_edit_paths(reference)
+    url_helpers = Rails.application.routes.url_helpers
+    [
+      url_helpers.candidate_interface_decoupled_references_edit_name_path(reference),
+      url_helpers.candidate_interface_decoupled_references_edit_email_address_path(reference),
+      url_helpers.candidate_interface_decoupled_references_edit_type_path(reference),
+      url_helpers.candidate_interface_decoupled_references_edit_relationship_path(reference),
     ]
   end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
**As a...** candidate
**I need to...** change referee details I added
**So that...** so that I feel in control of what’s shown

## Changes proposed in this pull request
Update path helpers for 'Change' links on the review page.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Links can be clicked on the review app to confirm they go to the right page.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/UnHaN661
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
