### PR TITLE
Multiple English GCSEs

### DIFF
--- a/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
+++ b/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
@@ -1,6 +1,8 @@
-<p class="govuk-body">
-  <%= t('gcse_edit_grade.guidance.main') %>
-</p>
+<% unless FeatureFlag.active?('multiple_english_gcses') && @subject == 'english'%>
+  <p class="govuk-body">
+    <%= t('gcse_edit_grade.guidance.main') %>
+  </p>
+<% end %>
 
 <% if science? %>
   <p class="govuk-body">
@@ -13,26 +15,35 @@
 <% end %>
 
 <% if english? && (gcse? || gce_o_level?) %>
-  <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-    <summary class="govuk-details__summary">
+  <% if FeatureFlag.active?('multiple_english_gcses') %>
+    <p class="govuk-body">
+      <%= t('gcse_edit_grade.guidance.multiple_english_gcses.main') %>
+    </p>
+    <p class="govuk-body">
+      <%= t('gcse_edit_grade.guidance.multiple_english_gcses.secondary') %>
+    </p>
+  <% else %>
+    <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+      <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
         <% type = gcse? ? 'a GCSE' : 'an O level' %>
         <%= t('gcse_edit_grade.guidance.english_literature_only.summary', type: type) %>
       </span>
-    </summary>
-    <div class="govuk-details__text">
-      <%= t('gcse_edit_grade.guidance.english_literature_only.details') %>
-    </div>
-  </details>
+      </summary>
+      <div class="govuk-details__text">
+        <%= t('gcse_edit_grade.guidance.english_literature_only.details') %>
+      </div>
+    </details>
 
-  <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
-    <summary class="govuk-details__summary">
+    <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
+      <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
         <%= t('gcse_edit_grade.guidance.multiple_english_qualifications.summary') %>
       </span>
-    </summary>
-    <div class="govuk-details__text">
-      <%= t('gcse_edit_grade.guidance.multiple_english_qualifications.details') %>
-    </div>
-  </details>
+      </summary>
+      <div class="govuk-details__text">
+        <%= t('gcse_edit_grade.guidance.multiple_english_qualifications.details') %>
+      </div>
+    </details>
+  <% end %>
 <% end %>

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -72,19 +72,12 @@ module CandidateInterface
           "#{grades['chemistry']} (Chemistry)",
           "#{grades['physics']} (Physics)",
         ]
-      elsif application_qualification.subject == 'english'
+      elsif application_qualification.subject == 'english' && application_qualification.grades
         grades = JSON.parse(application_qualification.grades)
         grades.map { |k, v,| "#{v} (#{k.humanize.titleize})" }
       else
         application_qualification.grade
       end
-    end
-
-    def formatted_grades
-      return if application_qualification.grades.nil?
-
-      grades = JSON.parse(application_qualification.grades)
-      grades.map { |k, v,| "#{v} (#{k.humanize.titleize})" }
     end
 
     def missing_qualification_row

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -72,9 +72,19 @@ module CandidateInterface
           "#{grades['chemistry']} (Chemistry)",
           "#{grades['physics']} (Physics)",
         ]
+      elsif application_qualification.subject == 'english'
+        grades = JSON.parse(application_qualification.grades)
+        grades.map { |k, v,| "#{v} (#{k.humanize.titleize})" }
       else
         application_qualification.grade
       end
+    end
+
+    def formatted_grades
+      return if application_qualification.grades.nil?
+
+      grades = JSON.parse(application_qualification.grades)
+      grades.map { |k, v,| "#{v} (#{k.humanize.titleize})" }
     end
 
     def missing_qualification_row

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -13,7 +13,8 @@ module CandidateInterface
     end
 
     def update
-      if multiple_gsces_are_active?
+      @qualification_type = gcse_english_qualification.qualification_type
+      if multiple_gsces_are_active? && @qualification_type == 'gcse'
         @gcse_grade_form = english_gcse_grade_form.assign_values(english_details_params)
       else
         @qualification_type = gcse_english_qualification.qualification_type
@@ -22,7 +23,7 @@ module CandidateInterface
         @gcse_grade_form.other_grade = english_details_params[:other_grade]
       end
 
-      save_successful = multiple_gsces_are_active? ? @gcse_grade_form.save_grades : @gcse_grade_form.save_grade
+      save_successful = multiple_gsces_are_active? && @qualification_type == 'gcse' ? @gcse_grade_form.save_grades : @gcse_grade_form.save_grade
 
       if save_successful
         update_gcse_completed(false)

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -6,30 +6,85 @@ module CandidateInterface
     before_action :set_subject
 
     def edit
-      @application_qualification = details_form
-      @qualification_type = details_form.qualification.qualification_type
+      @gcse_grade_form = english_gcse_grade_form
+      @qualification_type = gcse_english_qualification.qualification_type
+
+      render view_path
     end
 
     def update
-      @qualification_type = details_form.qualification.qualification_type
+      if multiple_gsces_are_active?
+        @gcse_grade_form = english_gcse_grade_form.assign_values(english_details_params)
+      else
+        @qualification_type = gcse_english_qualification.qualification_type
+        @gcse_grade_form = english_gcse_grade_form
+        @gcse_grade_form.grade = english_details_params[:grade]
+        @gcse_grade_form.other_grade = english_details_params[:other_grade]
+      end
 
-      details_form.grade = details_params[:grade]
-      details_form.other_grade = details_params[:other_grade]
+      save_successful = multiple_gsces_are_active? ? @gcse_grade_form.save_grades : @gcse_grade_form.save_grade
 
