### PR TITLE
Change references factory traits to be in line with the feedback status enum

### DIFF
--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
 
   context 'when reference state is "cancelled" but there are already 2 references provided' do
     let(:cancelled) { create(:reference, :cancelled) }
-    let(:provided_references) { create_list(:reference, 2, :complete, application_form: cancelled.application_form) }
+    let(:provided_references) { create_list(:reference, 2, :feedback_provided, application_form: cancelled.application_form) }
 
     it 'a send request link is NOT available' do
       FeatureFlag.activate(:decoupled_references)
@@ -183,7 +183,7 @@ private
     feedback_overdue = create(:reference, :feedback_overdue, application_form: af)
     sent_less_than_5_days_ago = create(:reference, :feedback_requested_less_than_5_days_ago, application_form: af)
     sent_more_than_5_days_ago = create(:reference, :feedback_requested_more_than_5_days_ago, application_form: af)
-    feedback_provided = create(:reference, :complete, application_form: af)
+    feedback_provided = create(:reference, :feedback_provided, application_form: af)
 
     status_struct = Struct.new(:reference, :colour, :status_identifier, :info_identifier, :info_args)
     stub_const('Status', status_struct)

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
   end
 
   context 'when reference state is "feedback_requested"' do
-    let(:feedback_requested) { create(:reference, :requested) }
+    let(:feedback_requested) { create(:reference, :feedback_requested) }
     let(:feedback_refused) { create(:reference, :feedback_refused) }
 
     it 'a cancel link is available' do
@@ -73,7 +73,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
   end
 
   context 'when reference state is "not_requested_yet" and the reference is complete' do
-    let(:feedback_requested) { create(:reference, :requested) }
+    let(:feedback_requested) { create(:reference, :feedback_requested) }
     let(:not_requested_yet) { create(:reference, :not_requested_yet) }
 
     it 'a send request link is available' do
@@ -100,7 +100,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
   end
 
   context 'when reference state is "cancelled" and the reference is complete' do
-    let(:feedback_requested) { create(:reference, :requested) }
+    let(:feedback_requested) { create(:reference, :feedback_requested) }
     let(:cancelled) { create(:reference, :cancelled) }
 
     it 'a re-send request link is available' do
@@ -140,7 +140,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
   end
 
   context 'rendering history' do
-    let(:reference) { create(:reference, :requested) }
+    let(:reference) { create(:reference, :feedback_requested) }
 
     it 'does not render by default' do
       result = render_inline(described_class.new(references: [reference]))
@@ -181,8 +181,8 @@ private
     cancelled_at_end_of_cycle = create(:reference, :cancelled_at_end_of_cycle, application_form: af)
     cancelled = create(:reference, :cancelled, application_form: af)
     feedback_overdue = create(:reference, :feedback_overdue, application_form: af)
-    sent_less_than_5_days_ago = create(:reference, :sent_less_than_5_days_ago, application_form: af)
-    sent_more_than_5_days_ago = create(:reference, :sent_more_than_5_days_ago, application_form: af)
+    sent_less_than_5_days_ago = create(:reference, :feedback_requested_less_than_5_days_ago, application_form: af)
+    sent_more_than_5_days_ago = create(:reference, :feedback_requested_more_than_5_days_ago, application_form: af)
     feedback_provided = create(:reference, :complete, application_form: af)
 
     status_struct = Struct.new(:reference, :colour, :status_identifier, :info_identifier, :info_args)

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
 
   context 'when reference state is "feedback_requested"' do
     let(:feedback_requested) { create(:reference, :requested) }
-    let(:feedback_refused) { create(:reference, :refused) }
+    let(:feedback_refused) { create(:reference, :feedback_refused) }
 
     it 'a cancel link is available' do
       result = render_inline(described_class.new(references: [feedback_requested, feedback_refused]))
@@ -176,7 +176,7 @@ private
     af = create(:application_form)
 
     not_requested_yet = create(:reference, :not_requested_yet, application_form: af)
-    feedback_refused = create(:reference, :refused, application_form: af)
+    feedback_refused = create(:reference, :feedback_refused, application_form: af)
     email_bounced = create(:reference, :email_bounced, application_form: af)
     cancelled_at_end_of_cycle = create(:reference, :cancelled_at_end_of_cycle, application_form: af)
     cancelled = create(:reference, :cancelled, application_form: af)

