### PR TITLE
Add pagination to audit history pages in support

### DIFF
--- a/app/components/support_interface/audit_trail_component.html.erb
+++ b/app/components/support_interface/audit_trail_component.html.erb
@@ -12,3 +12,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= render(PaginatorComponent.new(scope: audits)) %>

--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -15,7 +15,7 @@ module SupportInterface
                  standard_audits
                end
 
-      audits.includes(:user).order('id desc')
+      audits.includes(:user).order('id desc').page(params[:page] || 1).per(30)
     end
 
     attr_reader :audited_thing


### PR DESCRIPTION
## Context

The provider history pages includes all changes to courses, and are becoming very slow.

![image](https://user-images.githubusercontent.com/233676/95855754-ce9ef200-0d50-11eb-80ff-e6e14b3d6983.png)


## Changes proposed in this pull request

Add pagination to all audits. Didn't seem necessary to add tests.

(with 5 page limit:)

![image](https://user-images.githubusercontent.com/233676/95855809-e6767600-0d50-11eb-83eb-18324b0b532f.png)
