### PR TITLE
Refactor course availability logic in the course model 

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -112,7 +112,7 @@ module CandidateInterface
     end
 
     def study_mode_row(application_choice)
-      return unless application_choice.course.both_study_modes_available?
+      return unless application_choice.course.full_time_or_part_time?
 
       change_path = candidate_interface_course_choices_study_mode_path(
         application_choice.provider.id,

--- a/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/course_selection_controller.rb
@@ -35,7 +35,7 @@ module CandidateInterface
             @pick_course.provider_id,
             @pick_course.course_id,
           )
-        elsif @pick_course.both_study_modes_available?
+        elsif @pick_course.currently_has_both_study_modes_available?
           redirect_to candidate_interface_course_choices_study_mode_path(
             @pick_course.provider_id,
             @pick_course.course_id,

--- a/app/controllers/candidate_interface/find_course_selections_controller.rb
+++ b/app/controllers/candidate_interface/find_course_selections_controller.rb
@@ -22,7 +22,7 @@ module CandidateInterface
       if CourseOption.where(course_id: course.id).one?
         course_option = CourseOption.where(course_id: course.id).first
         pick_site_for_course(course, course_option.id)
-      elsif course.both_study_modes_available?
+      elsif course.currently_has_both_study_modes_available?
         redirect_to candidate_interface_course_choices_study_mode_path(
           provider_id: course.provider_id,
           course_id: course.id,

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -53,7 +53,7 @@ module CandidateInterface
       provider.courses.current_cycle
     end
 
-    delegate :both_study_modes_available?, to: :course
+    delegate :currently_has_both_study_modes_available?, to: :course
 
     delegate :study_mode, to: :course
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -91,11 +91,11 @@ class Course < ApplicationRecord
   end
 
   def supports_study_mode?(mode)
-    both_study_modes_available? || study_mode == mode
+    available_study_modes_from_options.include?(mode)
   end
 
   def available_study_modes_from_options
-    course_options.pluck(:study_mode).uniq
+    course_options.select(&:site_still_valid).pluck(:study_mode).uniq
   end
 
   def full?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -86,8 +86,8 @@ class Course < ApplicationRecord
     "#{provider.name} - #{name_and_code}"
   end
 
-  def both_study_modes_available?
-    study_mode == 'full_time_or_part_time'
+  def currently_has_both_study_modes_available?
+    available_study_modes_from_options.count == 2
   end
 
   def supports_study_mode?(mode)

--- a/app/services/find_sync/course_study_modes.rb
+++ b/app/services/find_sync/course_study_modes.rb
@@ -6,7 +6,7 @@ module FindSync
 
     def derive
       both_modes = %w[full_time part_time]
-      return both_modes if @course.both_study_modes_available?
+      return both_modes if @course.full_time_or_part_time?
 
       from_existing_course_options = @course.course_options.pluck(:study_mode).uniq
       (from_existing_course_options + [@course.study_mode]).uniq

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -363,6 +363,7 @@ FactoryBot.define do
     site { association(:site, provider: course.provider) }
 
     vacancy_status { 'vacancies' }
+    site_still_valid { true }
 
     trait :full_time do
       study_mode { :full_time }

--- a/spec/forms/candidate_interface/pick_course_form_spec.rb
+++ b/spec/forms/candidate_interface/pick_course_form_spec.rb
@@ -152,33 +152,4 @@ RSpec.describe CandidateInterface::PickCourseForm do
       expect(pick_course_form).not_to be_single_site
     end
   end
-
-  describe '#both_study_modes_available?' do
-    let(:provider) { create(:provider) }
-    let(:full_time_course) { create(:course, provider: provider) }
-    let(:part_time_course) do
-      create(:course, provider: provider, study_mode: :part_time)
-    end
-    let(:full_time_or_part_time_course) do
-      create(:course, provider: provider, study_mode: :full_time_or_part_time)
-    end
-
-    let(:form) { described_class.new(provider_id: provider.id) }
-
-    it 'returns false for a full time course' do
-      form.course_id = full_time_course.id
-      expect(form.both_study_modes_available?).to be false
-    end
-
-    it 'returns false for a part time course' do
-      form.course_id = part_time_course.id
-      expect(form.both_study_modes_available?).to be false
-    end
-
-    it 'returns true if both study modes are available' do
-      form.course_id = full_time_or_part_time_course.id
-
-      expect(form.both_study_modes_available?).to be true
-    end
-  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -8,17 +8,23 @@ RSpec.describe Course, type: :model do
     it { is_expected.to validate_uniqueness_of(:code).scoped_to(%i[recruitment_cycle_year provider_id]) }
   end
 
-  describe '#both_study_modes_available?' do
-    it 'is true when the study_mode value indicates both modes are available' do
-      course = build_stubbed(:course, study_mode: 'full_time_or_part_time')
-      expect(course.both_study_modes_available?).to be true
+  describe '#currently_has_both_study_modes_available?' do
+    it 'is true when a course has full time and part time course options' do
+      course_option1 = build_stubbed(:course_option, :full_time)
+      course_option2 = build_stubbed(:course_option, :part_time)
+      course = build_stubbed(:course, course_options: [course_option1, course_option2])
+
+      expect(course.currently_has_both_study_modes_available?).to be true
     end
 
-    it 'is false when the study_mode value is a specific mode' do
-      course = build_stubbed(:course, study_mode: 'full_time')
-      expect(course.both_study_modes_available?).to be false
-      course.study_mode = 'part_time'
-      expect(course.both_study_modes_available?).to be false
+    it 'is false when a course only has full time or part time course options' do
+      course_option1 = build_stubbed(:course_option, :full_time)
+      course_option2 = build_stubbed(:course_option, :part_time)
+      course1 = build_stubbed(:course, course_options: [course_option1])
+      course2 = build_stubbed(:course, course_options: [course_option2])
+
+      expect(course1.currently_has_both_study_modes_available?).to be false
+      expect(course2.currently_has_both_study_modes_available?).to be false
     end
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -22,6 +22,25 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe '#available_study_modes_from_options' do
+    it 'returns an array of unique study modes for a courses course options' do
+      course_option1 = build_stubbed(:course_option, :full_time)
+      course_option2 = build_stubbed(:course_option, :full_time)
+      course_option3 = build_stubbed(:course_option, :part_time)
+      course = build_stubbed(:course, course_options: [course_option1, course_option2, course_option3])
+
+      expect(course.available_study_modes_from_options).to eq [course_option1.study_mode, course_option3.study_mode]
+    end
+
+    it 'does not return course_options which have been invalidated by the SyncCoursesFromFind job' do
+      valid_course_option = build_stubbed(:course_option, :full_time)
+      invalid_course_option = build_stubbed(:course_option, :part_time, site_still_valid: false)
+      course = build_stubbed(:course, course_options: [valid_course_option, invalid_course_option])
+
+      expect(course.available_study_modes_from_options).to eq [valid_course_option.study_mode]
+    end
+  end
+
   describe '#full?' do
     subject(:course) { create(:course) }
 


### PR DESCRIPTION
## Context

There are two methods in the course model which deal with course option availability.

The `both_study_modes_available?` method checks if a course's study mode is `:full_time_or_part_time` and the `available_study_modes_from_options` which plucks it's associated course options study modes and uniques them.

This causes some undesirable behaviour. When the SyncProviderFromFind job runs, it invalidates course_options whose site has been deleted on find if they are not associated with an application. 

If they are associated with an application it sets the site_still_valid boolean on the course option to false.

With the current implementation, we do not check if the course options have been invalidated by find in the  `available_study_modes_from_options` method.

We also don't check to see if there are valid course_options for both study modes before passing them onto the select study mode page in the add course flow.

## Changes proposed in this pull request

Change the `available_study_modes_from_options` so it rejects course options which have `site_still_valid: false` before performing unique.

Change `both_study_modes_available?` so it only passes if `available_study_modes_from_options.count == 2`

## Guidance to review

Does this make sense? I don't think that for the most part using `study_mode == 'full_time_or_part_time'` makes sense for the add course flow, as it will continue to show invalidated course options. 

## Link to Trello card

https://trello.com/c/kxl26vEI/2416-course-availability-logic-is-confusing

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
