### PR TITLE
Rework referee system specs with flag toggled off and fix chaser email workers

### DIFF
--- a/app/queries/get_references_to_chase.rb
+++ b/app/queries/get_references_to_chase.rb
@@ -1,9 +1,17 @@
 class GetReferencesToChase
   def self.call
-    ApplicationReference
-      .feedback_requested
-      .where(['requested_at < ?', chase_referee_time_limit])
-      .where.not(id: ChaserSent.reference_request.select(:chased_id))
+    if FeatureFlag.active?(:decoupled_references)
+      ApplicationReference
+        .feedback_requested
+        .where(['requested_at < ?', chase_referee_time_limit])
+        .where(application_form_id: ApplicationForm.where(submitted_at: nil).pluck(:id))
+        .where.not(id: ChaserSent.reference_request.select(:chased_id))
+    else
+      ApplicationReference
+        .feedback_requested
+        .where(['requested_at < ?', chase_referee_time_limit])
+        .where.not(id: ChaserSent.reference_request.select(:chased_id))
+    end
   end
 
   def self.chase_referee_time_limit

--- a/spec/queries/get_references_to_chase_spec.rb
+++ b/spec/queries/get_references_to_chase_spec.rb
@@ -8,8 +8,15 @@ RSpec.describe GetReferencesToChase do
       expect(described_class.call).to include reference
     end
 
-    it 'only returns application choices which are awaiting references' do
+    it 'only returns application references which are awaiting references' do
       create(:reference, :complete, requested_at: 8.days.ago)
+
+      expect(described_class.call).to be_empty
+    end
+
+    it 'does not return application forms that have been submitted' do
+      application_form = create(:completed_application_form)
+      create(:reference, feedback_status: 'feedback_requested', requested_at: 8.days.ago, application_form: application_form)
 
       expect(described_class.call).to be_empty
     end

