### PR TITLE
Update to Candidate emails for decoupled references

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -139,7 +139,6 @@ class CandidateMailer < ApplicationMailer
 
   def reference_received(reference)
     @reference = reference
-    @candidate_magic_link = candidate_magic_link(application_form.candidate)
 
     email_for_candidate(
       reference.application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -139,6 +139,7 @@ class CandidateMailer < ApplicationMailer
 
   def reference_received(reference)
     @reference = reference
+    @candidate_magic_link = candidate_magic_link(application_form.candidate)
 
     email_for_candidate(
       reference.application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -142,6 +142,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       reference.application_form,
+      subject: I18n.t!('candidate_mailer.reference_received.subject', referee_name: @reference.name),
     )
   end
 

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -18,15 +18,8 @@ Sign in to your account anytime to check the progress of your application:
 
 If your training provider decides to progress your application, they’ll contact you to organise an interview.
 
-# Get your references
-
-Ask your referees to check their email and give a reference as soon as possible.
-
-Courses can become full at any time and your application will not be considered without references.
-
 # Get support
 
 Email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
 
 We typically respond within one working day for urgent queries or 5 working days for less urgent queries.
-

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-m"><%= @referee.name %> has not responded yet</h1>
+# <%= @reference.name %> has not responded yet
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.
 

--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -1,23 +1,11 @@
-Dear <%= @application_form.first_name %>,
+<h1 class="govuk-heading-m"><%= @referee.name %> has not responded yet</h1>
 
-# Get in contact with <%= @reference.name %> as soon as possible
+You can add as many referees as you like to increase the chances of getting 2 references quickly.
 
-<%= @reference.name %> has not given you a reference yet.
+You can also send one reminder to each referee from your account.
 
-Ask them to check their inbox including their junk or spam emails and give a reference as soon as possible.
-
-# Check you’ve given the right details
-
-You gave us this email address:
-
-<%= @reference.email_address %>
-
-If this is not correct, cancel the reference request and add in the referee details again:
+Manage your references:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-We cannot send applications to teacher training providers without 2 references. Courses can become full at any time - get your reference as soon as possible.
-
-# Need help?
-
-Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -1,17 +1,11 @@
-Dear <%= @application_form.first_name %>,
+<h1 class="govuk-heading-m"><%= @referee.name %> has not responded yet</h1>
 
-# Give a new referee as soon as possible
+You can add as many referees as you like to increase the chances of getting 2 references quickly.
 
-We have not had a reference from <%= @referee.name %> yet.
+You can also send one reminder to each referee from your account.
 
-Add a new referee:
+Manage your references:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-If you know <%= @referee.name %> is planning on giving a reference, you can keep chasing them instead. The email may have gone to junk or spam.
-
-We cannot send applications to teacher training providers without 2 references. Courses can become full at any time - get your reference as soon as possible.
-
-# Need help?
-
-Contact us at becomingateacher@digital.education.gov.uk
+You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.

--- a/app/views/candidate_mailer/chase_reference_again.text.erb
+++ b/app/views/candidate_mailer/chase_reference_again.text.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-m"><%= @referee.name %> has not responded yet</h1>
+# <%= @referee.name %> has not responded yet
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.
 

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,23 +1,19 @@
-Dear <%= @application_form.first_name %>,
-
-<% if @reason == :email_bounced ||  @reason == :refused %>
-# Give a new referee as soon as possible
-<% else %>
-# Give details of a new referee
-<% end %>
-
-<%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name, referee_email: @reference.email_address) %>
-
 <% if @reason == :email_bounced %>
-Give a new referee or add <%= @reference.name %>’s details again if they were not correct:
+<h1 class="govuk-heading-m">Referee request did not reach<%= @referee.name %></h1>
+
+Check you gave the correct email address and request the reference again.
+<% elsif @reason == :refused %>
+<h1 class="govuk-heading-m"><%= @referee.name %> has declined your reference request</h1>
 <% else %>