--- a/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
+++ b/spec/components/candidate_interface/decoupled_references_review_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :component do
   it 'renders the referee name and email' do
-    reference = create(:reference, :unsubmitted)
+    reference = create(:reference, :not_requested_yet)
     result = render_inline(described_class.new(references: [reference]))
 
     name_row = result.css('.govuk-summary-list__row')[0].text
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
   end
 
   it 'renders the reference type' do
-    reference = create(:reference, :unsubmitted, referee_type: :school_based)
+    reference = create(:reference, :not_requested_yet, referee_type: :school_based)
     result = render_inline(described_class.new(references: [reference]))
 
     type_row = result.css('.govuk-summary-list__row')[2].text
@@ -23,7 +23,7 @@ RSpec.describe CandidateInterface::DecoupledReferencesReviewComponent, type: :co
   end
 
   it 'renders the relationship' do
-    reference = create(:reference, :unsubmitted)
+    reference = create(:reference, :not_requested_yet)
     result = render_inline(described_class.new(references: [reference]))
 
     relationship_row = result.css('.govuk-summary-list__row')[3].text
@@ -175,7 +175,7 @@ private
   def status_table
     af = create(:application_form)
 
-    not_requested_yet = create(:reference, :unsubmitted, application_form: af)
+    not_requested_yet = create(:reference, :not_requested_yet, application_form: af)
     feedback_refused = create(:reference, :refused, application_form: af)
     email_bounced = create(:reference, :email_bounced, application_form: af)
     cancelled_at_end_of_cycle = create(:reference, :cancelled_at_end_of_cycle, application_form: af)

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
     course_option_for_provider(provider: provider)
     @application_form = create(:application_form)
     create(:application_choice, application_form: @application_form, course_option: provider.courses.first.course_options.first)
-    create(:reference, :requested, application_form: @application_form)
+    create(:reference, :feedback_requested, application_form: @application_form)
   end
 
   around do |example|
@@ -56,7 +56,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
   context 'when two references are in the feedback_requested state' do
     context 'when the candidates courses all have the same provider' do
       it 'renders the correct pluralization for referees, references and providers' do
-        create(:reference, :requested, application_form: @application_form)
+        create(:reference, :feedback_requested, application_form: @application_form)
         result = render_inline(described_class.new(application_form: @application_form, editable_days: 5))
 
         expect(result.css('.govuk-heading-m').text).to eq('References')
@@ -70,7 +70,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
         provider2 = create(:provider)
         course_option_for_provider(provider: provider2)
         create(:application_choice, application_form: @application_form, course_option: provider2.courses.first.course_options.first)
-        create(:reference, :requested, application_form: @application_form)
+        create(:reference, :feedback_requested, application_form: @application_form)
         result = render_inline(described_class.new(application_form: @application_form, editable_days: 5))
 
         expect(result.css('.govuk-heading-m').text).to eq('References')

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
     let(:application_form) do
       create(
         :completed_application_form,
-        references_state: 'unsubmitted',
+        references_state: 'not_requested_yet',
         references_count: 2,
         with_gcses: true,
       )

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -112,7 +112,7 @@ FactoryBot.define do
         work_experiences_count { 0 }
         volunteering_experiences_count { 0 }
         references_count { 0 }
-        references_state { :requested }
+        references_state { :feedback_requested }
         with_gcses { false }
         full_work_history { false }
         with_degree { false }
@@ -687,19 +687,19 @@ FactoryBot.define do
       requested_at { Time.zone.now }
     end
 
-    trait :requested do
+    trait :feedback_requested do
       feedback_status { 'feedback_requested' }
       feedback { nil }
       requested_at { Time.zone.now }
     end
 
-    trait :sent_less_than_5_days_ago do
+    trait :feedback_requested_less_than_5_days_ago do
       feedback_status { 'feedback_requested' }
       feedback { nil }
       requested_at { Time.zone.now - 2.days }
     end
 
