### PR TITLE
Candidate feedback form data export

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -30,6 +30,11 @@ class DataExport < ApplicationRecord
       description: 'This provides the compiled results of all the candidate satisfaction surveys',
       class: SupportInterface::CandidateSurveyExport,
     },
+    candidate_feedback: {
+      name: 'Candidate feedback',
+      description: 'This provides the compiled results of all the candidate feedback forms',
+      class: SupportInterface::CandidateFeedbackExport,
+    },
     active_provider_users: {
       name: 'Active provider users',
       description: 'The list of provider users that have signed in to apply at least once.',

--- a/app/services/support_interface/candidate_feedback_export.rb
+++ b/app/services/support_interface/candidate_feedback_export.rb
@@ -2,8 +2,6 @@ module SupportInterface
   class CandidateFeedbackExport
     def data_for_export
       application_forms.find_each.map do |application_form|
-        survey = application_form.satisfaction_survey
-
         {
           'Name' => application_form.full_name,
           'Recruitment cycle year' => application_form.recruitment_cycle_year,

--- a/app/services/support_interface/candidate_feedback_export.rb
+++ b/app/services/support_interface/candidate_feedback_export.rb
@@ -7,7 +7,9 @@ module SupportInterface
           'Recruitment cycle year' => application_form.recruitment_cycle_year,
           'Email_address' => application_form.candidate.email_address,
           'Phone number' => application_form.phone_number,
+          'Submitted at' => application_form.submitted_at&.iso8601,
           'Satisfaction level' => application_form.feedback_satisfaction_level,
+          'CSAT score' => csat_score(application_form.feedback_satisfaction_level),
           'Suggestions' => application_form.feedback_suggestions,
         }
       end
@@ -19,6 +21,18 @@ module SupportInterface
       @application_forms ||= ApplicationForm.where.not(
         feedback_satisfaction_level: nil,
       ).includes(:candidate)
+    end
+
+    CSAT_SCORES = {
+      very_satisfied: 5,
+      satisfied: 4,
+      neither_satisfied_or_dissatisfied: 3,
+      dissatisfied: 2,
+      very_dissatisfied: 1,
+    }.with_indifferent_access.freeze
+
+    def csat_score(satisfaction_level)
+      CSAT_SCORES[satisfaction_level]
     end
   end
 end

--- a/app/services/support_interface/candidate_feedback_export.rb
+++ b/app/services/support_interface/candidate_feedback_export.rb
@@ -1,0 +1,26 @@
+module SupportInterface
+  class CandidateFeedbackExport
+    def data_for_export
+      application_forms.find_each.map do |application_form|
+        survey = application_form.satisfaction_survey
+
+        {
+          'Name' => application_form.full_name,
+          'Recruitment cycle year' => application_form.recruitment_cycle_year,
+          'Email_address' => application_form.candidate.email_address,
+          'Phone number' => application_form.phone_number,
+          'Satisfaction level' => application_form.feedback_satisfaction_level,
+          'Suggestions' => application_form.feedback_suggestions,
+        }
+      end
+    end
+
+  private
+
+    def application_forms
+      @application_forms ||= ApplicationForm.where.not(
+        feedback_satisfaction_level: nil,
+      ).includes(:candidate)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -157,6 +157,11 @@ FactoryBot.define do
         end
       end
 
+      trait :with_feedback_completed do
+        feedback_satisfaction_level { ApplicationForm.feedback_satisfaction_levels.values.sample }
+        feedback_suggestions { Faker::Lorem.paragraph_by_chars(number: 200) }
+      end
+
       trait :with_equality_and_diversity_data do
         equality_and_diversity do
           ethnicity = Class.new.extend(EthnicBackgroundHelper).all_combinations.sample

--- a/spec/services/support_interface/candidate_feedback_export_spec.rb
+++ b/spec/services/support_interface/candidate_feedback_export_spec.rb
@@ -24,7 +24,9 @@ private
       'Recruitment cycle year' => application_form.recruitment_cycle_year,
       'Email_address' => application_form.candidate.email_address,
       'Phone number' => application_form.phone_number,
+      'Submitted at' => application_form.submitted_at,
       'Satisfaction level' => application_form.feedback_satisfaction_level,
+      'CSAT score' => described_class::CSAT_SCORES[application_form.feedback_satisfaction_level],
       'Suggestions' => application_form.feedback_suggestions,
     }
   end

--- a/spec/services/support_interface/candidate_feedback_export_spec.rb
+++ b/spec/services/support_interface/candidate_feedback_export_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CandidateFeedbackExport do
+  describe '#data_for_export' do
+    it 'returns a hash of candidates satisfaction survey answers' do
+      application_form1 = create(:completed_application_form, :with_feedback_completed)
+      application_form2 = create(:completed_application_form, :with_feedback_completed)
+      application_form3 = create(:completed_application_form, :with_feedback_completed)
+      create(:completed_application_form)
+
+      expect(described_class.new.data_for_export).to match_array([
+        expected_hash(application_form1),
+        expected_hash(application_form2),
+        expected_hash(application_form3),
+      ])
+    end
+  end
+
+private
+
+  def expected_hash(application_form)
+    {
+      'Name' => application_form.full_name,
+      'Recruitment cycle year' => application_form.recruitment_cycle_year,
+      'Email_address' => application_form.candidate.email_address,
+      'Phone number' => application_form.phone_number,
+      'Satisfaction level' => application_form.feedback_satisfaction_level,
+      'Suggestions' => application_form.feedback_suggestions,
+    }
+  end
+end


### PR DESCRIPTION
## Context

We want to replace the current multi-step survey form with a simpler one page form, that is based on the GDS feedback form.

This PR implements a new data export to download the data collected by the new feedback form.

## Changes proposed in this pull request

- [x] Add a new report to the support interface. It is separate to the original candidate survey data export which will remain.

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/450843/97122748-31fd2c80-1720-11eb-90ec-5c573efc27d0.png">

Example CSV output:
```
Name,Recruitment cycle year,Email_address,Phone number,Submitted at,Satisfaction level,CSAT score,Suggestions
Carolin Kassulke,2021,carolin.kassulke@example.com,07150 345175,2020-10-26T11:25:47+00:00,very_satisfied,5,It would be nice if I could add emojis to my personal statement
```

## Guidance to review

- To test manually it should be possible to sign in as a candidate and fill out a feedback form by navigating to `/candidate/application/feedback-form` (or following the normal steps on application submission). The data input should be available to download from `/support/performance/data-exports/new`

## Link to Trello card

https://trello.com/c/lQdpvtmy/2281-dev-replace-multi-step-survey-with-single-page-feedback-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
