### PR TITLE
Run test application specs with :decoupled_references on

### DIFF
--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe TestApplications do
   include DateComparisonHelper
 
-  before { FeatureFlag.deactivate(:decoupled_references) }
-
   it 'generates an application with choices in the given states' do
     create(:course_option, course: create(:course, :open_on_apply))
     create(:course_option, course: create(:course, :open_on_apply))

--- a/spec/requests/vendor_api/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_generate_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request do
   include VendorAPISpecHelpers
 
-  before { FeatureFlag.deactivate(:decoupled_references) }
-
   it 'generates test data' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 


### PR DESCRIPTION
## Context

This code was updated to run with decoupled_references on, so we can remove the deactivation.

## Link to Trello card

https://trello.com/c/ykZiAQ1s
