### PR TITLE
Add filtering to UCAS matches page

### DIFF
--- a/app/components/support_interface/ucas_matches_table_component.html.erb
+++ b/app/components/support_interface/ucas_matches_table_component.html.erb
@@ -1,0 +1,27 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header">Candidate</th>
+      <th scope="col" class="govuk-table__header">Last update</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% table_rows.each do |table_row| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= table_row[:status] %> <%= table_row[:action_needed] %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= table_row[:match_link] %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= table_row[:last_update] %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/components/support_interface/ucas_matches_table_component.rb
+++ b/app/components/support_interface/ucas_matches_table_component.rb
@@ -11,7 +11,7 @@ module SupportInterface
     def table_rows
       matches.map do |match|
         {
-          status: render(TagComponent.new(text: match.matching_state.humanize, type: match.processed? ? :green : :purple)),
+          status: render(TagComponent.new(text: match.matching_data_updated? ? 'Updated' : match.matching_state.humanize, type: match.processed? ? :green : :purple)),
           action_needed: action_needed(match),
           match_link: govuk_link_to(match.candidate.email_address, support_interface_ucas_match_path(match)),
           last_update: match.updated_at.to_s(:govuk_date),

--- a/app/components/support_interface/ucas_matches_table_component.rb
+++ b/app/components/support_interface/ucas_matches_table_component.rb
@@ -1,0 +1,32 @@
+module SupportInterface
+  class UCASMatchesTableComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :matches
+
+    def initialize(matches:)
+      @matches = matches
+    end
+
+    def table_rows
+      matches.map do |match|
+        {
+          status: render(TagComponent.new(text: match.matching_state.humanize, type: match.processed? ? :green : :purple)),
+          action_needed: action_needed(match),
+          match_link: govuk_link_to(match.candidate.email_address, support_interface_ucas_match_path(match)),
+          last_update: match.updated_at.to_s(:govuk_date),
+        }
+      end
+    end
+
+  private
+
+    def action_needed(match)
+      if match.invalid_matching_data?
+        render(TagComponent.new(text: 'Invalid data', type: :red))
+      elsif match.action_needed?
+        render(TagComponent.new(text: 'Action needed', type: :yellow))
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -1,7 +1,10 @@
 module SupportInterface
   class UCASMatchesController < SupportInterfaceController
     def index
-      @matches = UCASMatch.includes(:candidate)
+      @filter = SupportInterface::UCASMatchesFilter.new(params: params)
+      @matches = @filter.filter_records(UCASMatch.includes(:candidate))
+        .order(updated_at: :desc)
+        .page(params[:page] || 1).per(15)
     end
 
     def show

--- a/app/models/support_interface/ucas_matches_filter.rb
+++ b/app/models/support_interface/ucas_matches_filter.rb
@@ -1,0 +1,40 @@
+module SupportInterface
+  class UCASMatchesFilter
+    attr_reader :applied_filters
+
+    def initialize(params:)
+      @applied_filters = params
+    end
+
+    def filter_records(ucas_matches)
+      if applied_filters[:years]
+        ucas_matches = ucas_matches.where('recruitment_cycle_year IN (?)', applied_filters[:years])
+      end
+
+      ucas_matches
+    end
+
+    def filters
+      [year_filter]
+    end
+
+  private
+
+    def year_filter
+      cycle_options = RecruitmentCycle::CYCLES.map do |year, label|
+        {
+          value: year,
+          label: label,
+          checked: applied_filters[:years]&.include?(year),
+        }
+      end
+
+      {
+        type: :checkboxes,
+        heading: 'Recruitment cycle year',
+        name: 'years',
+        options: cycle_options,
+      }
+    end
+  end
+end

--- a/app/views/support_interface/candidates/_candidates_navigation.html.erb
+++ b/app/views/support_interface/candidates/_candidates_navigation.html.erb
@@ -4,7 +4,7 @@
 <%= render TabNavigationComponent.new(items: [
   { name: 'Applications', url: support_interface_applications_path, current: local_assigns[:current] == 'Applications' },
   { name: 'Candidates', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
-  { name: 'UCAS matches', url: support_interface_ucas_matches_path, current: local_assigns[:current] == 'UCAS matches' },
+  { name: 'UCAS matches', url: support_interface_ucas_matches_path(years: RecruitmentCycle.current_year), current: local_assigns[:current] == 'UCAS matches' },
 ]) %>
 
 <h2 class="govuk-visually-hidden"><%= title %></h2>

--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -1,35 +1,3 @@
 <%= render 'support_interface/candidates/candidates_navigation', title: 'UCAS matches' %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Status</th>
-      <th scope="col" class="govuk-table__header">Candidate</th>
-      <th scope="col" class="govuk-table__header">Last update</th>
-    </tr>
-  </thead>
-
-  <tbody class="govuk-table__body">
-    <% @matches.each do |match| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          <%= render TagComponent.new(text: match.matching_state.humanize, type: match.processed? ? :green : :purple) %>
-
-          <% if match.invalid_matching_data? %>
-            <%= render TagComponent.new(text: "Invalid data", type: :red) %>
-          <% elsif match.action_needed? %>
-            <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
-          <% end %>
-        </td>
-
-        <td class="govuk-table__cell">
-          <%= govuk_link_to match.candidate.email_address, support_interface_ucas_match_path(match) %>
-        </td>
-
-        <td class="govuk-table__cell">
-          <%= match.updated_at.to_s(:govuk_date_and_time) %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render SupportInterface::UCASMatchesTableComponent.new(matches: @matches) %>

--- a/app/views/support_interface/ucas_matches/index.html.erb
+++ b/app/views/support_interface/ucas_matches/index.html.erb
@@ -1,3 +1,5 @@
 <%= render 'support_interface/candidates/candidates_navigation', title: 'UCAS matches' %>
 
-<%= render SupportInterface::UCASMatchesTableComponent.new(matches: @matches) %>
+<%= render PaginatedFilterComponent.new(filter: @filter, collection: @matches) do %>
+  <%= render SupportInterface::UCASMatchesTableComponent.new(matches: @matches) %>
+<% end %>

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -5,9 +5,11 @@
 <% application = @match.candidate.application_forms.first %>
 
 <%= render SummaryListComponent.new(rows: {
+  'Recruitment cycle year' => @match.recruitment_cycle_year.to_s,
   'Candidate name' => "#{application.first_name} #{application.last_name}",
   'Candidate email' => @match.candidate.email_address.to_s,
   'Last updated' => @match.updated_at.to_s(:govuk_date_and_time),
+  'First added' => @match.created_at.to_s(:govuk_date_and_time),
   'Status' => render(TagComponent.new(text: @match.matching_state.humanize, type: @match.processed? ? :green : :purple)),
   'Application on Apply' => govuk_link_to('View application', support_interface_application_form_path(application)),
 }) %>

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -14,17 +14,19 @@
   'Application on Apply' => govuk_link_to('View application', support_interface_application_form_path(application)),
 }) %>
 
