### PR TITLE
Don't show additional referee interstitial/flow when decoupled references is active

### DIFF
--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class AdditionalRefereesController < CandidateInterfaceController
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     before_action :redirect_to_contact_support_if_at_maximum_reference_count, only: %i[type update_type new create]
+    before_action :redirect_to_dashboard_if_decoupled_reference_flag_as_active
 
     def type
       @page_title = page_title_for_new_page
@@ -197,6 +198,10 @@ module CandidateInterface
                         .application_references
                         .includes(:application_form)
                         .find(referee_id)
+    end
+
+    def redirect_to_dashboard_if_decoupled_reference_flag_as_active
+      redirect_to candidate_interface_application_form_path if FeatureFlag.active?(:decoupled_references)
     end
   end
 end

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -7,7 +7,7 @@ module CandidateInterface
       service.execute
 
       if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
-        if more_reference_needed?
+        if more_reference_needed? && !FeatureFlag.active?(:decoupled_references)
           redirect_to candidate_interface_additional_referee_path
         elsif current_candidate.current_application.blank_application?
           redirect_to candidate_interface_before_you_start_path

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe 'A Provider can sign in as a candidate' do
     then_i_am_redirected_to_the_candidate_interface
     and_i_see_a_flash_message
     and_i_am_logged_in_as_that_candidate
-
-    when_i_visit_that_application_in_the_provider_interface
-    and_the_application_has_a_referee_that_rejected_to_give_feedback
-    and_i_click_on_the_sign_in_button
-
-    then_i_am_redirected_to_the_candidate_additional_referee_path
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -57,13 +51,5 @@ RSpec.describe 'A Provider can sign in as a candidate' do
 
   def and_i_am_logged_in_as_that_candidate
     expect(page).to have_content(@candidate.email_address)
-  end
-
-  def and_the_application_has_a_referee_that_rejected_to_give_feedback
-    @application_choice.application_form.application_references << create(:reference, :refused)
-  end
-
-  def then_i_am_redirected_to_the_candidate_additional_referee_path
-    expect(page).to have_current_path(candidate_interface_additional_referee_path)
   end
 end

--- a/spec/system/support_interface/sign_in_as_candidate_spec.rb
+++ b/spec/system/support_interface/sign_in_as_candidate_spec.rb
@@ -9,12 +9,6 @@ RSpec.feature 'Sign in as candidate' do
     when_i_visit_the_application_form_page
     and_click_the_sign_in_button
     then_i_am_logged_in_as_the_candidate
-
-    when_i_visit_the_application_form_page
-    and_the_application_has_a_referee_that_rejected_to_give_feedback
-    and_click_the_sign_in_button
-
-    then_i_am_redirected_to_the_candidate_interface_additional_referee_path
   end
 
   def given_i_am_a_support_user
@@ -36,14 +30,5 @@ RSpec.feature 'Sign in as candidate' do
 
   def then_i_am_logged_in_as_the_candidate
     expect(page).to have_content 'You are now signed in as candidate'
-  end
-
-  def and_the_application_has_a_referee_that_rejected_to_give_feedback
-    @application.application_references << create(:reference, :refused)
-    @application.application_references << create(:reference, :refused)
-  end
-
-  def then_i_am_redirected_to_the_candidate_interface_additional_referee_path
-    expect(page).to have_current_path(candidate_interface_additional_referee_path)
   end
 end


### PR DESCRIPTION
## Context

Previous pr #3120 removes the post submission journey for replacing a referee.

When the decoupled references flag is active then there is no need to replace referees.

## Changes proposed in this pull request

This PR stops the interstitial page and redirects away from the additional referee page if the :decopled_references flag is active

## Guidance to review

All the additional referees' related code can go once the flag is removed.

Have I missed anything?

## Link to Trello card

https://trello.com/c/92zaVaUn/2320-%F0%9F%92%94-dev-interstitial-audit

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
