### PR TITLE
Prevent unnecessary checks for feature flag

### DIFF
--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -53,7 +53,7 @@ private
   end
 
   def trace_request?
-    FeatureFlag.active?('vendor_api_request_tracing') && vendor_api_path?
+    vendor_api_path? && FeatureFlag.active?('vendor_api_request_tracing')
   end
 
   def vendor_api_path?


### PR DESCRIPTION
If we swap the conditionals, we won't check the feature flag in normal requests. This saves a database query.