### PR TITLE
Add service object for sending decoupled references emails

### DIFF
--- a/app/controllers/candidate_interface/decoupled_references/candidate_name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/candidate_name_controller.rb
@@ -17,9 +17,7 @@ module CandidateInterface
 
         @reference_candidate_name_form.save(@reference)
 
-        # TODO: Refactor this to DRY wrt to RequestController
-        CandidateInterface::RequestReference.call(@reference)
-        flash[:success] = "Reference request sent to #{@reference.name}"
+        CandidateInterface::DecoupledReferences::RequestReference.call(@reference, flash)
         redirect_to candidate_interface_decoupled_references_review_path
       end
 

--- a/app/controllers/candidate_interface/decoupled_references/request_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/request_controller.rb
@@ -16,8 +16,7 @@ module CandidateInterface
 
       def create
         if request_now?
-          CandidateInterface::RequestReference.call(@reference)
-          flash[:success] = "Reference request sent to #{@reference.name}"
+          CandidateInterface::DecoupledReferences::RequestReference.call(@reference, flash)
         end
         redirect_to candidate_interface_decoupled_references_review_path
       end

--- a/app/services/candidate_interface/decoupled_references/request_reference.rb
+++ b/app/services/candidate_interface/decoupled_references/request_reference.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  module DecoupledReferences
+    class RequestReference
+      def self.call(reference, flash)
+        if reference.not_requested_yet?
+          RefereeMailer.reference_request_email(reference).deliver_later
+          reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
+          flash[:success] = "Reference request sent to #{reference.name}"
+        else
+          flash[:warning] = "Reference request already sent to #{reference.name}"
+        end
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -38,6 +38,9 @@ RSpec.feature 'Candidate requests a reference' do
     then_i_see_a_confirmation_message
     and_the_reference_is_moved_to_the_requested_state
     and_an_email_is_sent_to_the_referee
+    when_i_navigate_back_to_a_stale_confirmation_page
+    and_i_confirm_that_i_am_ready_to_send_a_reference_request
+    then_i_am_told_a_reference_has_already_been_sent
   end
 
   def given_i_am_signed_in
@@ -129,5 +132,15 @@ RSpec.feature 'Candidate requests a reference' do
   def and_i_confirm_that_i_am_ready_to_send_a_reference_request
     expect(page).to have_content('Are you ready to send a reference request?')
     click_button 'Yes I’m sure - send my reference request'
+  end
+
+  def when_i_navigate_back_to_a_stale_confirmation_page
+    visit candidate_interface_decoupled_references_new_request_path(@reference)
+  end
+
+  def then_i_am_told_a_reference_has_already_been_sent
+    expect(page).to have_content "Reference request already sent to #{@reference.name}"
+    reference_requests = all_emails.select { |e| e.to.shift == @reference.email_address }
+    expect(reference_requests.count).to eq 1
   end
 end


### PR DESCRIPTION

## Context
Currently, if a candidate navigates back to a stale page that asks them
to confirm if they want to send a reference request email, and they
click 'yes', we send an email each time. We want to put a check in place
to ensure only one email may be sent per referee.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Introduce a separate service object to accommodate the change in behaviour
from the existing SendReferenceRequest.

Differences in this implementation:

- Pass the flash object in to conditionally set success/failure messages
- Check the state of the reference and then either send the request or
  set a failure message.
## Guidance to review
- Brand new app, no first/last name filled in. Add a reference. Don't send it yet. Click 'Send request' on the review page. Fill in names and confirm send. Click back button and confirm again. Should see error and only one email should be sent.
- Add another reference and repeat the above (same flow, except name form won't appear). 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/Bt876U5Q
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