-      @application_qualification = details_form.save_grade
-
-      if @application_qualification
+      if save_successful
         update_gcse_completed(false)
         redirect_to next_gcse_path
       else
-        @application_qualification = details_form
-        track_validation_error(@application_qualification)
-
-        render :edit
+        track_validation_error(@gcse_grade_form)
+        render view_path
       end
     end
 
   private
+
+    def english_details_params
+      params.require(:candidate_interface_english_gcse_grade_form).permit([
+        :english_single_award,
+        :grade_english_single,
+        :english_double_award,
+        :grade_english_double,
+        :english_language,
+        :grade_english_language,
+        :english_literature,
+        :grade_english_literature,
+        :english_studies_single_award,
+        :grade_english_studies_single,
+        :english_studies_double_award,
+        :grade_english_studies_double,
+        :other_english_gcse,
+        :other_english_gcse_name,
+        :grade_other_english_gcse,
+        :grade,
+        :other_grade,
+        english_gcses: [],
+      ])
+    end
+
+    def view_path
+      if gcse_qualification? && multiple_gsces_are_active? && application_not_submitted_yet?
+        'candidate_interface/gcse/english/grade/multiple_gcse_edit'
+      else
+        'candidate_interface/gcse/english/grade/edit'
+      end
+    end
+
+    def gcse_qualification?
+      gcse_english_qualification.qualification_type == 'gcse'
+    end
+
+    def multiple_gsces_are_active?
+      FeatureFlag.active?('multiple_english_gcses')
+    end
+
+    def application_not_submitted_yet?
+      @current_application.submitted_at.nil?
+    end
+
+    def gcse_english_qualification
+      @gcse_english_qualification ||= current_application.qualification_in_subject(:gcse, @subject)
+    end
+
+    def english_gcse_grade_form
+      @english_gcse_grade_form ||= EnglishGcseGradeForm.build_from_qualification(gcse_english_qualification)
+    end
 
     def set_subject
       @subject = 'english'

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -14,14 +14,7 @@ module CandidateInterface
 
     def update
       @qualification_type = gcse_english_qualification.qualification_type
-      if multiple_gsces_are_active? && @qualification_type == 'gcse'
-        @gcse_grade_form = english_gcse_grade_form.assign_values(english_details_params)
-      else
-        @qualification_type = gcse_english_qualification.qualification_type
-        @gcse_grade_form = english_gcse_grade_form
-        @gcse_grade_form.grade = english_details_params[:grade]
-        @gcse_grade_form.other_grade = english_details_params[:other_grade]
-      end
+      @gcse_grade_form = english_gcse_grade_form.assign_values(english_details_params)
 
       save_successful = multiple_gsces_are_active? && @qualification_type == 'gcse' ? @gcse_grade_form.save_grades : @gcse_grade_form.save_grade
 

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -4,7 +4,6 @@ module CandidateInterface
     include ValidationUtils
 
     attr_accessor :grade,
-                  :award_year,
                   :qualification,
                   :other_grade,
                   :grades,
@@ -47,7 +46,6 @@ module CandidateInterface
       def build_params_from(qualification)
         params = {
           grade: qualification.grade,
-          award_year: qualification.award_year,
           qualification: qualification,
         }
 
@@ -154,7 +152,7 @@ module CandidateInterface
         log_validation_errors(:grade)
         return false
       end
-      qualification.update(grade: set_grade, award_year: award_year)
+      qualification.update(grade: set_grade)
     end
 
   private

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -27,9 +27,9 @@ module CandidateInterface
 
     validates :grade, presence: true, on: :grade
     validates :other_grade, presence: true, if: :grade_is_other?
-    validate :validate_grade_format, on: :grade, unless: :multiple_gsces_are_active? || :new_record?
-    validate :validate_grades, unless: :new_record?, on: :grades, if: :multiple_gsces_are_active?
-    validate :gcse_selected, on: :grades, if: :multiple_gsces_are_active?
+    validate :validate_grade_format, on: :grade, unless: :is_multiple_gcse? || :new_record?
+    validate :validate_grades, unless: :new_record?, on: :grades, if: :is_multiple_gcse?
+    validate :gcse_selected, on: :grades, if: :is_multiple_gcse?
 
     class << self
       def build_from_qualification(qualification)
@@ -269,6 +269,10 @@ module CandidateInterface
 
     def multiple_gsces_are_active?
       FeatureFlag.active?('multiple_english_gcses')
