### PR TITLE
Filter more Sentry errors

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -2,12 +2,33 @@ Raven.configure do |config|
   config.silence_ready = true
   config.current_environment = HostingEnvironment.environment_name
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.inspect_exception_causes_for_exclusion = true
+
   config.excluded_exceptions += [
+    # The following exceptions are user-errors that aren't actionable, and can be
+    # safely ignored.
     'ActionController::BadRequest',
     'ActionController::UnknownFormat',
     'ActionController::UnknownHttpMethod',
     'ActionDispatch::Http::Parameters::ParseError',
-    'Redis::CannotConnectError',
+    'Mime::Type::InvalidMimeType',
+
+    # Errors in the Find sync are often transient errors with the Find API. We
+    # have monitoring in place to make sure the sync succeeds every couple of
+    # hours, so we don't need to be notified of individual failures.
     'FindSync::SyncError',
+
+    # These Postgres errors often occur when Azure has maintenance and drops
+    # connections. Most of the time they aren't actionable. We are able to filter
+    # them because our smoke tests and healthchecks will alert on persistent
+    # database issues.
+    'PG::ConnectionBad',
+    'PG::UnableToSend',
+    'PG::QueryCanceled',
+
+    # Similarly, errors in Redis don't provide us with actionable information
+    # in Sentry.
+    'Redis::TimeoutError',
+    'Redis::CannotConnectError',
   ]
 end


### PR DESCRIPTION
## Context

We get too many unactionable Sentry notifications in Slack, which means we ignore the ones that are important.  

## Changes proposed in this pull request

See comments for explanation.

## Guidance to review

I'm mostly looking to cut down on database errors:

<img width="1134" alt="Screenshot 2020-10-29 at 08 46 36" src="https://user-images.githubusercontent.com/233676/97546459-6264f500-19c4-11eb-968c-01dadcc3398b.png">

Note that these errors are re-raised by Rails as `ActiveRecord::StatementInvalid`. We _don't_ want to filter out those, because that would possibly also filter exceptions that are very relevant. Therefore we filter on the cause as well (see https://github.com/getsentry/sentry-ruby/issues/765 for some in-depth nerdery on this). 

## Link to Trello card

https://trello.com/c/H8ePHFGv
