### PR TITLE
Ensure sent/received references cannot be edited

### DIFF
--- a/app/controllers/candidate_interface/decoupled_references/base_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/base_controller.rb
@@ -18,6 +18,10 @@ module CandidateInterface
           candidate_interface_decoupled_references_review_path
         end
       end
+
+      def redirect_to_review_page_unless_reference_is_not_requested_yet
+        redirect_to candidate_interface_decoupled_references_review_path unless @reference.not_requested_yet?
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/decoupled_references/candidate_name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/candidate_name_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   module DecoupledReferences
     class CandidateNameController < BaseController
       before_action :set_reference
+      before_action :redirect_to_review_page_unless_reference_is_not_requested_yet
 
       def new
         @reference_candidate_name_form =

--- a/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/email_address_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module DecoupledReferences
     class EmailAddressController < BaseController
-      before_action :set_reference
+      before_action :set_reference, :redirect_to_review_page_unless_not_requested_or_email_bounced
 
       def new
         @reference_email_address_form = Reference::RefereeEmailAddressForm.new
@@ -43,6 +43,10 @@ module CandidateInterface
         params
           .require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
           .merge!(reference_id: @reference.id)
+      end
+
+      def redirect_to_review_page_unless_not_requested_or_email_bounced
+        redirect_to candidate_interface_decoupled_references_review_path unless @reference.not_requested_yet? || @reference.email_bounced?
       end
     end
   end

--- a/app/controllers/candidate_interface/decoupled_references/name_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/name_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module DecoupledReferences
     class NameController < BaseController
-      before_action :set_reference
+      before_action :set_reference, :redirect_to_review_page_unless_reference_is_not_requested_yet
 
       def new
         @reference_name_form = Reference::RefereeNameForm.new

--- a/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/relationship_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module DecoupledReferences
     class RelationshipController < BaseController
-      before_action :set_reference
+      before_action :set_reference, :redirect_to_review_page_unless_reference_is_not_requested_yet
 
       def new
         @references_relationship_form = Reference::RefereeRelationshipForm.new

--- a/app/controllers/candidate_interface/decoupled_references/type_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/type_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   module DecoupledReferences
     class TypeController < BaseController
       before_action :set_reference, only: %i[edit update]
+      before_action :redirect_to_review_page_unless_reference_is_not_requested_yet, only: %i[edit update]
 
       def new
         @reference_type_form = Reference::RefereeTypeForm.new

--- a/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/decoupled_references/candidate_requests_a_reference_spec.rb
@@ -41,6 +41,18 @@ RSpec.feature 'Candidate requests a reference' do
     and_i_confirm_that_i_am_ready_to_send_a_reference_request
     then_i_am_told_a_reference_has_already_been_sent
 
+    when_i_manually_try_and_edit_my_references_type
+    then_i_am_redirected_to_the_review_page
+
+    when_i_manually_try_and_edit_my_references_name
+    then_i_am_redirected_to_the_review_page
+
+    when_i_manually_try_and_edit_my_references_email_address
+    then_i_am_redirected_to_the_review_page
+
+    when_i_manually_try_and_edit_my_references_relationship
+    then_i_am_redirected_to_the_review_page
+
     when_i_have_added_an_incomplete_reference
     and_i_visit_the_all_references_review_page
     then_i_should_not_see_a_send_reference_link
@@ -150,6 +162,26 @@ RSpec.feature 'Candidate requests a reference' do
     expect(page).to have_content "Reference request already sent to #{@reference.name}"
     reference_requests = all_emails.select { |e| e.to.shift == @reference.email_address }
     expect(reference_requests.count).to eq 1
+  end
+
+  def when_i_manually_try_and_edit_my_references_type
+    visit candidate_interface_decoupled_references_edit_type_path(@reference.id)
+  end
+
+  def then_i_am_redirected_to_the_review_page
+    expect(page).to have_current_path candidate_interface_decoupled_references_review_path
+  end
+
+  def when_i_manually_try_and_edit_my_references_name
+    visit candidate_interface_decoupled_references_edit_name_path(@reference.id)
+  end
+
+  def when_i_manually_try_and_edit_my_references_email_address
+    visit candidate_interface_decoupled_references_edit_email_address_path(@reference.id)
+  end
+
+  def when_i_manually_try_and_edit_my_references_relationship
+    visit candidate_interface_decoupled_references_edit_relationship_path(@reference.id)
   end
 
   def when_i_have_added_an_incomplete_reference


### PR DESCRIPTION
## Context

At the moment, a candidate can manually visit a references edit/new paths. This allows then to update previously sent references. This allows them to change the email/name of the received reference which is not good for obvious reasons.

## Changes proposed in this pull request

- Redirect away from the type name and relationship controllers unless the reference is in the not_requested_yet state
- Redirect away from the email controller unless the reference is in the not_requested_yet or email_bounced state

## Link to Trello card

https://trello.com/c/TPXBtAdm/2385-%F0%9F%92%94-dont-allow-edits-to-references-that-have-already-been-requested

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
