### PR TITLE
Terms of service checkbox bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ spec/system/ucas_matching/matching_data_example.zip
 # jmeter stuff
 ruby-jmeter.jmx
 jmeter.log
+
+# RubyMine files
+.idea

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -29,7 +29,7 @@
           <li>checking you’re safe to work with children</li>
         </ul>
 
-        <%= f.govuk_check_box :accept_ts_and_cs, true, multiple: false, link_errors: true, label: { text: t('authentication.sign_up.accept_terms_checkbox') } %>
+        <%= f.govuk_check_box :accept_ts_and_cs, 'true', multiple: false, link_errors: true, label: { text: t('authentication.sign_up.accept_terms_checkbox') } %>
       <% end %>
       <%= f.govuk_submit t('authentication.sign_up.button_continue') %>
     <% end %>

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -14,6 +14,12 @@ RSpec.feature 'Candidate account' do
 
     when_i_visit_the_signup_page
     and_i_accept_the_ts_and_cs
+    and_i_submit_without_entering_an_email
+    then_i_see_form_errors_on_the_page
+    and_the_ts_and_cs_are_still_checked
+
+    when_i_visit_the_signup_page
+    and_i_accept_the_ts_and_cs
     and_i_submit_my_email_address
     then_i_receive_an_email_with_a_signup_link
     when_i_click_on_the_link_in_my_email
@@ -75,6 +81,14 @@ RSpec.feature 'Candidate account' do
   def and_i_submit_my_email_address(email = @email)
     fill_in t('authentication.sign_up.email_address.label'), with: email
     click_on t('authentication.sign_up.button_continue')
+  end
+
+  def and_i_submit_without_entering_an_email
+    click_on t('authentication.sign_up.button_continue')
+  end
+
+  def and_the_ts_and_cs_are_still_checked
+    expect(page).to have_checked_field t('authentication.sign_up.accept_terms_checkbox')
   end
 
   def and_i_submit_my_email_address_in_uppercase


### PR DESCRIPTION
## Context

The terms of service checkbox doesn't persist answer if there is a validation error with the email address on the sign up page.

## Changes proposed in this pull request

Edit the sign up form template to read in the `@sign_up_form` object for the checkbox value.

## Guidance to review

To test this manually:

- Create new account on staging
- Navigate to terms of service agreement page
- Check checkbox, but omit email address
- Submit page
- Get returned to page without checkbox persisted.

## Link to Trello card

https://trello.com/c/zWvC0NDW/2035-bug-terms-of-service-checkbox-doesnt-persist-answer-if-there-is-a-validation-error-with-the-email-address

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
