### PR TITLE
Use radio buttons on equality and diversity start page

### DIFF
--- a/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
@@ -1,5 +1,1 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render(SummaryCardComponent.new(rows: equality_and_diversity_rows, border: false, editable: @editable)) %>
-  </div>
-</div>
+<%= render(SummaryCardComponent.new(rows: equality_and_diversity_rows, border: false, editable: @editable)) %>

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -3,6 +3,13 @@ module CandidateInterface
     before_action :redirect_to_review_unless_ready_to_submit
 
     def start
+      @choice_form = EqualityAndDiversity::ChoiceForm.new
+    end
+
+    def choice
+      @choice_form = EqualityAndDiversity::ChoiceForm.new(choice: choice_param)
+      render :start and return unless @choice_form.valid?
+
       entrypoint_path =
         if current_application.equality_and_diversity_answers_provided?
           candidate_interface_review_equality_and_diversity_path
@@ -10,7 +17,11 @@ module CandidateInterface
           candidate_interface_edit_equality_and_diversity_sex_path
         end
 
-      render :start, locals: { entrypoint_path: entrypoint_path }
+      if @choice_form.choice == 'yes'
+        redirect_to entrypoint_path
+      else
+        redirect_to candidate_interface_application_submit_show_path
+      end
     end
 
     def edit_sex
@@ -108,6 +119,10 @@ module CandidateInterface
     def review; end
 
   private
+
+    def choice_param
+      params.dig(:candidate_interface_equality_and_diversity_choice_form, :choice)
+    end
 
     def sex_param
       params.dig(:candidate_interface_equality_and_diversity_sex_form, :sex)

--- a/app/forms/candidate_interface/equality_and_diversity/choice_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/choice_form.rb
@@ -1,0 +1,14 @@
+module CandidateInterface
+  class EqualityAndDiversity::ChoiceForm
+    include ActiveModel::Model
+
+    attr_accessor :choice
+
+    validates :choice, presence: true
+
+    def initialize(params = {})
+      super
+      self.choice ||= 'yes'
+    end
+  end
+end

--- a/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
+++ b/app/forms/candidate_interface/equality_and_diversity/disabilities_form.rb
@@ -2,15 +2,9 @@ module CandidateInterface
   class EqualityAndDiversity::DisabilitiesForm
     include ActiveModel::Model
 
-    DISABILITIES = [
-      %w[blind Blind],
-      %w[deaf Deaf],
-      ['learning', 'Learning difficulty'],
-      ['long_standing', 'Long-standing illness'],
-      ['mental', 'Mental health condition'],
-      ['physical', 'Physical disability or mobility issue'],
-      ['social', 'Social or communication impairment'],
-    ].freeze
+    DISABILITIES = %w[blind deaf learning long_standing mental physical social].map { |disability|
+      [disability, I18n.t("equality_and_diversity.disabilities.#{disability}.label")]
+    }.freeze
 
     attr_accessor :disabilities, :other_disability
 

--- a/app/helpers/ethnic_background_helper.rb
+++ b/app/helpers/ethnic_background_helper.rb
@@ -40,13 +40,9 @@ module EthnicBackgroundHelper
   end
 
   def ethnic_background_title(group)
-    return 'Which of the following best describes your ethnicity?' if group == 'Another ethnic group'
+    return t('equality_and_diversity.ethnic_background.title_other') if group == 'Another ethnic group'
 
-    "Which of the following best describes your #{group} background?"
-  end
-
-  def equality_and_diversity_caption
-    '<span class="govuk-caption-xl">Equality and diversity</span>'.html_safe
+    t('equality_and_diversity.ethnic_background.title', group: group)
   end
 
   # return every possible combination of group + background

--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix('Please select all that apply to you', @disabilities.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('equality_and_diversity.disabilities.title'), @disabilities.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_disability_status_path) %>
 
 <div class="govuk-grid-row">
@@ -6,17 +6,14 @@
     <%= form_with model: @disabilities, url: candidate_interface_update_equality_and_diversity_disabilities_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_check_boxes_fieldset :disabilities, multiple: false, legend: { size: 'xl', text: equality_and_diversity_caption + 'Please select all that apply to you' } do %>
