### PR TITLE
Refactor - HESA Disability codes

### DIFF
--- a/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
@@ -59,8 +59,7 @@ module CandidateInterface
 
     def hesa_disability_codes
       disabilities.map { |disability|
-        disability_type = Hesa::Disability.convert_to_hesa_value(disability)
-        Hesa::Disability.find_by_value(disability_type)&.hesa_code
+        Hesa::Disability.find(disability)&.hesa_code
       }.compact
     end
   end

--- a/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -19,12 +19,9 @@ module CandidateInterface
       return false unless valid?
 
       if application_form.equality_and_diversity.nil?
-        hesa_code = Hesa::Disability
-                      .find_by_value(HesaDisabilityValues::NONE)
-                      .hesa_code
         application_form.update(equality_and_diversity: {
           'disabilities' => [],
-          'hesa_disabilities' => [hesa_code],
+          'hesa_disabilities' => [hesa_code].compact,
         })
       elsif reset_disabilities?(application_form)
         application_form.equality_and_diversity['disabilities'] = []
@@ -38,6 +35,14 @@ module CandidateInterface
     end
 
   private
+
+    def hesa_code
+      if disability_status == 'no'
+        Hesa::Disability
+          .find(disability_status)
+          .hesa_code
+      end
+    end
 
     def reset_disabilities?(application_form)
       application_form.equality_and_diversity['disabilities'].nil? ||

--- a/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/ethnic_background_form.rb
@@ -30,18 +30,17 @@ module CandidateInterface
       other_background_present = ethnic_background == EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group].first && other_background.present?
 
       background = other_background_present ? other_background : ethnic_background
-      ethnicity_value = hesa_ethnicity_value(ethnic_background)
 
       if application_form.equality_and_diversity.nil?
         application_form.update(
           equality_and_diversity: {
             'ethnic_background' => background,
-            'hesa_ethnicity' => hesa_ethnicity_code(ethnicity_value),
+            'hesa_ethnicity' => hesa_ethnicity_code,
           },
         )
       else
         application_form.equality_and_diversity['ethnic_background'] = background
-        application_form.equality_and_diversity['hesa_ethnicity'] = hesa_ethnicity_code(ethnicity_value)
+        application_form.equality_and_diversity['hesa_ethnicity'] = hesa_ethnicity_code
         application_form.save
       end
     end
@@ -52,13 +51,9 @@ module CandidateInterface
 
   private
 
-    def hesa_ethnicity_value(background)
-      Hesa::Ethnicity.convert_to_hesa_value(background)
-    end
-
-    def hesa_ethnicity_code(type)
+    def hesa_ethnicity_code
       Hesa::Ethnicity
-        .find_by_value(type, RecruitmentCycle.current_year)
+        .find(ethnic_background, RecruitmentCycle.current_year)
         &.hesa_code
     end
   end

--- a/app/forms/candidate_interface/equality_and_diversity/sex_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/sex_form.rb
@@ -32,11 +32,7 @@ module CandidateInterface
   private
 
     def hesa_sex_code
-      Hesa::Sex.find_by_type(hesa_sex_type)&.hesa_code
-    end
-
-    def hesa_sex_type
-      sex == 'intersex' ? 'other' : sex
+      Hesa::Sex.find(sex)&.hesa_code
     end
   end
 end

--- a/app/lib/hesa/disability.rb
+++ b/app/lib/hesa/disability.rb
@@ -6,13 +6,14 @@ module Hesa
       HESA_DISABILITIES.map { |disability| DisabilityStruct.new(*disability) }
     end
 
-    def self.find_by_value(value)
-      all.find { |disability| disability.value == value }
+    def self.find(value)
+      converted_value = convert_to_hesa_value(value)
+      all.find { |hesa_disability| hesa_disability.value == converted_value }
     end
 
     def self.convert_to_hesa_value(disability)
-      {
-        'None' => HesaDisabilityValues::NONE,
+      hesa_conversion = {
+        'no' => HesaDisabilityValues::NONE,
         'Multiple' => HesaDisabilityValues::MULTIPLE,
         'Learning difficulty' => HesaDisabilityValues::LEARNING,
         'Social or communication impairment' => HesaDisabilityValues::SOCIAL_OR_COMMUNICATION,
@@ -22,7 +23,9 @@ module Hesa
         'Deaf' => HesaDisabilityValues::DEAF,
         'Blind' => HesaDisabilityValues::BLIND,
         'Other' => HesaDisabilityValues::OTHER,
-      }.freeze[disability]
+      }.freeze
+
+      hesa_conversion[disability] || HesaDisabilityValues::OTHER
     end
   end
 end

