### PR TITLE
Add work history data export

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -70,6 +70,11 @@ class DataExport < ApplicationRecord
       description: 'Anonymised candidate equality and diversity data',
       class: SupportInterface::EqualityAndDiversityExport,
     },
+    unexplained_breaks_in_work_history: {
+        name: 'Unexplained breaks in work history',
+        description: 'A list of candidates with unexplained breaks in their work history',
+        class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
+    },
   }.freeze
 
   belongs_to :initiator, polymorphic: true, optional: true

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -71,9 +71,9 @@ class DataExport < ApplicationRecord
       class: SupportInterface::EqualityAndDiversityExport,
     },
     unexplained_breaks_in_work_history: {
-        name: 'Unexplained breaks in work history',
-        description: 'A list of candidates with unexplained breaks in their work history',
-        class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
+      name: 'Unexplained breaks in work history',
+      description: 'A list of candidates with unexplained breaks in their work history',
+      class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
     },
   }.freeze
 

--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -27,12 +27,16 @@ module SupportInterface
         next if unexplained_breaks.nil?
 
         total_unexplained_time = unexplained_breaks.sum(&:length)
+        unexplained_breaks_in_last_five_years = unexplained_breaks.select {
+            |unexplained_break| unexplained_break.start_date > (submitted_at(application_form) - 5.years).to_date }
+
         output = {
             'Candidate id' => application_form.candidate_id,
             'Application id' => application_form.id,
             'Start of working life' => get_start_of_working_life(application_form),
+            'Total unexplained time (months)' => total_unexplained_time,
             'Number of unexplained breaks' => unexplained_breaks.length,
-            'Total unexplained time (months)' => total_unexplained_time
+            'Number of unexplained breaks in last 5 years' => unexplained_breaks_in_last_five_years.count,
         }
         output
       end

--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -1,0 +1,108 @@
+module SupportInterface
+  class UnexplainedBreaksInWorkHistoryExport
+    class UnexplainedBreak
+      def initialize(month_range:)
+        @month_range = month_range
+      end
+
+      def start_date
+        @month_range.first.prev_month
+      end
+
+      def end_date
+        @month_range.last.next_month
+      end
+
+      def length
+        ((end_date.year * 12) + end_date.month) - ((start_date.year * 12) + start_date.month)
+      end
+    end
+
+    def data_for_export
+      data_for_export = Candidate.all.map do |candidate|
+        application_form = candidate.application_forms.order(:submitted_at).last
+        next if application_form.nil?
+
+        unexplained_breaks = get_unexplained_breaks(application_form)
+        next if unexplained_breaks.nil?
+
+        total_unexplained_time = unexplained_breaks.sum(&:length)
+        output = {
+            'Candidate id' => application_form.candidate_id,
+            'Application id' => application_form.id,
+            'Start of working life' => get_start_of_working_life(application_form),
+            'Number of unexplained breaks' => unexplained_breaks.length,
+            'Total unexplained time (months)' => total_unexplained_time
+        }
+        output
+      end
+
+      data_for_export.compact
+    end
+
+    private
+
+    def get_unexplained_breaks(application_form)
+      work_history = application_form.application_work_experiences.sort_by(&:start_date)
+      existing_breaks = application_form.application_work_history_breaks.sort_by(&:start_date)
+
+      work_history_with_breaks = []
+      work_history.each { |job| work_history_with_breaks << job }
+      existing_breaks.each { |existing_break| work_history_with_breaks << existing_break }
+
+      if work_history.any?
+        timeline_in_months = month_range(
+            start_date: get_start_of_working_life(application_form),
+            end_date: submitted_at(application_form) - 1.month,
+        )
+        break_months_in_timeline = remove_months(timeline: timeline_in_months, entries: work_history, application_form: application_form)
+        remaining_months = remove_months(timeline: break_months_in_timeline, entries: existing_breaks, application_form: application_form)
+
+        create_unexplained_breaks(remaining_months)
+      end
+    end
+
+    def get_start_of_working_life(application_form)
+      application_form.date_of_birth.beginning_of_month + 18.years
+    end
+
+    def submitted_at(application_form)
+      application_form.submitted_at || Time.zone.now
+    end
+
+    def month_range(start_date:, end_date:)
+      (start_date.to_date..end_date.to_date).map(&:beginning_of_month).uniq
+    end
+
+    def remove_months(timeline:, entries:, application_form:)
+      remaining_months_in_timeline = timeline
+
+      entries.each do |entry|
+        entry_end_date = entry.end_date.nil? ? submitted_at(application_form) : entry.end_date
+        months_in_entry_period = month_range(start_date: entry.start_date, end_date: entry_end_date)
+
+        remaining_months_in_timeline -= months_in_entry_period
+      end
+
+      remaining_months_in_timeline
+    end
+
+    def create_unexplained_breaks(break_months_in_timeline)
+      return [] if break_months_in_timeline.empty?
+
+      breaks = []
+      current_break = [break_months_in_timeline.first]
+
+      break_months_in_timeline.drop(1).each do |month|
+        if current_break.last.next_month == month
+          current_break << month
+        else
+          breaks << UnexplainedBreak.new(month_range: current_break)
+          current_break = [month]
+        end
+      end
+
+      breaks << UnexplainedBreak.new(month_range: current_break)
+    end
+  end
+end