-    trait :sent_more_than_5_days_ago do
+    trait :feedback_requested_more_than_5_days_ago do
       feedback_status { 'feedback_requested' }
       feedback { nil }
       requested_at { Time.zone.now - 6.days }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -663,7 +663,7 @@ FactoryBot.define do
       feedback { nil }
     end
 
-    trait :refused do
+    trait :feedback_refused do
       feedback_status { 'feedback_refused' }
       feedback { nil }
       requested_at { Time.zone.now }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -134,7 +134,7 @@ FactoryBot.define do
 
       trait :with_completed_references do
         transient do
-          references_state { :complete }
+          references_state { :feedback_provided }
         end
       end
 
@@ -712,7 +712,15 @@ FactoryBot.define do
       created_at { 11.business_days.ago }
     end
 
-    trait :complete do
+    trait :feedback_provided do
+      feedback_status { 'feedback_provided' }
+      feedback { Faker::Lorem.paragraph(sentence_count: 10) }
+      requested_at { Time.zone.now }
+      safeguarding_concerns { '' }
+      relationship_correction { '' }
+    end
+
+    trait :feedback_provided_with_completed_referee_questionnaire do
       feedback_status { 'feedback_provided' }
       feedback { Faker::Lorem.paragraph(sentence_count: 10) }
       requested_at { Time.zone.now }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -658,7 +658,7 @@ FactoryBot.define do
     referee_type { %i[academic professional school_based character].sample }
     questionnaire { nil }
 
-    trait :unsubmitted do
+    trait :not_requested_yet do
       feedback_status { 'not_requested_yet' }
       feedback { nil }
     end

--- a/spec/forms/referee_interface/reference_review_form_spec.rb
+++ b/spec/forms/referee_interface/reference_review_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe RefereeInterface::ReferenceReviewForm do
   describe 'validations' do
-    let(:review_form) { described_class.new(reference: build_stubbed(:reference, :complete)) }
+    let(:review_form) { described_class.new(reference: build_stubbed(:reference, :feedback_provided)) }
 
     it 'is valid when all questions are complete' do
       expect(review_form).to be_valid

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     it 'sends an email with the correct body if one reference complete' do
       application_form = create(:completed_application_form, :with_completed_references)
       create(:reference, :complete, application_form: application_form)
-      create(:reference, :requested, application_form: application_form)
+      create(:reference, :feedback_requested, application_form: application_form)
 
       email = described_class.send(:reference_received, application_form.application_references.first)
       expect(email.body).to include('You need to get another reference')

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe '.reference_received' do
     it 'sends an email with the correct body if one reference complete' do
       application_form = create(:completed_application_form, :with_completed_references)
