### PR TITLE
Fix back-links in decoupled references

### DIFF
--- a/app/views/candidate_interface/decoupled_references/candidate_name/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/candidate_name/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.references_candidate_name') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_referees_type_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/decoupled_references/review/confirm_cancel.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/confirm_cancel.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.referee_cancel') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_referees_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/decoupled_references/review/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/confirm_destroy.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.referee_destroy') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_decoupled_references_review_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/referees/confirm_cancel.html.erb
+++ b/app/views/candidate_interface/referees/confirm_cancel.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.referee_cancel') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_review_referees_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Context

These pages are in the decoupled references flow, but link out to the old-style referees flow.

## Changes proposed in this pull request

Remove the back links for now, because I don't know what the correct links are. @davidgisbey ?

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ykZiAQ1s/2344-%F0%9F%92%94-decoupled-references-delete-feature-flag-and-clean-up-code

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
