### PR TITLE
Expect differing data types for hesa disabilities

### DIFF
--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -82,7 +82,7 @@ module ProviderInterface
 
       {
         'sex' => application.application_form.equality_and_diversity['hesa_sex'] || 'not specified',
-        'disabilities' => (application.application_form.equality_and_diversity['hesa_disabilities'] || ['not specified']).join(' '),
+        'disabilities' => Array(application.application_form.equality_and_diversity.fetch('hesa_disabilities', 'not specified')).join(' '),
         'ethnicity' => application.application_form.equality_and_diversity['hesa_ethnicity'] || 'not specified',
       }
     end

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -76,5 +76,14 @@ RSpec.describe ProviderInterface::HesaDataExport do
       expect(row['disabilities']).to eq('53 55 54')
       expect(row['ethnicity']).to eq('15')
     end
+
+    context 'when hesa disabilities is stored as string' do
+      let(:hesa_disabilities) { '55' }
+
+      it 'exports this value' do
+        exported_data = CSV.parse(export_data, headers: true)
+        expect(exported_data.first['disabilities']).to eq('55')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

HESA disability codes are serialized as either a string for a single code or an array for multiple codes, the HESA export service did not expect this...

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Make the export service test a bit more readable.
- Allow for string or array data when exporting HESA disabilities.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

None - caught in product review.
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
