### PR TITLE
Expand Reference History

### DIFF
--- a/app/components/reference_history_component.html.erb
+++ b/app/components/reference_history_component.html.erb
@@ -1,8 +1,8 @@
-<ul class='govuk-list qa-reference-history'>
+<ul class="govuk-list" data-qa="reference-history">
   <% history.each do |event| %>
     <li>
       <%= formatted_title event %>
-      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= formatted_date event.time %></span>
+      <span class="govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16"><%= formatted_date event.time %></span>
     </li>
   <% end %>
 </ul>

--- a/app/components/reference_history_component.html.erb
+++ b/app/components/reference_history_component.html.erb
@@ -1,15 +1,8 @@
 <ul class='govuk-list qa-reference-history'>
-  <% if requested_at %>
+  <% history.each do |event| %>
     <li>
-      Request sent
-      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= requested_at %></span>
-    </li>
-  <% end %>
-
-  <% if reminder_sent_at %>
-    <li>
-      Reminder sent
-      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= reminder_sent_at %></span>
+      <%= formatted_title event %>
+      <span class='govuk-hint govuk-!-margin-bottom-0 govuk-!-font-size-16'><%= formatted_date event.time %></span>
     </li>
   <% end %>
 </ul>

--- a/app/components/reference_history_component.rb
+++ b/app/components/reference_history_component.rb
@@ -5,21 +5,19 @@ class ReferenceHistoryComponent < ViewComponent::Base
     @reference = reference
   end
 
-  def requested_at
-    return if reference.requested_at.blank?
-
-    date_format(reference.requested_at)
+  def history
+    ReferenceHistory.new(reference).all_events
   end
 
-  def reminder_sent_at
-    return if reference.reminder_sent_at.blank?
-
-    date_format(reference.reminder_sent_at)
+  def formatted_date(event)
+    event.time.to_s(:govuk_date_and_time)
   end
 
-private
-
-  def date_format(datetime)
-    datetime.to_s(:govuk_date_and_time)
+  def formatted_title(event)
+    if event.name == 'request_bounced'
+      "The request did not reach #{event.extra_info.bounced_email}"
+    else
+      event.name.humanize
+    end
   end
 end

--- a/app/models/reference_history.rb
+++ b/app/models/reference_history.rb
@@ -59,7 +59,7 @@ class ReferenceHistory
 private
 
   def audits
-    reference.audits.updates
+    @audits ||= reference.audits.updates
   end
 
   def status_change(audit, to:)

--- a/app/models/reference_history.rb
+++ b/app/models/reference_history.rb
@@ -25,7 +25,7 @@ class ReferenceHistory
 
   def request_cancelled
     audits
-      .select { |a| status_change(a, to: 'cancelled') }
+      .select { |a| status_change(a, to: 'cancelled') || status_change(a, to: 'cancelled_at_end_of_cycle') }
       .map { |a| Event.new('request_cancelled', a.created_at) }
   end
 

--- a/app/models/reference_history.rb
+++ b/app/models/reference_history.rb
@@ -19,13 +19,13 @@ class ReferenceHistory
 
   def request_sent
     audits
-      .select { |a| a.audited_changes['feedback_status']&.second == 'feedback_requested' }
+      .select { |a| status_change(a, to: 'feedback_requested') }
       .map { |a| Event.new('request_sent', a.created_at) }
   end
 
   def request_cancelled
     audits
-      .select { |a| a.audited_changes['feedback_status']&.second == 'cancelled' }
+      .select { |a| status_change(a, to: 'cancelled') }
       .map { |a| Event.new('request_cancelled', a.created_at) }
   end
 
@@ -37,7 +37,7 @@ class ReferenceHistory
 
   def request_bounced
     audits
-      .select { |a| a.audited_changes['feedback_status']&.second == 'email_bounced' }
+      .select { |a| status_change(a, to: 'email_bounced') }
       .map do |audit|
         bounced_email = reference.revision(audit.version).email_address
         Event.new('request_bounced', audit.created_at, OpenStruct.new(bounced_email: bounced_email))
@@ -46,13 +46,13 @@ class ReferenceHistory
 
   def request_declined
     audits
-      .select { |a| a.audited_changes['feedback_status']&.second == 'feedback_refused' }
+      .select { |a| status_change(a, to: 'feedback_refused') }
       .map { |a| Event.new('request_declined', a.created_at) }
   end
 
   def reference_given
     audits
-      .select { |a| a.audited_changes['feedback_status']&.second == 'feedback_provided' }
+      .select { |a| status_change(a, to: 'feedback_provided') }
       .map { |a| Event.new('reference_given', a.created_at) }
   end
 
