### PR TITLE
Update reference creation in TestApplications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -70,7 +70,6 @@ class TestApplications
         application_choices_count: 0,
         full_work_history: true,
         volunteering_experiences_count: 1,
-        references_count: 2,
         with_gcses: true,
         with_degree: true,
         submitted_at: nil,
@@ -83,6 +82,11 @@ class TestApplications
         recruitment_cycle_year: recruitment_cycle_year,
         phase: apply_again ? 'apply_2' : 'apply_1',
       )
+
+      2.times { FactoryBot.create(:reference, :not_requested_yet, application_form: @application_form) }
+      @application_form.application_references.each do |reference|
+        reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
+      end
 
       fast_forward(1..2)
       application_choices = courses_to_apply_to.map do |course|


### PR DESCRIPTION
Create references and move them to `feedback_requested` in two distinct
steps. This creates the 'update' audit entry, allowing us to display the
initial 'Request sent' stage of a reference's history.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
