### PR TITLE
Add recruitment cycle year to references export

### DIFF
--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -5,6 +5,7 @@ module SupportInterface
 
       application_forms.map do |af|
         output = {
+          'Recruitment cycle year' => af.recruitment_cycle_year,
           'Support ref number' => af.support_reference,
           'Phase' => af.phase,
           'Application state' => ProcessState.new(af).state,

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
 
   def return_expected_hash(application_form)
     {
+      'Recruitment cycle year' => application_form.recruitment_cycle_year,
       'Support ref number' => application_form.support_reference,
       'Phase' => application_form.phase,
       'Application state' => ProcessState.new(application_form).state,


### PR DESCRIPTION
## Context

This was missed in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3107.

## Changes proposed in this pull request

Add the cycle year.

## Link to Trello card

https://trello.com/c/HM6l3Scq/2339-add-cycle-column-to-references-data-extracts-in-support
