### PR TITLE
Make "Applications" the first page in the support UI 

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -21,7 +21,7 @@ class NavigationItems
     def for_support_primary_nav(current_support_user, current_controller)
       if current_support_user
         [
-          NavigationItem.new('Candidates', support_interface_applications_path, is_active(current_controller, %w[candidates change_course import_references application_forms ucas_matches])),
+          NavigationItem.new('Applications', support_interface_applications_path, is_active(current_controller, %w[candidates change_course import_references application_forms ucas_matches])),
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses provider_users api_tokens])),
           NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance performance_data course_options email_log validation_errors])),
           NavigationItem.new('Settings', support_interface_feature_flags_path, is_active(current_controller, %w[feature_flags cycles support_users tasks])),

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -9,7 +9,7 @@ module SupportInterface
     def filter_records(application_forms)
       application_forms = application_forms
         .joins(:candidate)
-        .includes(:candidate, :application_choices)
+        .includes(:candidate, application_choices: [:course, :provider])
         .order(updated_at: :desc)
         .page(applied_filters[:page] || 1).per(15)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -696,7 +696,7 @@ Rails.application.routes.draw do
   end
 
   namespace :support_interface, path: '/support' do
-    get '/' => redirect('/support/candidates')
+    get '/' => redirect('/support/applications')
 
     get '/provider-flow', to: 'docs#provider_flow', as: :provider_flow
     get '/candidate-flow', to: 'docs#candidate_flow', as: :candidate_flow

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Add comments to the application history', with_audited: true do
   end
 
   def and_i_visit_the_support_page
-    visit support_interface_path
+    visit support_interface_candidates_path
   end
 
   def when_i_click_on_an_application

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'See application history', with_audited: true do
   end
 
   def and_i_visit_the_support_page
-    visit support_interface_path
+    visit support_interface_candidates_path
   end
 
   def when_i_click_on_an_application

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -185,7 +185,9 @@ RSpec.feature 'Providers and courses' do
   end
 
   def when_i_click_on_applications
-    click_link 'Applications'
+    within '#main-content' do
+      click_link 'Applications'
+    end
   end
 
   def then_i_see_the_provider_applications

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'See applications' do
   end
 
   def and_i_visit_the_support_page
-    visit support_interface_path
+    visit support_interface_candidates_path
   end
 
   def then_i_should_see_the_latest_applications
@@ -48,7 +48,9 @@ RSpec.feature 'See applications' do
   end
 
   def when_i_follow_the_link_to_applications
-    click_link 'Applications'
+    within '#main-content' do
+      click_link 'Applications'
+    end
   end
 
   def then_i_should_see_the_application_references

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'See an application' do
   end
 
   def and_i_visit_the_support_page
-    visit support_interface_path
+    visit support_interface_candidates_path
   end
 
   def when_i_click_on_a_completed_application
@@ -91,7 +91,7 @@ RSpec.feature 'See an application' do
   end
 
   def when_i_return_to_the_support_page
-    click_on 'Candidates', match: :prefer_exact
+    click_on 'Applications', match: :prefer_exact
   end
 
   def and_i_click_on_an_unsubmitted_application

--- a/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
+++ b/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Send survey email to candidate', with_audited: true do
   end
 
   def and_i_visit_the_support_page
-    visit support_interface_path
+    visit support_interface_candidates_path
   end
 
   def when_i_click_on_the_application

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature 'See UCAS matches' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
     and_there_are_ucas_matches_in_the_system
-    and_i_visit_the_support_page
 
     when_i_go_to_ucas_matches_page
     then_i_should_see_list_of_ucas_matches
@@ -48,10 +47,6 @@ RSpec.feature 'See UCAS matches' do
         'Provider code' => @course2.provider.code.to_s,
       }
     create(:ucas_match, matching_state: 'new_match', application_form: @application_form, matching_data: [ucas_matching_data, dfe_matching_data])
-  end
-
-  def and_i_visit_the_support_page
-    visit support_interface_path
   end
 
   def when_i_go_to_ucas_matches_page


### PR DESCRIPTION
## Context

This page is much more used, and is already the first element in the navigation.

## Changes proposed in this pull request

- Redirect /support to /support/applications (instead of /support/candidates)
- Rename "Candidates" in the primary nav to "Applications"

## Guidance to review

OK?

