### PR TITLE
Export only applications in the current recruitment cycle for UCAS

### DIFF
--- a/app/services/ucas_matching/matching_data_export.rb
+++ b/app/services/ucas_matching/matching_data_export.rb
@@ -54,6 +54,7 @@ module UCASMatching
 
     def relevant_applications
       ApplicationForm
+        .current_cycle
         .includes(
           :candidate,
         )

--- a/spec/services/ucas_matching/matching_data_export_spec.rb
+++ b/spec/services/ucas_matching/matching_data_export_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 RSpec.describe UCASMatching::MatchingDataExport do
   let(:unsubmitted_form) { create(:application_form) }
-  let(:submitted_form) { create(:completed_application_form, application_choices_count: 3) }
+  let(:previous_recruitment_cycle_form) { create(:completed_application_form, application_choices_count: 3, recruitment_cycle_year: RecruitmentCycle.previous_year) }
+  let(:submitted_current_recruitment_cycle_form) { create(:completed_application_form, application_choices_count: 3) }
 
   describe '#relevant_applications' do
     let(:result) { described_class.new.send(:relevant_applications) }
 
     it 'includes ApplicationForms which are submitted' do
-      expect(result).to include(submitted_form)
+      expect(result).to include(submitted_current_recruitment_cycle_form)
     end
 
     it 'does not include ApplicationForms which are unsubmitted' do
@@ -16,8 +17,12 @@ RSpec.describe UCASMatching::MatchingDataExport do
     end
 
     it 'does not include submitted ApplicationForms where the candidate has hide_in_reporting set' do
-      submitted_form.candidate.update(hide_in_reporting: true)
-      expect(result).not_to include(submitted_form)
+      submitted_current_recruitment_cycle_form.candidate.update(hide_in_reporting: true)
+      expect(result).not_to include(submitted_current_recruitment_cycle_form)
+    end
+
+    it 'does not include ApplicationForms from the previous recruitment cycle' do
+      expect(result).not_to include(previous_recruitment_cycle_form)
     end
   end
 


### PR DESCRIPTION
 ## Context

During the October 2020 Data Matching DSA Review we spoke with UCAS about two ways handling data in different recruitment cycles. 
The first option was to only send through candidates from the 2021 cycle going forward. 
The second was adding a 'recruitment cycle year' field in the data we send over and receive, which would require an amendment to the DSA. As discussed, both parties favoured the former.

## Changes proposed in this pull request

Change UCAS export to only send candidate data from
the current recruitment cycle.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/E1Cjp1iK/2965-export-only-applications-in-the-current-recruitment-cycle

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