--- a/spec/system/candidate_interface/specs_to_be_deleted/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_with_decoupled_references_flag_off_spec.rb
+++ b/spec/system/candidate_interface/specs_to_be_deleted/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_with_decoupled_references_flag_off_spec.rb
@@ -1,0 +1,232 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee can submit reference', with_audited: true do
+  include CandidateHelper
+
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
+  scenario 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do
+    given_a_candidate_completed_an_application
+    when_the_candidate_submits_the_application
+    then_i_receive_an_email_with_a_magic_link
+
+    when_i_try_to_access_the_reference_page_with_invalid_token
+    then_i_see_page_not_found
+
+    when_i_click_on_the_link_within_the_email
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+
+    when_i_click_on_continue
+    then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
+
+    when_i_confirm_that_the_described_relationship_is_not_correct
+    and_i_click_on_continue
+    then_i_see_an_error_to_enter_my_relationship_with_the_candidate
+
+    when_i_confirm_that_the_described_relationship_is_correct
+    and_i_click_on_continue
+    then_i_see_the_safeguarding_page
+
+    when_i_click_on_continue
+    then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
+
+    when_i_choose_the_candidate_is_not_suitable_for_working_with_children
+    and_i_click_on_continue
+    then_i_see_an_error_to_enter_my_safeguarding_concerns
+
+    when_i_choose_the_candidate_is_suitable_for_working_with_children
+    and_i_click_on_continue
+    then_i_see_the_reference_comment_page
+
+    when_i_fill_in_the_reference_field
+    and_i_click_on_continue
+    then_i_see_the_reference_review_page
+
+    when_i_click_change_relationship
+    and_i_amend_the_relationship
+    and_i_click_on_continue
+    then_i_can_review_the_amended_relationship
+
+    when_i_click_change_safeguarding_concerns
+    and_i_amend_the_safeguarding_concerns
+    and_i_click_on_continue
+    then_i_can_review_the_amended_safeguarding_concerns
+
+    and_i_click_the_submit_reference_button
+    then_i_see_am_told_i_submittted_my_refernce
+    then_i_see_the_confirmation_page
+    and_i_receive_an_email_confirmation
+    and_the_candidate_receives_a_notification
+
+    when_i_choose_to_be_contactable
+    and_i_click_the_finish_button
+    then_i_see_the_thank_you_page
+    and_i_am_told_i_will_be_contacted
+
+    when_i_retry_to_edit_the_feedback
+    then_i_see_the_thank_you_page
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+  end
+
+  def then_i_receive_an_email_with_a_magic_link
+    open_email('terri@example.com')
+
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
+    @token = Rack::Utils.parse_query(URI(matches.captures.first).query)['token']
+    @reference_feedback_url = matches.captures.first unless matches.nil?
+
+    expect(@reference_feedback_url).not_to be_nil
+  end
+
+  def when_i_try_to_access_the_reference_page_with_invalid_token
+    visit referee_interface_reference_feedback_path(token: 'invalid-token')
+  end
+
+  def then_i_see_page_not_found
+    expect(page).to have_content('Page not found')
+  end
+
+  def when_i_click_on_the_link_within_the_email
+    current_email.click_link(@reference_feedback_url)
+  end
+
+  def then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+  end
+
+  def when_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content('Choose if the described relationship is correct')
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_not_correct
+    choose 'No'
+  end
+
+  def then_i_see_an_error_to_enter_my_relationship_with_the_candidate
+    expect(page).to have_content("Enter your relationship to #{@application.full_name}")
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_correct
+    choose 'Yes'
+  end
+
+  def then_i_see_the_safeguarding_page
+    expect(page).to have_content("Do you know of any reason why #{@application.full_name} should not work with children?")
+  end
+
+  def then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
+    expect(page).to have_content("Select if you know of any reason why #{@application.full_name} should not work with children")
+  end
+
+  def when_i_choose_the_candidate_is_not_suitable_for_working_with_children
+    choose 'Yes'
+  end
+
+  def then_i_see_an_error_to_enter_my_safeguarding_concerns
+    expect(page).to have_content("Enter a reason why #{@application.full_name} should not work with children")
+  end
+
+  def when_i_choose_the_candidate_is_suitable_for_working_with_children
+    choose 'No'
+  end
+
+  def and_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_reference_comment_page
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+  end
+
+  def when_i_fill_in_the_reference_field
+    fill_in 'Your reference', with: 'This is a reference for the candidate.'
+  end
+
+  def then_i_see_the_reference_review_page
+    expect(page).to have_content('Check your answers before submitting your reference')
+  end
+
+  def when_i_click_change_relationship
+    click_link 'Change relationship'
+  end
+
+  def and_i_amend_the_relationship
+    choose 'No'
+    fill_in "Tell us what your relationship is to #{@application.full_name} and how long you’ve known them", with: 'he is not my friend'
+  end
+
+  def then_i_can_review_the_amended_relationship
+    click_button 'Continue'
+    expect(page).to have_content('Amended by referee to: he is not my friend')
+  end
+
+  def when_i_click_change_safeguarding_concerns
+    click_link 'Change concerns about candidate working with children'
+  end
+
+  def and_i_amend_the_safeguarding_concerns
+    choose 'Yes'
+    fill_in "Tell us why you think #{@application.full_name} should not work with children", with: 'telling dirty jokes'
+  end
+
+  def then_i_can_review_the_amended_safeguarding_concerns
+    expect(page).to have_content('telling dirty jokes')
+  end
+
+  def and_i_click_the_submit_reference_button
+    click_button t('reference_form.confirm')
+  end
+
+  def and_i_click_the_finish_button
+    click_button t('questionnaire_form.confirm')
+  end
+
+  def then_i_see_am_told_i_submittted_my_refernce
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+  end
+
+  def and_i_receive_an_email_confirmation
+    open_email('terri@example.com')
+
+    expect(current_email.subject).to have_content(t('reference_confirmation_email.subject', candidate_name: @application.full_name))
+  end
+
+  def and_the_candidate_receives_a_notification
+    open_email(current_candidate.email_address)
+
+    expect(current_email.subject).to end_with('You have a reference from Terri Tudor')
+    expect(current_email.body).to have_content('You need to get another reference')
+  end
+
+  def then_i_see_the_thank_you_page
+    expect(page).to have_content('Thank you')
+  end
+
+  def and_i_am_told_i_will_be_contacted
+    expect(page).to have_content('Our user research team will contact you shortly')
+  end
+
+  def when_i_retry_to_edit_the_feedback
+    visit @reference_feedback_url
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path(referee_interface_confirmation_path(token: @token))
+  end
+
+  def when_i_choose_to_be_contactable
+    choose t('questionnaire_form.consent_to_be_contacted')
+    fill_in 'Please let us know when you’re available', with: 'anytime 012345 678900'
+  end
+end

