### PR TITLE
Restrict access to 'Update status of conditions' for recruited applications

### DIFF
--- a/app/components/provider_interface/status_box_components/recruited_component.html.erb
+++ b/app/components/provider_interface/status_box_components/recruited_component.html.erb
@@ -14,11 +14,5 @@
 
   <h3 class="govuk-heading-m">Conditions</h3>
 
-  <% if provider_can_respond %>
-  <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
-    <%= govuk_link_to 'Update status of conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-2 govuk-!-display-none-print' %>
-  </p>
-  <% end %>
-
   <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 </div>

--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -40,5 +40,11 @@ module ProviderInterface
 
       redirect_to provider_interface_application_choice_path(@application_choice.id)
     end
+
+    def check_application_status
+      unless @application_choice.pending_conditions?
+        redirect_to provider_interface_application_choice_path(@application_choice.id) and return
+      end
+    end
   end
 end

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -10,6 +10,10 @@ RSpec.feature 'Confirm conditions not met' do
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
 
+    when_i_navigate_to_a_conditions_met_application
+    and_i_navigate_to_the_offer_tab
+    then_i_cannot_update_the_status_of_conditions
+
     when_i_navigate_to_an_offer_accepted_by_the_candidate
     and_i_navigate_to_the_offer_tab
     and_click_on_confirm_conditions
@@ -54,12 +58,25 @@ RSpec.feature 'Confirm conditions not met' do
     visit provider_interface_application_choice_path(@application_choice.id)
   end
 
+  def when_i_navigate_to_a_conditions_met_application
+    conditions_met = create(
+      :application_choice,
+      :with_recruited,
+      course_option: course_option_for_provider_code(provider_code: @provider.code),
+    )
+    visit provider_interface_application_choice_path(conditions_met.id)
+  end
+
   def and_i_navigate_to_the_offer_tab
     click_on 'Offer'
   end
 
   def and_click_on_confirm_conditions
     click_on 'Update status of conditions'
+  end
+
+  def then_i_cannot_update_the_status_of_conditions
+    expect(page).not_to have_content 'Update status of conditions'
   end
 
   def and_select_they_have_not_met_the_conditions


### PR DESCRIPTION
## Context

Once an application reaches the `recruited` stage, we do not allow the (re-)confirming of conditions met/not met. The only valid transitions are to withdraw or defer the offer.

The UI, however, still shows the 'Update status of conditions' link and allows access to the relevant views, even though the final step will fail.

## Changes proposed in this pull request

Hide the link, restrict access to the relevant views.

## Guidance to review

Standard stuff.

## Link to Trello card

https://trello.com/c/NOtxTcq6

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
