### PR TITLE
Decoupled references - edit email address for failed request

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -1,5 +1,9 @@
 <% references.each do |reference| %>
-  <%= render(SummaryCardComponent.new(rows: reference_rows(reference), editable: editable && reference.editable?, ignore_editable: ['History'])) do %>
+  <%= render(SummaryCardComponent.new(
+    rows: reference_rows(reference),
+    editable: editable && reference.editable?,
+    ignore_editable: ignore_editable_for(reference),
+  )) do %>
     <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
       <div class="app-summary-card__actions">
         <ul class="app-summary-card__actions-list">

--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -46,6 +46,13 @@
                 <span class="govuk-visually-hidden"> to <%= reference.name %></span>
               <% end %>
             </li>
+          <% elsif can_retry?(reference) %>
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to candidate_interface_decoupled_references_retry_request_path(reference.id), class: 'govuk-link' do %>
+                <%= t('application_form.referees.retry_request') %>
+                <span class="govuk-visually-hidden"> to <%= reference.name %></span>
+              <% end %>
+            </li>
           <% end %>
         </ul>
       </div>

--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -16,6 +16,15 @@
             </div>
           <% end %>
 
+          <% if can_retry?(reference) %>
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to candidate_interface_decoupled_references_retry_request_path(reference.id), class: 'govuk-link' do %>
+                <%= t('application_form.referees.retry_request') %>
+                <span class="govuk-visually-hidden"> to <%= reference.name %></span>
+              <% end %>
+            </li>
+          <% end %>
+
           <% if reference.can_be_destroyed? %>
             <li class="app-summary-card__actions-list-item">
               <%= link_to candidate_interface_destroy_decoupled_reference_path(reference), class: 'govuk-link' do %>
@@ -43,13 +52,6 @@
             <li class="app-summary-card__actions-list-item">
               <%= link_to candidate_interface_decoupled_references_new_request_path(reference.id), class: 'govuk-link' do %>
                 <%= t('application_form.referees.resend_request') %>
-                <span class="govuk-visually-hidden"> to <%= reference.name %></span>
-              <% end %>
-            </li>
-          <% elsif can_retry?(reference) %>
-            <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_decoupled_references_retry_request_path(reference.id), class: 'govuk-link' do %>
-                <%= t('application_form.referees.retry_request') %>
                 <span class="govuk-visually-hidden"> to <%= reference.name %></span>
               <% end %>
             </li>

--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -2,7 +2,7 @@
   <%= render(SummaryCardComponent.new(
     rows: reference_rows(reference),
     editable: editable && reference.editable?,
-    ignore_editable: ignore_editable_for(reference),
+    ignore_editable: ignore_editable_for,
   )) do %>
     <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
       <div class="app-summary-card__actions">

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -32,7 +32,16 @@ module CandidateInterface
     end
 
     def can_resend?(reference)
-      (reference.cancelled? || reference.cancelled_at_end_of_cycle? || reference.email_bounced?) &&
+      (reference.cancelled? || reference.cancelled_at_end_of_cycle?) &&
+        !reference.application_form.enough_references_have_been_provided? &&
+        CandidateInterface::Reference::SubmitRefereeForm.new(
+          submit: 'yes',
+          reference_id: reference.id,
+        ).valid?
+    end
+
+    def can_retry?(reference)
+      reference.email_bounced? &&
         !reference.application_form.enough_references_have_been_provided? &&
         CandidateInterface::Reference::SubmitRefereeForm.new(
           submit: 'yes',

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -50,7 +50,7 @@ module CandidateInterface
     end
 
     def ignore_editable_for(reference)
-      can_resend?(reference) ? ['History', 'Email address'] : ['History']
+      ['History']
     end
 
   private

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -49,8 +49,8 @@ module CandidateInterface
         ).valid?
     end
 
-    def ignore_editable_for(reference)
-      ['History']
+    def ignore_editable_for
+      %w[History]
     end
 
   private

--- a/app/components/candidate_interface/decoupled_references_review_component.rb
+++ b/app/components/candidate_interface/decoupled_references_review_component.rb
@@ -40,6 +40,10 @@ module CandidateInterface
         ).valid?
     end
 