-      create(:reference, :complete, application_form: application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
       create(:reference, :feedback_requested, application_form: application_form)
 
       email = described_class.send(:reference_received, application_form.application_references.first)
@@ -83,8 +83,8 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it 'sends an email with the correct body if two references complete' do
       application_form = create(:completed_application_form, :with_completed_references)
-      create(:reference, :complete, application_form: application_form)
-      create(:reference, :complete, application_form: application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
 
       email = described_class.send(:reference_received, application_form.application_references.first)
       expect(email.body).to include('You’ve got 2 references back now.')

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe ApplicationReference, type: :model do
     end
 
     it 'is false when state is not feedback_requested' do
-      reference = build(:reference, :unsubmitted, reminder_sent_at: nil)
+      reference = build(:reference, :not_requested_yet, reminder_sent_at: nil)
       expect(reference.can_send_reminder?).to eq false
     end
 
@@ -217,7 +217,7 @@ RSpec.describe ApplicationReference, type: :model do
     let(:submitted_application_form) { build_stubbed(:application_form, submitted_at: Time.zone.now) }
 
     it 'is true when state is not_requested_yet and the application form has not been submitted' do
-      reference = build_stubbed(:reference, :unsubmitted, application_form: unsubmitted_application_form)
+      reference = build_stubbed(:reference, :not_requested_yet, application_form: unsubmitted_application_form)
       expect(reference.can_be_destroyed?).to eq true
     end
 
@@ -232,7 +232,7 @@ RSpec.describe ApplicationReference, type: :model do
     end
 
     it 'is false when state is not_requested_yet and the application form has been submitted' do
-      reference = build(:reference, :unsubmitted, application_form: submitted_application_form)
+      reference = build(:reference, :not_requested_yet, application_form: submitted_application_form)
       expect(reference.can_be_destroyed?).to eq false
     end
 

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe ApplicationReference, type: :model do
 
   describe '#can_send_reminder?' do
     it 'is true when state is feedback_requested and reminder_sent_at is nil' do
-      reference = build(:reference, :requested, reminder_sent_at: nil)
+      reference = build(:reference, :feedback_requested, reminder_sent_at: nil)
       expect(reference.can_send_reminder?).to eq true
     end
 
@@ -207,7 +207,7 @@ RSpec.describe ApplicationReference, type: :model do
     end
 
     it 'is false when reminder_sent_at is filled' do
-      reference = build(:reference, :requested, reminder_sent_at: Time.zone.now)
+      reference = build(:reference, :feedback_requested, reminder_sent_at: Time.zone.now)
       expect(reference.can_send_reminder?).to eq false
     end
   end
@@ -227,7 +227,7 @@ RSpec.describe ApplicationReference, type: :model do
     end
 
     it 'is false when state is feedback_requested state aand the application form has not been submitted' do
-      reference = build(:reference, :requested, application_form: unsubmitted_application_form)
+      reference = build(:reference, :feedback_requested, application_form: unsubmitted_application_form)
       expect(reference.can_be_destroyed?).to eq false
     end
 

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe ApplicationReference, type: :model do
     end
 
     it 'is true when state is feedback_provided and the application form has not been submitted' do
-      reference = build(:reference, :complete, application_form: unsubmitted_application_form)
+      reference = build(:reference, :feedback_provided, application_form: unsubmitted_application_form)
       expect(reference.can_be_destroyed?).to eq true
     end
 
@@ -237,7 +237,7 @@ RSpec.describe ApplicationReference, type: :model do
     end
 
     it 'is false when state is feedback_provided and the application form has been submitted' do
-      reference = build(:reference, :complete, application_form: submitted_application_form)
+      reference = build(:reference, :feedback_provided, application_form: submitted_application_form)
       expect(reference.can_be_destroyed?).to eq false
     end
   end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       refused = create(
         :reference,
-        :refused,
+        :feedback_refused,
         application_form: application_choice.application_form,
       )
 

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     it 'returns only references with feedback' do
       with_feedback = create(
         :reference,
-        :complete,
+        :feedback_provided,
         application_form: application_choice.application_form,
       )
 
@@ -344,7 +344,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     it 'returns application references with their respective ids' do
       reference = create(
         :reference,
-        :complete,
+        :feedback_provided,
         application_form: application_choice.application_form,
       )
       presenter = VendorAPI::SingleApplicationPresenter.new(application_choice)

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SubmitReference do
           application_form = create(:application_form)
           reference1 = create(:reference, :requested, application_form: application_form)
           reference2 = create(:reference, :requested, application_form: application_form)
-          reference3 = create(:reference, :refused, application_form: application_form)
+          reference3 = create(:reference, :feedback_refused, application_form: application_form)
           reference4 = create(:reference, :requested, application_form: application_form)
 
           SubmitReference.new(reference: reference1).save!

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe SubmitReference do
       it 'updates the reference state to "feedback_provided"' do
         application_choice = create(:application_choice, status: :unsubmitted)
         application_form = application_choice.application_form
-        reference_one = create(:reference, :requested)
-        reference_two = create(:reference, :requested, application_form: reference_one.application_form)
+        reference_one = create(:reference, :feedback_requested)
+        reference_two = create(:reference, :feedback_requested, application_form: reference_one.application_form)
 
         SubmitReference.new(reference: reference_one).save!
         SubmitReference.new(reference: reference_two).save!
@@ -22,10 +22,10 @@ RSpec.describe SubmitReference do
       context 'when the second reference is received' do
         it 'cancels reference requests for all remaining "awaiting_feedback" references' do
           application_form = create(:application_form)
-          reference1 = create(:reference, :requested, application_form: application_form)
-          reference2 = create(:reference, :requested, application_form: application_form)
+          reference1 = create(:reference, :feedback_requested, application_form: application_form)
+          reference2 = create(:reference, :feedback_requested, application_form: application_form)
           reference3 = create(:reference, :feedback_refused, application_form: application_form)
-          reference4 = create(:reference, :requested, application_form: application_form)
+          reference4 = create(:reference, :feedback_requested, application_form: application_form)
 
           SubmitReference.new(reference: reference1).save!
           SubmitReference.new(reference: reference2).save!

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe SubmitReference do
           active_application_choice = create(:application_choice, application_form: application_form, status: 'awaiting_references')
           cancelled_application_choice = create(:application_choice, application_form: application_form, status: 'cancelled')
 
-          create(:reference, :complete, application_form: application_form)
+          create(:reference, :feedback_provided, application_form: application_form)
           reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
@@ -65,7 +65,7 @@ RSpec.describe SubmitReference do
         it 'progresses the application choices to the "awaiting_provider_decision" if edit_by has elapsed' do
           application_form = create(:completed_application_form, edit_by: 1.day.ago)
           create(:application_choice, application_form: application_form, status: 'awaiting_references')
-          create(:reference, :complete, application_form: application_form)
+          create(:reference, :feedback_provided, application_form: application_form)
           reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
@@ -80,7 +80,7 @@ RSpec.describe SubmitReference do
         it 'sets edit_by to current time if the candidate is applying again' do
           application_form = create(:completed_application_form, previous_application_form: create(:application_form), edit_by: 2.days.from_now)
           create(:application_choice, application_form: application_form, status: 'awaiting_references')
-          create(:reference, :complete, application_form: application_form)
+          create(:reference, :feedback_provided, application_form: application_form)
           reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
@@ -98,7 +98,7 @@ RSpec.describe SubmitReference do
           application_form = create(:completed_application_form, edit_by: 1.day.ago)
 
           create(:application_choice, application_form: application_form, status: 'awaiting_references')
-          create(:reference, :complete, application_form: application_form)
+          create(:reference, :feedback_provided, application_form: application_form)
           reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SubmitReference do
           cancelled_application_choice = create(:application_choice, application_form: application_form, status: 'cancelled')
 
           create(:reference, :complete, application_form: application_form)
-          reference = create(:reference, :unsubmitted, application_form: application_form)
+          reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
@@ -66,7 +66,7 @@ RSpec.describe SubmitReference do
           application_form = create(:completed_application_form, edit_by: 1.day.ago)
           create(:application_choice, application_form: application_form, status: 'awaiting_references')
           create(:reference, :complete, application_form: application_form)
-          reference = create(:reference, :unsubmitted, application_form: application_form)
+          reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
@@ -81,7 +81,7 @@ RSpec.describe SubmitReference do
           application_form = create(:completed_application_form, previous_application_form: create(:application_form), edit_by: 2.days.from_now)
           create(:application_choice, application_form: application_form, status: 'awaiting_references')
           create(:reference, :complete, application_form: application_form)
-          reference = create(:reference, :unsubmitted, application_form: application_form)
+          reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
@@ -99,7 +99,7 @@ RSpec.describe SubmitReference do
 
           create(:application_choice, application_form: application_form, status: 'awaiting_references')
           create(:reference, :complete, application_form: application_form)
-          reference = create(:reference, :unsubmitted, application_form: application_form)
+          reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
@@ -107,7 +107,7 @@ RSpec.describe SubmitReference do
             reference: reference,
           ).save!
 
-          another_reference = create(:reference, :unsubmitted, application_form: application_form)
+          another_reference = create(:reference, :not_requested_yet, application_form: application_form)
 
           another_reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 

--- a/spec/services/support_interface/candidate_journey_tracker_spec.rb
+++ b/spec/services/support_interface/candidate_journey_tracker_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     it 'returns the time when the first reference was received' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :unsubmitted, application_form: application_form)
-      application_reference = create(:reference, :requested, application_form: application_form)
+      application_reference = create(:reference, :feedback_requested, application_form: application_form)
       Timecop.freeze(now + 1.day) do
         application_reference.update!(feedback_status: 'feedback_provided')
       end
