### PR TITLE
Record that initial emails regarding dual application were sent

### DIFF
--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -21,5 +21,21 @@ module SupportInterface
       flash[:success] = 'Match marked as processed'
       redirect_to support_interface_ucas_match_path(match)
     end
+
+    def record_initial_emails_sent
+      match = UCASMatch.find(params[:id])
+
+      if match.update!(
+        action_taken: 'initial_emails_sent',
+        candidate_last_contacted_at: Time.zone.now,
+      )
+        flash[:success] = 'The date of the initial emails was recorded'
+      else
+        flash[:warning] = 'There was a problem and the date of the initial emails was not recorded'
+
+      end
+
+      redirect_to support_interface_ucas_match_path(match)
+    end
   end
 end

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -2,6 +2,35 @@
 
 <%= render 'ucas_match_navigation', title: 'Details', match: @match %>
 
+<% if @match.action_needed? || @match.initial_emails_sent? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <div class="govuk-inset-text govuk-!-margin-top-0">
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
+          <%= @match.action_needed? ? "Action needed: send initial email" :  'No action required' %>
+        </h2>
+        <% if @match.initial_emails_sent? %>
+          <p class="govuk-body">
+            We sent the initial emails to the candidate and the providers on <%= @match.candidate_last_contacted_at.to_s(:govuk_date_and_time) %>.
+          </p>
+        <% else %>
+          <p class="govuk-body">
+            We need to contact the candidate and the provider.
+            Use an appropriate templates from <%= govuk_link_to 'this document', "https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE" %>.
+          </p>
+          <p class="govuk-body">
+            Please refer to <%= govuk_link_to 'Dual-running user support manual', "https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4" %> for more information about the current process.
+          </p>
+          <%= form_with url: support_interface_record_initial_emails_sent_path(@match), method: :post do |f| %>
+            <%= f.submit 'Confirm initial emails were sent', class: 'govuk-button' %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<h2 class='govuk-heading-l'>UCAS match</h2>
 <% application = @match.candidate.application_forms.first %>
 
 <%= render SummaryListComponent.new(rows: {

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -33,23 +33,25 @@
 <h2 class='govuk-heading-l'>UCAS match</h2>
 <% application = @match.candidate.application_forms.first %>
 
+<% status = [render(TagComponent.new(text: @match.matching_state.humanize, type: @match.processed? ? :green : :purple))] %>
+<% status << render(TagComponent.new(text: @match.action_taken.humanize, type: :purple)) if @match.action_taken.present? %>
+<% if @match.invalid_matching_data? %>
+  <% status << render(TagComponent.new(text: "Invalid data", type: :red)) %>
+<% elsif @match.action_needed? %>
+  <% status << render(TagComponent.new(text: "Action needed", type: :yellow)) %>
+<% end %>
+
 <%= render SummaryListComponent.new(rows: {
   'Recruitment cycle year' => @match.recruitment_cycle_year.to_s,
   'Candidate name' => "#{application.first_name} #{application.last_name}",
   'Candidate email' => @match.candidate.email_address.to_s,
   'Last updated' => @match.updated_at.to_s(:govuk_date_and_time),
   'First added' => @match.created_at.to_s(:govuk_date_and_time),
-  'Status' => render(TagComponent.new(text: @match.matching_state.humanize, type: @match.processed? ? :green : :purple)),
+  'Status' => status,
   'Application on Apply' => govuk_link_to('View application', support_interface_application_form_path(application)),
 }) %>
 
 <p class="govuk-body">
-  <% if @match.invalid_matching_data? %>
-    <%= render TagComponent.new(text: "Invalid data", type: :red) %>
-  <% elsif @match.action_needed? %>
-    <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
-  <% end %>
-
   <% unless @match.processed? %>
     <%= form_with url: support_interface_process_match_path(@match), method: :post do |f| %>
       <%= f.submit 'Mark as processed', class: 'govuk-button govuk-!-margin-bottom-0' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -659,6 +659,7 @@ Rails.application.routes.draw do
     scope path: '/ucas-matches/:id' do
       get '/' => 'ucas_matches#show', as: :ucas_match
       get '/audit' => 'ucas_matches#audit', as: :ucas_match_audit
+      post '/initial-emails' => 'ucas_matches#record_initial_emails_sent', as: :record_initial_emails_sent
       post '/process-match' => 'ucas_matches#process_match', as: :process_match
     end
 

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -13,6 +13,24 @@ RSpec.describe UCASMatch do
       expect(ucas_match.action_needed?).to eq(false)
     end
 
+    it 'returns false if initial emails were sent and we don not need to send the reminders yet' do
+      initial_emails_sent_at = Time.zone.now
+      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
+
+      Timecop.travel(1.business_days.after(initial_emails_sent_at)) do
+        expect(ucas_match.action_needed?).to eq(false)
+      end
+    end
+
+    it 'returns true if initial emails were sent and it is time to send reminder emails' do
+      initial_emails_sent_at = Time.zone.now
+      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
+
+      Timecop.travel(5.business_days.after(initial_emails_sent_at)) do
+        expect(ucas_match.action_needed?).to eq(true)
+      end
+    end
+
     it 'returns true if a candidate applied for the same course on both services and both applications are still in progress' do
       ucas_matching_data = { 'Scheme' => 'B',
                              'Course code' => course1.code.to_s,

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -18,6 +18,12 @@ RSpec.feature 'See UCAS matches' do
 
     when_i_follow_the_link_to_ucas_match_for_a_candidate
     then_i_should_see_ucas_match_summary
+
+    when_i_go_to_ucas_matches_page
+    when_i_follow_the_link_to_ucas_match_for_a_candidate_which_needs_an_action
+    then_i_see_what_action_is_needed
+    and_when_i_confirm_i_took_the_action
+    then_i_see_last_performed_action
   end
 
   def given_i_am_a_support_user
@@ -122,5 +128,23 @@ RSpec.feature 'See UCAS matches' do
     end
 
     expect(page).to have_content('This applicant has applied to the same course on both services.')
+  end
+
+  def when_i_follow_the_link_to_ucas_match_for_a_candidate_which_needs_an_action
+    click_link @candidate2.email_address
+  end
+
+  def then_i_see_what_action_is_needed
+    expect(page).to have_text 'Action needed: send initial email'
+    expect(page).to have_text 'We need to contact the candidate and the provider'
+  end
+
+  def and_when_i_confirm_i_took_the_action
+    click_button 'Confirm initial emails were sent'
+  end
+
+  def then_i_see_last_performed_action
+    expect(page).to have_content 'No action required'
+    expect(page).to have_content 'We sent the initial emails to the candidate and the providers'
   end
 end


### PR DESCRIPTION
## Context

We need to start the process of resolving dual applications.
This is very much an MVP. 
A component will follow: https://github.com/DFE-Digital/apply-for-teacher-training/compare/initial-email-for-ucas-matches

## Changes proposed in this pull request
<kbd>
<img width="663" alt="Screenshot 2020-11-04 at 14 33 15" src="https://user-images.githubusercontent.com/38078064/98127619-d0228c80-1eae-11eb-8abe-a3bbecaf45ac.png">
</kbd>

<kbd>
<img width="740" alt="Screenshot 2020-11-04 at 14 29 32" src="https://user-images.githubusercontent.com/38078064/98127709-e892a700-1eae-11eb-8b25-b9f2282e86ef.png">
</kbd>

## Guidance to review

Will also refactor `need_to_send_reminder_emails?` later  to use `TimeLimitConfig` and `TimeLimitCalculator`

## Link to Trello card

https://trello.com/c/XRWaVD60/2933-action-ucas-matches

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
