### PR TITLE
Support: Refactor provider user

### DIFF
--- a/app/components/support_interface/provider_user_permissions_component.html.erb
+++ b/app/components/support_interface/provider_user_permissions_component.html.erb
@@ -1,0 +1,6 @@
+<% @provider_user.provider_permissions.includes(:provider, provider: [:ratifying_provider_permissions, :training_provider_permissions]).each do |permission| %>
+  <section class="govuk-!-margin-bottom-2">
+    <h3 class="govuk-heading-s"><%= permission.provider.name_and_code %></h3>
+    <%= render PermissionsListComponent.new(permission, user_is_viewing_their_own_permissions: false) %>
+  </section>
+<% end %>

--- a/app/components/support_interface/provider_user_permissions_component.rb
+++ b/app/components/support_interface/provider_user_permissions_component.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class ProviderUserPermissionsComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(provider_user:)
+      @provider_user = provider_user
+    end
+  end
+end

--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -4,7 +4,7 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name and email address</th>
         <th scope="col" class="govuk-table__header">Providers</th>
-        <th scope="col" class="govuk-table__header">Last signed in at</th>
+        <th scope="col" class="govuk-table__header">Actions</th>
       </tr>
     </thead>
 
@@ -12,26 +12,19 @@
       <% table_rows.each do |row| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= govuk_link_to(provider_user_name(row[:provider_user]), edit_support_interface_provider_user_path(row[:provider_user])) %><br/>
-            <span style='word-break: break-all;'><%= row[:provider_user].email_address %></span>
+            <%= govuk_link_to(provider_user_name(row[:provider_user]), support_interface_provider_user_path(row[:provider_user])) %><br/>
+            <span class="govuk-hint" style="word-break: break-all;"><%= row[:provider_user].email_address %></span>
           </td>
           <td class="govuk-table__cell">
+            <ul class="govuk-list govuk-list--spaced">
             <% row[:provider_user].provider_permissions.each do |permission| %>
-              <div class='govuk-!-margin-bottom-2'>
-                <h3 class='govuk-heading-s'><%= permission.provider.name_and_code %></h3>
-                <%= render PermissionsListComponent.new(permission, user_is_viewing_their_own_permissions: false) %>
-              </div>
+              <li><%= permission.provider.name %></li>
             <% end %>
+            </ul>
           </td>
-          <% if row[:last_signed_in_at] %>
-            <td class="govuk-table__cell"><%= row[:last_signed_in_at] %></td>
-          <% else %>
-            <% if row[:created_at] < Date.new(2019, 12, 25) %>
-              <td class="govuk-table__cell"><em>Unknown (records began 24 December 2019)</em></td>
-            <% else %>
-              <td class="govuk-table__cell"><em>Never signed in</em></td>
-            <% end %>
-          <% end %>
+          <td class="govuk-table__cell">
+            <%= govuk_link_to('Update permissions', edit_support_interface_provider_user_path(row[:provider_user])) %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -73,7 +73,7 @@ module SupportInterface
       provider_user = ProviderUser.find(params[:provider_user_id])
       provider_user.update!(send_notifications: !provider_user.send_notifications)
       flash[:success] = 'Provider user updated'
-      redirect_to edit_support_interface_provider_user_path(provider_user)
+      redirect_to support_interface_provider_user_path(provider_user)
     end
 
   private

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -13,7 +13,7 @@ module SupportInterface
     end
 
     def show
-      redirect_to edit_support_interface_provider_user_path(params[:id])
+      @provider_user = ProviderUser.find(params[:id])
     end
 
     def new
@@ -59,15 +59,14 @@ module SupportInterface
 
       if service.call!
         flash[:success] = 'Provider user updated'
-        redirect_to edit_support_interface_provider_user_path(provider_user)
+        redirect_to support_interface_provider_user_path(provider_user)
       else
         render :edit
       end
     end
 
     def audits
-      provider_user = ProviderUser.find(params[:provider_user_id])
-      @form = ProviderUserForm.from_provider_user(provider_user)
+      @provider_user = ProviderUser.find(params[:provider_user_id])
     end
 
     def toggle_notifications

