### PR TITLE
Improve search for application forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.7.1'
 gem 'rails', '~> 6.0'
 gem 'puma', '~> 5.0'
 gem 'pg', '~> 1.2.3'
+gem 'pg_search'
 
 # do not rely on host’s timezone data, which can be inconsistent
 gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,9 @@ GEM
       trollop (~> 1.16)
     pdfkit (0.8.4.3.2)
     pg (1.2.3)
+    pg_search (2.3.4)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -560,6 +563,7 @@ DEPENDENCIES
   openapi3_parser (= 0.8.2)
   pdfkit
   pg (~> 1.2.3)
+  pg_search
   pry
   pry-byebug
   pry-rails

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -5,6 +5,12 @@ class ApplicationForm < ApplicationRecord
 
   include Chased
 
+  include PgSearch::Model
+
+  pg_search_scope :full_text_search,
+                  against: %i[first_name last_name support_reference],
+                  associated_against: { candidate: [:email_address] }
+
   belongs_to :candidate, touch: true
   has_many :application_choices
   has_many :application_work_experiences

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -14,7 +14,7 @@ module SupportInterface
         .page(applied_filters[:page] || 1).per(15)
 
       if applied_filters[:q]
-        application_forms = application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address, ' ', application_forms.support_reference) ILIKE ?", "%#{applied_filters[:q]}%")
+        application_forms = application_forms.full_text_search(applied_filters[:q])
       end
 
       if applied_filters[:phase]

--- a/spec/services/support_interface/applications_filter_spec.rb
+++ b/spec/services/support_interface/applications_filter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationsFilter do
+  describe '#filter_records' do
+    it 'allows searching by a string' do
+      application_form_in = create(:application_form, first_name: 'Foo', last_name: 'Bar')
+      create(:application_form, first_name: 'Not', last_name: 'Bar')
+
+      expect(results_for(q: 'foo')).to match_array([application_form_in])
+    end
+
+    it 'allows searching by a partial matching string' do
+      application_form_in = create(:application_form, first_name: 'Foo Baz', last_name: 'Bar')
+      create(:application_form, first_name: 'Not', last_name: 'Bar')
+
+      expect(results_for(q: 'Foo Bar')).to match_array([application_form_in])
+    end
+
+    it 'allows searching by a candidate email' do
+      application_form_in = create(:application_form, candidate: create(:candidate, email_address: 'foo@example.com'))
+      create(:application_form)
+
+      expect(results_for(q: 'foo@example.com')).to match_array([application_form_in])
+    end
+  end
+
+  def results_for(params)
+    SupportInterface::ApplicationsFilter
+      .new(params: params)
+      .filter_records(ApplicationForm)
+  end
+end


### PR DESCRIPTION
## Context

Our current "ILIKE" based search isn't very good, because it doesn't do fuzzy-like matching. For example, if the user is named "Sam Norman Seaborn", a search for "Sam Seaborn" will not return anything.

## Changes proposed in this pull request

Luckily, Postgres is a beast and supports very cool full-text search out of the box. To make things even easier we can use the `pg_search` gem, which allows us to create a scope for nice searching.

## Guidance to review

Makes sense?

