### PR TITLE
Add please to referee emails

### DIFF
--- a/app/views/referee_mailer/reference_request_chaser_email.text.erb
+++ b/app/views/referee_mailer/reference_request_chaser_email.text.erb
@@ -1,8 +1,8 @@
 Dear <%= @reference.name %>,
 
-# Give a reference for <%= @candidate_name %> as soon as possible
+# Please give a reference for <%= @candidate_name %> as soon as possible
 
-We have not had your reference for <%= @candidate_name %>. They put us in touch with you to get a reference for their teacher training application.
+We have not had your reference for <%= @candidate_name %> yet. They put us in touch with you to get a reference for their teacher training application.
 
 Give a reference as soon as possible by filling in this short form (it does not take long):
 

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @reference.name %>,
 
-# Give a reference for <%= @candidate_name %> as soon as possible
+# Please give a reference for <%= @candidate_name %>
 
 <%= @candidate_name %> put us in touch with you to get a reference for their teacher training application.
 

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Candidate requests a reference' do
   def and_an_email_is_sent_to_the_referee
     open_email(@reference.email_address)
     expect(current_email).to have_content "Dear #{@reference.name},"
-    expect(current_email).to have_content "Give a reference for #{@application_form.reload.full_name} as soon as possible"
+    expect(current_email).to have_content "Please give a reference for #{@application_form.reload.full_name}"
   end
 
   def when_i_have_added_a_second_reference


### PR DESCRIPTION
## Context

The language in our emails to referees is too blunt.

## Changes proposed in this pull request

Pending a more substantial review of our tone of voice in these emails, add ‘Please’ to the title. It costs nothing to be polite.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
