### PR TITLE
Cancel outstanding reference requests when two receive feedback

### DIFF
--- a/app/services/cancel_referee.rb
+++ b/app/services/cancel_referee.rb
@@ -1,14 +1,18 @@
 class CancelReferee
-  def call(reference:)
+  def call(reference:, cancelled_by_default: false)
     reference.update!(feedback_status: 'cancelled')
     RefereeMailer.reference_cancelled_email(reference).deliver_later
-    send_slack_message(reference, reference.application_form)
+    send_slack_message(reference, reference.application_form, cancelled_by_default)
   end
 
 private
 
-  def send_slack_message(reference, application_form)
-    message = "Candidate #{reference.application_form.first_name} has cancelled one of their references"
+  def send_slack_message(reference, application_form, cancelled_by_default)
+    message = if cancelled_by_default
+                "Candidate #{reference.application_form.first_name}'s reference request has been cancelled as they have recieved two sets of feedback"
+              else
+                "Candidate #{reference.application_form.first_name} has cancelled one of their references"
+              end
     url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
 
     SlackNotificationWorker.perform_async(message, url)

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -25,12 +25,7 @@ class SubmitReference
         reference_feedback_provided!
 
         application_form.application_references.select(&:feedback_requested?).each do |reference|
-          # TODO: use the CancelReference service once George merges it in. I'm thinking of adding another
-          # argument to the service which is something like maximum_references_received: false)
-          # which will trigger a different slack message for these cancelled references.
-
-          reference.update!(feedback_status: 'cancelled')
-          RefereeMailer.reference_cancelled_email(reference).deliver_later
+          CancelReferee.new.call(reference: reference, cancelled_by_default: true)
         end
       else
         progress_applications

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SubmitReference do
       end
 
       context 'when the second reference is received' do
-        it 'sets cancels reference requests for all remaining "awaiting_feedback" references' do
+        it 'cancels reference requests for all remaining "awaiting_feedback" references' do
           application_form = create(:application_form)
           reference1 = create(:reference, :requested, application_form: application_form)
           reference2 = create(:reference, :requested, application_form: application_form)

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -18,6 +18,24 @@ RSpec.describe SubmitReference do
         expect(reference_two).to be_feedback_provided
         expect(application_form.reload.application_choices).to all(be_unsubmitted)
       end
+
+      context 'when the second reference is received' do
+        it 'sets cancels reference requests for all remaining "awaiting_feedback" references' do
+          application_form = create(:application_form)
+          reference1 = create(:reference, :requested, application_form: application_form)
+          reference2 = create(:reference, :requested, application_form: application_form)
+          reference3 = create(:reference, :refused, application_form: application_form)
+          reference4 = create(:reference, :requested, application_form: application_form)
+
+          SubmitReference.new(reference: reference1).save!
+          SubmitReference.new(reference: reference2).save!
+
+          expect(reference1).to be_feedback_provided
+          expect(reference2).to be_feedback_provided
+          expect(reference3.reload).to be_feedback_refused
+          expect(reference4.reload).to be_cancelled
+        end
+      end
     end
 
     describe 'decoupled_references feature OFF' do

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -109,7 +109,7 @@ module CandidateHelper
       reference: first_reference,
     ).save!
 