--- a/app/lib/hesa/ethnicity.rb
+++ b/app/lib/hesa/ethnicity.rb
@@ -12,12 +12,13 @@ module Hesa
       end
     end
 
-    def self.find_by_value(value, cycle_year)
-      all(cycle_year).find { |ethnicity| ethnicity.value == value }
+    def self.find(value, cycle_year)
+      converted_value = convert_to_hesa_value(value)
+      all(cycle_year).find { |hesa_ethnicity| hesa_ethnicity.value == converted_value }
     end
 
     def self.convert_to_hesa_value(background)
-      {
+      hesa_conversion = {
         'British, English, Northern Irish, Scottish, or Welsh' => HesaEthnicityValues::WHITE,
         'Irish' => HesaEthnicityValues::WHITE,
         'Irish Traveller or Gypsy' => HesaEthnicityValues::GYPSY_OR_TRAVELLER,
@@ -37,7 +38,9 @@ module Hesa
         'Another Mixed background' => HesaEthnicityValues::OTHER_MIXED,
         'Arab' => HesaEthnicityValues::ARAB,
         'Another ethnic background' => HesaEthnicityValues::OTHER_ETHNIC,
-      }.freeze[background]
+      }.freeze
+
+      hesa_conversion[background] || HesaEthnicityValues::NOT_KNOWN
     end
   end
 end

--- a/app/lib/hesa/sex.rb
+++ b/app/lib/hesa/sex.rb
@@ -6,8 +6,12 @@ module Hesa
       HESA_SEX.map { |sex| SexStruct.new(*sex) }
     end
 
-    def self.find_by_type(sex_type)
-      all.find { |sex| sex.type == sex_type }
+    def self.find(sex)
+      if sex == 'intersex'
+        sex = 'other'
+      end
+
+      all.find { |hesa_sex| hesa_sex.type == sex }
     end
   end
 end

--- a/spec/lib/hesa/disability_spec.rb
+++ b/spec/lib/hesa/disability_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Hesa::Disability do
     end
   end
 
-  describe '.find_by_value' do
+  describe '.find' do
     context 'given a valid value' do
       it 'returns the matching struct' do
-        result = described_class.find_by_value('Deaf or a serious hearing impairment')
+        result = described_class.find('Deaf')
 
         expect(result.value).to eq HesaDisabilityValues::DEAF
         expect(result.hesa_code).to eq '57'
@@ -26,9 +26,10 @@ RSpec.describe Hesa::Disability do
 
     context 'given an unrecognised value' do
       it 'returns nil' do
-        result = described_class.find_by_value('Unrecognised disability')
+        result = described_class.find('Unrecognised disability')
 
-        expect(result).to eq nil
+        expect(result.value).to eq HesaDisabilityValues::OTHER
+        expect(result.hesa_code).to eq '96'
       end
     end
   end
@@ -46,7 +47,7 @@ RSpec.describe Hesa::Disability do
       it 'returns nil' do
         result = described_class.convert_to_hesa_value('unrecognised disability')
 
-        expect(result).to eq nil
+        expect(result).to eq 'A disability, impairment or medical condition that is not listed above'
       end
     end
   end

--- a/spec/lib/hesa/ethnicity_spec.rb
+++ b/spec/lib/hesa/ethnicity_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe Hesa::Ethnicity do
     end
   end
 
-  describe '.find_by_value' do
+  describe '.find' do
     context 'given a valid value' do
       it 'returns the matching struct' do
         cycle_year = 2021
-        result = described_class.find_by_value('Chinese', cycle_year)
+        result = described_class.find('Chinese', cycle_year)
 
         expect(result.value).to eq HesaEthnicityValues::CHINESE
         expect(result.hesa_code).to eq 34
@@ -44,7 +44,7 @@ RSpec.describe Hesa::Ethnicity do
 
     context 'given an unrecognised value' do
       it 'returns nil' do
-        result = described_class.find_by_value('Information refused', 2021)
+        result = described_class.find('Information refused', 2021)
 
         expect(result).to eq nil
       end
