### PR TITLE
Start removing deprecated states

### DIFF
--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -27,9 +27,8 @@ RSpec.describe GenerateTestApplications do
       'withdrawn',
       'recruited',
     )
+
     # there is at least one unsubmitted application to a full course
-    expect(ApplicationChoice.where(status: 'unsubmitted').map(&:course_option).select(&:no_vacancies?)).not_to be_empty
-    # there is at least one awaiting_references application to a full course
     expect(ApplicationChoice.where(status: 'unsubmitted').map(&:course_option).select(&:no_vacancies?)).not_to be_empty
   end
 end


### PR DESCRIPTION
## Context

We're going to delete the `awaiting_references` and `application_complete` states.

## Changes proposed in this pull request

Add a check that makes sure that the environment doesn't contain any applications in the states that we're about to delete.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/ykZiAQ1s

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
