### PR TITLE
Structured pre-degree quals | Decoupling Gcse::GradeController

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -60,7 +60,7 @@ module CandidateInterface
         key: 'Grade',
         value: application_qualification.grade || t('gcse_summary.not_specified'),
         action: "grade for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
-        change_path: candidate_interface_gcse_details_edit_grade_path(subject: subject),
+        change_path: grade_edit_path,
       }
     end
 
@@ -126,6 +126,17 @@ module CandidateInterface
         action: t('application_form.gcse.comparable_uk_qualification.change_action'),
         change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
       }
+    end
+
+    def grade_edit_path
+      case subject
+      when 'maths'
+        candidate_interface_gcse_maths_edit_grade_path
+      when 'science'
+        candidate_interface_gcse_science_edit_grade_path
+      when 'english'
+        candidate_interface_gcse_english_edit_grade_path
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -1,0 +1,38 @@
+module CandidateInterface
+  class Gcse::English::GradeController < CandidateInterfaceController
+    include Gcse::GradeControllerConcern
+
+    before_action :redirect_to_dashboard_if_submitted
+    before_action :set_subject
+
+    def edit
+      @application_qualification = details_form
+      @qualification_type = details_form.qualification.qualification_type
+    end
+
+    def update
+      @qualification_type = details_form.qualification.qualification_type
+
+      details_form.grade = details_params[:grade]
+      details_form.other_grade = details_params[:other_grade]
+
+      @application_qualification = details_form.save_grade
+
+      if @application_qualification
+        update_gcse_completed(false)
+        redirect_to next_gcse_path
+      else
+        @application_qualification = details_form
+        track_validation_error(@application_qualification)
+
+        render :edit
+      end
+    end
+
+  private
+
+    def set_subject
+      @subject = 'english'
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/grade_controller_concern.rb
+++ b/app/controllers/candidate_interface/gcse/grade_controller_concern.rb
@@ -1,0 +1,38 @@
+module CandidateInterface
+  module Gcse
+    module GradeControllerConcern
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :autocomplete_grades?
+      end
+
+      def autocomplete_grades?
+        @subject.in?(%w[maths english]) && @qualification_type == 'gcse'
+      end
+
+      def next_gcse_path
+        if details_form.award_year.nil?
+          candidate_interface_gcse_details_edit_year_path(subject: @subject)
+        else
+          candidate_interface_gcse_review_path(subject: @subject)
+        end
+      end
+
+      def details_params
+        params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year other_grade])
+      end
+
+      def details_form
+        @details_form ||= GcseQualificationDetailsForm.build_from_qualification(
+          current_application.qualification_in_subject(:gcse, @subject),
+        )
+      end
+
+      def update_gcse_completed(value)
+        attribute_to_update = "#{@subject}_gcse_completed"
+        current_application.update!("#{attribute_to_update}": value)
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
@@ -1,0 +1,38 @@
+module CandidateInterface
+  class Gcse::Maths::GradeController < CandidateInterfaceController
+    include Gcse::GradeControllerConcern
+
+    before_action :redirect_to_dashboard_if_submitted
+    before_action :set_subject
+
+    def edit
+      @application_qualification = details_form
+      @qualification_type = details_form.qualification.qualification_type
+    end
+
+    def update
+      @qualification_type = details_form.qualification.qualification_type
+
+      details_form.grade = details_params[:grade]
+      details_form.other_grade = details_params[:other_grade]
+
+      @application_qualification = details_form.save_grade
+
+      if @application_qualification
+        update_gcse_completed(false)
+        redirect_to next_gcse_path
+      else
+        @application_qualification = details_form
+        track_validation_error(@application_qualification)
+
+        render :edit
+      end
+    end
+
+  private
+
+    def set_subject
+      @subject = 'maths'
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Gcse::NaricReferenceController < Gcse::DetailsController
+    include Gcse::ResolveGcseEditPathConcern
+
     before_action :redirect_to_dashboard_if_submitted, :set_subject, :render_404_if_flag_is_inactive
 
     def edit
