### PR TITLE
Temporarily remove Action needed from UCAS matches

### DIFF
--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -14,9 +14,6 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= render TagComponent.new(text: match.matching_state.humanize, type: match.processed? ? :green : :purple) %>
-          <% if match.action_needed?  %>
-            <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
-          <% end %>
         </td>
 
         <td class="govuk-table__cell">

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'See UCAS matches' do
 
     when_i_go_to_ucas_matches_page
     then_i_should_see_list_of_ucas_matches
-    and_i_should_which_ucas_matches_need_action
+    # and_i_should_see_which_ucas_matches_need_action
 
     when_i_follow_the_link_to_ucas_match_for_a_candidate
     then_i_should_see_ucas_match_summary
@@ -63,7 +63,7 @@ RSpec.feature 'See UCAS matches' do
     expect(page).to have_content @candidate.email_address
   end
 
-  def and_i_should_which_ucas_matches_need_action
+  def and_i_should_see_which_ucas_matches_need_action
     expect(page).to have_content 'Matching data updated Action needed'
   end
 


### PR DESCRIPTION
## Context

Temporarily remove Action needed from UCAS matches as it's causing an error:
https://sentry.io/organizations/dfe-bat/issues/1937345465/?project=1765973

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