+    end
+
+    def is_multiple_gcse?
+      qualification.qualification_type == 'gcse' && multiple_gsces_are_active?
     end
   end
 end

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -1,0 +1,274 @@
+module CandidateInterface
+  class EnglishGcseGradeForm
+    include ActiveModel::Model
+    include ValidationUtils
+
+    attr_accessor :grade,
+                  :award_year,
+                  :qualification,
+                  :other_grade,
+                  :grades,
+                  :english_gcses,
+                  :english_single_award,
+                  :grade_english_single,
+                  :english_double_award,
+                  :grade_english_double,
+                  :english_language,
+                  :grade_english_language,
+                  :english_literature,
+                  :grade_english_literature,
+                  :english_studies_single_award,
+                  :grade_english_studies_single,
+                  :english_studies_double_award,
+                  :grade_english_studies_double,
+                  :other_english_gcse,
+                  :other_english_gcse_name,
+                  :grade_other_english_gcse
+
+    validates :grade, presence: true, on: :grade
+    validates :other_grade, presence: true, if: :grade_is_other?
+    validate :validate_grade_format, on: :grade, unless: :multiple_gsces_are_active? || :new_record?
+    validate :validate_grades, unless: :new_record?, on: :grades, if: :multiple_gsces_are_active?
+    validate :gcse_selected, on: :grades, if: :multiple_gsces_are_active?
+
+    class << self
+      def build_from_qualification(qualification)
+        if qualification.qualification_type == 'non_uk'
+          new(grade: qualification.set_grade,
+              other_grade: qualification.set_other_grade,
+              qualification: qualification)
+        else
+          new(build_params_from(qualification))
+        end
+      end
+
+    private
+
+      def build_params_from(qualification)
+        params = {
+          grade: qualification.grade,
+          award_year: qualification.award_year,
+          qualification: qualification,
+        }
+
+        if qualification.grades
+          grades = JSON.parse(qualification.grades)
+          english_gcses = []
+
+          if grades.keys.include? 'english_single_award'
+            english_gcses << 'english_single_award'
+            params[:grade_english_single] = grades['english_single_award']
+            params[:english_single_award] = true
+          end
+
+          if grades.keys.include? 'english_double_award'
+            english_gcses << 'english_double_award'
+            params[:grade_english_double] = grades['english_double_award']
+            params[:english_double_award] = true
+          end
+
+          if grades.keys.include? 'english_language'
+            english_gcses << 'english_language'
+            params[:grade_english_language] = grades['english_language']
+            params[:english_language] = true
+          end
+
+          if grades.keys.include? 'english_literature'
+            english_gcses << 'english_literature'
+            params[:grade_english_literature] = grades['english_literature']
+            params[:english_literature] = true
+          end
+
+          if grades.keys.include? 'english_studies_single_award'
+            english_gcses << 'english_studies_single_award'
+            params[:grade_english_studies_single] = grades['english_studies_single_award']
+            params[:english_studies_single_award] = true
+          end
+
+          if grades.keys.include? 'english_studies_double_award'
+            english_gcses << 'english_studies_double_award'
+            params[:grade_english_studies_double] = grades['english_studies_double_award']
+            params[:english_studies_double_award] = true
+          end
+
+          other_english_gcse_name = grades.keys.select { |k|
+            %w[
+              english_single_award english_double_award
+              english_language
+              english_literature
+              english_studies_single_award english_studies_double_award
+            ].exclude? k
+          } .first
+
+          english_gcses << 'other_english_gcse' if other_english_gcse_name
+          params[:english_gcses] = english_gcses
+
+          params[:other_english_gcse] = other_english_gcse_name
+          params[:other_english_gcse_name] = other_english_gcse_name if other_english_gcse_name
+          params[:grade_other_english_gcse] = grades[other_english_gcse_name] if other_english_gcse_name
+        end
+
+        params
+      end
+    end
+
+    def assign_values(params)
+      english_gcses = params[:english_gcses]
+      self.english_gcses = english_gcses
+
+      self.english_single_award = english_gcses.include? 'english_single_award'
+      self.grade_english_single = params[:grade_english_single]
+
+      self.english_double_award = english_gcses.include? 'english_double_award'
+      self.grade_english_double = params[:grade_english_double]
+
+      self.english_language = english_gcses.include? 'english_language'
+      self.grade_english_language = params[:grade_english_language]
+
+      self.english_literature = english_gcses.include? 'english_literature'
+      self.grade_english_literature = params[:grade_english_literature]
+
+      self.english_studies_single_award = english_gcses.include? 'english_studies_single_award'
+      self.grade_english_studies_single = params[:grade_english_studies_single]
+
+      self.english_studies_double_award = english_gcses.include? 'english_studies_double_award'
+      self.grade_english_studies_double = params[:grade_english_studies_double]
+
+      self.other_english_gcse = english_gcses.include? 'other_english_gcse'
+      self.other_english_gcse_name = params[:other_english_gcse_name]
+      self.grade_other_english_gcse = params[:grade_other_english_gcse]
+      self
+    end
+
+    def save_grades
+      grades = build_grades_json
+      if !valid?(:grades)
+        log_validation_errors(:grades)
+        return false
+      end
+      qualification.update(grades: grades, grade: nil)
+    end
+
+    def save_grade
+      if !valid?(:grade)
+        log_validation_errors(:grade)
+        return false
+      end
+      qualification.update(grade: set_grade, award_year: award_year)
+    end
+
+  private
+
+    def build_grades_json
+      grades = {}.tap do |model|
+        model[:english_single_award] = grade_english_single if english_single_award
+        model[:english_double_award] = grade_english_double if english_double_award
+        model[:english_language] = grade_english_language if english_language
+        model[:english_literature] = grade_english_literature if english_literature
+        model[:english_studies_single_award] = grade_english_studies_single if english_studies_single_award
+        model[:english_studies_double_award] = grade_english_studies_double if english_studies_double_award
+        model[other_english_gcse_name] = grade_other_english_gcse if other_english_gcse
+      end
+      grades.to_json if grades.any?
+    end
+
+    def gcse_selected
+      if english_gcses.nil? || english_gcses.reject(&:empty?).empty?
+        errors.add(:english_gcses, :blank)
+      end
+    end
+
+    def validate_grades
+      if english_single_award
+        errors.add(:grade_english_single, :blank) if grade_english_single.blank?
+        errors.add(:grade_english_single, :invalid) unless SINGLE_GCSE_GRADES.include?(grade_english_single.strip.upcase)
+      end
+
+      if english_double_award
+        errors.add(:grade_english_double, :blank) if grade_english_double.blank?
+        errors.add(:grade_english_double, :invalid) unless DOUBLE_GCSE_GRADES.include?(grade_english_double.delete(' ').upcase)
+      end
+
+      if english_language
+        errors.add(:grade_english_language, :blank) if grade_english_language.blank?
+        errors.add(:grade_english_language, :invalid) unless SINGLE_GCSE_GRADES.include?(grade_english_language.strip.upcase)
+      end
+
+      if english_literature
+        errors.add(:grade_english_literature, :blank) if grade_english_literature.blank?
+        errors.add(:grade_english_literature, :invalid) unless SINGLE_GCSE_GRADES.include?(grade_english_literature.strip.upcase)
+      end
+
+      if english_studies_single_award
+        errors.add(:grade_english_studies_single, :blank) if grade_english_studies_single.blank?
+        errors.add(:grade_english_studies_single, :invalid) unless SINGLE_GCSE_GRADES.include?(grade_english_studies_single.strip.upcase)
+      end
+
+      if english_studies_double_award
+        errors.add(:grade_english_studies_double, :blank) if grade_english_studies_double.blank?
+        errors.add(:grade_english_double, :invalid) unless DOUBLE_GCSE_GRADES.include?(grade_english_studies_double.delete(' ').upcase)
+      end
+
+      if other_english_gcse
+        errors.add(:other_english_gcse_name, :blank) if other_english_gcse_name.blank?
+        errors.add(:grade_other_english_gcse, :blank) if grade_other_english_gcse.blank?
+        errors.add(:grade_other_english_gcse, :invalid) unless SINGLE_GCSE_GRADES.include?(grade_other_english_gcse.strip.upcase)
+      end
+    end
+
+    def validate_grade_format
+      return if qualification.qualification_type.nil? || qualification.qualification_type == 'other_uk' || qualification.qualification_type == 'non_uk'
+
+      qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
+
+      if qualification_rexp && grade.match(qualification_rexp)
+        errors.add(:grade, :invalid)
+      end
+    end
+
+    def invalid_grades
+      {
+        gcse: /[^1-9A-GU\*\s\-]/i,
+        gce_o_level: /[^A-EU\s\-]/i,
+        scottish_national_5: /[^A-D1-7\s\-]/i,
+      }
+    end
+
+    def new_record?
+      qualification.nil?
+    end
+
+    def log_validation_errors(field)
+      return unless errors.key?(field)
+
+      error_message = {
+        field: field.to_s,
+        error_messages: errors[field].join(' - '),
+        value: instance_values[field.to_s],
+      }
+
+      Rails.logger.info("Validation error: #{error_message.inspect}")
+    end
+
+    def grade_is_other?
+      grade == 'other'
+    end
+
+    def set_grade
+      case grade
+      when 'other'
+        other_grade
+      when 'not_applicable'
+        'N/A'
+      when 'unknown'
+        'Unknown'
+      else
+        grade
+      end
+    end
+
+    def multiple_gsces_are_active?
+      FeatureFlag.active?('multiple_english_gcses')
+    end
+  end
+end

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -111,40 +111,44 @@ module CandidateInterface
     end
 
     def assign_values(params)
