### PR TITLE
Update misleading titles on performance dashboard

### DIFF
--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -95,7 +95,7 @@
   <caption class="govuk-table__caption govuk-heading-m">Apply again</caption>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Awaiting decision from provider</th>
+      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Submitted</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.apply_again_submitted_count %></td>
       <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t("performance_dashboard_other_metrics.apply_again_submitted.description") %></td>
     </tr>
@@ -112,7 +112,7 @@
 <table class="govuk-table">
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Providers onboarded</th>
+      <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">Providers with open courses on Apply</th>
       <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.percentage_of_providers_onboarded %></td>
       <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t("performance_dashboard_other_metrics.percentage_of_providers_onboarded.description") %></td>
     </tr>


### PR DESCRIPTION
## Context

This PR updates a couple of titles on the performance dashboard following product review.

## Changes proposed in this pull request

- [x] Update the titles for providers onboarded and for submitted apply again applications

![image](https://user-images.githubusercontent.com/450843/98104859-f59f9e00-1e8e-11eb-8b14-e4ec4d8c0c84.png)

- [ ] Verify the total returned for submitted apply again applications

## Guidance to review



## Link to Trello card

https://trello.com/c/bSoFxjhp/2399-dev-pa-dashboard-for-ministerial-reports
(see comments)

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
