### PR TITLE
Correct copy on delete reference confirmation page

### DIFF
--- a/app/views/candidate_interface/decoupled_references/review/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/confirm_destroy.html.erb
@@ -5,10 +5,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: candidate_interface_destroy_decoupled_reference_path(@reference), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
-        <%= t('page_titles.reference_destroy') %>
+        <%= t('page_titles.referee_destroy') %>
       </h1>
 
-      <%= f.submit 'Yes I’m sure - delete this reference request' , class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit 'Yes I’m sure - delete this referee' , class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
         <%= govuk_link_to 'No, I’ve changed my mind', candidate_interface_decoupled_references_review_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,7 +115,6 @@ en:
     referee_type: What kind of referee do you want to add?
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?
-    reference_destroy: Are you sure you want to delete this reference request?
     add_referee: Details of referee
     maximum_referees: You cannot add any more referees
     give_a_reference:


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Delete a reference on the review app - text should refer to the 'referee', not the 'reference request'.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