-      english_gcses = params[:english_gcses]
-      self.english_gcses = english_gcses
+      if is_multiple_gcse?
+        english_gcses = params[:english_gcses]
+        self.english_gcses = english_gcses
 
-      self.english_single_award = english_gcses.include? 'english_single_award'
-      self.grade_english_single = params[:grade_english_single]
+        self.english_single_award = english_gcses.include? 'english_single_award'
+        self.grade_english_single = params[:grade_english_single]
 
-      self.english_double_award = english_gcses.include? 'english_double_award'
-      self.grade_english_double = params[:grade_english_double]
+        self.english_double_award = english_gcses.include? 'english_double_award'
+        self.grade_english_double = params[:grade_english_double]
 
-      self.english_language = english_gcses.include? 'english_language'
-      self.grade_english_language = params[:grade_english_language]
+        self.english_language = english_gcses.include? 'english_language'
+        self.grade_english_language = params[:grade_english_language]
 
-      self.english_literature = english_gcses.include? 'english_literature'
-      self.grade_english_literature = params[:grade_english_literature]
+        self.english_literature = english_gcses.include? 'english_literature'
+        self.grade_english_literature = params[:grade_english_literature]
 
-      self.english_studies_single_award = english_gcses.include? 'english_studies_single_award'
-      self.grade_english_studies_single = params[:grade_english_studies_single]
+        self.english_studies_single_award = english_gcses.include? 'english_studies_single_award'
+        self.grade_english_studies_single = params[:grade_english_studies_single]
 
-      self.english_studies_double_award = english_gcses.include? 'english_studies_double_award'
-      self.grade_english_studies_double = params[:grade_english_studies_double]
+        self.english_studies_double_award = english_gcses.include? 'english_studies_double_award'
+        self.grade_english_studies_double = params[:grade_english_studies_double]
 
-      self.other_english_gcse = english_gcses.include? 'other_english_gcse'
-      self.other_english_gcse_name = params[:other_english_gcse_name]
-      self.grade_other_english_gcse = params[:grade_other_english_gcse]
+        self.other_english_gcse = english_gcses.include? 'other_english_gcse'
+        self.other_english_gcse_name = params[:other_english_gcse_name]
+        self.grade_other_english_gcse = params[:grade_other_english_gcse]
+      else
+        self.grade = params[:grade]
+        self.other_grade = params [:other_grade]
+      end
       self
     end
 
     def save_grades
-      grades = build_grades_json
       if !valid?(:grades)
         log_validation_errors(:grades)
         return false
       end
-      qualification.update(grades: grades, grade: nil)
+      qualification.update(grades: build_grades_json, grade: nil)
     end
 
     def save_grade
@@ -152,7 +156,7 @@ module CandidateInterface
         log_validation_errors(:grade)
         return false
       end
