### PR TITLE
Add invariant check for weird reference state

### DIFF
--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DetectInvariants do
   before { allow(Raven).to receive(:capture_exception) }
 
   describe '#perform' do
-    it 'detects weird references state' do
+    it 'detects application choices in deprecated states' do
       application_choice_bad = create(:application_choice)
       application_choice_bad.update_columns(status: 'application_complete')
       application_choice_bad_too = create(:application_choice)
@@ -20,6 +20,32 @@ RSpec.describe DetectInvariants do
 
             #{application_choice_bad.id}
             #{application_choice_bad_too.id}
+          MSG
+        ),
+      )
+    end
+
+    it 'detects outstanding references on submitted applications' do
+      weird_application_form = create(:completed_application_form)
+      create(:submitted_application_choice, application_form: weird_application_form)
+      create(:reference, :feedback_requested, application_form: weird_application_form)
+      create(:reference, :feedback_provided, application_form: weird_application_form)
+
+      # Two further applications with no reference weirdness
+      ok_form_one = create(:completed_application_form)
+      create(:submitted_application_choice, application_form: ok_form_one)
+      create(:reference, :feedback_provided, application_form: ok_form_one)
+      ok_form_two = create(:application_form)
+      create(:reference, :feedback_requested, application_form: ok_form_two)
+
+      DetectInvariants.new.perform
+
+      expect(Raven).to have_received(:capture_exception).with(
+        DetectInvariants::WeirdSituationDetected.new(
+          <<~MSG,
+            One or more references are still pending on these applications,
+            even though they've already been submitted:
+            #{weird_application_form.id}
           MSG
         ),
       )


### PR DESCRIPTION




## Context
An important property of the system is that submitted application forms
not have any outstanding reference requests. Such a state could lead to
unexpected reference chase emails being sent, or a bad user experience
if a referee tries to provide a reference when it's no longer needed.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
This invariant check looks for this state in the database and sends a
message to Sentry with the ids of any applications it finds.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Does the SQL query look right?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/qSOCkAhQ
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
