### PR TITLE
If the candidate has no references redirect from the references review pages to the start page 

### DIFF
--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   module References
     class ReviewController < BaseController
-      before_action :set_reference
+      before_action :set_reference, :redirect_to_start_path_if_candidate_has_no_references
 
       def show
         @application_form = current_application
@@ -90,6 +90,10 @@ module CandidateInterface
 
       def redirect_to_review_page
         redirect_to candidate_interface_references_review_path
+      end
+
+      def redirect_to_start_path_if_candidate_has_no_references
+        redirect_to candidate_interface_references_start_path if current_application.application_references.blank?
       end
     end
   end

--- a/spec/system/candidate_interface/references/review_references_spec.rb
+++ b/spec/system/candidate_interface/references/review_references_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature 'Review references' do
 
   scenario 'the candidate has several references in different states' do
     given_i_am_signed_in
+
+    when_i_have_no_references_and_try_to_visit_the_review_page
+    then_i_am_redirected_to_the_start_page
+
     when_i_view_my_application
     then_the_references_section_is_incomplete
 
@@ -24,6 +28,14 @@ RSpec.feature 'Review references' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def when_i_have_no_references_and_try_to_visit_the_review_page
+    visit candidate_interface_references_review_path
+  end
+
+  def then_i_am_redirected_to_the_start_page
+    expect(page).to have_current_path candidate_interface_references_start_path
   end
 
   def when_i_view_my_application


### PR DESCRIPTION
## Context

At the moment a candidate can access the references review page when they have added 0 references. The correct behaviour is for them to be redirected to the start page


## Changes proposed in this pull request

- Redirect from the review controller to the start page if a candidate has no references

## Link to Trello card

https://trello.com/c/TkguFcuR/2478-%F0%9F%92%94-dont-show-review-page-if-no-referees-requests-or-references

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
