### PR TITLE
Track validation errors for decoupled references

### DIFF
--- a/app/controllers/candidate_interface/decoupled_references/candidate_name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/candidate_name_controller.rb
@@ -13,12 +13,15 @@ module CandidateInterface
           first_name: first_name_param,
           last_name: last_name_param,
         )
-        return render :new unless @reference_candidate_name_form.valid?
 
-        @reference_candidate_name_form.save(@reference)
+        if @reference_candidate_name_form.save(@reference)
+          CandidateInterface::DecoupledReferences::RequestReference.new.call(@reference, flash)
 
-        CandidateInterface::DecoupledReferences::RequestReference.new.call(@reference, flash)
-        redirect_to candidate_interface_decoupled_references_review_path
+          redirect_to candidate_interface_decoupled_references_review_path
+        else
+          track_validation_error(@reference_candidate_name_form)
+          render :new
+        end
       end
 
     private

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -9,11 +9,13 @@ module CandidateInterface
 
       def create
         @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
-        return render :new unless @reference_email_address_form.valid?
 
-        @reference_email_address_form.save(@reference)
-
-        redirect_to candidate_interface_decoupled_references_relationship_path(@reference.id)
+        if @reference_email_address_form.save(@reference)
+          redirect_to candidate_interface_decoupled_references_relationship_path(@reference.id)
+        else
+          track_validation_error(@reference_email_address_form)
+          render :new
+        end
       end
 
       def edit
@@ -22,14 +24,16 @@ module CandidateInterface
 
       def update
         @reference_email_address_form = Reference::RefereeEmailAddressForm.new(referee_email_address_param)
-        return render :edit unless @reference_email_address_form.valid?
 
-        @reference_email_address_form.save(@reference)
-
-        if return_to_path.present?
-          redirect_to return_to_path
+        if @reference_email_address_form.save(@reference)
+          if return_to_path.present?
+            redirect_to return_to_path
+          else
+            redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          end
         else
-          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          track_validation_error(@reference_email_address_form)
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/decoupled_references/name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/name_controller.rb
@@ -9,11 +9,13 @@ module CandidateInterface
 
       def create
         @reference_name_form = Reference::RefereeNameForm.new(referee_name_param)
-        return render :new unless @reference_name_form.valid?
 
-        @reference_name_form.save(@reference)
-
-        redirect_to candidate_interface_decoupled_references_email_address_path(@reference.id)
+        if @reference_name_form.save(@reference)
+          redirect_to candidate_interface_decoupled_references_email_address_path(@reference.id)
+        else
+          track_validation_error(@reference_name_form)
+          render :new
+        end
       end
 
       def edit
@@ -22,14 +24,16 @@ module CandidateInterface
 
       def update
         @reference_name_form = Reference::RefereeNameForm.new(referee_name_param)
-        return render :edit unless @reference_name_form.valid?
 
-        @reference_name_form.save(@reference)
-
-        if return_to_path.present?
-          redirect_to return_to_path
+        if @reference_name_form.save(@reference)
+          if return_to_path.present?
+            redirect_to return_to_path
+          else
+            redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          end
         else
-          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          track_validation_error(@reference_name_form)
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
@@ -9,11 +9,13 @@ module CandidateInterface
 
       def create
         @references_relationship_form = Reference::RefereeRelationshipForm.new(references_relationship_params)
-        return render :new unless @references_relationship_form.valid?
 
-        @references_relationship_form.save(@reference)
-
-        redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        if @references_relationship_form.save(@reference)
+          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+        else
+          track_validation_error(@references_relationship_form)
+          render :new
+        end
       end
 
       def edit
@@ -22,14 +24,16 @@ module CandidateInterface
 
       def update
         @references_relationship_form = Reference::RefereeRelationshipForm.new(references_relationship_params)
-        return render :edit unless @references_relationship_form.valid?
 
-        @references_relationship_form.save(@reference)
-
-        if return_to_path.present?
-          redirect_to return_to_path
+        if @references_relationship_form.save(@reference)
+          if return_to_path.present?
+            redirect_to return_to_path
+          else
+            redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          end
         else