-        <div class="govuk-!-margin-top-6">
-          <% disabilities_checkboxes.each do |checkbox| %>
-            <%= f.govuk_check_box :disabilities, checkbox.name, label: { text: checkbox.name, size: 's' }, hint: { text: checkbox.hint_text } %>
-          <% end %>
+      <%= f.govuk_check_boxes_fieldset :disabilities, multiple: false, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.disabilities.title'), size: 'xl' } do %>
+        <% disabilities_checkboxes.each do |checkbox| %>
+          <%= f.govuk_check_box :disabilities, checkbox.name, label: { text: checkbox.name, size: 's' }, hint: { text: checkbox.hint_text } %>
+        <% end %>
 
-          <%= f.govuk_check_box :disabilities, 'Other', label: { text: 'Other', size: 's' } do %>
-            <%= f.govuk_text_field :other_disability, label: { text: 'Describe your disability (optional)' } %>
-          <% end %>
-
-        </div>
+        <%= f.govuk_check_box :disabilities, t('equality_and_diversity.disabilities.other.label'), label: { text: t('equality_and_diversity.disabilities.other.label'), size: 's' } do %>
+          <%= f.govuk_text_field :other_disability, label: { text: t('equality_and_diversity.disabilities.other_disability.label') } %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix('Are you disabled?', @disability_status.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('equality_and_diversity.disability_status.title'), @disability_status.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_sex_path) %>
 
 <div class="govuk-grid-row">
@@ -6,13 +6,11 @@
     <%= form_with model: @disability_status, url: candidate_interface_update_equality_and_diversity_disability_status_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :disability_status, legend: { size: 'xl', text: equality_and_diversity_caption + 'Are you disabled?' } do %>
-        <div class="govuk-!-margin-top-6">
-          <%= f.govuk_radio_button :disability_status, :yes, label: { text: 'Yes' }, link_errors: true %>
-          <%= f.govuk_radio_button :disability_status, :no, label: { text: 'No' } %>
-          <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :disability_status, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
-        </div>
+      <%= f.govuk_radio_buttons_fieldset :disability_status, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.disability_status.title'), size: 'xl' } do %>
+        <%= f.govuk_radio_button :disability_status, :yes, label: { text: t('equality_and_diversity.disability_status.yes.label') }, link_errors: true %>
+        <%= f.govuk_radio_button :disability_status, :no, label: { text: t('equality_and_diversity.disability_status.no.label') } %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :disability_status, t('equality_and_diversity.disability_status.opt_out.label'), label: { text: t('equality_and_diversity.disability_status.opt_out.label') } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -6,20 +6,18 @@
     <%= form_with model: @ethnic_background, url: candidate_interface_update_equality_and_diversity_ethnic_background_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :ethnic_background, legend: { size: 'xl', text: equality_and_diversity_caption + ethnic_background_title(@ethnic_group) } do %>
-        <div class="govuk-!-margin-top-6">
-          <% ethnic_backgrounds(@ethnic_group).each_with_index do |background, i| %>
-              <% if background.textfield_label.nil? %>
-                <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label }, link_errors: i.zero? %>
-              <% else %>
-                <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label } do %>
-                <%= f.govuk_text_field :other_background, label: { text: background.textfield_label } %>
-              <% end %>
+      <%= f.govuk_radio_buttons_fieldset :ethnic_background, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: ethnic_background_title(@ethnic_group), size: 'xl' } do %>
+        <% ethnic_backgrounds(@ethnic_group).each_with_index do |background, i| %>
+            <% if background.textfield_label.nil? %>
+              <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label }, link_errors: i.zero? %>
+            <% else %>
+              <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label } do %>
+              <%= f.govuk_text_field :other_background, label: { text: background.textfield_label } %>
             <% end %>
           <% end %>
-          <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :ethnic_background, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
-        </div>
+        <% end %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :ethnic_background, t('equality_and_diversity.ethnic_background.opt_out.label'), label: { text: t('equality_and_diversity.ethnic_background.opt_out.label') } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix('What is your ethnic group?', @ethnic_group.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('equality_and_diversity.ethnic_group.title'), @ethnic_group.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_disability_status_path) %>
 
 <div class="govuk-grid-row">