+    def ignore_editable_for(reference)
+      can_resend?(reference) ? ['History', 'Email address'] : ['History']
+    end
+
   private
 
     def formatted_reference_type(reference)

--- a/app/components/reference_history_component.rb
+++ b/app/components/reference_history_component.rb
@@ -16,6 +16,8 @@ class ReferenceHistoryComponent < ViewComponent::Base
   def formatted_title(event)
     if event.name == 'request_bounced'
       "The request did not reach #{event.extra_info.bounced_email}"
+    elsif event.name == 'request_sent'
+      "Request sent to #{event.extra_info.email_address}"
     else
       event.name.humanize
     end

--- a/app/controllers/candidate_interface/decoupled_references/retry_request_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/retry_request_controller.rb
@@ -1,0 +1,48 @@
+module CandidateInterface
+  module DecoupledReferences
+    class RetryRequestController < BaseController
+      before_action :set_reference
+
+      def new
+        render_404 and return unless can_retry?
+
+        @request_form = Reference::RefereeEmailAddressForm.build_from_reference(@reference)
+      end
+
+      def create
+        #TODO: validate presence of email_address?
+        #TODO: other validation rules for email_address
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.new(retry_params)
+        if @reference_email_address_form.valid?
+          #TODO: txn?
+          @reference_email_address_form.save(@reference)
+          CandidateInterface::DecoupledReferences::RequestReference.new.call(
+            @reference,
+            flash,
+          )
+          redirect_to candidate_interface_decoupled_references_review_path
+        else
+          # TODO: 
+          render :new
+        end
+      end
+
+    private
+
+      def can_retry?
+        @reference.email_bounced? &&
+          !@reference.application_form.enough_references_have_been_provided? &&
+          CandidateInterface::Reference::SubmitRefereeForm.new(
+            submit: 'yes',
+            reference_id: @reference.id,
+          ).valid?
+      end
+
+      def retry_params
+        params
+          .require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
+          .merge!(reference_id: @reference.id)
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/decoupled_references/retry_request_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/retry_request_controller.rb
@@ -6,23 +6,21 @@ module CandidateInterface
       def new
         render_404 and return unless can_retry?
 
-        @request_form = Reference::RefereeEmailAddressForm.build_from_reference(@reference)
+        @reference_email_address_form = Reference::RefereeEmailAddressForm.build_from_reference(@reference)
       end
 
       def create
-        #TODO: validate presence of email_address?
-        #TODO: other validation rules for email_address
         @reference_email_address_form = Reference::RefereeEmailAddressForm.new(retry_params)
         if @reference_email_address_form.valid?
-          #TODO: txn?
-          @reference_email_address_form.save(@reference)
-          CandidateInterface::DecoupledReferences::RequestReference.new.call(
-            @reference,
-            flash,
-          )
+          ActiveRecord::Base.transaction do
+            @reference_email_address_form.save(@reference)
+            CandidateInterface::DecoupledReferences::RequestReference.new.call(
+              @reference,
+              flash,
+            )
+          end
           redirect_to candidate_interface_decoupled_references_review_path
         else
-          # TODO: 
           render :new
         end
       end

--- a/app/forms/candidate_interface/reference/retry_request_form.rb
+++ b/app/forms/candidate_interface/reference/retry_request_form.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  class Reference::RetryRequestForm
+    include ActiveModel::Model
+
+    attr_accessor :email_address
+
+    validates :email_address, presence: true
+
+    def self.build_from_reference(reference)
+      new(referee_name: reference.name)
+    end
+  end
+end

--- a/app/models/reference_history.rb
+++ b/app/models/reference_history.rb
@@ -21,7 +21,10 @@ class ReferenceHistory
   def request_sent
     audits
       .select { |a| status_change(a, to: 'feedback_requested') }
-      .map { |a| Event.new('request_sent', a.created_at) }
+      .map do |audit|
+        email_address = reference.revision(audit.version).email_address
+        Event.new('request_sent', audit.created_at, OpenStruct.new(email_address: email_address))
+      end
   end
 
   def request_cancelled

