### PR TITLE
Review reference states

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -106,38 +106,36 @@ module CandidateInterface
     end
 
     def feedback_status_content(reference)
-      if reference.not_requested_yet?
-        tag.p(t('application_form.referees.info.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2')
-      elsif reference.feedback_refused?
-        tag.p(t('application_form.referees.info.declined'), class: 'govuk-body govuk-!-margin-top-2')
-      elsif reference.cancelled_at_end_of_cycle?
-        tag.p(t('application_form.referees.info.cancelled_at_end_of_cycle'), class: 'govuk-body govuk-!-margin-top-2')
-      elsif reference.cancelled?
-        tag.p(t('application_form.referees.info.cancelled'), class: 'govuk-body govuk-!-margin-top-2')
-      elsif reference.feedback_overdue?
-        tag.p(t('application_form.referees.info.feedback_overdue'), class: 'govuk-body govuk-!-margin-top-2')
-      elsif reference.feedback_requested? && reference.requested_at > Time.zone.now - 5.days
-        tag.p(t('application_form.referees.info.awaiting_reference_sent_less_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
-      elsif reference.feedback_requested?
-        tag.p(t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
+      text =
+        if reference.feedback_refused?
+          t('application_form.referees.info.declined', referee_name: reference.name)
+        elsif reference.cancelled_at_end_of_cycle?
+          t('application_form.referees.info.cancelled_at_end_of_cycle')
+        elsif reference.cancelled?
+          t('application_form.referees.info.cancelled')
+        elsif reference.feedback_overdue?
+          t('application_form.referees.info.feedback_overdue')
+        elsif reference.feedback_requested?
+          t('application_form.referees.info.feedback_requested')
+        elsif reference.email_bounced?
+          t('application_form.referees.info.email_bounced')
+        end
+
+      return '' if text.blank?
+
+      if text.is_a?(Array)
+        text.each_with_object('') { |line, content| content.concat(tag.p(line, class: 'govuk-body govuk-!-margin-top-2')) }.html_safe
+      else
+        tag.p(text, class: 'govuk-body govuk-!-margin-top-2')
       end
     end
 
     def feedback_status_colour(reference)
-      case reference.feedback_status
-      when 'not_requested_yet'
-        :grey
-      when 'feedback_refused', 'email_bounced'
-        :red
-      when 'cancelled', 'cancelled_at_end_of_cycle'
-        :orange
-      when 'feedback_overdue'
-        :yellow
-      when 'feedback_requested'
-        reference.feedback_overdue? ? :yellow : :purple
-      when 'feedback_provided'
-        :green
+      if reference.feedback_overdue? && !reference.cancelled_at_end_of_cycle?
+        return t('candidate_reference_colours.feedback_overdue')
       end
+
+      t("candidate_reference_colours.#{reference.feedback_status}")
     end
   end
 end

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -95,19 +95,19 @@ module CandidateInterface
 
     def feedback_status_content(referee)
       if referee.not_requested_yet? && !referee.application_form.submitted?
-        tag.p(t('application_form.referees.info.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2')
+        tag.p(t('application_form.referees.info_without_decoupled_references.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.feedback_refused?
-        tag.p(t('application_form.referees.info.declined'), class: 'govuk-body govuk-!-margin-top-2')
+        tag.p(t('application_form.referees.info_without_decoupled_references.declined'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.cancelled_at_end_of_cycle?
-        tag.p(t('application_form.referees.info.cancelled_at_end_of_cycle'), class: 'govuk-body govuk-!-margin-top-2')
+        tag.p(t('application_form.referees.info_without_decoupled_references.cancelled_at_end_of_cycle'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.feedback_overdue?
-        tag.p(t('application_form.referees.info.feedback_overdue'), class: 'govuk-body govuk-!-margin-top-2')
+        tag.p(t('application_form.referees.info_without_decoupled_references.feedback_overdue'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.feedback_requested? && referee.requested_at > Time.zone.now - 5.days
-        tag.p(t('application_form.referees.info.awaiting_reference_sent_less_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
+        tag.p(t('application_form.referees.info_without_decoupled_references.awaiting_reference_sent_less_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.feedback_requested?
-        tag.p(t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
+        tag.p(t('application_form.referees.info_without_decoupled_references.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.cancelled?
-        tag.p(t('application_form.referees.info.cancelled'), class: 'govuk-body govuk-!-margin-top-2')
+        tag.p(t('application_form.referees.info_without_decoupled_references.cancelled'), class: 'govuk-body govuk-!-margin-top-2')
       end
     end
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -418,6 +418,19 @@ en:
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:
         before_submission: You need to add 2 referees.
+        declined: "%{referee_name} said they will not give a reference."
+        feedback_requested: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
+        feedback_overdue:
+          - Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
+          - You can also add more referees to increase your chances of getting a reference quickly.
+        cancelled: Training providers will not see any information about this reference request.
+        cancelled_at_end_of_cycle: The referee did not respond before courses closed.
+        email_bounced: The reference request never reached your referee.
+        not_requested_yet: We’ll contact your referees after you submit your application.
+        awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
+        awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
+      info_without_decoupled_references:
+        before_submission: You need to add 2 referees.
         not_requested_yet:  We’ll contact your referees after you submit your application.
         declined: Your referee chose not to give a reference.
         awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.

--- a/config/locales/reference.yml
+++ b/config/locales/reference.yml
@@ -8,13 +8,13 @@ en:
     feedback_refused: Reference declined
     email_bounced: Email bounced
   candidate_reference_status:
-    cancelled: Cancelled
-    cancelled_at_end_of_cycle: Cancelled
+    cancelled: Request cancelled
+    cancelled_at_end_of_cycle: Request cancelled
     not_requested_yet: Not requested yet
     feedback_requested: Awaiting response
     feedback_provided: Reference given
     feedback_refused: Reference declined
-    email_bounced: Email address incorrect
+    email_bounced: Request failed
     feedback_overdue: Response overdue
   candidate_reference_colours:
     cancelled: orange

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -40,9 +40,12 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
       )
       next if row.info_identifier.blank?
 
-      expect(result.css('.govuk-summary-list__value')[4].text).to(
-        include(t("application_form.referees.info.#{row.info_identifier}")),
-      )
+      info = t("application_form.referees.info.#{row.info_identifier}", row.info_args || {})
+      if info.is_a?(Array)
+        info.each { |line| expect(result.css('.govuk-summary-list__value')[4].text).to(include(line)) }
+      else
+        expect(result.css('.govuk-summary-list__value')[4].text).to(include(info))
+      end
     end
   end
 
@@ -142,17 +145,17 @@ private
     sent_more_than_5_days_ago = create(:reference, :sent_more_than_5_days_ago, application_form: af)
     feedback_provided = create(:reference, :complete, application_form: af)
 
-    status_struct = Struct.new(:reference, :colour, :status_identifier, :info_identifier)
+    status_struct = Struct.new(:reference, :colour, :status_identifier, :info_identifier, :info_args)
     stub_const('Status', status_struct)
     [
-      Status.new(not_requested_yet, :grey, 'not_requested_yet', 'not_requested_yet'),
-      Status.new(feedback_refused, :red, 'feedback_refused', 'declined'),
+      Status.new(not_requested_yet, :grey, 'not_requested_yet', ''),
+      Status.new(feedback_refused, :red, 'feedback_refused', 'declined', referee_name: feedback_refused.name),
       Status.new(email_bounced, :red, 'email_bounced', ''),
       Status.new(cancelled_at_end_of_cycle, :orange, 'cancelled_at_end_of_cycle', 'cancelled_at_end_of_cycle'),
       Status.new(cancelled, :orange, 'cancelled', 'cancelled'),
       Status.new(feedback_overdue, :yellow, 'feedback_overdue', 'feedback_overdue'),
-      Status.new(sent_less_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_less_than_5_days_ago'),
-      Status.new(sent_more_than_5_days_ago, :purple, 'feedback_requested', 'awaiting_reference_sent_more_than_5_days_ago'),
+      Status.new(sent_less_than_5_days_ago, :purple, 'feedback_requested', 'feedback_requested'),
+      Status.new(sent_more_than_5_days_ago, :purple, 'feedback_requested', 'feedback_requested'),
       Status.new(feedback_provided, :green, 'feedback_provided', ''),
     ]
   end

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Not requested')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.not_requested_yet'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info_without_decoupled_references.not_requested_yet'))
     end
 
     it 'renders component with correct value for status for given reference' do
@@ -55,7 +55,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-tag.govuk-tag--red.app-tag').to_html).to include('Reference declined')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.declined'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info_without_decoupled_references.declined'))
     end
 
     it 'renders component with correct value for status for (non-expired) request reference sent less than 5 days ago' do
@@ -69,7 +69,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-tag.govuk-tag--purple.app-tag').to_html).to include('Awaiting response')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.awaiting_reference_sent_less_than_5_days_ago'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info_without_decoupled_references.awaiting_reference_sent_less_than_5_days_ago'))
     end
 
     it 'renders component with correct value for status for (non-expired) request reference sent more than 5 days ago' do
@@ -83,7 +83,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-tag.govuk-tag--purple.app-tag').to_html).to include('Awaiting response')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info_without_decoupled_references.awaiting_reference_sent_more_than_5_days_ago'))
     end
 
     it 'renders component with correct value for status for expired reference request' do
@@ -97,7 +97,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-tag.govuk-tag--yellow.app-tag').to_html).to include('Response overdue')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.feedback_overdue'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info_without_decoupled_references.feedback_overdue'))
     end
 
     it 'renders component with correct value for status for cancelled reference request' do
@@ -108,8 +108,8 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-tag.govuk-tag--orange.app-tag').to_html).to include('Cancelled')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.cancelled'))
+      expect(result.css('.govuk-tag.govuk-tag--orange.app-tag').to_html).to include('Request cancelled')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info_without_decoupled_references.cancelled'))
     end
 
     it 'renders component with correct value for status for cancelled_at_end_of_cycle reference request' do
@@ -120,8 +120,8 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-tag.govuk-tag--orange.app-tag').to_html).to include('Cancelled')
-      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.cancelled_at_end_of_cycle'))
+      expect(result.css('.govuk-tag.govuk-tag--orange.app-tag').to_html).to include('Request cancelled')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info_without_decoupled_references.cancelled_at_end_of_cycle'))
     end
 
     it 'renders component along with a delete link for each referee' do
@@ -206,7 +206,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Not requested')
-      expect(result.css('.govuk-summary-list__value').to_html).not_to include(t('application_form.referees.info.not_requested_yet'))
+      expect(result.css('.govuk-summary-list__value').to_html).not_to include(t('application_form.referees.info_without_decoupled_references.not_requested_yet'))
     end
   end
 end

--- a/spec/system/candidate_interface/decoupled_references/candidate_receives_feedback_from_their_reference_requests_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_receives_feedback_from_their_reference_requests_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Decoupled references' do
   def and_i_can_see_my_remaining_reference_request_has_been_cancelled
     within all('.app-summary-card')[3] do
       expect(find('.app-summary-card__title').text).to have_content 'Character reference from Ms Cancelled'
-      expect(all('.govuk-summary-list__row')[4].text).to have_content 'Cancelled'
+      expect(all('.govuk-summary-list__row')[4].text).to have_content 'Request cancelled'
     end
   end
 

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature 'Review references' do
 
     expect(page).to have_current_path candidate_interface_decoupled_references_review_path
     expect(page).to have_content("Reference request cancelled for #{@requested_reference.name}")
-    expect(page).to have_content('Cancelled')
+    expect(page).to have_content('Request cancelled')
   end
 
   def and_referee_receives_email_about_reference_cancellation


### PR DESCRIPTION
## Context

As a candidate I need to know the status of my references so that I can take the appropriate follow-on action.

This PR updates the reference review page with the latest design and content.

## Changes proposed in this pull request

- [x] Updates to the content and colours for the `DecoupledReferenceReviewComponent`

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229479-e06dd880-0f8e-11eb-84c3-ce60523f5c9e.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229511-eb286d80-0f8e-11eb-8788-9f5f7bc82c90.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229537-f54a6c00-0f8e-11eb-8151-06908a164206.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229566-01cec480-0f8f-11eb-82a0-a8d4a9ffbe7e.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229579-0a26ff80-0f8f-11eb-80f2-3a7e66993b65.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229603-1317d100-0f8f-11eb-8828-67d3f80c73a3.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229623-1b700c00-0f8f-11eb-961d-eef7a8172192.png">
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96229654-2460dd80-0f8f-11eb-91c7-c455f80cf130.png">


## Guidance to review

- Colours are now looked up from `reference.yml`
- Some of the status title changes will have leaked into the old `ReferenceReviewComponent` (I've not attempted to keep all these changes behind the `decoupled_references` feature flag).
- To test every single combination will probably need a bit of direct database manipulation.

## Link to Trello card

https://trello.com/c/V9nKgrg3/2225-💔-dev-review-reference-states

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
