### PR TITLE
Use scoped query when deleting references

### DIFF
--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -30,12 +30,9 @@ module CandidateInterface
         end
       end
 
-      def confirm_destroy
-        @reference = ApplicationReference.find(params[:id])
-      end
+      def confirm_destroy; end
 
       def destroy
-        @reference = ApplicationReference.find(params[:id])
         @reference.destroy!
         redirect_to candidate_interface_decoupled_references_review_path
       end


### PR DESCRIPTION
## Context

This query is not scoped to the current user, so just gave me a heart attack because it looked like it could be used to delete any reference in the system. Luckily [BaseController#set_referee](https://github.com/DFE-Digital/apply-for-teacher-training/blob/da381583a804669e7651849cfe4d54d3988af557/app/controllers/candidate_interface/decoupled_references/base_controller.rb#L14-L20) runs as a before_action, which means that it if you change the ID to something else, you'll see a 404 anyway if the reference isn't yours. 

Follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3101.

## Changes proposed in this pull request

Use the existing `@reference`.

## Link to Trello card

https://trello.com/c/ykZiAQ1s/2344-%F0%9F%92%94-decoupled-references-delete-feature-flag-and-clean-up-code