### PR TITLE
Don't show references on application dashboard

### DIFF
--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -23,12 +23,13 @@
 
     <%= render(CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form, editable: false, show_status: true)) %>
 
+    <% unless FeatureFlag.active?(:decoupled_references) %>
+      <hr class="govuk-section-break govuk-section-break--m">
 
-    <hr class="govuk-section-break govuk-section-break--m">
+      <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
 
-    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
-
-    <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: @application_form, editable: false)) %>
+      <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: @application_form, editable: false)) %>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Submitting an application' do
     and_i_receive_an_email_about_my_submitted_application
     and_a_slack_notification_is_sent
     and_i_can_review_my_application
+    and_i_do_not_see_references
   end
 
   def given_i_am_signed_in
@@ -116,6 +117,11 @@ RSpec.feature 'Submitting an application' do
     expect(page).to have_content 'Application dashboard'
     expect(page).to have_content 'Application submitted'
     expect(page).to have_link 'View application'
+  end
+
+  def and_i_do_not_see_references
+    expect(page).not_to have_content 'First referee'
+    expect(page).not_to have_content application.application_references.first.name
   end
 
 private


### PR DESCRIPTION
## Context

It no longer makes sense to show references on the application dashboard because they are always going to be given by the time the candidate sees the dashboard.

## Changes proposed in this pull request

- [x] Just removed the section from the dashboard view template and update specs to assert the change.

<img width="748" alt="image" src="https://user-images.githubusercontent.com/450843/96511137-8acb5180-1256-11eb-80af-3923b5870296.png">

## Guidance to review

- Check the references are not seen on the dashboard any longer.
- I have feature-flagged this but given that `decoupled_references` is a one-way activation this may be overkill.

## Link to Trello card

https://trello.com/c/ra3mEOjS/2226-💔-dev-remove-references-from-application-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
