### PR TITLE
Allow candidates to send reference reminder email

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -1,7 +1,6 @@
 <% references.each do |reference| %>
-  <%= render(SummaryCardComponent.new(rows: reference_rows(reference), editable: editable && reference.editable?)) do %>
+  <%= render(SummaryCardComponent.new(rows: reference_rows(reference), editable: editable && reference.editable?, ignore_editable: ['History'])) do %>
     <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
-
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">
           <% if reference.feedback_requested? %>

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -101,6 +101,20 @@ module CandidateInterface
 
     def history_row(reference)
       return nil unless reference.requested_at && show_history
+
+      row_attributes = {
+        key: 'History',
+        value: render(ReferenceHistoryComponent.new(reference)),
+      }
+
+      if reference.can_send_reminder?
+        row_attributes.merge!(
+          action: 'Send a reminder to this referee',
+          action_path: candidate_interface_decoupled_references_new_reminder_path(reference),
+        )
+      end
+
+      row_attributes
     end
 
     def feedback_status_label(reference)

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -1,10 +1,11 @@
 module CandidateInterface
   class DecoupledReferencesReviewComponent < ViewComponent::Base
-    attr_reader :references, :editable
+    attr_reader :references, :editable, :show_history
 
-    def initialize(references:, editable: true)
+    def initialize(references:, editable: true, show_history: false)
       @references = references
       @editable = editable
+      @show_history = show_history
     end
 
     def card_title(reference)
@@ -18,6 +19,7 @@ module CandidateInterface
         reference_type_row(reference),
         relationship_row(reference),
         feedback_status_row(reference),
+        history_row(reference),
       ].compact
     end
 
@@ -95,6 +97,10 @@ module CandidateInterface
         key: 'Status',
         value: value,
       }
+    end
+
+    def history_row(reference)
+      return nil unless reference.requested_at && show_history
     end
 
     def feedback_status_label(reference)

--- a/app/components/reference_history_component.html.erb
+++ b/app/components/reference_history_component.html.erb
@@ -1,0 +1,15 @@
+<ul class='govuk-list qa-reference-history'>
+  <% if requested_at %>
+    <li>
+      Request sent
+      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= requested_at %></span>
+    </li>
+  <% end %>
+
+  <% if reminder_sent_at %>
+    <li>
+      Reminder sent
+      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= reminder_sent_at %></span>
+    </li>
+  <% end %>
+</ul>

--- a/app/components/reference_history_component.rb
+++ b/app/components/reference_history_component.rb
@@ -1,0 +1,25 @@
+class ReferenceHistoryComponent < ViewComponent::Base
+  attr_reader :reference
+
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def requested_at
+    return if reference.requested_at.blank?
+
+    date_format(reference.requested_at)
+  end
+
+  def reminder_sent_at
+    return if reference.reminder_sent_at.blank?
+
+    date_format(reference.reminder_sent_at)
+  end
+
+private
+
+  def date_format(datetime)
+    datetime.to_s(:govuk_date_and_time)
+  end
+end

--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -1,9 +1,9 @@
 class SummaryCardComponent < ViewComponent::Base
   validates :rows, presence: true
 
-  def initialize(rows:, border: true, editable: true)
+  def initialize(rows:, border: true, editable: true, ignore_editable: [])
     rows = transform_hash(rows) if rows.is_a?(Hash)
-    @rows = rows_including_actions_if_editable(rows, editable)
+    @rows = rows_including_actions_if_editable(rows, editable, ignore_editable)
     @border = border
   end
 
@@ -13,11 +13,13 @@ class SummaryCardComponent < ViewComponent::Base
 
 private
 
-  attr_reader :rows
+  attr_reader :rows, :ignore_editable
 
-  def rows_including_actions_if_editable(rows, editable)
+  def rows_including_actions_if_editable(rows, editable, ignore_editable)
     rows.map do |row|
       row.tap do |r|
+        next if r[:key].in? ignore_editable
+
         unless editable
           r.delete(:change_path)
           r.delete(:action_path)

--- a/app/controllers/candidate_interface/decoupled_references/reminder_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/reminder_controller.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  module DecoupledReferences
+    class ReminderController < BaseController
+      before_action :set_reference
+
+      def new; end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/decoupled_references/reminder_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/reminder_controller.rb
@@ -4,6 +4,11 @@ module CandidateInterface
       before_action :set_reference
 
       def new; end
