### PR TITLE
Add nil check for DoB in work history export

### DIFF
--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -20,6 +20,7 @@ module SupportInterface
 
     def data_for_export
       applications = ApplicationForm
+                         .where.not(date_of_birth: nil)
                          .select(:id, :candidate_id, :submitted_at, :date_of_birth)
                          .includes(:application_qualifications, :application_work_experiences, :application_work_history_breaks)
                          .order(submitted_at: :desc).uniq(&:candidate_id)


### PR DESCRIPTION
## Context

This fix adds a check for nil in the work history export. The bug was spotted by Sentry ([link here](https://sentry.io/organizations/dfe-bat/issues/2004487361/?project=1765973&referrer=slack))

## Changes proposed in this pull request

Having spoken to Mike, we want to remove any application forms without a date of birth, since we can't calculate when their working life should have begun (~ D.o.B + 18years). 

I've checked through to look for any other `NoMethodError` exceptions by looking for anything else that could be nil.

## Guidance to review

## Link to Trello card

https://trello.com/c/jPJLjr4Q/2392-dev-how-much-work-history

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
