### PR TITLE
Re-request a failed reference

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -25,7 +25,7 @@
             <li class="app-summary-card__actions-list-item">
               <%= link_to candidate_interface_decoupled_references_new_request_path(reference.id), class: 'govuk-link' do %>
                 <%= t('application_form.referees.resend_request') %>
-                <span class="govuk-visually-hidden"> <%= reference.name %></span>
+                <span class="govuk-visually-hidden"> to <%= reference.name %></span>
               <% end %>
             </li>
           <% end %>

--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -21,6 +21,13 @@
                 <span class="govuk-visually-hidden"> <%= reference.name %></span>
               <% end %>
             </li>
+          <% elsif can_resend?(reference) %>
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to candidate_interface_decoupled_references_new_request_path(reference.id), class: 'govuk-link' do %>
+                <%= t('application_form.referees.resend_request') %>
+                <span class="govuk-visually-hidden"> <%= reference.name %></span>
+              <% end %>
+            </li>
           <% end %>
         </ul>
       </div>

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -30,7 +30,8 @@ module CandidateInterface
     end
 
     def can_resend?(reference)
-      (reference.cancelled? || reference.email_bounced?) &&
+      (reference.cancelled? || reference.cancelled_at_end_of_cycle? || reference.email_bounced?) &&
+        !reference.application_form.enough_references_have_been_provided? &&
         CandidateInterface::Reference::SubmitRefereeForm.new(
           submit: 'yes',
           reference_id: reference.id,

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -29,6 +29,14 @@ module CandidateInterface
         ).valid?
     end
 
+    def can_resend?(reference)
+      (reference.cancelled? || reference.email_bounced?) &&
+        CandidateInterface::Reference::SubmitRefereeForm.new(
+          submit: 'yes',
+          reference_id: reference.id,
+        ).valid?
+    end
+
   private
 
     def formatted_reference_type(reference)

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -7,7 +7,7 @@ module CandidateInterface
         @application_form = current_application
         @references_given = current_application.application_references.feedback_provided
         @references_waiting_to_be_sent = current_application.application_references.not_requested_yet
-        @references_sent = current_application.application_references.pending_feedback_or_failed
+        @references_sent = current_application.application_references.includes(:application_form).pending_feedback_or_failed
       end
 
       def unsubmitted

--- a/app/services/candidate_interface/decoupled_references/request_reference.rb
+++ b/app/services/candidate_interface/decoupled_references/request_reference.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module DecoupledReferences
     class RequestReference
       def self.call(reference, flash)
-        if reference.not_requested_yet? || reference.cancelled? || reference.email_bounced?
+        if reference.not_requested_yet? || reference.cancelled? || reference.cancelled_at_end_of_cycle? || reference.email_bounced?
           RefereeMailer.reference_request_email(reference).deliver_later
           reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
           flash[:success] = "Reference request sent to #{reference.name}"

--- a/app/services/candidate_interface/decoupled_references/request_reference.rb
+++ b/app/services/candidate_interface/decoupled_references/request_reference.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module DecoupledReferences
     class RequestReference
       def self.call(reference, flash)
-        if reference.not_requested_yet?
+        if reference.not_requested_yet? || reference.cancelled? || reference.email_bounced?
           RefereeMailer.reference_request_email(reference).deliver_later
           reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
           flash[:success] = "Reference request sent to #{reference.name}"

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -393,6 +393,7 @@ en:
       cancel: Cancel referee
       cancel_request: Cancel request
       send_request: Send request
+      resend_request: Send request again
       email_address:
         label: Email address
         hint_text:

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -154,6 +154,19 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
   end
 
+  context 'when reference state is "cancelled" but there are already 2 references provided' do
+    let(:cancelled) { create(:reference, :cancelled) }
+    let(:provided_references) { create_list(:reference, 2, :complete, application_form: cancelled.application_form) }
+
+    it 'a send request link is NOT available' do
+      FeatureFlag.activate(:decoupled_references)
+      result = render_inline(described_class.new(references: [cancelled, *provided_references]))
+
+      feedback_not_requested_summary = result.css('.app-summary-card')[0]
+      expect(feedback_not_requested_summary.text).not_to include 'Send request again'
+    end
+  end
+
 private
 
   def status_table

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
   end
 
-  context 'when reference state is "not_requested_yet" and the reference is incomplete' do
+  context 'when reference state is "cancelled" and the reference is incomplete' do
     let(:cancelled) { create(:reference, :cancelled, name: nil) }
 
     it 'a send request link is NOT available' do

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -127,6 +127,33 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
   end
 
