### PR TITLE
Update brakeman config to include UnscopedFind check

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -15,7 +15,7 @@ module CandidateInterface
     end
 
     def edit
-      @qualification_type = OtherQualificationTypeForm.build_from_qualification(ApplicationQualification.find(params[:id]))
+      @qualification_type = OtherQualificationTypeForm.build_from_qualification(current_qualification)
     end
 
     def update

--- a/brakeman.yml
+++ b/brakeman.yml
@@ -1,6 +1,8 @@
 ---
 pager: false
 quiet: true
+enable_checks:
+  - CheckUnscopedFind
 skip_checks:
   # This Check issues a lot of false positives because it thinks that
   # our component calls `Render` use user input.

--- a/brakeman.yml
+++ b/brakeman.yml
@@ -3,6 +3,8 @@ pager: false
 quiet: true
 enable_checks:
   - CheckUnscopedFind
+skip_files:
+  - /app/controllers/support_interface/
 skip_checks:
   # This Check issues a lot of false positives because it thinks that
   # our component calls `Render` use user input.

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,146 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "07081676ffe0bf0ef753045ae9dcc86c848df5f35a9e48a22692159d5352fbd1",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
+      "file": "app/controllers/provider_interface/provider_relationship_permissions_controller.rb",
+      "line": 32,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "ProviderRelationshipPermissions.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::ProviderRelationshipPermissionsController",
+        "method": "render_404_unless_permissions_found"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "4c106936481ffa09c60383aed2a7b8e931b1672602d3f5a69ccaf9bd688cbf62",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
+      "file": "app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb",
+      "line": 40,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "ProviderRelationshipPermissions.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::ProviderRelationshipPermissionsSetupController",
+        "method": "save_permissions"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "6ef6028f663074c27a5022a598ab480021906f24a15525d47be3a5be44348320",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
+      "file": "app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "ProviderRelationshipPermissions.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::ProviderRelationshipPermissionsSetupController",
+        "method": "setup_permissions"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "77d33cae7c75a2a5315e9cae27cdcf4fcfccfca45eedb3202e75043fd5801bf0",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `CourseOption#find`",
+      "file": "app/controllers/provider_interface/decisions_controller.rb",
+      "line": 35,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "CourseOption.find(params[:course_option_id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::DecisionsController",
+        "method": "confirm_offer"
+      },
+      "user_input": "params[:course_option_id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "888df680e5c3ed7e243853bd4e44a6a4d10fe664576ff034ae15da1480ca8b15",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `ProviderRelationshipPermissions#find`",
+      "file": "app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb",
+      "line": 113,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "ProviderRelationshipPermissions.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::ProviderRelationshipPermissionsSetupController",
+        "method": "require_access_to_manage_provider_relationship_permissions!"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "c156deb252a43bc828b89928a0bccce9f8d8e776f8e742ed012929f3211205f4",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `CourseOption#find`",
+      "file": "app/controllers/provider_interface/decisions_controller.rb",
+      "line": 22,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "CourseOption.find(params[:course_option_id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::DecisionsController",
+        "method": "new_offer"
+      },
+      "user_input": "params[:course_option_id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "d910924006fc5ba7182ea2b067b9113b5ea86616fc332f0f15291fd9f34cec66",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `CourseOption#find`",
+      "file": "app/controllers/provider_interface/decisions_controller.rb",
+      "line": 53,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "CourseOption.find(params[:course_option_id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProviderInterface::DecisionsController",
+        "method": "create_offer"
+      },
+      "user_input": "params[:course_option_id]",
+      "confidence": "Weak",
+      "note": ""
+    }
+  ],
+  "updated": "2020-11-03 09:57:34 +0000",
+  "brakeman_version": "4.10.0"
+}

--- a/docs/brakeman.md
+++ b/docs/brakeman.md
@@ -1,0 +1,13 @@
+# Brakeman
+
+[Brakeman](https://github.com/presidentbeef/brakeman) is a static analysis tool which checks for security vulnerabilities.
+
+It is run as part of our CI process and will fail if new vulnerabilities have been introduced.
+
+To run it locally use: `brakeman -c brakeman.yml`
+
+This looks at the `brakeman.yml` config file which can be used to include/skip checks and files/directories.
+
+We are also using a `brakeman.ignore` file which lives in `/config` and is checked in to Git. This file is used to ignore false positive results.
+
+To update the `brakeman.ignore` file run `brakeman -c brakeman.yml -I`. There are good docs for ignoring false positives [here](https://brakemanscanner.org/docs/ignoring_false_positives/).


### PR DESCRIPTION
## Context

We want to catch unscoped update actions and make sure they don't enter the codebase and cause security risks.

## Changes proposed in this pull request

- Update the brakeman.yml config to include the `CheckUnscopedFind` check. 
- Fix the instances of this issue currently in the codebase (15 found)

## Guidance to review



## Link to Trello card

https://trello.com/c/5cJK6zDm/2394-investigate-ways-to-detect-un-scoped-queries

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
