### PR TITLE
Send reference request #2

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -1,27 +1,29 @@
 <% references.each do |reference| %>
   <%= render(SummaryCardComponent.new(rows: reference_rows(reference), editable: editable && reference.editable?)) do %>
     <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
-
-      <% if reference.feedback_requested? %>
-        <div class="app-summary-card__actions">
-          <% # TODO: add cancel path for decoupled references once it's ready %>
-        </div>
-      <% elsif editable %>
-        <div class="app-summary-card__actions">
-          <%= link_to candidate_interface_destroy_decoupled_reference_path(reference), class: 'govuk-link' do %>
-            <%= t('application_form.referees.delete') %>
-            <span class="govuk-visually-hidden"> <%= reference.name %></span>
+          
+      <div class="app-summary-card__actions">
+        <ul class="app-summary-card__actions-list">
+          <% if reference.feedback_requested? %>
+            <% # TODO: add cancel path for decoupled references once it's ready %>
+          <% elsif editable %>
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to candidate_interface_destroy_decoupled_reference_path(reference), class: 'govuk-link' do %>
+                <%= t('application_form.referees.delete') %>
+                <span class="govuk-visually-hidden"> <%= reference.name %></span>
+              <% end %>
+            </li>
           <% end %>
-        </div>
-      <% end %>
-      <% if reference.not_requested_yet? %>
-        <div class="app-summary-card__actions">
-          <%= link_to candidate_interface_decoupled_references_new_request_path(reference.id), class: 'govuk-link' do %>
-            <%= t('application_form.referees.send_request') %>
-            <span class="govuk-visually-hidden"> <%= reference.name %></span>
+          <% if reference.not_requested_yet? %>
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to candidate_interface_decoupled_references_new_request_path(reference.id), class: 'govuk-link' do %>
+                <%= t('application_form.referees.send_request') %>
+                <span class="govuk-visually-hidden"> <%= reference.name %></span>
+              <% end %>
+            </li>
           <% end %>
-        </div>
-      <% end %>
+        </ul>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -14,6 +14,14 @@
           <% end %>
         </div>
       <% end %>
+      <% if reference.not_requested_yet? %>
+        <div class="app-summary-card__actions">
+          <%= link_to candidate_interface_decoupled_references_new_request_path(reference.id), class: 'govuk-link' do %>
+            <%= t('application_form.referees.send_request') %>
+            <span class="govuk-visually-hidden"> <%= reference.name %></span>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/controllers/candidate_interface/decoupled_references/request_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/request_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
       before_action :set_reference
       before_action :prompt_for_candidate_name_if_not_already_given, only: :create
 
+      # TODO: Replace this action when integrating with ref summary page
       def start
         @request_form = Reference::RequestForm.build_from_reference(@reference)
       end

--- a/app/controllers/candidate_interface/decoupled_references/request_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/request_controller.rb
@@ -4,8 +4,13 @@ module CandidateInterface
       before_action :set_reference
       before_action :prompt_for_candidate_name_if_not_already_given, only: :create
 
+      def start
+        @request_form = Reference::RequestForm.build_from_reference(@reference)
+      end
+
       def new
         @request_form = Reference::RequestForm.build_from_reference(@reference)
+        @request_form.request_now = 'yes'
       end
 
       def create

--- a/app/views/candidate_interface/decoupled_references/request/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/request/new.html.erb
@@ -7,10 +7,11 @@
 
     <p class="govuk-body">We’ll send <%= @reference.name %> an email asking them to give you a reference.</p>
     <%= form_with model: @request_form, url: candidate_interface_decoupled_references_create_request_path(@reference.id) do |f| %>
-      <%= f.govuk_text_field :request_now, hidden: true %>
+      <%= f.govuk_text_field :request_now, label: { hidden: true }, hidden: true %>
       <%= f.govuk_submit 'Yes I’m sure - send my reference request' %>
-      <p class="govuk-body">or</p>
-      <%= govuk_link_to 'No - I’ve changed my mind', candidate_interface_decoupled_references_review_path, class: 'govuk-body' %>
+      <p class="govuk-body">
+        <%= govuk_link_to 'No - I’ve changed my mind', candidate_interface_decoupled_references_review_path, class: 'govuk-body' %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/decoupled_references/request/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/request/new.html.erb
@@ -1,17 +1,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @request_form, url: candidate_interface_decoupled_references_create_request_path, method: :post do |f| %>
-      <%= f.govuk_error_summary %>
+    <span class="govuk-caption-xl">
+      <%= @reference.name %>
+    </span>
+    <h1 class="govuk-heading-xl">Are you ready to send a reference request?</h1>
 
