### PR TITLE
Update to App Form Presenter to flow back to add new

### DIFF
--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -13,10 +13,11 @@ module CandidateInterface
         .find(current_volunteering_role_id)
         .destroy!
 
-      current_application.update!(volunteering_completed: false)
       if current_application.application_volunteering_experiences.blank?
+        current_application.update!(volunteering_completed: false, volunteering_experience: false)
         redirect_to candidate_interface_volunteering_experience_path
       else
+        current_application.update!(volunteering_completed: false)
         redirect_to candidate_interface_review_volunteering_path
       end
     end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -294,7 +294,9 @@ module CandidateInterface
   private
 
     def show_review_volunteering?
-      volunteering_completed? || volunteering_added?
+      volunteering_experience_is_set = @application_form.volunteering_experience == true
+
+      volunteering_completed? || volunteering_added? || volunteering_experience_is_set
     end
 
     def gcse_completed?(gcse)

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -294,9 +294,7 @@ module CandidateInterface
   private
 
     def show_review_volunteering?
-      volunteering_experience_is_set = [true, false].include?(@application_form.volunteering_experience)
-
-      volunteering_completed? || volunteering_added? || volunteering_experience_is_set
+      volunteering_completed? || volunteering_added?
     end
 
     def gcse_completed?(gcse)

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -402,7 +402,7 @@ en:
         confirm: Yes I’m sure - delete this role
         cancel: Cancel
       another:
-        button: Add another role
+        button: Add a role
       review:
         button: Continue
         completed_checkbox: I have completed this section

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -391,12 +391,12 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       )
     end
 
-    it 'returns the review path if no volunteering experience' do
+    it 'returns the experience path if no volunteering experience' do
       application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: false, volunteering_experiences_count: 0)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
-        Rails.application.routes.url_helpers.candidate_interface_review_volunteering_path,
+        Rails.application.routes.url_helpers.candidate_interface_volunteering_experience_path,
       )
     end
 

--- a/spec/system/candidate_interface/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -10,23 +10,26 @@ RSpec.feature 'Candidate edits their volunteering section' do
     when_i_visit_the_application_page
     then_the_volunteering_section_should_be_marked_as_complete
 
-    when_i_visit_the_review_volunteering_page
+    when_i_click_the_volunteering_section_link
     and_i_click_to_change_my_role
     and_i_change_my_role
     and_i_click_on_save_and_continue
     and_visit_my_application_page
     then_the_volunteering_section_should_be_marked_as_incomplete
 
-    when_i_visit_the_review_volunteering_page
+    when_i_click_the_volunteering_section_link
     and_i_mark_this_section_as_completed
     and_i_click_on_continue
     then_the_volunteering_section_should_be_marked_as_complete
 
-    when_i_visit_the_review_volunteering_page
+    when_i_click_the_volunteering_section_link
     and_i_click_delete_role
     and_i_confirm_i_want_to_delete_the_role
     and_visit_my_application_page
     then_the_volunteering_section_should_be_marked_as_incomplete
+
+    when_i_click_the_volunteering_section_link
+    then_i_should_be_prompted_to_add_new_experience
   end
 
   def given_i_am_signed_in
@@ -48,7 +51,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
     expect(page.text).to include 'Unpaid experience and volunteering Completed'
   end
 
-  def when_i_visit_the_review_volunteering_page
+  def when_i_click_the_volunteering_section_link
     click_link 'Unpaid experience and volunteering'
   end
 
@@ -86,5 +89,9 @@ RSpec.feature 'Candidate edits their volunteering section' do
 
   def and_i_confirm_i_want_to_delete_the_role
     click_button t('application_form.volunteering.delete.confirm')
+  end
+
+  def then_i_should_be_prompted_to_add_new_experience
+    expect(page).to have_current_path(candidate_interface_volunteering_experience_path)
   end
 end


### PR DESCRIPTION
## Context

Bug identified the the routing of the volunteer after all choices have been deleted section if no volunteer information entered. Currently routes to review screen when it should direct to add a new volunteer.

## Changes proposed in this pull request

The change made is to the application presenter and the destroy action on the volunteering controller. This means that when there is no available volunteering information and the section is incomplete that the user will be routed to provide new experience. The only drawback of this is that this will happen each time if there is both the section is not completed and no experience is added. If a user selects no and does not complete the section, they will be routed to this path each time.

## Guidance to review

Please check code quality and review proposed changes to see if this solution is acceptable.

## Link to Trello card

https://trello.com/c/Rka0HnJF/2021-volunteering-section-should-always-show-intro-page-unless-candidate-has-explicitly-said-they-have-no-experience

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
