### PR TITLE
Remove the references completed boolean

### DIFF
--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -48,12 +48,7 @@ class DuplicateApplication
 
       if references_cancelled_at_eoc.present?
         references_cancelled_at_eoc.each(&:not_requested_yet!)
-        new_application_form.update!(references_completed: false)
       end
-    end
-
-    if new_application_form.can_add_reference?
-      new_application_form.update! references_completed: false
     end
 
     original_application_form.application_work_history_breaks.each do |w|

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -13,7 +13,6 @@ module SupportInterface
       reference_reminder_email_sent
       new_reference_request_email_sent
       new_reference_added
-      references_completed
       waiting_to_be_sent_to_provider
       rbd_date
       rbd_reminder_sent
@@ -66,10 +65,6 @@ module SupportInterface
     def new_reference_added
       references_created_at = all_references.map(&:created_at).sort
       references_created_at.size >= 2 ? references_created_at[2] : nil
-    end
-
-    def references_completed
-      earliest_update_audit_for(@application_choice.application_form, references_completed: true)
     end
 
     def waiting_to_be_sent_to_provider

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -105,7 +105,6 @@ FactoryBot.define do
       becoming_a_teacher_completed { true }
       subject_knowledge_completed { true }
       interview_preferences_completed { true }
-      references_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -305,24 +305,17 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     before { FeatureFlag.activate(:decoupled_references) }
 
     it 'returns true if the referees section has been created and two references have been provided' do
-      application_form = create(:application_form, references_completed: true)
-      create_list(:reference, 2, application_form: application_form, feedback_status: :feedback_provided)
+      application_form = create(:application_form)
+      create_list(:reference, 2, :feedback_provided, application_form: application_form)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_enough_references_provided
     end
 
     it 'returns false if the referees section has been completed and only one reference has been provided' do
-      application_form = create(:application_form, references_completed: true)
-      create(:reference, application_form: application_form, feedback_status: :feedback_provided)
-      create(:reference, application_form: application_form, feedback_status: :feedback_requested)
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
-
-      expect(presenter).not_to be_enough_references_provided
-    end
-
-    it 'returns false if the referees section is incomplete' do
-      application_form = build(:application_form, references_completed: false)
+      application_form = create(:application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
+      create(:reference, :feedback_requested, application_form: application_form)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).not_to be_enough_references_provided

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CarryOverApplication do
 
     let(:application_form) { create(:completed_application_form) }
 
-    it 'sets the reference to the not_requested state and sets the application forms references_completed value to false' do
+    it 'sets the reference to the not_requested state' do
       create(:reference, feedback_status: :feedback_provided, application_form: application_form)
       create(:reference, feedback_status: :cancelled_at_end_of_cycle, application_form: application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: application_form)
@@ -60,7 +60,6 @@ RSpec.describe CarryOverApplication do
       described_class.new(application_form).call
 
       expect(ApplicationForm.count).to eq 2
-      expect(ApplicationForm.last.references_completed).to eq false
       expect(ApplicationForm.last.application_references.count).to eq 2
       expect(ApplicationForm.last.application_references.map(&:feedback_status)).to eq %w[feedback_provided not_requested_yet]
     end

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -22,14 +22,6 @@ RSpec.shared_examples 'duplicates application form' do |expected_phase, expected
     expect(duplicate_application_form.application_choices).to be_empty
   end
 
-  it 'sets references_completed correctly' do
-    if duplicate_application_form.can_add_reference?
-      expect(duplicate_application_form.references_completed).to be_falsey
-    else
-      expect(duplicate_application_form.references_completed).to be_truthy
-    end
-  end
-
   it 'resets the state to unsubmitted' do
     expect(duplicate_application_form.submitted_at).to be_nil
     expect(duplicate_application_form.course_choices_completed).to be false

--- a/spec/services/support_interface/candidate_journey_tracker_spec.rb
+++ b/spec/services/support_interface/candidate_journey_tracker_spec.rb
@@ -173,33 +173,7 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
     end
   end
 
-  describe '#references_completed' do
-    it 'returns nil when references_complete is not present in the audit trail' do
-      application_form = create(:application_form)
-      application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
-
-      expect(described_class.new(application_choice).references_completed).to be_nil
-    end
-
-    it 'returns the first time when the value changed to true in the audit trail' do
-      application_form = create(:application_form)
-      application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
-      Timecop.freeze(now + 1.day) { application_form.update(references_completed: true) }
-      Timecop.freeze(now + 2.days) { application_form.update(references_completed: false) }
-      Timecop.freeze(now + 3.days) { application_form.update(references_completed: true) }
-
-      expect(described_class.new(application_choice).references_completed).to eq(now + 1.day)
-    end
-  end
-
   describe '#waiting_to_be_sent_to_provider' do
-    it 'returns nil if the application never made it to application_complete status' do
-      application_form = create(:application_form)
-      application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)
-
-      expect(described_class.new(application_choice).references_completed).to be_nil
-    end
-
     it 'returns the first time when the status changed to `application_complete` in the audit trail', audited: true do
       application_form = create(:application_form)
       application_choice = create(:application_choice, status: :awaiting_references, application_form: application_form)

--- a/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
@@ -70,7 +70,6 @@ RSpec.feature 'Submitting an application' do
   def when_i_have_added_references
     @reference1 = create(:reference, :not_requested_yet, application_form: current_candidate.current_application)
     @reference2 = create(:reference, :not_requested_yet, application_form: current_candidate.current_application)
-    application.update(references_completed: true)
   end
 
   def and_i_submit_the_application


### PR DESCRIPTION
## Context

We no longer use the references_completed boolean to indicate that the references section is complete.

It needs to be removed as part of pulling out the decoupled references flag

## Changes proposed in this pull request

- Remove all the code related to. references_completed  

## Link to Trello card

https://trello.com/c/pizcHLeY/2307-%F0%9F%9A%A2-%F0%9F%92%94-epic-remaining-dev-work-for-decoupled-references

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