--- a/spec/system/candidate_interface/specs_to_be_deleted/referee_does_not_respond_with_decoupled_references_flag_off_spec.rb
+++ b/spec/system/candidate_interface/specs_to_be_deleted/referee_does_not_respond_with_decoupled_references_flag_off_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee does not respond in time' do
+  include CandidateHelper
+
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
+  scenario 'Emails are sent if a referee does not respond in time' do
+    given_a_candidate_completed_an_application
+    when_the_candidate_submits_the_application
+    and_the_referee_does_not_respond_within_7_days
+    then_the_referee_is_sent_a_chase_email
+    and_an_email_is_sent_to_the_candidate
+
+    when_the_candidate_does_not_respond_within_14_days
+    then_an_email_is_sent_to_the_candidate_asking_for_a_new_referee
+
+    when_the_candidate_does_not_respond_within_28_days
+    then_the_candidate_is_sent_a_chase_email
+    and_the_referee_is_sent_a_chase_email
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+    @application.application_references.first.update!(feedback_status: :feedback_refused)
+  end
+
+  def and_the_referee_does_not_respond_within_7_days
+    Timecop.travel(7.days.from_now) do
+      SendReferenceChaseEmailToBothPartiesWorker.perform_async
+    end
+  end
+
+  def then_the_referee_is_sent_a_chase_email
+    open_email('anne@other.com')
+
+    expect(current_email.text).to include('We have not had your reference')
+  end
+
+  def and_an_email_is_sent_to_the_candidate
+    open_email(@application.candidate.email_address)
+
+    expect(current_email.subject).to end_with('Anne Other has not responded yet')
+  end
+
+  def when_the_candidate_does_not_respond_within_14_days
+    Timecop.travel(14.days.from_now) do
+      AskCandidatesForNewRefereesWorker.perform_async
+    end
+  end
+
+  def then_an_email_is_sent_to_the_candidate_asking_for_a_new_referee
+    open_email(@application.candidate.email_address)
+
+    expect(current_email.subject).to have_content('Anne Other has not responded yet')
+  end
+
+  def when_the_candidate_does_not_respond_within_28_days
+    Timecop.travel(28.days.from_now) do
+      SendAdditionalReferenceChaseEmailToBothPartiesWorker.perform_async
+    end
+  end
+
+  def then_the_candidate_is_sent_a_chase_email
+    open_email(@application.candidate.email_address)
+
+    expect(current_email.subject).to have_content('Anne Other has not responded yet')
+  end
+
+  def and_the_referee_is_sent_a_chase_email
+    open_email(@application.application_references.second.email_address)
+
+    expect(current_email.subject).to have_content("Will you not give #{@application.full_name} a reference?")
+  end
+end

