### PR TITLE
Add deferred offer reminder email

### DIFF
--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -20,6 +20,10 @@ module SupportInterface
         DeleteTestApplications.perform_async
         flash[:success] = 'Scheduled job to delete test applications'
         redirect_to support_interface_tasks_path
+      when 'send_deferred_offer_reminder_emails'
+        SendDeferredOfferReminderEmailToCandidatesWorker.perform_async
+        flash[:success] = 'Scheduled job to send emails to candidates with pending offers from the previous cycle'
+        redirect_to support_interface_tasks_path
       when 'cancel_applications_at_end_of_cycle'
         CancelUnsubmittedApplicationsWorker.perform_async
         flash[:success] = 'Scheduled job to cancel unsubmitted applications that reached end-of-cycle'

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -214,6 +214,16 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def deferred_offer_reminder(application_choice)
+    @application_choice = application_choice
+    @course_option = @application_choice.offered_option
+
+    email_for_candidate(
+      @application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.deferred_offer_reminder.subject', provider_name: @course_option.course.provider.name),
+    )
+  end
+
   def reinstated_offer(application_choice)
     @application_choice = application_choice
     @course_option = @application_choice.offered_option

--- a/app/queries/get_deferred_application_choices_for_current_cycle.rb
+++ b/app/queries/get_deferred_application_choices_for_current_cycle.rb
@@ -1,0 +1,8 @@
+class GetDeferredApplicationChoicesForCurrentCycle
+  def self.call
+    ApplicationChoice
+      .joins(:course)
+      .where(status: :offer_deferred)
+      .where('courses.recruitment_cycle_year': RecruitmentCycle.previous_year)
+  end
+end

--- a/app/services/send_deferred_offer_reminder_email_to_candidate.rb
+++ b/app/services/send_deferred_offer_reminder_email_to_candidate.rb
@@ -1,0 +1,5 @@
+class SendDeferredOfferReminderEmailToCandidate
+  def self.call(application_choice:)
+    CandidateMailer.deferred_offer_reminder(application_choice).deliver_later
+  end
+end

--- a/app/views/candidate_mailer/deferred_offer_reminder.text.erb
+++ b/app/views/candidate_mailer/deferred_offer_reminder.text.erb
@@ -1,0 +1,15 @@
+Dear <%= @application_form.first_name %>,
+
+# Reminder of your deferred offer
+
+On <%= @application_choice.offer_deferred_at.to_s(:govuk_date) %>, <%= @course_option.course.provider.name %> deferred your offer to study <%= @course_option.course.name_and_code %>.
+
+You'll shortly receive another email from us, confirming that you’ll start training in the new academic year (<%= RecruitmentCycle.current_year %>). If you don’t receive this message, you should contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sign in to your account to view the details of your deferred offer:
+
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) with any questions or feedback.

--- a/app/views/candidate_mailer/deferred_offer_reminder.text.erb
+++ b/app/views/candidate_mailer/deferred_offer_reminder.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application_form.first_name %>,
 
 On <%= @application_choice.offer_deferred_at.to_s(:govuk_date) %>, <%= @course_option.course.provider.name %> deferred your offer to study <%= @course_option.course.name_and_code %>.
 
-You'll shortly receive another email from us, confirming that you’ll start training in the new academic year (<%= RecruitmentCycle.current_year %>). If you don’t receive this message, you should contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+You’ll shortly receive an email to confirm the offer. If you do not receive this, you should contact <%= @course_option.course.provider.name %>.
 
 Sign in to your account to view the details of your deferred offer:
 

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -27,6 +27,19 @@
 <section class="app-section app-section--with-top-border">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds app-styled-content">
+      <h3>Start-of-cycle: Send reminder of deferred offers</h3>
+      <p>This task finds any deferred offers from the previous recruitment cycle and emails the candidates to remind them of the offer.</p>
+      <p>It should be run shortly after the cycle begins.</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= button_to 'Send reminder emails', support_interface_run_task_path('send_deferred_offer_reminder_emails'), class: 'govuk-button govuk-button--secondary' %>
+    </div>
+  </div>
+</section>
+
+<section class="app-section app-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-styled-content">
       <h3>End-of-cycle: Cancel unsubmitted applications</h3>
       <p>This task finds any unsubmitted applications from the most recently closed recruitment cycle and moves them to the <code>application_not_sent</code> status.</p>
       <p>It should be run shortly after the Apply 2 deadline closes at midnight on <%= EndOfCycleTimetable.date(:apply_2_deadline).to_s(:govuk_date) %>.</p>
@@ -73,6 +86,6 @@
       <div class="govuk-grid-column-one-third">
         <%= button_to 'Create a fake provider', support_interface_tasks_create_fake_provider_path, class: 'govuk-button govuk-button--secondary' %>
       </div>
-    <div>
+    </div>
   </section>
 <% end %>

