### PR TITLE
Support: Consistent placement for ‘Needs attention’ message on provider pages

### DIFF
--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -13,6 +13,8 @@
   ].concat(title != 'Details' ? [{ text: title }] : [])) %>
 <% end %>
 
+<%= render 'no_admin_users_warning' %>
+
 <%= render TabNavigationComponent.new(items: [
   { name: 'Details', url: support_interface_provider_path },
   { name: 'Applications', url: support_interface_provider_applications_path },

--- a/app/views/support_interface/providers/applications.html.erb
+++ b/app/views/support_interface/providers/applications.html.erb
@@ -1,5 +1,3 @@
-<%= render 'no_admin_users_warning' %>
-
 <%= render 'provider_navigation', title: 'Applications' %>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_forms) do %>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -1,7 +1,5 @@
 <%= render 'provider_navigation', title: 'Courses' %>
 
-<%= render 'no_admin_users_warning' %>
-
 <% if @provider.sync_courses? %>
   <% unless @courses[RecruitmentCycle.current_year].to_a.all?(&:open_on_apply?) %>
     <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>

--- a/app/views/support_interface/providers/history.html.erb
+++ b/app/views/support_interface/providers/history.html.erb
@@ -1,5 +1,3 @@
 <%= render 'provider_navigation', title: 'History' %>
 
-<%= render 'no_admin_users_warning' %>
-
 <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider) %>

--- a/app/views/support_interface/providers/no_relationships.html.erb
+++ b/app/views/support_interface/providers/no_relationships.html.erb
@@ -1,5 +1,3 @@
-<%= render 'no_admin_users_warning' %>
-
 <%= render 'provider_navigation', title: 'Details' %>
 
 <p class="govuk-body">This provider has no relationships to manage.</p>

--- a/app/views/support_interface/providers/ratified_courses.html.erb
+++ b/app/views/support_interface/providers/ratified_courses.html.erb
@@ -1,7 +1,5 @@
 <%= render 'provider_navigation', title: 'Ratified courses' %>
 
-<%= render 'no_admin_users_warning' %>
-
 <% RecruitmentCycle.years_visible_in_support.each do |year| %>
   <% if @ratified_courses[year] %>
     <h3 class="govuk-heading-m"><%= year %>: ratifies <%= pluralize(@ratified_courses[year].size, 'course') %> (<%= @ratified_courses[year].count(&:open_on_apply?) %> on DfE Apply)</h3>

--- a/app/views/support_interface/providers/relationships.html.erb
+++ b/app/views/support_interface/providers/relationships.html.erb
@@ -1,5 +1,3 @@
-<%= render 'no_admin_users_warning' %>
-
 <%= render 'provider_navigation', title: 'Relationships' %>
 
 <%= form_with model: @relationships_form, url: support_interface_update_provider_relationships_path do |f| %>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -1,7 +1,5 @@
 <%= render 'provider_navigation', title: 'Details' %>
 
-<%= render 'no_admin_users_warning' %>
-
 <% dsa = capture do %>
   <% if @provider_agreement %>
     Accepted by <strong>

--- a/app/views/support_interface/providers/sites.html.erb
+++ b/app/views/support_interface/providers/sites.html.erb
@@ -1,7 +1,5 @@
 <%= render 'provider_navigation', title: 'Sites' %>
 
-<%= render 'no_admin_users_warning' %>
-
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,7 +1,5 @@
 <%= render 'provider_navigation', title: 'Provider users' %>
 
-<%= render 'no_admin_users_warning' %>
-
 <%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
 
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider.provider_users)) %>

--- a/app/views/support_interface/providers/vacancies.html.erb
+++ b/app/views/support_interface/providers/vacancies.html.erb
@@ -1,5 +1,3 @@
 <%= render 'provider_navigation', title: 'Vacancies' %>
 
-<%= render 'no_admin_users_warning' %>
-
 <%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>


### PR DESCRIPTION
## Context

The ‘needs attention’ message that appears on provider pages in support sometimes appears above the sub navigation, sometimes below.

## Changes proposed in this pull request

This partial appears on every page the navigation appears on also. So let’s move the warning partial into the navigation partial, ensuring it always appears in the same position on the page.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