-      <%= f.govuk_radio_buttons_fieldset :request_now, legend: { text: "Are you ready to send a reference request to #{@request_form.referee_name}?", size: 'xl' } do %>
-        <div class="govuk-!-margin-top-7">
-          <%= f.govuk_radio_button :request_now, 'yes', link_errors: true, label: { text: 'Yes, send a reference request now' } %>
-          <%= f.govuk_radio_button :request_now, 'no', label: { text: 'No, not at the moment' } %>
-        </div>
-      <% end %>
-
-      <%= f.govuk_submit 'Save and continue' %>
+    <p class="govuk-body">We’ll send <%= @reference.name %> an email asking them to give you a reference.</p>
+    <%= form_with model: @request_form, url: candidate_interface_decoupled_references_create_request_path(@reference.id) do |f| %>
+      <%= f.govuk_text_field :request_now, hidden: true %>
+      <%= f.govuk_submit 'Yes I’m sure - send my reference request' %>
+      <p class="govuk-body">or</p>
+      <%= govuk_link_to 'No - I’ve changed my mind', candidate_interface_decoupled_references_review_path, class: 'govuk-body' %>
     <% end %>
   </div>
 </div>
-

--- a/app/views/candidate_interface/decoupled_references/request/start.html.erb
+++ b/app/views/candidate_interface/decoupled_references/request/start.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @request_form, url: candidate_interface_decoupled_references_create_request_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :request_now, legend: { text: "Are you ready to send a reference request to #{@request_form.referee_name}?", size: 'xl' } do %>
+        <div class="govuk-!-margin-top-7">
+          <%= f.govuk_radio_button :request_now, 'yes', link_errors: true, label: { text: 'Yes, send a reference request now' } %>
+          <%= f.govuk_radio_button :request_now, 'no', label: { text: 'No, not at the moment' } %>
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit 'Save and continue' %>
+    <% end %>
+  </div>
+</div>
+

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -388,6 +388,7 @@ en:
       delete: Delete referee
       cancel: Cancel referee
       cancel_request: Cancel request
+      send_request: Send request
       email_address:
         label: Email address
         hint_text:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -425,6 +425,7 @@ Rails.application.routes.draw do
         get '/review/delete/:id' => 'decoupled_references/review#confirm_destroy', as: :destroy_decoupled_reference
         delete '/review/delete/:id' => 'decoupled_references/review#destroy'
 
+        get '/request/:id/start' => 'decoupled_references/request#start', as: :decoupled_references_start_request
         get '/request/:id' => 'decoupled_references/request#new', as: :decoupled_references_new_request
         post '/request/:id' => 'decoupled_references/request#create', as: :decoupled_references_create_request
 

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -100,6 +100,20 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
   end
 
+  context 'when reference state is "not_requested_yet"' do
+    let(:feedback_requested) { create(:reference, :requested) }
+    let(:not_requested_yet) { create(:reference, :not_requested_yet) }
+
+    it 'a send request link is available' do
+      result = render_inline(described_class.new(references: [feedback_requested, not_requested_yet]))
+
+      feedback_requested_summary = result.css('.app-summary-card')[0]
+      feedback_refused_summary = result.css('.app-summary-card')[1]
+      expect(feedback_requested_summary.text).not_to include 'Send request'
+      expect(feedback_refused_summary.text).to include 'Send request'
+    end
+  end
+
 private
 
   def status_table

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Candidate requests a reference' do
 
   def and_i_visit_the_reference_review_page
     # TODO: Navigate to the last page of the reference creation flow
-    visit candidate_interface_decoupled_references_new_request_path(@reference.id)
+    visit candidate_interface_decoupled_references_start_request_path(@reference.id)
   end
 
   def and_i_choose_to_request_reference_immediately

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -32,6 +32,12 @@ RSpec.feature 'Candidate requests a reference' do
     then_i_do_not_see_a_confirmation_message
     and_the_reference_is_not_moved_to_the_requested_state
     and_an_email_is_not_sent_to_the_referee
+
+    when_i_click_the_send_reference_link
+    and_i_confirm_that_i_am_ready_to_send_a_reference_request
+    then_i_see_a_confirmation_message
+    and_the_reference_is_moved_to_the_requested_state
+    and_an_email_is_sent_to_the_referee
   end
 
   def given_i_am_signed_in
@@ -114,5 +120,14 @@ RSpec.feature 'Candidate requests a reference' do
   def and_an_email_is_not_sent_to_the_referee
     open_email(@reference.email_address)
     expect(current_email).to be_nil
+  end
+
+  def when_i_click_the_send_reference_link
+    click_link 'Send request'
+  end
+
+  def and_i_confirm_that_i_am_ready_to_send_a_reference_request
+    expect(page).to have_content('Are you ready to send a reference request?')
+    click_button 'Yes I’m sure - send my reference request'
   end
 end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3093 that adds link to reference review component so that candidate can request a reference that they didn't want to send immediately.

## Changes proposed in this pull request

- [x] Add _Send request_ link to `DecoupledReferencesReviewComponent`
- [x] Add confirmation view that gets displayed right after clicking the above link.
- [x] Extend existing system spec

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/450843/95603946-e4f63680-0a4e-11eb-9d28-c4945a8fca21.png">

<img width="629" alt="image" src="https://user-images.githubusercontent.com/450843/95604394-72398b00-0a4f-11eb-857b-fd9e6793aef0.png">

Not covered in this PR is the final integration with the summary page at the end of the create decoupled reference flow.

## Guidance to review

- To manually test it should be possible to send a request from the reference review on any `not_requested_yet` reference.

## Link to Trello card

https://trello.com/c/50ncVpYS/2215-💔-dev-send-reference-request-mvp

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