--- a/app/workers/send_deferred_offer_reminder_email_to_candidates_worker.rb
+++ b/app/workers/send_deferred_offer_reminder_email_to_candidates_worker.rb
@@ -1,0 +1,9 @@
+class SendDeferredOfferReminderEmailToCandidatesWorker
+  include Sidekiq::Worker
+
+  def perform
+    GetDeferredApplicationChoicesForCurrentCycle.call.each do |application_choice|
+      SendDeferredOfferReminderEmailToCandidate.call(application_choice: application_choice)
+    end
+  end
+end

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -156,6 +156,8 @@ en:
     offer_deferred:
       name: Offer deferred
       description: The provider has deferred the candidate’s offer to the next recruitment cycle. The offer will have to be reinstated by the provider at the start of the next cycle.
+      emails:
+        - candidate_mailer-deferred_offer_reminder
 
   events:
     unsubmitted-send_to_provider:

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -62,6 +62,8 @@ en:
       subject: "Offer changed by %{provider_name}"
     deferred_offer:
       subject: "%{provider_name} has deferred your offer"
+    deferred_offer_reminder:
+      subject: "Reminder of your deferred offer"
     reinstated_offer:
       subject: "You’re due to take up your deferred offer"
     apply_again_call_to_action:

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -306,8 +306,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'heading' => 'Dear Jeff',
       'when offer deferred' => 'On 15 April 2020',
       'provider name' => 'Amazon University',
-      'course name and code' => 'Business (BIZ)',
-      'when new course starts' => -> { "new academic year (#{RecruitmentCycle.current_year})" }
+      'course name and code' => 'Business (BIZ)'
     )
   end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -363,6 +363,28 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.deferred_offer(application_form.application_choices.first)
   end
 
+  def deferred_offer_reminder
+    course_option = FactoryBot.build_stubbed(
+      :course_option,
+      course: FactoryBot.build_stubbed(
+        :course,
+        recruitment_cycle_year: RecruitmentCycle.previous_year,
+      ),
+    )
+
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      :with_deferred_offer,
+      course_option: course_option,
+      offered_course_option: course_option,
+      application_form: application_form,
+      decline_by_default_at: 10.business_days.from_now,
+      offer_deferred_at: Time.zone.local(2020, 2, 3),
+    )
+
+    CandidateMailer.deferred_offer_reminder(application_choice)
+  end
+
   def reinstated_offer_with_conditions
     application_choice = FactoryBot.build_stubbed(
       :application_choice,

--- a/spec/workers/send_deferred_offer_reminder_email_to_candidates_worker_spec.rb
+++ b/spec/workers/send_deferred_offer_reminder_email_to_candidates_worker_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe SendDeferredOfferReminderEmailToCandidatesWorker, sidekiq: true do
+  let(:course_this_year) { create(:course, recruitment_cycle_year: RecruitmentCycle.current_year) }
+  let(:course_last_year) { create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year) }
+
+  describe '#perform' do
+    it 'sends reminder emails to all candidates with deferred offers from the previous cycle' do
+      candidate1 = create(:candidate)
+      candidate2 = create(:candidate)
+      candidate3 = create(:candidate)
+
+      create(
+        :application_choice,
+        :with_deferred_offer,
+        course_option: create(
+          :course_option,
+          course: course_this_year,
+        ),
+        application_form: application_form(candidate1),
+      )
+      create(
+        :application_choice,
+        :with_deferred_offer,
+        course_option: create(
+          :course_option,
+          course: course_last_year,
+        ),
+        application_form: application_form(candidate2),
+      )
+      create(
+        :application_choice,
+        :with_deferred_offer,
+        offer_deferred_at: Time.zone.local(2019, 4, 13),
+        course_option: create(
+          :course_option,
+          course: course_last_year,
+        ),
+        application_form: application_form(candidate3),
+      )
+
+      described_class.new.perform
+
+      expect(email_for_candidate(candidate1)).not_to be_present
+
+      expect(email_for_candidate(candidate2)).to be_present
+
+      email_for_candidate3 = email_for_candidate(candidate3)
+      expect(email_for_candidate3).to be_present
+      expect(email_for_candidate3.subject).to include 'Reminder of your deferred offer'
+      expect(email_for_candidate3.body).to include 'On 13 April 2019'
+    end
+  end
+
+  def application_form(candidate)
+    create(:completed_application_form, candidate: candidate)
+  end
+
+  def email_for_candidate(candidate)
+    ActionMailer::Base.deliveries.find { |e| e.header['to'].value == candidate.email_address }
+  end
+end


### PR DESCRIPTION
## Context
This email is being added so that candidates might chase providers about deferred offers that should be reinstated.
The job to send all these emails can be triggered in the support interface tasks section

## Changes proposed in this pull request
New email looks like: 
![image](https://user-images.githubusercontent.com/30071178/97627525-6a07b680-1a23-11eb-80a6-1a7eca407c20.png)

## Guidance to review
I can't think of a good reason we would want to limit the number of times this button can be pressed per cycle - it's not a big deal if it happens twice and it's unlikely.

## Link to Trello card
https://trello.com/c/2FdZQ2SY/2854-dev-deferral-email-notifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
