### PR TITLE
Invariant check for unauthorised application edits

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -10,7 +10,7 @@ class DetectInvariants
 
   def detect_application_choices_in_old_states
     choices_in_wrong_state = begin
-      ApplicationChoice.where(status: %w[awaiting_references application_complete])
+      ApplicationChoice.where(status: %w[awaiting_references application_complete]).map(&:id).sort
     end
 
     if choices_in_wrong_state.any?
@@ -18,7 +18,7 @@ class DetectInvariants
         One or more application choices are still in `awaiting_references` or
         `application_complete` state, but all these states have been removed:
 
-        #{choices_in_wrong_state.map(&:id).sort.join("\n")}
+        #{choices_in_wrong_state.join("\n")}
       MSG
 
       Raven.capture_exception(WeirdSituationDetected.new(message))
@@ -31,6 +31,7 @@ class DetectInvariants
       .where.not(application_choices: { status: 'unsubmitted' })
       .where(references: { feedback_status: :feedback_requested })
       .pluck(:application_form_id).uniq
+      .sort
 
     if applications_with_reference_weirdness.any?
       message = <<~MSG
@@ -49,12 +50,14 @@ class DetectInvariants
       .joins('INNER JOIN candidates ON candidates.id = application_forms.candidate_id')
       .where(audits: { user_type: 'Candidate' })
       .where('candidates.id != audits.user_id')
+      .pluck('application_forms.id').uniq
+      .sort
 
     if unauthorised_changes.any?
       message = <<~MSG
         The following application forms have had unauthorised edits:
 
-        #{unauthorised_changes.pluck('application_forms.id').uniq.join("\n")}
+        #{unauthorised_changes.join("\n")}
       MSG
 
       Raven.capture_exception(WeirdSituationDetected.new(message))

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -18,7 +18,7 @@ class DetectInvariants
         One or more application choices are still in `awaiting_references` or
         `application_complete` state, but all these states have been removed:
 
-        #{choices_in_wrong_state.map(&:id).join("\n")}
+        #{choices_in_wrong_state.map(&:id).sort.join("\n")}
       MSG
 
       Raven.capture_exception(WeirdSituationDetected.new(message))


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
To ensure we aren't allowing unscoped access to application form data.
## Changes proposed in this pull request
An invariant check that looks for audit log entries describing application edits
by a candidate who isn't the owner of the application in question.
 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
The query relies on any `audited` declarations in a model to be associated with the application form. Here's what we cover:
```
app/models/application_choice.rb
app/models/application_work_experience.rb
app/models/application_work_history_break.rb
app/models/application_qualification.rb
app/models/application_reference.rb
app/models/application_volunteering_experience.rb
```
Does anything else need covering by this check?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/hChP4g58/2395-run-query-against-audit-log-to-find-any-historical-un-scoped-updates
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
