### PR TITLE
Allow deletion of bounced, declined and cancelled referees

### DIFF
--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -19,6 +19,13 @@
                 <span class="govuk-visually-hidden"> <%= reference.name %></span>
               <% end %>
             </li>
+          <% elsif reference.request_can_be_deleted? %>
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to candidate_interface_delete_decoupled_reference_path(reference), class: 'govuk-link' do %>
+                <%= t('application_form.referees.delete_request') %>
+                <span class="govuk-visually-hidden"> <%= reference.name %></span>
+              <% end %>
+            </li>
           <% end %>
 
           <% if can_send?(reference) %>

--- a/app/components/candidate_interface/decoupled_references_review_component.html.erb
+++ b/app/components/candidate_interface/decoupled_references_review_component.html.erb
@@ -21,7 +21,7 @@
             </li>
           <% elsif reference.request_can_be_deleted? %>
             <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_delete_decoupled_reference_path(reference), class: 'govuk-link' do %>
+              <%= link_to candidate_interface_delete_decoupled_reference_request_path(reference), class: 'govuk-link' do %>
                 <%= t('application_form.referees.delete_request') %>
                 <span class="govuk-visually-hidden"> <%= reference.name %></span>
               <% end %>

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -34,8 +34,12 @@ module CandidateInterface
         redirect_to candidate_interface_decoupled_references_review_path unless @reference.can_be_destroyed?
       end
 
+      def confirm_delete_request
+        redirect_to candidate_interface_decoupled_references_review_path unless @reference.request_can_be_deleted?
+      end
+
       def destroy
-        redirect_to candidate_interface_decoupled_references_review_path unless @reference.can_be_destroyed?
+        redirect_to candidate_interface_decoupled_references_review_path unless @reference.can_be_destroyed? || @reference.request_can_be_deleted?
 
         @reference.destroy!
         redirect_to candidate_interface_decoupled_references_review_path

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -114,6 +114,10 @@ class ApplicationReference < ApplicationRecord
     (not_requested_yet? || feedback_provided?) && !application_form.submitted?
   end
 
+  def request_can_be_deleted?
+    (cancelled? || feedback_refused? || email_bounced?) && !application_form.submitted?
+  end
+
   def can_send_reminder?
     feedback_requested? && reminder_sent_at.nil?
   end

--- a/app/views/candidate_interface/decoupled_references/review/confirm_delete_request.html.erb
+++ b/app/views/candidate_interface/decoupled_references/review/confirm_delete_request.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, t('page_titles.references_delete_request') %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @reference, url: candidate_interface_destroy_decoupled_reference_path(@reference), method: :delete do |f| %>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.references_delete_request') %>
+      </h1>
+
+      <%= f.submit t('application_form.references.delete_request.confirm_delete') , class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('application_form.references.delete_request.do_not_delete'), candidate_interface_decoupled_references_review_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -393,6 +393,7 @@ en:
       add_referees_later: I’ll add referees later
       complete_form_button: Save and continue
       delete: Delete referee
+      delete_request: Delete request
       cancel: Cancel referee
       cancel_request: Cancel request
       send_request: Send request

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -383,6 +383,9 @@ en:
           professional: 'For example, ‘He was my line manager in my last job. I’ve known him for 2 years’.'
           school_based: 'For example, ‘She’s the deputy head at the school where I currently volunteer. I’ve known her for 3 years’.'
           character: 'For example, ‘She’s the head coach for my athletics club. I’ve known her for 5 years’.'
+      delete_request:
+        confirm_delete: Yes I’m sure - delete this reference request
+        do_not_delete: No, I’ve changed my mind
     decoupled_references:
       sure_cancel_entry: Yes I’m sure - cancel this reference request
       cancel: Cancel request

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,7 @@ en:
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?
     references_cancel_request: Are you sure you want to cancel this reference request?
+    references_delete_request: Are you sure you want to delete this reference request?
     add_referee: Details of referee
     maximum_referees: You cannot add any more referees
     give_a_reference:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -421,8 +421,9 @@ Rails.application.routes.draw do
         post '/review-unsubmitted/:id' => 'decoupled_references/review#submit', as: :decoupled_references_submit
 
         get '/review' => 'decoupled_references/review#show', as: :decoupled_references_review
