### PR TITLE
Show validation error to candidates for references with same email

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,6 +294,10 @@ en:
               blank: could not be found
               not_open_on_apply: is not open for applications via the Apply service
               not_in_current_cycle: does not belong to the current cycle
+        candidate_interface/reference/referee_email_address_form:
+          attributes:
+            email_address:
+              own: Enter an email address that’s not your own
   activerecord:
     attributes:
       application_qualification/qualification_type:


### PR DESCRIPTION
## Context

When a candidate submits a reference with an email that is the same as that of the candidate, we should show a validation error.

## Changes proposed in this pull request

This adds the validation the form model, which is copied from the ApplicationReference model. The validation error is also duplicated in the localisation file.

I also changed `:email_address_unique?` to not use a `?` as it doesn't technically return a boolean, and I fixed up another confusing variable name.

## Guidance to review

Does duplicating the validation from the model to the form object make sense?

The implementation for `email_address_not_own` is very similar to `email_address_unique`. Suggestions welcome on how best to DRY up these.

### After

![2020-10-22_11-16](https://user-images.githubusercontent.com/1650875/96899336-b33a9200-1488-11eb-9b20-c63677759ff8.png)


## Link to Trello card

https://trello.com/c/a4sy81GP/2390-show-error-when-users-try-to-submit-their-own-email-address-as-a-referees-email-address

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)