@@ -6,16 +6,14 @@
     <%= form_with model: @ethnic_group, url: candidate_interface_update_equality_and_diversity_ethnic_group_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :ethnic_group, legend: { size: 'xl', text: equality_and_diversity_caption + 'What is your ethnic group?' } do %>
-        <div class="govuk-!-margin-top-6">
-          <%= f.govuk_radio_button :ethnic_group, 'Asian or Asian British', label: { text: 'Asian or Asian British', size: 's' }, hint: { text: '(includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani)' }, link_errors: true %>
-          <%= f.govuk_radio_button :ethnic_group, 'Black, African, Black British or Caribbean', label: { text: 'Black, African, Black British or Caribbean', size: 's' }, hint: { text: '(includes any Black background)' } %>
-          <%= f.govuk_radio_button :ethnic_group, 'Mixed or multiple ethnic groups', label: { text: 'Mixed or multiple ethnic groups', size: 's' }, hint: { text: '(includes any Mixed background)' } %>
-          <%= f.govuk_radio_button :ethnic_group, 'White', label: { text: 'White', size: 's' }, hint: { text: '(includes any White background)' } %>
-          <%= f.govuk_radio_button :ethnic_group, 'Another ethnic group', label: { text: 'Another ethnic group', size: 's' }, hint: { text: '(includes any other ethnic group, for example, Arab)' } %>
-          <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :ethnic_group, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
-        </div>
+      <%= f.govuk_radio_buttons_fieldset :ethnic_group, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.ethnic_group.title'), size: 'xl' } do %>
+        <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.asian.label'), label: { text: t('equality_and_diversity.ethnic_group.asian.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.asian.hint_text') }, link_errors: true %>
+        <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.black.label'), label: { text: t('equality_and_diversity.ethnic_group.black.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.black.hint_text') } %>
+        <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.mixed.label'), label: { text: t('equality_and_diversity.ethnic_group.mixed.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.mixed.hint_text') } %>
+        <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.white.label'), label: { text: t('equality_and_diversity.ethnic_group.white.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.white.hint_text') } %>
+        <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.other.label'), label: { text: t('equality_and_diversity.ethnic_group.other.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.other.hint_text') } %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.opt_out.label'), label: { text: t('equality_and_diversity.ethnic_group.opt_out.label') } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix('What is your sex?', @sex.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('equality_and_diversity.sex.title'), @sex.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_equality_and_diversity_path) %>
 
 <div class="govuk-grid-row">
@@ -6,14 +6,12 @@
     <%= form_with model: @sex, url: candidate_interface_update_equality_and_diversity_sex_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :sex, legend: { size: 'xl', text: equality_and_diversity_caption + 'What is your sex?' } do %>
-        <div class="govuk-!-margin-top-6">
-          <%= f.govuk_radio_button :sex, :female, label: { text: 'Female' }, link_errors: true %>
-          <%= f.govuk_radio_button :sex, :male, label: { text: 'Male' } %>
-          <%= f.govuk_radio_button :sex, :intersex, label: { text: 'Intersex' } %>
-          <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :sex, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
-        </div>
+      <%= f.govuk_radio_buttons_fieldset :sex, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.sex.title'), size: 'xl' } do %>
+        <%= f.govuk_radio_button :sex, :female, label: { text: t('equality_and_diversity.sex.female.label') }, link_errors: true %>
+        <%= f.govuk_radio_button :sex, :male, label: { text: t('equality_and_diversity.sex.male.label') } %>
+        <%= f.govuk_radio_button :sex, :intersex, label: { text: t('equality_and_diversity.sex.intersex.label') } %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :sex, t('equality_and_diversity.sex.opt_out.label'), label: { text: t('equality_and_diversity.sex.opt_out.label') } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -2,7 +2,7 @@
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_equality_and_diversity_path) %>
 
 <h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">Equality and diversity</span>
