### PR TITLE
Only show references that have feedback to providers

### DIFF
--- a/app/services/support_interface/tad_application_export.rb
+++ b/app/services/support_interface/tad_application_export.rb
@@ -1,0 +1,71 @@
+module SupportInterface
+  class TADApplicationExport
+    attr_reader :application_choice
+
+    delegate :course_option, :course, :application_form, to: :application_choice
+    delegate :candidate, to: :application_form
+
+    def initialize(application_choice)
+      @application_choice = application_choice
+    end
+
+    def as_json
+      accrediting_provider = course.accredited_provider || application_choice.provider
+
+      # https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1602583138300500
+      {
+        application_choice_id: application_choice.id,
+        application_id: application_form.id,
+        status: application_choice.status,
+        phase: application_form.phase,
+        first_name: application_form.first_name,
+        last_name: application_form.last_name,
+        date_of_birth: application_form.date_of_birth,
+        email: candidate.email_address,
+        postcode: application_form.postcode,
+        country: application_form.country,
+        nationality: nationalities,
+
+        sex: application_form.equality_and_diversity.try(:[], 'sex'),
+        disability_status: application_form.equality_and_diversity.try(:[], 'disability_status'),
+        disabilities: application_form.equality_and_diversity.try(:[], 'disabilities'),
+        other_disability: application_form.equality_and_diversity.try(:[], 'other_disability'),
+        ethnic_group: application_form.equality_and_diversity.try(:[], 'ethnic_group'),
+        ethnic_background: application_form.equality_and_diversity.try(:[], 'ethnic_background'),
+
+        degree_classification: application_form.application_qualifications.find { |q| q.level == 'degree' }.grade,
+
+        provider_code: application_choice.provider.code,
+        provider_id: application_choice.provider.id,
+        provider_name: application_choice.provider.region_code,
+
+        accrediting_provider_code: accrediting_provider.code,
+        accrediting_provider_id: accrediting_provider.id,
+        accrediting_provider_name: accrediting_provider.region_code,
+
+        course_level: course.level,
+
+        program_type: application_choice.course.program_type,
+        programme_outcome: application_choice.course.description,
+
+        course_name: application_choice.course.name,
+        course_code: application_choice.course.code,
+
+        nctl_subject: application_choice.course.subject_codes,
+      }
+    end
+
+  private
+
+    def nationalities
+      [
+        application_form.first_nationality,
+        application_form.second_nationality,
+        application_form.third_nationality,
+        application_form.fourth_nationality,
+        application_form.fifth_nationality,
+      ].map { |n| NATIONALITIES_BY_NAME[n] }.compact.uniq
+        .sort.partition { |e| %w[GB IE].include? e }.flatten
+    end
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -66,11 +66,11 @@
     <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="personal-statement">Personal statement</h2>
     <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
 
-    <% if @application_choice.application_form.application_references.any? %>
+    <% if @application_choice.application_form.application_references.feedback_provided.any? %>
       <h2 class="govuk-heading-l govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="references">References</h2>
       <%= render 'references_context' %>
 
-      <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>
+      <% @application_choice.application_form.application_references.feedback_provided.each_with_index do |reference, i| %>
         <h3 class="govuk-heading-m govuk-!-margin-top-8"><%= "#{TextOrdinalizer.call((i + 1)).capitalize} referee" %></h3>
         <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference) %>
       <% end %>

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            end_date: nil)
 
     create(:reference,
+           :complete,
            application_form: application_form,
            name: 'R2D2',
            email_address: 'r2d2@rebellion.org',
@@ -139,11 +140,17 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            feedback: 'beep boop beep')
 
     create(:reference,
+           :complete,
            application_form: application_form,
            name: 'C3PO',
            email_address: 'c3p0@rebellion.org',
            relationship: 'Companion droid',
            feedback: 'The possibility of successfully navigating training is approximately three thousand seven hundred and twenty to one')
+
+    create(:reference,
+           :refused,
+           application_form: application_form,
+           name: 'BB-8')
 
     @application_choice = create(:application_choice,
                                  status: :application_complete,
@@ -247,6 +254,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_content 'c3p0@rebellion.org'
     expect(page).to have_content 'Companion droid'
     expect(page).to have_content 'The possibility of successfully'
+
+    expect(page).not_to have_content 'BB-8'
   end
 
   def and_i_should_see_the_disability_disclosure


### PR DESCRIPTION
## Context

We're currently showing the provider all references for a candidate, even unsubmitted/cancelled/refused ones.

When it was built we only ever sent applications to providers when there were 2 references, so we didn't think to filter.

We noticed this in the API 2 weeks ago https://github.com/DFE-Digital/apply-for-teacher-training/pull/3039.

## Changes proposed in this pull request

Only show references that have feedback and add a test.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/r2ae9tZs

