### PR TITLE
Update content when asking for candidate’s name in references flow

### DIFF
--- a/app/views/candidate_interface/references/candidate_name/new.html.erb
+++ b/app/views/candidate_interface/references/candidate_name/new.html.erb
@@ -7,15 +7,19 @@
       model: @reference_candidate_name_form,
       url: candidate_interface_references_create_candidate_name_path(@reference.id),
     ) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.references_candidate_name') %>
       </h1>
 
-      <%= f.govuk_error_summary %>
+      <p class="govuk-body">
+        Tell the referee who the reference is for.
+      </p>
 
-      <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' }, hint_text: 'Or given names' %>
+      <%= f.govuk_text_field :first_name, label: { text: t('application_form.references.candidate_name.first_name.label'), size: 'm' }, hint: { text: t('application_form.references.candidate_name.first_name.hint_text') } %>
 
-      <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' }, hint_text: 'Or family name' %>
+      <%= f.govuk_text_field :last_name, label: { text: t('application_form.references.candidate_name.last_name.label'), size: 'm' }, hint: { text: t('application_form.references.candidate_name.last_name.hint_text') } %>
 
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -424,6 +424,13 @@ en:
           professional: 'For example, ‘He was my line manager in my last job. I’ve known him for 2 years’.'
           school_based: 'For example, ‘She’s the deputy head at the school where I currently volunteer. I’ve known her for 3 years’.'
           character: 'For example, ‘She’s the head coach for my athletics club. I’ve known her for 5 years’.'
+      candidate_name:
+        first_name:
+          label: First name
+          hint_text: Or given names
+        last_name:
+          label: Last name
+          hint_text: Or family name
       delete_referee:
         action: Delete referee
         confirm: Yes I’m sure - delete this referee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,7 +127,7 @@ en:
     references_email_address: What is the referee’s email address?
     references_relationship: How do you know this referee and how long have you known them?
     references_unsubmitted_review: Check your answers before sending your request
-    references_candidate_name: Tell the referee your name
+    references_candidate_name: What is your name?
     references_reminder: Would you like to send a reminder to this referee?
     retry_reference_request: Retry reference request
     providers: Courses on this service

--- a/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def then_i_am_prompted_for_my_name
-    expect(page).to have_content('Tell the referee your name')
+    expect(page).to have_content('What is your name?')
   end
 
   def when_i_continue_without_entering_my_name


### PR DESCRIPTION
## Context

Update content:

* Revised title for page that asks for candidate’s own name
* Add extra paragraph

Plus fix a few bugs on this page:

* Move error summary above `h1`
* Use `hint.text` not `hint_text` to ensure hint text appears

…and also do a bit of house cleaning:

* Add localised strings for labels and hints

## Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="660" alt="before" src="https://user-images.githubusercontent.com/813383/98137934-7627c400-1eba-11eb-90f5-8c973633eee1.png"> | <img width="660" alt="after" src="https://user-images.githubusercontent.com/813383/98137932-758f2d80-1eba-11eb-8cca-7f22c3c4767e.png"> |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Fxj6XLom/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