--- a/app/views/candidate_interface/decoupled_references/retry_request/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/retry_request/new.html.erb
@@ -1,15 +1,19 @@
+<% content_for :title, t('page_titles.retry_reference_request') %>
+<% content_for :before_content, govuk_back_link_to %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">
       <%= @reference.name %>
     </span>
-    <h1 class="govuk-heading-xl">Retry reference request</h1>
+    <h1 class="govuk-heading-xl"><%= t('page_titles.retry_reference_request') %></h1>
 
-    <%= form_with model: @request_form, url: candidate_interface_decoupled_references_retry_request_path(@reference.id) do |f| %>
+    <%= form_with model: @reference_email_address_form, url: candidate_interface_decoupled_references_retry_request_path(@reference.id) do |f| %>
+      <%= f.govuk_error_summary %>
       <%= f.govuk_text_field(
         :email_address,
-        label: { text: 'Referee’s email address', class: 'govuk-heading-xl govuk-!-margin-top-0', size: 'm' },
-        hint_text: 'In most cases, this should be a work address.',
+        label: { text: 'Referee’s email address', size: 'm' },
+        hint: { text: 'In most cases, this should be a work address.' },
       ) %>
       <%= f.govuk_submit 'Send reference request' %>
     <% end %>

--- a/app/views/candidate_interface/decoupled_references/retry_request/new.html.erb
+++ b/app/views/candidate_interface/decoupled_references/retry_request/new.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl">
+      <%= @reference.name %>
+    </span>
+    <h1 class="govuk-heading-xl">Retry reference request</h1>
+
+    <%= form_with model: @request_form, url: candidate_interface_decoupled_references_retry_request_path(@reference.id) do |f| %>
+      <%= f.govuk_text_field(
+        :email_address,
+        label: { text: 'Referee’s email address', class: 'govuk-heading-xl govuk-!-margin-top-0', size: 'm' },
+        hint_text: 'In most cases, this should be a work address.',
+      ) %>
+      <%= f.govuk_submit 'Send reference request' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -401,6 +401,7 @@ en:
       cancel_request: Cancel request
       send_request: Send request
       resend_request: Send request again
+      retry_request: Retry request
       email_address:
         label: Email address
         hint_text:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,6 +128,7 @@ en:
     references_unsubmitted_review: Check your answers before sending your request
     references_candidate_name: Tell the referee your name
     references_reminder: Would you like to send a reminder to this referee?
+    retry_reference_request: Retry reference request
     providers: Courses on this service
     view_and_respond_to_offer: Details of offer
     api_docs:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,6 +372,9 @@ Rails.application.routes.draw do
         get '/request/:id' => 'decoupled_references/request#new', as: :decoupled_references_new_request
         post '/request/:id' => 'decoupled_references/request#create', as: :decoupled_references_create_request
 
+        get '/retry_request/:id' => 'decoupled_references/retry_request#new', as: :decoupled_references_retry_request
+        post '/retry_request/:id' => 'decoupled_references/retry_request#create'
+
         get '/reminder/:id' => 'decoupled_references/reminder#new', as: :decoupled_references_new_reminder
         post '/reminder/:id' => 'decoupled_references/reminder#create'
 

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
   context 'when reference state is "cancelled" and the reference is complete' do
     let(:application_form) { create(:application_form) }
     let(:feedback_requested) { create(:reference, :feedback_requested, application_form: application_form) }
-    let(:feedback_provided) { create(:reference, :complete, application_form: application_form) }
-    let(:second_feedback_provided) { create(:reference, :complete, application_form: application_form) }
+    let(:feedback_provided) { create(:reference, :feedback_provided, application_form: application_form) }
+    let(:second_feedback_provided) { create(:reference, :feedback_provided, application_form: application_form) }
     let(:cancelled) { create(:reference, :cancelled, application_form: application_form) }
 
     it 'a re-send request link is available' do
@@ -114,7 +114,6 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
 
     it 'an edit email address link is available' do
-      FeatureFlag.activate(:decoupled_references)
       result = render_inline(described_class.new(references: [feedback_provided, cancelled]))
 
       feedback_provided_summary = result.css('.app-summary-card')[0]
