### PR TITLE
Rename SubmitApplicationWithDecoupledReferences service to SubmitApplication

### DIFF
--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -41,13 +41,7 @@ module CandidateInterface
       @further_information_form = FurtherInformationForm.new(further_information_params)
 
       if @further_information_form.save(current_application)
-        if FeatureFlag.active?(:decoupled_references)
-          # TODO: rename this to SubmitApplication when removing the
-          # decoupled_references feature flag
-          SubmitApplicationWithDecoupledReferences.new(current_application).call
-        else
-          SubmitApplication.new(current_application).call
-        end
+        SubmitApplication.new(current_application).call
 
         redirect_to candidate_interface_application_submit_success_path
       else

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -116,7 +116,7 @@ class TestApplications
 
       without_slack_message_sending do
         fast_forward(1..2)
-        SubmitApplicationWithDecoupledReferences.new(@application_form).call
+        SubmitApplication.new(@application_form).call
 
         @application_form.application_choices.each do |choice|
           choice.update_columns(

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -1,4 +1,4 @@
-class SubmitApplicationWithDecoupledReferences
+class SubmitApplication
   attr_reader :application_form, :application_choices
 
   def initialize(application_form)

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SubmitApplicationWithDecoupledReferences do
+RSpec.describe SubmitApplication do
   describe '#call' do
     it 'updates timestamps relevant to submitting an application' do
       Timecop.freeze(Time.zone.local(0)) do

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'See an application' do
 
   def and_there_are_applications_in_the_system
     @completed_application = create(:completed_application_form, references_count: 2, with_gcses: true)
-    SubmitApplicationWithDecoupledReferences.new(@completed_application).call
+    SubmitApplication.new(@completed_application).call
     @unsubmitted_application = create(:application_form)
     @application_with_reference = create(:completed_application_form, references_count: 2, with_gcses: true)
   end


### PR DESCRIPTION
## Context

Follow on PR from #3230 to quiten the diff.

## Changes proposed in this pull request

This PR renames the submit_application_with_decoupled_references  to submit_application

## Link to Trello card

https://trello.com/c/pizcHLeY/2307-%F0%9F%9A%A2-%F0%9F%92%94-epic-remaining-dev-work-for-decoupled-references

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