@@ -81,8 +81,8 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     it 'returns nil if only one reference has been received' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :unsubmitted, application_form: application_form)
-      application_reference1 = create(:reference, :requested, application_form: application_form)
-      _application_reference2 = create(:reference, :requested, application_form: application_form)
+      application_reference1 = create(:reference, :feedback_requested, application_form: application_form)
+      _application_reference2 = create(:reference, :feedback_requested, application_form: application_form)
       Timecop.freeze(now + 1.day) do
         application_reference1.update!(feedback_status: 'feedback_provided')
       end
@@ -92,8 +92,8 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     it 'returns the time when the second reference was received' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :unsubmitted, application_form: application_form)
-      application_reference1 = create(:reference, :requested, application_form: application_form)
-      application_reference2 = create(:reference, :requested, application_form: application_form)
+      application_reference1 = create(:reference, :feedback_requested, application_form: application_form)
+      application_reference2 = create(:reference, :feedback_requested, application_form: application_form)
       Timecop.freeze(now + 1.day) do
         application_reference1.update!(feedback_status: 'feedback_provided')
       end
@@ -115,8 +115,8 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     it 'returns time of the earliest chaser sent' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
-      application_reference1 = create(:reference, :requested, application_form: application_form)
-      application_reference2 = create(:reference, :requested, application_form: application_form)
+      application_reference1 = create(:reference, :feedback_requested, application_form: application_form)
+      application_reference2 = create(:reference, :feedback_requested, application_form: application_form)
       Timecop.freeze(now + 1.day) do
         ChaserSent.create!(chased: application_reference1, chaser_type: :reference_request)
       end
