### PR TITLE
Fire slack notification when candidate sends reminder to referee

### DIFF
--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -51,7 +51,7 @@ module CandidateInterface
 
       def cancel
         if @reference.feedback_requested?
-          CancelReference.new.call(reference: @reference)
+          CancelReference.call(@reference)
 
           redirect_to candidate_interface_decoupled_references_review_path
           flash[:success] = "Reference request cancelled for #{@reference.name}"

--- a/app/services/candidate_interface/decoupled_references/send_reference_reminder.rb
+++ b/app/services/candidate_interface/decoupled_references/send_reference_reminder.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
   module DecoupledReferences
     class SendReferenceReminder
+      include SlackNotifications
+
       def self.call(reference, flash)
         new(reference, flash).call
       end
@@ -14,10 +16,27 @@ module CandidateInterface
 
       def call
         if reference.can_send_reminder?
-          RefereeMailer.reference_request_chaser_email(reference.application_form, reference).deliver_later
+          RefereeMailer.reference_request_chaser_email(application_form, reference).deliver_later
           reference.update!(reminder_sent_at: Time.zone.now)
-          flash[:success] = "Reminder sent to #{reference.name}"
+
+          send_slack_message(application_form, message)
+
+          flash[:success] = "Reminder sent to #{reference_name}"
         end
+      end
+
+    private
+
+      def message
+        "Candidate #{application_form.first_name} has sent a reminder to #{reference_name}"
+      end
+
+      def reference_name
+        reference.name
+      end
+
+      def application_form
+        reference.application_form
       end
     end
   end

--- a/app/services/candidate_interface/decoupled_references/slack_notifications.rb
+++ b/app/services/candidate_interface/decoupled_references/slack_notifications.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  module DecoupledReferences
+    module SlackNotifications
+      def send_slack_message(application_form, message)
+        url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
+
+        SlackNotificationWorker.perform_async(message, url)
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/decoupled_references/cancel_reference_spec.rb
+++ b/spec/services/candidate_interface/decoupled_references/cancel_reference_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::DecoupledReferences::CancelReference do
       expect(RefereeMailer).to have_received(:reference_cancelled_email).with(reference)
     end
 
-    it 'sends a the slack notification worker' do
+    it 'sends a message and url to the Slack notification worker' do
       expect(SlackNotificationWorker).to have_received(:perform_async).with(message, url)
     end
   end

--- a/spec/services/candidate_interface/decoupled_references/cancel_reference_spec.rb
+++ b/spec/services/candidate_interface/decoupled_references/cancel_reference_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::DecoupledReferences::CancelReference do
-  describe '#call' do
+  describe '.call' do
     let(:reference) { create(:reference, feedback_status: 'feedback_requested') }
-    let(:execute_service) { described_class.new.call(reference: reference) }
+    let(:execute_service) { described_class.call(reference) }
     let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
     let(:message) { "Candidate #{reference.application_form.first_name} has cancelled one of their references" }
     let(:url) { Rails.application.routes.url_helpers.support_interface_application_form_url(reference.application_form) }
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::DecoupledReferences::CancelReference do
       execute_service
     end
 
-    it 'updates the references feeedback status to cancelled' do
+    it 'updates the references feedback status to cancelled' do
       expect(reference.feedback_status).to eq('cancelled')
     end
 

--- a/spec/services/candidate_interface/decoupled_references/send_reference_reminder_spec.rb
+++ b/spec/services/candidate_interface/decoupled_references/send_reference_reminder_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::DecoupledReferences::SendReferenceReminder do
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 10, 21)) do
+      example.run
+    end
+  end
+
+  describe '.call' do
+    let(:reference) { create(:reference, feedback_status: 'feedback_requested') }
+    let(:flash) { {} }
+    let(:execute_service) { described_class.call(reference, flash) }
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+    let(:message) { "Candidate #{reference.application_form.first_name} has sent a reminder to #{reference.name}" }
+    let(:url) { Rails.application.routes.url_helpers.support_interface_application_form_url(reference.application_form) }
+
+    before do
+      allow(RefereeMailer).to receive(:reference_request_chaser_email).and_return(mail)
+      allow(SlackNotificationWorker).to receive(:perform_async).and_return(true)
+      execute_service
+    end
+
+    it 'updates the reference to record when the reminder was sent' do
+      expect(reference.reminder_sent_at).to eq(Time.zone.now)
+    end
+
+    it 'sends a reference chaser request to the referee mailer' do
+      expect(RefereeMailer).to have_received(:reference_request_chaser_email).with(reference.application_form, reference)
+    end
+
+    it 'sends a message and url to the Slack notification worker' do
+      expect(SlackNotificationWorker).to have_received(:perform_async).with(message, url)
+    end
+  end
+end


### PR DESCRIPTION
## Context
```
As a... product owner
I need to... get a feel for when and how often candidate’s are sending referee reminder emails
So that... so I can adjust the design of this feature.
```

## Changes proposed in this pull request

- Fire Slack notification when candidate sends reminder to referee
- Add specs for `RequestReference` service
- Refactor `CancelReference` service to use `SlackNotifications` module

## Guidance to review

When you send a reminder you should see a Slack request appear in the Sidekiq logs

## Link to Trello card

https://trello.com/c/dxaZlu7i/2250-%F0%9F%92%94-dev-slack-notification-when-candidate-sends-reminder-to-referee

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
