### PR TITLE
Add email for reinstated deffered offer

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -224,6 +224,17 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def reinstated_offer(application_choice)
+    @application_choice = application_choice
+    @course_option = @application_choice.offered_option
+    @conditions = @application_choice.offer&.dig('conditions') || []
+
+    email_for_candidate(
+      @application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.reinstated_offer.subject'),
+    )
+  end
+
   def withdraw_last_application_choice(application_form)
     @withdrawn_courses = application_form.application_choices.select(&:withdrawn?)
     @withdrawn_course_names = @withdrawn_courses.map { |application_choice| "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}" }

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -24,6 +24,7 @@ class ReinstateConditionsMet
         ApplicationStateChange.new(application_choice).reinstate_conditions_met!
         application_choice.update(attrs)
         StateChangeNotifier.call(:reinstate_offer_conditions_met, application_choice: application_choice)
+        CandidateMailer.reinstated_offer(application_choice).deliver_later
       end
     end
   rescue Workflow::NoTransitionAllowed

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -24,6 +24,7 @@ class ReinstatePendingConditions
           recruited_at: nil,
         )
         StateChangeNotifier.call(:reinstate_offer_pending_conditions, application_choice: application_choice)
+        CandidateMailer.reinstated_offer(application_choice).deliver_later
       end
     end
   rescue Workflow::NoTransitionAllowed

--- a/app/views/candidate_mailer/_offer_conditions.text.erb
+++ b/app/views/candidate_mailer/_offer_conditions.text.erb
@@ -1,0 +1,5 @@
+The provider has set the following <%= 'condition'.pluralize(@conditions.count) %>:
+
+<% @conditions.each do |condition| %>
+  - <%= condition %>
+<% end %>

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -4,11 +4,7 @@ Dear <%= @application_form.first_name %>,
 
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
-The provider has set the following condition(s):
-
-<% @conditions.each do |condition| %>
-  - <%= condition %>
-<% end %>
+<%= render "candidate_mailer/offer_conditions" %>
 
 Contact <%= @provider_name %> if you have any questions about this.
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -4,11 +4,7 @@ Dear <%= @application_form.first_name %>,
 
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
-The provider has set the following condition(s):
-
-<% @conditions.each do |condition| %>
-  - <%= condition %>
-<% end %>
+<%= render "candidate_mailer/offer_conditions" %>
 
 Contact <%= @provider_name %> if you have any questions about this.
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -4,11 +4,7 @@ Dear <%= @application_form.first_name %>,
 
 You have an offer from <%= @provider_name %> to study <%= @course_name %>.
 
-The provider has set the following condition(s):
-
-<% @conditions.each do |condition| %>
-  - <%= condition %>
-<% end %>
+<%= render "candidate_mailer/offer_conditions" %>
 
 Contact <%= @provider_name %> if you have any questions about this.
 

--- a/app/views/candidate_mailer/reinstated_offer.text.erb
+++ b/app/views/candidate_mailer/reinstated_offer.text.erb
@@ -1,0 +1,19 @@
+Dear <%= @application_form.first_name %>,
+
+# You’re due to take up your deferred offer
+
+You have an offer from <%= @course_option.course.provider.name %> to study <%= @course_option.course.name_and_code %> in <%= @course_option.course.start_date.to_s(:month_and_year) %>. This was deferred from last year (<%= @application_choice.offer_deferred_at.to_s(:month_and_year) %>).
+
+<% if @conditions.any? %>
+  <%= render "candidate_mailer/offer_conditions" %>
+<% else %>
+  There are no conditions for this offer.
+<% end %>
+
+# Next steps
+
+You can see further details of the offer by signing in to your account:
+
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
+
+If you have any questions about the offer, contact us at becomingateacher@digital.education.gov.uk. You can contact us at the same address with any other questions or feedback.

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -395,11 +395,15 @@ en:
       name: Provider reinstates deferred offer and conditions are still valid
       by: provider
       description: ""
+      emails:
+        - candidate_mailer-reinstated_offer
 
     offer_deferred-reinstate_pending_conditions:
       name: Provider reinstates deferred offer but conditions changed or are no longer valid
       by: provider
       description: ""
+      emails:
+        - candidate_mailer-reinstated_offer
 
     offer_deferred-withdraw:
       name: Withdraw

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -64,6 +64,8 @@ en:
       subject: "Offer changed by %{provider_name}"
     deferred_offer:
       subject: "%{provider_name} has deferred your offer"
+    reinstated_offer:
+      subject: "You’re due to take up your deferred offer"
     apply_again_call_to_action:
       subject: You can still apply for teacher training
     course_unavailable_notification:

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -363,6 +363,29 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.deferred_offer(application_form.application_choices.first)
   end
 
+  def reinstated_offer_with_conditions
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      :with_accepted_offer,
+      application_form: application_form,
+      course_option: course_option,
+      offer_deferred_at: Time.zone.local(2019, 10, 14),
+    )
+    CandidateMailer.reinstated_offer(application_choice)
+  end
+
+  def reinstated_offer_without_condidtions
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      :with_recruited,
+      application_form: application_form,
+      course_option: course_option,
+      offer: { 'conditions' => [] },
+      offer_deferred_at: Time.zone.local(2019, 10, 14),
+    )
+    CandidateMailer.reinstated_offer(application_choice)
+  end
+
 private
 
   def candidate


### PR DESCRIPTION
## Context
When a provider reinstates a deferred offer, no email is sent saying as much. This adds the relevant email

## Changes proposed in this pull request
Send a reinstated deferred offer email when a provider does this.

![image](https://user-images.githubusercontent.com/30071178/97445508-3d6d7500-1925-11eb-883b-4fdcbc86be77.png)


## Guidance to review
Are these emails documented correctly? I've added the preview, and the event they are sent on to the yml.

## Link to Trello card
https://trello.com/c/2FdZQ2SY/2854-dev-deferral-email-notifications
This work is only 1/3 of the stuff to do on this ticket, so more PRs on the way!

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
