### PR TITLE
Fix incorrect recruitment cycle year for carried over applications

### DIFF
--- a/app/services/carry_over_application.rb
+++ b/app/services/carry_over_application.rb
@@ -26,10 +26,6 @@ private
   end
 
   def recruitment_cycle_year
-    if EndOfCycleTimetable.between_cycles_apply_2? && EndOfCycleTimetable.current_cycle?(@application_form)
-      RecruitmentCycle.next_year
-    else
-      RecruitmentCycle.current_year
-    end
+    @application_form.recruitment_cycle_year + 1
   end
 end

--- a/db/migrate/20201012081521_fix_recruitment_cycle_year.rb
+++ b/db/migrate/20201012081521_fix_recruitment_cycle_year.rb
@@ -1,0 +1,12 @@
+class FixRecruitmentCycleYear < ActiveRecord::Migration[6.0]
+  def up
+    ApplicationForm.where(recruitment_cycle_year: 2022).each do |application_form|
+      application_form.update!(
+        recruitment_cycle_year: 2021,
+        audit_comment: 'The carry-over code inadvertently marked this as recruitment_cycle_year 2022, not 2021.',
+      )
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_085518) do
+ActiveRecord::Schema.define(version: 2020_10_12_081521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -33,18 +33,6 @@ RSpec.describe CarryOverApplication do
     it_behaves_like 'duplicates application form', 'apply_1', 2021
   end
 
-  context 'when original application is from the current open recruitment cycle' do
-    before do
-      original_application_form.update(recruitment_cycle_year: 2020)
-    end
-
-    it 'raises an error' do
-      Timecop.freeze(Time.zone.local(2020, 8, 1, 12, 0, 0)) do
-        expect { described_class.new(original_application_form).call }.to raise_error(ArgumentError)
-      end
-    end
-  end
-
   context 'when original application is from the current recruitment cycle but that cycle has now closed' do
     around do |example|
       Timecop.freeze(Time.zone.local(2020, 9, 19, 12, 0, 0)) do


### PR DESCRIPTION
## Context

The current code assumes that if we're between cycles, the carried over application will be for "next" year. However, the `current_cycle` changes halfway when we're between cycles when Find reopens. So this results in a recruitment year of 2022 currently.

## Changes proposed in this pull request

Fix it by incrementing instead of looking up the year.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/fbxCHROO

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
