### PR TITLE
Update data export labels for surveys/feedback

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -27,12 +27,12 @@ class DataExport < ApplicationRecord
     },
     candidate_survey: {
       name: 'Candidate survey',
-      description: 'This provides the compiled results of all the candidate satisfaction surveys',
+      description: 'This provides the compiled results of all the multi-page candidate satisfaction surveys',
       class: SupportInterface::CandidateSurveyExport,
     },
     candidate_feedback: {
       name: 'Candidate feedback',
-      description: 'This provides the compiled results of all the candidate feedback forms',
+      description: 'This provides the compiled results of all the new single-page candidate feedback forms',
       class: SupportInterface::CandidateFeedbackExport,
     },
     active_provider_users: {

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -22,17 +22,17 @@ class DataExport < ApplicationRecord
     },
     referee_survey: {
       name: 'Referee survey',
-      description: 'This provides the compiled results of all the referee surveys',
+      description: 'This provides the compiled results of all the referee surveys.',
       class: SupportInterface::RefereeSurveyExport,
     },
     candidate_survey: {
       name: 'Candidate survey',
-      description: 'This provides the compiled results of all the multi-page candidate satisfaction surveys',
+      description: 'This provides the compiled results of all the multi-page candidate satisfaction surveys.',
       class: SupportInterface::CandidateSurveyExport,
     },
     candidate_feedback: {
       name: 'Candidate feedback',
-      description: 'This provides the compiled results of all the new single-page candidate feedback forms',
+      description: 'This provides the compiled results of all the new single-page candidate feedback forms.',
       class: SupportInterface::CandidateFeedbackExport,
     },
     active_provider_users: {
@@ -67,12 +67,12 @@ class DataExport < ApplicationRecord
     },
     equality_and_diversity: {
       name: 'Equality and diversity data',
-      description: 'Anonymised candidate equality and diversity data',
+      description: 'Anonymised candidate equality and diversity data.',
       class: SupportInterface::EqualityAndDiversityExport,
     },
     unexplained_breaks_in_work_history: {
       name: 'Unexplained breaks in work history',
-      description: 'A list of candidates with unexplained breaks in their work history',
+      description: 'A list of candidates with unexplained breaks in their work history.',
       class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
     },
   }.freeze


### PR DESCRIPTION
## Context

We are replacing the candidate survey with a new single-page feedback form. You will be able to export data from both for the foreseeable future in the support interface (even after the feature flag for this is switched on). This PR just updates the copy on the data export links in an attempt to make it a little clearer which is the old and which is the new one.

## Changes proposed in this pull request

<img width="757" alt="image" src="https://user-images.githubusercontent.com/450843/98012177-b3278400-1df0-11eb-9695-0b6b5183feb3.png">

## Guidance to review

- Suggestions for better labels welcome.

Original card:
https://trello.com/c/lQdpvtmy/2281-dev-replace-multi-step-survey-with-single-page-feedback-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
