### PR TITLE
Fix the decoupled references link from the application page

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -118,6 +118,14 @@ module CandidateInterface
       @application_form.work_history_completed
     end
 
+    def references_path
+      if @application_form.application_references.present?
+        Rails.application.routes.url_helpers.candidate_interface_decoupled_references_review_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_decoupled_references_start_path
+      end
+    end
+
     def work_experience_path
       if @application_form.application_work_experiences.any? || @application_form.work_history_explanation.present?
         Rails.application.routes.url_helpers.candidate_interface_work_history_show_path

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -118,6 +118,14 @@ module CandidateInterface
       @application_form.work_history_completed
     end
 
+    def references_link_text
+      if @application_form.application_references.present?
+        'Manage your references'
+      else
+        'Add your references'
+      end
+    end
+
     def references_path
       if @application_form.application_references.present?
         Rails.application.routes.url_helpers.candidate_interface_decoupled_references_review_path

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -53,7 +53,7 @@
         <li class="app-task-list__item">
           <%= render(
             TaskListItemComponent.new(
-              text: 'Add your references',
+              text: @application_form_presenter.references_link_text,
               completed: @application_form_presenter.enough_references_provided?,
               path: @application_form_presenter.references_path,
             )

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -54,8 +54,8 @@
           <%= render(
             TaskListItemComponent.new(
               text: 'Add your references',
-              completed: @application_form_presenter.all_referees_provided_by_candidate?,
-              path: candidate_interface_decoupled_references_start_path, submitted: false
+              completed: @application_form_presenter.enough_references_provided?,
+              path: @application_form_presenter.references_path,
             )
           ) %>
         </li>

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -694,6 +694,28 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#references_link_text' do
+    context 'no references present' do
+      let(:application_form) { create(:application_form) }
+
+      it 'returns the correct link text' do
+        presenter = described_class.new(application_form)
+        expect(presenter.references_link_text).to eq 'Add your references'
+      end
+    end
+
+    context 'references present' do
+      let(:application_form) { create(:application_form) }
+
+      before { create(:reference, application_form: application_form) }
+
+      it 'returns the correct link text' do
+        presenter = described_class.new(application_form)
+        expect(presenter.references_link_text).to eq 'Manage your references'
+      end
+    end
+  end
+
   describe '#references_path' do
     context 'no references present' do
       let(:application_form) { create(:application_form) }

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -693,4 +693,26 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       expect(presenter).not_to be_no_incomplete_qualifications
     end
   end
+
+  describe '#references_path' do
+    context 'no references present' do
+      let(:application_form) { create(:application_form) }
+
+      it 'is the references start page' do
+        presenter = described_class.new(application_form)
+        expect(presenter.references_path).to eq Rails.application.routes.url_helpers.candidate_interface_decoupled_references_start_path
+      end
+    end
+
+    context 'references present' do
+      let(:application_form) { create(:application_form) }
+
+      before { create(:reference, application_form: application_form) }
+
+      it 'is the references review page' do
+        presenter = described_class.new(application_form)
+        expect(presenter.references_path).to eq Rails.application.routes.url_helpers.candidate_interface_decoupled_references_review_path
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Review references' do
     then_the_references_section_is_incomplete
 
     when_i_have_added_references
-    then_the_references_section_is_incomplete
+    then_the_references_section_is_still_incomplete
 
     when_enough_references_have_been_given
     then_the_references_section_is_complete
@@ -39,6 +39,13 @@ RSpec.feature 'Review references' do
     end
   end
 
+  def then_the_references_section_is_still_incomplete
+    when_i_view_my_application
+    within '#manage-your-references-badge-id' do
+      expect(page).to have_content 'Incomplete'
+    end
+  end
+
   def when_i_have_added_references
     application_form = current_candidate.current_application
     @complete_reference = create(:reference, :complete, application_form: application_form)
@@ -53,13 +60,13 @@ RSpec.feature 'Review references' do
 
   def then_the_references_section_is_complete
     when_i_view_my_application
-    within '#add-your-references-badge-id' do
+    within '#manage-your-references-badge-id' do
       expect(page).to have_content 'Complete'
     end
   end
 
   def and_i_can_review_my_references_before_submission
-    click_link 'Add your references'
+    click_link 'Manage your references'
     expect(page).to have_current_path candidate_interface_decoupled_references_review_path
 
     within '#references_given' do

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -6,8 +6,15 @@ RSpec.feature 'Review references' do
   scenario 'the candidate has several references in different states' do
     given_i_am_signed_in
     and_the_decoupled_references_flag_is_on
-    and_i_have_added_references
-    then_i_can_review_my_references_before_submission
+    when_i_view_my_application
+    then_the_references_section_is_incomplete
+
+    when_i_have_added_references
+    then_the_references_section_is_incomplete
+
+    when_enough_references_have_been_given
+    then_the_references_section_is_complete
+    and_i_can_review_my_references_before_submission
     and_i_can_edit_a_reference
     and_i_can_delete_a_reference
     and_i_can_return_to_the_application_page
@@ -21,7 +28,18 @@ RSpec.feature 'Review references' do
     FeatureFlag.activate('decoupled_references')
   end
 
-  def and_i_have_added_references
+  def when_i_view_my_application
+    visit candidate_interface_application_form_path
+  end
+
+  def then_the_references_section_is_incomplete
+    when_i_view_my_application
+    within '#add-your-references-badge-id' do
+      expect(page).to have_content 'Incomplete'
+    end
+  end
+
+  def when_i_have_added_references
     application_form = current_candidate.current_application
     @complete_reference = create(:reference, :complete, application_form: application_form)
     @not_sent_reference = create(:reference, :unsubmitted, application_form: application_form)
@@ -29,8 +47,20 @@ RSpec.feature 'Review references' do
     @refused_reference = create(:reference, :refused, application_form: application_form)
   end
 
-  def then_i_can_review_my_references_before_submission
-    visit candidate_interface_decoupled_references_review_path
+  def when_enough_references_have_been_given
+    create(:reference, :complete, application_form: current_candidate.current_application)
+  end
+
+  def then_the_references_section_is_complete
+    when_i_view_my_application
+    within '#add-your-references-badge-id' do
+      expect(page).to have_content 'Complete'
+    end
+  end
+
+  def and_i_can_review_my_references_before_submission
+    click_link 'Add your references'
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
 
     within '#references_given' do
       expect(page).to have_content @complete_reference.email_address


### PR DESCRIPTION
Fix the decoupled references link from the application page

- Link to the start page if no references present. Link to the review page
  if at least one reference present.
- Make sure the Incomplete/Complete label next to the link is correct,
  based on how many complete references are present.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Check the link to the references section on the application form page:

![Screenshot_20201012_160926](https://user-images.githubusercontent.com/519250/95762251-5b8c7180-0ca5-11eb-8c64-c0d8a3ccc47d.png)

- Should link to start page if no references, review page once a reference has been added.
- Should switch to Complete once two references given.



<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
