### PR TITLE
Update copy for deferred offer notification email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -207,7 +207,7 @@ class CandidateMailer < ApplicationMailer
   def deferred_offer(application_choice)
     @application_choice = application_choice
     @course = @application_choice.offered_option.course
-    @deferred_to_year = @course.recruitment_cycle_year + 1
+    @new_course_academic_year = "#{@course.recruitment_cycle_year + 1} to #{@course.recruitment_cycle_year + 2}"
 
     email_for_candidate(
       @application_choice.application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -206,11 +206,12 @@ class CandidateMailer < ApplicationMailer
 
   def deferred_offer(application_choice)
     @application_choice = application_choice
-    @course_option = @application_choice.offered_option
+    @course = @application_choice.offered_option.course
+    @deferred_to_year = @course.recruitment_cycle_year + 1
 
     email_for_candidate(
       @application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.deferred_offer.subject', provider_name: @course_option.course.provider.name),
+      subject: I18n.t!('candidate_mailer.deferred_offer.subject', provider_name: @course.provider.name),
     )
   end
 

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -41,4 +41,4 @@ Contact <%= @course_option.course.provider.name %> directly if you have any ques
 
 # Get support
 
-Email us at becomingateacher@digital.education.gov.uk. We respond within 5 working days, or one working day for more urgent queries.
+Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk). We respond within 5 working days, or one working day for more urgent queries.

--- a/app/views/candidate_mailer/deferred_offer.text.erb
+++ b/app/views/candidate_mailer/deferred_offer.text.erb
@@ -2,12 +2,12 @@ Dear <%= @application_form.first_name %>,
 
 # Your offer has been deferred
 
-<%= @course.provider.name %> has deferred your offer to study <%= @course.name_and_code %> until <%= @deferred_to_year %>.
+<%= @course.provider.name %> has deferred your offer to study <%= @course.name_and_code %> until the next academic year (<%= @new_course_academic_year %>).
 
 Any conditions for this offer will be confirmed closer to the start date of the course.
 
 # Next steps
 
-<%= @course.provider.name %> will send you an email shortly after September <%= @deferred_to_year %>, to confirm that you’ll soon start training.
+<%= @course.provider.name %> will send you an email shortly after October <%= @course.recruitment_cycle_year %>, to confirm the offer.
 
 If you don’t receive a message from <%= @course.provider.name %>, you should contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk). You can contact us at the same address with any other questions or feedback.

--- a/app/views/candidate_mailer/deferred_offer.text.erb
+++ b/app/views/candidate_mailer/deferred_offer.text.erb
@@ -1,13 +1,13 @@
 Dear <%= @application_form.first_name %>,
 
-<%= @course_option.course.provider.name %> has deferred your offer.
+# Your offer has been deferred
 
-Contact <%= @course_option.course.provider.name %> directly if you have any questions about this.
+<%= @course.provider.name %> has deferred your offer to study <%= @course.name_and_code %> until <%= @deferred_to_year %>.
 
-You can sign in to Apply for teacher training to check the status of your application(s):
+Any conditions for this offer will be confirmed closer to the start date of the course.
 
-<%= candidate_magic_link(@application_choice.application_form.candidate) %>
+# Next steps
 
-# Give feedback or report a problem
+<%= @course.provider.name %> will send you an email shortly after September <%= @deferred_to_year %>, to confirm that you’ll soon start training.
 
-Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+If you don’t receive a message from <%= @course.provider.name %>, you should contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk). You can contact us at the same address with any other questions or feedback.

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -61,7 +61,7 @@ en:
     changed_offer:
       subject: "Offer changed by %{provider_name}"
     deferred_offer:
-      subject: "%{provider_name} has deferred your offer"
+      subject: "Your offer has been deferred"
     deferred_offer_reminder:
       subject: "Reminder of your deferred offer"
     reinstated_offer:

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -167,6 +167,39 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
   end
 
+  describe '.deferred_offer' do
+    before do
+      application_form = build_stubbed(:application_form, first_name: 'Harold')
+      provider = build_stubbed(:provider, name: 'Jerome Horwitz Elementary School')
+      course_option = build_stubbed(
+        :course_option,
+        course: build_stubbed(:course, name: 'Sport', code: 'SP0', provider: provider, recruitment_cycle_year: 2021),
+        site: build_stubbed(:site, provider: provider),
+      )
+
+      @application_choice = build_stubbed(
+        :application_choice,
+        :with_deferred_offer,
+        course_option: course_option,
+        offered_course_option: course_option,
+        application_form: application_form,
+        decline_by_default_at: 10.business_days.from_now,
+      )
+
+      magic_link_stubbing(application_form.candidate)
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      :deferred_offer,
+      'Your offer has been deferred',
+      'heading' => 'Dear Harold',
+      'name and code for course' => 'Sport (SP0)',
+      'name of provider' => 'Jerome Horwitz Elementary School',
+      'year of new course' => 'until 2022',
+    )
+  end
+
   describe '.reinstated_offer' do
     before do
       @application_form = build_stubbed(:application_form, first_name: 'Ron')

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'heading' => 'Dear Harold',
       'name and code for course' => 'Sport (SP0)',
       'name of provider' => 'Jerome Horwitz Elementary School',
-      'year of new course' => 'until 2022',
+      'year of new course' => 'until the next academic year (2022 to 2023)',
     )
   end
 


### PR DESCRIPTION
## Context
Copy change for deferred offer notification email.

## Changes proposed in this pull request
New email looks like:
![image](https://user-images.githubusercontent.com/30071178/97967294-f06e2080-1db4-11eb-997e-0689c9781a0a.png)

## Guidance to review
We now explicitly refer to academic years, and October of the start of the next cycle for when the candidate can expect to start hearing back

## Link to Trello card
https://trello.com/c/2FdZQ2SY/2854-dev-deferral-email-notifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
