### PR TITLE
Refactor work history and volunteering review components and localisation strings

### DIFF
--- a/app/components/candidate_interface/volunteering_review_component.html.erb
+++ b/app/components/candidate_interface/volunteering_review_component.html.erb
@@ -4,7 +4,7 @@
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' do %>
-            <%= t('application_form.volunteering.delete') %><span class="govuk-visually-hidden"><%= generate_action(volunteering_role: volunteering_role) %></span>
+            <%= t('application_form.volunteering.delete.action') %><span class="govuk-visually-hidden"><%= generate_action(volunteering_role: volunteering_role) %></span>
           <% end %>
         </div>
       <% end %>

--- a/app/components/candidate_interface/volunteering_review_component.html.erb
+++ b/app/components/candidate_interface/volunteering_review_component.html.erb
@@ -1,6 +1,6 @@
 <% @volunteering_roles.each do |volunteering_role| %>
   <%= render(SummaryCardComponent.new(rows: volunteering_role_rows(volunteering_role), editable: @editable)) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: volunteering_role.role, heading_level: @heading_level, check_icon: volunteering_role.working_with_children)) do %>
+    <%= render(SummaryCardHeaderComponent.new(title: volunteering_role.role, heading_level: @heading_level)) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' do %>

--- a/app/components/candidate_interface/volunteering_review_component.rb
+++ b/app/components/candidate_interface/volunteering_review_component.rb
@@ -51,27 +51,27 @@ module CandidateInterface
 
     def working_with_children_row(volunteering_role)
       {
-        key: t('application_form.volunteering.review_working_with_children.review_label'),
+        key: t('application_form.volunteering.working_with_children.review_label'),
         value: volunteering_role.working_with_children ? 'Yes' : 'No',
-        action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_working_with_children.change_action')),
+        action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.working_with_children.change_action')),
         change_path: edit_path(volunteering_role),
       }
     end
 
     def length_row(volunteering_role)
       {
-        key: t('application_form.volunteering.review_length.review_label'),
+        key: t('application_form.volunteering.length.review_label'),
         value: formatted_length(volunteering_role),
-        action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_length.change_action')),
+        action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.length.change_action')),
         change_path: edit_path(volunteering_role),
       }
     end
 
     def details_row(volunteering_role)
       {
-        key: t('application_form.volunteering.review_details.review_label'),
+        key: t('application_form.volunteering.details.review_label'),
         value: formatted_details(volunteering_role),
-        action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_details.change_action')),
+        action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.details.change_action')),
         change_path: edit_path(volunteering_role),
       }
     end

--- a/app/components/candidate_interface/volunteering_review_component.rb
+++ b/app/components/candidate_interface/volunteering_review_component.rb
@@ -17,6 +17,7 @@ module CandidateInterface
       [
         role_row(volunteering_role),
         organisation_row(volunteering_role),
+        working_with_children_row(volunteering_role),
         length_row(volunteering_role),
         details_row(volunteering_role),
       ]
@@ -44,6 +45,15 @@ module CandidateInterface
         key: t('application_form.volunteering.organisation.review_label'),
         value: volunteering_role.organisation,
         action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.organisation.change_action')),
+        change_path: edit_path(volunteering_role),
+      }
+    end
+
+    def working_with_children_row(volunteering_role)
+      {
+        key: t('application_form.volunteering.review_working_with_children.review_label'),
+        value: volunteering_role.working_with_children ? 'Yes' : 'No',
+        action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_working_with_children.change_action')),
         change_path: edit_path(volunteering_role),
       }
     end

--- a/app/components/candidate_interface/work_history_review_component.html.erb
+++ b/app/components/candidate_interface/work_history_review_component.html.erb
@@ -5,7 +5,7 @@
         <% if @editable %>
           <div class="app-summary-card__actions">
             <%= link_to candidate_interface_work_history_destroy_path(entry.id), class: 'govuk-link' do %>
-              <%= t('application_form.work_history.delete_entry') %><span class="govuk-visually-hidden"><%= generate_action(work: entry) %></span>
+              <%= t('application_form.work_history.delete_entry.action') %><span class="govuk-visually-hidden"><%= generate_action(work: entry) %></span>
             <% end %>
           </div>
         <% end %>

--- a/app/components/candidate_interface/work_history_review_component.html.erb
+++ b/app/components/candidate_interface/work_history_review_component.html.erb
@@ -1,7 +1,7 @@
 <% @work_history_with_breaks.each do |entry| %>
   <% if entry.is_a?(ApplicationWorkExperience) %>
     <%= render(SummaryCardComponent.new(rows: work_experience_rows(entry), editable: @editable)) do %>
-      <%= render(SummaryCardHeaderComponent.new(title: entry.role, heading_level: @heading_level, check_icon: entry.working_with_children)) do %>
+      <%= render(SummaryCardHeaderComponent.new(title: entry.role, heading_level: @heading_level)) do %>
         <% if @editable %>
           <div class="app-summary-card__actions">
             <%= link_to candidate_interface_work_history_destroy_path(entry.id), class: 'govuk-link' do %>

--- a/app/components/candidate_interface/work_history_review_component.rb
+++ b/app/components/candidate_interface/work_history_review_component.rb
@@ -15,8 +15,9 @@ module CandidateInterface
       [
         job_row(work),
         working_pattern_row(work),
-        description_row(work),
         dates_row(work),
+        description_row(work),
+        working_with_children_row(work),
       ]
         .compact
     end
@@ -79,6 +80,15 @@ module CandidateInterface
       }
     end
 
