### PR TITLE
Add query param to edit links on DecoupledReferencesReviewComponent

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -32,7 +32,9 @@ module CandidateInterface
         key: 'Name',
         value: reference.name,
         action: "name for #{reference.name}",
-        change_path: candidate_interface_decoupled_references_edit_name_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_name_path(
+          reference.id, return_to: :review
+        ),
       }
     end
 
@@ -41,7 +43,9 @@ module CandidateInterface
         key: 'Email address',
         value: reference.email_address,
         action: "email address for #{reference.name}",
-        change_path: candidate_interface_decoupled_references_edit_email_address_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_email_address_path(
+          reference.id, return_to: :review
+        ),
       }
     end
 
@@ -50,7 +54,9 @@ module CandidateInterface
         key: 'Relationship to referee',
         value: reference.relationship,
         action: "relationship for #{reference.name}",
-        change_path: candidate_interface_decoupled_references_edit_relationship_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_relationship_path(
+          reference.id, return_to: :review
+        ),
       }
     end
 
@@ -59,7 +65,9 @@ module CandidateInterface
         key: 'Reference type',
         value: formatted_reference_type(reference),
         action: "reference type for #{reference.name}",
-        change_path: candidate_interface_decoupled_references_edit_type_path(reference.id),
+        change_path: candidate_interface_decoupled_references_edit_type_path(
+          reference.id, return_to: :review
+        ),
       }
     end
 

--- a/app/controllers/candidate_interface/decoupled_references/base_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/base_controller.rb
@@ -17,6 +17,13 @@ module CandidateInterface
                                       .includes(:application_form)
                                       .find_by(id: params[:id])
       end
+
+      def return_to_path
+        case params[:return_to]&.to_sym
+        when :review
+          candidate_interface_decoupled_references_review_path
+        end
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -26,14 +26,19 @@ module CandidateInterface
 
         @reference_email_address_form.save(@reference)
 
-        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        if return_to_path.present?
+          redirect_to return_to_path
+        else
+          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        end
       end
 
     private
 
       def referee_email_address_param
-        params.require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
-        .merge!(reference_id: @reference.id)
+        params
+          .require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
+          .merge!(reference_id: @reference.id)
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/name_controller.rb
@@ -26,7 +26,11 @@ module CandidateInterface
 
         @reference_name_form.save(@reference)
 
-        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        if return_to_path.present?
+          redirect_to return_to_path
+        else
+          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        end
       end
 
     private

--- a/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
@@ -26,7 +26,11 @@ module CandidateInterface
 
         @references_relationship_form.save(@reference)
 
-        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        if return_to_path.present?
+          redirect_to return_to_path
+        else
+          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        end
       end
 
     private

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -26,7 +26,11 @@ module CandidateInterface
 
         @reference_type_form.update(@reference)
 
-        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        if return_to_path.present?
+          redirect_to return_to_path
+        else
+          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        end
       end
 
     private

--- a/app/views/candidate_interface/decoupled_references/email_address/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/email_address/edit.html.erb
@@ -3,7 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_edit_email_address_path(@reference.id), method: :patch do |f| %>
+    <%= form_with(
+      model: @reference_email_address_form,
+      url: candidate_interface_decoupled_references_edit_email_address_path(@reference.id, return_to: params[:return_to]),
+      method: :patch
+    ) do |f| %>
       <% render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/decoupled_references/name/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/name/edit.html.erb
@@ -3,7 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_name_form, url: candidate_interface_decoupled_references_edit_name_path(@reference.id), method: :patch do |f| %>
+    <%= form_with(
+      model: @reference_name_form,
+      url: candidate_interface_decoupled_references_edit_name_path(@reference.id, return_to: params[:return_to]),
+      method: :patch
+    ) do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/decoupled_references/relationship/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/relationship/edit.html.erb
@@ -3,7 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @references_relationship_form, url: candidate_interface_decoupled_references_edit_relationship_path(@reference.id), method: :patch do |f| %>
+    <%= form_with(
+      model: @references_relationship_form,
+      url: candidate_interface_decoupled_references_edit_relationship_path(@reference.id, return_to: params[:return_to]),
+      method: :patch,
+    ) do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/decoupled_references/type/edit.html.erb
+++ b/app/views/candidate_interface/decoupled_references/type/edit.html.erb
@@ -3,7 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_type_form, url: candidate_interface_decoupled_references_edit_type_path(@reference.id), method: :patch do |f| %>
+    <%= form_with(
+      model: @reference_type_form,
+      url: candidate_interface_decoupled_references_edit_type_path(@reference.id, return_to: params[:return_to]),
+      method: :patch
+    ) do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -133,10 +133,18 @@ private
   def ordered_edit_paths(reference)
     url_helpers = Rails.application.routes.url_helpers
     [
-      url_helpers.candidate_interface_decoupled_references_edit_name_path(reference),
-      url_helpers.candidate_interface_decoupled_references_edit_email_address_path(reference),
-      url_helpers.candidate_interface_decoupled_references_edit_type_path(reference),
-      url_helpers.candidate_interface_decoupled_references_edit_relationship_path(reference),
+      url_helpers.candidate_interface_decoupled_references_edit_name_path(
+        reference, return_to: :review
+      ),
+      url_helpers.candidate_interface_decoupled_references_edit_email_address_path(
+        reference, return_to: :review
+      ),
+      url_helpers.candidate_interface_decoupled_references_edit_type_path(
+        reference, return_to: :review
+      ),
+      url_helpers.candidate_interface_decoupled_references_edit_relationship_path(
+        reference, return_to: :review
+      ),
     ]
   end
 end

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Review references' do
     and_the_decoupled_references_flag_is_on
     and_i_have_added_references
     then_i_can_review_my_references_before_submission
+    and_i_can_edit_a_reference
     and_i_can_delete_a_reference
     and_i_can_return_to_the_application_page
   end
@@ -49,6 +50,21 @@ RSpec.feature 'Review references' do
       expect(page).not_to have_link 'Change'
       expect(page).not_to have_link 'Delete referee'
     end
+  end
+
+  def and_i_can_edit_a_reference
+    within '#references_waiting_to_be_sent' do
+      click_link 'Change name'
+    end
+
+    fill_in 'candidate-interface-reference-referee-name-form-name-field', with: 'John Major'
+    click_button 'Save and continue'
+
+    within '#references_waiting_to_be_sent' do
+      expect(page).to have_content 'John Major'
+    end
+
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
   end
 
   def and_i_can_delete_a_reference


### PR DESCRIPTION


## Context
When clicking the 'Change' link on any attribute displayed in the review
component, the candidate is sent to the corresponding edit page. As
currently implemented, saving any changes here redirects the candidate
to the summary screen at the end of the flow where they are prompted to
send the email request. This happens because this summary screen also
provides edit links for each attribute, and the default behaviour is to
return to this screen after any edit.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

What should happen is that the candidate returns to the review page if
that's where they initiated the edit. Achieve this by introducing a
`return_to` query param on each edit link in the review component, and
make all controllers in the decoupled references flow aware of this
param. If present, the `update` action in each controller redirects to
the value of the param, otherwise we redirect to the summary screen by
default.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Edit the attributes of a reference from the review page. You should be redirected back to the review page.
- Edit the attributes of a reference from the summary/send a request page you see when adding a reference. You should be redirected back to the summary after each edit.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/UnHaN661
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
