### PR TITLE
Bugfix - check for existence of reference in destroy actions

### DIFF
--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -35,19 +35,23 @@ module CandidateInterface
       end
 
       def confirm_destroy_referee
-        redirect_to candidate_interface_decoupled_references_review_path unless @reference.not_requested_yet?
+        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
+        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.not_requested_yet?
       end
 
       def confirm_destroy_reference
-        redirect_to candidate_interface_decoupled_references_review_path unless @reference.feedback_provided?
+        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
+        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.feedback_provided?
       end
 
       def confirm_destroy_reference_request
-        redirect_to candidate_interface_decoupled_references_review_path unless @reference.request_can_be_deleted?
+        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
+        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.request_can_be_deleted?
       end
 
       def destroy
-        redirect_to candidate_interface_decoupled_references_review_path unless @reference.can_be_destroyed? || @reference.request_can_be_deleted?
+        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
+        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.can_be_destroyed? || @reference.request_can_be_deleted?
 
         @reference.destroy!
         redirect_to candidate_interface_decoupled_references_review_path

--- a/app/controllers/candidate_interface/decoupled_references/review_controller.rb
+++ b/app/controllers/candidate_interface/decoupled_references/review_controller.rb
@@ -24,9 +24,9 @@ module CandidateInterface
             redirect_to candidate_interface_decoupled_references_new_candidate_name_path(@reference.id)
           elsif @submit_reference_form.send_request?
             CandidateInterface::DecoupledReferences::RequestReference.new.call(@reference, flash)
-            redirect_to candidate_interface_decoupled_references_review_path
+            redirect_to_review_page
           else
-            redirect_to candidate_interface_decoupled_references_review_path
+            redirect_to_review_page
           end
         else
           track_validation_error(@submit_reference_form)
@@ -35,33 +35,37 @@ module CandidateInterface
       end
 
       def confirm_destroy_referee
-        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
-        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.not_requested_yet?
+        unless @reference.present? && @reference.not_requested_yet?
+          redirect_to_review_page
+        end
       end
 
       def confirm_destroy_reference
-        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
-        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.feedback_provided?
+        unless @reference.present? && @reference.feedback_provided?
+          redirect_to_review_page
+        end
       end
 
       def confirm_destroy_reference_request
-        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
-        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.request_can_be_deleted?
+        unless @reference.present? && @reference.request_can_be_deleted?
+          redirect_to_review_page
+        end
       end
 
       def destroy
-        redirect_to candidate_interface_decoupled_references_review_path and return if @reference.blank?
-        redirect_to candidate_interface_decoupled_references_review_path and return unless @reference.can_be_destroyed? || @reference.request_can_be_deleted?
+        unless @reference.present? && (@reference.can_be_destroyed? || @reference.request_can_be_deleted?)
+          redirect_to_review_page
+        end
 
         @reference.destroy!
-        redirect_to candidate_interface_decoupled_references_review_path
+        redirect_to_review_page
       end
 
       def confirm_cancel
         if @reference.feedback_requested?
           @application_form = current_application
         else
-          redirect_to candidate_interface_decoupled_references_review_path
+          redirect_to_review_page
         end
       end
 
@@ -69,10 +73,10 @@ module CandidateInterface
         if @reference.feedback_requested?
           CancelReference.call(@reference)
 
-          redirect_to candidate_interface_decoupled_references_review_path
+          redirect_to_review_page
           flash[:success] = "Reference request cancelled for #{@reference.name}"
         else
-          redirect_to candidate_interface_decoupled_references_review_path
+          redirect_to_review_page
         end
       end
 
@@ -80,6 +84,10 @@ module CandidateInterface
 
       def submit_param
         params.dig(:candidate_interface_reference_submit_referee_form, :submit)
+      end
+
+      def redirect_to_review_page
+        redirect_to candidate_interface_decoupled_references_review_path
       end
     end
   end


### PR DESCRIPTION


## Context
Hitting the back button after a destroy raises an error, as we attempt
to call methods on `@reference` which is now nil. 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add a guard clause to
prevent the error.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
n/a - https://sentry.io/organizations/dfe-bat/issues/1993095275/?project=1765973&referrer=slack
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