--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -19,8 +19,13 @@ module SupportInterface
     end
 
     def data_for_export
-      data_for_export = Candidate.all.map do |candidate|
-        application_form = candidate.application_forms.order(:submitted_at).last
+      data_for_export = Candidate
+          .includes(:application_forms)
+          .all.map do |candidate|
+        application_form = candidate.application_forms
+          .select(:submitted_at, :date_of_birth, :candidate_id, :id)
+          .includes(:application_qualifications, :application_work_experiences, :application_work_history_breaks)
+          .order(:submitted_at).last
         next if application_form.nil?
 
         unexplained_breaks = get_unexplained_breaks(application_form)

--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -19,15 +19,12 @@ module SupportInterface
     end
 
     def data_for_export
-      data_for_export = Candidate
-          .includes(:application_forms)
-          .all.map do |candidate|
-        application_form = candidate.application_forms
-          .select(:submitted_at, :date_of_birth, :candidate_id, :id)
-          .includes(:application_qualifications, :application_work_experiences, :application_work_history_breaks)
-          .order(:submitted_at).last
-        next if application_form.nil?
+      applications = ApplicationForm
+                         .select(:id, :candidate_id, :submitted_at, :date_of_birth)
+                         .includes(:application_qualifications, :application_work_experiences, :application_work_history_breaks)
+                         .order(submitted_at: :desc).uniq(&:candidate_id)
 
+      data_for_export = applications.map do |application_form|
         unexplained_breaks = get_unexplained_breaks(application_form)
         next if unexplained_breaks.nil?
 

--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -28,21 +28,23 @@ module SupportInterface
 
         total_unexplained_time = unexplained_breaks.sum(&:length)
 
-        unexplained_breaks_in_last_five_years = unexplained_breaks.count {
-            |unexplained_break| unexplained_break.start_date > (submitted_at(application_form) - 5.years).to_date }
+        unexplained_breaks_in_last_five_years = unexplained_breaks.count do |unexplained_break|
+          unexplained_break.start_date > (submitted_at(application_form) - 5.years).to_date
+        end
 
         degrees = application_form.application_qualifications.degrees