+    def dates_row(work)
+      {
+        key: 'Dates',
+        value: "#{formatted_start_date(work)} - #{formatted_end_date(work)}",
+        action: generate_action(work: work, attribute: 'dates'),
+        change_path: candidate_interface_work_history_edit_path(work.id),
+      }
+    end
+
     def description_row(work)
       {
         key: 'Description',
@@ -88,11 +98,11 @@ module CandidateInterface
       }
     end
 
-    def dates_row(work)
+    def working_with_children_row(work)
       {
-        key: 'Dates',
-        value: "#{formatted_start_date(work)} - #{formatted_end_date(work)}",
-        action: generate_action(work: work, attribute: 'dates'),
+        key: 'Did this job involve working in a school or with children?',
+        value: work.working_with_children ? 'Yes' : 'No',
+        action: generate_action(work: work, attribute: 'if this job involved working in a school or with children'),
         change_path: candidate_interface_work_history_edit_path(work.id),
       }
     end

--- a/app/components/candidate_interface/work_history_review_component.rb
+++ b/app/components/candidate_interface/work_history_review_component.rb
@@ -13,10 +13,10 @@ module CandidateInterface
 
     def work_experience_rows(work)
       [
-        job_row(work),
+        role_row(work),
         working_pattern_row(work),
         dates_row(work),
-        description_row(work),
+        details_row(work),
         working_with_children_row(work),
       ]
         .compact
@@ -25,20 +25,20 @@ module CandidateInterface
     def no_work_experience_rows
       [
         {
-          key: 'Explanation of why you’ve been out of the workplace',
+          key: t('application_form.work_history.explanation.review_label'),
           value: @application_form.work_history_explanation,
-          action: 'explanation of why you’ve been out of the workplace',
+          action: t('application_form.work_history.explanation.change_action'),
           change_path: candidate_interface_work_history_explanation_path,
         },
       ]
     end
 
     def break_in_work_history_rows
