### PR TITLE
Set Commit SHA as ENV variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,12 +68,14 @@ RUN yarn jest && \
 # If a existing base image name is specified Stage 1 & 2 will not be built and gems and dev packages will be used from the supplied image.
 FROM ${BASE_RUBY_IMAGE} AS production
 
+ARG VERSION
 ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine \
     RAILS_ENV=production \
     GOVUK_NOTIFY_API_KEY=TestKey \
     AUTHORISED_HOSTS=127.0.0.1 \
     SECRET_KEY_BASE=TestKey \
-    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey
+    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey \
+    SHA=${VERSION}
 
 RUN apk -U upgrade && \
     apk add --update --no-cache tzdata libpq libxml2 libxslt graphviz && \

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,3 +1,7 @@
 class HealthcheckController < ApplicationController
   def show; end
+
+  def version
+    render json: { version: ENV['SHA'] }
+  end
 end

--- a/app/views/healthcheck/show.html.erb
+++ b/app/views/healthcheck/show.html.erb
@@ -1,3 +1,3 @@
 <p class="govuk-body">
-  <%= service_name %> is a new GOV.UK service.
+  <%= service_name %> @<%= ENV['SHA'] %>
 </p>

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -33,3 +33,6 @@ OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatenc
 OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
 OkComputer::Registry.register 'find_sync', FindSyncCheck.new
+OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
+
+OkComputer.make_optional %w[version]

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,6 +1,7 @@
 Raven.configure do |config|
   config.silence_ready = true
   config.current_environment = HostingEnvironment.environment_name
+  config.release = ENV['SHA']
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.inspect_exception_causes_for_exclusion = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -793,6 +793,7 @@ Rails.application.routes.draw do
   end
 
   get '/check', to: 'healthcheck#show'
+  get '/check/version', to: 'healthcheck#version'
 
   scope via: :all do
     match '/404', to: 'errors#not_found'

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -6,6 +6,7 @@ services:
       args:
         bundleWithout: 'development'
         BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES: ${gemsNodeModulesImageName:-apply-for-teacher-training-gems-node-modules}
+        VERSION: ${dockerHubImageTag}
     image: ${dockerHubUsername}/${dockerHubImageName}:${dockerHubImageTag}
     environment:
       - RAILS_ENV

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,6 +9,7 @@ services:
     environment:
       - RAILS_ENV=development
       - AUTHORISED_HOSTS=localhost
+      - SHA=development
 # disable clock and worker when running locally
   clock:
     entrypoint: ["/bin/true"]


### PR DESCRIPTION
Register OKComputer:AppVersionCheck, which checks for presense of ENV['SHA']
[`/check/version`](https://dev.apply-for-teacher-training.service.gov.uk/check/version) endpoint to respond with current version.
Set version info in Raven configuration for identifying version in Sentry.

## Context

Make it easy to identify offending versions in [Sentry](https://docs.sentry.io/platforms/ruby/configuration/releases/).
And the current version in each environment.

## Changes proposed in this pull request

`SHA` env variable set to the git commit (same as the docker image tag).

Adds optional [`OkComputer:AppVersionCheck`](https://github.com/sportngin/okcomputer/blob/master/lib/ok_computer/built_in_checks/app_version_check.rb#L4)

## Guidance to review


## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
