### PR TITLE
Stop syncing providers and courses for the 2020 recruitment cycle

### DIFF
--- a/app/services/find_sync/sync_all_providers_from_find.rb
+++ b/app/services/find_sync/sync_all_providers_from_find.rb
@@ -4,11 +4,7 @@ module FindSync
       # Request basic details for all providers
       #
       # For the full response, see:
-      # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers
-      sync_providers(
-        FindAPI::Provider.recruitment_cycle(2020).all,
-      )
-
+      # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2021/providers
       sync_providers(
         FindAPI::Provider.recruitment_cycle(2021).all,
       )

--- a/spec/components/support_interface/applications_table_component_spec.rb
+++ b/spec/components/support_interface/applications_table_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SupportInterface::ApplicationsTableComponent do
   let(:application_form_apply_again) { create(:application_form, updated_at: 1.day.ago, phase: 'apply_2') }
   let(:application_forms) { [application_form_apply_again] + create_list(:application_form, 3, updated_at: 1.day.ago) }
 
-  it 'renders the apply again text for the first application' do
+  it 'renders the apply again text for the first application', recruitment_cycle: 2020 do
     expect(render_result.text).to include('(2020, apply again)')
   end
 

--- a/spec/services/candidate_interface/hesa_code_backfill_spec.rb
+++ b/spec/services/candidate_interface/hesa_code_backfill_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                   ethnic_background: 'Caribbean',
                                   disabilities: %w[Blind Deaf],
                                 })
-      cycle_year = 2020
 
-      described_class.call(cycle_year)
+      described_class.call(RecruitmentCycle.current_year)
 
       application_form.reload
 
@@ -32,9 +31,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                     disabilities: ['Prefer not to say'],
                                   })
 
-        cycle_year = 2020
-
-        described_class.call(cycle_year)
+        described_class.call(RecruitmentCycle.current_year)
 
         application_form.reload
 
@@ -52,9 +49,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                     disabilities: nil,
                                   })
 
-        cycle_year = 2020
-
-        described_class.call(cycle_year)
+        described_class.call(RecruitmentCycle.current_year)
 
         application_form.reload
 
@@ -72,10 +67,9 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                     disabilities: ['Acquired brain injury', 'Many unexplained illnesses'],
                                   })
 
-        cycle_year = 2020
         hesa_disability_code_other = '96'
 
-        described_class.call(cycle_year)
+        described_class.call(RecruitmentCycle.current_year)
 
         application_form.reload
 
@@ -94,11 +88,12 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                   equality_and_diversity: {
                                     ethnic_background: 'Maori',
                                     disabilities: [],
-                                  })
-        cycle_year = 2020
+                                  },
+                                  recruitment_cycle_year: 2020)
+
         hesa_ethnicity_code_unknown = 90
 
-        described_class.call(cycle_year)
+        described_class.call(2020)
 
         application_form.reload
 
@@ -117,12 +112,12 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                     equality_and_diversity: {
                                       ethnic_group: 'Prefer not to say',
                                       disabilities: [],
-                                    })
+                                    },
+                                    recruitment_cycle_year: 2020)
+
           hesa_ethnicity_code_refused = 98
 
-          cycle_year = 2020
-
-          described_class.call(cycle_year)
+          described_class.call(2020)
 
           application_form.reload
 
@@ -145,9 +140,7 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
                                     },
                                     recruitment_cycle_year: 2021)
 
-          cycle_year = 2021
-
-          described_class.call(cycle_year)
+          described_class.call(2021)
 
           application_form.reload
 
@@ -167,13 +160,11 @@ RSpec.describe CandidateInterface::HesaCodeBackfill do
         application_form = create(:application_form,
                                   equality_and_diversity: {
                                     sex: 'intersex',
-                                  },
-                                  recruitment_cycle_year: 2021)
+                                  })
 
-        cycle_year = 2021
         hesa_sex_code_intersex = 3
 
-        described_class.call(cycle_year)
+        described_class.call(RecruitmentCycle.current_year)
 
         application_form.reload
 

--- a/spec/support/dates.rb
+++ b/spec/support/dates.rb
@@ -1,8 +1,16 @@
-MID_CYCLE_DATE = Time.zone.local(2020, 1, 1, 12, 0, 0)
+MID_CYCLE_DATES = {
+  2020 => Time.zone.local(2020, 1, 1, 12, 0, 0),
+  2021 => Time.zone.local(2021, 11, 1, 12, 0, 0),
+}.freeze
 
 RSpec.configure do |config|
   config.around do |example|