@@ -124,7 +123,6 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
 
     it 'an edit email address link is not available if there are sufficient references provided' do
-      FeatureFlag.activate(:decoupled_references)
       result = render_inline(described_class.new(references: [feedback_provided, second_feedback_provided, cancelled]))
 
       feedback_cancelled_summary = result.css('.app-summary-card')[2]

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -97,36 +97,28 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
     end
   end
 
-  context 'when reference state is "cancelled" and the reference is complete' do
+  context 'when reference state is "cancelled" or "email_bounced" and the reference is complete' do
     let(:application_form) { create(:application_form) }
     let(:feedback_requested) { create(:reference, :feedback_requested, application_form: application_form) }
     let(:feedback_provided) { create(:reference, :feedback_provided, application_form: application_form) }
     let(:second_feedback_provided) { create(:reference, :feedback_provided, application_form: application_form) }
     let(:cancelled) { create(:reference, :cancelled, application_form: application_form) }
+    let(:email_bounced) { create(:reference, :email_bounced, application_form: application_form) }
 
-    it 'a re-send request link is available' do
-      result = render_inline(described_class.new(references: [feedback_requested, cancelled]))
+    it 'a retry request link is available' do
+      result = render_inline(described_class.new(references: [feedback_requested, email_bounced]))
 
       feedback_requested_summary = result.css('.app-summary-card')[0]
       feedback_cancelled_summary = result.css('.app-summary-card')[1]
-      expect(feedback_requested_summary.text).not_to include 'Send request again'
-      expect(feedback_cancelled_summary.text).to include 'Send request again'
+      expect(feedback_requested_summary.text).not_to include 'Retry request'
+      expect(feedback_cancelled_summary.text).to include 'Retry request'
     end
 
-    it 'an edit email address link is available' do
-      result = render_inline(described_class.new(references: [feedback_provided, cancelled]))
-
-      feedback_provided_summary = result.css('.app-summary-card')[0]
-      feedback_cancelled_summary = result.css('.app-summary-card')[1]
-      expect(feedback_provided_summary.text).not_to include 'Change email address'
-      expect(feedback_cancelled_summary.text).to include 'Change email address'
-    end
-
-    it 'an edit email address link is not available if there are sufficient references provided' do
-      result = render_inline(described_class.new(references: [feedback_provided, second_feedback_provided, cancelled]))
+    it 'a retry request link is not available if there are sufficient references provided' do
+      result = render_inline(described_class.new(references: [feedback_provided, second_feedback_provided, email_bounced]))
 
       feedback_cancelled_summary = result.css('.app-summary-card')[2]
-      expect(feedback_cancelled_summary.text).not_to include 'Change email address'
+      expect(feedback_cancelled_summary.text).not_to include 'Retry request'
     end
   end
 

--- a/spec/components/reference_history_component_spec.rb
+++ b/spec/components/reference_history_component_spec.rb
@@ -24,4 +24,14 @@ RSpec.describe ReferenceHistoryComponent, type: :component do
     list_item = result.css('li').first
     expect(list_item.text).to include 'The request did not reach example@email.com'
   end
+
+  it 'uses a special title format for request_sent events', with_audited: true do
+    reference = create(:reference, :not_requested_yet, email_address: 'example@email.com')
+    reference.feedback_requested!
+
+    result = render_inline(described_class.new(reference))
+
+    list_item = result.css('li').first
+    expect(list_item.text).to include 'Request sent to example@email.com'
+  end
 end

--- a/spec/models/reference_history_spec.rb
+++ b/spec/models/reference_history_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe ReferenceHistory do
       events = described_class.new(reference).all_events
 
       expected_attributes = [
-        { name: 'request_sent', time: start_time + 1.day, extra_info: nil },
+        { name: 'request_sent', time: start_time + 1.day, extra_info: OpenStruct.new(email_address: 'ericandre@email.com') },
         { name: 'request_bounced', time: start_time + 2.days, extra_info: OpenStruct.new(bounced_email: 'ericandre@email.com') },
-        { name: 'request_sent', time: start_time + 3.days, extra_info: nil },
+        { name: 'request_sent', time: start_time + 3.days, extra_info: OpenStruct.new(email_address: 'ericandre@email.com') },
         { name: 'reminder_sent', time: start_time + 4.days, extra_info: nil },
         { name: 'reference_given', time: start_time + 5.days, extra_info: nil },
       ]
