### PR TITLE
Additions to the performance dashboard

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -65,7 +65,10 @@ class PerformanceStatistics
   end
 
   def [](key)
-    candidate_status_counts.find { |x| x['status'] == key.to_s }&.[]('count')
+    candidate_status_counts
+      .select { |x| x['status'] == key.to_s }
+      .map { |row| row['count'] }
+      .sum
   end
 
   def total_candidate_count(only: nil, except: [], phase: nil)
@@ -82,6 +85,12 @@ class PerformanceStatistics
       .connection
       .execute(candidate_query)
       .to_a
+  end
+
+  def candidate_status_total_counts
+    candidate_status_counts.group_by { |row| row['status'] }.map do |status, rows|
+      { 'status' => status, 'count' => rows.map { |r| r['count'] }.sum }
+    end
   end
 
   def total_submitted_count

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -73,7 +73,7 @@ class PerformanceStatistics
   def total_candidate_count(only: nil, except: [], phase: nil)
     candidate_status_counts
       .select { |row| only.nil? || row['status'].to_sym.in?(only) }
-      .select { |row| phase.nil? || row['phase'].to_sym == phase.to_sym }
+      .select { |row| phase.nil? || row['phase']&.to_sym == phase.to_sym }
       .reject { |row| row['status'].to_sym.in?(except) }
       .map { |row| row['count'] }
       .sum

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -73,7 +73,7 @@ class PerformanceStatistics
   def total_candidate_count(only: nil, except: [], phase: nil)
     candidate_status_counts
       .select { |row| only.nil? || row['status'].to_sym.in?(only) }
-      .select { |row| phase.nil? ||  row['phase'].to_sym == phase.to_sym}
+      .select { |row| phase.nil? || row['phase'].to_sym == phase.to_sym }
       .reject { |row| row['status'].to_sym.in?(except) }
       .map { |row| row['count'] }
       .sum
@@ -119,7 +119,7 @@ class PerformanceStatistics
         .where('application_choices.status': 'rejected', 'application_choices.rejected_by_default': true)
         .distinct
       scope = scope.where('application_forms.recruitment_cycle_year': year) if year.present?
-      scope.count    
+      scope.count
     end
   end
 

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -124,9 +124,11 @@ class PerformanceStatistics
   end
 
   def percentage_of_providers_onboarded
-    @percentage_of_providers_onboarded ||= begin
-      counts = Provider.group(:sync_courses).count
-      "#{((counts[true] * 100).to_f / (counts[true] + counts[false])).round}%"
-    end
+    @percentage_of_providers_onboarded ||=
+      begin
+        total_count = Provider.count
+        onboarded_count = Provider.joins(:courses).where('courses.open_on_apply': true).distinct.count
+        "#{((onboarded_count * 100).to_f / total_count).round}%"
+      end
   end
 end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -127,8 +127,12 @@ class PerformanceStatistics
     @percentage_of_providers_onboarded ||=
       begin
         total_count = Provider.count
-        onboarded_count = Provider.joins(:courses).where('courses.open_on_apply': true).distinct.count
-        "#{((onboarded_count * 100).to_f / total_count).round}%"
+        if total_count > 0
+          onboarded_count = Provider.joins(:courses).where('courses.open_on_apply': true).distinct.count
+          "#{((onboarded_count * 100).to_f / total_count).round}%"
+        else
+          '-'
+        end
       end
   end
 end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -120,7 +120,7 @@ class PerformanceStatistics
   def percentage_of_providers_onboarded
     @percentage_of_providers_onboarded ||= begin
       counts = Provider.group(:sync_courses).count
-      "#{(counts[true] * 100) / (counts[true] + counts[false])}%"
+      "#{((counts[true] * 100).to_f / (counts[true] + counts[false])).round}%"
     end
   end
 end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -127,7 +127,7 @@ class PerformanceStatistics
     @percentage_of_providers_onboarded ||=
       begin
         total_count = Provider.count
-        if total_count > 0
+        if total_count.positive?
           onboarded_count = Provider.joins(:courses).where('courses.open_on_apply': true).distinct.count
           "#{((onboarded_count * 100).to_f / total_count).round}%"
         else

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -13,6 +13,7 @@ class PerformanceStatistics
           SELECT
               c.id,
               f.id,