-Give a new referee:
+<h1 class="govuk-heading-m"><%= @referee.name %> has not responded yet</h1>
 <% end %>
+
+You can add as many referees as you like to increase the chances of getting 2 references quickly.
+
+You can also send one reminder to each referee from your account.
+
+Manage your references:
 
 <%= candidate_magic_link(@candidate) %>
 
-We cannot send applications to teacher training providers without 2 references. Courses can become full at any time - get your reference as soon as possible.
-
-# Need help?
-
-Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible.

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,11 +1,11 @@
 <% if @reason == :email_bounced %>
-<h1 class="govuk-heading-m">Referee request did not reach<%= @referee.name %></h1>
+# Referee request did not reach <%= @reference.name %>
 
 Check you gave the correct email address and request the reference again.
 <% elsif @reason == :refused %>
-<h1 class="govuk-heading-m"><%= @referee.name %> has declined your reference request</h1>
+# <%= @reference.name %> has declined your reference request
 <% else %>
-<h1 class="govuk-heading-m"><%= @referee.name %> has not responded yet</h1>
+# <%= @reference.name %> has not responded yet
 <% end %>
 
 You can add as many referees as you like to increase the chances of getting 2 references quickly.

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,6 +1,6 @@
-<h1 class="govuk-heading-m">You have a reference from<%= @referee.name %></h1>
+# You have a reference from <%= @reference.name %>
 
-<% if current_application.application_references.feedback_provided > 1 %>
+<% if @application_form.application_references.any?(&:feedback_provided) %>
 You’ve got 2 references back now.
 
 When you’re ready, you can send your application to training providers.
@@ -14,4 +14,4 @@ You can add as many referees as you like to increase the chances of getting 2 re
 Manage your references:
 <% end %>
 
-<%= @candidate_magic_link %>
+<%= candidate_magic_link(@application_form.candidate) %>

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,11 +1,17 @@
-Dear <%= @application_form.first_name %>,
+<h1 class="govuk-heading-m">You have a reference from<%= @referee.name %></h1>
 
-# You have a reference
+<% if current_application.application_references.feedback_provided > 1 %>
+You’ve got 2 references back now.
 
-<%= @reference.name %> submitted a reference for your teacher training application.
+When you’re ready, you can send your application to training providers.
 
-We’ve attached this to your application form.
+Sign in to continue your application:
+<% else %>
+You need to get another reference back before you can send your application to training providers.
 
-# Give feedback or report a problem
+You can add as many referees as you like to increase the chances of getting 2 references quickly.
 
-Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+Manage your references:
+<% end %>
+
+<%= @candidate_magic_link %>

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,6 +1,6 @@
 # You have a reference from <%= @reference.name %>
 
-<% if @application_form.application_references.any?(&:feedback_provided) %>
+<% if @application_form.enough_references_have_been_provided? %>
 You’ve got 2 references back now.
 
 When you’re ready, you can send your application to training providers.

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -11,7 +11,7 @@ en:
     survey_chaser_email:
       subject: We’d love to hear from you about your teacher training application
     reference_received:
-      subject: "You have a reference for your teacher training application"
+      subject: "You have a reference from %{referee_name}"
     application_submitted:
       subject: "You’ve submitted your teacher training application"
     application_submitted_apply_again:
@@ -19,24 +19,24 @@ en:
     application_sent_to_provider:
       subject: Your application is being considered
     chase_reference:
-      subject: "Chase %{referee_name}: they have not given a reference yet"
+      subject: "%{referee_name} has not responded yet"
     chase_reference_again:
-      subject: "Give new referee as soon as possible: %{referee_name} has not responded"
+      subject: "%{referee_name} has not responded yet"
     find_another_course:
       subject: "Find another course - %{course_name_and_code} at %{provider_name} is not available"
     offer_accepted:
       subject: "You’ve accepted %{provider_name}’s offer to study %{course_name_and_code}"
     new_referee_request:
       not_responded:
