### PR TITLE
Remove code to ordinalise the application reference

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -38,10 +38,6 @@ class ApplicationReference < ApplicationRecord
     where.not(feedback_status: %i[not_requested_yet feedback_provided])
   end
 
-  def ordinal
-    application_form.application_references.find_index(self).to_i + 1
-  end
-
   def email_address_not_own
     return if application_form.nil?
 

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -3,50 +3,6 @@ require 'rails_helper'
 RSpec.describe ApplicationReference, type: :model do
   subject { build(:reference) }
 
-  describe 'saving a new reference' do
-    context 'when there is no existing reference on the same application_form' do
-      let!(:application_form) { create(:application_form) }
-      let(:new_reference) { build(:reference, application_form: application_form) }
-
-      it 'sets the ordinal to 1' do
-        new_reference.save!
-        expect(new_reference.ordinal).to eq(1)
-      end
-    end
-
-    context 'when there is an existing reference on the same application_form' do
-      let!(:application_form) { create(:application_form) }
-      let(:new_reference) { build(:reference) }
-
-      before do
-        create(:reference, application_form: application_form)
-        application_form.application_references << new_reference
-      end
-
-      it 'sets the ordinal to 2' do
-        new_reference.save!
-        expect(new_reference.ordinal).to eq(2)
-      end
-    end
-  end
-
-  # potential edge case: someone adds 2 references, then deletes the first
-  # we want to make sure it updates the ordinal of the remaining second ref. to
-  # be 1, so that we can still use that to describe 'First referee' etc in the
-  # interface
-  describe 'after deleting a reference' do
-    let!(:application_form) { create(:completed_application_form, references_count: 2, with_gcses: true) }
-
-    describe 'the ordinal of the remaining references' do
-      let(:ordinals) { application_form.application_references.map(&:ordinal) }
-
-      it 'still starts at 1' do
-        application_form.application_references.first.destroy
-        expect(ordinals.first).to eq(1)
-      end
-    end
-  end
-
   describe 'auditing', with_audited: true do
     let(:application_form) { create(:application_form) }
 


### PR DESCRIPTION
## Context

This code was necessary to add "1st reference" and "2nd reference" to the page. No longer!

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ykZiAQ1s