@@ -139,7 +139,7 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     it 'returns time of the earliest chaser sent' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
-      create(:reference, :requested, application_form: application_form)
+      create(:reference, :feedback_requested, application_form: application_form)
       application_reference2 = create(:reference, :feedback_refused, application_form: application_form)
       Timecop.freeze(now + 1.day) do
         ChaserSent.create!(chased: application_reference2, chaser_type: :reference_replacement)
@@ -153,8 +153,8 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     it 'returns nil when there are only two references' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
-      create(:reference, :requested, application_form: application_form)
-      create(:reference, :requested, application_form: application_form)
+      create(:reference, :feedback_requested, application_form: application_form)
+      create(:reference, :feedback_requested, application_form: application_form)
 
       expect(described_class.new(application_choice).new_reference_added).to be_nil
     end
@@ -162,11 +162,11 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     it 'returns time of the earliest chaser sent' do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
-      create(:reference, :requested, application_form: application_form)
+      create(:reference, :feedback_requested, application_form: application_form)
       create(:reference, :feedback_refused, application_form: application_form)
 
       Timecop.freeze(now + 1.day) do
-        create(:reference, :requested, application_form: application_form)
+        create(:reference, :feedback_requested, application_form: application_form)
       end
 
       expect(described_class.new(application_choice).new_reference_added).to eq(now + 1.day)

--- a/spec/services/support_interface/candidate_journey_tracker_spec.rb
+++ b/spec/services/support_interface/candidate_journey_tracker_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
       create(:reference, :requested, application_form: application_form)
-      application_reference2 = create(:reference, :refused, application_form: application_form)
+      application_reference2 = create(:reference, :feedback_refused, application_form: application_form)
       Timecop.freeze(now + 1.day) do
         ChaserSent.create!(chased: application_reference2, chaser_type: :reference_replacement)
       end
@@ -163,7 +163,7 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
       create(:reference, :requested, application_form: application_form)
-      create(:reference, :refused, application_form: application_form)
+      create(:reference, :feedback_refused, application_form: application_form)
 
       Timecop.freeze(now + 1.day) do
         create(:reference, :requested, application_form: application_form)

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Candidate requests a reference' do
 
   def and_i_have_added_a_reference
     @application_form = current_candidate.current_application
-    @reference = create(:reference, :unsubmitted, application_form: @application_form)
+    @reference = create(:reference, :not_requested_yet, application_form: @application_form)
   end
 
   def and_i_visit_the_reference_review_page
@@ -113,11 +113,11 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def when_i_have_added_a_second_reference
-    @reference = create(:reference, :unsubmitted, application_form: @application_form)
+    @reference = create(:reference, :not_requested_yet, application_form: @application_form)
   end
 
   def when_i_have_added_a_third_reference