-          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          track_validation_error(@references_relationship_formsss)
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -16,17 +16,21 @@ module CandidateInterface
 
       def submit
         @submit_reference_form = Reference::SubmitRefereeForm.new(submit: submit_param, reference_id: @reference.id)
-        return render :unsubmitted unless @submit_reference_form.valid?
 
-        @candidate_name_form = Reference::CandidateNameForm.build_from_reference(@reference)
+        if @submit_reference_form.valid?
+          @candidate_name_form = Reference::CandidateNameForm.build_from_reference(@reference)
 
-        if @submit_reference_form.send_request? && !@candidate_name_form.valid?
-          redirect_to candidate_interface_decoupled_references_new_candidate_name_path(@reference.id)
-        elsif @submit_reference_form.send_request?
-          CandidateInterface::DecoupledReferences::RequestReference.new.call(@reference, flash)
-          redirect_to candidate_interface_decoupled_references_review_path
+          if @submit_reference_form.send_request? && !@candidate_name_form.valid?
+            redirect_to candidate_interface_decoupled_references_new_candidate_name_path(@reference.id)
+          elsif @submit_reference_form.send_request?
+            CandidateInterface::DecoupledReferences::RequestReference.new.call(@reference, flash)
+            redirect_to candidate_interface_decoupled_references_review_path
+          else
+            redirect_to candidate_interface_decoupled_references_review_path
+          end
         else
-          redirect_to candidate_interface_decoupled_references_review_path
+          track_validation_error(@submit_reference_form)
+          render :unsubmitted
         end
       end
 

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -9,11 +9,13 @@ module CandidateInterface
 
       def create
         @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
-        return render :new unless @reference_type_form.valid?
 
-        @reference_type_form.save(current_application)
-
-        redirect_to candidate_interface_decoupled_references_name_path(current_application.application_references.last.id)
+        if @reference_type_form.save(current_application)
+          redirect_to candidate_interface_decoupled_references_name_path(current_application.application_references.last.id)
+        else
+          track_validation_error(@reference_type_form)
+          render :new
+        end
       end
 
       def edit
@@ -22,14 +24,16 @@ module CandidateInterface
 
       def update
         @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
-        return render :edit unless @reference_type_form.valid?
 
-        @reference_type_form.update(@reference)
-
-        if return_to_path.present?
-          redirect_to return_to_path
+        if @reference_type_form.update(@reference)
+          if return_to_path.present?
+            redirect_to return_to_path
+          else
+            redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          end
         else
-          redirect_to candidate_interface_decoupled_references_review_unsubmitted_path(@reference.id)
+          track_validation_error(@reference_type_form)
+          render :edit
         end
       end
 

--- a/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_adds_a_new_reference_spec.rb
@@ -15,31 +15,39 @@ RSpec.feature 'Decoupled references' do
     when_i_click_continue
     then_i_see_the_type_page
 
+    when_i_click_save_and_continue_without_providing_a_type
+    then_i_should_be_told_to_provide_a_type
+    and_a_validation_error_is_logged_for_type
+
     when_i_select_academic
     and_i_click_save_and_continue
     then_i_should_see_the_referee_name_page
 
     when_i_click_save_and_continue_without_providing_a_name
     then_i_should_be_told_to_provide_a_name
+    and_a_validation_error_is_logged_for_name
 
     when_i_fill_in_my_references_name
     and_i_click_save_and_continue
 
     when_i_click_save_and_continue_without_providing_an_emailing
     then_i_should_be_told_to_provide_an_email_address
+    and_a_validation_error_is_logged_for_blank_email_address
 
     when_i_provide_an_email_address_with_an_invalid_format
     and_i_click_save_and_continue
     then_i_am_told_my_email_address_needs_a_valid_format
+    and_a_validation_error_is_logged_for_invalid_email_address
 
     when_i_provide_a_valid_email_address
     and_i_click_save_and_continue