@@ -32,7 +32,7 @@ RSpec.describe ReferenceHistory do
       events = described_class.new(reference).all_events
 
       expected_attributes = [
-        { name: 'request_sent', time: start_time + 1.day, extra_info: nil },
+        { name: 'request_sent', time: start_time + 1.day, extra_info: OpenStruct.new(email_address: 'ericandre@email.com') },
         { name: 'request_declined', time: start_time + 2.days, extra_info: nil },
       ]
       compare_data(expected_attributes, events)

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -219,7 +219,7 @@ RSpec.feature 'Candidate requests a reference' do
   def when_i_change_the_email_address
     fill_in 'Referee’s email address', with: 'john@example.com'
   end
-  
+
   def and_i_confirm_that_i_am_ready_to_retry_a_reference_request
     click_button 'Send reference request'
   end

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -57,15 +57,13 @@ RSpec.feature 'Candidate requests a reference' do
 
     when_i_have_a_failed_reference
     and_i_visit_the_all_references_review_page
-    and_i_click_the_change_email_address_link
-    then_i_see_the_email_address_edit_form
-    when_i_update_the_email_address
     then_i_see_the_references_review_page
-    and_i_see_the_updated_email_address
-    when_i_click_the_resend_reference_link
-    and_i_confirm_that_i_am_ready_to_send_a_reference_request
+    when_i_click_the_retry_request_link
+    and_i_change_the_email_address
+    and_i_confirm_that_i_am_ready_to_retry_a_reference_request
     then_i_see_a_confirmation_message
     and_the_reference_is_moved_to_the_requested_state
+    and_the_reference_email_address_has_been_updated
     and_an_email_is_sent_to_the_referee
   end
 
@@ -196,34 +194,24 @@ RSpec.feature 'Candidate requests a reference' do
   def and_i_click_the_resend_reference_link
     click_link 'Send request again'
   end
-  alias_method :when_i_click_the_resend_reference_link, :and_i_click_the_resend_reference_link
-
-  def and_i_click_the_change_email_address_link
-    within '#references_sent' do
-      click_link 'Change email address'
-    end
-  end
-
-  def then_i_see_the_email_address_edit_form
-    expect(page).to have_current_path candidate_interface_decoupled_references_edit_email_address_path(id: @reference.id, return_to: :review)
-  end
-    
-  def when_i_update_the_email_address
-    save_and_open_page
-    fill_in(
-      'candidate-interface-reference-referee-email-address-form-email-address-field',
-      with: 'john@example.com',
-    )
-    click_button 'Save and continue'
-  end
 
   def then_i_see_the_references_review_page
     expect(page).to have_current_path candidate_interface_decoupled_references_review_path
   end
 
-  def and_i_see_the_updated_email_address
-    within '#references_sent' do
-      expect(page).to have_content 'john@example.com'
-    end
+  def when_i_click_the_retry_request_link
+    click_link 'Retry request'
+  end
+
+  def and_i_change_the_email_address
+    fill_in 'Referee’s email address', with: 'john@example.com'
+  end
+  
+  def and_i_confirm_that_i_am_ready_to_retry_a_reference_request
+    click_button 'Send reference request'
+  end
+
+  def and_the_reference_email_address_has_been_updated
+    expect(@reference.reload.email_address).to eq('john@example.com')
   end
 end

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -58,8 +58,12 @@ RSpec.feature 'Candidate requests a reference' do
     when_i_have_a_failed_reference
     and_i_visit_the_all_references_review_page
     then_i_see_the_references_review_page
+
     when_i_click_the_retry_request_link
-    and_i_change_the_email_address
+    and_i_continue_with_a_blank_email_address
+    then_i_see_email_address_validation_errors
+
+    when_i_change_the_email_address
     and_i_confirm_that_i_am_ready_to_retry_a_reference_request
     then_i_see_a_confirmation_message
     and_the_reference_is_moved_to_the_requested_state
