### PR TITLE
Display UCAS accepted statuses

### DIFF
--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -56,6 +56,10 @@ class UCASMatchedApplication
       'withdrawn'
     elsif @matching_data['Declined offers'] == '1'
       'declined'
+    elsif @matching_data['Conditional firm'] == '1'
+      'pending_conditions'
+    elsif @matching_data['Unconditional firm'] == '1'
+      'recruited'
     elsif @matching_data['Offers'] == '1'
       'offer'
     else

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,6 +17,8 @@ FactoryBot.define do
           withdrawn: { 'Withdrawns' => '1' },
           declined: { 'Declined offers' => '1' },
           offer: { 'Offers' => '1' },
+          pending_conditions: { 'Offers' => '1', 'Conditional firm' => '1' },
+          recruited: { 'Offers' => '1', 'Unconditional firm' => '1' },
           awaiting_provider_decision: { 'Applications' => '1' },
         }.freeze
 


### PR DESCRIPTION
## Context

We were not sure how UCAS marked their applications before and would map `recruited` and `pending_conditions` as `offer`. We now know that 
- UCAS 'Conditional firm' is `pending_conditions` on Apply
- UCAS 'Unconditional firm' is `recruited` on Apply

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

:shipit: 

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