-    second_reference = application_form.application_references.last
+    second_reference = application_form.application_references.second
 
     second_reference.update!(
       feedback: 'Lovable',

--- a/spec/system/candidate_interface/decoupled_references/candidate_receives_feedback_from_their_reference_requests_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_receives_feedback_from_their_reference_requests_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.feature 'Decoupled references' do
+  include CandidateHelper
+
+  before { FeatureFlag.activate(:decoupled_references) }
+
+  scenario 'The candidate receives feedback from two of their four referees' do
+    given_i_am_signed_in
+    and_i_have_provided_my_name
+    and_i_have_provided_4_references
+    and_one_my_references_has_declined_to_give_feedback
+    and_i_have_received_feedback_from_two_references
+
+    when_i_visit_my_reference_review_page
+    then_i_can_see_my_references_have_provided_feedback
+    and_i_can_see_that_one_of_my_referees_declined_my_request
+    and_i_can_see_my_remaining_reference_request_has_been_cancelled
+    and_my_final_referee_has_been_told_that_they_do_not_need_to_provide_feedback
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+    @application = @candidate.current_application
+  end
+
+  def and_i_have_provided_my_name
+    @application.update!(first_name: 'Lando', last_name: 'Calrissian')
+  end
+
+  def and_i_have_provided_4_references
+    visit candidate_interface_decoupled_references_start_path
+    click_link 'Continue'
+    choose 'Academic'
+    click_button 'Save and continue'
+
+    candidate_fills_in_referee
+    choose 'Yes, send a reference request now'
+    click_button 'Save and continue'
+
+    click_link 'Add another referee'
+    click_link 'Continue'
+    choose 'Professional'
+    click_button 'Save and continue'
+
+    candidate_fills_in_referee(
+      name: 'Anne Other',
+      email_address: 'anne@other.com',
+      relationship: 'First boss',
+    )
+    choose 'Yes, send a reference request now'
+    click_button 'Save and continue'
+
+    click_link 'Add another referee'
+    click_link 'Continue'
+    choose 'School-based'
+    click_button 'Save and continue'
+
+    candidate_fills_in_referee(
+      name: 'Mr Declined',
+      email_address: 'mr@declined.com',
+      relationship: 'Mentor',
+    )
+    choose 'Yes, send a reference request now'
+    click_button 'Save and continue'
+
+    click_link 'Add another referee'
+    click_link 'Continue'
+    choose 'Character'
+    click_button 'Save and continue'
+
+    candidate_fills_in_referee(
+      name: 'Ms Cancelled',
+      email_address: 'ms@ocancelled.com',
+      relationship: 'Worked with me at a charity.',
+    )
+    choose 'Yes, send a reference request now'
+    click_button 'Save and continue'
+  end
+
+  def and_one_my_references_has_declined_to_give_feedback
+    @application.application_references.school_based.first.feedback_refused!
+  end
+
+  def and_i_have_received_feedback_from_two_references
+    receive_references
+  end
+
+  def when_i_visit_my_reference_review_page
+    visit candidate_interface_decoupled_references_review_path
+  end
+
+  def then_i_can_see_my_references_have_provided_feedback
+    within all('.app-summary-card')[0] do
+      expect(find('.app-summary-card__title').text).to have_content 'Academic reference from Terri Tudor'
+      expect(all('.govuk-summary-list__row')[4].text).to have_content 'Reference given'
+    end
+
+    within all('.app-summary-card')[1] do
+      expect(find('.app-summary-card__title').text).to have_content 'Professional reference from Anne Other'
+      expect(all('.govuk-summary-list__row')[4].text).to have_content 'Reference given'
+    end
+  end
+
+  def and_i_can_see_that_one_of_my_referees_declined_my_request
+    within all('.app-summary-card')[2] do
+      expect(find('.app-summary-card__title').text).to have_content 'School-based reference from Mr Declined'
+      expect(all('.govuk-summary-list__row')[4].text).to have_content 'Reference declined'
+    end
+  end
+
+  def and_i_can_see_my_remaining_reference_request_has_been_cancelled
+    within all('.app-summary-card')[3] do
+      expect(find('.app-summary-card__title').text).to have_content 'Character reference from Ms Cancelled'
+      expect(all('.govuk-summary-list__row')[4].text).to have_content 'Cancelled'
+    end
+  end
+
+  def and_my_final_referee_has_been_told_that_they_do_not_need_to_provide_feedback
+    open_email('ms@ocancelled.com')
+
+    expect(current_email.body).to have_content('You do not need to give a reference for Lando Calrissian')
+  end
+end


### PR DESCRIPTION
## Context

As part of the investigation on 💔 Dev: investigate remaining work for decoupled references, it was discovered that a candidate would be able to receive feedback from more than 2 references.

After discussion here https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1602757043369600 it was decided that outstanding reference requests will be cancelled once two references receive feedback.

## Changes proposed in this pull request

- Update the SubmitReference service to it implements the above behaviour

## Guidance to review

Does this approach make sense?

## Link to Trello card

https://trello.com/c/pizcHLeY/2307-%F0%9F%92%94-dev-investigate-remaining-work-for-decoupled-references

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