-      qualification.update(grade: set_grade)
+      qualification.update(grade: set_grade, grades: nil)
     end
 
   private
@@ -204,7 +208,7 @@ module CandidateInterface
 
       if english_studies_double_award
         errors.add(:grade_english_studies_double, :blank) if grade_english_studies_double.blank?
-        errors.add(:grade_english_double, :invalid) unless DOUBLE_GCSE_GRADES.include?(grade_english_studies_double.delete(' ').upcase)
+        errors.add(:grade_english_studies_double, :invalid) unless DOUBLE_GCSE_GRADES.include?(grade_english_studies_double.delete(' ').upcase)
       end
 
       if other_english_gcse

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -30,6 +30,7 @@ class FeatureFlag
     [:feedback_form, 'New simplified feedback form to replace old multi-page satisfaction survey.', 'Steve Hook'],
     [:feedback_prompts, 'Candidates can give feedback while completing their application form', 'David Gisbey'],
     [:science_gcse_awards, 'New UI layout for science GCSE', 'Toby Retallick'],
+    [:multiple_english_gcses, 'Candidates can enter structured data for multiple English GCSEs.', 'Raam Chauhan'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @application_qualification.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @gcse_grade_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_english_edit_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_english_edit_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
+      <% if @gcse_grade_form.qualification.qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>

--- a/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
@@ -1,0 +1,51 @@
+<% content_for :title, title_with_error_prefix(t('multiple_gcse_edit_grade.page_title', subject: @subject), @gcse_grade_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_english_edit_grade_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= t('multiple_gcse_edit_grade.page_title')%></h1>
+
+      <% if @gcse_grade_form.qualification.qualification_type == 'non_uk' %>
+        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
+          <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
+          <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
+            <%=  f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: t('multiple_gcse_edit_grade.hints.other') }, width: 10 %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
+
+        <%= f.govuk_check_boxes_fieldset :english_gcses, legend: { text: t('multiple_gcse_edit_grade.question'), size: "m" } do %>
+          <%= f.govuk_check_box :english_gcses, 'english_single_award', label: { text: t('multiple_gcse_edit_grade.answers.english_single_award') }, link_errors: true do %>
+            <%= f.govuk_text_field :grade_english_single, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
+          <% end %>
+          <%= f.govuk_check_box :english_gcses, 'english_double_award', label: { text: t('multiple_gcse_edit_grade.answers.english_double_award') } do %>
+            <%= f.govuk_text_field :grade_english_double, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.double_award')}, width: 4 %>
+          <% end %>
+          <%= f.govuk_check_box :english_gcses, 'english_language', label: { text: t('multiple_gcse_edit_grade.answers.english_language') } do %>
+            <%= f.govuk_text_field :grade_english_language, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2  %>
+          <% end %>
+          <%= f.govuk_check_box :english_gcses, 'english_literature', label: { text: t('multiple_gcse_edit_grade.answers.english_literature') } do %>
+            <%= f.govuk_text_field :grade_english_literature, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2  %>
+          <% end %>
+          <%= f.govuk_check_box :english_gcses, 'english_studies_single_award', label: { text: t('multiple_gcse_edit_grade.answers.english_studies_single_award') } do %>
+            <%= f.govuk_text_field :grade_english_studies_single, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2  %>
+          <% end %>
+          <%= f.govuk_check_box :english_gcses, 'english_studies_double_award', label: { text: t('multiple_gcse_edit_grade.answers.english_studies_double_award') } do %>
+            <%= f.govuk_text_field :grade_english_studies_double, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.double_award') }, width: 4  %>
+          <% end %>
+          <%= f.govuk_check_box :english_gcses, 'other_english_gcse', label: { text: t('multiple_gcse_edit_grade.answers.other_english_gcse') } do %>
+            <%= f.govuk_text_field :other_english_gcse_name, label: { text: t('multiple_gcse_edit_grade.answers.other_english_gcse_name') } %>
+            <%= f.govuk_text_field :grade_other_english_gcse, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -849,6 +849,7 @@ en:
           attributes:
             grade:
               blank: Enter your grade
+              invalid: Enter a real grade
             english_gcses:
               blank: Select at least one GCSE
             grade_english_single:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -845,6 +845,35 @@ en:
               in_future: Enter a year before %{date}
             other_grade:
               blank: Enter your grade
+        candidate_interface/english_gcse_grade_form:
+          attributes:
+            grade:
+              blank: Enter your grade
+            english_gcses:
+              blank: Select at least one GCSE
+            grade_english_single:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            grade_english_double:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            grade_english_language:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            grade_english_literature:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            grade_english_studies_single:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            grade_english_studies_double:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            grade_other_english_gcse:
+              blank: Enter your grade
+              invalid: Enter a real grade
+            other_english_gcse_name:
+              blank: Enter an English GCSE
         candidate_interface/gcse_qualification_type_form:
           attributes:
             qualification_type:

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -12,6 +12,9 @@ en:
         to train. If you do not have this, contact your provider to discuss your
         options. You might be able to retake an exam or do an equivalence test.
       o_level_triple_gcse_science: If you have a combined or triple O Level in science, enter your total grade.
+      multiple_english_gcses:
+        main: You need a grade C or 4 (or the equivalent). Contact your provider if you do not have this. You might be able to retake an exam or do an equivalence test.
+        secondary: An English Language GCSE is preferred.
       triple_scottish_national_science: If you studied three science subjects separately or took a general science qualification, enter your total grade.
       english_literature_only:
         summary: If you have %{type} in English Literature only
@@ -44,3 +47,19 @@ en:
       english: English GCSE or equivalent
       science: Science GCSE or equivalent
     not_specified: Not entered
+  multiple_gcse_edit_grade:
+    page_title: What English GCSE did you do?
+    question: Select the GCSE(s) you did and include your grade
+    answers:
+      english_single_award: English (Single award)
+      english_double_award: English (Double award)
+      english_language: English Language
+      english_literature: English Literature
+      english_studies_single_award: English Studies (Single award)
+      english_studies_double_award: English Studies (Double award)
+      other_english_gcse: Other English subject
+      other_english_gcse_name: What English GCSE do you have?
+    hints:
+      single_award: For example, ‘C’ or ‘4’
+      double_award: For example, ‘CD’, ‘4-3’
+      other: For example, ‘A’, ‘4.5’, ‘94%’

--- a/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
@@ -97,11 +97,22 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
   context 'when the subject is english' do
     it 'displays the guidance around the expectation of providers' do
+      FeatureFlag.deactivate(:multiple_english_gcses)
       subject = 'english'
 
       result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
 
       expect(result.text).to include(t('gcse_edit_grade.guidance.main'))
+    end
+
+    it 'displays the guidance around the expectation of providers for multiple English GCSEs' do
+      FeatureFlag.activate(:multiple_english_gcses)
+      subject = 'english'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, 'gcse'))
+
+      expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
+      expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
     end
 
     it 'does not display the guidance around triple science' do
