### PR TITLE
Add new test application generator for unsubmitted with complete references

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -104,9 +104,9 @@ class TestApplications
 
       if states.include? :unsubmitted_with_completed_references
         @application_form.application_references.each { |reference| submit_reference!(reference) }
-        return @application_form
+        return application_choices
       elsif states.include? :unsubmitted
-        return @application_form
+        return application_choices
       end
 
       if states.include? :cancelled

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -17,6 +17,7 @@ class GenerateTestApplications
 
     create recruitment_cycle_year: 2021, states: %i[unsubmitted]
     create recruitment_cycle_year: 2021, states: %i[unsubmitted], course_full: true
+    create recruitment_cycle_year: 2021, states: %i[unsubmitted_with_completed_references]
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -114,17 +114,17 @@ RSpec.describe TestApplications do
 
       references = application_choice.application_form.application_references
 
-      expect(references.any?(&:feedback_requested?)).to be false
+      expect(references.all?(&:feedback_provided?)).to be true
     end
 
-    it 'completes all references for other types of applications' do
+    it 'completes all references for other types of application' do
       courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
       application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision offer], courses_to_apply_to: courses_we_want).first
 
       references = application_choice.application_form.application_references
 
-      expect(references.any?(&:feedback_requested?)).to be false
+      expect(references.all?(&:feedback_provided?)).to be true
     end
 
     it 'does not complete any references for unsubmitted applications' do
@@ -134,7 +134,7 @@ RSpec.describe TestApplications do
 
       references = application_choice.application_form.application_references
 
-      expect(references.any?(&:feedback_provided?)).to be false
+      expect(references.all?(&:feedback_requested?)).to be true
     end
 
   end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -136,6 +136,5 @@ RSpec.describe TestApplications do
 
       expect(references.all?(&:feedback_requested?)).to be true
     end
-
   end
 end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -105,4 +105,37 @@ RSpec.describe TestApplications do
       expect(choices.first.application_form.application_work_history_breaks.count).to eq(1)
     end
   end
+
+  describe 'reference completion' do
+    it 'completes all references for unsubmitted_with_completed_references applications' do
+      courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[unsubmitted_with_completed_references], courses_to_apply_to: courses_we_want).first
+
+      references = application_choice.application_form.application_references
+
+      expect(references.any?(&:feedback_requested?)).to be false
+    end
+
+    it 'completes all references for other types of applications' do
+      courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision offer], courses_to_apply_to: courses_we_want).first
+
+      references = application_choice.application_form.application_references
+
+      expect(references.any?(&:feedback_requested?)).to be false
+    end
+
+    it 'does not complete any references for unsubmitted applications' do
+      courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[unsubmitted], courses_to_apply_to: courses_we_want).first
+
+      references = application_choice.application_form.application_references
+
+      expect(references.any?(&:feedback_provided?)).to be false
+    end
+
+  end
 end


### PR DESCRIPTION
## Context
This will be required for the feature in sandbox to prefill application forms for candidates

## Changes proposed in this pull request
Add a new test application generator for unsubmitted with complete references, alongside the existing unsubmitted state

## Link to Trello card
https://trello.com/c/QiEcDyYo/2343-%F0%9F%92%94-decoupled-references-update-test-applications-to-reflect-the-new-references-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