+              f.phase,
               COUNT(f.id) FILTER (WHERE f.id IS NOT NULL) application_forms,
               COUNT(ch.id) FILTER (WHERE f.id IS NOT NULL) application_choices,
               CASE
@@ -24,6 +25,7 @@ class PerformanceStatistics
                 WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['8', 'recruited']
                 WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'pending_conditions']
                 WHEN 'offer_deferred' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['10', 'offer_deferred']
+                WHEN 'rejected' = ANY(ARRAY_AGG(ch.status)) AND true = ANY(ARRAY_AGG(ch.rejected_by_default)) THEN ARRAY['11', 'rejected_by_default']
                 WHEN #{ended_without_success_sql} = '{}' THEN ARRAY['5', 'ended_without_success']
                 ELSE ARRAY['10', 'unknown_state']
               END status
@@ -37,15 +39,16 @@ class PerformanceStatistics
               NOT c.hide_in_reporting
               #{year_clause}
           GROUP BY
-              c.id, f.id
+              c.id, f.id, f.phase
       )
       SELECT
           raw_data.status[2],
+          raw_data.phase,
           COUNT(*)
       FROM
           raw_data
       GROUP BY
-          raw_data.status
+          raw_data.status, raw_data.phase
       ORDER BY
           raw_data.status[1]
     SQL
@@ -65,12 +68,13 @@ class PerformanceStatistics
     candidate_status_counts.find { |x| x['status'] == key.to_s }&.[]('count')
   end
 
-  def total_candidate_count(only: nil, except: [])
+  def total_candidate_count(only: nil, except: [], phase: nil)
     candidate_status_counts
-     .select { |row| only.nil? || row['status'].to_sym.in?(only) }
-     .reject { |row| row['status'].to_sym.in?(except) }
-     .map { |row| row['count'] }
-     .sum
+      .select { |row| only.nil? || row['status'].to_sym.in?(only) }
+      .select { |row| phase.nil? ||  row['phase'].to_sym == phase.to_sym}
+      .reject { |row| row['status'].to_sym.in?(except) }
+      .map { |row| row['count'] }
+      .sum
   end
 
   def candidate_status_counts
@@ -84,11 +88,30 @@ class PerformanceStatistics
     total_candidate_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress])
   end
 
+  def apply_again_submitted_count
+    total_candidate_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress], phase: :apply_2)
+  end
+
   def ended_without_success_count
-    total_candidate_count(only: %i[ended_without_success])
+    total_candidate_count(only: %i[rejected_by_default ended_without_success])
   end
 
   def accepted_offer_count
     total_candidate_count(only: %i[pending_conditions recruited offer_deferred])
+  end
+
+  def apply_again_accepted_offer_count
+    total_candidate_count(only: %i[pending_conditions recruited offer_deferred], phase: :apply_2)
+  end
+
+  def rejected_by_default_count
+    total_candidate_count(only: %i[rejected_by_default])
+  end
+
+  def percentage_of_providers_onboarded
+    @percentage_of_providers_onboarded ||= begin
+      counts = Provider.group(:sync_courses).count
+      "#{(counts[true] * 100) / (counts[true] + counts[false])}%"
+    end
   end
 end

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -65,29 +65,6 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.apply_again_submitted_count, label: 'apply again submitted', size: :reduced) %>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.apply_again_accepted_offer_count, label: 'accepted an offer (apply again)', size: :reduced, colour: :green) %>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.percentage_of_providers_onboarded, label: 'providers onboarded', size: :reduced) %>
-      </div>
-    </div>
-  </div>
-  <div class="govuk-grid-column-one-half">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.rejected_by_default_count, label: 'rejected by default', size: :reduced) %>
-      </div>
-    </div>
-  </div>
-</div>
-
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 <table class="govuk-table">
@@ -108,6 +85,32 @@
         <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
       </tr>
     <% end %>