--- a/spec/system/candidate_interface/specs_to_be_deleted/referee_refuses_to_give_a_reference_with_decoupled_references_flag_off_spec.rb
+++ b/spec/system/candidate_interface/specs_to_be_deleted/referee_refuses_to_give_a_reference_with_decoupled_references_flag_off_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.feature 'Refusing to give a reference' do
+  include CandidateHelper
+
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
+  scenario 'Referee refuses to give a reference' do
+    given_a_candidate_completed_an_application
+    when_the_candidate_submits_the_application
+    then_i_receive_an_email_with_a_reference_request
+
+    when_i_click_the_refuse_reference_link_in_the_email
+    and_i_say_that_i_do_actually_want_to_give_a_reference
+    then_i_see_the_reference_comment_page
+
+    when_i_click_the_refuse_reference_link_in_the_email
+    and_i_confirm_that_i_wont_give_a_reference
+    and_a_slack_notification_is_sent
+    then_an_email_is_sent_to_the_candidate
+    and_i_should_see_the_thank_you_page
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+  end
+
+  def then_i_receive_an_email_with_a_reference_request
+    open_email('terri@example.com')
+  end
+
+  def when_i_click_the_refuse_reference_link_in_the_email
+    current_email.click_link(refuse_feedback_url)
+  end
+
+  def and_i_say_that_i_do_actually_want_to_give_a_reference
+    click_link 'Cancel'
+  end
+
+  def then_i_see_the_reference_comment_page
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+  end
+
+  def and_a_slack_notification_is_sent
+    expect_slack_message_with_text ":sadparrot: A referee declined to give feedback for #{@application.first_name}’s application"
+  end
+
+  def and_i_confirm_that_i_wont_give_a_reference
+    click_button 'Yes - I’m sure'
+  end
+
+  def then_an_email_is_sent_to_the_candidate
+    open_email(@application.candidate.email_address)
+
+    expect(current_email.subject).to have_content(t('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Terri Tudor'))
+  end
+
+  def and_i_should_see_the_thank_you_page
+    expect(page).to have_content('Thank you')
+  end
+
+private
+
+  def refuse_feedback_url
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\/refuse-feedback\?token=[\w-]{20})/)
+    matches.captures.first unless matches.nil?
+  end
+end

--- a/spec/system/candidate_interface/specs_to_be_deleted/referee_tries_to_submit_incomplete_reference_with_decoupled_references_feature_flag_off_spec.rb
+++ b/spec/system/candidate_interface/specs_to_be_deleted/referee_tries_to_submit_incomplete_reference_with_decoupled_references_feature_flag_off_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.feature 'Stop submission of incomplete references', with_audited: true do
+  include CandidateHelper
+
+  before { FeatureFlag.deactivate(:decoupled_references) }
+
+  scenario 'Referee tries to submit incomplete reference' do
+    given_a_candidate_completed_an_application
+    when_the_candidate_submits_the_application
+    then_i_receive_an_email_with_a_magic_link
+
+    when_i_click_on_the_link_within_the_email
+    and_i_confirm_my_relationship_with_the_candidate
+    and_i_manually_skip_ahead_to_the_review_page
+    then_i_cannot_submit_the_reference
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+  end
+
+  def then_i_receive_an_email_with_a_magic_link
+    open_email('terri@example.com')
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
+    @token = Rack::Utils.parse_query(URI(matches.captures.first).query)['token']
+    @reference_feedback_url = matches.captures.first unless matches.nil?
+  end
+
+  def when_i_click_on_the_link_within_the_email
+    current_email.click_link(@reference_feedback_url)
+  end
+
+  def and_i_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+    choose 'Yes'
+    click_button 'Continue'
+  end
+
+  def and_i_manually_skip_ahead_to_the_review_page
+    visit referee_interface_reference_review_path(token: @token)
+  end
+
+  def then_i_cannot_submit_the_reference
+    click_button 'Submit reference'
+    expect(page).to have_content 'Cannot submit a reference without answers to all questions'
+    expect(ApplicationReference.feedback_provided).to be_empty
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.feature 'Referee can submit reference', with_audited: true do
   include CandidateHelper
 
