### PR TITLE
Relax rejection_reason character limit to match the API docs

### DIFF
--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -4,7 +4,7 @@ class RejectApplication
   attr_accessor :rejection_reason
 
   validates_presence_of :rejection_reason
-  validates_length_of :rejection_reason, maximum: 255
+  validates_length_of :rejection_reason, maximum: 10240
 
   def initialize(actor:, application_choice:, rejection_reason: nil)
     @auth = ProviderAuthorisation.new(actor: actor)

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -13,7 +13,6 @@
         <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
         <%= f.govuk_text_area :rejection_reason,
           label: { text: 'Tell the candidate why you’re rejecting their application', size: 'xl' },
-          max_chars: 255,
           rows: 5 %>
       </div>
 


### PR DESCRIPTION
## Context

The UI suggests that `rejection_reason` is limited to 255 chars and the service enforces that. However, our API docs advertise a much more generous limit (10240 characters) and vendor software seems to submit longer reasons (akin to the email they send to the candidate). Considering we are rebuilding the provider UI to support structured reasons for rejection, while vendors will continue to submit unstructured reasons for rejection for the conceivable future, it's probably ok to relax the `rejection_reason` length restriction for now, and re-enforce various such limits within the 'structured reasons for rejection' work.

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/107591/97907736-a0a04280-1d3d-11eb-9326-325402175873.png)

After:
![image](https://user-images.githubusercontent.com/107591/97907757-a72eba00-1d3d-11eb-9a2e-a418bc3c37d7.png)

## Guidance to review

Easy-peasy.

## Link to Trello card

No card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