-      action_label = t("application_form.work_history.break.#{@application_form.work_history_breaks ? 'change' : 'enter'}_label")
+      action_label = t("application_form.work_history.breaks.#{@application_form.work_history_breaks ? 'change' : 'enter'}_action")
 
       [
         {
-          key: t('application_form.work_history.break.label'),
+          key: t('application_form.work_history.breaks.review_label'),
           value: @application_form.work_history_breaks,
           action: action_label,
           action_path: Rails.application.routes.url_helpers.candidate_interface_work_history_breaks_path,
@@ -62,47 +62,47 @@ module CandidateInterface
 
     attr_reader :application_form
 
-    def job_row(work)
+    def role_row(work)
       {
-        key: 'Job',
+        key: t('application_form.work_history.role.review_label'),
         value: [work.role, work.organisation],
-        action: generate_action(work: work, attribute: 'job title'),
+        action: generate_action(work: work, attribute: t('application_form.work_history.role.change_action')),
         change_path: candidate_interface_work_history_edit_path(work.id),
       }
     end
 
     def working_pattern_row(work)
       {
-        key: 'Working pattern',
+        key: t('application_form.work_history.working_pattern.review_label'),
         value: working_pattern(work),
-        action: generate_action(work: work, attribute: 'type'),
+        action: generate_action(work: work, attribute: t('application_form.work_history.working_pattern.change_action')),
         change_path: candidate_interface_work_history_edit_path(work.id),
       }
     end
 
     def dates_row(work)
       {
-        key: 'Dates',
+        key: t('application_form.work_history.dates.review_label'),
         value: "#{formatted_start_date(work)} - #{formatted_end_date(work)}",
-        action: generate_action(work: work, attribute: 'dates'),
+        action: generate_action(work: work, attribute: t('application_form.work_history.dates.change_action')),
         change_path: candidate_interface_work_history_edit_path(work.id),
       }
     end
 
-    def description_row(work)
+    def details_row(work)
       {
-        key: 'Description',
+        key: t('application_form.work_history.details.review_label'),
         value: work.details,
-        action: generate_action(work: work, attribute: 'description'),
+        action: generate_action(work: work, attribute: t('application_form.work_history.details.change_action')),
         change_path: candidate_interface_work_history_edit_path(work.id),
       }
     end
 
     def working_with_children_row(work)
       {
-        key: 'Did this job involve working in a school or with children?',
-        value: work.working_with_children ? 'Yes' : 'No',
-        action: generate_action(work: work, attribute: 'if this job involved working in a school or with children'),
+        key: t('application_form.work_history.working_with_children.review_label'),
+        value: work.working_with_children ? t('application_form.work_history.working_with_children.yes.label') : t('application_form.work_history.working_with_children.no.label'),
+        action: generate_action(work: work, attribute: t('application_form.work_history.working_with_children.change_action')),
         change_path: candidate_interface_work_history_edit_path(work.id),
       }
     end

--- a/app/components/candidate_interface/work_history_review_component.rb
+++ b/app/components/candidate_interface/work_history_review_component.rb
@@ -14,6 +14,7 @@ module CandidateInterface
     def work_experience_rows(work)
       [
         role_row(work),
+        organisation_row(work),
         working_pattern_row(work),
         dates_row(work),
         details_row(work),
@@ -65,8 +66,17 @@ module CandidateInterface
     def role_row(work)
       {
         key: t('application_form.work_history.role.review_label'),
-        value: [work.role, work.organisation],
+        value: work.role,
         action: generate_action(work: work, attribute: t('application_form.work_history.role.change_action')),
+        change_path: candidate_interface_work_history_edit_path(work.id),
+      }
+    end
+
+    def organisation_row(work)
+      {
+        key: t('application_form.work_history.organisation.review_label'),
+        value: work.organisation,
+        action: generate_action(work: work, attribute: t('application_form.work_history.organisation.change_action')),
         change_path: candidate_interface_work_history_edit_path(work.id),
       }
     end

--- a/app/components/summary_card_header_component.html.erb
+++ b/app/components/summary_card_header_component.html.erb
@@ -1,14 +1,6 @@
 <header class="app-summary-card__header">
   <h<%= @heading_level %> class="app-summary-card__title">
     <%= @title %>
-    <% if @check_icon %>
-      <span class="app-summary-card__meta">
-        <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
-          <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
-        </svg>
-        <%= t('application_form.review.role_involved_working_with_children') %>
-      </span>
-    <% end %>
   </h<%= @heading_level %>>
   <%= content %>
 </header>

--- a/app/components/summary_card_header_component.rb
+++ b/app/components/summary_card_header_component.rb
@@ -1,7 +1,6 @@
 class SummaryCardHeaderComponent < ViewComponent::Base
-  def initialize(title:, heading_level: 2, check_icon: false)
+  def initialize(title:, heading_level: 2)
     @title = title
     @heading_level = heading_level
-    @check_icon = check_icon
   end
 end

--- a/app/views/candidate_interface/volunteering/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/volunteering/destroy/confirm_destroy.html.erb
@@ -9,10 +9,10 @@
         <%= t('page_titles.destroy_volunteering_role') %>
       </h1>
 
-      <%= f.submit t('application_form.volunteering.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.volunteering.delete.confirm'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Cancel', candidate_interface_review_volunteering_path %>
+        <%= govuk_link_to t('application_form.volunteering.delete.cancel'), candidate_interface_review_volunteering_path %>
       </p>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/break/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/work_history/break/confirm_destroy.html.erb
@@ -9,10 +9,10 @@
         <%= t('page_titles.destroy_work_history_break') %>
       </h1>
 
-      <%= f.submit t('application_form.work_history.sure_delete_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.work_history.delete_entry.confirm'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Cancel', candidate_interface_work_history_show_path %>
+        <%= govuk_link_to t('application_form.work_history.delete_entry.cancel'), candidate_interface_work_history_show_path %>
       </p>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/breaks/edit.html.erb
+++ b/app/views/candidate_interface/work_history/breaks/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @work_breaks_form, url: candidate_interface_work_history_breaks_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_area :work_history_breaks, label: { text: t('application_form.work_history.break.label'), tag: 'h1', size: 'xl' }, max_words: 400, rows: 10 do %>
+      <%= f.govuk_text_area :work_history_breaks, label: { text: t('application_form.work_history.breaks.label'), tag: 'h1', size: 'xl' }, max_words: 400, rows: 10 do %>
         <p class="govuk-body">
           For example, reasons for a break in employment might include parenting
           or caring responsibilities, study, travel, unemployment, a career

--- a/app/views/candidate_interface/work_history/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/work_history/destroy/confirm_destroy.html.erb
@@ -9,10 +9,10 @@
         <%= t('page_titles.work_history_destroy') %>
       </h1>
 
-      <%= f.submit t('application_form.work_history.sure_delete_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.work_history.delete_entry.confirm'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Cancel', candidate_interface_work_history_show_path %>
+        <%= govuk_link_to t('application_form.work_history.delete_entry.cancel'), candidate_interface_work_history_show_path %>
       </p>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -3,28 +3,26 @@
 
 <%= f.govuk_text_field :role, label: { text: t('application_form.work_history.role.label'), size: 'm' } %>
 
-<%= f.govuk_text_field :organisation, label: { text: t('application_form.work_history.organisation.label'), size: 'm' }, hint: { text: 'If you worked for yourself, enter ‘self-employed’. Include the name of your company if you had one.' } %>
+<%= f.govuk_text_field :organisation, label: { text: t('application_form.work_history.organisation.label'), size: 'm' }, hint: { text: t('application_form.work_history.organisation.hint_text') } %>
 
-<%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: 'Was this job full-time or part-time?', tag: 'span' } do %>
-  <%= f.govuk_radio_button :commitment, 'full_time', label: { text: 'Full-time' }, link_errors: true %>
-  <%= f.govuk_radio_button :commitment, 'part_time', label: { text: 'Part-time' } do %>
-    <%= f.govuk_text_area :working_pattern, label: { text: 'Give details about your working pattern', size: 's' }, hint: { text: 'For example: ‘20 hours per week’' }, rows: 3 %>
+<%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: t('application_form.work_history.commitment.label'), tag: 'span' } do %>
+  <%= f.govuk_radio_button :commitment, 'full_time', label: { text: t('application_form.work_history.commitment.full_time.label') }, link_errors: true %>
+  <%= f.govuk_radio_button :commitment, 'part_time', label: { text: t('application_form.work_history.commitment.part_time.label') } do %>
+    <%= f.govuk_text_area :working_pattern, label: { text: t('application_form.work_history.working_pattern.label'), size: 's' }, hint: { text: t('application_form.work_history.working_pattern.hint_text') }, rows: 3 %>
   <% end %>
 <% end %>
 
 <div class="app-work-experience__start-date" data-qa="start-date">
-  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: 'Start date', size: 'm', tag: 'span' }, hint: { text: 'For example, 5 2018' } %>
+  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.work_history.start_date.label'), size: 'm', tag: 'span' }, hint: { text: t('application_form.work_history.start_date.hint_text') } %>
 </div>
 
 <div class="app-work-experience__end-date" data-qa="end-date">
-  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: 'End date (leave blank if this is your current role)', size: 'm', tag: 'span' }, hint: { text: 'For example, 5 2019' } %>
+  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.work_history.end_date.label'), size: 'm', tag: 'span' }, hint: { text: t('application_form.work_history.end_date.hint_text') } %>
 </div>
 
-<%= f.govuk_text_area :details, label: { text: t('application_form.work_history.details.label'), size: 'm' }, hint: { text: 'Give a brief overview of your role and explain how you developed transferable skills like communication, creativity and organisation' }, max_words: 150 %>
+<%= f.govuk_text_area :details, label: { text: t('application_form.work_history.details.label'), size: 'm' }, hint: { text: t('application_form.work_history.details.hint_text') }, max_words: 150 %>
 
-<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: 'Did this job involve working in a school or with children?', tag: 'span' } do %>
-  <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
-  <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
+<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.work_history.working_with_children.label'), tag: 'span' } do %>
+  <%= f.govuk_radio_button :working_with_children, true, label: { text: t('application_form.work_history.working_with_children.yes.label') }, link_errors: true %>
+  <%= f.govuk_radio_button :working_with_children, false, label: { text: t('application_form.work_history.working_with_children.no.label') } %>
 <% end %>
-
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -17,6 +17,7 @@
 
       <%= render 'form', f: f %>
 
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
         <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -25,15 +25,15 @@
 
       <div class="govuk-!-margin-top-6">
         <%= f.govuk_radio_buttons_fieldset :work_history, legend: { size: 'm', text: 'How long have you been working?', tag: 'h2' } do %>
-          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5.label'), size: 's' }, hint: { text: t('application_form.work_history.less_than_5.hint') }, link_errors: true %>
+          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5.label'), size: 's' }, hint: { text: t('application_form.work_history.less_than_5.hint_text') }, link_errors: true %>
 
-          <%= f.govuk_radio_button :work_history, :more_than_5, label: { text: t('application_form.work_history.more_than_5.label'), size: 's' }, hint: { text: t('application_form.work_history.more_than_5.hint') } %>
+          <%= f.govuk_radio_button :work_history, :more_than_5, label: { text: t('application_form.work_history.more_than_5.label'), size: 's' }, hint: { text: t('application_form.work_history.more_than_5.hint_text') } %>
 
-          <%= f.govuk_radio_button :work_history, :more_than_5_with_breaks, label: { text: t('application_form.work_history.more_than_5_with_breaks.label'), size: 's' }, hint: { text: t('application_form.work_history.more_than_5_with_breaks.hint') } %>
+          <%= f.govuk_radio_button :work_history, :more_than_5_with_breaks, label: { text: t('application_form.work_history.more_than_5_with_breaks.label'), size: 's' }, hint: { text: t('application_form.work_history.more_than_5_with_breaks.hint_text') } %>
 
           <%= f.govuk_radio_divider %>
 
-          <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing.label'), size: 's' }, hint: { text: t('application_form.work_history.missing.hint') } %>
+          <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing.label'), size: 's' }, hint: { text: t('application_form.work_history.missing.hint_text') } %>
         <% end %>
 
         <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <%= form_with model: @application_form, url: candidate_interface_work_history_complete_path do |f| %>
-  <div class='govuk-form-group'>
+  <div class="govuk-form-group">
     <%= f.hidden_field :work_history_completed, value: false %>
     <%= f.govuk_check_box :work_history_completed, true, multiple: false, label: { text: t('application_form.work_history.review.completed_checkbox') } %>
   </div>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -8,9 +8,9 @@
 <%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form)) %>
 
 <% if @application_form.application_work_experiences.any? %>