+
+      def create
+        SendReferenceReminder.call(@reference, flash)
+        redirect_to candidate_interface_decoupled_references_review_path
+      end
     end
   end
 end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -86,6 +86,19 @@ class ApplicationReference < ApplicationRecord
     TimeLimitConfig.replace_referee_by.days.after(requested_at)
   end
 
+  def additional_chase_referee_at
+    return unless requested_at
+
+    TimeLimitConfig.additional_reference_chase_calendar_days.days.after(requested_at)
+  end
+
+  def next_automated_chase_at
+    return unless requested_at
+    return if additional_chase_referee_at < Time.zone.now
+
+    Time.zone.now < chase_referee_at ? chase_referee_at : additional_chase_referee_at
+  end
+
   def feedback_overdue?
     return unless replace_referee_at
     return unless feedback_requested? || cancelled_at_end_of_cycle?

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -109,4 +109,8 @@ class ApplicationReference < ApplicationRecord
   def editable?
     feedback_status == 'not_requested_yet'
   end
+
+  def can_send_reminder?
+    feedback_requested? && reminder_sent_at.nil?
+  end
 end

--- a/app/services/candidate_interface/decoupled_references/send_reference_reminder.rb
+++ b/app/services/candidate_interface/decoupled_references/send_reference_reminder.rb
@@ -1,0 +1,24 @@
+module CandidateInterface
+  module DecoupledReferences
+    class SendReferenceReminder
+      def self.call(reference, flash)
+        new(reference, flash).call
+      end
+
+      attr_reader :reference, :flash
+
+      def initialize(reference, flash)
+        @reference = reference
+        @flash = flash
+      end
+
+      def call
+        if reference.can_send_reminder?
+          RefereeMailer.reference_request_chaser_email(reference.application_form, reference).deliver_later
+          reference.update!(reminder_sent_at: Time.zone.now)
+          flash[:success] = "Reminder sent to #{reference.name}"
+        end
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/decoupled_references/reminder/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/reminder/new.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, t('page_titles.references_reminder') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_decoupled_references_review_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @reference, url: candidate_interface_decoupled_references_new_reminder_path(@reference), method: :post do |f| %>
+      <span class="govuk-caption-xl"> <%= @reference.name %> </span>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.references_reminder') %>
+      </h1>
+
+      <div class="govuk-inset-text govuk-!-margin-top-0">
+        You can only send one reminder to this referee.
+      </div>
+
+      <p class="govuk-body">
+        The referee will also get an automatic reminder on <%= @reference.next_automated_chase_at.strftime('%-d %B %Y') %>.
+      </p>
+
+      <%= f.govuk_submit 'Yes I’m sure - send a reminder'  %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'No - I’ve changed my mind', candidate_interface_decoupled_references_review_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/decoupled_references/review/show.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/show.html.erb
@@ -17,7 +17,7 @@
   <div id='references_given'>
     <h2 class="govuk-heading-m">References that have been given</h2>
     <%= render(
-      CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_given, editable: false)
+      CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_given, editable: false, show_history: true)
     ) %>
   </div>
 <% end %>
@@ -25,14 +25,14 @@
 <% if @references_waiting_to_be_sent.present? %>
   <div id='references_waiting_to_be_sent'>
     <h2 class="govuk-heading-m">Requests that have not been sent</h2>
-    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_waiting_to_be_sent)) %>
+    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_waiting_to_be_sent, show_history: true)) %>
   </div>
 <% end %>
 
 <% if @references_sent.present? %>
   <div id='references_sent'>
     <h2 class="govuk-heading-m">Reference requests</h2>
-    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_sent, editable: false)) %>
+    <%= render(CandidateInterface::DecoupledReferencesReviewComponent.new(references: @references_sent, editable: false, show_history: true)) %>
   </div>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,7 @@ en:
     references_relationship: How do you know this referee and how long have you known them?
     references_unsubmitted_review: Check your answers before sending your request
     references_candidate_name: Tell the referee your name
+    references_reminder: Would you like to send a reminder to this referee?
     providers: Courses on this service
     view_and_respond_to_offer: Details of offer
     api_docs:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -432,6 +432,9 @@ Rails.application.routes.draw do
         get '/request/:id' => 'decoupled_references/request#new', as: :decoupled_references_new_request
         post '/request/:id' => 'decoupled_references/request#create', as: :decoupled_references_create_request
 
