### PR TITLE
Don't create test UCAS matches for applications in the next cycle

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -148,7 +148,7 @@ class TestApplications
           put_application_choice_in_state(application_choice, state)
         end
 
-        FactoryBot.create(:ucas_match, application_form: @application_form) if rand < 0.5
+        FactoryBot.create(:ucas_match, application_form: @application_form) if (courses_to_apply_to.map(&:recruitment_cycle_year).uniq == [Time.zone.now.year]) && rand < 0.7
       end
 
       application_choices.each do |application_choice|

--- a/app/services/generate_test_data.rb
+++ b/app/services/generate_test_data.rb
@@ -45,6 +45,7 @@ class GenerateTestData
           )
         end
 
+        application_form.reload
         FactoryBot.create(:ucas_match, application_form: application_form) if rand < 0.5
       end
     end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe TestApplications do
     }.to raise_error(/You cannot have zero courses per application/)
   end
 
+  it 'does not create UCAS match for applications in the next cycle' do
+    srand(1)
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: Time.zone.now.year + 1))
+    TestApplications.new.create_application(states: %i[offer])
+
+    expect(UCASMatch.count).to eq(0)
+  end
+
   describe 'supplying our own courses' do
     it 'creates applications only for the supplied courses' do
       course_we_want = create(:course_option, course: create(:course, :open_on_apply)).course


### PR DESCRIPTION
## Context

UCAS matches page was breaking because it relies on the fact that Course's recruitment cycle year has to be the same at the year UCAS match was created in. 

## Changes proposed in this pull request

When generating test applications we don't want to create UCAS matches if application choices include courses in the next recruitment cycle year.

## Guidance to review

- visit `/support/tasks`
- click 'Generate test applications'
- visit `/support/ucas-matches`, all should work

## Link to Trello card

https://trello.com/c/t6GQeL0D/2837-fix-ucas-matches-summary-in-support

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
