### PR TITLE
Add option to prefill candidate application form on sandbox

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -26,7 +26,11 @@ module CandidateInterface
       return false unless course_from_find.nil?
 
       if current_application.blank_application?
-        redirect_to candidate_interface_before_you_start_path
+        if HostingEnvironment.sandbox_mode?
+          redirect_to candidate_interface_prefill_path
+        else
+          redirect_to candidate_interface_before_you_start_path
+        end
       elsif current_application.submitted?
         redirect_to candidate_interface_application_complete_path
       else

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class PrefillApplicationFormController < CandidateInterfaceController
-
     def new
       @prefill_application_or_not_form = PrefillApplicationOrNotForm.new
     end
@@ -20,10 +19,10 @@ module CandidateInterface
 
     def prefill_candidate_application_form
       example_application_choices = TestApplications.new.create_application(
-          recruitment_cycle_year: RecruitmentCycle.current_year,
-          states: [:unsubmitted_with_completed_references],
-          courses_to_apply_to: Course.includes(:course_options).joins(:course_options).distinct.open_on_apply,
-          candidate: current_candidate
+        recruitment_cycle_year: RecruitmentCycle.current_year,
+        states: [:unsubmitted_with_completed_references],
+        courses_to_apply_to: Course.includes(:course_options).joins(:course_options).distinct.open_on_apply,
+        candidate: current_candidate,
       )
       example_application_form = example_application_choices.first.application_form
       current_candidate.application_forms << example_application_form

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -21,7 +21,7 @@ module CandidateInterface
       example_application_choices = TestApplications.new.create_application(
         recruitment_cycle_year: RecruitmentCycle.current_year,
         states: [:unsubmitted_with_completed_references],
-        courses_to_apply_to: Course.includes(:course_options).joins(:course_options).distinct.open_on_apply,
+        courses_to_apply_to: Course.current_cycle.open_on_apply.joins(:course_options).merge(CourseOption.available),
         candidate: current_candidate,
       )
       example_application_form = example_application_choices.first.application_form

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -1,0 +1,38 @@
+module CandidateInterface
+  class PrefillApplicationFormController < CandidateInterfaceController
+
+    def new
+      @prefill_application_or_not_form = PrefillApplicationOrNotForm.new
+    end
+
+    def create
+      @prefill_application_or_not_form = PrefillApplicationOrNotForm.new(prefill_application_or_not_params)
+      render :new and return unless @prefill_application_or_not_form.valid?
+
+      if @prefill_application_or_not_form.prefill?
+        prefill_candidate_application_form
+        flash[:info] = 'This application has been prefilled with example data'
+        redirect_to candidate_interface_application_form_path
+      else
+        redirect_to candidate_interface_before_you_start_path
+      end
+    end
+
+    def prefill_candidate_application_form
+      example_application_choices = TestApplications.new.create_application(
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+          states: [:unsubmitted_with_completed_references],
+          courses_to_apply_to: Course.includes(:course_options).joins(:course_options).distinct.open_on_apply,
+          candidate: current_candidate
+      )
+      example_application_form = example_application_choices.first.application_form
+      current_candidate.application_forms << example_application_form
+    end
+
+  private
+
+    def prefill_application_or_not_params
+      params.fetch(:candidate_interface_prefill_application_or_not_form, {}).permit(:prefill)
+    end
+  end
+end

--- a/app/forms/candidate_interface/prefill_application_or_not_form.rb
+++ b/app/forms/candidate_interface/prefill_application_or_not_form.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  class PrefillApplicationOrNotForm
+    include ActiveModel::Model
+
+    attr_accessor :prefill
+
+    validates :prefill, presence: true
+
+    def prefill?
+      ActiveModel::Type::Boolean.new.cast(prefill)
+    end
+  end
+end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -14,9 +14,7 @@ class TestApplications
     end
   end
 
-  def create_application(recruitment_cycle_year:, states:, courses_to_apply_to:, apply_again: false, course_full: false)
-    candidate = nil
-
+  def create_application(recruitment_cycle_year:, states:, courses_to_apply_to:, apply_again: false, course_full: false, candidate: nil)
     min_days_in_the_past = recruitment_cycle_year == 2020 ? 375 : 10
     travel_to rand(min_days_in_the_past..(min_days_in_the_past + 20)).days.ago
 
