### PR TITLE
Remove ‘Sign in’ link in signed out candidate and support headers

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -37,9 +37,7 @@ class NavigationItems
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),
         ]
       else
-        [
-          NavigationItem.new('Sign in', support_interface_sign_in_path, false),
-        ]
+        []
       end
     end
 

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -12,9 +12,7 @@ class NavigationItems
           NavigationItem.new('Sign out', candidate_interface_sign_out_path, false),
         ]
       else
-        [
-          NavigationItem.new('Sign in', candidate_interface_sign_in_path, false),
-        ]
+        []
       end
     end
 

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -28,11 +28,11 @@ RSpec.feature 'Candidate account' do
     when_i_click_the_sign_out_button
     then_i_should_be_signed_out
 
-    when_i_click_the_signin_link
+    when_i_visit_the_signin_page
     and_i_submit_an_invalid_email_address
     then_i_see_form_errors_on_the_page
 
-    when_i_click_the_signin_link
+    when_i_visit_the_signin_page
     and_i_submit_my_email_address
     then_i_receive_an_email_with_a_signin_link
     when_i_click_on_the_link_in_my_email
@@ -49,7 +49,7 @@ RSpec.feature 'Candidate account' do
     when_i_signed_in_more_than_a_week_ago
     then_i_should_be_signed_out
 
-    when_i_click_the_signin_link
+    when_i_visit_the_signin_page
     and_i_submit_my_email_address_in_uppercase
     then_i_receive_an_email_with_a_signin_link
 
@@ -125,12 +125,8 @@ RSpec.feature 'Candidate account' do
     expect(page).to have_current_path(candidate_interface_create_account_or_sign_in_path)
   end
 
-  def when_i_click_the_signin_link
-    visit '/'
-
-    within('#navigation') do
-      click_on 'Sign in'
-    end
+  def when_i_visit_the_signin_page
+    visit candidate_interface_sign_in_path
   end
 
   def when_i_signed_in_more_than_a_week_ago

--- a/spec/system/candidate_interface/candidate_signs_in_without_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_in_without_account_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Candidate tries to sign in without an account' do
 
     given_i_am_a_candidate_without_an_account
 
-    when_i_go_to_sign_in
+    when_i_visit_the_signin_page
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
 
@@ -22,12 +22,8 @@ RSpec.feature 'Candidate tries to sign in without an account' do
     @email = "#{SecureRandom.hex}@example.com"
   end
 
-  def when_i_go_to_sign_in
-    visit '/'
-
-    within('#navigation') do
-      click_on 'Sign in'
-    end
+  def when_i_visit_the_signin_page
+    visit candidate_interface_sign_in_path
   end
 
   def and_i_submit_my_email_address

--- a/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_tries_to_reuse_magic_link_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Candidate account' do
     end
 
     click_link 'Sign out'
-    expect(page).to have_link 'Sign in'
+    expect(page).to have_current_path(candidate_interface_create_account_or_sign_in_path)
   end
 
   def and_i_try_to_resuse_the_same_magic_link


### PR DESCRIPTION
## Context

With the start page having moved to GOV.UK, the discoverability of Apply (and thus the sign in route) is now more visible. Also, the service title links to the landing page, which is where you sign up/sign in. TL;DR, the sign in link in the header is now redundant. The same can be said for the equivalent link for the support interface.

## Changes proposed in this pull request

| Before | After |
| - | - |
| ![header-before](https://user-images.githubusercontent.com/813383/97907110-acd7d000-1d3c-11eb-89d3-54aadbe59b4c.png) | ![header-after](https://user-images.githubusercontent.com/813383/97907103-a9dcdf80-1d3c-11eb-88fd-3696b1ae919a.png) |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
