### PR TITLE
Support: Redirect to applications page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -704,7 +704,7 @@ Rails.application.routes.draw do
   end
 
   namespace :support_interface, path: '/support' do
-    get '/' => redirect('/support/candidates')
+    get '/' => redirect('/support/applications')
 
     get '/cycles', to: 'cycles#index', as: :cycles
 

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Add comments to the application history', with_audited: true do
   end
 
   def when_i_click_on_an_application
-    click_on 'alice@example.com'
+    click_on 'Alice Wunder'
   end
 
   def when_i_click_on_an_application_history

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'See application history', with_audited: true do
   end
 
   def when_i_click_on_an_application
-    click_on 'alice@example.com'
+    click_on 'Alice Wunder'
   end
 
   def when_i_click_on_an_application_history

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -31,9 +31,9 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_see_the_latest_applications
-    expect(page).to have_content @completed_application.candidate.email_address
-    expect(page).to have_content @application_with_reference.candidate.email_address
-    expect(page).to have_content @unsubmitted_application.candidate.email_address
+    expect(page).to have_content @completed_application.full_name
+    expect(page).to have_content @application_with_reference.full_name
+    expect(page).to have_content @unsubmitted_application.full_name
   end
 
   def when_i_search_for_an_application

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'See an application' do
   end
 
   def when_i_click_on_a_completed_application
-    click_on @completed_application.candidate.email_address
+    click_on @completed_application.full_name
   end
 
   def then_i_should_be_on_the_application_view_page

--- a/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
+++ b/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Send survey email to candidate', with_audited: true do
   end
 
   def when_i_click_on_the_application
-    click_on @application.candidate.email_address
+    click_on @application.full_name
   end
 
   def then_i_should_be_on_the_view_application_page

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature 'See UCAS matches' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
     and_there_are_ucas_matches_in_the_system
-    and_i_visit_the_support_page
 
     when_i_go_to_ucas_matches_page
     then_i_should_see_list_of_ucas_matches
@@ -53,10 +52,6 @@ RSpec.feature 'See UCAS matches' do
       }
     create(:ucas_match, matching_state: 'new_match', application_form: @application_form, matching_data: [ucas_matching_data, dfe_matching_data])
     create(:ucas_match, matching_state: 'matching_data_updated', scheme: 'B', ucas_status: :offer, application_form: @application_form2)
-  end
-
-  def and_i_visit_the_support_page
-    visit support_interface_path
   end
 
   def when_i_go_to_ucas_matches_page


### PR DESCRIPTION
## Context

Addresses part of the issue uncovered in #3131. When you click on the link in the header, or visit `/support/` when signed in, currently taken to the lesser used Candidates view, which is also the second nav item under the first primary nav item, which is a bit weird.

This change simply redirects support interface path to Candidates → Applications (first primary nav item, first secondary nav item).

## Changes proposed in this pull request

Updates redirects and affected tests.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