@@ -25,7 +23,7 @@ class TestApplications
 
       create_application(recruitment_cycle_year: recruitment_cycle_year, states: [:rejected], courses_to_apply_to: courses_to_apply_to)
 
-      candidate = Candidate.last
+      candidate = candidate.presence || Candidate.last
       first_name = candidate.current_application.first_name
       last_name = candidate.current_application.last_name
     else
@@ -33,7 +31,7 @@ class TestApplications
 
       first_name = Faker::Name.first_name
       last_name = Faker::Name.last_name
-      candidate = FactoryBot.create(
+      candidate = candidate.presence || FactoryBot.create(
         :candidate,
         email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
         created_at: time,

--- a/app/views/candidate_interface/prefill_application_form/new.html.erb
+++ b/app/views/candidate_interface/prefill_application_form/new.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, t('page_titles.application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Start a new application
+    </h1>
+
+    <%= form_with(
+      model: @prefill_application_or_not_form,
+      url: candidate_interface_prefill_path,
+      method: :post,
+    ) do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :prefill, legend: { text: 'What do you want to do?' } do %>
+        <%= f.govuk_radio_button :prefill, false, label: { text: 'Start with a blank application form' }, link_errors: true %>
+        <%= f.govuk_radio_button :prefill, true, label: { text: 'Start with the form filled in automatically' } %>
+      <% end %>
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,8 @@ Rails.application.routes.draw do
       get '/review/submitted/:id' => 'application_form#review_previous_application', as: :review_previous_application
 
       get '/' => 'unsubmitted_application_form#show', as: :application_form
+      get '/prefill', to: 'prefill_application_form#new'
+      post '/prefill', to: 'prefill_application_form#create'
       get '/review' => 'unsubmitted_application_form#review', as: :application_review
       get '/before-you-start', to: 'unsubmitted_application_form#before_you_start'
       get '/submit' => 'unsubmitted_application_form#submit_show', as: :application_submit_show

--- a/spec/forms/candidate_interface/prefill_application_or_not_form_spec.rb
+++ b/spec/forms/candidate_interface/prefill_application_or_not_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CandidateInterface::PrefillApplicationOrNotForm, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:prefill) }
   end
+
   describe '#prefill?' do
     it "returns false if prefill is 'false'" do
       form = described_class.new(prefill: 'false')

--- a/spec/forms/candidate_interface/prefill_application_or_not_form_spec.rb
+++ b/spec/forms/candidate_interface/prefill_application_or_not_form_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PrefillApplicationOrNotForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:prefill) }
+  end
+  describe '#prefill?' do
+    it "returns false if prefill is 'false'" do
+      form = described_class.new(prefill: 'false')
+      expect(form.prefill?).to be false
+    end
+
+    it "returns true if prefill is 'true'" do
+      form = described_class.new(prefill: 'true')
+      expect(form.prefill?).to be true
+    end
+  end
+end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe TestApplications do
     courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
     application_choice = TestApplications.new.create_application(
-        recruitment_cycle_year: 2021,
-        states: %i[unsubmitted_with_completed_references],
-        courses_to_apply_to: courses_we_want,
-        candidate: expected_candidate
+      recruitment_cycle_year: 2021,
+      states: %i[unsubmitted_with_completed_references],
+      courses_to_apply_to: courses_we_want,
+      candidate: expected_candidate,
     ).first
 
     candidate = application_choice.application_form.candidate

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -62,6 +62,22 @@ RSpec.describe TestApplications do
     expect(offer_audit.user).to eq provider_user
   end
 
+  it 'generates an application for the specified candidate' do
+    expected_candidate = create(:candidate)
+    courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+    application_choice = TestApplications.new.create_application(
+        recruitment_cycle_year: 2021,
+        states: %i[unsubmitted_with_completed_references],
+        courses_to_apply_to: courses_we_want,
+        candidate: expected_candidate
+    ).first
+
+    candidate = application_choice.application_form.candidate
+
+    expect(candidate).to eq expected_candidate
+  end
+
   it 'throws an exception if there are not enough courses to apply to' do
     expect {
       TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[offer], courses_to_apply_to: [])