-    Timecop.travel(MID_CYCLE_DATE) do
+    mid_cycle_date = MID_CYCLE_DATES.fetch(
+      example.metadata[:recruitment_cycle],
+      MID_CYCLE_DATES[RecruitmentCycle.current_year],
+    )
+
+    Timecop.travel(mid_cycle_date) do
       example.run
     end
   end

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -4,24 +4,7 @@ module FindAPIHelper
   end
 
   def stubbed_recruitment_cycle_year
-    @stubbed_recruitment_cycle_year || 2020
-  end
-
-  # Stub out the 2021 sync. Once we've transitioned to the new recruitment cycle year,
-  # we'll set 2021 as the default and this method won't be necessary anymore.
-  def stub_new_recruitment_year_sync
-    stub_request(
-      :get,
-      "#{ENV.fetch('FIND_BASE_URL')}recruitment_cycles/2021/providers",
-    )
-    .to_return(
-      status: 200,
-      headers: { 'Content-Type': 'application/vnd.api+json' },
-      body: {
-        data: [],
-        jsonapi: { version: '1.0' },
-      }.to_json,
-    )
+    @stubbed_recruitment_cycle_year || 2021
   end
 
   def stub_find_api_provider_200(

--- a/spec/system/candidate_interface/references/candidate_views_reference_history_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_reference_history_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Reference history on review page' do
   include CandidateHelper
 
-  scenario 'candidate views reference history', with_audited: true do
+  scenario 'candidate views reference history', with_audited: true, recruitment_cycle: 2020 do
     given_i_am_signed_in
     and_i_add_a_reference
     and_i_send_it

--- a/spec/system/find_sync/syncing_providers_spec.rb
+++ b/spec/system/find_sync/syncing_providers_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe 'Syncing providers', sidekiq: true do
   include FindAPIHelper
 
   scenario 'Creates and updates providers' do
-    stub_new_recruitment_year_sync
-
     given_there_are_2_providers_in_find
     and_one_of_the_providers_exists_already
 

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def and_i_expect_the_relevant_recruitment_cycle_tags_to_be_visible
-    tag_text = '2019 to 2020'
+    tag_text = '2020 to 2021'
     expect(page).to have_css('.moj-filter-tags', text: tag_text)
   end
 

--- a/spec/system/support_interface/cycle_switching_spec.rb
+++ b/spec/system/support_interface/cycle_switching_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Cycle switching' do
   include DfESignInHelpers
 
-  scenario 'Support user switches cycle schedule' do
+  scenario 'Support user switches cycle schedule', recruitment_cycle: 2020 do
     given_i_am_a_support_user
     when_i_click_on_the_recruitment_cycle_link
     then_i_see_the_cycle_information

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'See provider course syncing' do
   include DfESignInHelpers
   include FindAPIHelper
 
-  before do
-    stub_new_recruitment_year_sync
-  end
-
   scenario 'User switches sync courses on Provider' do
     given_i_am_a_support_user
     and_a_provider_exists

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -4,11 +4,7 @@ RSpec.feature 'Providers and courses' do
   include DfESignInHelpers
   include FindAPIHelper
 
-  before do
-    stub_new_recruitment_year_sync
-  end
-
-  scenario 'User syncs provider and browses providers' do
+  scenario 'User syncs provider and browses providers', recruitment_cycle: 2021 do
     given_i_am_a_support_user
     and_providers_are_configured_to_be_synced
     when_i_visit_the_tasks_page
@@ -272,7 +268,7 @@ RSpec.feature 'Providers and courses' do
   end
 
   def and_i_choose_to_open_all_courses
-    click_button 'Open all courses for the 2020 cycle'
+    click_button 'Open all courses for the 2021 cycle'
   end
 
   def then_all_courses_should_be_open_on_apply

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Providers and courses' do
   include DfESignInHelpers
   include FindAPIHelper
 
-  scenario 'User syncs provider and browses providers', recruitment_cycle: 2021 do
+  scenario 'User syncs provider and browses providers' do
     given_i_am_a_support_user
     and_providers_are_configured_to_be_synced
     when_i_visit_the_tasks_page

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # This is an end-to-end test for the API response. To test complex logic in
 # the presenter, see spec/presenters/vendor_api/single_application_presenter_spec.rb.
-RSpec.feature 'Vendor receives the application' do
+RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
   include CandidateHelper
 
   scenario 'A completed application is submitted with references' do


### PR DESCRIPTION
## Context

This cycle is over. We're getting stale data where eg a site code changed from cycle to cycle. https://ukgovernmentdfe.slack.com/archives/CAHAJFR0X/p1604481446153700

## Changes proposed in this pull request

Stop syncing it