### PR TITLE
Decoupled references - update application page #1

### DIFF
--- a/app/components/task_list_item_component.html.erb
+++ b/app/components/task_list_item_component.html.erb
@@ -4,7 +4,7 @@
     Submitted
   </strong>
 <% elsif custom_status %>
-  <strong class="govuk-tag govuk-tag--<%= custom_status.parameterize %> app-tag" id=<%= tag_id %>>
+  <strong class="govuk-tag govuk-tag--purple app-tag" id=<%= tag_id %>>
     <%= custom_status %>
   </strong>
 <% elsif completed %>

--- a/app/components/task_list_item_component.html.erb
+++ b/app/components/task_list_item_component.html.erb
@@ -3,6 +3,10 @@
   <strong class="govuk-tag govuk-tag--grey app-tag" id=<%= tag_id %>>
     Submitted
   </strong>
+<% elsif custom_status %>
+  <strong class="govuk-tag govuk-tag--<%= custom_status.parameterize %> app-tag" id=<%= tag_id %>>
+    <%= custom_status %>
+  </strong>
 <% elsif completed %>
   <strong class="govuk-tag govuk-tag--complete app-tag" id=<%= tag_id %>>
     Completed

--- a/app/components/task_list_item_component.rb
+++ b/app/components/task_list_item_component.rb
@@ -3,12 +3,20 @@ class TaskListItemComponent < ViewComponent::Base
 
   validates :path, presence: true
 
-  def initialize(completed:, path:, text:, show_incomplete: true, submitted: false)
+  def initialize(
+    completed:,
+    path:,
+    text:,
+    show_incomplete: true,
+    submitted: false,
+    custom_status: nil
+  )
     @completed = completed
     @path = path
     @text = text
     @show_incomplete = show_incomplete
     @submitted = submitted
+    @custom_status = custom_status
   end
 
   def tag_id
@@ -17,5 +25,5 @@ class TaskListItemComponent < ViewComponent::Base
 
 private
 
-  attr_reader :completed, :path, :text, :show_incomplete, :submitted
+  attr_reader :completed, :path, :text, :show_incomplete, :submitted, :custom_status
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -119,7 +119,9 @@ module CandidateInterface
     end
 
     def references_link_text
-      if @application_form.application_references.present?
+      if @application_form.enough_references_have_been_provided?
+        'Review your references'
+      elsif @application_form.application_references.present?
         'Manage your references'
       else
         'Add your references'
@@ -269,9 +271,11 @@ module CandidateInterface
     end
 
     def all_referees_provided_by_candidate?
-      return true if FeatureFlag.active?(:decoupled_references)
-
       @application_form.references_completed
+    end
+
+    def references_in_progress?
+      !enough_references_provided? && @application_form.application_references.present?
     end
 
     def safeguarding_completed?

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -45,9 +45,11 @@
     <% if FeatureFlag.active?('decoupled_references') %>
       <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 
-      <p class="govuk-body">You have to get 2 references back before you can send your application to training providers.</p>
+      <% unless @application_form_presenter.enough_references_provided? %>
+        <p class="govuk-body">You have to get 2 references back before you can send your application to training providers.</p>
 
-      <p class="govuk-body">It takes 8 days to get a reference on average.</p>
+        <p class="govuk-body">It takes 8 days to get a reference on average.</p>
+      <% end %>
 
       <ul class="app-task-list govuk-!-margin-bottom-8">
         <li class="app-task-list__item">
@@ -56,6 +58,7 @@
               text: @application_form_presenter.references_link_text,
               completed: @application_form_presenter.enough_references_provided?,
               path: @application_form_presenter.references_path,
+              custom_status: @application_form_presenter.references_in_progress? ? 'In progress' : nil
             )
           ) %>
         </li>

--- a/spec/components/task_list_item_component_spec.rb
+++ b/spec/components/task_list_item_component_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe TaskListItemComponent do
   it 'renders with a custom status badge' do
     result = render_component(completed: false, custom_status: 'In progress')
     expect(result.css('#personal-details-badge-id').text).to include('In progress')
-    expect(result.css('#personal-details-badge-id').first[:class]).to include('govuk-tag--in-progress')
+    expect(result.css('#personal-details-badge-id').first[:class]).to include('govuk-tag--purple')
   end
 end

--- a/spec/components/task_list_item_component_spec.rb
+++ b/spec/components/task_list_item_component_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe TaskListItemComponent do
-  def render_component(completed:)
-    render_inline(TaskListItemComponent.new(text: 'Personal details', path: '/personal-details', completed: completed))
+  def render_component(completed:, custom_status: nil)
+    render_inline(TaskListItemComponent.new(text: 'Personal details', path: '/personal-details', completed: completed, custom_status: custom_status))
   end
 
   it 'renders the correct text, href' do
@@ -19,5 +19,11 @@ RSpec.describe TaskListItemComponent do
   it 'renders with an incomplete badge' do
     result = render_component(completed: false)
     expect(result.css('#personal-details-badge-id').text).to include('Incomplete')
