### PR TITLE
Fix referee email address validation

### DIFF
--- a/app/forms/candidate_interface/reference/referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/referee_email_address_form.rb
@@ -14,7 +14,7 @@ module CandidateInterface
 
     def self.build_from_reference(reference)
       new(
-        email_address: reference.email_address.downcase,
+        email_address: reference.email_address&.downcase,
         reference_id: reference.id,
       )
     end
@@ -32,7 +32,7 @@ module CandidateInterface
       current_email_addresses = (reference.application_form.application_references.map(&:email_address) - [reference.email_address]).compact
       return true if current_email_addresses.blank?
 
-      errors.add(:email_address, :duplicate) if current_email_addresses.map(&:downcase).include?(email_address)
+      errors.add(:email_address, :duplicate) if current_email_addresses.map(&:downcase).include?(email_address.downcase)
     end
   end
 end

--- a/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
+++ b/spec/forms/candidate_interface/reference/referee_email_address_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::Reference::RefereeEmailAddressForm, type: :mo
         create(:reference, email_address: 'iamtheone@whoknocks.com', application_form: application_form)
         application_reference = create(:reference, email_address: nil, application_form: application_form)
 
-        form = described_class.new(email_address: 'iamtheone@whoknocks.com', reference_id: application_reference.id)
+        form = described_class.new(email_address: 'iAMtheone@whoknocks.com', reference_id: application_reference.id)
         expect(form.save(application_reference)).to be(false)
       end
     end


### PR DESCRIPTION
## Context

I missed downcasing the email the candidate inputs before comparing it with the addresses already used.

## Changes proposed in this pull request

- Downcase the email address provided
- Change the test to a duplicate email with upper case chars doesn't save 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
