### PR TITLE
Enact permissions onboarding flow for orgs with 'invalid' permissions

### DIFF
--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -89,17 +89,14 @@ module ProviderInterface
 
     def grouped_provider_names_from_relationships
       provider_relationship_permissions_needing_setup
-        .includes(:training_provider, :ratifying_provider).each_with_object({}) do |prp, h|
+        .each_with_object({}) do |prp, h|
         h[prp.training_provider.name] ||= []
         h[prp.training_provider.name] << prp.ratifying_provider.name
       end
     end
 
     def provider_relationship_permissions_needing_setup
-      current_provider_user.authorisation
-        .training_provider_relationships_that_actor_can_manage_organisations_for
-        .where(setup_at: nil)
-        .order(created_at: :asc)
+      ProviderSetup.new(provider_user: current_provider_user).relationships_pending
     end
 
     def provider_relationships_attrs

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -42,12 +42,12 @@ class ProviderAuthorisation
   end
 
   def training_provider_relationships_that_actor_can_manage_organisations_for
-    manageable_provider_ids = ProviderPermissions
-      .where(provider_user: @actor, manage_organisations: true)
-      .pluck(:provider_id)
-
     ProviderRelationshipPermissions
-      .where(training_provider: manageable_provider_ids)
+      .includes(:ratifying_provider, :training_provider)
+      .joins("INNER JOIN #{ProviderPermissions.table_name} ON #{ProviderPermissions.table_name}.provider_id = provider_relationship_permissions.training_provider_id")
+      .where(training_provider: @actor.providers)
+      .where("#{ProviderPermissions.table_name}.provider_user_id": @actor.id, "#{ProviderPermissions.table_name}.manage_organisations": true)
+      .order(:created_at)
   end
 
   def can_manage_organisations_for_at_least_one_provider?

--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -23,14 +23,11 @@ class ProviderSetup
   end
 
   def next_relationship_pending
-    permissions = ProviderRelationshipPermissions
-      .order(:created_at)
-      .where(training_provider: @provider_user.providers)
-      .find { |prp| prp.setup_at.blank? || prp.invalid? }
+    relationships_pending&.first
+  end
 
-    if permissions.present?
-      auth = ProviderAuthorisation.new(actor: @provider_user)
-      permissions if auth.can_manage_organisation?(provider: permissions.training_provider)
-    end
+  def relationships_pending
+    auth = ProviderAuthorisation.new(actor: @provider_user)
+    auth.training_provider_relationships_that_actor_can_manage_organisations_for.select { |prp| prp.setup_at.blank? || prp.invalid? }
   end
 end

--- a/app/services/provider_setup.rb
+++ b/app/services/provider_setup.rb
@@ -23,10 +23,10 @@ class ProviderSetup
   end
 
   def next_relationship_pending
-    permissions = ProviderRelationshipPermissions.find_by(
-      setup_at: nil,
-      training_provider: @provider_user.providers,
-    )
+    permissions = ProviderRelationshipPermissions
+      .order(:created_at)
+      .where(training_provider: @provider_user.providers)
+      .find { |prp| prp.setup_at.blank? || prp.invalid? }
 
     if permissions.present?
       auth = ProviderAuthorisation.new(actor: @provider_user)

--- a/spec/services/provider_setup_spec.rb
+++ b/spec/services/provider_setup_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe ProviderSetup do
       expect(next_relationship_pending).to be_nil
     end
 
+    it 'provides the next invalid ProviderRelationshipPermissions record to set up' do
+      relationship = create(
+        :provider_relationship_permissions,
+        training_provider: training_provider,
+        training_provider_can_view_safeguarding_information: false,
+        ratifying_provider_can_view_safeguarding_information: false,
+        setup_at: nil,
+      )
+      relationship.setup_at = Time.zone.now
+      relationship.save(validate: false)
+
+      expect(next_relationship_pending).to eq(relationship)
+    end
+
     it 'returns nil if no relationships exist' do
       expect(next_relationship_pending).to be_nil
     end

--- a/spec/services/provider_setup_spec.rb
+++ b/spec/services/provider_setup_spec.rb
@@ -64,13 +64,15 @@ RSpec.describe ProviderSetup do
       expect(next_relationship_pending).to be_a(ProviderRelationshipPermissions)
     end
 
-    it 'provides all relationships pending setup for the user when called multiple times', skip: true do
-      relationships = 3.times.map do
-        create(
+    it 'provides all relationships pending setup for the user when called multiple times' do
+      relationships = []
+      3.times do |n|
+        relationships << create(
           :provider_relationship_permissions,
           training_provider: training_provider,
           ratifying_provider: create(:provider),
           setup_at: nil,
+          created_at: Time.zone.now + n,
         )
       end
       create(:provider_relationship_permissions, setup_at: nil) # pending setup but unrelated


### PR DESCRIPTION
## Context

We deliberately omitted enabling safeguarding and diversity permissions for existing organisations when setting up their default permissions.
This made some relationship permissions 'invalid' as at least one provider in the relationship should have each permission enabled. If the managing user in the organisation has not amended the permissions they are likely still in this state. We identified 181 records with this issue.

This has the side effect of restricting the visibility of safeguarding/diversity information completely if neither provider has the permission enabled. Users who are not able to manage permissions will be unaware of why they cannot see this information.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Amend the conditions of `ProviderSetup#next_pending_relationship` to return 'invalid' relationships. This will direct the managing user through the permissions setup flow when they log in.
- Unskip a test for `next_pending_relationship` which was relying on record order, this adds an order clause to ensure we retrieve the oldest records first.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

This PR covers the task _When a user with manage org/user permissions logs in and permissions haven't been set up, prompt them to set them up_

https://trello.com/c/UAsvSnET/2868-dev-changes-tweaks-for-permissions
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
