### PR TITLE
Redirect back to reference review page if reference not found

### DIFF
--- a/app/controllers/candidate_interface/references/base_controller.rb
+++ b/app/controllers/candidate_interface/references/base_controller.rb
@@ -19,8 +19,8 @@ module CandidateInterface
         end
       end
 
-      def redirect_to_review_page_unless_reference_is_not_requested_yet
-        redirect_to candidate_interface_references_review_path unless @reference.not_requested_yet?
+      def redirect_to_review_page_unless_reference_is_editable
+        redirect_to candidate_interface_references_review_path unless @reference.present? && @reference.not_requested_yet?
       end
     end
   end

--- a/app/controllers/candidate_interface/references/candidate_name_controller.rb
+++ b/app/controllers/candidate_interface/references/candidate_name_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module References
     class CandidateNameController < BaseController
       before_action :set_reference
-      before_action :redirect_to_review_page_unless_reference_is_not_requested_yet
+      before_action :redirect_to_review_page_unless_reference_is_editable
 
       def new
         @reference_candidate_name_form =

--- a/app/controllers/candidate_interface/references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/email_address_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module References
     class EmailAddressController < BaseController
-      before_action :set_reference, :redirect_to_review_page_unless_not_requested_or_email_bounced
+      before_action :set_reference, :redirect_to_review_page_unless_reference_is_not_requested_or_email_bounced
 
       def new
         @reference_email_address_form = Reference::RefereeEmailAddressForm.new
@@ -45,7 +45,7 @@ module CandidateInterface
           .merge!(reference_id: @reference.id)
       end
 
-      def redirect_to_review_page_unless_not_requested_or_email_bounced
+      def redirect_to_review_page_unless_reference_is_not_requested_or_email_bounced
         unless @reference.present? && (@reference.not_requested_yet? || @reference.email_bounced?)
           redirect_to candidate_interface_references_review_path
         end

--- a/app/controllers/candidate_interface/references/name_controller.rb
+++ b/app/controllers/candidate_interface/references/name_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module References
     class NameController < BaseController
-      before_action :set_reference, :redirect_to_review_page_unless_reference_is_not_requested_yet
+      before_action :set_reference, :redirect_to_review_page_unless_reference_is_editable
 
       def new
         @reference_name_form = Reference::RefereeNameForm.new

--- a/app/controllers/candidate_interface/references/relationship_controller.rb
+++ b/app/controllers/candidate_interface/references/relationship_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module References
     class RelationshipController < BaseController
-      before_action :set_reference, :redirect_to_review_page_unless_reference_is_not_requested_yet
+      before_action :set_reference, :redirect_to_review_page_unless_reference_is_editable
 
       def new
         @references_relationship_form = Reference::RefereeRelationshipForm.new

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -11,6 +11,8 @@ module CandidateInterface
       end
 
       def unsubmitted
+        redirect_to_review_page_unless_reference_is_editable
+
         @submit_reference_form = Reference::SubmitRefereeForm.new
       end
 

--- a/app/controllers/candidate_interface/references/type_controller.rb
+++ b/app/controllers/candidate_interface/references/type_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   module References
     class TypeController < BaseController
       before_action :set_reference, only: %i[edit update]
-      before_action :redirect_to_review_page_unless_reference_is_not_requested_yet, only: %i[edit update]
+      before_action :redirect_to_review_page_unless_reference_is_editable, only: %i[edit update]
 
       def new
         @reference_type_form = Reference::RefereeTypeForm.new

--- a/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adds_a_new_reference_spec.rb
@@ -77,6 +77,12 @@ RSpec.feature 'References' do
     then_i_see_the_review_references_page
     and_i_should_see_my_reference
 
+    when_i_try_to_edit_someone_elses_reference
+    then_i_see_the_review_references_page
+
+    when_i_try_and_edit_a_reference_that_does_not_exist
+    then_i_see_the_review_references_page
+
     when_i_visit_the_unsubmitted_reference_page
     and_i_choose_to_submit_my_reference_now
     and_i_click_save_and_continue
@@ -281,6 +287,15 @@ RSpec.feature 'References' do
 
   def and_i_should_see_my_reference
     expect(page).to have_content 'Character reference from Jessie Pinkman'
+  end
+
+  def when_i_try_to_edit_someone_elses_reference
+    non_associated_reference = create(:reference, :not_requested_yet)
+    visit candidate_interface_references_edit_name_path(non_associated_reference.id)
+  end
+
+  def when_i_try_and_edit_a_reference_that_does_not_exist
+    visit candidate_interface_references_edit_name_path('INVALID')
   end
 
   def when_i_visit_the_unsubmitted_reference_page


### PR DESCRIPTION
## Context

If a candidate manually tries to edit a reference that is not associated with their application or doesn't exist they trigger the not found and error out respectively. The desired behaviour laid out by Paul in the Trello card is that in both situations they should be redirected to the review page. This is the same behaviour that occurs when a user tries to edit a reference in an invalid state.

## Changes proposed in this pull request

- Redirect to the review page if a user tries to manually edit another candidates reference
- Redirect to the review page if a user inputs an id of a reference into the query string that doesn't exist in the db

## Link to Trello card

https://trello.com/c/TPXBtAdm/2385-%F0%9F%92%94-dont-allow-edits-to-references-that-have-already-been-requested

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