+  </tbody>
+</table>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-heading-m">Other metrics</caption>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Apply again submitted</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.apply_again_submitted_count %></td>
+      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.apply_again_submitted.description") %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Apply again accepted offer</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.apply_again_accepted_offer_count %></td>
+      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.apply_again_accepted_offer.description") %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Providers onboarded</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.percentage_of_providers_onboarded %></td>
+      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.percentage_of_providers_onboarded.description") %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Rejected by default</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.rejected_by_default_count %></td>
+      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.rejected_by_default.description") %></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -20,7 +20,7 @@
   <h2 class="govuk-visually-hidden">Performance for <%= params[:year] || "all years" %></h2>
 <% end %>
 
-<h3 class="govuk-heading-m">Candidates</h3>
+<h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Candidates</h3>
 
 <div id="headline-stat" class="govuk-!-margin-bottom-4">
   <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count, label: 'sign ups (excluding test users)', colour: :blue) %>
@@ -65,15 +65,13 @@
   </div>
 </div>
 
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-<table class="govuk-table">
+<table class="govuk-table govuk-!-margin-top-8">
   <caption class="govuk-table__caption govuk-heading-m">Candidate breakdown</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
       <th scope="col" class="govuk-table__header govuk-table__header--numeric">Count</th>
-      <th scope="col" class="govuk-table__header">Description</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Description</th>
     </tr>
   </thead>
 
@@ -85,31 +83,38 @@
         <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
       </tr>
     <% end %>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Rejected by default</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.rejected_by_default_count %></td>
+      <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t("performance_dashboard_other_metrics.rejected_by_default.description") %></td>
+    </tr>
   </tbody>
 </table>
 
-<table class="govuk-table">
-  <caption class="govuk-table__caption govuk-heading-m">Other metrics</caption>
+<table class="govuk-table govuk-!-margin-top-8">
+  <caption class="govuk-table__caption govuk-heading-m">Apply again</caption>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Apply again submitted</th>
+      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Awaiting decision from provider</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.apply_again_submitted_count %></td>
-      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.apply_again_submitted.description") %></td>
+      <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t("performance_dashboard_other_metrics.apply_again_submitted.description") %></td>
     </tr>
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Apply again accepted offer</th>
+      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Accepted offer, pending conditions</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.apply_again_accepted_offer_count %></td>
-      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.apply_again_accepted_offer.description") %></td>
+      <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t("performance_dashboard_other_metrics.apply_again_accepted_offer.description") %></td>
     </tr>
+  </tbody>
+</table>
+
+<h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Providers</h3>
+
+<table class="govuk-table">
+  <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Providers onboarded</th>
+      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Providers onboarded</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.percentage_of_providers_onboarded %></td>
-      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.percentage_of_providers_onboarded.description") %></td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Rejected by default</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.rejected_by_default_count %></td>
-      <td class="govuk-table__cell"><%= t("performance_dashboard_other_metrics.rejected_by_default.description") %></td>
+      <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t("performance_dashboard_other_metrics.percentage_of_providers_onboarded.description") %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -101,7 +101,7 @@
   </thead>
 
   <tbody class="govuk-table__body">
-    <% @statistics.candidate_status_counts.each do |row| %>
+    <% @statistics.candidate_status_total_counts.each do |row| %>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -35,7 +35,7 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
@@ -49,6 +49,7 @@
       </div>
     </div>
   </div>
+
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
@@ -59,6 +60,29 @@
       </div>
       <div class="govuk-grid-column-one-third">
         <%= render SupportInterface::TileComponent.new(count: @statistics.accepted_offer_count, label: 'accepted an offer', size: :reduced, colour: :green) %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= render SupportInterface::TileComponent.new(count: @statistics.apply_again_submitted_count, label: 'apply again submitted', size: :reduced) %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= render SupportInterface::TileComponent.new(count: @statistics.apply_again_accepted_offer_count, label: 'accepted an offer (apply again)', size: :reduced, colour: :green) %>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <%= render SupportInterface::TileComponent.new(count: @statistics.percentage_of_providers_onboarded, label: 'providers onboarded', size: :reduced) %>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= render SupportInterface::TileComponent.new(count: @statistics.rejected_by_default_count, label: 'rejected by default', size: :reduced) %>
       </div>
     </div>
   </div>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -30,6 +30,9 @@ en:
     offer_deferred:
       name: Offer deferred
       description: The provider deferred an offer to the next recruitment cycle. The offer will have to be reinstated by the provider at the start of the next cycle.
