### PR TITLE
Fix email subject in phase banner feedback link

### DIFF
--- a/app/components/phase_banner.rb
+++ b/app/components/phase_banner.rb
@@ -1,5 +1,5 @@
 class PhaseBanner < ViewComponent::Base
-  DEFAULT_FEEDBACK_LINK = 'mailto:becomingateacher@digital.education.gov.uk?subject=Apply+feedback'.freeze
+  DEFAULT_FEEDBACK_LINK = 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Apply%20for%20teacher%20training'.freeze
 
   def initialize(no_border: false, feedback_link: nil)
     @no_border = no_border
@@ -13,7 +13,7 @@ class PhaseBanner < ViewComponent::Base
 
     case HostingEnvironment.environment_name
     when 'production'
-      "This is a new service - <a href='#{@feedback_link || DEFAULT_FEEDBACK_LINK}' class='govuk-link govuk-link--no-visited-state'>give feedback or report a problem</a>".html_safe
+      "This is a new service – <a href='#{@feedback_link || DEFAULT_FEEDBACK_LINK}' class='govuk-link govuk-link--no-visited-state'>give feedback or report a problem</a>".html_safe
     when 'qa'
       'This is the QA version of the Apply service'
     when 'staging'

--- a/spec/components/phase_banner_spec.rb
+++ b/spec/components/phase_banner_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PhaseBanner do
     it 'renders a feedback link' do
       result = render_inline(PhaseBanner.new)
 
-      expect(result.css('.govuk-link').attribute('href').value).to eq('mailto:becomingateacher@digital.education.gov.uk?subject=Apply+feedback')
+      expect(result.css('.govuk-link').attribute('href').value).to eq('mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Apply%20for%20teacher%20training')
     end
 
     specify 'the feedback link can be overridden' do


### PR DESCRIPTION
## Context

Find and Apply phase banners should ask for feedback the same way.

## Changes proposed in this pull request

While [updating the text in Find’s phase banner](https://github.com/DFE-Digital/find-teacher-training/pull/498), I noticed that we’re incorrectly escaping spaces in the subject line. This fixes that, and also updates the subject line from `Apply feedback` to `Feedback about Apply for teacher training`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/RjtSqW9k

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