@@ -114,6 +125,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
     context 'and a GCSE' do
       it 'displays the guidance around only having english literature and more than one english qualification' do
+        FeatureFlag.deactivate(:multiple_english_gcses)
         subject = 'english'
         qualification_type = 'gcse'
 
@@ -128,6 +140,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
     context 'and an O Level' do
       it 'displays the guidance around only having english literature and more than one english qualification' do
+        FeatureFlag.deactivate(:multiple_english_gcses)
         subject = 'english'
         qualification_type = 'gce_o_level'
 

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -111,4 +111,34 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       end
     end
   end
+
+  context 'with the multiple_english_gcses flag on' do
+    context 'when the candidate has entered their English GCSE grades' do
+      it 'displays each English GCSE and associated grade' do
+        FeatureFlag.activate(:multiple_english_gcses)
+
+        application_form = build :application_form
+        @qualification = application_qualification = build(
+          :application_qualification,
+          application_form: application_form,
+          qualification_type: 'gcse',
+          level: 'gcse',
+          grade: nil,
+          grades: '{"english":"E","english_literature":"D","Cockney Rhyming Slang":"A*"}',
+          subject: 'english',
+        )
+
+        result = render_inline(
+          described_class.new(
+            application_form: application_form,
+            application_qualification: application_qualification,
+            subject: 'english',
+          ),
+        )
+
+        expect(result.css('.govuk-summary-list__key')[1].text).to include('Grade')
+        expect(result.css('.govuk-summary-list__value')[1].text).to include('E (English)D (English Literature)A* (Cockney Rhyming Slang)')
+      end
+    end
+  end
 end

--- a/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
+  describe 'validations' do
+
+    context 'when grade is "other"' do
+      let(:form) { subject }
+
+      before { allow(form).to receive(:grade_is_other?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:other_grade) }
+    end
+
+    context 'when qualification type is GCSE' do
+      context 'multiple GCSEs disabled' do
+        FeatureFlag.deactivate('multiple_english_gcses')
+        let(:qualification) do
+          FactoryBot.build_stubbed(
+              :application_qualification,
+              subject: 'english',
+              qualification_type: 'gcse',
+              level: 'gcse',
+              )
+        end
+        let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
+
+        it 'returns validation error if grade is blank' do
+          form.grade = ''
+          form.validate(:grade)
+
+          expect(form.errors[:grade]).to include('Enter your grade')
+        end
+
+        it 'returns no errors if grade is valid' do
+          mistyped_grades = %w[a b c]
+          valid_grades = SINGLE_GCSE_GRADES + mistyped_grades
+
+          valid_grades.each do |grade|
+            form.grade = grade
+            form.validate
+
+            expect(form.errors[:grade]).to be_empty
+          end
+        end
+
+        it 'return validation error if grade is invalid' do
+          invalid_grades = %w[012 XYZ T 54%]
+
+          invalid_grades.each do |grade|
+            form.grade = grade
+            form.validate(:grade)
+
+            expect(form.errors[:grade]).to include('Enter a real grade')
+          end
+        end
+
+        it 'logs validation errors if grade is invalid' do
+          allow(Rails.logger).to receive(:info)
+          form.grade = 'XYZ'
+          form.save_grade
+
+          expect(Rails.logger).to have_received(:info).with(
+              'Validation error: {:field=>"grade", :error_messages=>"Enter a real grade", :value=>"XYZ"}',
+              )
+        end
+      end
+    end
+
+    context 'when qualification type is GCE O LEVEL' do
+      let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse', subject: 'english') }
+      let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
+      FeatureFlag.deactivate('multiple_english_gcses')
+
+      it 'returns no errors if grade is valid' do
+        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
+
+        valid_grades.each do |grade|
+          form.grade = grade
+          form.validate(:grade)
+
+          expect(form.errors[:grade]).to be_empty
+        end
+      end
+
+      it 'return validation error if grade is invalid' do
+        invalid_grades = %w[123 A* XYZ]
+
+        invalid_grades.each do |grade|
+          form.grade = grade
+          form.validate(:grade)
+
+          expect(form.errors[:grade]).to include('Enter a real grade')
+        end
+      end
+    end
+
+    context 'when qualification type is Scottish National 5' do
+      FeatureFlag.deactivate('multiple_english_gcses')
+
+      let(:qualification) do
+        FactoryBot.build_stubbed(:application_qualification,
+                                 qualification_type: 'scottish_national_5',
+                                 level: 'gcse',
+                                 subject: 'english')
+      end
+      let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
+
+      it 'returns no errors if grade is valid' do
+        valid_grades = ['AAA', 'AAB', '765', 'CBD', 'aaa', 'C B D', 'C-B-D']
+
+        valid_grades.each do |grade|
+          form.grade = grade
+          form.validate(:grade)
+
+          expect(form.errors[:grade]).to be_empty
+        end
+      end
+
+      it 'return validation error if grade is invalid' do
+        invalid_grades = %w[89 AE A*]
+
+        invalid_grades.each do |grade|
+          form.grade = grade
+          form.validate(:grade)
+
+          expect(form.errors[:grade]).to include('Enter a real grade')
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
   describe 'validations' do