-        unexplained_breaks_that_coincide_with_degrees =  unexplained_breaks.count {
-            |unexplained_break| unexplained_break_coincides_with_a_degree(unexplained_break, degrees)}
-        
+        unexplained_breaks_that_coincide_with_degrees = unexplained_breaks.count do |unexplained_break|
+          unexplained_break_coincides_with_a_degree(unexplained_break, degrees)
+        end
+
         output = {
-            'Candidate id' => application_form.candidate_id,
-            'Application id' => application_form.id,
-            'Start of working life' => get_start_of_working_life(application_form),
-            'Total unexplained time (months)' => total_unexplained_time,
-            'Number of unexplained breaks' => unexplained_breaks.length,
-            'Number of unexplained breaks in last 5 years' => unexplained_breaks_in_last_five_years,
-            'Number of unexplained breaks that coincide with studying for a degree' => unexplained_breaks_that_coincide_with_degrees,
+          'Candidate id' => application_form.candidate_id,
+          'Application id' => application_form.id,
+          'Start of working life' => get_start_of_working_life(application_form),
+          'Total unexplained time (months)' => total_unexplained_time,
+          'Number of unexplained breaks' => unexplained_breaks.length,
+          'Number of unexplained breaks in last 5 years' => unexplained_breaks_in_last_five_years,
+          'Number of unexplained breaks that coincide with studying for a degree' => unexplained_breaks_that_coincide_with_degrees,
         }
         output
       end
@@ -50,11 +52,13 @@ module SupportInterface
       data_for_export.compact
     end
 
-    private
+  private
 
     def unexplained_break_coincides_with_a_degree(unexplained_break, degrees)
-      degrees.select { |degree| Date.new(degree.start_year.to_i,1,1) < unexplained_break.end_date &&
-          unexplained_break.start_date < Date.new(degree.award_year.to_i,12,31)}
+      degrees.select { |degree|
+        Date.new(degree.start_year.to_i, 1, 1) < unexplained_break.end_date &&
+          unexplained_break.start_date < Date.new(degree.award_year.to_i, 12, 31)
+      }
           .any?
     end
 
@@ -68,8 +72,8 @@ module SupportInterface
 
       if work_history.any?
         timeline_in_months = month_range(
-            start_date: get_start_of_working_life(application_form),
-            end_date: submitted_at(application_form) - 1.month,
+          start_date: get_start_of_working_life(application_form),
+          end_date: submitted_at(application_form) - 1.month,
         )
         break_months_in_timeline = remove_months(timeline: timeline_in_months, entries: work_history, application_form: application_form)
         remaining_months = remove_months(timeline: break_months_in_timeline, entries: existing_breaks, application_form: application_form)

