### PR TITLE
Decoupled references - delete a reference

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -5,10 +5,6 @@
       <% if reference.feedback_requested? %>
         <div class="app-summary-card__actions">
           <% # TODO: add cancel path for decoupled references once it's ready %>
-          <%= link_to '', class: 'govuk-link' do %>
-            <%= t('application_form.referees.cancel_request') + ' TODO' %>
-            <span class="govuk-visually-hidden"> <%= reference.name %></span>
-          <% end %>
         </div>
       <% elsif editable %>
         <div class="app-summary-card__actions">

--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -12,9 +12,8 @@
         </div>
       <% elsif editable %>
         <div class="app-summary-card__actions">
-          <% # TODO: add delete path for decoupled references once it's ready %>
-          <%= link_to '', class: 'govuk-link' do %>
-            <%= t('application_form.referees.delete') + ' TODO' %>
+          <%= link_to candidate_interface_destroy_decoupled_reference_path(reference), class: 'govuk-link' do %>
+            <%= t('application_form.referees.delete') %>
             <span class="govuk-visually-hidden"> <%= reference.name %></span>
           <% end %>
         </div>

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -11,6 +11,16 @@ module CandidateInterface
       end
 
       def unsubmitted; end
+
+      def confirm_destroy
+        @reference = ApplicationReference.find(params[:id])
+      end
+
+      def destroy
+        @reference = ApplicationReference.find(params[:id])
+        @reference.destroy!
+        redirect_to candidate_interface_decoupled_references_review_path
+      end
     end
   end
 end

--- a/app/views/candidate_interface/decoupled_references/review/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/confirm_destroy.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, t('page_titles.referee_destroy') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_decoupled_references_review_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @reference, url: candidate_interface_destroy_decoupled_reference_path(@reference), method: :delete do |f| %>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.reference_destroy') %>
+      </h1>
+
+      <%= f.submit 'Yes I’m sure - delete this reference request' , class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'No, I’ve changed my mind', candidate_interface_decoupled_references_review_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,7 @@ en:
     referee_type: What kind of referee do you want to add?
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?
+    reference_destroy: Are you sure you want to delete this reference request?
     add_referee: Details of referee
     maximum_referees: You cannot add any more referees
     give_a_reference:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -409,6 +409,8 @@ Rails.application.routes.draw do
         get '/review-unsubmitted/:id' => 'decoupled_references/review#unsubmitted', as: :decoupled_references_review_unsubmitted
 
         get '/review' => 'decoupled_references/review#show', as: :decoupled_references_review
+        get '/review/delete/:id' => 'decoupled_references/review#confirm_destroy', as: :destroy_decoupled_reference
+        delete '/review/delete/:id' => 'decoupled_references/review#destroy'
 
         get '/request/:id' => 'decoupled_references/request#new', as: :decoupled_references_new_request
         post '/request/:id' => 'decoupled_references/request#create', as: :decoupled_references_create_request

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -85,13 +85,14 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     let(:feedback_requested) { create(:reference, :requested) }
     let(:feedback_refused) { create(:reference, :refused) }
 
+    # TODO: uncomment this test when Cancel links are implemented
     it 'a cancel link is available' do
-      result = render_inline(described_class.new(references: [feedback_requested, feedback_refused]))
+      # result = render_inline(described_class.new(references: [feedback_requested, feedback_refused]))
 
-      feedback_requested_summary = result.css('.app-summary-card')[0]
-      feedback_refused_summary = result.css('.app-summary-card')[1]
-      expect(feedback_requested_summary.text).to include 'Cancel request'
-      expect(feedback_refused_summary.text).not_to include 'Cancel request'
+      # feedback_requested_summary = result.css('.app-summary-card')[0]
+      # feedback_refused_summary = result.css('.app-summary-card')[1]
+      # expect(feedback_requested_summary.text).to include 'Cancel request'
+      # expect(feedback_refused_summary.text).not_to include 'Cancel request'
     end
   end
 

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Review references' do
     and_the_decoupled_references_flag_is_on
     and_i_have_added_references
     then_i_can_review_my_references_before_submission
+    and_i_can_delete_a_reference
     and_i_can_return_to_the_application_page
   end
 
@@ -51,6 +52,17 @@ RSpec.feature 'Review references' do
       expect(page).not_to have_link 'Delete referee'
       expect(page).to have_link 'Cancel request'
     end
+  end
+
+  def and_i_can_delete_a_reference
+    within '#references_waiting_to_be_sent' do
+      click_link 'Delete referee'
+    end
+    click_button 'Yes I’m sure'
+
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
+    expect(page).not_to have_css('#references_waiting_to_be_sent')
+    expect(page).not_to have_link 'Delete referee'
   end
 
   def and_i_can_return_to_the_application_page

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -35,14 +35,12 @@ RSpec.feature 'Review references' do
       expect(page).to have_content @complete_reference.email_address
       expect(page).not_to have_link 'Change'
       expect(page).not_to have_link 'Delete referee'
-      expect(page).not_to have_link 'Cancel request'
     end
 
     within '#references_waiting_to_be_sent' do
       expect(page).to have_content @not_sent_reference.email_address
       expect(page).to have_link 'Change'
       expect(page).to have_link 'Delete referee'
-      expect(page).not_to have_link 'Cancel request'
     end
 
     within '#references_sent' do
@@ -50,7 +48,6 @@ RSpec.feature 'Review references' do
       expect(page).to have_content @refused_reference.email_address
       expect(page).not_to have_link 'Change'
       expect(page).not_to have_link 'Delete referee'
-      expect(page).to have_link 'Cancel request'
     end
   end
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
**As a...** candidate
**I need to...** delete previous referee details I added
**So that...** so that I feel in control of what’s shown

## Changes proposed in this pull request
Add a working delete link for reference requests that hasn't been sent yet. Received references and pending/failed ones can't be deleted for now.

Also, remove the Cancel link placeholder that was added previously.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Add and delete a reference in the review app.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/VtqDZ5y5
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
