### PR TITLE
MVP performance statistics for the new cycle

### DIFF
--- a/app/controllers/integrations/performance_dashboard_controller.rb
+++ b/app/controllers/integrations/performance_dashboard_controller.rb
@@ -1,7 +1,9 @@
 module Integrations
   class PerformanceDashboardController < ApplicationController
     def dashboard
-      @statistics = PerformanceStatistics.new
+      raise ArgumentError unless params[:year].in?([nil, '2020', '2021'])
+
+      @statistics = PerformanceStatistics.new(params[:year])
     end
   end
 end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -1,5 +1,13 @@
 class PerformanceStatistics
+  attr_reader :year
+
+  def initialize(year)
+    @year = year
+  end
+
   def candidate_query
+    year_clause = year ? "AND f.recruitment_cycle_year = #{year}" : ''
+
     <<-SQL
       WITH raw_data AS (
           SELECT
@@ -29,6 +37,7 @@ class PerformanceStatistics
               application_choices ch ON ch.application_form_id = f.id
           WHERE
               NOT c.hide_in_reporting
+              #{year_clause}
           GROUP BY
               c.id, f.id
       )

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -1,12 +1,24 @@
 <% content_for :title, 'Service performance' %>
 
-<h1 class='govuk-heading-xl'>Service performance</h1>
+<% if params[:screen] == "1" %>
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Performance for <%= params[:year] || "all cycles" %></h1>
+<% else %>
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Service performance</h1>
 
-<p class='govuk-body'>
-  <%= govuk_link_to 'View in large screen mode', '?screen=1' unless params[:screen] %>
-</p>
+  <p class="govuk-body govuk-!-margin-bottom-8">
+    <%= govuk_link_to 'View in large screen mode', '?screen=1' %>
+  </p>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27">Candidates</h2>
+  <%= render TabNavigationComponent.new(items: [
+    { name: 'All years', url: "?screen=#{params[:screen] || 0}", current: params[:year] == nil },
+    { name: '2020 to 2021', url: "?year=2020&screen=#{params[:screen] || 0}", current: params[:year] == '2020' },
+    { name: '2021 to 2022', url: "?year=2021&screen=#{params[:screen] || 0}", current: params[:year] == '2021' },
+  ]) %>
+
+  <h2 class="govuk-visually-hidden">Performance for <%= params[:year] || "all years" %></h2>
+<% end %>
+
+<h3 class="govuk-heading-m">Candidates</h3>
 
 <div id="headline-stat" class="govuk-!-margin-bottom-4">
   <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count, label: 'sign ups (excluding test users)', colour: :blue) %>
@@ -50,36 +62,34 @@
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-top-4">
-  <div class="govuk-grid-column-full">
-    <table class="govuk-table">
-      <caption class="govuk-table__caption">Candidate breakdown</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Status</th>
-          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Count</th>
-          <th scope="col" class="govuk-table__header">Description</th>
-        </tr>
-      </thead>
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <tbody class="govuk-table__body">
-        <% @statistics.candidate_status_counts.each do |row| %>
-          <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>
-            <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-heading-m">Candidate breakdown</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Count</th>
+      <th scope="col" class="govuk-table__header">Description</th>
+    </tr>
+  </thead>
 
-<% if params[:screen] %>
-<style media="screen">
-  header, footer, .govuk-phase-banner { display: none; }
-  .govuk-width-container { max-width: 99%; }
-</style>
+  <tbody class="govuk-table__body">
+    <% @statistics.candidate_status_counts.each do |row| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>
+        <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
 
-<meta http-equiv="refresh" content="60">
+<% if params[:screen] == "1" %>
+  <style media="screen">
+    header, footer, .govuk-phase-banner { display: none; }
+    .govuk-width-container { max-width: 99%; }
+  </style>
+
+  <meta http-equiv="refresh" content="60">
 <% end %>

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -109,15 +109,26 @@ RSpec.describe PerformanceStatistics, type: :model do
       create(:application_choice, status: 'recruited')
       create(:application_choice, status: 'pending_conditions')
 
-      stats = PerformanceStatistics.new
+      stats = PerformanceStatistics.new(nil)
 
       expect(stats.total_candidate_count(only: %i[recruited])).to eq(2)
       expect(stats.total_candidate_count(except: %i[pending_conditions])).to eq(2)
     end
   end
 
+  describe '#initialize' do
+    it 'can filter by year' do
+      create(:application_choice, status: 'recruited', application_form: create(:application_form, recruitment_cycle_year: 2020))
+      create(:application_choice, status: 'recruited', application_form: create(:application_form, recruitment_cycle_year: 2021))
+
+      stats = PerformanceStatistics.new(2021)
+
+      expect(stats.total_candidate_count).to eq(1)
+    end
+  end
+
   def count_for_process_state(process_state)
-    PerformanceStatistics.new[process_state]
+    PerformanceStatistics.new(nil)[process_state]
   end
 
   it 'excludes candidates marked as hidden from reporting' do
@@ -126,7 +137,7 @@ RSpec.describe PerformanceStatistics, type: :model do
     create(:application_form, candidate: hidden_candidate)
     create(:application_form, candidate: visible_candidate)
 
-    stats = PerformanceStatistics.new
+    stats = PerformanceStatistics.new(nil)
 
     expect(stats.total_candidate_count).to eq(1)
   end


### PR DESCRIPTION
## Context

Our stats are across all cycles, and tomorrow we'll start a new cycle. This allows us to filter the stats per year.

## Changes proposed in this pull request

Very functional MVP - UI should be improved (wink wink @paulrobertlloyd).

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/233676/95763893-998a9500-0ca7-11eb-804c-906ffc9d28ac.png)

![image](https://user-images.githubusercontent.com/233676/95763909-9ee7df80-0ca7-11eb-857b-fec0364be3f7.png)


## Guidance to review

Works?

## Link to Trello card

https://trello.com/c/F2cGQ9Di/2280-re-set-performance-dashboard-for-new-cycle

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
