### PR TITLE
Handle missing course and provider data in UCAS matches

### DIFF
--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -50,7 +50,7 @@ module SupportInterface
     end
 
     def course_choice_details(course)
-      "#{course.code} — #{course.name} — #{course.provider.name}"
+      "#{course.code} — #{course.name} — #{course.provider&.name || 'Provider not on Apply'}"
     end
   end
 end

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -13,8 +13,8 @@ class UCASMatchedApplication
 
     if course.nil?
       OpenStruct.new(
-        code: @matching_data['Course code'],
-        name: @matching_data['Course name'],
+        code: @matching_data['Course code'].presence || 'Missing course code',
+        name: @matching_data['Course name'].presence || 'Missing course name',
         provider: Provider.find_by(code: @matching_data['Provider code']),
       )
     else

--- a/spec/components/support_interface/ucas_match_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_table_component_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
              'Withdrawns' => '1',
            }])
   end
+  let(:ucas_match_for_welsh_provider) do
+    create(:ucas_match,
+           matching_data: [{
+             'Scheme' => 'U',
+             'Course code' => '',
+             'Course name' => '',
+             'Provider code' => 'T80',
+             'Apply candidate ID' => candidate.id.to_s,
+           }])
+  end
 
   it 'renders course choice details for a course on Apply' do
     result = render_inline(described_class.new(ucas_match))
@@ -31,6 +41,12 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
     result = render_inline(described_class.new(ucas_match_course_only_on_ucas))
 
     expect(result.css('td').first.text).to include("123 — Not on Apply — #{course.provider.name}")
+  end
+
+  it 'renders course choice details for a course with missing data and provider' do
+    result = render_inline(described_class.new(ucas_match_for_welsh_provider))
+
+    expect(result.css('td').first.text).to include('Missing course code — Missing course name — Provider not on Apply')
   end
 
   context 'when application is in both Apply and UCAS' do

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.course.name).to eq('Not on Apply')
       expect(ucas_matching_application.course.provider).to eq(course.provider)
     end
+
+    it 'handles missing course data' do
+      ucas_matching_data =
+        { 'Scheme' => 'U',
+          'Course code' => '',
+          'Course name' => '',
+          'Provider code' => 'T80',
+          'Apply candidate ID' => candidate.id.to_s }
+      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+
+      expect(ucas_matching_application.course.code).to eq('Missing course code')
+      expect(ucas_matching_application.course.name).to eq('Missing course name')
+      expect(ucas_matching_application.course.provider).to eq(nil)
+    end
   end
 
   describe '#status' do


### PR DESCRIPTION
## Context

UCAS accidentally sent us some application data for courses run by Welsh
providers.  They are going to remove them but we need to make sure our views
still work for those matches.

Example 
```
{"Apply candidate ID"=>"1368", 
"Provider code"=>"T80", 
"Provider name"=>"", 
"Phase"=>"", 
"Funding type"=>"", 
"Programme type"=>"", 
"Apply stage"=>"", 
"Programme outcome"=>"", 
"Qualifications"=>"", 
"NCTL subject"=>"", 
"Course name"=>"", 
"Course code"=>"3CPM", 
"Trackable applicant key"=>"25EBB0EF9CEDDE3569655E7C6A896078", 
"Applications"=>".", "
Withdrawns"=>".", 
"Offers"=>".", 
"Declined offers"=>".", 
"DBD date"=>".", 
"Rejects"=>".", 
"RBD date"=>".", 
"Conditional firm"=>".", 
"Unconditional firm"=>".", 
"Applicant withdrawn entirely from scheme"=>".", 
"Applicant withdrawn fromscheme while offer awaiting applicant reply"=>".", 
"Applicant withdrawn from scheme after firmly accepting an unconditional offer"=>".", 
"Applicant withdrawn from scheme after firmly accepting a conditional  offer"=>".", 
"UCAS DfE Match applicant (Y/N)"=>"Y", 
"UCAS DFE Match application (Y/N)"=>"N", 
"Scheme"=>"U"}
```
## Changes proposed in this pull request

Say that this info is missing.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/CGTMARVG/2810-show-ucas-matches

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