+    rejected_by_default:
+      name: Rejected by default
+      description: This application was rejected by default because the provider took too long to respond.
     ended_without_success:
       name: Ended without success
       description: All of the candidate’s applications have been withdrawn, rejected or declined.

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -30,9 +30,6 @@ en:
     offer_deferred:
       name: Offer deferred
       description: The provider deferred an offer to the next recruitment cycle. The offer will have to be reinstated by the provider at the start of the next cycle.
-    rejected_by_default:
-      name: Rejected by default
-      description: The candidate had one or more application choices rejected by default because the provider took too long to respond.
     ended_without_success:
       name: Ended without success
       description: All of the candidate’s applications have been withdrawn, rejected or declined.
@@ -67,6 +64,20 @@ en:
     withdrawn: Application withdrawn
     conditions_not_met: Conditions not met
     offer_deferred: Deferred
+
+  performance_dashboard_other_metrics:
+    apply_again_submitted:
+      name: Apply again submitted
+      description: The candidate has submitted an Apply Again application.
+    apply_again_accepted_offer:
+      name: Apply again offers accepted
+      description: The candidate has accepted an offer for an Apply Again application.
+    percentage_of_providers_onboarded:
+      name: Providers onboarded
+      description: The percentage of providers that have one or more courses available on Apply.
+    rejected_by_default:
+      name: Rejected by default
+      description: The candidate had one or more application choices rejected by default because the provider took too long to respond.
 
   application_states:
     unsubmitted:

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -68,10 +68,10 @@ en:
   performance_dashboard_other_metrics:
     apply_again_submitted:
       name: Apply again submitted
-      description: The candidate has submitted an Apply Again application.
+      description: The candidate has applied again and submitted an application.
     apply_again_accepted_offer:
       name: Apply again offers accepted
-      description: The candidate has accepted an offer for an Apply Again application.
+      description: The candidate has applied again and accepted an offer.
     percentage_of_providers_onboarded:
       name: Providers onboarded
       description: The percentage of providers that have one or more courses available on Apply.

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -32,7 +32,7 @@ en:
       description: The provider deferred an offer to the next recruitment cycle. The offer will have to be reinstated by the provider at the start of the next cycle.
     rejected_by_default:
       name: Rejected by default
-      description: This application was rejected by default because the provider took too long to respond.
+      description: The candidate had one or more application choices rejected by default because the provider took too long to respond.
     ended_without_success:
       name: Ended without success
       description: All of the candidate’s applications have been withdrawn, rejected or declined.

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       form.update_column(:updated_at, form.created_at)
 
       apply_again_form = create(:application_form, phase: 'apply_2')
-      apply_again_application_choice = create(:application_choice, status: 'unsubmitted', application_form: apply_again_form)
+      create(:application_choice, status: 'unsubmitted', application_form: apply_again_form)
       apply_again_form.update_column(:updated_at, form.created_at)
 
       expect(ProcessState.new(form).state).to be :unsubmitted_not_started_form
@@ -157,7 +157,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       create(:application_choice, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2020))
       create_list(:application_choice, 2, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2021))
       create(:application_choice, status: 'rejected', rejected_by_default: false, application_form: create(:application_form, recruitment_cycle_year: 2021))
-      
+
       stats = PerformanceStatistics.new(nil)
 
       expect(stats.rejected_by_default_count).to eq(2)

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -143,11 +143,12 @@ RSpec.describe PerformanceStatistics, type: :model do
   describe '#percentage_of_providers_onboarded' do
     it 'returns the percentage of providers onboarded to the nearest whole number' do
       create(:provider)
-      create_list(:provider, 2, sync_courses: true)
+      synced_providers = create_list(:provider, 2, sync_courses: true)
+      create_list(:course, 3, provider: synced_providers.first, open_on_apply: true)
 
       stats = PerformanceStatistics.new(2021)
 
-      expect(stats.percentage_of_providers_onboarded).to eq('67%')
+      expect(stats.percentage_of_providers_onboarded).to eq('33%')
     end
   end
 

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -151,6 +151,28 @@ RSpec.describe PerformanceStatistics, type: :model do
     end
   end
 