-
     context 'when grade is "other"' do
       let(:form) { subject }
 
@@ -16,11 +15,11 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
         FeatureFlag.deactivate('multiple_english_gcses')
         let(:qualification) do
           FactoryBot.build_stubbed(
-              :application_qualification,
-              subject: 'english',
-              qualification_type: 'gcse',
-              level: 'gcse',
-              )
+            :application_qualification,
+            subject: 'english',
+            qualification_type: 'gcse',
+            level: 'gcse',
+          )
         end
         let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
 
@@ -60,8 +59,8 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
           form.save_grade
 
           expect(Rails.logger).to have_received(:info).with(
-              'Validation error: {:field=>"grade", :error_messages=>"Enter a real grade", :value=>"XYZ"}',
-              )
+            'Validation error: {:field=>"grade", :error_messages=>"Enter a real grade", :value=>"XYZ"}',
+          )
         end
       end
     end
@@ -69,6 +68,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
     context 'when qualification type is GCE O LEVEL' do
       let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse', subject: 'english') }
       let(:form) { CandidateInterface::EnglishGcseGradeForm.build_from_qualification(qualification) }
+
       FeatureFlag.deactivate('multiple_english_gcses')
 
       it 'returns no errors if grade is valid' do

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -24,6 +24,7 @@ module CandidateHelper
 
   def candidate_completes_application_form(with_referees: true)
     FeatureFlag.deactivate(:efl_section)
+    FeatureFlag.deactivate(:multiple_english_gcses)
 
     given_courses_exist
     create_and_sign_in_candidate

--- a/spec/system/candidate_interface/candidate_entering_english_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_english_gcse_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate entering GCSE English details' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their GCSE English qualification' do
+    FeatureFlag.activate(:multiple_english_gcses)
+
+    given_i_am_signed_in
+    and_i_wish_to_apply_to_a_course_that_requires_gcse_english
+    and_i_visit_the_site
+
+    and_i_click_on_the_english_gcse_link
+    then_i_see_the_add_gcse_english_page
+
+    when_i_select_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_the_english_gcse_grade_page
+
+    and_i_click_save_and_continue
+    then_i_see_the_gcses_blank_error
+
+    when_i_click_english_single_award
+    and_i_click_save_and_continue
+    then_i_see_the_enter_your_grade_error
+
+    when_i_click_english_single_award
+    and_i_enter_an_invalid_grade
+    and_i_click_save_and_continue
+    then_i_see_the_invalid_grade_error
+
+    when_i_click_other_english_subject
+    and_i_uncheck_english_single_award
+    and_i_click_save_and_continue
+    then_i_see_the_enter_an_english_gcse_error
+    then_i_see_the_enter_your_grade_error
+
+    when_i_click_other_english_subject
+    and_i_enter_a_valid_english_gcse
+    and_i_enter_a_valid_other_english_grade
+    and_i_click_save_and_continue
+    then_i_see_the_grade_year_page
+    end
+
+    def given_i_am_signed_in
+      create_and_sign_in_candidate
+    end
+
+    def and_i_wish_to_apply_to_a_course_that_requires_gcse_english
+      course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English')
+      course_option = create(:course_option, course: course)
+      current_candidate.current_application.application_choices << create(:application_choice, course_option: course_option)
+    end
+
+    def and_i_visit_the_site
+      visit candidate_interface_application_form_path
+    end
+
+    def and_i_click_on_the_english_gcse_link
+      click_on 'English GCSE or equivalent'
+    end
+
+    def then_i_see_the_add_gcse_english_page
+      expect(page).to have_content 'Add English GCSE grade 4 (C) or above, or equivalent'
+    end
+
+    def when_i_select_gcse_option
+      choose('GCSE')
+    end
+
+    def and_i_click_save_and_continue
+      click_button 'Save and continue'
+    end
+
+    def then_i_see_the_english_gcse_grade_page
+      expect(page).to have_content t('multiple_gcse_edit_grade.page_title', subject: 'english')
+      expect(page).to have_content t('multiple_gcse_edit_grade.page_title', subject: 'english')
+    end
+
+  def then_i_see_the_gcses_blank_error
+    expect(page).to have_content 'Select at least one GCSE'
+  end
+
+  def when_i_click_english_single_award
+    check 'English (Single award)'
+  end
+
+  def then_i_see_the_enter_your_grade_error
+    expect(page).to have_content 'Enter your grade'
+  end
+
+  def and_i_enter_an_invalid_grade
+    within find('#candidate-interface-english-gcse-grade-form-english-gcses-english-single-award-conditional') do
+      fill_in('Grade', with: 'AWESOME')
+    end
+  end
+
+  def then_i_see_the_invalid_grade_error
+    expect(page).to have_content 'Enter a real grade'
+  end
+
+  def and_i_uncheck_english_single_award
+    uncheck 'English (Single award)'
+    end
+
+  def when_i_click_other_english_subject
+    check 'Other English subject'
+  end
+
+  def then_i_see_the_enter_an_english_gcse_error
+    expect(page).to have_content 'Enter an English GCSE'
+  end
+
+  def and_i_enter_a_valid_english_gcse
+    within find('#candidate-interface-english-gcse-grade-form-english-gcses-other-english-gcse-conditional') do
+      fill_in('What English GCSE do you have?', with: 'Cockney rhyming slang')
+    end
+  end
+
+  def and_i_enter_a_valid_other_english_grade
+    within find('#candidate-interface-english-gcse-grade-form-english-gcses-other-english-gcse-conditional') do
+      fill_in('Grade', with: 'A*')
+    end
+  end
+
+  def then_i_see_the_grade_year_page
+    expect(page).to have_content 'When was your english qualification awarded?'
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_english_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_english_gcse_spec.rb
@@ -40,42 +40,42 @@ RSpec.feature 'Candidate entering GCSE English details' do
     and_i_enter_a_valid_other_english_grade
     and_i_click_save_and_continue
     then_i_see_the_grade_year_page
