### PR TITLE
Temporary fix for UCAS matching page crashing

### DIFF
--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -12,7 +12,9 @@ class UCASMatch < ApplicationRecord
   def action_needed?
     return false if processed?
 
-    application_for_the_same_course_in_progress_on_both_services? || application_accepted_on_ucas_and_in_progress_on_apply? || application_accepted_on_apply_and_in_progress_on_ucas?
+    application_for_the_same_course_in_progress_on_both_services? ||
+      application_accepted_on_ucas_and_in_progress_on_apply? ||
+      application_accepted_on_apply_and_in_progress_on_ucas?
   end
 
 private
@@ -25,14 +27,18 @@ private
 
   def application_for_the_same_course_in_progress_on_both_services?
     application_for_the_same_course_on_both_services = ucas_matched_applications.select(&:both_scheme?)
-    application_for_the_same_course_on_both_services.map(&:application_in_progress_on_ucas?).any? && application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
+
+    application_for_the_same_course_on_both_services.map(&:application_in_progress_on_ucas?).any? &&
+      application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
   end
 
   def application_accepted_on_ucas_and_in_progress_on_apply?
-    ucas_matched_applications.map(&:application_accepted_on_ucas?).any? && ucas_matched_applications.map(&:application_in_progress_on_apply?).any?
+    ucas_matched_applications.map(&:application_accepted_on_ucas?).any? &&
+      ucas_matched_applications.map(&:application_in_progress_on_apply?).any?
   end
 
   def application_accepted_on_apply_and_in_progress_on_ucas?
-    ucas_matched_applications.map(&:application_accepted_on_apply?).any? && ucas_matched_applications.map(&:application_in_progress_on_ucas?).any?
+    ucas_matched_applications.map(&:application_accepted_on_apply?).any? &&
+      ucas_matched_applications.map(&:application_in_progress_on_ucas?).any?
   end
 end

--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -14,9 +14,6 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= render TagComponent.new(text: match.matching_state.humanize, type: match.processed? ? :green : :purple) %>
-          <% if match.action_needed?  %>
-            <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
-          <% end %>
         </td>
 
         <td class="govuk-table__cell">

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'See UCAS matches' do
   end
 
   def and_i_should_which_ucas_matches_need_action
-    expect(page).to have_content 'Matching data updated Action needed'
+    # expect(page).to have_content 'Matching data updated Action needed'
   end
 
   def when_i_follow_the_link_to_ucas_match_for_a_candidate


### PR DESCRIPTION
## Context

We can't figure out why the index page is crashing: https://sentry.io/organizations/dfe-bat/issues/1937345465

## Changes proposed in this pull request

Remove the offending code so the list will be visible, and we can find out why this is happening.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/XRWaVD60/2933-action-ucas-matches

