### PR TITLE
Fix test data generation for new references flow

### DIFF
--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -20,17 +20,16 @@ class GenerateTestApplications
     raise 'You cannot generate test data in production' if HostingEnvironment.production?
 
     create states: [:unsubmitted]
-    create states: [:awaiting_references]
     create states: [:unsubmitted], course_full: true
-    create states: [:awaiting_references], course_full: true
-    create states: [:application_not_sent]
-    create states: [:application_complete]
+    create states: [:awaiting_provider_decision] * 3
+    create states: [:awaiting_provider_decision] * 3
     create states: [:awaiting_provider_decision] * 3
     create states: [:offer] * 2
     create states: %i[offer rejected]
     create states: [:rejected] * 2
     create states: [:offer_withdrawn]
-    create states: [:offer_deferred] * 2
+    create states: [:offer_deferred]
+    create states: [:offer_deferred]
     create states: [:declined]
     create states: [:accepted]
     create states: [:accepted_no_conditions]

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -6,12 +6,12 @@ class GenerateTestApplications
     @for_year = for_year
 
     if (dev_support_user = ProviderUser.find_by_dfe_sign_in_uid('dev-support'))
-      open_courses = dev_support_user.providers.map(&:courses).map(&:open_on_apply)
+      open_courses_per_provider = dev_support_user.providers.map { |p| p.courses.open_on_apply }
 
       @courses_to_apply_to = if @for_year == :previous_year
-                               open_courses.map(&:previous_cycle).flatten
+                               open_courses_per_provider.map(&:previous_cycle).flatten
                              else
-                               open_courses.map(&:current_cycle).flatten
+                               open_courses_per_provider.map(&:current_cycle).flatten
                              end
     end
   end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -44,14 +44,8 @@ task sync_dev_providers_and_open_courses: :environment do
 
   provider_codes = HostingEnvironment.review? ? %w[1JA 24J] : %w[1JA 24J 1N1]
   provider_codes.each do |code|
-    FindSync::SyncProviderFromFind.call(provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.previous_year)
-    FindSync::SyncProviderFromFind.call(provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.current_year)
-
-    # Temporary hack to make sure that we run this background inline, and the
-    # next bit of the script has courses to work with. This is a duplication, because
-    # `SyncProviderFromFind` already schedules a background job.
-    FindSync::SyncCoursesFromFind.new.perform(Provider.find_by(code: code).id, RecruitmentCycle.previous_year)
-    FindSync::SyncCoursesFromFind.new.perform(Provider.find_by(code: code).id, RecruitmentCycle.current_year)
+    FindSync::SyncProviderFromFind.call(run_in_background: false, provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.previous_year)
+    FindSync::SyncProviderFromFind.call(run_in_background: false, provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 
   puts 'Making all the courses open on Apply...'

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -45,6 +45,7 @@ task sync_dev_providers_and_open_courses: :environment do
   provider_codes = HostingEnvironment.review? ? %w[1JA 24J] : %w[1JA 24J 1N1]
   provider_codes.each do |code|
     FindSync::SyncProviderFromFind.call(run_in_background: false, provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.previous_year)
+    Provider.find_by_code(code).courses.previous_cycle.exposed_in_find.update_all(open_on_apply: true)
     FindSync::SyncProviderFromFind.call(run_in_background: false, provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe TestApplications do
     expect(candidate.created_at).to eq candidate.last_signed_in_at
     expect(days_between_ignoring_time_of_day(application_choice.created_at, candidate.created_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_form.submitted_at, application_choice.created_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_choice.sent_to_provider_at, application_form.submitted_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_choice.offered_at, application_choice.sent_to_provider_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_choice.accepted_at, application_choice.offered_at)).to be >= 1
   end
@@ -39,7 +38,6 @@ RSpec.describe TestApplications do
     candidate = application_form.candidate
     expect(days_between_ignoring_time_of_day(application_choice.created_at, candidate.created_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_form.submitted_at, application_choice.created_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_choice.sent_to_provider_at, application_form.submitted_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_choice.offered_at, application_choice.sent_to_provider_at)).to be >= 1
   end
 
@@ -50,7 +48,7 @@ RSpec.describe TestApplications do
     application_form = application_choice.application_form
     candidate = application_form.candidate
 
-    submission_audit = application_choice.audits.where("audited_changes @> '{\"status\": [\"unsubmitted\", \"awaiting_references\"]}'").first
+    submission_audit = application_choice.audits.where("audited_changes @> '{\"status\": [\"unsubmitted\", \"awaiting_provider_decision\"]}'").first
     expect(submission_audit).not_to be_nil
     expect(submission_audit.user).to eq candidate
   end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe GenerateTestApplications do
     expect(ApplicationChoice.pluck(:status)).to include(
       'unsubmitted',
       'awaiting_provider_decision',
-      'awaiting_references',
-      'application_not_sent',
       'offer',
       'rejected',
       'declined',
@@ -30,6 +28,6 @@ RSpec.describe GenerateTestApplications do
     # there is at least one unsubmitted application to a full course
     expect(ApplicationChoice.where(status: 'unsubmitted').map(&:course_option).select(&:no_vacancies?)).not_to be_empty
     # there is at least one awaiting_references application to a full course
-    expect(ApplicationChoice.where(status: 'awaiting_references').map(&:course_option).select(&:no_vacancies?)).not_to be_empty
+    expect(ApplicationChoice.where(status: 'unsubmitted').map(&:course_option).select(&:no_vacancies?)).not_to be_empty
   end
 end


### PR DESCRIPTION
## Context

Test data generation is broken because of the new references flow. The service responsible for progressing applications now is `SubmitApplicationWithDecoupledReferences` and some states are never visited anymore and will probably be removed (e.g. `awaiting_references` and `application_complete`).

## Changes proposed in this pull request

Fix all this by removing test data generation for states no longer supported and submitting applications via the new service.

## Guidance to review

Drop your database and populate it again with `setup_local_dev_data`.

## Link to Trello card

https://trello.com/c/QiEcDyYo/2343-💔-decoupled-references-update-test-applications-to-reflect-the-new-references-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
