### PR TITLE
Add 'Action needed' tag back to UCAS matches page

### DIFF
--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -14,6 +14,9 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= render TagComponent.new(text: match.matching_state.humanize, type: match.processed? ? :green : :purple) %>
+          <% if match.action_needed?  %>
+            <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
+          <% end %>
         </td>
 
         <td class="govuk-table__cell">

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'See UCAS matches' do
   end
 
   def and_i_should_which_ucas_matches_need_action
-    # expect(page).to have_content 'Matching data updated Action needed'
+    expect(page).to have_content 'Matching data updated Action needed'
   end
 
   def when_i_follow_the_link_to_ucas_match_for_a_candidate


### PR DESCRIPTION
## Context

This was temporarily removed as the UCAS matches page was crashing. We manually
resolved matches `205`, `206` by updating recruitment_cycle_year and `161` by
splitting the date into two matches one for each cycle (`161` and `247`).

UCAS only sends us data for matched application in the current recruitment cycle
year so when we create UCASMatches we record current recruitment cycle year.
However when our download broke the had some outstanding matches for 2020 cycle
year which were incorrectly assigned as 2021.  For this reason we were not able
to find correct application choices to determine the status of candidates
application which broke the “Action needed” logic.

Tested all individual matches and they seem to work so 🤞 
We also have a way of handing it in the future #3270 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
