### PR TITLE
Create a new UCAS match for a new recruitment cycle year

### DIFF
--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -86,9 +86,10 @@ module UCASMatching
       existing_matches = 0
 
       candidates.each do |candidate_id, matching_data|
-        match = UCASMatch.find_or_initialize_by(candidate_id: candidate_id) do |ucas_match|
-          ucas_match.recruitment_cycle_year = RecruitmentCycle.current_year
-        end
+        match = UCASMatch.find_or_initialize_by(
+          candidate_id: candidate_id,
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        )
         match.matching_data = matching_data
 
         if match.matching_data_changed?


### PR DESCRIPTION
## Context

In a situation when a candidate had dual applications in multiple
recruitment cycles we don't want to update the same record.

## Changes proposed in this pull request

Create a new record for a candidate in the new cycle

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
