### PR TITLE
Display UCAS match course details when course is not on Apply

### DIFF
--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -5,11 +5,21 @@ class UCASMatchedApplication
   end
 
   def course
-    Course.find_by(
+    course = Course.find_by(
       code: @matching_data['Course code'],
       provider: Provider.find_by(code: @matching_data['Provider code']),
       recruitment_cycle_year: @recruitment_cycle_year,
     )
+
+    if course.nil?
+      OpenStruct.new(
+        code: @matching_data['Course code'],
+        name: @matching_data['Course name'],
+        provider: Provider.find_by(code: @matching_data['Provider code']),
+      )
+    else
+      course
+    end
   end
 
   def scheme

--- a/spec/components/support_interface/ucas_match_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_table_component_spec.rb
@@ -9,11 +9,28 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
   let(:ucas_match_for_apply_application) { create(:ucas_match, scheme: 'D', application_form: application_form) }
   let(:ucas_match_for_ucas_application) { create(:ucas_match, scheme: 'U', ucas_status: :rejected, application_form: application_form) }
   let(:ucas_match) { create(:ucas_match, scheme: 'B', ucas_status: :rejected, application_form: application_form) }
+  let(:ucas_match_course_only_on_ucas) do
+    create(:ucas_match,
+           matching_data: [{
+             'Scheme' => 'U',
+             'Course code' => '123',
+             'Course name' => 'Not on Apply',
+             'Provider code' => course.provider.code.to_s,
+             'Apply candidate ID' => candidate.id.to_s,
+             'Withdrawns' => '1',
+           }])
+  end
 
-  it 'renders course choice details' do
+  it 'renders course choice details for a course on Apply' do
     result = render_inline(described_class.new(ucas_match))
 
     expect(result.css('td').first.text).to include("#{course.code} — #{course.name} — #{course.provider.name}")
+  end
+
+  it 'renders course choice details for a course not on Apply' do
+    result = render_inline(described_class.new(ucas_match_course_only_on_ucas))
+
+    expect(result.css('td').first.text).to include("123 — Not on Apply — #{course.provider.name}")
   end
 
   context 'when application is in both Apply and UCAS' do
@@ -47,10 +64,17 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
   end
 
   context 'when application is only on UCAS' do
-    it 'renders correct statuses' do
+    it 'renders correct statuses for a course on Apply' do
       result = render_inline(described_class.new(ucas_match_for_ucas_application))
 
       expect(result.css('td')[1].text).to include('Rejected')
+      expect(result.css('td')[2].text).to include('N/A')
+    end
+
+    it 'renders correct statuses for a course which is not on Apply' do
+      result = render_inline(described_class.new(ucas_match_course_only_on_ucas))
+
+      expect(result.css('td')[1].text).to include('Withdrawn')
       expect(result.css('td')[2].text).to include('N/A')
     end
 

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe UCASMatchedApplication do
 
       expect(ucas_matching_application.course).to eq(course)
     end
+
+    it 'returns the course details for a course which is not on Apply' do
+      ucas_matching_data =
+        { 'Scheme' => 'U',
+          'Course code' => '123',
+          'Course name' => 'Not on Apply',
+          'Provider code' => course.provider.code.to_s,
+          'Apply candidate ID' => candidate.id.to_s }
+      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+
+      expect(ucas_matching_application.course.code).to eq('123')
+      expect(ucas_matching_application.course.name).to eq('Not on Apply')
+      expect(ucas_matching_application.course.provider).to eq(course.provider)
+    end
   end
 
   describe '#status' do


### PR DESCRIPTION
## Context
Fixes https://sentry.io/organizations/dfe-bat/issues/1937345314/?project=1765973

<img width="874" alt="Screenshot 2020-10-12 at 10 53 40" src="https://user-images.githubusercontent.com/38078064/95732872-3e41ae00-0c79-11eb-8bca-d161a922e753.png">

This was happening for courses, which are not in Apply's db

## Changes proposed in this pull request

If a course is not on Apply, take details directly from UCAS matching data.

## Guidance to review


## Link to Trello card

https://trello.com/c/t6GQeL0D/2837-fix-ucas-matches-summary-in-support

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