+  context 'when reference state is "cancelled" and the reference is complete' do
+    let(:feedback_requested) { create(:reference, :requested) }
+    let(:cancelled) { create(:reference, :cancelled) }
+
+    it 'a re-send request link is available' do
+      FeatureFlag.activate(:decoupled_references)
+      result = render_inline(described_class.new(references: [feedback_requested, cancelled]))
+
+      feedback_requested_summary = result.css('.app-summary-card')[0]
+      feedback_cancelled_summary = result.css('.app-summary-card')[1]
+      expect(feedback_requested_summary.text).not_to include 'Send request again'
+      expect(feedback_cancelled_summary.text).to include 'Send request again'
+    end
+  end
+
+  context 'when reference state is "not_requested_yet" and the reference is incomplete' do
+    let(:cancelled) { create(:reference, :cancelled, name: nil) }
+
+    it 'a send request link is NOT available' do
+      FeatureFlag.activate(:decoupled_references)
+      result = render_inline(described_class.new(references: [cancelled]))
+
+      feedback_not_requested_summary = result.css('.app-summary-card')[0]
+      expect(feedback_not_requested_summary.text).not_to include 'Send request again'
+    end
+  end
+
 private
 
   def status_table

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -43,13 +43,13 @@ RSpec.feature 'Candidate requests a reference' do
     then_i_am_told_a_reference_has_already_been_sent
 
     when_i_have_added_an_incomplete_reference
-    and_i_visit_the_reference_review_page
+    and_i_visit_the_all_references_review_page
     then_i_should_not_see_a_send_reference_link
     when_i_navigate_to_the_send_request_page
     then_i_should_see_a_not_found_message
 
     when_i_have_a_cancelled_reference
-    and_i_visit_the_reference_review_page
+    and_i_visit_the_all_references_review_page
     and_i_click_the_resend_reference_link
     and_i_confirm_that_i_am_ready_to_send_a_reference_request
     then_i_see_a_confirmation_message
@@ -158,6 +158,10 @@ RSpec.feature 'Candidate requests a reference' do
 
   def when_i_have_added_an_incomplete_reference
     @reference = create(:reference, :unsubmitted, name: nil, application_form: @application_form)
+  end
+
+  def and_i_visit_the_all_references_review_page
+    visit candidate_interface_decoupled_references_review_path
   end
 
   def then_i_should_not_see_a_send_reference_link

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -47,6 +47,13 @@ RSpec.feature 'Candidate requests a reference' do
     then_i_should_not_see_a_send_reference_link
     when_i_navigate_to_the_send_request_page
     then_i_should_see_a_not_found_message
+
+    when_i_have_a_cancelled_reference
+    and_i_visit_the_reference_review_page
+    and_i_click_the_resend_reference_link
+    and_i_confirm_that_i_am_ready_to_send_a_reference_request
+    then_i_see_a_confirmation_message
+    and_the_reference_is_moved_to_the_requested_state
   end
 
   def given_i_am_signed_in
@@ -163,5 +170,13 @@ RSpec.feature 'Candidate requests a reference' do
 
   def then_i_should_see_a_not_found_message
     expect(page).to have_content('Page not found')
+  end
+
+  def when_i_have_a_cancelled_reference
+    @reference = create(:reference, :cancelled, application_form: @application_form)
+  end
+
+  def and_i_click_the_resend_reference_link
+    click_link 'Send request again'
   end
 end

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature 'Candidate requests a reference' do
     and_i_confirm_that_i_am_ready_to_send_a_reference_request
     then_i_see_a_confirmation_message
     and_the_reference_is_moved_to_the_requested_state
+    and_an_email_is_sent_to_the_referee
   end
 
   def given_i_am_signed_in


### PR DESCRIPTION
## Context

As a candidate I need to re-open a reference request so that I can request reference that may have been cancelled by me, cancelled during the end-of-cycle carry over or failed to be delivered.

## Changes proposed in this pull request

- [x] Add _Send reference again_ link to review component
- [x] Extend system spec
- [x] Handle cancelled at end-of-cycle status
- [x] Hide link when 2 references have been provided

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/450843/96013934-bc4eb200-0e3d-11eb-953c-a3013a9b3fc4.png">


## Guidance to review

- To test manually I had to put a reference into a `cancelled`, `cancelled_at_end_of_cycle` or `email_bounced` state by changing the data manually.

## Link to Trello card

https://trello.com/c/Lwt9lQMb/2237-💔-dev-re-request-a-cancelled-failed-reference-request

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