@@ -60,5 +60,9 @@ private
 
   def audits
     reference.audits.updates
+  end
+
+  def status_change(audit, to:)
+    audit.audited_changes['feedback_status']&.second == to
   end
 end

--- a/app/models/reference_history.rb
+++ b/app/models/reference_history.rb
@@ -1,0 +1,64 @@
+class ReferenceHistory
+  Event = Struct.new(:name, :time, :extra_info)
+
+  attr_reader :reference
+
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def all_events
+    request_sent
+      .concat(request_cancelled)
+      .concat(reminder_sent)
+      .concat(request_bounced)
+      .concat(request_declined)
+      .concat(reference_given)
+      .sort_by(&:time)
+  end
+
+  def request_sent
+    audits
+      .select { |a| a.audited_changes['feedback_status']&.second == 'feedback_requested' }
+      .map { |a| Event.new('request_sent', a.created_at) }
+  end
+
+  def request_cancelled
+    audits
+      .select { |a| a.audited_changes['feedback_status']&.second == 'cancelled' }
+      .map { |a| Event.new('request_cancelled', a.created_at) }
+  end
+
+  def reminder_sent
+    audits
+      .select { |a| a.audited_changes['reminder_sent_at'].present? }
+      .map { |a| Event.new('reminder_sent', a.created_at) }
+  end
+
+  def request_bounced
+    audits
+      .select { |a| a.audited_changes['feedback_status']&.second == 'email_bounced' }
+      .map do |audit|
+        bounced_email = reference.revision(audit.version).email_address
+        Event.new('request_bounced', audit.created_at, OpenStruct.new(bounced_email: bounced_email))
+      end
+  end
+
+  def request_declined
+    audits
+      .select { |a| a.audited_changes['feedback_status']&.second == 'feedback_refused' }
+      .map { |a| Event.new('request_declined', a.created_at) }
+  end
+
+  def reference_given
+    audits
+      .select { |a| a.audited_changes['feedback_status']&.second == 'feedback_provided' }
+      .map { |a| Event.new('reference_given', a.created_at) }
+  end
+
+private
+
+  def audits
+    reference.audits.updates
+  end
+end

--- a/spec/components/reference_history_component_spec.rb
+++ b/spec/components/reference_history_component_spec.rb
@@ -1,25 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe ReferenceHistoryComponent, type: :component do
-  it 'renders the requested_at time if present' do
-    reference = build(:reference)
-    result = render_inline(described_class.new(reference))
-    expect(result.text).not_to include 'Request sent'
+  it 'renders the events of a reference history', with_audited: true do
+    reference = create(:reference, :not_requested_yet, created_at: Time.zone.local(2020, 1, 1, 9))
+    Timecop.freeze(reference.created_at) { reference.feedback_requested! }
+    Timecop.freeze(reference.created_at + 1.day) { reference.feedback_provided! }
 
-    reference.requested_at = Time.zone.local(2020, 1, 1, 13, 30)
     result = render_inline(described_class.new(reference))
-    expect(result.text).to include 'Request sent'
-    expect(result.text).to include '1 January 2020 at  1:30pm'
+
+    list_items = result.css('li')
+    expect(list_items[0].text).to include 'Request sent'
+    expect(list_items[0].text.squish).to include '1 January 2020 at 9:00am'
+    expect(list_items[1].text).to include 'Reference given'
+    expect(list_items[1].text.squish).to include '2 January 2020 at 9:00am'
   end
 
-  it 'renders the reminder_sent_at time if present' do
-    reference = build(:reference)
-    result = render_inline(described_class.new(reference))
-    expect(result.text).not_to include 'Reminder sent'
+  it 'uses a special title format for request_bounced events', with_audited: true do
+    reference = create(:reference, :not_requested_yet, email_address: 'example@email.com')
+    reference.email_bounced!
 
-    reference.reminder_sent_at = Time.zone.local(2020, 1, 1, 13, 30)
     result = render_inline(described_class.new(reference))
-    expect(result.text).to include 'Reminder sent'
-    expect(result.text).to include '1 January 2020 at  1:30pm'
+
+    list_item = result.css('li').first
+    expect(list_item.text).to include 'The request did not reach example@email.com'
   end
 end