@@ -203,7 +207,16 @@ RSpec.feature 'Candidate requests a reference' do
     click_link 'Retry request'
   end
 
-  def and_i_change_the_email_address
+  def and_i_continue_with_a_blank_email_address
+    fill_in 'Referee’s email address', with: ''
+    click_button 'Send reference request'
+  end
+
+  def then_i_see_email_address_validation_errors
+    expect(page).to have_content('Enter your referee’s email address')
+  end
+
+  def when_i_change_the_email_address
     fill_in 'Referee’s email address', with: 'john@example.com'
   end
   

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -54,6 +54,19 @@ RSpec.feature 'Candidate requests a reference' do
     then_i_see_a_confirmation_message
     and_the_reference_is_moved_to_the_requested_state
     and_an_email_is_sent_to_the_referee
+
+    when_i_have_a_failed_reference
+    and_i_visit_the_all_references_review_page
+    and_i_click_the_change_email_address_link
+    then_i_see_the_email_address_edit_form
+    when_i_update_the_email_address
+    then_i_see_the_references_review_page
+    and_i_see_the_updated_email_address
+    when_i_click_the_resend_reference_link
+    and_i_confirm_that_i_am_ready_to_send_a_reference_request
+    then_i_see_a_confirmation_message
+    and_the_reference_is_moved_to_the_requested_state
+    and_an_email_is_sent_to_the_referee
   end
 
   def given_i_am_signed_in
@@ -176,7 +189,41 @@ RSpec.feature 'Candidate requests a reference' do
     @reference = create(:reference, :cancelled, application_form: @application_form)
   end
 
+  def when_i_have_a_failed_reference
+    @reference = create(:reference, :email_bounced, application_form: @application_form)
+  end
+
   def and_i_click_the_resend_reference_link
     click_link 'Send request again'
+  end
+  alias_method :when_i_click_the_resend_reference_link, :and_i_click_the_resend_reference_link
+
+  def and_i_click_the_change_email_address_link
+    within '#references_sent' do
+      click_link 'Change email address'
+    end
+  end
+
+  def then_i_see_the_email_address_edit_form
+    expect(page).to have_current_path candidate_interface_decoupled_references_edit_email_address_path(id: @reference.id, return_to: :review)
+  end
+    
+  def when_i_update_the_email_address
+    save_and_open_page
+    fill_in(
+      'candidate-interface-reference-referee-email-address-form-email-address-field',
+      with: 'john@example.com',
+    )
+    click_button 'Save and continue'
+  end
+
+  def then_i_see_the_references_review_page
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
+  end
+
+  def and_i_see_the_updated_email_address
+    within '#references_sent' do
+      expect(page).to have_content 'john@example.com'
+    end
   end
 end


### PR DESCRIPTION
## Context

As a candidate I need to edit the address on a reference request and resend so that I can re-request a reference that may have been sent to an incorrect or unreachable email address.

## Changes proposed in this pull request

- [x] For failed reference requests (`email_bounced` status) allow the user to _Retry request_ when there are less than two other references provided.
- [x] The user is prompted to optionally change the email address before resending. Otherwise the original email address is used again.
- [x] Extend `ReferenceHistoryComponent` to include the recipient's email address for retry and send reference request operations.

<img width="994" alt="image" src="https://user-images.githubusercontent.com/450843/97328770-40f1f500-186e-11eb-9e2f-0c4ca00439b4.png">
<img width="680" alt="image" src="https://user-images.githubusercontent.com/450843/97329029-86aebd80-186e-11eb-94dd-d196a562f3c1.png">
<img width="998" alt="image" src="https://user-images.githubusercontent.com/450843/97329159-ac3bc700-186e-11eb-8035-1c1f87cb4eed.png">

## Guidance to review

- Should be testable via review app
- Is the conditional logic for the change link correct?
- I have not added the edit email address feature for applications in the cancelled state. Is this correct?

## Link to Trello card

https://trello.com/c/FqNl6q0u/2238-💔-dev-edit-email-address-of-failed-reference-request

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
