### PR TITLE
Allow refused references to be reinstated from support

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,7 +1,7 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title)) do %>
-      <% if reference.cancelled? %>
+      <% if reference.cancelled? || reference.feedback_refused? %>
         <div class='app-summary-card__actions'>
           <%= link_to support_interface_reinstate_reference_path(reference), class: 'govuk-link' do %>
           Reinstate reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>

--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,16 +1,16 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title)) do %>
-      <% if cancelled? %>
+      <% if reference.cancelled? %>
         <div class='app-summary-card__actions'>
-          <%= link_to support_interface_reinstate_reference_path(@reference), class: 'govuk-link' do %>
-          Reinstate reference<span class="govuk-visually-hidden"> for <%= @reference.name %></span>
+          <%= link_to support_interface_reinstate_reference_path(reference), class: 'govuk-link' do %>
+          Reinstate reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>
           <% end %>
         </div>
-      <% elsif feedback_requested? %>
+      <% elsif reference.feedback_requested? %>
         <div class='app-summary-card__actions'>
-          <%= link_to support_interface_cancel_reference_path(@reference), class: 'govuk-link' do %>
-            Cancel reference<span class="govuk-visually-hidden"> for <%= @reference.name %></span>
+          <%= link_to support_interface_cancel_reference_path(reference), class: 'govuk-link' do %>
+            Cancel reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>
           <% end %>
         </div>
       <% end %>

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -9,8 +9,6 @@ module SupportInterface
              :relationship,
              :feedback_status,
              :consent_to_be_contacted,
-             :cancelled?,
-             :feedback_requested?,
              to: :reference
 
     def initialize(reference:, reference_number:)

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
       expect(rendered_component).to include('Reinstate reference')
       expect(rendered_component).not_to include('Cancel reference')
     end
+
+    it 'Reinstate link is present when the reference is refused' do
+      reference = build_stubbed(:reference, feedback_status: 'feedback_refused')
+
+      render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
+
+      expect(rendered_component).to include('Reinstate reference')
+      expect(rendered_component).not_to include('Cancel reference')
+    end
   end
 
   describe 'title' do


### PR DESCRIPTION
## Context

Referees sometimes accidentally refuse a reference.

## Changes proposed in this pull request

Allow us to reinstate the reference via support, so Zendesk tickets can be solved quickly without a developer. 

## Guidance to review

Per commit.

## Link to Trello card

https://becomingateacher.zendesk.com/agent/tickets/10180 