-        subject: "Give details of a new referee: %{referee_name} has not responded"
+        subject: "%{referee_name} has not responded yet"
         explanation: |-
           We have not had a reference from %{referee_name}.
       refused:
-        subject: "Give new referee as soon as possible: %{referee_name} will not give a reference"
+        subject: "%{referee_name} has declined your reference request"
         explanation: |-
           %{referee_name} said they will not give a reference.
       email_bounced:
-        subject: "Give new referee as soon as possible. Our email did not reach %{referee_name}"
+        subject: "Referee request did not reach %{referee_name}"
         explanation: |-
           Our email requesting a reference did not reach %{referee_name}.
 

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -74,20 +74,20 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe '.reference_received' do
     it 'sends an email with the correct body if one reference complete' do
       application_form = create(:completed_application_form, :with_completed_references)
-      reference1 = create(:reference, :complete, application_form: application_form)
-      reference2 = create(:reference, :requested, application_form: application_form)
+      create(:reference, :complete, application_form: application_form)
+      create(:reference, :requested, application_form: application_form)
 
       email = described_class.send(:reference_received, application_form.application_references.first)
-      expect(email.body).to include("You need to get another reference")
+      expect(email.body).to include('You need to get another reference')
     end
 
     it 'sends an email with the correct body if two references complete' do
       application_form = create(:completed_application_form, :with_completed_references)
-      reference1 = create(:reference, :complete, application_form: application_form)
-      reference2 = create(:reference, :complete, application_form: application_form)
+      create(:reference, :complete, application_form: application_form)
+      create(:reference, :complete, application_form: application_form)
 
       email = described_class.send(:reference_received, application_form.application_references.first)
-      expect(email.body).to include("You’ve got 2 references back now.")
+      expect(email.body).to include('You’ve got 2 references back now.')
     end
   end
 end

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -16,11 +16,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include("Dear #{application_form.first_name}")
-    end
-
-    it 'sends an email containing the referee email' do
-      expect(mail.body.encoded).to include(reference.email_address)
+      expect(mail.body.encoded).to include("#{reference.name} has not responded yet")
     end
   end
 
@@ -54,8 +50,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a new reference request mail with subject and content', :not_responded,
         I18n.t!('candidate_mailer.new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'),
-        'heading' => 'Dear Tyrell',
-        'explanation' => I18n.t!('candidate_mailer.new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles')
+        'heading' => 'Scott Knowles has not responded yet'
       )
     end
 
@@ -63,8 +58,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a new reference request mail with subject and content', :refused,
         I18n.t!('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Scott Knowles'),
-        'heading' => 'Dear Tyrell',
-        'explanation' => I18n.t!('candidate_mailer.new_referee_request.refused.explanation', referee_name: 'Scott Knowles')
+        'heading' => 'Scott Knowles has declined your reference request'
       )
     end
 
@@ -72,9 +66,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a new reference request mail with subject and content', :email_bounced,
         I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
-        'heading' => 'Dear Tyrell',
-        'explanation' => 'Our email requesting a reference did not reach Scott Knowles.',
-        'referee email' => 'ting@canpaint.com'
+        'heading' => 'Referee request did not reach Scott Knowles',
       )
     end
   end

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -66,8 +66,28 @@ RSpec.describe CandidateMailer, type: :mailer do
       it_behaves_like(
         'a new reference request mail with subject and content', :email_bounced,
         I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
-        'heading' => 'Referee request did not reach Scott Knowles',
+        'heading' => 'Referee request did not reach Scott Knowles'
       )
+    end
+  end
+
+  describe '.reference_received' do
+    it 'sends an email with the correct body if one reference complete' do
+      application_form = create(:completed_application_form, :with_completed_references)
+      reference1 = create(:reference, :complete, application_form: application_form)
+      reference2 = create(:reference, :requested, application_form: application_form)
+
+      email = described_class.send(:reference_received, application_form.application_references.first)
+      expect(email.body).to include("You need to get another reference")
+    end
+
+    it 'sends an email with the correct body if two references complete' do
+      application_form = create(:completed_application_form, :with_completed_references)
+      reference1 = create(:reference, :complete, application_form: application_form)
+      reference2 = create(:reference, :complete, application_form: application_form)
+
+      email = described_class.send(:reference_received, application_form.application_references.first)
+      expect(email.body).to include("You’ve got 2 references back now.")
     end
   end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -333,9 +333,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     it 'has the right subject and content' do