@@ -37,7 +39,7 @@ module CandidateInterface
         current_application.qualification_in_subject(:gcse, subject_param),
       )
       if @details_form.qualification.grade.nil?
-        candidate_interface_gcse_details_edit_grade_path
+        resolve_gcse_edit_path(subject_param)
       else
         candidate_interface_gcse_review_path
       end

--- a/app/controllers/candidate_interface/gcse/resolve_gcse_edit_path_concern.rb
+++ b/app/controllers/candidate_interface/gcse/resolve_gcse_edit_path_concern.rb
@@ -1,0 +1,16 @@
+module CandidateInterface
+  module Gcse
+    module ResolveGcseEditPathConcern
+      def resolve_gcse_edit_path(subject)
+        case subject
+        when 'maths'
+          Rails.application.routes.url_helpers.candidate_interface_gcse_maths_edit_grade_path
+        when 'science'
+          candidate_interface_gcse_science_edit_grade_path
+        when 'english'
+          candidate_interface_gcse_english_edit_grade_path
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -1,0 +1,39 @@
+module CandidateInterface
+  class Gcse::Science::GradeController < CandidateInterfaceController
+    include Gcse::GradeControllerConcern
+
+    before_action :redirect_to_dashboard_if_submitted
+    before_action :set_subject
+
+    def edit
+      @application_qualification = details_form
+      @qualification_type = details_form.qualification.qualification_type
+    end
+
+    def update
+      @qualification_type = details_form.qualification.qualification_type
+
+      details_form.grade = details_params[:grade]
+      details_form.other_grade = details_params[:other_grade]
+
+      @application_qualification = details_form.save_grade
+
+      if @application_qualification
+        update_gcse_completed(false)
+        redirect_to next_gcse_path
+      else
+        @application_qualification = details_form
+        track_validation_error(@application_qualification)
+
+        render :edit
+      end
+    end
+
+  private
+
+    # Required by the GradeControllerConcern
+    def set_subject
+      @subject = 'english'
+    end
+  end
+end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Gcse::TypeController < Gcse::DetailsController
+    include Gcse::ResolveGcseEditPathConcern
+
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
 
@@ -54,7 +56,7 @@ module CandidateInterface
       if new_non_uk_qualification?
         candidate_interface_gcse_details_edit_institution_country_path
       elsif !@application_qualification.missing_qualification? && @details_form.grade.nil?
-        candidate_interface_gcse_details_edit_grade_path
+        resolve_gcse_edit_path(@subject)
       else
         candidate_interface_gcse_review_path
       end

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @application_qualification.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_english_edit_grade_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
+
+      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
+        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
+          <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
+          <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
+            <%=  f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
+
+        <% if autocomplete_grades? %>
+          <div class="govuk-!-width-one-third">
+            <%= f.govuk_collection_select(
+                  :grade,
+                  CandidateInterface::GcseQualificationDetailsForm.all_grade_drop_down_options,
+                  :value,
+                  :option,
+                  label: { text: 'Grade', size: 'm' },
+                  hint: { text: 'For example, ‘C’ or ‘4’' },
+                  ) %>
+          </div>
+        <% else %>
+          <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
+        <% end %>
+      <% end %>
+
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @application_qualification.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_maths_edit_grade_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
+
+      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
+        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
+          <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
+          <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
+            <%=  f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
+
+        <% if autocomplete_grades? %>
+          <div class="govuk-!-width-one-third">
+            <%= f.govuk_collection_select(
+                  :grade,
+                  CandidateInterface::GcseQualificationDetailsForm.all_grade_drop_down_options,
+                  :value,
+                  :option,
+                  label: { text: 'Grade', size: 'm' },
+                  hint: { text: 'For example, ‘C’ or ‘4’' },
+                  ) %>
+          </div>
+        <% else %>
+          <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
+        <% end %>
+      <% end %>
+
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @application_qualification.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_science_edit_grade_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
+
+      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
+        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
+          <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
+          <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
+            <%=  f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
+
+        <% if autocomplete_grades? %>
+          <div class="govuk-!-width-one-third">
+            <%= f.govuk_collection_select(
+                  :grade,
+                  CandidateInterface::GcseQualificationDetailsForm.all_grade_drop_down_options,
+                  :value,
+                  :option,
+                  label: { text: 'Grade', size: 'm' },
+                  hint: { text: 'For example, ‘C’ or ‘4’' },
+                  ) %>
+          </div>
+        <% else %>
+          <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
+        <% end %>
+      <% end %>
+
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,16 @@ Rails.application.routes.draw do
         post '/complete' => 'contact_details/review#complete', as: :contact_details_complete
       end
 
