### PR TITLE
Increase OkComputer sidekiq retries threshold to 50

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -15,7 +15,7 @@ class SidekiqRetriesCheck < OkComputer::Check
   def check
     retries_queue_length = Sidekiq::RetrySet.new.size
     queue_length_text = " (#{retries_queue_length})"
-    if retries_queue_length > 10
+    if retries_queue_length > 50
       mark_failure
       mark_message "Sidekiq pending retries depth is high #{queue_length_text}. Suggests high error rate"
     else


### PR DESCRIPTION
## Context

We already have queue latency checks on `default` and `mailers` queues, so this sidekiq retries check will mostly detect high number of errors when pulling data from other services (Find, UCAS) (`low_priority` queue). We also used to have a single Sync with Find task, but now we trigger parallel per-provider syncs instead of one big task, so exceeding the limit has become very easy even with the tiniest network connectivity glitches. This causes too much noice. If there is something seriously wrong with Find Sync we have another check for that, too.

## Changes proposed in this pull request

Increase the threshold from 10 retries to 50. Production reached ~70 retries during the recent Postgresql maintanance window/outage.

## Guidance to review

Reasonable?

## Link to Trello card

No Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