-      expect(email.subject).to eq "Give new referee as soon as possible: #{@referee.name} has not responded"
-      expect(email).to have_content 'Dear Bob'
-      expect(email).to have_content "We have not had a reference from #{@referee.name} yet."
+      expect(email.subject).to eq "#{@referee.name} has not responded yet"
     end
   end
 

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -205,8 +205,8 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   def and_the_candidate_receives_a_notification
     open_email(current_candidate.email_address)
 
-    expect(current_email.subject).to end_with('You have a reference for your teacher training application')
-    expect(current_email.body).to have_content('Terri Tudor submitted a reference for your teacher training application')
+    expect(current_email.subject).to end_with('You have a reference from Terri Tudor')
+    expect(current_email.body).to have_content('You need to get another reference')
   end
 
   def then_i_see_the_thank_you_page

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Referee does not respond in time' do
   def and_an_email_is_sent_to_the_candidate
     open_email(@application.candidate.email_address)
 
-    expect(current_email.subject).to end_with('Chase Anne Other: they have not given a reference yet')
+    expect(current_email.subject).to end_with('Anne Other has not responded yet')
   end
 
   def when_the_candidate_does_not_respond_within_14_days
@@ -56,7 +56,7 @@ RSpec.feature 'Referee does not respond in time' do
   def then_an_email_is_sent_to_the_candidate_asking_for_a_new_referee
     open_email(@application.candidate.email_address)
 
-    expect(current_email.subject).to have_content('Give details of a new referee')
+    expect(current_email.subject).to have_content('Anne Other has not responded yet')
   end
 
   def when_the_candidate_does_not_respond_within_28_days
@@ -68,7 +68,7 @@ RSpec.feature 'Referee does not respond in time' do
   def then_the_candidate_is_sent_a_chase_email
     open_email(@application.candidate.email_address)
 
-    expect(current_email.subject).to have_content('Give new referee as soon as possible: Anne Other has not responded')
+    expect(current_email.subject).to have_content('Anne Other has not responded yet')
   end
 
   def and_the_referee_is_sent_a_chase_email

--- a/spec/workers/send_additional_reference_chase_email_to_both_parties_worker_spec.rb
+++ b/spec/workers/send_additional_reference_chase_email_to_both_parties_worker_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe SendAdditionalReferenceChaseEmailToBothPartiesWorker do
 
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 4
-      expect(emails.first.subject).to match "Give new referee as soon as possible: #{reference_triggering_a_chase.name} has not responded"
+      expect(emails.first.subject).to match "#{reference_triggering_a_chase.name} has not responded yet"
       expect(emails.second.subject).to match "Will you not give #{application_form.full_name} a reference?"
-      expect(emails.third.subject).to match "Give new referee as soon as possible: #{other_overdue_reference.name} has not responded"
+      expect(emails.third.subject).to match "#{other_overdue_reference.name} has not responded yet"
       expect(emails.fourth.subject).to match "Will you not give #{application_form.full_name} a reference?"
 
       expect(application_form_id_of(emails.first)).to eq reference_triggering_a_chase.application_form.id


### PR DESCRIPTION
## Context

As part of the decoupled references feature the candidate reference email content needs to be updated to reflect the functionality.

## Changes proposed in this pull request

I have updated the content in the emails as per the prototypes. In the case of of the last email I have introduced some logic that will send different email content based on the number of completed references. 

## Guidance to review

View the email previews via the support interface.

## Link to Trello card

https://trello.com/c/oUQxxBUp/2220-%F0%9F%92%94-dev-update-emails-reference-and-other-service-emails-mvp

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
