### PR TITLE
Move candidate survey link to the application submitted email

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -24,9 +24,7 @@ module CandidateInterface
   private
 
     def redirect_to_path_if_path_params_are_present_and_valid
-      return false if params[:path].blank? || valid_paths.exclude?(params[:path])
-
-      redirect_to path_params
+      redirect_to path_params if params[:path].present? || valid_paths.include?(params[:path])
     end
 
     def redirect_to_application_form_unless_course_from_find_is_present

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class AfterSignInController < CandidateInterfaceController
+    before_action :redirect_to_path_if_path_params_are_present_and_valid
     before_action :redirect_to_application_form_unless_course_from_find_is_present
 
     def interstitial
@@ -22,6 +23,12 @@ module CandidateInterface
 
   private
 
+    def redirect_to_path_if_path_params_are_present_and_valid
+      return false if params[:path].blank? || valid_paths.exclude?(params[:path])
+
+      redirect_to path_params
+    end
+
     def redirect_to_application_form_unless_course_from_find_is_present
       return false unless course_from_find.nil?
 
@@ -36,6 +43,14 @@ module CandidateInterface
       else
         redirect_to candidate_interface_application_form_path
       end
+    end
+
+    def valid_paths
+      Rails.application.routes.named_routes.helper_names
+    end
+
+    def path_params
+      Rails.application.routes.url_helpers.send(params[:path])
     end
 
     def course_from_find

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -20,7 +20,7 @@ module CandidateInterface
       if FindCandidateByToken.token_not_expired?(candidate)
         render 'confirm_authentication'
       else
-        redirect_to candidate_interface_expired_sign_in_path(u: params[:u])
+        redirect_to candidate_interface_expired_sign_in_path(u: params[:u], path: params[:path])
       end
     end
 
@@ -39,10 +39,11 @@ module CandidateInterface
         sign_in(candidate, scope: :candidate)
         add_identity_to_log candidate.id
         candidate.update_sign_in_fields!
-        redirect_to candidate_interface_interstitial_path
+
+        redirect_to candidate_interface_interstitial_path(path: params[:path])
       else
         encrypted_candidate_id = Encryptor.encrypt(candidate.id)
-        redirect_to candidate_interface_expired_sign_in_path(u: encrypted_candidate_id)
+        redirect_to candidate_interface_expired_sign_in_path(u: encrypted_candidate_id, path: params[:path])
       end
     end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,6 +1,7 @@
 class CandidateMailer < ApplicationMailer
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
+    @candidate_survey_magic_link_with_token = candidate_survey_magic_link_with_token(application_form.candidate)
 
     email_for_candidate(
       application_form,
@@ -327,5 +328,11 @@ private
     raw_token = candidate.refresh_magic_link_token!
     candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token)
   end
-  helper_method :candidate_magic_link
+
+  def candidate_survey_magic_link_with_token(candidate)
+    raw_token = candidate.refresh_magic_link_token!
+    candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token, path: 'candidate_interface_feedback_form_path')
+  end
+
+  helper_method :candidate_magic_link, :candidate_survey_magic_link_with_token
 end

--- a/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
+++ b/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: candidate_interface_authenticate_path, method: :post do |f| %>
+    <%= form_with url: candidate_interface_authenticate_path(path: params[:path]), method: :post do |f| %>
       <h1 class="govuk-heading-xl">
         <%= t('authentication.confirm_authentication.heading') %>
       </h1>

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -22,11 +22,9 @@
     <p class="govuk-body">You can track or withdraw your application from your application dashboard.</p>
     <p class="govuk-body"><%= govuk_link_to 'To view your application, return to your application dashboard', candidate_interface_application_complete_path %>.</p>
 
-    <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
-    <p class="govuk-body">Your feedback will help us improve.</p>
-    <% if FeatureFlag.active?(:feedback_form) %>
-      <%= govuk_button_link_to 'Give feedback', candidate_interface_feedback_form_path %>
-    <% else %>
+    <% unless FeatureFlag.active?('feedback_form') %>
+      <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
+      <p class="govuk-body">Your feedback will help us improve.</p>
       <%= govuk_button_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path %>
     <% end %>
   </div>

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -18,6 +18,16 @@ Sign in to your account anytime to check the progress of your application:
 
 If your training provider decides to progress your application, they’ll contact you to organise an interview.
 