@@ -64,7 +64,7 @@ RSpec.describe Hesa::Ethnicity do
       it 'returns nil' do
         result = described_class.convert_to_hesa_value('unknown ethnicity')
 
-        expect(result).to eq nil
+        expect(result).to eq 'Not known'
       end
     end
   end

--- a/spec/lib/hesa/sex_spec.rb
+++ b/spec/lib/hesa/sex_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Hesa::Sex do
     end
   end
 
-  describe '.find_by_type' do
+  describe '.find' do
     context 'given a valid type' do
       it 'returns the matching struct' do
-        result = described_class.find_by_type('female')
+        result = described_class.find('female')
 
         expect(result.type).to eq 'female'
         expect(result.hesa_code).to eq 2
@@ -26,7 +26,7 @@ RSpec.describe Hesa::Sex do
 
     context 'given an unrecognised type' do
       it 'returns nil' do
-        result = described_class.find_by_type('An unrecognised type')
+        result = described_class.find('An unrecognised type')
 
         expect(result).to eq nil
       end

--- a/spec/services/candidate_interface/hesa_code_backfill_spec.rb
+++ b/spec/services/candidate_interface/hesa_code_backfill_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                   })
 
         cycle_year = 2020
+        hesa_disability_code_other = '96'
 
         described_class.call(cycle_year)
 
@@ -80,7 +81,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
 
         expect(application_form.equality_and_diversity).to eq(
           'disabilities' => ['Acquired brain injury', 'Many unexplained illnesses'],
-          'hesa_disabilities' => [described_class::HESA_DISABILITY_CODE_OTHER],
+          'hesa_disabilities' => [hesa_disability_code_other],
           'hesa_ethnicity' => nil,
           'hesa_sex' => nil,
         )
@@ -94,8 +95,8 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                     ethnic_background: 'Maori',
                                     disabilities: [],
                                   })
-
         cycle_year = 2020
+        hesa_ethnicity_code_unknown = 90
 
         described_class.call(cycle_year)
 
@@ -105,7 +106,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
           'ethnic_background' => 'Maori',
           'disabilities' => [],
           'hesa_disabilities' => nil,
-          'hesa_ethnicity' => described_class::HESA_ETHNICITY_CODE_UNKNOWN,
+          'hesa_ethnicity' => hesa_ethnicity_code_unknown,
           'hesa_sex' => nil,
         )
       end
@@ -117,6 +118,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                       ethnic_group: 'Prefer not to say',
                                       disabilities: [],
                                     })
+          hesa_ethnicity_code_refused = 98
 
           cycle_year = 2020
 
@@ -128,7 +130,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
             'ethnic_group' => 'Prefer not to say',
             'disabilities' => [],
             'hesa_disabilities' => nil,
-            'hesa_ethnicity' => described_class::HESA_ETHNICITY_CODE_REFUSED,
+            'hesa_ethnicity' => hesa_ethnicity_code_refused,
             'hesa_sex' => nil,
           )
         end
@@ -169,6 +171,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                   recruitment_cycle_year: 2021)
 
         cycle_year = 2021
+        hesa_sex_code_intersex = 3
 
         described_class.call(cycle_year)
 
@@ -176,7 +179,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
 
         expect(application_form.equality_and_diversity).to eq(
           'sex' => 'intersex',
-          'hesa_sex' => described_class::HESA_SEX_CODE_OTHER,
+          'hesa_sex' => hesa_sex_code_intersex,
           'hesa_disabilities' => nil,
           'hesa_ethnicity' => nil,
         )


### PR DESCRIPTION
## Context

Some of the HESA disability code logic is currently replicated in more than one place - in the back fill and in the form objects. 
It's possible that HESA disability codes may change year on year and there is a danger that bugs could be silently introduced as a result of having the duplication.

## Changes proposed in this pull request

Centralise more of the HESA disability code logic so that it is in one place and reduces the chance of future bugs occurring between the backfill and form completion. Specifically, duplicated logic (conversion and edge casing) is moved into each of the `Hesa` modules.

## Guidance to review

- Changes make sense and are worth it?
- Is there enough test coverage - should we be testing that all form inputs match the correct HESA code?

## Link to Trello card

https://trello.com/c/mxKdgR5L/2178-dev-collect-hesa-codes-at-source-in-ed-qs

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