-    @reference = create(:reference, :unsubmitted, application_form: @application_form)
+    @reference = create(:reference, :not_requested_yet, application_form: @application_form)
   end
 
   def and_i_choose_not_to_request_reference_immediately
@@ -158,7 +158,7 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def when_i_have_added_an_incomplete_reference
-    @reference = create(:reference, :unsubmitted, name: nil, application_form: @application_form)
+    @reference = create(:reference, :not_requested_yet, name: nil, application_form: @application_form)
   end
 
   def and_i_visit_the_all_references_review_page

--- a/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Candidate sends a reference reminder' do
   end
 
   def and_i_have_added_and_sent_a_reference
-    @reference = create(:reference, :requested, application_form: current_candidate.current_application)
+    @reference = create(:reference, :feedback_requested, application_form: current_candidate.current_application)
     current_candidate.current_application.update(first_name: 'Jeremy', last_name: 'Corbyn')
   end
 

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Review references' do
   def when_i_have_added_references
     application_form = current_candidate.current_application
     @complete_reference = create(:reference, :complete, application_form: application_form)
-    @not_sent_reference = create(:reference, :unsubmitted, application_form: application_form)
+    @not_sent_reference = create(:reference, :not_requested_yet, application_form: application_form)
     @requested_reference = create(:reference, :requested, application_form: application_form)
     @refused_reference = create(:reference, :refused, application_form: application_form)
   end

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -50,14 +50,14 @@ RSpec.feature 'Review references' do
 
   def when_i_have_added_references
     application_form = current_candidate.current_application
-    @complete_reference = create(:reference, :complete, application_form: application_form)
+    @complete_reference = create(:reference, :feedback_provided, application_form: application_form)
     @not_sent_reference = create(:reference, :not_requested_yet, application_form: application_form)
     @requested_reference = create(:reference, :feedback_requested, application_form: application_form)
     @refused_reference = create(:reference, :feedback_refused, application_form: application_form)
   end
 
   def when_enough_references_have_been_given
-    create(:reference, :complete, application_form: current_candidate.current_application)
+    create(:reference, :feedback_provided, application_form: current_candidate.current_application)
   end
 
   def then_the_references_section_is_complete

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Review references' do
     application_form = current_candidate.current_application
     @complete_reference = create(:reference, :complete, application_form: application_form)
     @not_sent_reference = create(:reference, :not_requested_yet, application_form: application_form)
-    @requested_reference = create(:reference, :requested, application_form: application_form)
+    @requested_reference = create(:reference, :feedback_requested, application_form: application_form)
     @refused_reference = create(:reference, :feedback_refused, application_form: application_form)
   end
 

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Review references' do
     @complete_reference = create(:reference, :complete, application_form: application_form)
     @not_sent_reference = create(:reference, :not_requested_yet, application_form: application_form)
     @requested_reference = create(:reference, :requested, application_form: application_form)
-    @refused_reference = create(:reference, :refused, application_form: application_form)
+    @refused_reference = create(:reference, :feedback_refused, application_form: application_form)
   end
 
   def when_enough_references_have_been_given

--- a/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
@@ -68,8 +68,8 @@ RSpec.feature 'Submitting an application' do
   end
 
   def when_i_have_added_references
