### PR TITLE
Fixes for failing specs due to timezone issues

### DIFF
--- a/app/services/provider_interface/sort_application_choices.rb
+++ b/app/services/provider_interface/sort_application_choices.rb
@@ -56,9 +56,9 @@ module ProviderInterface
             AND (
               DATE(reject_by_default_at)
               BETWEEN
-                DATE('#{Time.zone.now.iso8601}')
+                DATE('#{Time.zone.now.iso8601}'::TIMESTAMPTZ)
               AND
-                DATE('#{5.business_days.after(Time.zone.now).iso8601}')
+                DATE('#{5.business_days.after(Time.zone.now).iso8601}'::TIMESTAMPTZ)
             )
         )
       AWAITING_PROVIDER_DECISION
@@ -69,7 +69,7 @@ module ProviderInterface
         (
           status = 'awaiting_provider_decision'
             AND (
-              DATE(reject_by_default_at) >= DATE('#{Time.zone.now.iso8601}')
+              DATE(reject_by_default_at) >= DATE('#{Time.zone.now.iso8601}'::TIMESTAMPTZ)
             )
         )
       AWAITING_PROVIDER_DECISION

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -54,9 +54,7 @@ RSpec.describe ProviderInterface::SortApplicationChoices do
     end
 
     it '#awaiting_provider_decision_non_urgent' do
-      pending 'broken due to time mismatch'
-
-      create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 6.business_days.after(Time.zone.now))
+      create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 6.business_days.from_now)
       expect(application_choice.task_view_group).to eq(4)
     end
 

--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Receives rejection email' do
   include CandidateHelper
 
   around do |example|
+    Time.zone = 'Pacific Time (US & Canada)'
     date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 1, 13)
     Timecop.freeze(date_that_avoids_clocks_changing_by_ten_days) do
       example.run
@@ -96,8 +97,6 @@ RSpec.feature 'Receives rejection email' do
   end
 
   def and_it_includes_details_of_my_offer
-    pending 'broken due to time mismatch'
-
     expect(current_email.text).to include(@offer.provider.name)
     expect(current_email.text).to include(@offer.course.name_and_code)
 

--- a/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Candidate sends a reference reminder' do
   def and_the_reference_history_shows_the_reminder_i_just_sent
     within '#references_sent' do
       within '.qa-reference-history' do
-        expect(page).to have_content @reference.reload.reminder_sent_at.to_s(:govuk_date_and_time)
+        expect(page).to have_content @reference.reload.reminder_sent_at.to_s(:govuk_date_and_time).squish
       end
     end
   end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3176

Several tests started failing today. This seems to be due to the CI server running with a different UTC offset to GMT but I don't have an explanation for why that might be. I was able to reproduce most of the errors locally only by forcing the timezone to be elsewhere `Time.zone = 'Paris'`.

## Changes proposed in this pull request

- Fixes described in the individual commits.

## Guidance to review

- Per commit.

## Link to Trello card

n/a

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
