### PR TITLE
Move 404 catch-all route to application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,9 @@ module ApplyForPostgraduateTeacherTraining
     config.middleware.use VendorAPIRequestMiddleware
     config.middleware.use PDFKit::Middleware, { print_media_type: true }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
     config.skylight.environments = ENV['SKYLIGHT_ENABLE'].to_s == 'true' ? [Rails.env] : []
+
+    config.after_initialize do |app|
+      app.routes.append { get '*path', to: 'errors#not_found' }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -865,6 +865,4 @@ Rails.application.routes.draw do
     match '/422', to: 'errors#unprocessable_entity'
     match '/500', to: 'errors#internal_server_error'
   end
-
-  get '*path', to: 'errors#not_found'
 end


### PR DESCRIPTION
## Context

When the route is defined in `routes.rb`, it overrides any custom routes that are defined in engines from 3rd party libraries.

This breaks in the newest version of ViewComponent, which has switched from `.prepend` to `.append` for routes: https://github.com/github/view_component/pull/493/files#diff-fe26dc052312860cc076b99a7f3c0913bf834fc73fe246def378024ffc038164R91

## Changes proposed in this pull request

Move 404 catch-all route to application.rb, so that it can kick-in after engines have defined their custom routes. This is recommended in the README for `vidibus-routing_error`: https://github.com/vidibus/vidibus-routing_error#alternative-two

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/V7FqNNN3/2380-re-enable-accessibility-end-to-end-tests

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)