### PR TITLE
Use Redis to back the ProviderUserInvitationWizard

### DIFF
--- a/app/controllers/provider_interface/provider_users_invitations_controller.rb
+++ b/app/controllers/provider_interface/provider_users_invitations_controller.rb
@@ -114,7 +114,7 @@ module ProviderInterface
       options[:checking_answers] = true if params[:checking_answers] == 'true'
 
       ProviderUserInvitationWizard.new(
-        WizardStateStores::SessionStore.new(session: session, key: persistence_key_for_current_user),
+        WizardStateStores::RedisStore.new(key: persistence_key_for_current_user),
         options,
       )
     end


### PR DESCRIPTION
## Context

Once the stored data got to a certain size the `SessionStore` started silently (!) rejecting updates, which meant data got lost and users inviting others to more than ~8 providers (depending on how many permissions they assigned, being as is is that including a permission takes up more space in the session) saw a [500 error](https://sentry.io/organizations/dfe-bat/issues/1954172191/?referrer=slack) on the Check Answers page. Redis can hold arbitrary amounts of data, so use that instead.

I don't understand why we weren't seeing `CookieOverflowErrors` on trying to store too much data in the session — I'd like to!

## Changes proposed in this pull request

Switch this wizard's backing store straight over to Redis. In the event a user is mid-flow with a session-backed wizard at the time of deployment, they'll lose their data and see a 404. This is a) unlikely and b) less painful than that user seeing a 500 at the end of the flow, so I think we should ship this without spending time handling existing sessions.

## Guidance to review

It's short!

## Link to Trello card

https://trello.com/c/K1SrOgM9/2949-fix-bug-where-providers-cant-invite-users

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
