### PR TITLE
Correct form label sizes and weights

### DIFF
--- a/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
@@ -3,12 +3,12 @@
   <%= f.govuk_radio_button :have_naric_reference, 'yes', label: { text: 'Yes' } do %>
     <%= f.govuk_text_field(
       :naric_reference,
-      label: { text: t('application_form.degree.naric_reference.label'), size: 'm' },
+      label: { text: t('application_form.degree.naric_reference.label'), size: 's' },
       hint_text: t('application_form.degree.naric_reference.hint_text')
     ) %>
     <%= f.govuk_radio_buttons_fieldset(
       :comparable_uk_degree,
-      legend: { text: t('application_form.degree.comparable_uk_degree.label'), size: 'm' },
+      legend: { text: t('application_form.degree.comparable_uk_degree.label'), size: 's' },
       hint_text: t('application_form.degree.comparable_uk_degree.hint_text'),
     ) do %>
       <%  ApplicationQualification.comparable_uk_degrees.values.each do |value| %>

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -12,7 +12,7 @@
     <%= f.govuk_radio_button :uk_degree, 'no', label: { text: t('application_form.degree.non_uk_degree.label') } do %>
       <%= f.govuk_text_field(
         :international_type_description,
-        label: { text: t('application_form.degree.international_qualification_type.label'), size: 'm' },
+        label: { text: t('application_form.degree.international_qualification_type.label'), size: 's' },
         hint_text: t('application_form.degree.international_qualification_type.hint_text')
       ) %>
     <% end %>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -38,7 +38,7 @@
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label') }, rows: 8, max_words: 200 %>
+          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label'), size: 's' }, rows: 8, max_words: 200 %>
         <% end %>
 
         <%= f.govuk_radio_button :any_preferences, 'no', label: { text: 'No' } %>


### PR DESCRIPTION
## Context

## Changes proposed in this pull request

* Use small label size for NARIC question in degree flow (match that used in corresponding GCSE flow)
* Use small label size for international type question in degree flow (match that used in corresponding GCSE flow)
* Use small label size for interview needs (match that used in similar disability/safeguarding questions)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