+  <span class="govuk-caption-xl"><%= t('equality_and_diversity.title') %></span>
   Check your answers
 </h1>
 

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -1,13 +1,17 @@
 <% content_for :title, 'Check your answers' %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_equality_and_diversity_path) %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= t('equality_and_diversity.title') %></span>
-  Check your answers
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= t('equality_and_diversity.title') %></span>
+      Check your answers
+    </h1>
 
-<%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>
+    <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>
 
-<p class="govuk-body">
-  <%= govuk_button_link_to 'Continue', candidate_interface_application_submit_show_path %>
-</p>
+    <p class="govuk-body">
+      <%= govuk_button_link_to 'Continue', candidate_interface_application_submit_show_path %>
+    </p>
+  </div>
+</div>

--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Equality and diversity questionnaire' %>
+<% content_for :title, t('equality_and_diversity.title') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_review_path) %>
 
 <div class="govuk-grid-row">
@@ -6,15 +6,15 @@
     <%= form_with model: @choice_form, url: candidate_interface_start_equality_and_diversity_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Equality and diversity questionnaire</h1>
+      <h1 class="govuk-heading-xl"><%= t('equality_and_diversity.title') %></h1>
       <p class="govuk-body">The Department for Education (DfE) uses equality and diversity data to improve the teacher training application process and make government policy better.</p>
       <p class="govuk-body">We use the information you give in this questionnaire to help prevent discrimination in teacher recruitment. We also share it with your teacher training provider if you accept a place on their course.</p>
       <p class="govuk-body"><%= govuk_link_to 'Find out how we use and look after your data', candidate_interface_privacy_policy_path %></p>
       <p class="govuk-body">Completing the questionnaire is optional and will not affect the progress of your application.</p>
 
-      <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: 'Can you complete a 3-minute questionnaire?' } do %>
-        <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, continue to the questionnaire' }, link_errors: true %>
-        <%= f.govuk_radio_button :choice, :no, label: { text: 'No, continue without completing questionnaire' } %>
+      <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: t('equality_and_diversity.choice.title') } do %>
+        <%= f.govuk_radio_button :choice, :yes, label: { text: t('equality_and_diversity.choice.yes.label') }, link_errors: true %>
+        <%= f.govuk_radio_button :choice, :no, label: { text: t('equality_and_diversity.choice.no.label') } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -1,22 +1,23 @@
-<% content_for :title, 'Equality and diversity' %>
+<% content_for :title, 'Equality and diversity questionnaire' %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Can you complete a 3-minute equality and diversity questionnaire?
-    </h1>
+    <%= form_with model: @choice_form, url: candidate_interface_start_equality_and_diversity_path do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <p class="govuk-body">Completing the questionnaire is optional and will not affect the progress of your application.</p>
-    <p class="govuk-body">The Department for Education (DfE) uses equality and diversity data to improve the teacher training application process and make government policy better.</p>
-    <p class="govuk-body">For example, DfE will use the information you give in this questionnaire to help prevent discrimination in teacher recruitment.</p>
-    <p class="govuk-body">The information you give in this questionnaire will also be shared with your teacher training provider if you accept a place on their course.</p>
-    <p class="govuk-body"><% govuk_link_to 'Find out how we use and look after your data', candidate_interface_privacy_policy_path %></p>
+      <h1 class="govuk-heading-xl">Equality and diversity questionnaire</h1>
+      <p class="govuk-body">The Department for Education (DfE) uses equality and diversity data to improve the teacher training application process and make government policy better.</p>
+      <p class="govuk-body">We use the information you give in this questionnaire to help prevent discrimination in teacher recruitment. We also share it with your teacher training provider if you accept a place on their course.</p>
+      <p class="govuk-body"><%= govuk_link_to 'Find out how we use and look after your data', candidate_interface_privacy_policy_path %></p>
+      <p class="govuk-body">Completing the questionnaire is optional and will not affect the progress of your application.</p>
 
-    <%= govuk_button_link_to 'Yes, continue to the questionnaire', entrypoint_path %>
+      <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: 'Can you complete a 3-minute questionnaire?' } do %>
+        <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, continue to the questionnaire' }, link_errors: true %>
+        <%= f.govuk_radio_button :choice, :no, label: { text: 'No, continue without completing questionnaire' } %>
+      <% end %>
 
