### PR TITLE
Add diversity information to org-org permissions diagram

### DIFF
--- a/app/presenters/support_interface/provider_relationships_diagram.rb
+++ b/app/presenters/support_interface/provider_relationships_diagram.rb
@@ -78,11 +78,19 @@ module SupportInterface
     end
 
     def translate_training_permissions(permission)
-      "#{permission.training_provider_can_view_safeguarding_information ? '✅ view safeguarding' : '❌ view safeguarding'} #{permission.training_provider_can_make_decisions ? '✅ make decisions' : '❌ make decisions'}"
+      "#{value_indicator(permission.training_provider_can_view_safeguarding_information)} view safeguarding "\
+      "#{value_indicator(permission.training_provider_can_view_diversity_information)} view diversity "\
+      "#{value_indicator(permission.training_provider_can_make_decisions)} make decisions"
     end
 
     def translate_ratifying_permissions(permission)
-      "#{permission.ratifying_provider_can_view_safeguarding_information ? '✅ view safeguarding' : '❌ view safeguarding'} #{permission.ratifying_provider_can_make_decisions ? '✅ make decisions' : '❌ make decisions'}"
+      "#{value_indicator(permission.ratifying_provider_can_view_safeguarding_information)} view safeguarding "\
+      "#{value_indicator(permission.ratifying_provider_can_view_diversity_information)} view diversity "\
+      "#{value_indicator(permission.ratifying_provider_can_make_decisions)} make decisions"
+    end
+
+    def value_indicator(permission_value)
+      permission_value ? '✅' : '❌'
     end
   end
 end

--- a/spec/system/support_interface/viewing_provider_permissions_spec.rb
+++ b/spec/system/support_interface/viewing_provider_permissions_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing provider-provider permissions via support' do
+  include DfESignInHelpers
+
+  scenario 'Support user views provider permissions via users page' do
+    given_i_am_a_support_user
+    and_there_are_two_providers_in_a_partnership
+
+    when_i_visit_the_training_provider
+    and_click_users
+    then_i_should_see_the_training_provider_permissions_diagram
+
+    when_i_visit_the_ratifying_provider
+    and_click_users
+    then_i_should_see_the_ratifying_provider_permissions_diagram
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_two_providers_in_a_partnership
+    training = create(:provider, sync_courses: true, name: 'Numan College')
+    ratifying = create(:provider, sync_courses: true, name: 'Oldman University')
+
+    create(
+      :provider_relationship_permissions,
+      training_provider: training,
+      ratifying_provider: ratifying,
+      ratifying_provider_can_make_decisions: true,
+      ratifying_provider_can_view_safeguarding_information: false,
+      ratifying_provider_can_view_diversity_information: true,
+      training_provider_can_make_decisions: false,
+      training_provider_can_view_safeguarding_information: true,
+      training_provider_can_view_diversity_information: false,
+    )
+  end
+
+  def when_i_visit_the_training_provider
+    click_on 'Providers'
+    click_on 'Numan College'
+  end
+
+  def and_click_users
+    click_on 'Users'
+  end
+
+  def then_i_should_see_the_training_provider_permissions_diagram
+    expect(page).to have_content 'can ✅ view safeguarding ❌ view diversity ❌ make decisions for courses ratified by'
+  end
+
+  def when_i_visit_the_ratifying_provider
+    visit '/support'
+    click_on 'Providers'
+    click_on 'Oldman University'
+  end
+
+  def then_i_should_see_the_ratifying_provider_permissions_diagram
+    expect(page).to have_content 'can ❌ view safeguarding ✅ view diversity ✅ make decisions for courses run by'
+  end
+end


### PR DESCRIPTION
## Context
Diversity permissions should be shown in the support console diagram

## Changes proposed in this pull request
Add diversity to permissions diagram
![image](https://user-images.githubusercontent.com/30071178/97703252-3d49b280-1aa8-11eb-8276-b0980e5231d8.png)

## Guidance to review
Not a big change - the diagram can get a bit busy now, but it's not major

## Link to Trello card
https://trello.com/c/ICDdIYIY/2871-show-diversity-permissions-on-the-org-org-relationship-diagram

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