+        get '/reminder/:id' => 'decoupled_references/reminder#new', as: :decoupled_references_new_reminder
+        post '/reminder/:id' => 'decoupled_references/reminder#create'
+
         get '/candidate_name/:id' => 'decoupled_references/candidate_name#new', as: :decoupled_references_new_candidate_name
         post '/candidate_name/:id' => 'decoupled_references/candidate_name#create', as: :decoupled_references_create_candidate_name
       end

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -169,6 +169,37 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
   end
 
+  context 'rendering history' do
+    let(:reference) { create(:reference, :requested) }
+
+    it 'does not render by default' do
+      result = render_inline(described_class.new(references: [reference]))
+      expect(result.text).not_to include 'History'
+    end
+
+    it 'renders when argument flag is set to true' do
+      result = render_inline(described_class.new(references: [reference], show_history: true))
+      expect(result.text).to include 'History'
+    end
+
+    it 'does not render if reference has never been requested' do
+      reference.requested_at = nil
+      result = render_inline(described_class.new(references: [reference], show_history: true))
+      expect(result.text).not_to include 'History'
+    end
+
+    it 'renders a reminder link if a reminder has not been sent' do
+      result = render_inline(described_class.new(references: [reference], show_history: true))
+      expect(result.text).to include 'Send a reminder to this referee'
+    end
+
+    it 'does not render a reminder link if a reminder has already been sent' do
+      reference.reminder_sent_at = Time.zone.now
+      result = render_inline(described_class.new(references: [reference], show_history: true))
+      expect(result.text).not_to include 'Send a reminder to this referee'
+    end
+  end
+
 private
 
   def status_table

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -92,14 +92,13 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     let(:feedback_requested) { create(:reference, :requested) }
     let(:feedback_refused) { create(:reference, :refused) }
 
-    # TODO: uncomment this test when Cancel links are implemented
     it 'a cancel link is available' do
-      # result = render_inline(described_class.new(references: [feedback_requested, feedback_refused]))
+      result = render_inline(described_class.new(references: [feedback_requested, feedback_refused]))
 
-      # feedback_requested_summary = result.css('.app-summary-card')[0]
-      # feedback_refused_summary = result.css('.app-summary-card')[1]
-      # expect(feedback_requested_summary.text).to include 'Cancel request'
-      # expect(feedback_refused_summary.text).not_to include 'Cancel request'
+      feedback_requested_summary = result.css('.app-summary-card')[0]
+      feedback_refused_summary = result.css('.app-summary-card')[1]
+      expect(feedback_requested_summary.text).to include 'Cancel request'
+      expect(feedback_refused_summary.text).not_to include 'Cancel request'
     end
   end
 

--- a/spec/components/reference_history_component_spec.rb
+++ b/spec/components/reference_history_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ReferenceHistoryComponent, type: :component do
+  it 'renders the requested_at time if present' do
+    reference = build(:reference)
+    result = render_inline(described_class.new(reference))
+    expect(result.text).not_to include 'Request sent'
+
+    reference.requested_at = Time.zone.local(2020, 1, 1, 13, 30)
+    result = render_inline(described_class.new(reference))
+    expect(result.text).to include 'Request sent'
+    expect(result.text).to include '1 January 2020 at  1:30pm'
+  end
+
+  it 'renders the reminder_sent_at time if present' do
+    reference = build(:reference)
+    result = render_inline(described_class.new(reference))
+    expect(result.text).not_to include 'Reminder sent'
+
+    reference.reminder_sent_at = Time.zone.local(2020, 1, 1, 13, 30)
+    result = render_inline(described_class.new(reference))
+    expect(result.text).to include 'Reminder sent'
+    expect(result.text).to include '1 January 2020 at  1:30pm'
+  end
+end

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -164,4 +164,34 @@ RSpec.describe ApplicationReference, type: :model do
       expect(ApplicationReference.pending_feedback_or_failed.size).to eq expected_states.size
     end
   end