-  <%= govuk_button_link_to 'Add another job', candidate_interface_work_history_new_path, class: 'govuk-button--secondary' %>
+  <%= govuk_button_link_to t('application_form.work_history.another.button'), candidate_interface_work_history_new_path, class: 'govuk-button--secondary' %>
 <% else %>
-  <%= govuk_button_link_to t('application_form.work_history.add_job'), candidate_interface_work_history_new_path, class: 'govuk-button--secondary' %>
+  <%= govuk_button_link_to t('application_form.work_history.add.button'), candidate_interface_work_history_new_path, class: 'govuk-button--secondary' %>
 <% end %>
 
 <%= form_with model: @application_form, url: candidate_interface_work_history_complete_path do |f| %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -4,8 +4,6 @@ en:
     completed_checkbox: I have completed this section
     continue: Continue
     complete_form_button: Save and continue
-    review:
-      role_involved_working_with_children: This role involved working with children
     courses:
       intro: You can apply for up to 3 courses.
       delete: Delete choice
@@ -337,7 +335,7 @@ en:
         review_label: Organisation
         change_action: organisation
       working_with_children:
-        label: Did this job involve working in a school or with children?
+        label: Did this role involve working in a school or with children?
       length:
         label: How long have you been in this role and what does it involve?
       start_date:
@@ -351,6 +349,9 @@ en:
         hint_text: For example, ‘I volunteer in the classroom every Friday morning’
           or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved
           in activities throughout the year’
+      review_working_with_children:
+        review_label: Did this role involve working in a school or with children?
+        change_action: if this role involve working in a school or with children
       review_length:
         review_label: Tell us how long you’ve been in this role
         change_action: dates

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -104,11 +104,13 @@ en:
         hint_text: You’ll be able to explain why you’ve been out of the workplace.
       role:
         label: Job title
-        review_label: Job
-        change_action: job
+        review_label: Job title
+        change_action: job title
       organisation:
         label: Name of employer
         hint_text: If you worked for yourself, enter ‘self-employed’. Include the name of your company if you had one.
+        review_label: Employer
+        change_action: employer
       commitment:
         label: Was this job full time or part time?
         full_time:
@@ -119,7 +121,7 @@ en:
         label: Give details about your working pattern
         hint_text: 'For example: ‘20 hours per week’'
         review_label: Working pattern
-        change_action: type
+        change_action: working pattern
       dates:
         review_label: Dates
         change_action: dates
@@ -132,8 +134,8 @@ en:
       details:
         label: Skills and experience relevant to teaching you gained in this role
         hint_text: Give a brief overview of your role and explain how you developed transferable skills like communication, creativity and organisation
-        review_label: Description
-        change_action: description
+        review_label: Skills and experience
+        change_action: skills and experience
       working_with_children:
         label: Did this job involve working in a school or with children?
         'yes':
@@ -379,7 +381,7 @@ en:
         change_action: if this role involved working in a school or with children
       length:
         label: How long have you been in this role and what does it involve?
-        review_label: Tell us how long you’ve been in this role
+        review_label: Dates
         change_action: dates
       start_date:
         label: Start date
@@ -392,8 +394,8 @@ en:
         hint_text: For example, ‘I volunteer in the classroom every Friday morning’
           or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved
           in activities throughout the year’
-        review_label: Tell us what it involves
-        change_action: details
+        review_label: Time commitment and responsibilities
+        change_action: time commitment and responsibilities
       complete_form_button: Save and continue
       delete:
         action: Delete role

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -92,37 +92,72 @@ en:
     work_history:
       less_than_5:
         label: Less than 5 years
-        hint: Give us as much of your work history as you can. For example, if you are a recent graduate, tell us about your employment before, during and since leaving university.
+        hint_text: Give us as much of your work history as you can. For example, if you are a recent graduate, tell us about your employment before, during and since leaving university.
       more_than_5:
         label: More than 5 years
-        hint: You can list your complete work history – or just the roles you think are relevant – going back further than 5 years if you wish.
+        hint_text: You can list your complete work history – or just the roles you think are relevant – going back further than 5 years if you wish.
       more_than_5_with_breaks:
         label: More than 5 years, but with breaks
-        hint: You’ll be able to give details once you’ve entered your employment history. Please explain any break longer than a month.
+        hint_text: You’ll be able to give details once you’ve entered your employment history. Please explain any break longer than a month.
       missing:
         label: I have not worked in the last 5 years
-        hint: You’ll be able to explain why you’ve been out of the workplace.
+        hint_text: You’ll be able to explain why you’ve been out of the workplace.
       role:
         label: Job title
+        review_label: Job
+        change_action: job
       organisation:
         label: Name of employer
+        hint_text: If you worked for yourself, enter ‘self-employed’. Include the name of your company if you had one.
+      commitment:
+        label: Was this job full time or part time?
+        full_time:
+          label: Full-time
+        part_time:
+          label: Part-time
+      working_pattern:
+        label: Give details about your working pattern
+        hint_text: 'For example: ‘20 hours per week’'
+        review_label: Working pattern
+        change_action: type
+      dates:
+        review_label: Dates
+        change_action: dates
+      start_date:
+        label: Start date
+        hint_text: For example, 5 2018
+      end_date:
+        label: End date (leave blank if this is your current role)
+        hint_text: For example, 5 2019
       details:
         label: Skills and experience relevant to teaching you gained in this role
+        hint_text: Give a brief overview of your role and explain how you developed transferable skills like communication, creativity and organisation
+        review_label: Description
+        change_action: description
+      working_with_children:
+        label: Did this job involve working in a school or with children?
+        'yes':
+          label: 'Yes'
+        'no':
+          label: 'No'
+        review_label: Did this job involve working in a school or with children?
+        change_action: if this job involved working in a school or with children
+      explanation:
+        label: Tell us why you’ve been out of the workplace
+        review_label: Explanation of why you’ve been out of the workplace
+        change_action: explanation of why you’ve been out of the workplace
+      breaks:
+        review_label: Tell us about any breaks in your work history
+        enter_action: Enter explanation
+        change_action: Change explanation
       complete_form_button: Save and continue
-      delete_entry: Delete entry
       add_job: Add job
       add_another_job: Add another job
+      delete_entry: Delete entry
       sure_delete_entry: Yes I’m sure - delete this entry
-      break:
-        label: Tell us about any breaks in your work history
-        enter_label: Enter explanation
-        change_label: Change explanation
-        button: Continue
       review:
         completed_checkbox: I have completed this section
         button: Continue
-      explanation:
-        label: Tell us why you’ve been out of the workplace
     degree:
       base:
         button: Save and continue

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -360,7 +360,7 @@ en:
         label: Do you have any experience to add?
         button: Save and continue
       no_experience:
-        summary_card_title: "Children and young people: no volunteering or experience in school roles entered"
+        summary_card_title: 'Children and young people: no volunteering or experience in school roles entered'
       role:
         label: Your role
         review_label: Role
@@ -371,8 +371,12 @@ en:
         change_action: organisation
       working_with_children:
         label: Did this role involve working in a school or with children?
+        review_label: Did this role involve working in a school or with children?
+        change_action: if this role involved working in a school or with children
       length:
         label: How long have you been in this role and what does it involve?
+        review_label: Tell us how long you’ve been in this role
+        change_action: dates
       start_date:
         label: Start date
         hint_text: For example, 5 2018
@@ -384,13 +388,6 @@ en:
         hint_text: For example, ‘I volunteer in the classroom every Friday morning’
           or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved
           in activities throughout the year’