--- a/spec/models/reference_history_spec.rb
+++ b/spec/models/reference_history_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe ReferenceHistory do
+  describe '#all_events' do
+    it 'returns the event history for a successful reference', with_audited: true do
+      reference = create(:reference, :not_requested_yet, email_address: 'ericandre@email.com')
+      start_time = reference.created_at
+      Timecop.freeze(start_time + 1.day) { reference.feedback_requested! }
+      Timecop.freeze(start_time + 2.days) { reference.email_bounced! }
+      Timecop.freeze(start_time + 3.days) { reference.feedback_requested! }
+      Timecop.freeze(start_time + 4.days) { reference.update!(reminder_sent_at: Time.zone.now) }
+      Timecop.freeze(start_time + 5.days) { reference.feedback_provided! }
+
+      events = described_class.new(reference).all_events
+
+      expected_attributes = [
+        { name: 'request_sent', time: start_time + 1.day, extra_info: nil },
+        { name: 'request_bounced', time: start_time + 2.days, extra_info: OpenStruct.new(bounced_email: 'ericandre@email.com') },
+        { name: 'request_sent', time: start_time + 3.days, extra_info: nil },
+        { name: 'reminder_sent', time: start_time + 4.days, extra_info: nil },
+        { name: 'reference_given', time: start_time + 5.days, extra_info: nil },
+      ]
+      compare_data(expected_attributes, events)
+    end
+
+    it 'returns the event history for a failed reference', with_audited: true do
+      reference = create(:reference, :not_requested_yet, email_address: 'ericandre@email.com')
+      start_time = reference.created_at
+      Timecop.freeze(start_time + 1.day) { reference.feedback_requested! }
+      Timecop.freeze(start_time + 2.days) { reference.feedback_refused! }
+
+      events = described_class.new(reference).all_events
+
+      expected_attributes = [
+        { name: 'request_sent', time: start_time + 1.day, extra_info: nil },
+        { name: 'request_declined', time: start_time + 2.days, extra_info: nil },
+      ]
+      compare_data(expected_attributes, events)
+    end
+
+    it 'returns as many events for each event type as exists in the audit log', with_audited: true do
+      reference = create(:reference, :not_requested_yet, email_address: 'ericandre@email.com')
+      2.times do
+        reference.feedback_requested!
+        reference.cancelled!
+        reference.update!(reminder_sent_at: Time.zone.now)
+        reference.email_bounced!
+        reference.feedback_provided!
+        reference.feedback_refused!
+      end
+
+      events = described_class.new(reference).all_events
+
+      all_event_names.each do |event_name|
+        expect(events.select { |e| e.name == event_name }.count).to eq 2
+      end
+    end
+
+  private
+
+    def compare_data(expected_attributes, events)
+      expect(events.size).to eq expected_attributes.size
+      expected_attributes.each_with_index do |attr, index|
+        returned_event = events[index]
+        expect(returned_event.name).to eq attr[:name]
+        expect(returned_event.time).to eq attr[:time]
+        expect(returned_event.extra_info).to eq attr[:extra_info]
+      end
+    end
+
+    def all_event_names
+      %w[
+        request_sent
+        request_cancelled
+        reminder_sent
+        request_bounced
+        request_declined
+        reference_given
+      ]
+    end
+  end
+end

--- a/spec/models/reference_history_spec.rb
+++ b/spec/models/reference_history_spec.rb
@@ -52,8 +52,19 @@ RSpec.describe ReferenceHistory do
       events = described_class.new(reference).all_events
 
       all_event_names.each do |event_name|
-        expect(events.select { |e| e.name == event_name }.count).to eq 2
+        expect(events.select { |e| e.name == event_name }.size).to eq 2
       end
+    end
+
+    it 'detects two types of cancel', with_audited: true do
+      reference = create(:reference, :not_requested_yet, email_address: 'ericandre@email.com')
+      reference.cancelled!
+      reference.cancelled_at_end_of_cycle!
+
+      events = described_class.new(reference).all_events
+
+      expect(events.size).to eq 2
+      events.each { |e| expect(e.name).to eq 'request_cancelled' }
     end
 
   private

--- a/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_sends_a_reminder_email_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'Candidate sends a reference reminder' do
     then_i_see_the_date_of_the_next_automated_reminder
     and_i_can_send_a_single_reminder_manually
     and_submitting_a_stale_confirmation_form_does_nothing
-    and_the_reference_history_shows_the_reminder_i_just_sent
   end
 
   def given_i_am_signed_in
@@ -61,13 +60,5 @@ RSpec.feature 'Candidate sends a reference reminder' do
     click_button 'Yes I’m sure - send a reminder'
     expect(page).to have_current_path candidate_interface_decoupled_references_review_path
     expect(all_emails.size).to eq 1