+  end
+
+  it 'renders with a custom status badge' do
+    result = render_component(completed: false, custom_status: 'In progress')
+    expect(result.css('#personal-details-badge-id').text).to include('In progress')
+    expect(result.css('#personal-details-badge-id').first[:class]).to include('govuk-tag--in-progress')
   end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -22,7 +22,7 @@ module CandidateHelper
     login_as(current_candidate)
   end
 
-  def candidate_completes_application_form
+  def candidate_completes_application_form(with_referees: true)
     FeatureFlag.deactivate(:international_addresses)
     FeatureFlag.deactivate(:international_personal_details)
     FeatureFlag.deactivate(:efl_section)
@@ -78,7 +78,7 @@ module CandidateHelper
     click_link t('page_titles.interview_preferences')
     candidate_fills_in_interview_preferences
 
-    candidate_provides_two_referees
+    candidate_provides_two_referees if with_referees
   end
 
   def candidate_submits_application

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Review references' do
   def then_the_references_section_is_still_incomplete
     when_i_view_my_application
     within '#manage-your-references-badge-id' do
-      expect(page).to have_content 'Incomplete'
+      expect(page).to have_content 'In progress'
     end
   end
 
@@ -60,13 +60,13 @@ RSpec.feature 'Review references' do
 
   def then_the_references_section_is_complete
     when_i_view_my_application
-    within '#manage-your-references-badge-id' do
+    within '#review-your-references-badge-id' do
       expect(page).to have_content 'Complete'
     end
   end
 
   def and_i_can_review_my_references_before_submission
-    click_link 'Manage your references'
+    click_link 'Review your references'
     expect(page).to have_current_path candidate_interface_decoupled_references_review_path
 
     within '#references_given' do

--- a/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
@@ -7,11 +7,14 @@ RSpec.feature 'Submitting an application' do
     given_i_am_signed_in
     and_the_decoupled_references_flag_is_on
     and_i_have_completed_my_application
+    then_i_can_see_references_are_incomplete
 
     when_i_have_added_references
+    then_i_can_see_references_are_in_progress
     and_i_submit_the_application
     then_i_get_an_error_about_my_references
     when_my_references_have_been_provided
+    then_i_can_see_references_are_complete
     and_i_submit_the_application
 
     then_i_can_see_my_application_has_been_successfully_submitted
@@ -31,6 +34,32 @@ RSpec.feature 'Submitting an application' do
 
   def and_i_have_completed_my_application
     candidate_completes_application_form
+  end
+
+  def then_i_can_see_references_are_incomplete
+    expect(page).to have_content('You have to get 2 references back before you can send your application to training providers.')
+    within(all('.app-task-list')[1]) do
+      expect(page).to have_content('Incomplete')
+      expect(page).to have_link('Add your references')
+    end
+  end
+
+  def then_i_can_see_references_are_in_progress
+    visit candidate_interface_application_form_path
+    expect(page).to have_content('You have to get 2 references back before you can send your application to training providers.')
+    within(all('.app-task-list')[1]) do
+      expect(page).to have_content('In progress')
+      expect(page).to have_link('Manage your references')
+    end
+  end
+
+  def then_i_can_see_references_are_complete
+    visit candidate_interface_application_form_path
+    expect(page).not_to have_content('You have to get 2 references back before you can send your application to training providers.')
+    within(all('.app-task-list')[1]) do
+      expect(page).to have_content('Complete')
+      expect(page).to have_link('Review your references')
+    end
   end
 
   def when_i_have_added_references

--- a/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Submitting an application' do
   end
 
   def and_i_have_completed_my_application
-    candidate_completes_application_form
+    candidate_completes_application_form(with_referees: false)
   end
 
   def then_i_can_see_references_are_incomplete
@@ -65,6 +65,7 @@ RSpec.feature 'Submitting an application' do
   def when_i_have_added_references
     create(:reference, :unsubmitted, application_form: current_candidate.current_application)
     create(:reference, :unsubmitted, application_form: current_candidate.current_application)
+    application.update(references_completed: true)
   end
 
   def and_i_submit_the_application


### PR DESCRIPTION
## Context

As a candidate I need to quickly understand the status of my references so that so I know if I need to manage my references.

This PR is the first of 2 or more and just addresses the 3 state tags (Incomplete, In progress, Completed) and visibility of the help text.

## Changes proposed in this pull request

- [x] Extend `TaskListItemComponent` to include and custom tag name.
- [x] Display the appropriate tag and link text according to reference status.
- [x] Extend existing system specs to assert the 3 states.

<img width="685" alt="image" src="https://user-images.githubusercontent.com/450843/95961915-a02b2080-0dfd-11eb-9bd3-ffc4e7a200e5.png">

<img width="685" alt="image" src="https://user-images.githubusercontent.com/450843/95961878-92759b00-0dfd-11eb-85b8-d9a5ca2b7bcf.png">

<img width="685" alt="image" src="https://user-images.githubusercontent.com/450843/95961958-b1742d00-0dfd-11eb-9392-a10b4862a2c6.png">

To be covered in a follow-up PR:

- Showing the status of individual references

## Guidance to review

- Is the logic correct for the 3 states?
- Are the tests adequate?

## Link to Trello card

https://trello.com/c/ZdPrMUfo/2219-💔-dev-update-your-application-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