--- a/app/frontend/styles/support/_checkboxes-scroll.scss
+++ b/app/frontend/styles/support/_checkboxes-scroll.scss
@@ -1,5 +1,5 @@
 .app-checkboxes-scroll {
-  border: 1px solid $govuk-border-colour;
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   height: 75vh;
   min-height: 13.5em;
   overflow-y: scroll;

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,27 +1,25 @@
-<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Edit providers and permissions', tag: 'h2' } do %>
-  <div class="app-checkboxes-scroll">
-    <% f.object.forms_for_possible_permissions.each do |permission_form| %>
-      <%= cache [permission_form.provider, permission_form.provider_permission] do %>
-        <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
-          <%= pf.govuk_check_box :active, true, multiple: false,
-                                 label: { text: permission_form.provider.name_and_code } do %>
-            <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
-              <%= ppf.hidden_field :provider_id %>
-              <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-                <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
-                <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
-                                        label: { text: 'Manage organisations' } %>
-                <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
-                                        label: { text: 'Make decisions' } %>
-                <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
-                                        label: { text: 'Access safeguarding information' } %>
-                <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
-                                        label: { text: 'Access diversity information' } %>
-              <% end %>
+<div class="app-checkboxes-scroll">
+  <% f.object.forms_for_possible_permissions.each do |permission_form| %>
+    <%= cache [permission_form.provider, permission_form.provider_permission] do %>
+      <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
+        <%= pf.govuk_check_box :active, true, multiple: false,
+                                label: { text: permission_form.provider.name_and_code } do %>
+          <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+            <%= ppf.hidden_field :provider_id %>
+            <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
+              <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+              <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
+                                      label: { text: 'Manage organisations' } %>
+              <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
+                                      label: { text: 'Make decisions' } %>
+              <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
+                                      label: { text: 'Access safeguarding information' } %>
+              <%= ppf.govuk_check_box :view_diversity_information, true, multiple: false,
+                                      label: { text: 'Access diversity information' } %>
             <% end %>
           <% end %>
         <% end %>
       <% end %>
     <% end %>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_navigation.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, provider_user_name(@form.provider_user) %>
+<% content_for :title, provider_user_name(provider_user) %>
 
 <% content_for :before_content do %>
   <%= render BreadcrumbComponent.new(items: [
@@ -11,13 +11,13 @@
       path: support_interface_provider_users_path
     },
     {
-      text: provider_user_name(@form.provider_user),
-      path: support_interface_provider_user_path(@form.provider_user)
+      text: provider_user_name(provider_user),
+      path: support_interface_provider_user_path(provider_user)
     }
   ].concat(title != 'Details' ? [{ text: title }] : [])) %>
 <% end %>
 
 <%= render TabNavigationComponent.new(items: [
-  { name: 'Details', url: edit_support_interface_provider_user_path(@form.provider_user) },
-  { name: 'History', url: support_interface_provider_user_audits_path(@form.provider_user) },
+  { name: 'Details', url: support_interface_provider_user_path(provider_user) },
+  { name: 'History', url: support_interface_provider_user_audits_path(provider_user) },
 ]) %>

--- a/app/views/support_interface/provider_users/audits.html.erb
+++ b/app/views/support_interface/provider_users/audits.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, "History - #{provider_user_name(@form.provider_user)}" %>
-<%= render 'provider_user_navigation', title: 'History' %>
+<% content_for :browser_title, "History - #{provider_user_name(@provider_user)}" %>
+<%= render 'provider_user_navigation', title: 'History', provider_user: @provider_user %>
 