--- a/spec/services/support_interface/unexplained_breaks_in_work_history_export_spec.rb
+++ b/spec/services/support_interface/unexplained_breaks_in_work_history_export_spec.rb
@@ -7,32 +7,32 @@ RSpec.describe SupportInterface::UnexplainedBreaksInWorkHistoryExport do
       candidate_one = create(:candidate)
       application_form_one = create(:completed_application_form,
                                     candidate: candidate_one,
-                                    date_of_birth: Date.new(1982,1,15),
-                                    submitted_at: Date.new(2020,10,30))
+                                    date_of_birth: Date.new(1982, 1, 15),
+                                    submitted_at: Date.new(2020, 10, 30))
       create(:application_work_experience,
              application_form: application_form_one,
-             start_date: Date.new(2000,1,1),
-             end_date: Date.new(2019,1,1))
+             start_date: Date.new(2000, 1, 1),
+             end_date: Date.new(2019, 1, 1))
 
       candidate_two = create(:candidate)
       application_form_two = create(:completed_application_form,
                                     candidate: candidate_two,
-                                    date_of_birth: Date.new(1992,4,23),
-                                    submitted_at: Date.new(2020,10,30))
+                                    date_of_birth: Date.new(1992, 4, 23),
+                                    submitted_at: Date.new(2020, 10, 30))
       create(:application_work_experience,
              application_form: application_form_two,
-             start_date: Date.new(2014,10,19),
-             end_date: Date.new(2020,10,30))
+             start_date: Date.new(2014, 10, 19),
+             end_date: Date.new(2020, 10, 30))
 
       candidate_three = create(:candidate)
       create(:completed_application_form,
-              candidate: candidate_three,
-              date_of_birth: Date.new(1994,7,8),
-              submitted_at: Date.new(2019,1,1))
+             candidate: candidate_three,
+             date_of_birth: Date.new(1994, 7, 8),
+             submitted_at: Date.new(2019, 1, 1))
       application_form_three = create(:completed_application_form,
                                       candidate: candidate_three,
-                                      date_of_birth: Date.new(1994,7,8),
-                                      submitted_at: Date.new(2020,10,30))
+                                      date_of_birth: Date.new(1994, 7, 8),
+                                      submitted_at: Date.new(2020, 10, 30))
       create(:application_qualification,
              application_form: application_form_three,
              level: 'degree',
@@ -40,37 +40,37 @@ RSpec.describe SupportInterface::UnexplainedBreaksInWorkHistoryExport do
              award_year: 2015)
       create(:application_work_experience,
              application_form: application_form_three,
-             start_date: Date.new(2015,10,19),
-             end_date: Date.new(2020,10,30))
+             start_date: Date.new(2015, 10, 19),
+             end_date: Date.new(2020, 10, 30))
 
       expect(described_class.new.data_for_export).to contain_exactly(
-       {
-           'Candidate id' => candidate_one.id,
-           'Application id' => application_form_one.id,
-           'Start of working life' => Date.new(2000,1,1),
-           'Total unexplained time (months)' => 21,
-           'Number of unexplained breaks' => 1,
-           'Number of unexplained breaks in last 5 years' => 1,
-           'Number of unexplained breaks that coincide with studying for a degree' => 0
-       },
-       {
-           'Candidate id' => candidate_two.id,
-           'Application id' => application_form_two.id,
-           'Start of working life' => Date.new(2010,4,1),
-           'Total unexplained time (months)' => 55,
-           'Number of unexplained breaks' => 1,
-           'Number of unexplained breaks in last 5 years' => 0,
-           'Number of unexplained breaks that coincide with studying for a degree' => 0
-       },
-       {
-           'Candidate id' => candidate_three.id,
-           'Application id' => application_form_three.id,
-           'Start of working life' => Date.new(2012,7,1),
-           'Total unexplained time (months)' => 40,
-           'Number of unexplained breaks' => 1,
-           'Number of unexplained breaks in last 5 years' => 0,
-           'Number of unexplained breaks that coincide with studying for a degree' => 1
-       }
+        {
+          'Candidate id' => candidate_one.id,
+          'Application id' => application_form_one.id,
+          'Start of working life' => Date.new(2000, 1, 1),
+          'Total unexplained time (months)' => 21,
+          'Number of unexplained breaks' => 1,
+          'Number of unexplained breaks in last 5 years' => 1,
+          'Number of unexplained breaks that coincide with studying for a degree' => 0,
+        },
+        {
+          'Candidate id' => candidate_two.id,
+          'Application id' => application_form_two.id,
+          'Start of working life' => Date.new(2010, 4, 1),
+          'Total unexplained time (months)' => 55,
+          'Number of unexplained breaks' => 1,
+          'Number of unexplained breaks in last 5 years' => 0,
+          'Number of unexplained breaks that coincide with studying for a degree' => 0,
+        },
+        {
+          'Candidate id' => candidate_three.id,
+          'Application id' => application_form_three.id,
+          'Start of working life' => Date.new(2012, 7, 1),
+          'Total unexplained time (months)' => 40,
+          'Number of unexplained breaks' => 1,
+          'Number of unexplained breaks in last 5 years' => 0,
+          'Number of unexplained breaks that coincide with studying for a degree' => 1,
+        },
       )
     end
   end

