### PR TITLE
Downcase referee emails when saving

### DIFF
--- a/app/forms/candidate_interface/reference/referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/referee_email_address_form.rb
@@ -14,7 +14,7 @@ module CandidateInterface
 
     def self.build_from_reference(reference)
       new(
-        email_address: reference.email_address,
+        email_address: reference.email_address.downcase,
         reference_id: reference.id,
       )
     end

--- a/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :mo
 
   describe '.build_from_reference' do
     it 'creates an object based on the reference' do
-      application_reference = create(:reference, email_address: 'iamtheone@whoknocks.com')
+      application_reference = create(:reference, email_address: 'iAmTheOne@whoknocks.com')
       form = described_class.build_from_reference(application_reference)
 
       expect(form.email_address).to eq('iamtheone@whoknocks.com')


### PR DESCRIPTION
## Context

Emails should be downcased when submitted.

## Changes proposed in this pull request

Add a `.downcase` call when building the form object.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/jorKBGZt/2324-save-case-insensitive-email-for-referees

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)