-      review_working_with_children:
-        review_label: Did this role involve working in a school or with children?
-        change_action: if this role involve working in a school or with children
-      review_length:
-        review_label: Tell us how long you’ve been in this role
-        change_action: dates
-      review_details:
         review_label: Tell us what it involves
         change_action: details
       complete_form_button: Save and continue

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -151,10 +151,14 @@ en:
         enter_action: Enter explanation
         change_action: Change explanation
       complete_form_button: Save and continue
-      add_job: Add job
-      add_another_job: Add another job
-      delete_entry: Delete entry
-      sure_delete_entry: Yes I’m sure - delete this entry
+      delete_entry:
+        action: Delete entry
+        confirm: Yes I’m sure - delete this entry
+        cancel: Cancel
+      add:
+        button: Add job
+      another:
+        button: Add another job
       review:
         completed_checkbox: I have completed this section
         button: Continue
@@ -391,8 +395,10 @@ en:
         review_label: Tell us what it involves
         change_action: details
       complete_form_button: Save and continue
-      delete: Delete role
-      confirm_delete: Yes I’m sure - delete this role
+      delete:
+        action: Delete role
+        confirm: Yes I’m sure - delete this role
+        cancel: Cancel
       another:
         button: Add another role
       review:

--- a/spec/components/candidate_interface/volunteering_review_component_spec.rb
+++ b/spec/components/candidate_interface/volunteering_review_component_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('School Experience Intern')
     end
 
-    it 'renders component with working with children in the summary card title' do
-      result = render_inline(described_class.new(application_form: application_form))
-
-      expect(result.css('.app-summary-card__title')[0].text).to include(t('application_form.review.role_involved_working_with_children'))
-    end
-
     it 'renders component with correct values for role' do
       result = render_inline(described_class.new(application_form: application_form))
 
@@ -71,6 +65,19 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
       )
       expect(result.css('.govuk-summary-list__actions').text).to include(
         "Change #{t('application_form.volunteering.organisation.change_action')} for School Experience Intern, A Noice School",
+      )
+    end
+
+    it 'renders component with correct values for working with children' do
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_working_with_children.review_label'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Yes')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
+      )
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.volunteering.review_working_with_children.change_action')} for School Experience Intern, A Noice School",
       )
     end
 
@@ -131,8 +138,8 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
 
       result = render_inline(described_class.new(application_form: application_form))
 
-      change_role_for_unique = result.css('.govuk-summary-list__actions')[8].text.strip
-      change_role_for_same1 = result.css('.govuk-summary-list__actions')[4].text.strip
+      change_role_for_unique = result.css('.govuk-summary-list__actions')[10].text.strip
+      change_role_for_same1 = result.css('.govuk-summary-list__actions')[5].text.strip
       change_role_for_same2 = result.css('.govuk-summary-list__actions')[0].text.strip
 
       expect(change_role_for_unique).to eq(

--- a/spec/components/candidate_interface/volunteering_review_component_spec.rb
+++ b/spec/components/candidate_interface/volunteering_review_component_spec.rb
@@ -71,39 +71,39 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
     it 'renders component with correct values for working with children' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_working_with_children.review_label'))
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.working_with_children.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('Yes')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.review_working_with_children.change_action')} for School Experience Intern, A Noice School",
+        "Change #{t('application_form.volunteering.working_with_children.change_action')} for School Experience Intern, A Noice School",
       )
     end
 
     it 'renders component with correct values for length' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_length.review_label'))
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.length.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('August 2019 - Present')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.review_length.change_action')} for School Experience Intern, A Noice School",
+        "Change #{t('application_form.volunteering.length.change_action')} for School Experience Intern, A Noice School",
       )
     end
 
     it 'renders component with correct values for details of experience' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_details.review_label'))
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.details.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('<p class="govuk-body">I interned.</p>')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.volunteering.review_details.change_action')} for School Experience Intern, A Noice School",
+        "Change #{t('application_form.volunteering.details.change_action')} for School Experience Intern, A Noice School",
       )
     end
 

