### PR TITLE
Show "Invalid data" when a UCAS match is invalid

### DIFF
--- a/app/components/support_interface/ucas_match_table_component.html.erb
+++ b/app/components/support_interface/ucas_match_table_component.html.erb
@@ -25,6 +25,8 @@
         <td class="govuk-table__cell">
           <% if table_row[:status_on_apply] == 'N/A' %>
             N/A
+          <% elsif table_row[:status_on_apply] == 'invalid_data' %>
+            <%= render TagComponent.new(text: "Invalid data", type: :red) %>
           <% else %>
             <%= render SupportInterface::ApplicationStatusTagComponent.new(status: table_row[:status_on_apply]) %>
           <% end %>

--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -14,15 +14,16 @@ module SupportInterface
           course_details: course_details(course),
         }
 
-        matched_applications_for_course(course).each do |application|
-          status = application.status
-          if application.ucas_scheme?
+        matched_applications_for_course(course).each do |ucas_matched_application|
+          status = ucas_matched_application.status
+
+          if ucas_matched_application.ucas_scheme?
             row_data.merge!(status_on_ucas: status, status_on_apply: 'N/A')
-          elsif application.dfe_scheme?
+          elsif ucas_matched_application.dfe_scheme?
             row_data.merge!(status_on_ucas: 'N/A', status_on_apply: status)
           else
             row_data.merge!(
-              status_on_ucas: application.mapped_ucas_status,
+              status_on_ucas: ucas_matched_application.mapped_ucas_status,
               status_on_apply: status,
             )
           end

--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -39,9 +39,7 @@ module SupportInterface
     end
 
     def ucas_matched_applications
-      @match.matching_data.map do |data|
-        UCASMatchedApplication.new(data, @match.recruitment_cycle_year)
-      end
+      @match.ucas_matched_applications
     end
 
     def matched_applications_for_course(course)

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -17,6 +17,9 @@ class UCASMatch < ApplicationRecord
       application_accepted_on_apply_and_in_progress_on_ucas?
   end
 
+  def invalid_matching_data?
+    !ucas_matched_applications.all?(&:valid_matching_data?)
+  end
 
   def ucas_matched_applications
     matching_data.map do |data|

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -17,13 +17,14 @@ class UCASMatch < ApplicationRecord
       application_accepted_on_apply_and_in_progress_on_ucas?
   end
 
-private
 
   def ucas_matched_applications
     matching_data.map do |data|
       UCASMatchedApplication.new(data, recruitment_cycle_year)
     end
   end
+
+private
 
   def application_for_the_same_course_in_progress_on_both_services?
     application_for_the_same_course_on_both_services = ucas_matched_applications.select(&:both_scheme?)

--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -14,7 +14,10 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= render TagComponent.new(text: match.matching_state.humanize, type: match.processed? ? :green : :purple) %>
-          <% if match.action_needed?  %>
+
+          <% if match.invalid_matching_data? %>
+            <%= render TagComponent.new(text: "Invalid data", type: :red) %>
+          <% elsif match.action_needed? %>
             <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
           <% end %>
         </td>

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -12,6 +12,12 @@
   'Application on Apply' => govuk_link_to('View application', support_interface_application_form_path(application)),
 }) %>
 
+<% if @match.invalid_matching_data? %>
+  <%= render TagComponent.new(text: "Invalid data", type: :red) %>
+<% elsif @match.action_needed? %>
+  <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
+<% end %>
+
 <% unless @match.processed? %>
   <%= form_with url: support_interface_process_match_path(@match), method: :post do |f| %>
     <%= f.submit 'Mark as processed', class: 'govuk-button govuk-!-margin-bottom-0' %>


### PR DESCRIPTION
## Context

If we encounter a UCAS match with an invalid course code, provider code or a course that doesn't exist in the current recruitment cycle, we currently raise an error (https://sentry.io/organizations/dfe-bat/issues/1937345465).

## Changes proposed in this pull request

This changes the flow so that we check if the match is valid, and output an error status instead of crashing

## Guidance to review

Does this work?

## Link to Trello card

https://trello.com/c/XRWaVD60/2933-action-ucas-matches
