### PR TITLE
Use consistent labelling for recruitment cycle years

### DIFF
--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -51,18 +51,10 @@ module ProviderInterface
     def recruitment_cycle_filter
       return nil unless FeatureFlag.active?(:providers_can_filter_by_recruitment_cycle)
 
-      current_year = RecruitmentCycle.current_year
-      previous_year = RecruitmentCycle.previous_year
-
-      label = {
-        current_year => "#{current_year - 1} to #{current_year} (Current)",
-        previous_year => "#{previous_year - 1} to #{previous_year}",
-      }
-
-      cycle_options = [current_year, previous_year].map do |year|
+      cycle_options = RecruitmentCycle::CYCLES.map do |year, label|
         {
           value: year,
-          label: label[year],
+          label: label,
           checked: applied_filters[:recruitment_cycle_year]&.include?(year.to_s),
         }
       end

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -55,7 +55,7 @@ module ProviderInterface
         {
           value: year,
           label: label,
-          checked: applied_filters[:recruitment_cycle_year]&.include?(year.to_s),
+          checked: applied_filters[:recruitment_cycle_year]&.include?(year),
         }
       end
 

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,8 +1,8 @@
 module RecruitmentCycle
   CYCLES = {
-    2021 => "2021 (current)",
-    2020 => "2020 (previous)",
-  }
+    '2021' => '2021 (current)',
+    '2020' => '2020 (previous)',
+  }.freeze
 
   def self.current_year
     if Time.zone.today < EndOfCycleTimetable.find_reopens

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,4 +1,9 @@
 module RecruitmentCycle
+  CYCLES = {
+    2021 => "2020 to 2021 (current)",
+    2020 => "2019 to 2020 (previous)",
+  }
+
   def self.current_year
     if Time.zone.today < EndOfCycleTimetable.find_reopens
       2020

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,7 +1,7 @@
 module RecruitmentCycle
   CYCLES = {
-    2021 => "2020 to 2021 (current)",
-    2020 => "2019 to 2020 (previous)",
+    2021 => "2021 (current)",
+    2020 => "2020 (previous)",
   }
 
   def self.current_year

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -35,22 +35,19 @@ module SupportInterface
   private
 
     def year_filter
+      cycle_options = RecruitmentCycle::CYCLES.map do |year, label|
+        {
+          value: year,
+          label: label,
+          checked: applied_filters[:year]&.include?(year.to_s),
+        }
+      end
+
       {
         type: :checkboxes,
         heading: 'Recruitment cycle year',
         name: 'year',
-        options: [
-          {
-            value: '2020',
-            label: '2020 to 2021',
-            checked: applied_filters[:year]&.include?('2020'),
-          },
-          {
-            value: '2021',
-            label: '2021 to 2022',
-            checked: applied_filters[:year]&.include?('2021'),
-          },
-        ],
+        options: cycle_options,
       }
     end
 

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -39,7 +39,7 @@ module SupportInterface
         {
           value: year,
           label: label,
-          checked: applied_filters[:year]&.include?(year.to_s),
+          checked: applied_filters[:year]&.include?(year),
         }
       end
 

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -10,7 +10,7 @@
   </p>
 
   <% year_choices = RecruitmentCycle::CYCLES.map do |year, label| %>
-    <% { name: label, url: "?year=#{year}&screen=#{params[:screen] || 0}", current: params[:year] == year.to_s } %>
+    <% { name: label, url: "?year=#{year}&screen=#{params[:screen] || 0}", current: params[:year] == year } %>
   <% end %>
 
   <%= render TabNavigationComponent.new(items: [

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -9,11 +9,13 @@
     <%= govuk_link_to 'View in large screen mode', '?screen=1' %>
   </p>
 
+  <% year_choices = RecruitmentCycle::CYCLES.map do |year, label| %>
+    <% { name: label, url: "?year=#{year}&screen=#{params[:screen] || 0}", current: params[:year] == year.to_s } %>
+  <% end %>
+
   <%= render TabNavigationComponent.new(items: [
     { name: 'All years', url: "?screen=#{params[:screen] || 0}", current: params[:year] == nil },
-    { name: '2020 to 2021', url: "?year=2020&screen=#{params[:screen] || 0}", current: params[:year] == '2020' },
-    { name: '2021 to 2022', url: "?year=2021&screen=#{params[:screen] || 0}", current: params[:year] == '2021' },
-  ]) %>
+  ] + year_choices ) %>
 
   <h2 class="govuk-visually-hidden">Performance for <%= params[:year] || "all years" %></h2>
 <% end %>

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -171,8 +171,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def and_i_expect_the_relevant_recruitment_cycle_tags_to_be_visible
-    current_year = RecruitmentCycle.current_year
-    tag_text = "#{current_year - 1} to #{current_year} (Current)"
+    tag_text = '2020 (previous)'
     expect(page).to have_css('.moj-filter-tags', text: tag_text)
   end
 


### PR DESCRIPTION
## Context

Some people on the team consider the current 2021 cycle to be the "2020 to 2021 cycle", others "2021 to 2022 cycle". I guess it comes down to the question if the cycle represents the year in which they are recruited, or that they attend the course.  

## Changes proposed in this pull request

Avoid the confusion alltogether by naming them "2021 (current)" and "2020 (previous)". Centralise the labelling so it's consistent across support and provider UI.

<img width="1089" alt="Screenshot 2020-10-13 at 11 41 39" src="https://user-images.githubusercontent.com/233676/95850651-1457bc80-0d49-11eb-90b9-ccf18f12b736.png">

## Guidance to review

Full Slack thread for posterity: https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1602583138300500
