### PR TITLE
Add automatic attribution to audited changes in console

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -165,3 +165,7 @@ Style/AsciiComments:
 
 Style/ConditionalAssignment:
   Enabled: false
+
+Rails/Output:
+  Exclude:
+    - config/initializers/console.rb

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'logstash-logger'
 gem 'logstash-event'
 gem 'request_store_rails'
 gem 'request_store-sidekiq'
+gem 'colorize'
 
 # Background processing
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       clockwork
       timecop
     coderay (1.1.3)
+    colorize (0.8.1)
     commonmarker (0.21.0)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.7)
@@ -526,6 +527,7 @@ DEPENDENCIES
   climate_control
   clockwork
   clockwork-test
+  colorize
   database_cleaner
   db-query-matchers
   deepsort

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -60,6 +60,10 @@ module HostingEnvironment
     environment_name == 'production'
   end
 
+  def self.development?
+    environment_name == 'development'
+  end
+
   def self.sandbox_mode?
     ENV.fetch('SANDBOX', 'false') == 'true'
   end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,0 +1,24 @@
+module ApplyConsole
+  def start
+    show_warning_message_about_environments
+    super
+  end
+
+  def show_warning_message_about_environments
+    if HostingEnvironment.production?
+      puts ("*" * 50).red
+      puts "** You are in the Rails console for PRODUCTION! **".red
+      puts ("*" * 50).red
+    else
+      puts ("-" * 65).blue
+      puts "-- This is the Rails console for the #{HostingEnvironment.environment_name} environment. --".blue
+      puts ("-" * 65).blue
+    end
+  end
+end
+
+module Rails
+  class Console
+    prepend ApplyConsole
+  end
+end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -18,13 +18,13 @@ module ApplyConsole
 
   def show_warning_message_about_environments
     if HostingEnvironment.production?
-      puts ("*" * 50).red
-      puts "** You are in the Rails console for PRODUCTION! **".red
-      puts ("*" * 50).red
+      puts ('*' * 50).red
+      puts '** You are in the Rails console for PRODUCTION! **'.red
+      puts ('*' * 50).red
     else
-      puts ("-" * 65).blue
+      puts ('-' * 65).blue
       puts "-- This is the Rails console for the #{HostingEnvironment.environment_name} environment. --".blue
-      puts ("-" * 65).blue
+      puts ('-' * 65).blue
     end
   end
 end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -29,4 +29,6 @@ module ApplyConsole
   end
 end
 
-Rails::Console.prepend(ApplyConsole)
+if defined?(Rails::Console)
+  Rails::Console.prepend(ApplyConsole)
+end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,7 +1,19 @@
 module ApplyConsole
   def start
     show_warning_message_about_environments
-    super
+
+    if HostingEnvironment.development?
+      super
+    else
+      puts 'Hello! Who are you? This name will be used in the audit log for any changes you make.'
+      who_are_you = $stdin.gets
+      audited_user = "#{who_are_you.chomp} via the Rails console"
+      puts "Any updates to models will be attributed in the audit logs to #{audited_user.inspect}"
+
+      Audited.audit_class.as_user(audited_user) do
+        super
+      end
+    end
   end
 
   def show_warning_message_about_environments
@@ -17,8 +29,4 @@ module ApplyConsole
   end
 end
 
-module Rails
-  class Console
-    prepend ApplyConsole
-  end
-end
+Rails::Console.prepend(ApplyConsole)


### PR DESCRIPTION
## Context

We sometimes make changes via the console. Half the time we remember to set the `audit_user` so the audit log has the correct attribution.

## Changes proposed in this pull request

On development nothing changes:

<img width="1316" alt="Screenshot 2020-11-03 at 12 31 09" src="https://user-images.githubusercontent.com/233676/97985686-806d9380-1dd0-11eb-8a6d-9cbcaf0574fc.png">

On deployed environments you'll have to identify yourself:

<img width="1316" alt="Screenshot 2020-11-03 at 12 34 06" src="https://user-images.githubusercontent.com/233676/97985973-ec4ffc00-1dd0-11eb-8c6e-0dfa269da678.png">

With production being _RED_ to avoid confusion. 

<img width="1316" alt="Screenshot 2020-11-03 at 12 33 45" src="https://user-images.githubusercontent.com/233676/97985942-dfcba380-1dd0-11eb-948d-b624d14bbcaa.png">

When you provide a name the audit log will automatically added to the log:

![image](https://user-images.githubusercontent.com/233676/97986193-4781ee80-1dd1-11eb-81cf-91235cfdf815.png)

## Guidance to review

Is this a dumb idea? Hijacking the Rails console feels weird. I got the idea [from some random medium post](https://medium.com/@sulabhjain/how-to-extend-rails-console-on-initialization-14ac79011332), which is usually the quickest way to organise a production incident.

Unfortunately we don't have access to a username or similar inside the container (I've checked all vars in `ENV`), so hence we need to `gets` the name.