### PR TITLE
Don't crash on audit log when encountering deleted referees

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -24,7 +24,11 @@ module SupportInterface
       if audit.user_type == 'Candidate'
         "#{audit.user.email_address} (Candidate)"
       elsif audit.user_type == 'ApplicationReference'
-        "#{audit.user.name} - #{audit.user.email_address} (Referee)"
+        if audit.user
+          "#{audit.user.name} - #{audit.user.email_address} (Referee)"
+        else
+          'Deleted referee'
+        end
       elsif audit.user_type == 'VendorApiUser'
         "#{audit.user.email_address} (Vendor API)"
       elsif audit.user_type == 'SupportUser'

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('Harry - harry@hogwarts.edu (Referee)')
   end
 
+  it 'renders an update on application form audit record with a deleted referee' do
+    audit.user_type = 'ApplicationReference'
+    audit.user_id = 412563789101
+    audit.action = 'update'
+
+    expect(render_result.text).to include('Deleted referee')
+  end
+
   it 'renders an update application form audit record with the username (rather than a persistent model)' do
     audit.user = nil
     audit.username = 'SYSTEM'


### PR DESCRIPTION
## Context

We allow deleting of references, and this interferes with audit log.

## Changes proposed in this pull request



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/2006562442