### PR TITLE
Cache requests to Find for 5 minutes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
       i18n (>= 1.6, < 2)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.12.2)
@@ -524,6 +526,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  faraday-http-cache
   govuk_design_system_formbuilder (~> 1.2.9)
   guard-rspec
   holidays

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,8 +141,6 @@ GEM
       i18n (>= 1.6, < 2)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (2.2.0)
-      faraday (>= 0.8)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     ffi (1.12.2)
@@ -526,7 +524,6 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  faraday-http-cache
   govuk_design_system_formbuilder (~> 1.2.9)
   guard-rspec
   holidays

--- a/app/models/find_api/resource.rb
+++ b/app/models/find_api/resource.rb
@@ -4,3 +4,24 @@ module FindAPI
     self.connection_options = { headers: { user_agent: 'Apply for teacher training' } }
   end
 end
+
+require 'faraday/logging/formatter'
+
+class APIRequestLoggingFormatter < Faraday::Logging::Formatter
+  # Don't do logging when the request starts
+  def request(env); end
+
+  def response(env)
+    info('Response') do
+      {
+        api_request_url: "#{env.method.upcase} #{env.url}",
+        response_status: env.status,
+        runtime_ms: (env.response_headers['x-runtime'].to_f * 1000).to_i,
+      }
+    end
+  end
+end
+
+FindAPI::Resource.connection do |connection|
+  connection.use Faraday::Response::Logger, Rails.logger, formatter: APIRequestLoggingFormatter
+end

--- a/app/models/find_api/resource.rb
+++ b/app/models/find_api/resource.rb
@@ -1,5 +1,6 @@
 module FindAPI
   class Resource < JsonApiClient::Resource
     self.site = ENV.fetch('FIND_BASE_URL')
+    self.connection_options = { headers: { user_agent: 'Apply for teacher training' } }
   end
 end

--- a/app/services/candidate_interface/apply_from_find_page.rb
+++ b/app/services/candidate_interface/apply_from_find_page.rb
@@ -21,7 +21,7 @@ module CandidateInterface
         @course_on_find = true
       end
     rescue ActiveRecord::RecordNotFound
-      @course = FindAPI::Course.fetch(@provider_code, @course_code)
+      @course = fetch_course_from_api
       @course_on_find = true if @course.present?
     end
 
@@ -37,6 +37,12 @@ module CandidateInterface
 
     def pilot_open?
       FeatureFlag.active?('pilot_open')
+    end
+
+    def fetch_course_from_api
+      Rails.cache.fetch ['course-api-request', @provider_code, @course_code], expires_in: 5.minutes do
+        FindAPI::Course.fetch(@provider_code, @course_code)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

We're launching the new cycle tomorrow, and we're expecting higher traffic than normal. One of the first pages that users will hit is the "Apply from Find" page (eg. https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?courseCode=2QW6&providerCode=G48). This page makes a request to the Find API if it can't find the course locally.

## Changes proposed in this pull request

Cache the response for 5 minutes, so we avoid hammering the API if there's a lot of traffic.

Also implements better logging - we'll be able to see outgoing API requests in Logit.

## Guidance to review

Ok?

## Link to Trello card

Not sure, @tvararu ?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