+
+  describe '#next_automated_chase_at' do
+    context 'requested_at is nil' do
+      it 'returns nil' do
+        reference = build(:reference, requested_at: nil)
+        expect(reference.next_automated_chase_at).to eq nil
+      end
+    end
+
+    context 'current time is before first chase due date' do
+      it 'returns first chase due date' do
+        reference = build(:reference, requested_at: Time.zone.now)
+        expect(reference.next_automated_chase_at).to eq reference.chase_referee_at
+      end
+    end
+
+    context 'current time is after first chase due date' do
+      it 'returns second chase due date' do
+        reference = build(:reference, requested_at: Time.zone.now - TimeLimitConfig.chase_referee_by.days)
+        expect(reference.next_automated_chase_at).to eq reference.additional_chase_referee_at
+      end
+    end
+
+    context 'current time is after second chase due date' do
+      it 'returns nil' do
+        reference = build(:reference, requested_at: Time.zone.now - TimeLimitConfig.additional_reference_chase_calendar_days.days)
+        expect(reference.next_automated_chase_at).to eq nil
+      end
+    end
+  end
 end

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -194,4 +194,21 @@ RSpec.describe ApplicationReference, type: :model do
       end
     end
   end
+
+  describe '#can_send_reminder?' do
+    it 'is true when state is feedback_requested and reminder_sent_at is nil' do
+      reference = build(:reference, :requested, reminder_sent_at: nil)
+      expect(reference.can_send_reminder?).to eq true
+    end
+
+    it 'is false when state is not feedback_requested' do
+      reference = build(:reference, :unsubmitted, reminder_sent_at: nil)
+      expect(reference.can_send_reminder?).to eq false
+    end
+
+    it 'is false when reminder_sent_at is filled' do
+      reference = build(:reference, :requested, reminder_sent_at: Time.zone.now)
+      expect(reference.can_send_reminder?).to eq false
+    end
+  end
 end

--- a/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate sends a reference reminder' do
+  include CandidateHelper
+
+  scenario 'the candidate has sent a reference request and decides to send a reminder' do
+    given_i_am_signed_in
+    and_the_decoupled_references_flag_is_on
+    and_i_have_added_and_sent_a_reference
+
+    when_i_review_my_references
+    and_decide_to_send_a_reminder
+
+    then_i_see_the_date_of_the_next_automated_reminder
+    and_i_can_send_a_single_reminder_manually
+    and_submitting_a_stale_confirmation_form_does_nothing
+    and_the_reference_history_shows_the_reminder_i_just_sent
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_decoupled_references_flag_is_on
+    FeatureFlag.activate('decoupled_references')
+  end
+
+  def and_i_have_added_and_sent_a_reference
+    @reference = create(:reference, :requested, application_form: current_candidate.current_application)
+    current_candidate.current_application.update(first_name: 'Jeremy', last_name: 'Corbyn')
+  end
+
+  def when_i_review_my_references
+    visit candidate_interface_decoupled_references_review_path
+  end
+
+  def and_decide_to_send_a_reminder
+    within '#references_sent' do
+      click_link 'Send a reminder to this referee'
+    end
+  end
+
+  def then_i_see_the_date_of_the_next_automated_reminder
+    expect(page).to have_content 'Would you like to send a reminder to this referee?'
+    expect(page).to have_content @reference.chase_referee_at.strftime('%-d %B %Y')
+  end
+
+  def and_i_can_send_a_single_reminder_manually
+    click_button 'Yes I’m sure - send a reminder'
+    open_email(@reference.email_address)
+    expect(current_email.subject).to include 'Jeremy Corbyn is waiting for you to give them a reference'
+    expect(all_emails.size).to eq 1
+
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
+    expect(page).to have_content "Reminder sent to #{@reference.name}"
+    expect(page).not_to have_link 'Send a reminder to this referee'
+  end
+
+  def and_submitting_a_stale_confirmation_form_does_nothing
+    visit candidate_interface_decoupled_references_new_reminder_path(@reference)
+    click_button 'Yes I’m sure - send a reminder'
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
+    expect(all_emails.size).to eq 1
+  end
+
+  def and_the_reference_history_shows_the_reminder_i_just_sent
+    within '#references_sent' do
+      within '.qa-reference-history' do
+        expect(page).to have_content @reference.reload.reminder_sent_at.to_s(:govuk_date_and_time)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
**As a...** candidate
**I need to...** send my referee a reminder
**So that...** so that I can get my reference back quickly.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add a 'Send reminder' flow with its own controller, confirmation page, and service object.
- Introduce a component for rendering a basic version of the reference history feature.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- On review app or locally, send a reference request. When reviewing the reference, it should have a `Send a reminder to this referee` link in the newly-added History row.
- Upon clicking through, the confirmation page should display the next automated reminder date.
- Sending the reminder should update the history of that reference and the 'Send' link should no longer be visible.


## Link to Trello card
https://trello.com/c/rjXbj7ky
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
