### PR TITLE
Add a service to handle adding a course after application submission

### DIFF
--- a/app/services/support_interface/add_course_choice_after_submission.rb
+++ b/app/services/support_interface/add_course_choice_after_submission.rb
@@ -1,0 +1,22 @@
+module SupportInterface
+  class AddCourseChoiceAfterSubmission
+    attr_reader :application_form, :course_option
+
+    def initialize(application_form:, course_option:)
+      @application_form = application_form
+      @course_option = course_option
+    end
+
+    def call
+      application_choice = ApplicationChoice.create!(
+        application_form: application_form,
+        course_option: course_option,
+        status: 'unsubmitted',
+      )
+
+      SendApplicationToProvider.call(application_choice)
+
+      application_choice
+    end
+  end
+end

--- a/spec/services/support_interface/add_course_choice_after_submission_spec.rb
+++ b/spec/services/support_interface/add_course_choice_after_submission_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::AddCourseChoiceAfterSubmission do
+  describe '#call' do
+    it 'creates a new application choice for an application form with the preferred course option and sends it to the provider' do
+      allow(SendApplicationToProvider).to receive(:call)
+      application_form = create(:application_form)
+      course_option = create(:course_option)
+
+      called = described_class.new(application_form: application_form, course_option: course_option).call
+
+      appended_application_choice = application_form.reload.application_choices.order(:created_at).last
+
+      expect(called).to eq(appended_application_choice)
+      expect(called.application_form).to eq(application_form)
+      expect(called.course_option).to eq(course_option)
+      expect(called.status).to eq('unsubmitted')
+      expect(SendApplicationToProvider).to have_received(:call).with(called)
+    end
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We have a support request to append a course to a submitted application, this isn't something trivial to do in the console.

## Changes proposed in this pull request

- Adds a service class to handle creating a new application choice for the course option provided and associates with the submitted application.
- Notifies the provider of the application.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