--- a/spec/components/candidate_interface/volunteering_review_component_spec.rb
+++ b/spec/components/candidate_interface/volunteering_review_component_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.app-summary-card__actions').text.strip).to include(
-        "#{t('application_form.volunteering.delete')} for School Experience Intern, A Noice School",
+        "#{t('application_form.volunteering.delete.action')} for School Experience Intern, A Noice School",
       )
       expect(result.css('.app-summary-card__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role),
@@ -158,7 +158,7 @@ RSpec.describe CandidateInterface::VolunteeringReviewComponent do
         result = render_inline(described_class.new(application_form: application_form, editable: false))
 
         expect(result.css('.app-summary-list__actions').text).not_to include('Change')
-        expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.volunteering.delete'))
+        expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.volunteering.delete.action'))
       end
     end
   end

--- a/spec/components/candidate_interface/work_history_review_component_spec.rb
+++ b/spec/components/candidate_interface/work_history_review_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         application_form.application_work_experiences.each do |work|
           expect(result.text).to include(work.role)
           expect(result.text).to include(work.start_date.to_s(:month_and_year))
-          expect(result.text).to include('Yes') # Answer for working with children
+          expect(result.text).to include(work.working_with_children ? 'Yes' : 'No')
         end
       end
 
@@ -54,7 +54,7 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         change_work_with_children = result.css('.govuk-summary-list__actions')[4].text.strip
 
         expect(change_job_title).to eq(
-          'Change job title for Teaching Assistant, Vararu School, January 2019 to June 2019',
+          'Change job for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
         expect(change_type).to eq(
           'Change type for Teaching Assistant, Vararu School, January 2019 to June 2019',
@@ -78,13 +78,13 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         change_job_title_for_same2 = result.css('.govuk-summary-list__actions')[10].text.strip
 
         expect(change_job_title_for_same1).to eq(
-          'Change job title for Teaching Assistant, Vararu School, January 2019 to June 2019',
+          'Change job for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
         expect(change_job_title_for_unique).to eq(
-          'Change job title for Teaching Assistant, Theo School',
+          'Change job for Teaching Assistant, Theo School',
         )
         expect(change_job_title_for_same2).to eq(
-          'Change job title for Teaching Assistant, Vararu School, August 2019 to October 2019',
+          'Change job for Teaching Assistant, Vararu School, August 2019 to October 2019',
         )
       end
     end
@@ -147,8 +147,8 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         result = render(explanation: 'I was sleeping.')
 
         expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
-        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
-        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.breaks.review_label'))
+        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.breaks.change_action'))
       end
     end
 

--- a/spec/components/candidate_interface/work_history_review_component_spec.rb
+++ b/spec/components/candidate_interface/work_history_review_component_spec.rb
@@ -48,22 +48,26 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         result = render_inline(described_class.new(application_form: application_form))
 
         change_job_title = result.css('.govuk-summary-list__actions')[0].text.strip
-        change_type = result.css('.govuk-summary-list__actions')[1].text.strip
-        change_dates = result.css('.govuk-summary-list__actions')[2].text.strip
-        change_description = result.css('.govuk-summary-list__actions')[3].text.strip
-        change_work_with_children = result.css('.govuk-summary-list__actions')[4].text.strip
+        change_employer = result.css('.govuk-summary-list__actions')[1].text.strip
+        change_type = result.css('.govuk-summary-list__actions')[2].text.strip
+        change_dates = result.css('.govuk-summary-list__actions')[3].text.strip
+        change_description = result.css('.govuk-summary-list__actions')[4].text.strip
+        change_work_with_children = result.css('.govuk-summary-list__actions')[5].text.strip
 
         expect(change_job_title).to eq(
-          'Change job for Teaching Assistant, Vararu School, January 2019 to June 2019',
+          'Change job title for Teaching Assistant, Vararu School, January 2019 to June 2019',
+        )
+        expect(change_employer).to eq(
+          'Change employer for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
         expect(change_type).to eq(
-          'Change type for Teaching Assistant, Vararu School, January 2019 to June 2019',
+          'Change working pattern for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
         expect(change_dates).to eq(
           'Change dates for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
         expect(change_description).to eq(
-          'Change description for Teaching Assistant, Vararu School, January 2019 to June 2019',
+          'Change skills and experience for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
         expect(change_work_with_children).to eq(
           'Change if this job involved working in a school or with children for Teaching Assistant, Vararu School, January 2019 to June 2019',
@@ -74,17 +78,17 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         result = render_inline(described_class.new(application_form: application_form))
 
         change_job_title_for_same1 = result.css('.govuk-summary-list__actions')[0].text.strip
-        change_job_title_for_unique = result.css('.govuk-summary-list__actions')[5].text.strip
-        change_job_title_for_same2 = result.css('.govuk-summary-list__actions')[10].text.strip
+        change_job_title_for_unique = result.css('.govuk-summary-list__actions')[6].text.strip
+        change_job_title_for_same2 = result.css('.govuk-summary-list__actions')[12].text.strip
 
         expect(change_job_title_for_same1).to eq(
-          'Change job for Teaching Assistant, Vararu School, January 2019 to June 2019',
+          'Change job title for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
         expect(change_job_title_for_unique).to eq(
-          'Change job for Teaching Assistant, Theo School',
+          'Change job title for Teaching Assistant, Theo School',
         )
         expect(change_job_title_for_same2).to eq(
-          'Change job for Teaching Assistant, Vararu School, August 2019 to October 2019',
+          'Change job title for Teaching Assistant, Vararu School, August 2019 to October 2019',
         )
       end
     end

--- a/spec/components/candidate_interface/work_history_review_component_spec.rb
+++ b/spec/components/candidate_interface/work_history_review_component_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         application_form.application_work_experiences.each do |work|
           expect(result.text).to include(work.role)
           expect(result.text).to include(work.start_date.to_s(:month_and_year))
-          if work.working_with_children
-            expect(result.text).to include(t('application_form.review.role_involved_working_with_children'))
-          end
+          expect(result.text).to include('Yes') # Answer for working with children
         end
       end
 
@@ -51,8 +49,9 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
 
         change_job_title = result.css('.govuk-summary-list__actions')[0].text.strip
         change_type = result.css('.govuk-summary-list__actions')[1].text.strip
-        change_description = result.css('.govuk-summary-list__actions')[2].text.strip
-        change_dates = result.css('.govuk-summary-list__actions')[3].text.strip
+        change_dates = result.css('.govuk-summary-list__actions')[2].text.strip
+        change_description = result.css('.govuk-summary-list__actions')[3].text.strip
+        change_work_with_children = result.css('.govuk-summary-list__actions')[4].text.strip
 
         expect(change_job_title).to eq(
           'Change job title for Teaching Assistant, Vararu School, January 2019 to June 2019',
@@ -60,11 +59,14 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         expect(change_type).to eq(
           'Change type for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
+        expect(change_dates).to eq(
+          'Change dates for Teaching Assistant, Vararu School, January 2019 to June 2019',
+        )
         expect(change_description).to eq(
           'Change description for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
-        expect(change_dates).to eq(
-          'Change dates for Teaching Assistant, Vararu School, January 2019 to June 2019',
+        expect(change_work_with_children).to eq(
+          'Change if this job involved working in a school or with children for Teaching Assistant, Vararu School, January 2019 to June 2019',
         )
       end
 
@@ -72,8 +74,8 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         result = render_inline(described_class.new(application_form: application_form))
 
         change_job_title_for_same1 = result.css('.govuk-summary-list__actions')[0].text.strip
-        change_job_title_for_unique = result.css('.govuk-summary-list__actions')[4].text.strip
-        change_job_title_for_same2 = result.css('.govuk-summary-list__actions')[8].text.strip
+        change_job_title_for_unique = result.css('.govuk-summary-list__actions')[5].text.strip
+        change_job_title_for_same2 = result.css('.govuk-summary-list__actions')[10].text.strip
 
         expect(change_job_title_for_same1).to eq(
           'Change job title for Teaching Assistant, Vararu School, January 2019 to June 2019',

--- a/spec/components/candidate_interface/work_history_review_component_spec.rb
+++ b/spec/components/candidate_interface/work_history_review_component_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe CandidateInterface::WorkHistoryReviewComponent do
         result = render_inline(described_class.new(application_form: application_form, editable: false))
 
         expect(result.css('.app-summary-list__actions').text).not_to include('Change')
-        expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.volunteering.delete'))
+        expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.work_history.delete_entry.action'))
       end
     end
   end

--- a/spec/components/summary_card_header_component_spec.rb
+++ b/spec/components/summary_card_header_component_spec.rb
@@ -12,11 +12,4 @@ RSpec.describe SummaryCardHeaderComponent do
     result = render_inline(SummaryCardHeaderComponent.new(title: 'Lando Calrissian', heading_level: 6))
     expect(result.css('h6.app-summary-card__title')).to be_present
   end
-
-  it 'renders a summary card header component with a title and check icon' do
-    result = render_inline(SummaryCardHeaderComponent.new(title: 'Lando Calrissian', check_icon: true))
-    expect(result.css('.app-summary-card__title').text).to include('Lando Calrissian')
-    expect(result.css('.app-summary-card__meta').text).to include(t('application_form.review.role_involved_working_with_children'))
-    expect(result.css('.app-icon')).to be_present
-  end
 end

--- a/spec/system/candidate_interface/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -81,10 +81,10 @@ RSpec.feature 'Candidate edits their volunteering section' do
   end
 
   def and_i_click_delete_role
-    click_link t('application_form.volunteering.delete')
+    click_link t('application_form.volunteering.delete.action')
   end
 
   def and_i_confirm_i_want_to_delete_the_role
-    click_button t('application_form.volunteering.confirm_delete')
+    click_button t('application_form.volunteering.delete.confirm')
   end
 end

--- a/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
@@ -92,11 +92,11 @@ RSpec.feature 'Candidate deletes their work history' do
   end
 
   def and_i_click_on_delete_entry
-    click_link t('application_form.work_history.delete_entry'), match: :first
+    click_link t('application_form.work_history.delete_entry.action'), match: :first
   end
 
   def and_i_click_on_confirm
-    click_button t('application_form.work_history.sure_delete_entry')
+    click_button t('application_form.work_history.delete_entry.confirm')
   end
 
   def when_i_mark_this_section_as_completed
@@ -108,7 +108,7 @@ RSpec.feature 'Candidate deletes their work history' do
   end
 
   def and_i_click_on_add_another_job
-    click_link t('application_form.work_history.add_another_job')
+    click_link t('application_form.work_history.another.button')
   end
 
   def when_i_click_on_work_history
@@ -116,7 +116,7 @@ RSpec.feature 'Candidate deletes their work history' do
   end
 
   def when_i_click_on_add_job
-    click_link t('application_form.work_history.add_job')
+    click_link t('application_form.work_history.add.button')
   end
 
   def and_i_mark_this_section_as_completed

--- a/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -144,11 +144,11 @@ RSpec.feature 'Entering volunteering and school experience' do
   end
 
   def when_i_delete_my_volunteering_role
-    click_link t('application_form.volunteering.delete')
+    click_link t('application_form.volunteering.delete.action')
   end
 
   def and_i_confirm
-    click_button t('application_form.volunteering.confirm_delete')
+    click_button t('application_form.volunteering.delete.confirm')
   end
 
   def then_i_no_longer_see_my_volunteering_role

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -139,15 +139,15 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_click_on_delete_entry
-    click_link t('application_form.work_history.delete_entry')
+    click_link t('application_form.work_history.delete_entry.action')
   end
 
   def and_i_confirm
-    click_button t('application_form.work_history.sure_delete_entry')
+    click_button t('application_form.work_history.delete_entry.confirm')
   end
 
   def when_i_click_on_add_job
-    click_link t('application_form.work_history.add_job')
+    click_link t('application_form.work_history.add.button')
   end
 
   def and_i_fill_in_the_job_form


### PR DESCRIPTION
## Context

* Removes check icon from summary card header if job/role involved working with children, instead makes it explicit item in summary with ‘Yes’/‘No’ response
* Updates summary row ordering and labels to better match the ordering of fields and their labels on respective question pages
* Uses consistent localisation of strings and string names

## Changes proposed in this pull request

| Before | After |
| - | - |
| ![job-before](https://user-images.githubusercontent.com/813383/98041381-c00c9d80-1e19-11eb-9c83-3a524cfbad4f.png) | ![job-after](https://user-images.githubusercontent.com/813383/98041379-bedb7080-1e19-11eb-8037-a124198fb858.png) |
| ![role-before](https://user-images.githubusercontent.com/813383/98041385-c0a53400-1e19-11eb-811f-0da86fd0d794.png) | ![role-after](https://user-images.githubusercontent.com/813383/98041383-c0a53400-1e19-11eb-99a5-bb1619640b4d.png) |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
