### PR TITLE
Update FIND_BASE_URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
-FIND_BASE_URL=https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/
+FIND_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/v3/
 HOSTING_ENVIRONMENT_NAME=development
 STATE_CHANGE_SLACK_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 REDIS_URL=redis://localhost:6379/1
-FIND_BASE_URL=
+FIND_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/v3/
 GOVUK_NOTIFY_API_KEY=
 LOGSTASH_ENABLE=false
 LOGSTASH_REMOTE=false


### PR DESCRIPTION
## Context

The Teacher Training API url needs updating as a result of a domain change.

## Changes proposed in this pull request

- update `FIND_BASE_URL` in `.env.development`
- add `FIND_BASE_URL` to `.env.example`


## Guidance to review

Questions for reviewers:

- Possibly a naming issue to consider. Should the Teaching Training API be referred to as `FIND_BASE_URL`? May potentially confuse now that the Find UI is now managed by Apply? Would a better alternative be `TEACHER_TRAINING_API_BASE_URL`?
- Removing `FIND_BASE_URL` from `.env.development` with break the app locally for devs. Best to leave in there?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
