### PR TITLE
Add permissions data for active provider users export

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -40,6 +40,11 @@ class DataExport < ApplicationRecord
       description: 'The list of provider users that have signed in to apply at least once.',
       class: SupportInterface::ActiveProviderUsersExport,
     },
+    active_provider_user_permissions: {
+      name: 'Active provider user permissions',
+      description: 'The list of provider users with the permissions they have for each of their organisations.',
+      class: SupportInterface::ActiveProviderUserPermissionsExport,
+    },
     course_choice_withdrawal: {
       name: 'Candidate course choice withdrawal survey',
       description: 'A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.',

--- a/app/services/support_interface/active_provider_user_permissions_export.rb
+++ b/app/services/support_interface/active_provider_user_permissions_export.rb
@@ -1,0 +1,28 @@
+module SupportInterface
+  class ActiveProviderUserPermissionsExport
+    def data_for_export
+      active_provider_users = ProviderUser.includes(:providers).where.not(last_signed_in_at: nil)
+
+      active_provider_users.flat_map { |provider_user| data_for_user(provider_user) }
+    end
+
+  private
+
+    def data_for_user(provider_user)
+      provider_user.providers.map do |provider|
+        permissions = provider_user.provider_permissions
+        {
+          name: provider_user.full_name,
+          email_address: provider_user.email_address,
+          provider: provider.name,
+          last_signed_in_at: provider_user.last_signed_in_at,
+          has_make_decisions: permissions.make_decisions.exists?(provider: provider),
+          has_view_safeguarding: permissions.view_safeguarding_information.exists?(provider: provider),
+          has_view_diversity: permissions.view_diversity_information.exists?(provider: provider),
+          has_manage_users: permissions.manage_users.exists?(provider: provider),
+          has_manage_organisations: permissions.manage_organisations.exists?(provider: provider),
+        }
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -785,6 +785,12 @@ FactoryBot.define do
         user.provider_permissions.update_all(view_safeguarding_information: true)
       end
     end
+
+    trait :with_view_diversity_information do
+      after(:create) do |user, _evaluator|
+        user.provider_permissions.update_all(view_diversity_information: true)
+      end
+    end
   end
 
   factory :provider_permissions do

--- a/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
+++ b/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
+  describe '#data_for_export' do
+    it 'returns provider_users and their permissions who have have signed in at least once' do
+      Timecop.freeze(2020, 5, 1, 12, 0, 0) do
+        provider1 = create(:provider)
+        provider2 = create(:provider)
+        provider_user_with_permissions = create(
+          :provider_user,
+          :with_view_safeguarding_information,
+          :with_manage_organisations,
+          :with_manage_users,
+          :with_make_decisions,
+          :with_view_diversity_information,
+          providers: [provider1],
+          last_signed_in_at: 5.days.ago,
+        )
+        provider_user2 = create(:provider_user, providers: [provider2], last_signed_in_at: 5.days.ago)
+        provider_user3 = create(:provider_user, providers: [provider1, provider2], last_signed_in_at: 3.days.ago)
+        create(:provider_user, providers: [provider1])
+
+        expect(described_class.new.data_for_export).to match_array([
+          {
+            name: provider_user_with_permissions.full_name,
+            email_address: provider_user_with_permissions.email_address,
+            provider: provider1.name,
+            last_signed_in_at: 5.days.ago,
+            has_make_decisions: true,
+            has_view_safeguarding: true,
+            has_view_diversity: true,
+            has_manage_users: true,
+            has_manage_organisations: true,
+          },
+          {
+            name: provider_user2.full_name,
+            email_address: provider_user2.email_address,
+            provider: provider2.name,
+            last_signed_in_at: 5.days.ago,
+            has_make_decisions: false,
+            has_view_safeguarding: false,
+            has_view_diversity: false,
+            has_manage_users: false,
+            has_manage_organisations: false,
+          },
+          {
+            name: provider_user3.full_name,
+            email_address: provider_user3.email_address,
+            provider: provider1.name,
+            last_signed_in_at: 3.days.ago,
+            has_make_decisions: false,
+            has_view_safeguarding: false,
+            has_view_diversity: false,
+            has_manage_users: false,
+            has_manage_organisations: false,
+          },
+          {
+            name: provider_user3.full_name,
+            email_address: provider_user3.email_address,
+            provider: provider2.name,
+            last_signed_in_at: 3.days.ago,
+            has_make_decisions: false,
+            has_view_safeguarding: false,
+            has_view_diversity: false,
+            has_manage_users: false,
+            has_manage_organisations: false,
+          },
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
A bit of the work for the ticket I'm working on below. Add permission data about users for each provider for performance analysis

## Changes proposed in this pull request
There is now one row per user/provider pair, rather than just per user. No info has been removed from the export.

## Guidance to review
Should be quite straightforward!

## Link to Trello card
https://trello.com/c/A5wsjz7z/2919-create-downloadable-csvs-for-access-control-performance-analysis

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
