### PR TITLE
Add super_diff gem for better hash comparisons in RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ group :test do
   gem 'clockwork-test'
   gem 'deepsort'
   gem 'ruby-jmeter'
+  gem 'super_diff'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     ast (2.4.1)
+    attr_extras (6.2.4)
     attr_required (1.0.1)
     bcrypt (3.1.16)
     bindata (2.4.8)
@@ -282,6 +283,8 @@ GEM
     parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)
+    patience_diff (1.1.0)
+      trollop (~> 1.16)
     pdfkit (0.8.4.3.2)
     pg (1.2.3)
     pry (0.13.1)
@@ -450,6 +453,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    super_diff (0.5.2)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     swd (1.2.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -457,6 +464,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     timecop (0.9.2)
+    trollop (1.16.2)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uk_postcode (2.1.6)
@@ -566,6 +574,7 @@ DEPENDENCIES
   simplecov
   simplecov-cobertura
   skylight
+  super_diff
   timecop
   uk_postcode
   view_component

--- a/spec/support/super_diff.rb
+++ b/spec/support/super_diff.rb
@@ -1,0 +1,1 @@
+require 'super_diff/rspec-rails'


### PR DESCRIPTION
## Context

I discovered a gem which makes hash comparisons much more readable in RSpec output. Proposing we include it in the `Gemfile`.

## Changes proposed in this pull request

### Before `super_diff`

<img width="1105" alt="Screenshot 2020-10-21 at 20 33 30" src="https://user-images.githubusercontent.com/642279/96777762-a6636300-13e2-11eb-8953-a4d500e4ce4c.png">

### After `super_diff`

<img width="1092" alt="Screenshot 2020-10-21 at 20 33 20" src="https://user-images.githubusercontent.com/642279/96777779-abc0ad80-13e2-11eb-81a8-403136adb7be.png">