-    then_i_see_the_description_page
+    then_i_see_the_relationship_page
 
-    when_i_click_save_and_continue_without_providing_a_description
-    then_i_should_be_told_to_provide_a_description
+    when_i_click_save_and_continue_without_providing_a_relationship
+    then_i_should_be_told_to_provide_a_relationship
+    and_a_validation_error_is_logged_for_relationship
 
-    when_i_fill_in_my_references_description
+    when_i_fill_in_my_references_relationship
     and_i_click_save_and_continue
     then_i_should_see_the_review_unsubmitted_page
     and_i_should_see_my_references_details
@@ -112,6 +120,18 @@ RSpec.feature 'Decoupled references' do
     expect(page).to have_current_path candidate_interface_decoupled_references_type_path
   end
 
+  def when_i_click_save_and_continue_without_providing_a_type
+    and_i_click_save_and_continue
+  end
+
+  def then_i_should_be_told_to_provide_a_type
+    expect(page).to have_content 'Choose a type of referee'
+  end
+
+  def and_a_validation_error_is_logged_for_type
+    expect(ValidationError.count).to be 1
+  end
+
   def when_i_select_academic
     choose 'Academic'
   end
@@ -132,6 +152,10 @@ RSpec.feature 'Decoupled references' do
     expect(page).to have_content 'Enter your referee’s name'
   end
 
+  def and_a_validation_error_is_logged_for_name
+    expect(ValidationError.count).to be 2
+  end
+
   def when_i_fill_in_my_references_name
     fill_in 'candidate-interface-reference-referee-name-form-name-field-error', with: 'Walter White'
   end
@@ -148,6 +172,10 @@ RSpec.feature 'Decoupled references' do
     expect(page).to have_content 'Enter your referee’s email address'
   end
 
+  def and_a_validation_error_is_logged_for_blank_email_address
+    expect(ValidationError.count).to be 3
+  end
+
   def when_i_provide_an_email_address_with_an_invalid_format
     fill_in 'candidate-interface-reference-referee-email-address-form-email-address-field-error', with: 'invalid.email.address'
   end
@@ -156,23 +184,31 @@ RSpec.feature 'Decoupled references' do
     expect(page).to have_content 'Enter an email address in the correct format, like name@example.com'
   end
 
+  def and_a_validation_error_is_logged_for_invalid_email_address
+    expect(ValidationError.count).to be 4
+  end
+
   def when_i_provide_a_valid_email_address
     fill_in 'candidate-interface-reference-referee-email-address-form-email-address-field-error', with: 'iamtheone@whoknocks.com'
   end
 
-  def then_i_see_the_description_page
+  def then_i_see_the_relationship_page
     expect(page).to have_current_path candidate_interface_decoupled_references_relationship_path(@application.application_references.last.id)
   end
 
-  def when_i_click_save_and_continue_without_providing_a_description
+  def when_i_click_save_and_continue_without_providing_a_relationship
     and_i_click_save_and_continue
   end
 
-  def then_i_should_be_told_to_provide_a_description
+  def then_i_should_be_told_to_provide_a_relationship
     expect(page).to have_content 'Enter how you know this referee and for how long'
   end
 
-  def when_i_fill_in_my_references_description
+  def and_a_validation_error_is_logged_for_relationship
+    expect(ValidationError.count).to be 5
+  end
+
+  def when_i_fill_in_my_references_relationship
     fill_in 'candidate-interface-reference-referee-relationship-form-relationship-field-error', with: 'Through nefarious behaviour.'
   end
 


### PR DESCRIPTION
## Context

The rest of the application form tracks validation errors. 

This should have been built into the flow (my fault).

## Changes proposed in this pull request

- Adds validation error tracking to all controllers that use Forms
- Updates the system spec to show they're being tracked

## Link to Trello card

https://trello.com/c/mIUgBACD/2377-%F0%9F%92%94-decoupled-references-theres-no-validation-error-tracking-for-the-decoupled-references-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
