### PR TITLE
Fix to prevent candidates sending request to incomplete reference

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -14,7 +14,7 @@
               <% end %>
             </li>
           <% end %>
-          <% if reference.not_requested_yet? %>
+          <% if can_send?(reference) %>
             <li class="app-summary-card__actions-list-item">
               <%= link_to candidate_interface_decoupled_references_new_request_path(reference.id), class: 'govuk-link' do %>
                 <%= t('application_form.referees.send_request') %>

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -21,6 +21,14 @@ module CandidateInterface
       ].compact
     end
 
+    def can_send?(reference)
+      reference.not_requested_yet? &&
+        CandidateInterface::Reference::SubmitRefereeForm.new(
+          submit: 'yes',
+          reference_id: reference.id
+        ).valid?
+    end
+
   private
 
     def formatted_reference_type(reference)

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -25,7 +25,7 @@ module CandidateInterface
       reference.not_requested_yet? &&
         CandidateInterface::Reference::SubmitRefereeForm.new(
           submit: 'yes',
-          reference_id: reference.id
+          reference_id: reference.id,
         ).valid?
     end
 

--- a/app/controllers/candidate_interface/decoupled_references/request_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/request_controller.rb
@@ -10,6 +10,8 @@ module CandidateInterface
       end
 
       def new
+        render_404 and return unless can_send?
+
         @request_form = Reference::RequestForm.build_from_reference(@reference)
         @request_form.request_now = 'yes'
       end
@@ -22,6 +24,13 @@ module CandidateInterface
       end
 
     private
+
+      def can_send?
+        CandidateInterface::Reference::SubmitRefereeForm.new(
+          submit: 'yes',
+          reference_id: @reference.id,
+        ).valid?
+      end
 
       def prompt_for_candidate_name_if_not_already_given
         if request_now? &&

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -100,17 +100,30 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
   end
 
-  context 'when reference state is "not_requested_yet"' do
+  context 'when reference state is "not_requested_yet" and the reference is complete' do
     let(:feedback_requested) { create(:reference, :requested) }
     let(:not_requested_yet) { create(:reference, :not_requested_yet) }
 
     it 'a send request link is available' do
+      FeatureFlag.activate(:decoupled_references)
       result = render_inline(described_class.new(references: [feedback_requested, not_requested_yet]))
 
       feedback_requested_summary = result.css('.app-summary-card')[0]
-      feedback_refused_summary = result.css('.app-summary-card')[1]
+      feedback_not_requested_summary = result.css('.app-summary-card')[1]
       expect(feedback_requested_summary.text).not_to include 'Send request'
-      expect(feedback_refused_summary.text).to include 'Send request'
+      expect(feedback_not_requested_summary.text).to include 'Send request'
+    end
+  end
+
+  context 'when reference state is "not_requested_yet" and the reference is incomplete' do
+    let(:not_requested_yet) { create(:reference, :not_requested_yet, name: nil) }
+
+    it 'a send request link is NOT available' do
+      FeatureFlag.activate(:decoupled_references)
+      result = render_inline(described_class.new(references: [not_requested_yet]))
+
+      feedback_not_requested_summary = result.css('.app-summary-card')[0]
+      expect(feedback_not_requested_summary.text).not_to include 'Send request'
     end
   end
 

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -41,6 +41,12 @@ RSpec.feature 'Candidate requests a reference' do
     when_i_navigate_back_to_a_stale_confirmation_page
     and_i_confirm_that_i_am_ready_to_send_a_reference_request
     then_i_am_told_a_reference_has_already_been_sent
+
+    when_i_have_added_an_incomplete_reference
+    and_i_visit_the_reference_review_page
+    then_i_should_not_see_a_send_reference_link
+    when_i_navigate_to_the_send_request_page
+    then_i_should_see_a_not_found_message
   end
 
   def given_i_am_signed_in
@@ -57,8 +63,7 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def and_i_visit_the_reference_review_page
-    # TODO: Navigate to the last page of the reference creation flow
-    visit candidate_interface_decoupled_references_start_request_path(@reference.id)
+    visit candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
   end
 
   def and_i_choose_to_request_reference_immediately
@@ -142,5 +147,21 @@ RSpec.feature 'Candidate requests a reference' do
     expect(page).to have_content "Reference request already sent to #{@reference.name}"
     reference_requests = all_emails.select { |e| e.to.shift == @reference.email_address }
     expect(reference_requests.count).to eq 1
+  end
+
+  def when_i_have_added_an_incomplete_reference
+    @reference = create(:reference, :unsubmitted, name: nil, application_form: @application_form)
+  end
+
+  def then_i_should_not_see_a_send_reference_link
+    expect(page).not_to have_link('Send request')
+  end
+
+  def when_i_navigate_to_the_send_request_page
+    visit candidate_interface_decoupled_references_new_request_path(@reference)
+  end
+
+  def then_i_should_see_a_not_found_message
+    expect(page).to have_content('Page not found')
   end
 end


### PR DESCRIPTION
## Context

It's possible to create a reference in an incomplete state - e.g. without an email address and/or name. Candidates should not be able to invoke the _Send request_ function on incomplete references.

## Changes proposed in this pull request

- [x] Change the `DecoupledReferencesReviewComponent` to hide the _Send request_ link for incomplete references.
- [x] Return a 404 from the Send request form for incomplete references (if the candidate gets there somehow).

## Guidance to review

- It should be possible to test manually by bailing out of the new create reference flow before entering a name/email address and visiting `/candidate/application/references/review`
- Are there any other loopholes to plug?

## Link to Trello card

?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