+<% if FeatureFlag.active?(:feedback_form) %>
+
+# Tell us what you think
+
+Your feedback will help us improve the Apply for teacher training service:
+
+<%= @candidate_survey_magic_link_with_token %>
+
+<% end %>
+
 # Get support
 
 Email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -121,6 +121,26 @@
       "note": ""
     },
     {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "cb6f23f5b570c8aed112a88283fabb07b15412263e43126b941534f3e99074d1",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/candidate_interface/after_sign_in_controller.rb",
+      "line": 53,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "Rails.application.routes.url_helpers.send(params[:path])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CandidateInterface::AfterSignInController",
+        "method": "path_params"
+      },
+      "user_input": "params[:path]",
+      "confidence": "High",
+      "note": ""
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "d910924006fc5ba7182ea2b067b9113b5ea86616fc332f0f15291fd9f34cec66",
@@ -141,6 +161,6 @@
       "note": ""
     }
   ],
-  "updated": "2020-11-03 09:57:34 +0000",
+  "updated": "2020-11-03 19:37:48 +0000",
   "brakeman_version": "4.10.0"
 }

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe '.application_submitted' do
     let(:mail) { mailer.application_submitted(@application_form) }
 
+    before { FeatureFlag.activate(:feedback_form) }
+
     it_behaves_like(
       'a mail with subject and content',
       :application_submitted,
@@ -36,6 +38,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
       'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id',
+      'magic link to to authenticate with path params' => 'http://localhost:3000/candidate/confirm_authentication?path=candidate_interface_feedback_form_path&token=raw_token&u=encrypted_id',
     )
   end
 

--- a/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_feedback_form_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe 'Candidate feedback form' do
 
   scenario 'Candidate completes the feedback form' do
     given_the_candidate_completes_and_submits_their_application
-    then_they_should_be_asked_to_give_feedback
+    then_i_should_receive_the_application_submitted_email
+    and_i_should_not_be_asked_to_give_feedback_on_the_submit_success_page
 
-    when_they_click_give_feedback
+    when_i_click_give_feedback
+    and_i_confirm_my_sign_in
     then_they_should_see_the_feedback_form
 
     when_i_click_send_feedback
@@ -29,12 +31,21 @@ RSpec.describe 'Candidate feedback form' do
     candidate_submits_application
   end
 
-  def then_they_should_be_asked_to_give_feedback
-    expect(page).to have_content('Your feedback will help us improve.')
+  def then_i_should_receive_the_application_submitted_email
+    open_email(current_candidate.email_address)
+    expect(current_email.subject).to have_content t('candidate_mailer.application_submitted.subject')
   end
 
-  def when_they_click_give_feedback
-    click_link 'Give feedback'
+  def and_i_should_not_be_asked_to_give_feedback_on_the_submit_success_page
+    expect(page).not_to have_content('Your feedback will help us improve.')
+  end
+
+  def when_i_click_give_feedback
+    current_email.find_css('a')[1].click
+  end
+
+  def and_i_confirm_my_sign_in
+    click_button 'Continue'
   end
 
   def then_they_should_see_the_feedback_form


### PR DESCRIPTION
## Context

When candidates submit an application we already prompt them to complete the equality and diversity questionnaire. Prompting them to complete a satisfaction survey might be excessive. 

So we're adding a link to the [Application submitted](https://qa.apply-for-teacher-training.service.gov.uk/rails/mailers/candidate_mailer/application_submitted) notification prompting users to fill in the satisfaction survey.  

## Changes proposed in this pull request

- Add a link to the application submitted email which has path=x in the query string. This allows us to retain their choice to complete the survey through the sign in process. This has to be done as going forward this will be the only way that a candidate can access the survey.

## Guidance to review

The final section of the card talks about making the link minimal as possible i.e. https://www.apply-for-teacher-training.service.gov.uk/candidate/survey

Should we be hiding the token & other query string params for the magic_link's in general?

If so is there an easy way to do this? I've had a bit of a google, but I've not seen a solution for ActionMailer.

## Link to Trello card

https://trello.com/c/lGQi3MZX/2401-dev-post-submit-satisfaction-survey-prompt

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
