### PR TITLE
EOC choice unavailable email cleanup

### DIFF
--- a/app/views/candidate_mailer/_application_rejected_intro.text.erb
+++ b/app/views/candidate_mailer/_application_rejected_intro.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @application_form.first_name %>,
 
-# Application decision
+# Application outcome
 
 <% if @application_choice.rejected_by_default? %>
   Your application for <%= @course.name_and_code %> has been automatically rejected because <%= @course.provider.name %> did not respond in time.

--- a/app/views/candidate_mailer/application_rejected_all_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_rejected.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @application_form.first_name %>,
 
-# Application decision
+# Application outcome
 
 <% if @application_choice.rejected_by_default %>
   <%= @course.provider.name %> did not respond to your application for <%= @course.name_and_code %> in time.

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -2,8 +2,6 @@ en:
   candidate_mailer:
     referees_did_not_respond_before_end_of_cycle:
       subject: "Your references did not come back in time"
-    eoc_choice_unavailable_has_other_choices:
-      subject: Application could not be sent for %{course_name} at %{provider_name}
     survey_email:
       subject: Was applying for teacher training easy?
     survey_chaser_email:

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -2,8 +2,6 @@ en:
   candidate_mailer:
     referees_did_not_respond_before_end_of_cycle:
       subject: "Your references did not come back in time"
-    eoc_choice_unavailable_no_other_choices:
-      subject: Find a different course and re-submit your application
     eoc_choice_unavailable_has_other_choices:
       subject: Application could not be sent for %{course_name} at %{provider_name}
     survey_email:


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We no longer trigger these emails so they need removal.

## Changes proposed in this pull request
- Get rid of the remaining EOC choice unavailable email
- Remove some bits left over from the prior removal of the other one
- Update some copy in the appliation rejected emails

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Double check these aren't invoked from anywhere.
- Have I missed anything related to these emails that also needs deleting?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/Msznd1s5
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
