### PR TITLE
Only show referee first name in reference reminder Slack message

### DIFF
--- a/app/services/candidate_interface/decoupled_references/send_reference_reminder.rb
+++ b/app/services/candidate_interface/decoupled_references/send_reference_reminder.rb
@@ -21,18 +21,22 @@ module CandidateInterface
 
           send_slack_message(application_form, message)
 
-          flash[:success] = "Reminder sent to #{reference_name}"
+          flash[:success] = "Reminder sent to #{referee_name}"
         end
       end
 
     private
 
       def message
-        "Candidate #{application_form.first_name} has sent a reminder to #{reference_name}"
+        "Candidate #{application_form.first_name} has sent a reminder to #{referee_first_name}"
       end
 
-      def reference_name
+      def referee_name
         reference.name
+      end
+
+      def referee_first_name
+        reference.name.split.first
       end
 
       def application_form

--- a/spec/services/candidate_interface/decoupled_references/send_reference_reminder_spec.rb
+++ b/spec/services/candidate_interface/decoupled_references/send_reference_reminder_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe CandidateInterface::DecoupledReferences::SendReferenceReminder do
   end
 
   describe '.call' do
-    let(:reference) { create(:reference, feedback_status: 'feedback_requested') }
+    let(:reference) { create(:reference, feedback_status: 'feedback_requested', name: 'Evo Morales') }
     let(:flash) { {} }
     let(:execute_service) { described_class.call(reference, flash) }
     let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
-    let(:message) { "Candidate #{reference.application_form.first_name} has sent a reminder to #{reference.name}" }
+    let(:message) { "Candidate #{reference.application_form.first_name} has sent a reminder to Evo" }
     let(:url) { Rails.application.routes.url_helpers.support_interface_application_form_url(reference.application_form) }
 
     before do


### PR DESCRIPTION
## Context

We're showing the full name currently, better for privacy to show first name only.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Use a string split to extract the first part of the name.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
See diff
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
n/a
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
