### PR TITLE
Add automated reminders to ReferenceHistory

### DIFF
--- a/app/models/reference_history.rb
+++ b/app/models/reference_history.rb
@@ -14,6 +14,7 @@ class ReferenceHistory
       .concat(request_bounced)
       .concat(request_declined)
       .concat(reference_given)
+      .concat(automated_reminder_sent)
       .sort_by(&:time)
   end
 
@@ -56,10 +57,20 @@ class ReferenceHistory
       .map { |a| Event.new('reference_given', a.created_at) }
   end
 
+  def automated_reminder_sent
+    chasers
+      .reference_request.or(chasers.follow_up_missing_references)
+      .map { |c| Event.new('automated_reminder_sent', c.created_at) }
+  end
+
 private
 
   def audits
     @audits ||= reference.audits.updates
+  end
+
+  def chasers
+    @chasers ||= reference.chasers_sent
   end
 
   def status_change(audit, to:)

--- a/spec/models/reference_history_spec.rb
+++ b/spec/models/reference_history_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe ReferenceHistory do
         reference.feedback_provided!
         reference.feedback_refused!
       end
+      create(:chaser_sent, chaser_type: :reference_request, chased: reference)
+      create(:chaser_sent, chaser_type: :follow_up_missing_references, chased: reference)
 
       events = described_class.new(reference).all_events
 
@@ -87,6 +89,7 @@ RSpec.describe ReferenceHistory do
         request_bounced
         request_declined
         reference_given
+        automated_reminder_sent
       ]
     end
   end


### PR DESCRIPTION


## Context
We send automated reference reminders to referees at fixed intervals and
want to add these events to the history of a given reference.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Make ReferenceHistory aware of the relevant ChaserSent records so that
it includes them in the history it returns.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Tricky to test manually, one way would be to adjust a sent reference's `requested_at` to 8 days (or 29 days to trigger the second chaser as well) and run `ChaseReferences.new.perform`.


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/JAWa9Xzt
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