--- a/spec/system/candidate_interface/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate signs in and prefills application in Sandbox', sandbox: true do
+  include SignInHelper
+
+  scenario 'User is directed to prefill option page and chooses to prefill the application' do
+    given_the_pilot_is_open
+    and_a_course_is_available
+    and_i_am_a_candidate_with_a_blank_application
+
+    when_i_fill_in_the_sign_in_form
+    and_i_click_on_the_link_in_my_email_and_sign_in
+    then_i_am_taken_to_the_prefill_application_page
+
+    when_i_select_prefill_and_submit_the_form
+    then_i_am_taken_to_the_application_page
+    and_there_is_a_flash_saying_the_application_was_prefilled
+    and_my_application_has_been_filled_in
+
+    when_i_click_submit_and_continue_and_send
+    then_my_application_is_submitted_successfully
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_a_course_is_available
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2021))
+  end
+
+  def and_i_am_a_candidate_with_a_blank_application
+    @candidate = create(:candidate)
+    @application_form = create(:application_form, candidate: @candidate)
+  end
+
+  def when_i_fill_in_the_sign_in_form
+    visit candidate_interface_sign_in_path
+    fill_in t('authentication.sign_up.email_address.label'), with: @candidate.email_address
+    click_on 'Continue'
+  end
+
+  def and_i_click_on_the_link_in_my_email_and_sign_in
+    open_email(@candidate.email_address)
+    click_magic_link_in_email
+    confirm_sign_in
+  end
+
+  def then_i_am_taken_to_the_prefill_application_page
+    expect(page).to have_current_path(candidate_interface_prefill_path)
+  end
+
+  def when_i_select_prefill_and_submit_the_form
+    choose 'Start with the form filled in automatically'
+    click_on 'Continue'
+  end
+
+  def then_i_am_taken_to_the_application_page
+    expect(page).to have_current_path(candidate_interface_application_form_path)
+  end
+
+  def and_there_is_a_flash_saying_the_application_was_prefilled
+    expect(page).to have_content 'This application has been prefilled with example data'
+  end
+
+  def and_my_application_has_been_filled_in
+    expect(page).to_not have_content 'Incomplete'
+    expect(page).to_not have_content 'In progress'
+  end
+
+  def when_i_click_submit_and_continue_and_send
+    click_on 'Check and submit your application'
+    click_on 'Continue'
+    expect(page).to_not have_content 'There is a problem'
+    click_on 'Continue without completing questionnaire'
+    choose 'No'
+    click_on 'Send application'
+  end
+
+  def then_my_application_is_submitted_successfully
+    expect(page).to have_content 'Application successfully submitted'
+  end
+end

--- a/spec/system/candidate_interface/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Candidate signs in and prefills application in Sandbox', sandbox:
   end
 
   def and_a_course_is_available
-    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: 2021))
+    create(:course_option, course: create(:course, :open_on_apply, recruitment_cycle_year: RecruitmentCycle.current_year))
   end
 
   def and_i_am_a_candidate_with_a_blank_application

--- a/spec/system/candidate_interface/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_in_and_prefills_application_in_sandbox_spec.rb
@@ -64,17 +64,18 @@ RSpec.feature 'Candidate signs in and prefills application in Sandbox', sandbox:
   end
 
   def and_my_application_has_been_filled_in
-    expect(page).to_not have_content 'Incomplete'
-    expect(page).to_not have_content 'In progress'
+    expect(page).not_to have_content 'Incomplete'
+    expect(page).not_to have_content 'In progress'
   end
 
   def when_i_click_submit_and_continue_and_send
     click_on 'Check and submit your application'
     click_on 'Continue'
-    expect(page).to_not have_content 'There is a problem'
-    click_on 'Continue without completing questionnaire'
+    expect(page).not_to have_content 'There is a problem'
+    choose t('equality_and_diversity.choice.no.label')
+    click_on 'Continue'
     choose 'No'
-    click_on 'Send application'
+    click_button t('submit_application.submit_button')
   end
 
   def then_my_application_is_submitted_successfully


### PR DESCRIPTION
User is now redirected to a new controller to choose whether or not to prefill the application form with valid example data

## Context
It takes a long time to fill out an application form, which is required in sandbox. This automates the process

## Changes proposed in this pull request
Sandbox candidate is now directed to the prefill or not page, where they can decide if the application should be prefilled
Prefilling adds a new application form for the current candidate

## Guidance to review
Do we need to clean up the unused empty application form?

## Link to Trello card
https://trello.com/c/fSFvRWe2/2853-prefill-application-form-for-sandbox

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