-        get '/review/delete/:id' => 'decoupled_references/review#confirm_destroy', as: :destroy_decoupled_reference
-        delete '/review/delete/:id' => 'decoupled_references/review#destroy'
+        get '/review/destroy/:id' => 'decoupled_references/review#confirm_destroy', as: :destroy_decoupled_reference
+        get '/review/delete/:id' => 'decoupled_references/review#confirm_delete_request', as: :delete_decoupled_reference_request
+        delete '/review/destroy/:id' => 'decoupled_references/review#destroy'
 
         get 'review/cancel/:id' => 'decoupled_references/review#confirm_cancel', as: :confirm_cancel_decoupled_reference
         patch 'review/cancel/:id' => 'decoupled_references/review#cancel', as: :cancel_decoupled_reference

--- a/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/review_references_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature 'Review references' do
     and_i_can_review_my_references_before_submission
     and_i_can_edit_a_reference
     and_i_can_delete_a_reference
+    and_i_can_delete_a_reference_request
     and_i_can_cancel_a_sent_reference
     and_referee_receives_email_about_reference_cancellation
     and_i_can_return_to_the_application_page
@@ -54,6 +55,8 @@ RSpec.feature 'Review references' do
     @not_sent_reference = create(:reference, :not_requested_yet, application_form: application_form)
     @requested_reference = create(:reference, :feedback_requested, application_form: application_form)
     @refused_reference = create(:reference, :feedback_refused, application_form: application_form)
+    @cancelled_reference = create(:reference, :cancelled, application_form: application_form)
+    @bounced_reference = create(:reference, :cancelled, application_form: application_form)
   end
 
   def when_enough_references_have_been_given
@@ -84,10 +87,18 @@ RSpec.feature 'Review references' do
     end
 
     within '#references_sent' do
-      expect(page).to have_content @requested_reference.email_address
-      expect(page).to have_content @refused_reference.email_address
-      expect(page).not_to have_link 'Change'
-      expect(page).not_to have_link 'Delete referee'
+      expect(all('.app-summary-card')[0].text).to have_content @requested_reference.email_address
+      expect(all('.app-summary-card')[0]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[0]).not_to have_link 'Delete'
+      expect(all('.app-summary-card')[1].text).to have_content @refused_reference.email_address
+      expect(all('.app-summary-card')[1]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[1]).to have_link 'Delete request'
+      expect(all('.app-summary-card')[2].text).to have_content @cancelled_reference.email_address
+      expect(all('.app-summary-card')[2]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[2]).to have_link 'Delete request'
+      expect(all('.app-summary-card')[3].text).to have_content @bounced_reference.email_address
+      expect(all('.app-summary-card')[3]).not_to have_link 'Change'
+      expect(all('.app-summary-card')[3]).to have_link 'Delete request'
     end
   end
 
@@ -114,6 +125,16 @@ RSpec.feature 'Review references' do
 
     expect(page).to have_current_path candidate_interface_decoupled_references_review_path
     expect(page).not_to have_css('#references_waiting_to_be_sent')
+  end
+
+  def and_i_can_delete_a_reference_request
+    within '#references_sent' do
+      click_link 'Delete request', match: :first
+    end
+    click_button 'Yes I’m sure'
+
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
+    expect(page).not_to have_content @refused_reference.name
   end
 
   def and_i_can_cancel_a_sent_reference


### PR DESCRIPTION
## Context

```
As a...candidate
I need to..delete previous references requests
So that...so that I feel in control of what’s shown
```

The summary card on the decoupled references review page needs delete request link for the cancelled, declined and bounced references.

## Changes proposed in this pull request

cancelled

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/96843531-56b68300-1446-11eb-8901-423a5387cb28.png)|![image](https://user-images.githubusercontent.com/42515961/96857210-a0a76500-1456-11eb-90c3-6724856b00dc.png)|


declined

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/96843693-85345e00-1446-11eb-8409-9b4d501f6e4c.png)|![image](https://user-images.githubusercontent.com/42515961/96856722-24ad1d00-1456-11eb-99ae-b08e56b16847.png)|


failed

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/96844188-1f94a180-1447-11eb-8f98-e693e758e80f.png)|![image](https://user-images.githubusercontent.com/42515961/96857039-6fc73000-1456-11eb-9f50-1d34d797807f.png)|

Confirm delete request page

![image](https://user-images.githubusercontent.com/42515961/96865529-fc2b2000-1461-11eb-8aa0-d81d1fa86736.png)


## Link to Trello card

https://trello.com/c/PlcJ384z/2242-%F0%9F%92%94-dev-delete-a-cancelled-failed-declined-request

## Guidance for review

There is a subtle difference between the behaviour for this and the delete actions for the feedback_provided and not_requested_yet states. The provided and not requested states show 'Delete referee' link that goes to the  confirm_destroy view. These states show a  'Delete request' link and show the confirm_delete_request view.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