--- a/spec/services/support_interface/unexplained_breaks_in_work_history_export_spec.rb
+++ b/spec/services/support_interface/unexplained_breaks_in_work_history_export_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::UnexplainedBreaksInWorkHistoryExport do
+  describe '#data_for_export' do
+    it 'returns an array of hashes for candidates with unexplained breaks in their work history' do
+      create(:candidate)
+      candidate_one = create(:candidate)
+      application_form_one = create(:completed_application_form,
+                                    candidate: candidate_one,
+                                    date_of_birth: Date.new(1982,1,15),
+                                    submitted_at: Date.new(2020,10,30))
+      create(:application_work_experience,
+             application_form: application_form_one,
+             start_date: Date.new(2000,1,1),
+             end_date: Date.new(2019,1,1))
+
+      candidate_two = create(:candidate)
+      application_form_two = create(:completed_application_form,
+                                    candidate: candidate_two,
+                                    date_of_birth: Date.new(1992,4,23),
+                                    submitted_at: Date.new(2020,10,30))
+      create(:application_work_experience,
+             application_form: application_form_two,
+             start_date: Date.new(2014,10,19),
+             end_date: Date.new(2020,10,30))
+
+      candidate_three = create(:candidate)
+      create(:completed_application_form,
+              candidate: candidate_three,
+              date_of_birth: Date.new(1994,7,8),
+              submitted_at: Date.new(2019,1,1))
+      application_form_three = create(:completed_application_form,
+                                      candidate: candidate_three,
+                                      date_of_birth: Date.new(1994,7,8),
+                                      submitted_at: Date.new(2020,10,30))
+      create(:application_qualification,
+             application_form: application_form_three,
+             level: 'degree',
+             start_year: 2012,
+             award_year: 2015)
+      create(:application_work_experience,
+             application_form: application_form_three,
+             start_date: Date.new(2015,10,19),
+             end_date: Date.new(2020,10,30))
+
+      expect(described_class.new.data_for_export).to contain_exactly(
+       {
+           'Candidate id' => candidate_one.id,
+           'Application id' => application_form_one.id,
+           'Start of working life' => Date.new(2000,1,1),
+           'Total unexplained time (months)' => 21,
+           'Number of unexplained breaks' => 1,
+           'Number of unexplained breaks in last 5 years' => 1,
+           'Number of unexplained breaks that coincide with studying for a degree' => 0
+       },
+       {
+           'Candidate id' => candidate_two.id,
+           'Application id' => application_form_two.id,
+           'Start of working life' => Date.new(2010,4,1),
+           'Total unexplained time (months)' => 55,
+           'Number of unexplained breaks' => 1,
+           'Number of unexplained breaks in last 5 years' => 0,
+           'Number of unexplained breaks that coincide with studying for a degree' => 0
+       },
+       {
+           'Candidate id' => candidate_three.id,
+           'Application id' => application_form_three.id,
+           'Start of working life' => Date.new(2012,7,1),
+           'Total unexplained time (months)' => 40,
+           'Number of unexplained breaks' => 1,
+           'Number of unexplained breaks in last 5 years' => 0,
+           'Number of unexplained breaks that coincide with studying for a degree' => 1
+       }
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

To validate/support DfE policy view that we should be enforcing collection of full rather than 5-years worth of Work history, we need to analyse how many candidates only provide 5-years of history (when they could have provided more).

I have chosen to create a data export over running queries directly on the DB because 
- we can reuse a lot of business logic for calculating unexplained breaks in work history
- it makes it easier to rerun the export again in future if needed
- we can write tests
- it doesn't require production access

## Changes proposed in this pull request

Add a new data export for work history

## Guidance to review

These changes broadly follow the changes made for another [data export recently](https://github.com/DFE-Digital/apply-for-teacher-training/commit/f8b45fb6dc802ffa273649ab5646e92ca3c39e39).

It also reuses a lot of logic from [work_history_with_breaks.rb](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/services/work_history_with_breaks.rb) and [work_history_item_component](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/components/work_history_item_component.rb).

## Link to Trello card

https://trello.com/c/jPJLjr4Q/2392-dev-how-much-work-history

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
