### PR TITLE
Set correct subject in GCSE::Science::GradeController

### DIFF
--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -33,7 +33,7 @@ module CandidateInterface
 
     # Required by the GradeControllerConcern
     def set_subject
-      @subject = 'english'
+      @subject = 'science'
     end
   end
 end


### PR DESCRIPTION
## Context

Spotted a bug after merging https://github.com/DFE-Digital/apply-for-teacher-training/pull/3288 🤦 

## Changes proposed in this pull request

Set correct subject in `GCSE::Science::GradeController` 

## Link to Trello card

https://trello.com/c/tg6YxlE2/2420-structured-pre-degree-quals-decoupling-gcsegradecontroller

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