-    <p class="govuk-body">
-      <%= govuk_link_to 'Continue without completing questionnaire', candidate_interface_application_submit_show_path %>
-    </p>
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/equality_and_diversity.yml
+++ b/config/locales/equality_and_diversity.yml
@@ -1,18 +1,78 @@
 en:
   equality_and_diversity:
+    title: Equality and diversity questionnaire
+    choice:
+      title: Can you complete a 3-minute questionnaire?
+      'yes':
+        label: Yes, continue to the questionnaire
+      'no':
+        label: No, continue without completing questionnaire
+    sex:
+      title: What is your sex?
+      female:
+        label: Female
+      male:
+        label: Male
+      intersex:
+        label: Intersex
+      opt_out:
+        label: Prefer not to say
+    disability_status:
+      title: Are you disabled?
+      'yes':
+        label: 'Yes'
+      'no':
+        label: 'No'
+      opt_out:
+        label: Prefer not to say
     disabilities:
+      title: Please select all that apply to you
       blind:
+        label: Blind
         hint_text: (or a serious visual impairment which is not corrected by glasses)
       deaf:
+        label: Deaf
         hint_text: (or a serious hearing impairment)
       learning:
+        label: Learning difficulty
         hint_text: (for example, dyslexia, dyspraxia or ADHD)
       long_standing:
+        label: Long-standing illness
         hint_text: (for example, cancer, HIV, diabetes, chronic heart disease or epilepsy)
       mental:
+        label: Mental health condition
         hint_text: (for example, depression, schizophrenia or anxiety disorder)
       physical:
+        label: Physical disability or mobility issue
         hint_text: (for example, impaired use of arms or legs, use of a wheelchair or crutches)
-      social: 
+      social:
+        label: Social or communication impairment
         hint_text: (for example Asperger’s, or another autistic spectrum disorder)
-    
+      other:
+        label: Other
+      other_disability:
+        label: Describe your disability (optional)
+    ethnic_group:
+      title: What is your ethnic group?
+      asian:
+        label: Asian or Asian British
+        hint_text: (includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani)
+      black:
+        label: Black, African, Black British or Caribbean
+        hint_text: (includes any Black background)
+      mixed:
+        label: Mixed or multiple ethnic groups
+        hint_text: (includes any Mixed background)
+      white:
+        label: White
+        hint_text: (includes any White background)
+      other:
+        label: Another ethnic group
+        hint_text: (includes any other ethnic group, for example, Arab)
+      opt_out:
+        label: Prefer not to say
+    ethnic_background:
+      title: Which of the following best describes your %{group} background?
+      title_other: Which of the following best describes your ethnicity?
+      opt_out:
+        label: Prefer not to say

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -381,6 +381,7 @@ Rails.application.routes.draw do
 
       scope '/equality-and-diversity' do
         get '/' => 'equality_and_diversity#start', as: :start_equality_and_diversity
+        post '/' => 'equality_and_diversity#choice'
         get '/sex' => 'equality_and_diversity#edit_sex', as: :edit_equality_and_diversity_sex
         post '/sex' => 'equality_and_diversity#update_sex', as: :update_equality_and_diversity_sex
         get '/disability-status' => 'equality_and_diversity#edit_disability_status', as: :edit_equality_and_diversity_disability_status

--- a/spec/forms/candidate_interface/equality_and_diversity/choice_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/choice_form_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EqualityAndDiversity::ChoiceForm, type: :model do
+  describe '#initialize' do
+    it 'defaults to yes' do
+      form = CandidateInterface::EqualityAndDiversity::ChoiceForm.new
+
+      expect(form.choice).to eq('yes')
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:choice) }
+  end
+end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -87,7 +87,8 @@ module CandidateHelper
     receive_references
     click_link 'Check and submit your application'
     click_link 'Continue'
-    click_link 'Continue without completing questionnaire'
+    choose 'No'
+    click_button 'Continue'
     choose 'No' # "Is there anything else you would like to tell us?"
     click_button 'Send application'
     @application = ApplicationForm.last

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature 'Entering their equality and diversity information' do
     then_i_can_submit_my_application
 
     when_i_am_on_the_equality_and_diversity_page
