### PR TITLE
Update error message for other qualification type autocomplete

### DIFF
--- a/app/frontend/packs/other-uk-qualifications-autocomplete.js
+++ b/app/frontend/packs/other-uk-qualifications-autocomplete.js
@@ -19,7 +19,7 @@ const initOtherUKQualificationsAutocomplete = () => {
     });
 
   } catch (err) {
-    console.error("Could not enhance degree type input:", err);
+    console.error("Could not enhance qualification type input:", err);
   }
 };
 


### PR DESCRIPTION
Smol tweak to error message if error showing other UK qualification type autocomplete.