-<%= render SupportInterface::AuditTrailComponent.new(audited_thing: @form.provider_user) %>
+<%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider_user) %>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -1,30 +1,28 @@
-<% content_for :browser_title, title_with_error_prefix("Edit - #{provider_user_name(@form.provider_user)}", @form.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix("Update providers and permissions - #{provider_user_name(@form.provider_user)}", @form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_user_path(@form.provider_user)) %>
 
-<%= render 'provider_user_navigation', title: 'Details' %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: support_interface_provider_user_path(@form.provider_user) do |f| %>
+      <%= f.govuk_error_summary %>
 
-<%= render SummaryListComponent.new(rows: {
-  'First name' => @form.provider_user.first_name,
-  'Last name' => @form.provider_user.last_name,
-  'Email address' => @form.provider_user.email_address,
-  'DfE Sign-in UID' => @form.provider_user.dfe_sign_in_uid,
-  'Account created at' => @form.provider_user.created_at.to_s(:govuk_date_and_time),
-  'Last sign in at' => @form.provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet',
-  'Send notifications?' => boolean_to_word(@form.provider_user.send_notifications?),
-}) %>
+      <%= f.govuk_check_boxes_fieldset :provider, caption: { text: provider_user_name(@form.provider_user), size: 'l' }, legend: { text: 'Update providers and permissions', tag: 'h1', size: 'l' }, classes: 'govuk-!-margin-top-6' do %>
+        <%= render 'provider_options', f: f %>
+      <% end %>
 
+      <%= f.govuk_submit 'Update permissions' %>
+    <% end %>
 
-<%= form_with model: @form, url: support_interface_provider_user_toggle_notifications_path(@form.provider_user) do |f| %>
-  <% if @form.provider_user.send_notifications? %>
-    <%= f.govuk_submit 'Disable notifications' %>
-  <% else %>
-    <%= f.govuk_submit 'Enable notifications' %>
-  <% end %>
-<% end %>
+    <%= form_with model: @form, url: support_interface_provider_user_toggle_notifications_path(@form.provider_user) do |f| %>
+      <%= render SummaryListComponent.new(rows: {
+        'Send notifications?' => boolean_to_word(@form.provider_user.send_notifications?),
+      }) %>
 
-<%= form_with model: @form, url: support_interface_provider_user_path(@form.provider_user) do |f| %>
-  <%= f.govuk_error_summary %>
-
-  <%= render 'provider_options', f: f %>
-
-  <%= f.govuk_submit 'Update user' %>
-<% end %>
+      <% if @form.provider_user.send_notifications? %>
+        <%= f.govuk_submit 'Disable notifications' %>
+      <% else %>
+        <%= f.govuk_submit 'Enable notifications' %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -9,10 +9,12 @@
       <h1 class='govuk-heading-l'>Add provider user</h1>
 
       <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
-      <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
-      <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
+      <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
 
-      <%= render 'provider_options', f: f %>
+      <%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Providers and permissions' } do %>
+        <%= render 'provider_options', f: f %>
+      <% end %>
 
       <%= f.govuk_submit 'Add provider user' %>
     <% end %>

--- a/app/views/support_interface/provider_users/show.html.erb
+++ b/app/views/support_interface/provider_users/show.html.erb
@@ -9,6 +9,11 @@
   { key: 'DfE Sign-in UID', value: @provider_user.dfe_sign_in_uid },
   { key: 'Account created at', value: @provider_user.created_at.to_s(:govuk_date_and_time) },
   { key: 'Last sign in at', value: @provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet' },
+  { key: 'Send notifications?',
+    value: boolean_to_word(@provider_user.send_notifications?),
+    action: 'notifications',
+    change_path: edit_support_interface_provider_user_path(@provider_user)
+  },
   {
     key: 'Permissions',
     value: render(SupportInterface::ProviderUserPermissionsComponent.new(provider_user: @provider_user)),

--- a/app/views/support_interface/provider_users/show.html.erb
+++ b/app/views/support_interface/provider_users/show.html.erb
@@ -1,0 +1,18 @@
+<% content_for :browser_title, "Provider user #{provider_user_name(@provider_user)}" %>
+
+<%= render 'provider_user_navigation', title: 'Details', provider_user: @provider_user %>
+
+<%= render SummaryListComponent.new(rows: [
+  { key: 'First name', value: @provider_user.first_name },
+  { key: 'Last name', value: @provider_user.last_name },
+  { key: 'Email address', value: @provider_user.email_address },
+  { key: 'DfE Sign-in UID', value: @provider_user.dfe_sign_in_uid },
+  { key: 'Account created at', value: @provider_user.created_at.to_s(:govuk_date_and_time) },
+  { key: 'Last sign in at', value: @provider_user.last_signed_in_at&.to_s(:govuk_date_and_time) || 'Not signed in yet' },
+  {
+    key: 'Permissions',
+    value: render(SupportInterface::ProviderUserPermissionsComponent.new(provider_user: @provider_user)),
+    action: 'permissions',
+    change_path: edit_support_interface_provider_user_path(@provider_user)
+  }
+]) %>

--- a/spec/components/support_interface/provider_users_table_component_spec.rb
+++ b/spec/components/support_interface/provider_users_table_component_spec.rb
@@ -20,25 +20,6 @@ RSpec.describe SupportInterface::ProviderUsersTableComponent do
     it 'renders all the fields' do
       expect(rendered_component).to include('provider@example.com')
       expect(rendered_component).to include('The Provider')
-      expect(rendered_component).to include('1 December 2019 at 10:45am')
-    end
-  end
-
-  context 'when the provider user has never signed in and was created before 24/12/2019' do
-    let(:provider_users) { [create(:provider_user, last_signed_in_at: nil, created_at: Time.zone.local(2019, 12, 23))] }
-
-    it 'shows that we do not know whether they’ve signed in or not (they’ve never signed in, or they signed in before records began on 24/12/2019)' do
-      expect(rendered_component).to include('Unknown (records began 24 December 2019)')
-    end
-  end
-
-  context 'when the provider user has never signed in and was created after 24/12/2019' do
-    let(:provider_users) { [create(:provider_user, last_signed_in_at: nil, created_at: Time.zone.local(2019, 12, 25))] }
-
-    it 'shows that we do not know whether they’ve signed in or not (they’ve never signed in, or they signed in before records began on 24/12/2019)' do
-      pending 'broken due to time mismatch'
-
-      expect(rendered_component).to include('Never signed in')
     end
   end
 

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature 'Managing provider users' do
   end
 
   def when_i_add_them_to_another_organisation
-    click_link 'Change'
+    click_link 'Change permissions'
     check 'Another provider (DEF)'
     click_button 'Update permissions'
   end
@@ -220,7 +220,7 @@ RSpec.feature 'Managing provider users' do
   end
 
   def when_i_click_to_change_their_permissions
-    click_on 'Change'
+    click_on 'Change permissions'
   end
 
   def and_i_remove_manage_users_permissions

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -44,10 +44,11 @@ RSpec.feature 'Managing provider users' do
     and_they_should_be_able_to_make_decisions
     and_they_should_be_able_to_view_diversity_information
 
-    when_i_remove_manage_users_permissions
+    when_i_click_to_change_their_permissions
+    and_i_remove_manage_users_permissions
     and_i_remove_manage_organisations_permissions
     and_i_remove_access_to_a_provider
-    and_i_click_update_user
+    and_i_click_update_permissions
     then_they_should_not_be_able_to_manage_users
     and_they_should_not_be_able_to_manage_organisations
     and_they_should_not_have_access_to_the_removed_provider
@@ -94,31 +95,31 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_i_check_permission_to_manage_users
-    within(permissions_fields_id_for_provider(@provider)) do
+    within(permissions_checkboxes_for_provider(@provider)) do
       check 'Manage users'
     end
   end
 
   def and_i_check_permission_to_manage_organisations
-    within(permissions_fields_id_for_provider(@provider)) do
+    within(permissions_checkboxes_for_provider(@provider)) do
       check 'Manage organisations'
     end
   end
 
   def and_i_check_permission_to_view_safeguarding_information
-    within(permissions_fields_id_for_provider(@provider)) do
+    within(permissions_checkboxes_for_provider(@provider)) do
       check 'Access safeguarding information'
     end
   end
 
   def and_i_check_permission_to_make_decisions
-    within(permissions_fields_id_for_provider(@provider)) do
+    within(permissions_checkboxes_for_provider(@provider)) do
       check 'Make decisions'
     end
   end
 
   def and_i_check_permission_to_view_diversity_information
-    within(permissions_fields_id_for_provider(@provider)) do
+    within(permissions_checkboxes_for_provider(@provider)) do
       check 'Access diversity information'
     end
   end
@@ -169,13 +170,14 @@ RSpec.feature 'Managing provider users' do
   end
 
   def when_i_add_them_to_another_organisation
+    click_link 'Change'
     check 'Another provider (DEF)'
-    click_button 'Update user'
+    click_button 'Update permissions'
   end
 
   def then_i_see_that_they_have_been_added_to_that_organisation
-    expect(page).to have_checked_field('Example provider (ABC)')
-    expect(page).to have_checked_field('Another provider (DEF)')
+    expect(page).to have_content('Example provider (ABC)')
+    expect(page).to have_content('Another provider (DEF)')
   end
 
   def when_i_click_the_audit_trail_tab
@@ -188,43 +190,47 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_they_should_be_able_to_manage_users
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_checked_field('Manage users')
+    within(permissions_summary_for_provider(@provider)) do
+      expect(page).to have_content('Manage users')
     end
   end
 
   def and_they_should_be_able_to_manage_organisations
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_checked_field('Manage organisations')
+    within(permissions_summary_for_provider(@provider)) do
+      expect(page).to have_content('Manage organisations')
     end
   end
 
   def and_they_should_be_able_to_view_safeguarding_information
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_checked_field('Access safeguarding information')
+    within(permissions_summary_for_provider(@provider)) do
+      expect(page).to have_content('Access safeguarding information')
     end
   end
 
   def and_they_should_be_able_to_make_decisions
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_checked_field('Make decisions')
+    within(permissions_summary_for_provider(@provider)) do
+      expect(page).to have_content('Make decisions')
     end
   end
 
   def and_they_should_be_able_to_view_diversity_information
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_checked_field('Access diversity information')
+    within(permissions_summary_for_provider(@provider)) do
+      expect(page).to have_content('Access diversity information')
     end
   end
 
-  def when_i_remove_manage_users_permissions
-    within(permissions_fields_id_for_provider(@provider)) do
+  def when_i_click_to_change_their_permissions
+    click_on 'Change'
+  end
+
+  def and_i_remove_manage_users_permissions
+    within(permissions_checkboxes_for_provider(@provider)) do
       uncheck 'Manage users'
     end
   end
 
   def and_i_remove_manage_organisations_permissions
-    within(permissions_fields_id_for_provider(@provider)) do
+    within(permissions_checkboxes_for_provider(@provider)) do
       uncheck 'Manage organisations'
     end
   end
@@ -233,30 +239,32 @@ RSpec.feature 'Managing provider users' do
     uncheck 'Another provider (DEF)'
   end
 
-  def and_i_click_update_user
-    click_on 'Update user'
+  def and_i_click_update_permissions
+    click_on 'Update permissions'
   end
 
   def then_they_should_not_be_able_to_manage_users
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_field('Manage users')
-      expect(page).not_to have_checked_field('Manage users')
+    within(permissions_summary_for_provider(@provider)) do
+      expect(page).not_to have_content('Manage users')
     end
   end
 
   def and_they_should_not_be_able_to_manage_organisations
-    within(permissions_fields_id_for_provider(@provider)) do
-      expect(page).to have_field('Manage organisations')
-      expect(page).not_to have_checked_field('Manage organisations')
+    within(permissions_summary_for_provider(@provider)) do
+      expect(page).not_to have_content('Manage organisations')
     end
   end
 
   def and_they_should_not_have_access_to_the_removed_provider
-    expect(page).to have_checked_field('Example provider (ABC)')
-    expect(page).not_to have_checked_field('Another provider (DEF)')
+    expect(page).to have_content('Example provider (ABC)')
+    expect(page).not_to have_content('Another provider (DEF)')
   end
 
-  def permissions_fields_id_for_provider(provider)
+  def permissions_summary_for_provider(provider)
+    "#provider-#{provider.id}-enabled-permissions"
+  end
+
+  def permissions_checkboxes_for_provider(provider)
     "#support-interface-provider-user-form-provider-permissions-forms-#{provider.id}-active-true-conditional"
   end
 end


### PR DESCRIPTION
## Context

* Shows summary of a user’s providers on table view (not all permissions), adds direct link to edit permissions
* Splits provider user into edit and show views
* Shows user’s providers and permissions on view page, with link to edit

## Changes proposed in this pull request

![provider-users](https://user-images.githubusercontent.com/813383/95889372-3b7ab200-0d7a-11eb-8090-39a2f75dddda.png)

![provider-user](https://user-images.githubusercontent.com/813383/95889484-5b11da80-0d7a-11eb-98b8-40f7f1b97657.png)

![edit-provider-user](https://user-images.githubusercontent.com/813383/95889805-d2e00500-0d7a-11eb-8659-b8374a265a50.png)

## Guidance to review

* Does this seem right, easy to use
* Tests are failing… and I can’t for the life of me figure out what’s wrong!

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