-    end
+  end
 
-    def given_i_am_signed_in
-      create_and_sign_in_candidate
-    end
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
 
-    def and_i_wish_to_apply_to_a_course_that_requires_gcse_english
-      course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English')
-      course_option = create(:course_option, course: course)
-      current_candidate.current_application.application_choices << create(:application_choice, course_option: course_option)
-    end
+  def and_i_wish_to_apply_to_a_course_that_requires_gcse_english
+    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'English')
+    course_option = create(:course_option, course: course)
+    current_candidate.current_application.application_choices << create(:application_choice, course_option: course_option)
+  end
 
-    def and_i_visit_the_site
-      visit candidate_interface_application_form_path
-    end
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
 
-    def and_i_click_on_the_english_gcse_link
-      click_on 'English GCSE or equivalent'
-    end
+  def and_i_click_on_the_english_gcse_link
+    click_on 'English GCSE or equivalent'
+  end
 
-    def then_i_see_the_add_gcse_english_page
-      expect(page).to have_content 'Add English GCSE grade 4 (C) or above, or equivalent'
-    end
+  def then_i_see_the_add_gcse_english_page
+    expect(page).to have_content 'Add English GCSE grade 4 (C) or above, or equivalent'
+  end
 
-    def when_i_select_gcse_option
-      choose('GCSE')
-    end
+  def when_i_select_gcse_option
+    choose('GCSE')
+  end
 
-    def and_i_click_save_and_continue
-      click_button 'Save and continue'
-    end
+  def and_i_click_save_and_continue
+    click_button 'Save and continue'
+  end
 
-    def then_i_see_the_english_gcse_grade_page
-      expect(page).to have_content t('multiple_gcse_edit_grade.page_title', subject: 'english')
-      expect(page).to have_content t('multiple_gcse_edit_grade.page_title', subject: 'english')
-    end
+  def then_i_see_the_english_gcse_grade_page
+    expect(page).to have_content t('multiple_gcse_edit_grade.page_title', subject: 'english')
+    expect(page).to have_content t('multiple_gcse_edit_grade.page_title', subject: 'english')
+  end
 
   def then_i_see_the_gcses_blank_error
     expect(page).to have_content 'Select at least one GCSE'
@@ -101,7 +101,7 @@ RSpec.feature 'Candidate entering GCSE English details' do
 
   def and_i_uncheck_english_single_award
     uncheck 'English (Single award)'
-    end
+  end
 
   def when_i_click_other_english_subject
     check 'Other English subject'

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'International candidate submits the application' do
   include EFLHelper
 
   scenario 'International candidate completes and submits an application' do
+    FeatureFlag.deactivate(:multiple_english_gcses)
+
     given_i_am_signed_in
     and_the_efl_feature_flag_is_active
 


### PR DESCRIPTION
## Context

English GCSEs currently use free text inputs. This is changing to a more structured approach.

More details:
https://bat-design-history.netlify.app/apply-for-teacher-training/structured-data-for-pre-degree-qualifications/#what-english-gcse-did-you-do
https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1604478676227000

## Changes proposed in this pull request

- [x] add a new feature flag
- [x] create a new multiple English gcse form to use when flag is on
- [x] convert response from form to a JSON blob to store in DB
- [x] update the review page to use new structured data, but fallback to old data if necessary
- [x] add autocomplete to new form when updating
- [x] new form validation and error handling
- [x] make sure old functionality is unaffected when feature flag is off
- [x] handle case where we need to invalidate the old GCSE value and create a new value
- [x] update validation on grades
- [x] ensure the international GCSEs feature is unaffected by changes
- [x] write tests

Also see https://trello.com/c/sLBZws9B/2548-refactor-english-gcses. Where I will refactor English GCSEs to be saved as multiple qualifications instead of as a JSON blob.

<!-- If there are UI changes, please include Before and After screenshots. -->

New multiple english GCSEs form

![image](https://user-images.githubusercontent.com/33458055/98955063-6467a180-24f6-11eb-9814-af75901e3a7f.png)


Review page 

![image](https://user-images.githubusercontent.com/33458055/98264458-d46aaa80-1f7f-11eb-9455-050b12d2e13c.png)

Fallback review case

![image](https://user-images.githubusercontent.com/33458055/98264583-f5330000-1f7f-11eb-8916-9cf556382ee3.png)



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/HLxaajFd/2428-%F0%9F%8F%88-allow-candidates-to-enter-multiple-english-gcses

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
