### PR TITLE
Add tzinfo-data gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem 'rails', '~> 6.0'
 gem 'puma', '~> 5.0'
 gem 'pg', '~> 1.2.3'
 
+# do not rely on host’s timezone data, which can be inconsistent
+gem 'tzinfo-data'
+
 gem 'webpacker'
 gem 'govuk_design_system_formbuilder', '~> 2.1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,8 @@ GEM
     trollop (1.16.2)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2020.4)
+      tzinfo (>= 1.0.0)
     uk_postcode (2.1.6)
     unf (0.1.4)
       unf_ext
@@ -534,8 +536,8 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  govuk_markdown
   govuk_design_system_formbuilder (~> 2.1.2)
+  govuk_markdown
   guard-rspec
   holidays
   http
@@ -579,6 +581,7 @@ DEPENDENCIES
   skylight
   super_diff
   timecop
+  tzinfo-data
   uk_postcode
   view_component
   web-console (>= 3.3.0)


### PR DESCRIPTION
Without this gem, `TZInfo`, which knows about which time zone we’re in,
will fall back to the system `zoneinfo` file. We’ve seen this file be in
a weird state inside containers eg where timezone data is incomplete, so
we want to insulate ourselves from that kind of inconsistency.

## Context

https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1604340589000400
