### PR TITLE
Single page feedback form

### DIFF
--- a/app/controllers/candidate_interface/feedback_form_controller.rb
+++ b/app/controllers/candidate_interface/feedback_form_controller.rb
@@ -1,0 +1,27 @@
+module CandidateInterface
+  class FeedbackFormController < CandidateInterfaceController
+    def new
+      @feedback_form = FeedbackForm.new
+    end
+
+    def create
+      @feedback_form = FeedbackForm.new(feedback_params)
+      if @feedback_form.save(current_application)
+        redirect_to candidate_interface_feedback_form_thank_you_path
+      else
+        track_validation_error(@feedback_form)
+        render :new
+      end
+    end
+
+    def thank_you; end
+
+  private
+
+    def feedback_params
+      params.require(:candidate_interface_feedback_form).permit(
+        :satisfaction_level, :suggestions
+      )
+    end
+  end
+end

--- a/app/forms/candidate_interface/feedback_form.rb
+++ b/app/forms/candidate_interface/feedback_form.rb
@@ -1,0 +1,17 @@
+module CandidateInterface
+  class FeedbackForm
+    include ActiveModel::Model
+
+    attr_accessor :satisfaction_level, :suggestions
+
+    validates :satisfaction_level, presence: true
+
+    def save(application_form)
+      return false unless valid?
+
+      application_form.feedback_satisfaction_level = satisfaction_level
+      application_form.feedback_suggestions = suggestions
+      application_form.save
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -55,6 +55,14 @@ class ApplicationForm < ApplicationRecord
   }
   attribute :address_type, :string, default: 'uk'
 
+  enum feedback_satisfaction_level: {
+    very_satisfied: 'very_satisfied',
+    satisfied: 'satisfied',
+    neither_satisfied_or_dissatisfied: 'neither_satisfied_or_dissatisfied',
+    dissatisfied: 'dissatisfied',
+    very_dissatisfied: 'very_dissatisfied',
+  }
+
   attribute :recruitment_cycle_year, :integer, default: -> { RecruitmentCycle.current_year }
 
   before_create lambda {

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],
     [:decoupled_references, 'Candidates now complete and request their references prior to submitting their application.', 'David Gisbey'],
     [:export_hesa_data, 'Providers can export applications including HESA data.', 'Steve Laing'],
