### PR TITLE
Reference History Spike II

### DIFF
--- a/app/components/reference_history_component.html.erb
+++ b/app/components/reference_history_component.html.erb
@@ -1,15 +1,8 @@
 <ul class='govuk-list qa-reference-history'>
-  <% if requested_at %>
+  <% history.each do |event| %>
     <li>
-      Request sent
-      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= requested_at %></span>
-    </li>
-  <% end %>
-
-  <% if reminder_sent_at %>
-    <li>
-      Reminder sent
-      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= reminder_sent_at %></span>
+      <%= event_title event %>
+      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= date_format event.time %></span>
     </li>
   <% end %>
 </ul>

--- a/app/components/reference_history_component.rb
+++ b/app/components/reference_history_component.rb
@@ -5,16 +5,12 @@ class ReferenceHistoryComponent < ViewComponent::Base
     @reference = reference
   end
 
-  def requested_at
-    return if reference.requested_at.blank?
-
-    date_format(reference.requested_at)
+  def history
+    ReferenceHistory.new(reference).all_events
   end
 
-  def reminder_sent_at
-    return if reference.reminder_sent_at.blank?
-
-    date_format(reference.reminder_sent_at)
+  def event_title(event)
+    event.name.humanize
   end
 
 private

--- a/app/models/reference_history.rb
+++ b/app/models/reference_history.rb
@@ -1,0 +1,41 @@
+class ReferenceHistory
+  Event = Struct.new(:name, :time)
+
+  attr_reader :reference
+
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def all_events
+    request_sent_events.concat(
+      request_cancelled_events.concat(
+        reminder_sent_events,
+      ),
+    ).sort_by(&:time)
+  end
+
+  def request_sent_events
+    audits
+      .select { |a| a.audited_changes['feedback_status']&.second == 'feedback_requested' }
+      .map { |a| Event.new('request_sent', a.created_at) }
+  end
+
+  def request_cancelled_events
+    audits
+      .select { |a| a.audited_changes['feedback_status']&.second == 'cancelled' }
+      .map { |a| Event.new('request_cancelled', a.created_at) }
+  end
+
+  def reminder_sent_events
+    audits
+      .select { |a| a.audited_changes['reminder_sent_at'].present? }
+      .map { |a| Event.new('reminder_sent', a.created_at) }
+  end
+
+private
+
+  def audits
+    reference.audits.updates
+  end
+end


### PR DESCRIPTION
## Context

Further to @tijmenb 's suggestion in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3194, this is a proof of concept for using the audit table to derive a history for any reference.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
A `ReferenceHistory` model. Wraps a single reference instance and returns a history of relevant events, derived from the audit log.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Raising this for visibility and feedback. Any issues to be aware of? Any changes you'd make?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/JAWa9Xzt
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