-  before { FeatureFlag.deactivate(:decoupled_references) }
-
   scenario 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do
+    FeatureFlag.activate(:decoupled_references)
+
     given_a_candidate_completed_an_application
-    when_the_candidate_submits_the_application
     then_i_receive_an_email_with_a_magic_link
 
     when_i_try_to_access_the_reference_page_with_invalid_token
@@ -69,10 +68,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def given_a_candidate_completed_an_application
     candidate_completes_application_form
-  end
-
-  def when_the_candidate_submits_the_application
-    candidate_submits_application
   end
 
   def then_i_receive_an_email_with_a_magic_link

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.feature 'Referee does not respond in time' do
   include CandidateHelper
 
-  before { FeatureFlag.deactivate(:decoupled_references) }
-
   scenario 'Emails are sent if a referee does not respond in time' do
+    FeatureFlag.activate(:decoupled_references)
+
     given_a_candidate_completed_an_application
-    when_the_candidate_submits_the_application
     and_the_referee_does_not_respond_within_7_days
     then_the_referee_is_sent_a_chase_email
     and_an_email_is_sent_to_the_candidate
@@ -22,10 +21,6 @@ RSpec.feature 'Referee does not respond in time' do
 
   def given_a_candidate_completed_an_application
     candidate_completes_application_form
-  end
-
-  def when_the_candidate_submits_the_application
-    candidate_submits_application
     @application.application_references.first.update!(feedback_status: :feedback_refused)
   end
 

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.feature 'Refusing to give a reference' do
   include CandidateHelper
 
-  before { FeatureFlag.deactivate(:decoupled_references) }
-
   scenario 'Referee refuses to give a reference' do
+    FeatureFlag.activate(:decoupled_references)
+
     given_a_candidate_completed_an_application
-    when_the_candidate_submits_the_application
     then_i_receive_an_email_with_a_reference_request
 
     when_i_click_the_refuse_reference_link_in_the_email
@@ -23,10 +22,6 @@ RSpec.feature 'Refusing to give a reference' do
 
   def given_a_candidate_completed_an_application
     candidate_completes_application_form
-  end
-
-  def when_the_candidate_submits_the_application
-    candidate_submits_application
   end
 
   def then_i_receive_an_email_with_a_reference_request

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.feature 'Stop submission of incomplete references', with_audited: true do
   include CandidateHelper
 
-  before { FeatureFlag.deactivate(:decoupled_references) }
-
   scenario 'Referee tries to submit incomplete reference' do
+    FeatureFlag.activate(:decoupled_references)
+
     given_a_candidate_completed_an_application
-    when_the_candidate_submits_the_application
     then_i_receive_an_email_with_a_magic_link
 
     when_i_click_on_the_link_within_the_email
@@ -18,10 +17,6 @@ RSpec.feature 'Stop submission of incomplete references', with_audited: true do
 
   def given_a_candidate_completed_an_application
     candidate_completes_application_form
-  end
-
-  def when_the_candidate_submits_the_application
-    candidate_submits_application
   end
 
   def then_i_receive_an_email_with_a_magic_link


### PR DESCRIPTION
## Context

Previous PRs 
#3148 duplicated the first set of specs. Moved them into the specs_to_be_deleted folder and made the originals pass

This PR does the same as above with the referee system specs.

It also updates the workers which send the first and second reference-request chaser emails to use references in the awaiting feedback state where the application form has not been submitted.

## Changes proposed in this pull request

- Move ref system specs with the decoupled references flag the specs_to_be_deleted_folder
- Get the originals passing with the flag active
- Update the workers to send chasers to the correct candidates 

## Guidance to review

Some eyes on the worker-related behaviour would be great. I'll leave a comment.

## Link to Trello card

https://trello.com/c/pizcHLeY/2307-%F0%9F%92%94-dev-rework-existing-specs-for-decoupled-references

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
