### PR TITLE
Don’t send MissingProvider exceptions to Sentry

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -19,9 +19,7 @@ module ProviderInterface
 
     layout 'application'
 
-    rescue_from MissingProvider, with: lambda { |e|
-      Raven.capture_exception(e)
-
+    rescue_from MissingProvider, with: lambda {
       render template: 'provider_interface/email_address_not_recognised', status: :forbidden
     }
 

--- a/spec/requests/provider_interface/account_creation_in_progress_spec.rb
+++ b/spec/requests/provider_interface/account_creation_in_progress_spec.rb
@@ -22,19 +22,5 @@ RSpec.describe 'GET /provider/applications' do
       expect(response).to have_http_status 403
       expect(response.body).to include('Your email address is not recognised')
     end
-
-    it 'reports the error to Sentry, appending the Sign-in UID' do
-      allow(Raven).to receive(:user_context)
-      allow(Raven).to receive(:capture_exception)
-
-      get '/provider/applications'
-
-      expect(Raven).to have_received(:user_context).with(
-        dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
-        provider_user_admin_url: 'http://www.example.com/support/users/provider/12345',
-      )
-
-      expect(Raven).to have_received(:capture_exception)
-    end
   end
 end


### PR DESCRIPTION
## Context

We now tell the user how to fix the problem, and the notifications aren’t actionable from our end

## Changes proposed in this pull request

Don't forward the `MissingProvider` exception when it hits the `ProviderInterfaceController`

## Link to Trello card

Too much of this https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1604307822172800

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
