### PR TITLE
Redirect to /candidate/account from sandbox homepage

### DIFF
--- a/app/components/gov_uk_start_button_component.html.erb
+++ b/app/components/gov_uk_start_button_component.html.erb
@@ -1,0 +1,6 @@
+<a href="<%= href %>" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
+  <%= title %>
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+  </svg>
+</a>

--- a/app/components/gov_uk_start_button_component.rb
+++ b/app/components/gov_uk_start_button_component.rb
@@ -1,0 +1,8 @@
+class GovUkStartButtonComponent < ViewComponent::Base
+  attr_accessor :title, :href
+
+  def initialize(title:, href:)
+    self.title = title
+    self.href = href
+  end
+end

--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -45,7 +45,7 @@
 
     <p class='govuk-body'>In the Apply sandbox, applications are sent immediately, if the references are complete.</p>
 
-    <a href="/candidate" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
+    <a href="/candidate/account" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
       Continue as a candidate
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -45,12 +45,12 @@
 
     <p class='govuk-body'>In the Apply sandbox, applications are sent immediately, if the references are complete.</p>
 
-    <a href="/candidate/account" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
-      Continue as a candidate
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
-        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-      </svg>
-    </a>
+    <%= render(
+      GovUkStartButtonComponent.new(
+        title: "Continue as a Candidate",
+        href: candidate_interface_account_path,
+      ),
+    ) %>
 
     <h2 class='govuk-heading-l'>Get started as a training provider</h2>
 
@@ -62,12 +62,12 @@
 
     <p class='govuk-body'>From the provider interface in the sandbox, you’ll be able to sign in as a specific candidate. This is useful if you have generated test applications via the API.</p>
 
-    <a href="/provider" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
-      Continue as a training provider
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
-        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-      </svg>
-    </a>
+    <%= render(
+      GovUkStartButtonComponent.new(
+        title: "Continue as a training provider",
+        href: provider_interface_path,
+      ),
+    ) %>
 
     <h2 class='govuk-heading-l'>Get started with the API</h2>
 
@@ -75,12 +75,12 @@
 
     <p class='govuk-body'>In the sandbox, you’ll be able to test your integration. You’ll also be able to generate dummy applications to process as a training provider.</p>
 
-    <a href="https://www.apply-for-teacher-training.service.gov.uk/api-docs" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
-      Review our API documentation
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
-        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-      </svg>
-    </a>
+    <%= render(
+      GovUkStartButtonComponent.new(
+        title: "Review our API documentation",
+        href: "https://www.apply-for-teacher-training.service.gov.uk/api-docs",
+      ),
+    ) %>
 
     <h2 class='govuk-heading-l'>Help and support</h2>
 

--- a/spec/components/gov_uk_start_button_component_spec.rb
+++ b/spec/components/gov_uk_start_button_component_spec.rb
@@ -1,8 +1,8 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe GovUkStartButtonComponent, type: :component do
   it 'renders with button with an icon and specified link and title' do
-    render_result = render_inline(described_class.new(title: "Button", href: "www.example.com"))
+    render_result = render_inline(described_class.new(title: 'Button', href: 'www.example.com'))
 
     expect(render_result.css('a').attr('href').value).to eq 'www.example.com'
     expect(render_result.text).to include('Button')

--- a/spec/components/gov_uk_start_button_component_spec.rb
+++ b/spec/components/gov_uk_start_button_component_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe GovUkStartButtonComponent, type: :component do
+  it 'renders with button with an icon and specified link and title' do
+    render_result = render_inline(described_class.new(title: "Button", href: "www.example.com"))
+
+    expect(render_result.css('a').attr('href').value).to eq 'www.example.com'
+    expect(render_result.text).to include('Button')
+    expect(render_result.search('svg').first[:class]).to include('govuk-button__start-icon')
+  end
+end


### PR DESCRIPTION
/candidate no longer exists within the apply service, so linking there causes us to forget we want to be in sandbox mode

## Context
Clicking the Continue as Candidate button currently results in being redirected away from sandbox to the live gov.uk site, and then clicking start redirects to the live apply service

## Changes proposed in this pull request
Specify /candidate/account so that we stay on the sandbox environment

## Link to Trello card
https://trello.com/c/mDekNsqF/2948-sandbox-continue-as-candidate-button-redirects-through-to-live-govuk-site

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
