### PR TITLE
Don't raise when saving previously setup provider relationship permis…

### DIFF
--- a/app/services/provider_interface/setup_provider_relationship_permissions.rb
+++ b/app/services/provider_interface/setup_provider_relationship_permissions.rb
@@ -1,13 +1,9 @@
 module ProviderInterface
-  class PermissionsSetupError < StandardError; end
-
   class SetupProviderRelationshipPermissions
     def self.call(models)
       ProviderRelationshipPermissions.transaction do
         models.map do |record|
-          raise PermissionsSetupError, 'Permissions record has already been setup' if record.setup_at.present?
-
-          record.setup_at = Time.zone.now
+          record.setup_at = Time.zone.now if record.setup_at.blank?
           record.save!
         end
       end

--- a/spec/services/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/services/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -25,11 +25,14 @@ RSpec.describe ProviderInterface::SetupProviderRelationshipPermissions do
       end
     end
 
-    context 'when a record has been set up' do
-      let(:permissions) { [create(:provider_relationship_permissions, setup_at: Time.zone.now)] }
+    context 'when a record has already been set up' do
+      let(:setup_at) { 1.hour.ago }
+      let(:permissions) { [create(:provider_relationship_permissions, setup_at: setup_at)] }
 
-      it 'raises ProviderInterface::PermissionsSetupError' do
-        expect { described_class.call(permissions) }.to raise_error(ProviderInterface::PermissionsSetupError)
+      it 'updates the record' do
+        permissions.first.ratifying_provider_can_make_decisions = true
+        expect { described_class.call(permissions) }.to(change { permissions.first.updated_at })
+        expect(permissions.first.reload.setup_at.to_s(:db)).to eq(setup_at.to_s(:db))
       end
     end
   end


### PR DESCRIPTION
…sions





## Context

https://sentry.io/organizations/dfe-bat/issues/1970711787/?project=1765973&referrer=slack

Some provider relationship permissions were automatically assigned a `setup_at` datetime when we granted
`make_decisions` permissions to all existing providers. 
We need to re-direct some orgs back into the onboarding flow so that they can assign at least one provider to each permission, this means that we also need to relax the constraint on saving a previously set up permission.

See https://github.com/DFE-Digital/apply-for-teacher-training/pull/3161 for the redirecting part.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Relax the constraint on saving a previously set up permission.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card


<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