+      scope '/gcse' do
+        get '/maths/grade' => 'gcse/maths/grade#edit', as: :gcse_maths_edit_grade
+        get '/science/grade' => 'gcse/science/grade#edit', as: :gcse_science_edit_grade
+        get '/english/grade' => 'gcse/english/grade#edit', as: :gcse_english_edit_grade
+
+        patch '/maths/grade' => 'gcse/maths/grade#update'
+        patch '/english/grade' => 'gcse/english/grade#update'
+        patch '/science/grade' => 'gcse/science/grade#update'
+      end
+
       scope '/gcse/:subject', constraints: { subject: /(maths|english|science)/ } do
         get '/' => 'gcse/type#edit', as: :gcse_details_edit_type
         post '/' => 'gcse/type#update', as: :gcse_details_update_type
@@ -138,9 +148,6 @@ Rails.application.routes.draw do
 
         get '/naric-reference' => 'gcse/naric_reference#edit', as: :gcse_details_edit_naric_reference
         post '/naric-reference' => 'gcse/naric_reference#update', as: :gcse_details_update_naric_reference
-
-        get '/grade' => 'gcse/grade#edit', as: :gcse_details_edit_grade
-        patch '/grade' => 'gcse/grade#update', as: :gcse_details_update_grade
 
         get '/year' => 'gcse/year#edit', as: :gcse_details_edit_year
         patch '/year' => 'gcse/year#update', as: :gcse_details_update_year

--- a/spec/system/candidate_interface/international/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/international/candidate_entering_international_gcse_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def then_i_see_the_add_grade_page
-    expect(page).to have_current_path candidate_interface_gcse_details_edit_grade_path('maths')
+    expect(page).to have_current_path candidate_interface_gcse_maths_edit_grade_path
   end
 
   def then_i_see_the_review_page_with_correct_details


### PR DESCRIPTION
## Context

As a developer
I want to reduce coupling across the GSCE grade update flow
So that it will be easier to make the necessary changes to allow candidates to enter multiple english and science GCSEs (https://trello.com/c/jJPtfRY3/1779-%F0%9F%8F%88-allow-candidates-to-enter-multiple-english-and-science-gcses)


## Changes proposed in this pull request

- Create separate controllers and views per GSCE subject for updating the grade
- Move common logic across the new controllers to a concern

## Guidance to review

Although there is now more duplication, I imagine much of this will disappear once https://trello.com/c/jJPtfRY3/1779-%F0%9F%8F%88-allow-candidates-to-enter-multiple-english-and-science-gcses is implemented. 

Hopefully this also gives us a better platform to begin work on the next spikes:
- https://trello.com/c/6hn5shti/2421-spike-structured-pre-degree-quals-science-gcse-data-model
- https://trello.com/c/XKkHzPM2/2422-spike-structured-pre-degree-quals-english-gcse-data-model

## Link to Trello card

https://trello.com/c/tg6YxlE2/2420-spike-structured-pre-degree-quals-decoupling-gcsegradecontroller

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
