### PR TITLE
Fail Rspec test task if rspec process has errored.

### DIFF
--- a/azure/pipelines/templates/run-rspec-test.yml
+++ b/azure/pipelines/templates/run-rspec-test.yml
@@ -17,6 +17,12 @@ steps:
         then
           seedvalue=$(grep -Pio 'name="seed" value="\d+"' $testResultFile)
           echo "##[command]$seedvalue"
+          if [ $(grep "^<testsuite name=\"rspec\"" $testResultFile | cut -d' ' -f3 | cut -d'"' -f2) -eq 0 ]
+          then
+            ## tests="0" in the rspec results file; Rspec has errored and tests haven't run
+            echo "##vso[task.logissue type=error]Rspec exited abnormally"
+            exit 1
+          fi
           if [ $(grep "^<testsuite name=\"rspec\"" $testResultFile | cut -d' ' -f5 | cut -d'"' -f2) -gt 0 ]
           then
             echo "##vso[task.logissue type=error]One or more rspec tests failed"


### PR DESCRIPTION
Rspec test results xml will be empty if tests aren't run due to code errors.
<testsuite name="rspec" tests="0" skipped="0" failures="0" errors="0">

## Context

Rspec test run always exists with error code 0, and the test results are arrived by parsing for number of test failures in the xml files. 
So even in the case where rspec could fail because of a missing file the process exits with error code 0 but this case is not handled in the script which parses the rspec results xml file.

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1603725811094000

## Changes proposed in this pull request

Fail the rspec task if `tests="0"` in the rspec xml output.

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