+    [:feedback_form, 'New simplified feedback form to replace old multi-page satisfaction survey.', 'Steve Hook'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.your_feedback') %>
-      </h2>
+      </h1>
       <%= f.govuk_radio_buttons_fieldset :satisfaction_level, legend: { text: 'How satisfied are you with this service?' } do %>
         <% ApplicationForm.feedback_satisfaction_levels.values.each do |value| %>
           <%= f.govuk_radio_button :satisfaction_level, value, label: { text: t("satisfaction_levels.#{value}") }  %>

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -13,7 +13,7 @@
           <%= f.govuk_radio_button :satisfaction_level, value, label: { text: t("satisfaction_levels.#{value}") }  %>
         <% end %>
       <% end %>
-      <%= f.govuk_text_area :suggestions, label: { text: 'How could we improve this service?' }, rows: 8, max_words: 400 %>
+      <%= f.govuk_text_area :suggestions, label: { text: 'How could we improve this service?', size: 'm' }, rows: 8, max_words: 400 %>
       <%= f.govuk_submit 'Send feedback' %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @feedback_form, url: candidate_interface_create_feedback_form_path, method: :post do |f| %>
+    <%= form_with model: @feedback_form, url: candidate_interface_feedback_form_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.your_feedback') %>

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.your_feedback'), @feedback_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_submit_success_path) %>
+
+<%= form_with model: @feedback_form, url: candidate_interface_create_feedback_form_path, method: :post do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-xl">
+        <%= t('page_titles.your_feedback') %>
+      </h2>
+      <%= f.govuk_radio_buttons_fieldset :satisfaction_level, legend: { text: 'How satisfied are you with this service?' } do %>
+        <% ApplicationForm.feedback_satisfaction_levels.values.each do |value| %>
+          <%= f.govuk_radio_button :satisfaction_level, value, label: { text: t("satisfaction_levels.#{value}") }  %>
+        <% end %>
+      <% end %>
+      <%= f.govuk_text_area :suggestions, label: { text: 'How could we improve this service?' }, rows: 8, max_words: 400 %>
+      <%= f.govuk_submit 'Send feedback' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @feedback_form, url: candidate_interface_create_feedback_form_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <h2 class="govuk-heading-xl">
+      <h1 class="govuk-heading-xl">
         <%= t('page_titles.your_feedback') %>
       </h2>
       <%= f.govuk_radio_buttons_fieldset :satisfaction_level, legend: { text: 'How satisfied are you with this service?' } do %>

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -1,9 +1,10 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.your_feedback'), @feedback_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_submit_success_path) %>
 
-<%= form_with model: @feedback_form, url: candidate_interface_create_feedback_form_path, method: :post do |f| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @feedback_form, url: candidate_interface_create_feedback_form_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
       <h2 class="govuk-heading-xl">
         <%= t('page_titles.your_feedback') %>
       </h2>
@@ -14,6 +15,6 @@
       <% end %>
       <%= f.govuk_text_area :suggestions, label: { text: 'How could we improve this service?' }, rows: 8, max_words: 400 %>
       <%= f.govuk_submit 'Send feedback' %>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/candidate_interface/feedback_form/thank_you.html.erb
+++ b/app/views/candidate_interface/feedback_form/thank_you.html.erb
@@ -3,11 +3,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h2 class="govuk-heading-xl">
+    <h1 class="govuk-heading-xl">
       <%= t('page_titles.thank_you') %>
     </h2>
 
     <%= govuk_link_to 'Go to your application dashboard', candidate_interface_application_form_path %>
   </div>
 </div>
-

--- a/app/views/candidate_interface/feedback_form/thank_you.html.erb
+++ b/app/views/candidate_interface/feedback_form/thank_you.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, t('page_titles.thank_you') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h2 class="govuk-heading-xl">
+      <%= t('page_titles.thank_you') %>
+    </h2>
+
+    <%= govuk_link_to 'Go to your application dashboard', candidate_interface_application_form_path %>
+  </div>
+</div>
+

--- a/app/views/candidate_interface/feedback_form/thank_you.html.erb
+++ b/app/views/candidate_interface/feedback_form/thank_you.html.erb
@@ -5,7 +5,7 @@
 
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.thank_you') %>
-    </h2>
+    </h1>
 
     <%= govuk_link_to 'Go to your application dashboard', candidate_interface_application_form_path %>
   </div>

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -38,6 +38,10 @@
 
     <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
     <p class="govuk-body">Your feedback will help us improve.</p>
-    <%= govuk_button_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path %>
+    <% if FeatureFlag.active?(:feedback_form) %>
+      <%= govuk_button_link_to 'Give feedback', candidate_interface_feedback_form_path %>
+    <% else %>
+      <%= govuk_button_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -889,3 +889,7 @@ en:
           attributes:
             service:
               blank: Choose if you want to use the new GOV.UK service
+        candidate_interface/feedback_form:
+          attributes:
+            satisfaction_level:
+              blank: Choose how satisfied are you with this service

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,7 @@ en:
     withdraw_application: Are you sure you want to withdraw your application?
     guidance: User guidance
     applications_closed: Create an Apply for teacher training account
+    your_feedback: Your feedback
   layout:
     support:
       title: Get support

--- a/config/locales/feedback_form.yml
+++ b/config/locales/feedback_form.yml
@@ -1,7 +1,7 @@
 en:
   satisfaction_levels:
-    very_satisfied: 'Very satisfied'
-    satisfied: 'Satisfied'
-    neither_satisfied_or_dissatisfied: 'Neither satisfied or dissatisfied'
-    dissatisfied: 'Dissatisfied'
-    very_dissatisfied: 'Very dissatisfied'
+    very_satisfied: Very satisfied
+    satisfied: Satisfied
+    neither_satisfied_or_dissatisfied: Neither satisfied or dissatisfied
+    dissatisfied: Dissatisfied
+    very_dissatisfied: Very dissatisfied

--- a/config/locales/feedback_form.yml
+++ b/config/locales/feedback_form.yml
@@ -1,0 +1,7 @@
+en:
+  satisfaction_levels:
+    very_satisfied: 'Very satisfied'
+    satisfied: 'Satisfied'
+    neither_satisfied_or_dissatisfied: 'Neither satisfied or dissatisfied'
+    dissatisfied: 'Dissatisfied'
+    very_dissatisfied: 'Very dissatisfied'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,6 +400,12 @@ Rails.application.routes.draw do
         post '/complete' => 'safeguarding#complete', as: :complete_safeguarding
       end
 
+      scope '/feedback-form' do
+        get '/' => 'feedback_form#new', as: :feedback_form
+        post '/' => 'feedback_form#create', as: :create_feedback_form
+        get '/thank-you' => 'feedback_form#thank_you', as: :feedback_form_thank_you
+      end
+
       scope '/satisfaction-survey' do
         get '/recommendation' => 'satisfaction_survey#recommendation', as: :satisfaction_survey_recommendation
         post '/recommendation' => 'satisfaction_survey#submit_recommendation', as: :satisfaction_survey_submit_recommendation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -402,7 +402,7 @@ Rails.application.routes.draw do
 
       scope '/feedback-form' do
         get '/' => 'feedback_form#new', as: :feedback_form
-        post '/' => 'feedback_form#create', as: :create_feedback_form
+        post '/' => 'feedback_form#create'
         get '/thank-you' => 'feedback_form#thank_you', as: :feedback_form_thank_you
       end
 

--- a/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Candidate feedback form' do
   include CandidateHelper
 
-  before do 
+  before do
     FeatureFlag.activate(:feedback_form)
     FeatureFlag.activate(:decoupled_references)
   end
@@ -59,7 +59,7 @@ RSpec.describe 'Candidate feedback form' do
   def and_i_make_a_suggestion
     fill_in 'How could we improve this service?', with: 'More rainbows and unicorns'
   end
-    
+
   def then_i_see_the_thank_you_page
     expect(page).to have_content(t('page_titles.thank_you'))
   end

--- a/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate feedback form' do
+  include CandidateHelper
+
+  before do 
+    FeatureFlag.activate(:feedback_form)
+    FeatureFlag.activate(:decoupled_references)
+  end
+
+  scenario 'Candidate completes the feedback form' do
+    given_the_candidate_completes_and_submits_their_application
+    then_they_should_be_asked_to_give_feedback
+
+    when_they_click_give_feedback
+    then_they_should_see_the_feedback_form
+
+    when_i_choose_very_satisfied
+    and_i_make_a_suggestion
+    and_click_send_feedback
+    then_i_see_the_thank_you_page
+    and_my_feedback_should_reflect_my_inputs
+  end
+
+  def given_the_candidate_completes_and_submits_their_application
+    candidate_completes_application_form
+    candidate_submits_application
+  end
+
+  def then_they_should_be_asked_to_give_feedback
+    expect(page).to have_content('Your feedback will help us improve.')
+  end
+
+  def when_they_click_give_feedback
+    click_link 'Give feedback'
+  end
+
+  def then_they_should_see_the_feedback_form
+    expect(page).to have_content(t('page_titles.your_feedback'))
+  end
+
+  def when_i_choose_1
+    choose 'Very satisfied'
+  end
+
+  def and_i_make_a_suggestion
+    fill_in 'How could we improve this service?', with: 'More rainbows and unicorns'
+  end
+
+  def and_click_send_feedback
+    click_button 'Send feedback'
+  end
+
+  def then_i_see_the_thank_you_page
+    expect(page).to have_content(t('page_titles.thank_you'))
+  end
+
+  def and_my_feedback_should_reflect_my_inputs
+    expect(ApplicationForm.last.feedback_satisfaction_level).to eq('very_satisfied')
+  end
+end

--- a/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe 'Candidate feedback form' do
     when_they_click_give_feedback
     then_they_should_see_the_feedback_form
 
+    when_i_click_send_feedback
+    then_i_should_see_a_validation_error
+
     when_i_choose_very_satisfied
     and_i_make_a_suggestion
     and_click_send_feedback
@@ -39,6 +42,16 @@ RSpec.describe 'Candidate feedback form' do
     expect(page).to have_content(t('page_titles.your_feedback'))
   end
 
+  def when_i_click_send_feedback
+    click_button 'Send feedback'
+  end
+  alias_method :and_click_send_feedback, :when_i_click_send_feedback
+
+  def then_i_should_see_a_validation_error
+    expect(page).to have_current_path(candidate_interface_feedback_form_path)
+    expect(page).to have_content('Choose how satisfied are you with this service')
+  end
+
   def when_i_choose_very_satisfied
     choose 'Very satisfied'
   end
@@ -46,11 +59,7 @@ RSpec.describe 'Candidate feedback form' do
   def and_i_make_a_suggestion
     fill_in 'How could we improve this service?', with: 'More rainbows and unicorns'
   end
-
-  def and_click_send_feedback
-    click_button 'Send feedback'
-  end
-
+    
   def then_i_see_the_thank_you_page
     expect(page).to have_content(t('page_titles.thank_you'))
   end

--- a/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Candidate feedback form' do
     expect(page).to have_content(t('page_titles.your_feedback'))
   end
 
-  def when_i_choose_1
+  def when_i_choose_very_satisfied
     choose 'Very satisfied'
   end
 

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Candidate satisfaction survey' do
   include CandidateHelper
 
-  before do 
+  before do
     FeatureFlag.deactivate(:feedback_form)
     FeatureFlag.activate(:decoupled_references)
   end

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Candidate satisfaction survey' do
   include CandidateHelper
 
-  before { FeatureFlag.activate(:decoupled_references) }
+  before do 
+    FeatureFlag.deactivate(:feedback_form)
+    FeatureFlag.activate(:decoupled_references)
+  end
 
   scenario 'Candidate completes the survey' do
     given_the_candidate_completes_and_submits_their_application


### PR DESCRIPTION
## Context

We want to replace the current multi-step survey form with a simpler one page form, that is based on the GDS feedback form.

This PR implements the new form behind a `feedback_form` feature flag.

## Changes proposed in this pull request

- [x] `feedback_form` feature flag
- [x] New routes, controller, form object for the new form that is swapped in depending on the feature flag.
- [x] System spec to cover the new flow.

<img width="564" alt="image" src="https://user-images.githubusercontent.com/450843/96985889-cdbc4c00-1518-11eb-8064-816a1f6f877d.png">

Note that the migration that this work depends on has already deployed to production. There will be a further PR to add a data export for the new feedback form (details TBC). Finally we can remove the old satisfaction survey views, controller, forms etc. when the `feedback_form` feature flag is retired.

## Guidance to review

- It should be possible to manually test the new form by enabling the feature flag and submitting an application. You can also see the interface by navigating direct to `/candidate/application/feedback-form`
- Note that we don't prevent visits to the feedback form via the URL outside the normal application submission process.

## Link to Trello card

https://trello.com/c/lQdpvtmy/2281-dev-replace-multi-step-survey-with-single-page-feedback-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
