### PR TITLE
Restrict access to old referee flow when the decoupled flag is active & update the candidate_helper

### DIFF
--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class AdditionalRefereesController < CandidateInterfaceController
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     before_action :redirect_to_contact_support_if_at_maximum_reference_count, only: %i[type update_type new create]
-    before_action :redirect_to_dashboard_if_decoupled_reference_flag_as_active
+    before_action :redirect_to_dashboard_if_decoupled_reference_flag_is_active
 
     def type
       @page_title = page_title_for_new_page
@@ -200,7 +200,7 @@ module CandidateInterface
                         .find(referee_id)
     end
 
-    def redirect_to_dashboard_if_decoupled_reference_flag_as_active
+    def redirect_to_dashboard_if_decoupled_reference_flag_is_active
       redirect_to candidate_interface_application_form_path if FeatureFlag.active?(:decoupled_references)
     end
   end

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -5,6 +5,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_referee_destroyed, only: %i[confirm_destroy destroy]
     before_action :set_referees, only: %i[type update_type new create index review]
     before_action :set_nth_referee, only: %i[type new]
+    before_action :redirect_to_dashboard_if_decoupled_reference_flag_is_active
 
     def index
       if @referees.empty?
@@ -178,6 +179,10 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:references_completed)
         .transform_values(&:strip)
+    end
+
+    def redirect_to_dashboard_if_decoupled_reference_flag_is_active
+      redirect_to candidate_interface_application_form_path if FeatureFlag.active?(:decoupled_references)
     end
   end
 end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -372,8 +372,12 @@ en:
           professional: 'For example: a manager.'
           school_based: 'For example: a colleague from a school where you did experience.'
           character: 'For example: a mentor, or someone you know from volunteering.'
+      name:
+        label: What is the referee’s name?
+      email_address:
+        label: What is the referee’s email address?
       relationship:
-        label: What is your relationship to this referee and how long have you known them?
+        label: How do you know this referee and how long have you known them?
         hint_text:
           academic: 'For example, ‘He was my course supervisor at university. I’ve known him for a year’.'
           professional: 'For example, ‘He was my line manager in my last job. I’ve known him for 2 years’.'

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -267,31 +267,65 @@ module CandidateHelper
   end
 
   def candidate_fills_in_referee(params = {})
-    fill_in t('application_form.referees.name.label'), with: params[:name] || 'Terri Tudor'
-    fill_in t('application_form.referees.email_address.label'), with: params[:email_address] || 'terri@example.com'
-    fill_in t('application_form.referees.relationship.label'), with: params[:relationship] || 'Tutor'
+    if FeatureFlag.active?(:decoupled_references)
+      fill_in t('application_form.references.name.label'), with: params[:name] || 'Terri Tudor'
+      click_button 'Save and continue'
+      fill_in t('application_form.references.email_address.label'), with: params[:email_address] || 'terri@example.com'
+      click_button 'Save and continue'
+      fill_in t('application_form.references.relationship.label'), with: params[:relationship] || 'Tutor'
+      click_button 'Save and continue'
+    else
+      fill_in t('application_form.referees.name.label'), with: params[:name] || 'Terri Tudor'
+      fill_in t('application_form.referees.email_address.label'), with: params[:email_address] || 'terri@example.com'
+      fill_in t('application_form.referees.relationship.label'), with: params[:relationship] || 'Tutor'
+    end
   end
 
   def candidate_provides_two_referees
-    visit candidate_interface_referees_type_path
-    choose 'Academic'
-    click_button 'Continue'
+    if FeatureFlag.active?(:decoupled_references)
+      visit candidate_interface_decoupled_references_start_path
+      click_link 'Continue'
+      choose 'Academic'
+      click_button 'Save and continue'
 
-    candidate_fills_in_referee
-    click_button 'Save and continue'
-    click_link 'Add another referee'
+      candidate_fills_in_referee
+      choose 'Yes, send a reference request now'
+      click_button 'Save and continue'
 
-    choose 'Professional'
-    click_button 'Continue'
+      click_link 'Add another referee'
+      click_link 'Continue'
+      choose 'Professional'
+      click_button 'Save and continue'
 
-    candidate_fills_in_referee(
-      name: 'Anne Other',
-      email_address: 'anne@other.com',
-      relationship: 'First boss',
-    )
-    click_button 'Save and continue'
-    check t('application_form.completed_checkbox')
-    click_button t('application_form.continue')
+      candidate_fills_in_referee(
+        name: 'Anne Other',
+        email_address: 'anne@other.com',
+        relationship: 'First boss',
+      )
+      choose 'Yes, send a reference request now'
+      click_button 'Save and continue'
+      visit candidate_interface_application_form_path
+    else
+      visit candidate_interface_referees_type_path
+      choose 'Academic'
+      click_button 'Continue'
+
+      candidate_fills_in_referee
+      click_button 'Save and continue'
+      click_link 'Add another referee'
+
+      choose 'Professional'
+      click_button 'Continue'
+
+      candidate_fills_in_referee(
+        name: 'Anne Other',
+        email_address: 'anne@other.com',
+        relationship: 'First boss',
+      )
+      click_button 'Save and continue'
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    end
   end
 
   def candidate_fills_in_a_gcse


### PR DESCRIPTION
## Context

Candidates shouldn't be able to access the old referees flow when the decoupled references flag is active.


## Changes proposed in this pull request

- Redirects the candidate to the dashboard if someone tries to hit a referees endpoint when the flag is active. 
- Updates the candidate helper to work with the decoupled references flow

## Link to Trello card

https://trello.com/c/92zaVaUn/2320-%F0%9F%92%94-dev-interstitial-audit

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