-  end
-
-  def and_the_reference_history_shows_the_reminder_i_just_sent
-    within '#references_sent' do
-      within '.qa-reference-history' do
-        expect(page).to have_content @reference.reload.reminder_sent_at.to_s(:govuk_date_and_time).squish
-      end
-    end
   end
 end

--- a/spec/system/candidate_interface/decoupled_references/candidate_views_reference_history_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_views_reference_history_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.feature 'Reference history on review page' do
+  include CandidateHelper
+
+  before { FeatureFlag.activate(:decoupled_references) }
+
+  scenario 'candidate views reference history', with_audited: true do
+    given_i_am_signed_in
+    and_i_add_a_reference
+    and_i_send_it
+    and_i_send_a_reminder
+    and_i_cancel_the_reference
+    then_i_see_a_history_of_these_events_on_the_review_page
+    and_i_do_not_see_these_when_reviewing_the_entire_application
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_add_a_reference
+    current_candidate.current_application.update!(first_name: 'Michael', last_name: 'Render')
+    visit candidate_interface_decoupled_references_start_path
+    click_link 'Continue'
+    choose 'Academic'
+    click_button 'Save and continue'
+
+    candidate_fills_in_referee
+  end
+
+  def and_i_send_it
+    Timecop.travel(Time.zone.local(2020, 1, 1, 14)) do
+      choose 'Yes, send a reference request now'
+      click_button 'Save and continue'
+    end
+  end
+
+  def and_i_send_a_reminder
+    Timecop.travel(Time.zone.local(2020, 1, 2, 14)) do
+      click_link 'Send a reminder to this referee'
+      click_button 'Yes I’m sure - send a reminder'
+    end
+  end
+
+  def and_i_cancel_the_reference
+    Timecop.travel(Time.zone.local(2020, 1, 3, 14)) do
+      click_link 'Cancel request'
+      click_button 'Yes I’m sure - cancel this reference request'
+    end
+  end
+
+  def then_i_see_a_history_of_these_events_on_the_review_page
+    expect(page).to have_content 'History'
+    expected_history = [
+      { event_name: 'Request sent', timestamp: '1 January 2020 at 2:00pm' },
+      { event_name: 'Reminder sent', timestamp: '2 January 2020 at 2:00pm' },
+      { event_name: 'Request cancelled', timestamp: '3 January 2020 at 2:00pm' },
+    ]
+    within '.qa-reference-history' do
+      all('li').zip(expected_history).each do |rendered, expected|
+        expect(rendered.text).to include expected[:event_name]
+        expect(rendered.text).to include expected[:timestamp]
+      end
+    end
+  end
+
+  def and_i_do_not_see_these_when_reviewing_the_entire_application
+    create(:reference, :feedback_provided, application_form: current_candidate.current_application)
+    create(:reference, :feedback_provided, application_form: current_candidate.current_application)
+    visit candidate_interface_application_form_path
+    click_link 'Check and submit your application'
+
+    expect(page).not_to have_content 'History'
+    expect(page).not_to have_content 'Request sent'
+  end
+end

--- a/spec/system/candidate_interface/decoupled_references/candidate_views_reference_history_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_views_reference_history_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Reference history on review page' do
       { event_name: 'Reminder sent', timestamp: '2 January 2020 at 2:00pm' },
       { event_name: 'Request cancelled', timestamp: '3 January 2020 at 2:00pm' },
     ]
-    within '.qa-reference-history' do
+    within '[data-qa="reference-history"]' do
       all('li').zip(expected_history).each do |rendered, expected|
         expect(rendered.text).to include expected[:event_name]
         expect(rendered.text).to include expected[:timestamp]


### PR DESCRIPTION
## Context
**As a...** candidate
**I need to...** know what has happened to my reference request
**So that...** so I can follow up with my referee or when contacting support.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Add a `ReferenceHistory` model. Wraps a single reference instance and returns a history of relevant events derived from the audit log.
- Use this model's output in `ReferenceHistoryComponent`.
![Screenshot_20201022_103330](https://user-images.githubusercontent.com/519250/96853249-09d8a980-1452-11eb-90b1-850b0f03b390.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Per-commit recommended.
- Can be tested in the review app by adding a reference and clicking various actions (request, remind, cancel, etc).
- The current implementation of the reference history isn't particularly efficient (multiple iterations across the audit array with a single call to `all_events`). I think this is fine given the low number of audits we're typically dealing with per reference, and the fact that a non-optimised implementation is probably easier to follow. WDYT?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/JAWa9Xzt

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
