### PR TITLE
Fix markup for feedback back to dashboard link

### DIFF
--- a/app/views/candidate_interface/feedback_form/thank_you.html.erb
+++ b/app/views/candidate_interface/feedback_form/thank_you.html.erb
@@ -7,6 +7,8 @@
       <%= t('page_titles.thank_you') %>
     </h1>
 
-    <%= govuk_link_to 'Go to your application dashboard', candidate_interface_application_form_path %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Go to your application dashboard', candidate_interface_application_form_path %>
+    </p>
   </div>
 </div>


### PR DESCRIPTION
## Context

Fixes markup issue spotted in product review. Add missing `p` wrapper for backlink.

## Changes proposed in this pull request

Just wraps the link in a `<p class="govuk-body">…</p>`

## Guidance to review

Is the markup correct now?

## Link to Trello card

https://trello.com/c/lQdpvtmy/2281-dev-replace-multi-step-survey-with-single-page-feedback-form
(see comments)

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