-<% if @match.invalid_matching_data? %>
-  <%= render TagComponent.new(text: "Invalid data", type: :red) %>
-<% elsif @match.action_needed? %>
-  <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
-<% end %>
-
-<% unless @match.processed? %>
-  <%= form_with url: support_interface_process_match_path(@match), method: :post do |f| %>
-    <%= f.submit 'Mark as processed', class: 'govuk-button govuk-!-margin-bottom-0' %>
+<p class="govuk-body">
+  <% if @match.invalid_matching_data? %>
+    <%= render TagComponent.new(text: "Invalid data", type: :red) %>
+  <% elsif @match.action_needed? %>
+    <%= render TagComponent.new(text: "Action needed", type: :yellow) %>
   <% end %>
-<% end %>
+
+  <% unless @match.processed? %>
+    <%= form_with url: support_interface_process_match_path(@match), method: :post do |f| %>
+      <%= f.submit 'Mark as processed', class: 'govuk-button govuk-!-margin-bottom-0' %>
+    <% end %>
+  <% end %>
+</p>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Course choices</h2>
 <%= render SupportInterface::UCASMatchTableComponent.new(@match) %>

--- a/spec/components/support_interface/ucas_matches_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_matches_table_component_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::UCASMatchesTableComponent do
+  let(:today) { Time.zone.local(2020, 1, 7, 12, 0, 0) }
+  let(:ucas_match) { create(:ucas_match, matching_state: 'new_match') }
+
+  around do |example|
+    Timecop.freeze(today) do
+      example.run
+    end
+  end
+
+  it 'renders the status' do
+    expect(render_result.css('.govuk-tag').first.text.strip).to eq('New match')
+  end
+
+  it 'renders candidates email address' do
+    expect(render_result.text).to include(ucas_match.candidate.email_address)
+  end
+
+  it 'renders last update' do
+    expect(render_result.text).to include('7 January 2020')
+  end
+
+  def render_result
+    render_inline(described_class.new(matches: [ucas_match]))
+  end
+end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'See UCAS matches' do
   end
 
   def and_i_should_which_ucas_matches_need_action
-    expect(page).to have_content 'Matching data updated Action needed'
+    expect(page).to have_content 'Updated Action needed'
     expect(page).to have_content 'Invalid data'
   end
 

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def and_the_existing_match_is_updated
     expect(page).to have_content @previously_matched_changed.email_address
-    expect(page).to have_content 'Matching data updated'
+    expect(page).to have_content 'Updated'
   end
 
   def and_the_unchanged_existing_match_is_left_alone


### PR DESCRIPTION
## Context

We want to be able to filter by the recruitment cycle year.

## Changes proposed in this pull request

- add filtering on the index page
<img width="742" alt="Screenshot 2020-10-29 at 16 54 57" src="https://user-images.githubusercontent.com/38078064/97678062-22b51080-1a8b-11eb-8315-28aeeb482e7c.png">

- display recruitment cycle year and first added date on the show page

| Before   |      After      |  
|----------|------------|
|<img width="736" alt="Screenshot 2020-10-29 at 17 02 44" src="https://user-images.githubusercontent.com/38078064/97676978-6a3a9d00-1a89-11eb-9859-8b39c116ea7c.png">| <img width="749" alt="Screenshot 2020-10-29 at 17 02 24" src="https://user-images.githubusercontent.com/38078064/97677004-73c40500-1a89-11eb-8bb3-f04f8f33a930.png">|

## Guidance to review

- visit `support/ucas-matches`

## Link to Trello card

https://trello.com/c/XRWaVD60/2933-action-ucas-matches

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
