### PR TITLE
Decoupled references - update review application page

### DIFF
--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -22,6 +22,23 @@
   ) %>
 <% end %>
 
+<% if FeatureFlag.active?(:decoupled_references) %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
+  <% if !application_form.enough_references_have_been_provided? && editable %>
+    <%= render(
+      SectionMissingBannerComponent.new(
+        section: :references_provided,
+        section_path: candidate_interface_decoupled_references_review_path,
+        text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
+        link_text: t('review_application.references_provided.complete_section'),
+        error: missing_error
+      ),
+    ) %>
+  <% else %>
+    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: application_form.application_references.feedback_provided, editable: false)) %>
+  <% end %>
+<% end %>
+
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 
 <h3 class="govuk-heading-m"><%= t('page_titles.personal_details') %></h3>
@@ -75,21 +92,7 @@
 <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 <%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
-<% if FeatureFlag.active?(:decoupled_references) %>
-  <% if !application_form.enough_references_have_been_provided? && editable %>
-    <%= render(
-      SectionMissingBannerComponent.new(
-        section: :references_provided,
-        section_path: candidate_interface_decoupled_references_review_path,
-        text: t('review_application.references_provided.incomplete', minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES),
-        link_text: t('review_application.references_provided.complete_section'),
-        error: missing_error
-      ),
-    ) %>
-  <% else %>
-    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: application_form.application_references.feedback_provided, editable: false)) %>
-  <% end %>
-<% else %>
+<% unless FeatureFlag.active?(:decoupled_references) %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
   <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error, submitting_application: true)) %>
 <% end %>


### PR DESCRIPTION
## Context

As a candidate I need to review the status of my references before submitting an application so that I know what I’m sending to providers.

## Changes proposed in this pull request

- [x] Move references section to be the second item on this page

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/450843/96279472-9e648700-0fce-11eb-94d9-4744bf097d94.png">


Also specified in the this card but already done:

- Only references that have been given are shown
- The incomplete section message has been updated:
  > **You need 2 references before you can submit your application**
  > [Manage your references](#)

## Guidance to review

- No tests for this 'feature'.

## Link to Trello card

https://trello.com/c/t9uX94DM/2224-💔-dev-update-review-your-application-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
