### PR TITLE
Don't show the Apply or UCAS page to candidates who have selected a course only available on Apply

### DIFF
--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -13,6 +13,11 @@ module CandidateInterface
         current_candidate.update!(course_from_find_id: @course.id)
 
         redirect_to candidate_interface_interstitial_path
+      elsif @provider&.not_accepting_appplications_on_ucas?
+        redirect_to candidate_interface_create_account_or_sign_in_path(
+          providerCode: @provider.code,
+          courseCode: @course.code,
+        )
       elsif @service.can_apply_on_apply?
         @apply_on_ucas_or_apply = CandidateInterface::ApplyOnUCASOrApplyForm.new(
           provider_code: params[:providerCode], course_code: params[:courseCode],
@@ -51,6 +56,7 @@ module CandidateInterface
       @service = ApplyFromFindPage.new(provider_code: provider_code, course_code: course_code)
       @service.determine_whether_course_is_on_find_or_apply
       @course = @service.course
+      @provider = @service.provider
     end
 
     def render_not_found

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -29,6 +29,8 @@ class Provider < ApplicationRecord
   audited
   has_associated_audits
 
+  NOT_ACCEPTING_APPLICATIONS_ON_UCAS = %w[8N5].freeze
+
   def self.with_users_manageable_by(provider_user)
     joins(:provider_permissions)
       .where(ProviderPermissions.table_name => { provider_user_id: provider_user.id, manage_users: true })
@@ -62,5 +64,9 @@ class Provider < ApplicationRecord
   def no_admin_users?
     !(provider_permissions.exists?(manage_users: true) &&
       provider_permissions.exists?(manage_organisations: true))
+  end
+
+  def not_accepting_appplications_on_ucas?
+    NOT_ACCEPTING_APPLICATIONS_ON_UCAS.include?(code)
   end
 end

--- a/app/services/candidate_interface/apply_from_find_page.rb
+++ b/app/services/candidate_interface/apply_from_find_page.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class ApplyFromFindPage
-    attr_accessor :course
+    attr_accessor :course, :provider
 
     def initialize(provider_code:, course_code:)
       @provider_code = provider_code
@@ -8,10 +8,11 @@ module CandidateInterface
       @can_apply_on_apply = false
       @course_on_find = false
       @course = nil
+      @provider = nil
     end
 
     def determine_whether_course_is_on_find_or_apply
-      provider = Provider.find_by!(code: @provider_code)
+      @provider = Provider.find_by!(code: @provider_code)
       @course = provider.courses.current_cycle.where(exposed_in_find: true).find_by!(code: @course_code)
 
       if @course&.open_on_apply? && pilot_open?

--- a/spec/system/candidate_interface/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_arrives_from_find_with_a_course_only_open_on_apply_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course params' do
+  scenario 'The provider is only accepting applications on the Apply service' do
+    given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+
+    when_i_follow_a_link_from_find
+    then_i_am_redirected_to_the_create_account_or_sign_in_path
+  end
+
+  def given_there_is_a_provider_with_a_course_that_is_only_accepting_applications_on_apply
+    @provider = create(:provider, code: '8N5')
+    @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions', provider: @provider)
+  end
+
+  def when_i_follow_a_link_from_find
+    visit candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code)
+  end
+
+  def then_i_am_redirected_to_the_create_account_or_sign_in_path
+    expect(page).to have_current_path candidate_interface_create_account_or_sign_in_path(providerCode: @provider.code, courseCode: @course.code)
+  end
+end


### PR DESCRIPTION
## Context

The University of Bolton are only using the Apply service to manage applications this year. This PR ensures that candidates arriving with Find with course params for any of their courses cannot see the Apply or UCAS page.

## Changes proposed in this pull request

- Redirect candidates that arrive with the University of Bolton provider code (8N5) to the signup path

## Guidance to review

Is this overkill? It just seems sensible to me to do as much as possible not to send them to UCAS.

I've added this section of the codebase to my refactor list, but i think this probably needs to go out ASAP.

## Link to Trello card

https://trello.com/c/4OiUSedJ/2323-dev-divert-course-pages-for-bolton

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