+  describe '#rejected_by_default_count' do
+    it 'returns the count of all rejected by default applications' do
+      create(:application_choice, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2020))
+      create_list(:application_choice, 2, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2021))
+      create(:application_choice, status: 'rejected', rejected_by_default: false, application_form: create(:application_form, recruitment_cycle_year: 2021))
+      
+      stats = PerformanceStatistics.new(nil)
+
+      expect(stats.rejected_by_default_count).to eq(2)
+    end
+
+    it 'returns the count of all rejected by default applications filtered by recruitment cycle year' do
+      create(:application_choice, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2020))
+      create_list(:application_choice, 2, status: 'rejected', rejected_by_default: true, application_form: create(:application_form, recruitment_cycle_year: 2021))
+      create(:application_choice, status: 'rejected', rejected_by_default: false, application_form: create(:application_form, recruitment_cycle_year: 2021))
+
+      stats = PerformanceStatistics.new(2021)
+
+      expect(stats.rejected_by_default_count).to eq(1)
+    end
+  end
+
   def count_for_process_state(process_state)
     PerformanceStatistics.new(nil)[process_state]
   end

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -150,6 +150,12 @@ RSpec.describe PerformanceStatistics, type: :model do
 
       expect(stats.percentage_of_providers_onboarded).to eq('33%')
     end
+
+    it 'returns "-" when there are no providers' do
+      stats = PerformanceStatistics.new(2021)
+
+      expect(stats.percentage_of_providers_onboarded).to eq('-')
+    end
   end
 
   describe '#rejected_by_default_count' do

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -140,6 +140,17 @@ RSpec.describe PerformanceStatistics, type: :model do
     end
   end
 
+  describe '#percentage_of_providers_onboarded' do
+    it 'returns the percentage of providers onboarded to the nearest whole number' do
+      create(:provider)
+      create_list(:provider, 2, sync_courses: true)
+
+      stats = PerformanceStatistics.new(2021)
+
+      expect(stats.percentage_of_providers_onboarded).to eq('67%')
+    end
+  end
+
   def count_for_process_state(process_state)
     PerformanceStatistics.new(nil)[process_state]
   end

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -119,13 +119,15 @@ RSpec.describe PerformanceStatistics, type: :model do
       create(:application_choice, status: 'recruited', application_form: apply_1_form)
       create(:application_choice, status: 'recruited', application_form: apply_2_form)
       create(:application_choice, status: 'pending_conditions')
+      create(:candidate)
 
       stats = PerformanceStatistics.new(nil)
 
       expect(stats.total_candidate_count(only: %i[recruited])).to eq(2)
       expect(stats.total_candidate_count(only: %i[recruited], phase: :apply_1)).to eq(1)
       expect(stats.total_candidate_count(only: %i[recruited], phase: :apply_2)).to eq(1)
-      expect(stats.total_candidate_count(except: %i[pending_conditions])).to eq(2)
+      expect(stats.total_candidate_count(phase: :apply_2)).to eq(1)
+      expect(stats.total_candidate_count(except: %i[pending_conditions])).to eq(3)
     end
   end
 


### PR DESCRIPTION
## Context

We need to update the performance dashboard with the following additions:

- Apply Again Submissions
- Apply Again Offer Accepted
- % of providers onboarded
- No. applications Rejected by Default (RBD)

## Changes proposed in this pull request

- [x] Change the query to group by `phase` as well as application form id and application choice id so that we can get the numbers for Apply again.
- [x] Add a separate query to get the percentage of providers onboarded
- [x] Add a separate 'state' to the query that picks out rejected by default applications
- [ ] Organise the tiles (design)

<img width="873" alt="image" src="https://user-images.githubusercontent.com/450843/97591196-44fd4e80-19f7-11eb-8eea-f15bcafd2e1b.png">


## Guidance to review

- How should we layout the new metrics? Is the separate table correct?
- Does grouping by `phase` make sense from an implementation point of view?
- Is it OK to assume that providers are onboarded when have one or more courses open on apply?
- Does it make sense to show the % or _Providers onboarded_ on any other tab than the _All years_ one? (It's find of meaningless to filter by recruitment cycle without some kind of historical data).

## Link to Trello card

https://trello.com/c/bSoFxjhp/2399-dev-pa-dashboard-for-ministerial-reports

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