+    and_i_can_see_a_link_to_the_privacy_policy
     and_i_choose_to_complete_equality_and_diversity
     then_i_am_asked_to_choose_my_sex
 
@@ -115,6 +116,10 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def when_i_am_on_the_equality_and_diversity_page
     visit candidate_interface_start_equality_and_diversity_path
+  end
+
+  def and_i_can_see_a_link_to_the_privacy_policy
+    expect(page).to have_link('Find out how we use and look after your data', href: candidate_interface_privacy_policy_path)
   end
 
   def and_i_choose_to_complete_equality_and_diversity

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -100,11 +100,13 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def then_i_see_the_equality_and_diversity_page
-    expect(page).to have_content 'Can you complete a 3-minute equality and diversity questionnaire?'
+    expect(page).to have_title 'Equality and diversity questionnaire'
+    expect(page).to have_content 'Can you complete a 3-minute questionnaire?'
   end
 
   def when_i_choose_not_to_complete_equality_and_diversity
-    click_link 'Continue without completing questionnaire'
+    choose 'No'
+    click_button 'Continue'
   end
 
   def then_i_can_submit_my_application
@@ -116,7 +118,7 @@ RSpec.feature 'Entering their equality and diversity information' do
   end
 
   def and_i_choose_to_complete_equality_and_diversity
-    click_link 'Yes, continue to the questionnaire'
+    click_button 'Continue'
   end
 
   def then_i_am_asked_to_choose_my_sex
@@ -283,7 +285,7 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def when_i_manually_restart_the_questionnaire
     visit candidate_interface_start_equality_and_diversity_path
-    click_link 'Yes, continue to the questionnaire'
+    click_button 'Continue'
   end
 
   def then_i_go_straight_to_the_review_page

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -160,7 +160,8 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_choose_not_to_fill_in_the_equality_and_diversity_survey
-    click_link 'Continue without completing questionnaire'
+    choose 'No'
+    click_button 'Continue'
   end
 
   def and_i_choose_to_add_further_information_but_omit_adding_details

--- a/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/submitting_an_application_spec.rb
@@ -86,7 +86,8 @@ RSpec.feature 'Submitting an application' do
   end
 
   def then_i_can_see_my_application_has_been_successfully_submitted
-    click_link 'Continue without completing questionnaire'
+    choose 'No'
+    click_button 'Continue'
     choose 'No'
     click_button 'Send application'
   end

--- a/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/international/international_candidate_submitting_application_spec.rb
@@ -172,7 +172,8 @@ RSpec.feature 'International candidate submits the application' do
   end
 
   def when_i_choose_not_to_fill_in_the_equality_and_diversity_survey
-    click_link 'Continue without completing questionnaire'
+    choose 'No'
+    click_button 'Continue'
   end
 
   def when_i_choose_not_to_provide_further_information


### PR DESCRIPTION
## Context

The equality and diversity start page has seen many revisions, but none have addressed us using a button and a link to direct users to different routes – ~~a situation that’s been made worse since the nearby inclusion of a link to our privacy policy as well~~ or would had that link appeared 😱.

## Changes proposed in this pull request

* Use radio buttons to show the two choices instead of a link and a button
* Fix link to privacy policy not being rendered
* Update tests to reflect new behaviour on this page
* Localise most of the strings in this section (which also ensures section title is used consistently across pages in this section)
* Use new `caption` attribute in the form builder, removing need for `equality_and_diversity_caption` helper
* Move grid layout out from review component and into view

## Guidance to review

Perhaps best to view each commit individually - the one that localises strings obviously touches a lot of code.

| Before | After |
| - | - |
| ![e q-old](https://user-images.githubusercontent.com/813383/97030122-442b6f00-1556-11eb-97b6-5a0f56ca3d98.png) | ![e q-new](https://user-images.githubusercontent.com/813383/97030117-42fa4200-1556-11eb-8e7c-29ffcc392688.png) |

## Link to Trello card

https://trello.com/c/jenqB5nt

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