-    @reference1 = create(:reference, :unsubmitted, application_form: current_candidate.current_application)
-    @reference2 = create(:reference, :unsubmitted, application_form: current_candidate.current_application)
+    @reference1 = create(:reference, :not_requested_yet, application_form: current_candidate.current_application)
+    @reference2 = create(:reference, :not_requested_yet, application_form: current_candidate.current_application)
     application.update(references_completed: true)
   end
 

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            feedback: 'The possibility of successfully navigating training is approximately three thousand seven hundred and twenty to one')
 
     create(:reference,
-           :refused,
+           :feedback_refused,
            application_form: application_form,
            name: 'BB-8')
 

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            end_date: nil)
 
     create(:reference,
-           :complete,
+           :feedback_provided,
            application_form: application_form,
            name: 'R2D2',
            email_address: 'r2d2@rebellion.org',
@@ -140,7 +140,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
            feedback: 'beep boop beep')
 
     create(:reference,
-           :complete,
+           :feedback_provided,
            application_form: application_form,
            name: 'C3PO',
            email_address: 'c3p0@rebellion.org',

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def given_i_am_a_referee_of_an_application
-    @reference = create(:reference, :requested, email_address: 'terri@example.com', name: 'Terri Tudor')
+    @reference = create(:reference, :feedback_requested, email_address: 'terri@example.com', name: 'Terri Tudor')
     @application = create(:completed_application_form, application_references: [@reference], candidate: current_candidate)
   end
 

--- a/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
+++ b/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Referee can use sign in link in the initial and chaser email' do
   end
 
   def given_i_am_a_referee_of_an_submitted_application
-    @reference = create(:reference, :requested)
+    @reference = create(:reference, :feedback_requested)
     @application = create(:completed_application_form, application_references: [@reference])
   end
 

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Referee does not respond in time' do
   end
 
   def given_there_is_an_application_with_a_reference
-    @reference = create(:reference, :requested, email_address: 'anne@other.com', name: 'Anne Other')
+    @reference = create(:reference, :feedback_requested, email_address: 'anne@other.com', name: 'Anne Other')
     @application = create(:application_form, first_name: 'F', last_name: 'B', application_references: [@reference])
   end
 

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Refusing to give a reference' do
   end
 
   def given_i_am_a_referee_of_an_application
-    @reference = create(:reference, :requested, email_address: 'terri@example.com', name: 'Terri Tudor')
+    @reference = create(:reference, :feedback_requested, email_address: 'terri@example.com', name: 'Terri Tudor')
     @application = create(:completed_application_form, application_references: [@reference])
   end
 

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Stop submission of incomplete references', with_audited: true do
   end
 
   def given_i_am_a_referee_of_an_application
-    @reference = create(:reference, :requested)
+    @reference = create(:reference, :feedback_requested)
     @application = create(:completed_application_form, application_references: [@reference])
   end
 

--- a/spec/system/support_interface/cancel_reference_spec.rb
+++ b/spec/system/support_interface/cancel_reference_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Cancelling references' do
 
   def and_there_is_an_application
     @application_with_reference = create(:completed_application_form)
-    create(:reference, :requested, name: 'Harry', application_form: @application_with_reference)
+    create(:reference, :feedback_requested, name: 'Harry', application_form: @application_with_reference)
   end
 
   def and_i_visit_the_application

--- a/spec/system/support_interface/change_courses/cancel_application_spec.rb
+++ b/spec/system/support_interface/change_courses/cancel_application_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Cancel application' do
 
   def and_there_is_a_candidate_who_wants_to_cancel_their_application
     @application_form = create(:completed_application_form)
-    create(:reference, :requested, application_form: @application_form)
+    create(:reference, :feedback_requested, application_form: @application_form)
 
     create(:application_choice, status: 'awaiting_references', application_form: @application_form)
     create(:application_choice, status: 'awaiting_references', application_form: @application_form)

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe DetectInvariants do
   describe '#perform' do
     it 'detects weird references state' do
       application_choice = create(:application_choice, status: 'application_complete')
-      create(:reference, :complete, application_form: application_choice.application_form)
-      create(:reference, :complete, application_form: application_choice.application_form)
+      create(:reference, :feedback_provided, application_form: application_choice.application_form)
+      create(:reference, :feedback_provided, application_form: application_choice.application_form)
 
       application_choice = create(:application_choice, status: 'awaiting_references')
-      create(:reference, :complete, application_form: application_choice.application_form)
-      create(:reference, :complete, application_form: application_choice.application_form)
+      create(:reference, :feedback_provided, application_form: application_choice.application_form)
+      create(:reference, :feedback_provided, application_form: application_choice.application_form)
 
       DetectInvariants.new.perform
 


### PR DESCRIPTION
## Context

At the moment, the traits in the references factory don't align the feedback_status enum in the application reference model. 

Ideally, these should align to allow for things like creating and iterating across each state in testing.

It's also just more intuitive.

## Changes proposed in this pull request

Update the traits in the references factory to align with the feedback status enum.

## Guidance to review

It might be easier to check per commit as I've broken it down by trait.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
