### PR TITLE
Various fixes to pages in references flow 

### DIFF
--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -122,7 +122,7 @@ module CandidateInterface
 
       if reference.can_send_reminder?
         row_attributes.merge!(
-          action: 'Send a reminder to this referee',
+          action: t('application_form.references.send_reminder.action'),
           action_path: candidate_interface_references_new_reminder_path(reference),
         )
       end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -22,7 +22,7 @@
   ) %>
 <% end %>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.referees') %></h2>
+<h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('page_titles.references') %></h2>
 <% if !application_form.enough_references_have_been_provided? && editable %>
   <%= render(
     CandidateInterface::SectionMissingBannerComponent.new(

--- a/app/views/candidate_interface/references/candidate_name/new.html.erb
+++ b/app/views/candidate_interface/references/candidate_name/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_candidate_name') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_candidate_name'), @reference_candidate_name_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/email_address/_shared_form.html.erb
@@ -17,6 +17,6 @@
   <%= @reference.name %>
 </span>
 
-<%= f.govuk_text_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' }, hint: { text: 'In most cases, this should be a work address.' } %>
+<%= f.govuk_email_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' }, hint: { text: 'In most cases, this should be a work address.' } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/email_address/_shared_form.html.erb
@@ -17,6 +17,6 @@
   <%= @reference.name %>
 </span>
 
-<%= f.govuk_text_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' }, hint_text: 'In most cases, this should be a work address.' %>
+<%= f.govuk_text_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' }, hint: { text: 'In most cases, this should be a work address.' } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/email_address/_shared_form.html.erb
@@ -13,10 +13,6 @@
   </div>
 <% end %>
 
-<span class="govuk-caption-xl">
-  <%= @reference.name %>
-</span>
-
-<%= f.govuk_email_field :email_address, label: { text: tag.h1(t('page_titles.references_email_address'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' }, hint: { text: 'In most cases, this should be a work address.' } %>
+<%= f.govuk_email_field :email_address, label: { text: t('page_titles.references_email_address'), size: 'xl', tag: 'h1' }, caption: { text: @reference.name, size: 'xl' }, hint: { text: 'In most cases, this should be a work address.' } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/email_address/_shared_form.html.erb
@@ -13,6 +13,6 @@
   </div>
 <% end %>
 
-<%= f.govuk_email_field :email_address, label: { text: t('page_titles.references_email_address'), size: 'xl', tag: 'h1' }, caption: { text: @reference.name, size: 'xl' }, hint: { text: 'In most cases, this should be a work address.' } %>
+<%= f.govuk_email_field :email_address, label: { text: t('application_form.references.email_address.label'), size: 'xl', tag: 'h1' }, caption: { text: @reference.name, size: 'xl' }, hint: { text: t('application_form.references.email_address.hint_text') } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/email_address/edit.html.erb
+++ b/app/views/candidate_interface/references/email_address/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_email_address') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_email_address'), @reference_email_address_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
       model: @reference_email_address_form,
       url: candidate_interface_references_edit_email_address_path(@reference.id, return_to: params[:return_to]),
       method: :patch,
-      html: { novalidate: true }
+      html: { novalidate: true },
     ) do |f| %>
       <% render 'shared_form', f: f %>
     <% end %>

--- a/app/views/candidate_interface/references/email_address/edit.html.erb
+++ b/app/views/candidate_interface/references/email_address/edit.html.erb
@@ -6,7 +6,8 @@
     <%= form_with(
       model: @reference_email_address_form,
       url: candidate_interface_references_edit_email_address_path(@reference.id, return_to: params[:return_to]),
-      method: :patch
+      method: :patch,
+      html: { novalidate: true }
     ) do |f| %>
       <% render 'shared_form', f: f %>
     <% end %>

--- a/app/views/candidate_interface/references/email_address/new.html.erb
+++ b/app/views/candidate_interface/references/email_address/new.html.erb
@@ -3,8 +3,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_email_address_form, url: candidate_interface_references_email_address_path(@reference.id), method: :patch do |f| %>
-      <% render 'shared_form', f: f  %>
+    <%= form_with(
+      model: @reference_email_address_form,
+      url: candidate_interface_references_email_address_path(@reference.id),
+      method: :patch,
+      html: { novalidate: true }
+    ) do |f| %>
+      <% render 'shared_form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/references/email_address/new.html.erb
+++ b/app/views/candidate_interface/references/email_address/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_email_address') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_email_address'), @reference_email_address_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
       model: @reference_email_address_form,
       url: candidate_interface_references_email_address_path(@reference.id),
       method: :patch,
-      html: { novalidate: true }
+      html: { novalidate: true },
     ) do |f| %>
       <% render 'shared_form', f: f %>
     <% end %>

--- a/app/views/candidate_interface/references/name/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/name/_shared_form.html.erb
@@ -1,5 +1,5 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_text_field :name, label: { text: tag.h1(t('page_titles.references_name'), class: 'govuk-heading-xl govuk-!-margin-top-0 govuk-!-margin-bottom-8'), size: 'm' } %>
+<%= f.govuk_text_field :name, label: { text: t('page_titles.references_name'), size: 'xl', tag: 'h1' } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/name/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/name/_shared_form.html.erb
@@ -1,5 +1,5 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_text_field :name, label: { text: t('page_titles.references_name'), size: 'xl', tag: 'h1' } %>
+<%= f.govuk_text_field :name, label: { text: t('application_form.references.name.label'), size: 'xl', tag: 'h1' } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/name/edit.html.erb
+++ b/app/views/candidate_interface/references/name/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_name') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_name'), @reference_name_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
@@ -6,7 +6,7 @@
     <%= form_with(
       model: @reference_name_form,
       url: candidate_interface_references_edit_name_path(@reference.id, return_to: params[:return_to]),
-      method: :patch
+      method: :patch,
     ) do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>

--- a/app/views/candidate_interface/references/name/new.html.erb
+++ b/app/views/candidate_interface/references/name/new.html.erb
@@ -1,9 +1,13 @@
-<% content_for :title, t('page_titles.references_name') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_name'), @reference_name_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_name_form, url: candidate_interface_references_name_path(@reference.id), method: :patch do |f| %>
+    <%= form_with(
+      model: @reference_name_form,
+      url: candidate_interface_references_name_path(@reference.id),
+      method: :patch,
+    ) do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/references/relationship/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/relationship/_shared_form.html.erb
@@ -6,6 +6,6 @@
 
 <%= f.govuk_text_area :relationship,
                         label: { text: tag.h1(t('page_titles.references_relationship'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' },
-                        hint_text: t("application_form.references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50  %>
+                        hint: { text: t("application_form.references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50 } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/relationship/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/relationship/_shared_form.html.erb
@@ -1,11 +1,8 @@
 <%= f.govuk_error_summary %>
 
-<span class="govuk-caption-xl">
-  <%= @reference.name %>
-</span>
-
 <%= f.govuk_text_area :relationship,
-                        label: { text: tag.h1(t('page_titles.references_relationship'), class: 'govuk-heading-xl govuk-!-margin-top-0'), size: 'm' },
-                        hint: { text: t("application_form.references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50 } %>
+                      caption: { text: @reference.name, size: 'xl' },
+                      label: { text: t('page_titles.references_relationship'), size: 'xl', tag: 'h1' },
+                      hint: { text: t("application_form.references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50 } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/relationship/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/relationship/_shared_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= f.govuk_text_area :relationship,
                       caption: { text: @reference.name, size: 'xl' },
-                      label: { text: t('page_titles.references_relationship'), size: 'xl', tag: 'h1' },
+                      label: { text: t('application_form.references.relationship.label'), size: 'xl', tag: 'h1' },
                       hint: { text: t("application_form.references.relationship.hint_text.#{@reference.referee_type.downcase}"), max_words: 50 } %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/relationship/edit.html.erb
+++ b/app/views/candidate_interface/references/relationship/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_relationship') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_relationship'), @references_relationship_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/references/relationship/new.html.erb
+++ b/app/views/candidate_interface/references/relationship/new.html.erb
@@ -1,9 +1,13 @@
-<% content_for :title, t('page_titles.references_relationship') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_relationship'), @references_relationship_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @references_relationship_form, url: candidate_interface_references_relationship_path(@reference.id), method: :patch do |f| %>
+    <%= form_with(
+      model: @references_relationship_form,
+      url: candidate_interface_references_relationship_path(@reference.id),
+      method: :patch,
+    ) do |f| %>
       <%= render 'shared_form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/references/reminder/new.html.erb
+++ b/app/views/candidate_interface/references/reminder/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_reminder') %>
+<% content_for :title, t('page_titles.references_send_reminder') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_references_review_path, 'Back') %>
 
 <div class="govuk-grid-row">
@@ -6,7 +6,7 @@
     <%= form_with model: @reference, url: candidate_interface_references_new_reminder_path(@reference), method: :post do |f| %>
       <span class="govuk-caption-xl"> <%= @reference.name %> </span>
       <h1 class="govuk-heading-xl">
-        <%= t('page_titles.references_reminder') %>
+        <%= t('page_titles.references_send_reminder') %>
       </h1>
 
       <div class="govuk-inset-text govuk-!-margin-top-0">
@@ -17,10 +17,10 @@
         The referee will also get an automatic reminder on <%= @reference.next_automated_chase_at.strftime('%-d %B %Y') %>.
       </p>
 
-      <%= f.govuk_submit 'Yes I’m sure - send a reminder'  %>
+      <%= f.govuk_submit t('application_form.references.send_reminder.confirm') %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'No - I’ve changed my mind', candidate_interface_references_review_path %>
+        <%= govuk_link_to t('application_form.references.send_reminder.cancel'), candidate_interface_references_review_path %>
       </p>
     <% end %>
   </div>

--- a/app/views/candidate_interface/references/reminder/new.html.erb
+++ b/app/views/candidate_interface/references/reminder/new.html.erb
@@ -4,8 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: candidate_interface_references_new_reminder_path(@reference), method: :post do |f| %>
-      <span class="govuk-caption-xl"> <%= @reference.name %> </span>
       <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @reference.name %></span>
         <%= t('page_titles.references_send_reminder') %>
       </h1>
 

--- a/app/views/candidate_interface/references/reminder/new.html.erb
+++ b/app/views/candidate_interface/references/reminder/new.html.erb
@@ -3,7 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference, url: candidate_interface_references_new_reminder_path(@reference), method: :post do |f| %>
+    <%= form_with(
+      model: @reference,
+      url: candidate_interface_references_new_reminder_path(@reference),
+      method: :post,
+    ) do |f| %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= @reference.name %></span>
         <%= t('page_titles.references_send_reminder') %>

--- a/app/views/candidate_interface/references/request/new.html.erb
+++ b/app/views/candidate_interface/references/request/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t('page_titles.references_send_request') %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/references/request/new.html.erb
+++ b/app/views/candidate_interface/references/request/new.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @reference.name %></span>
-      Are you ready to send a reference request?
+      <%= t('page_titles.references_send_request') %>
     </h1>
 
     <p class="govuk-body">We’ll send <%= @reference.name %> an email asking them to give you a reference.</p>

--- a/app/views/candidate_interface/references/request/new.html.erb
+++ b/app/views/candidate_interface/references/request/new.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">
-      <%= @reference.name %>
-    </span>
-    <h1 class="govuk-heading-xl">Are you ready to send a reference request?</h1>
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @reference.name %></span>
+      Are you ready to send a reference request?
+    </h1>
 
     <p class="govuk-body">We’ll send <%= @reference.name %> an email asking them to give you a reference.</p>
     <%= form_with model: @request_form, url: candidate_interface_references_create_request_path(@reference.id) do |f| %>

--- a/app/views/candidate_interface/references/request/start.html.erb
+++ b/app/views/candidate_interface/references/request/start.html.erb
@@ -4,10 +4,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :request_now, legend: { text: "Are you ready to send a reference request to #{@request_form.referee_name}?", size: 'xl' } do %>
-        <div class="govuk-!-margin-top-7">
-          <%= f.govuk_radio_button :request_now, 'yes', link_errors: true, label: { text: 'Yes, send a reference request now' } %>
-          <%= f.govuk_radio_button :request_now, 'no', label: { text: 'No, not at the moment' } %>
-        </div>
+        <%= f.govuk_radio_button :request_now, 'yes', link_errors: true, label: { text: 'Yes, send a reference request now' } %>
+        <%= f.govuk_radio_button :request_now, 'no', label: { text: 'No, not at the moment' } %>
       <% end %>
 
       <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/request/start.html.erb
+++ b/app/views/candidate_interface/references/request/start.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Are you ready to send a reference request to #{@request_form.referee_name}?" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @request_form, url: candidate_interface_references_create_request_path, method: :post do |f| %>

--- a/app/views/candidate_interface/references/retry_request/new.html.erb
+++ b/app/views/candidate_interface/references/retry_request/new.html.erb
@@ -3,10 +3,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl">
-      <%= @reference.name %>
-    </span>
-    <h1 class="govuk-heading-xl"><%= t('page_titles.references_retry_request') %></h1>
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @reference.name %></span>
+      <%= t('page_titles.references_retry_request') %>
+    </h1>
 
     <%= form_with model: @reference_email_address_form, url: candidate_interface_references_retry_request_path(@reference.id) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/references/retry_request/new.html.erb
+++ b/app/views/candidate_interface/references/retry_request/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.retry_reference_request') %>
+<% content_for :title, t('page_titles.references_retry_request') %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
@@ -6,7 +6,7 @@
     <span class="govuk-caption-xl">
       <%= @reference.name %>
     </span>
-    <h1 class="govuk-heading-xl"><%= t('page_titles.retry_reference_request') %></h1>
+    <h1 class="govuk-heading-xl"><%= t('page_titles.references_retry_request') %></h1>
 
     <%= form_with model: @reference_email_address_form, url: candidate_interface_references_retry_request_path(@reference.id) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/references/review/confirm_cancel.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_cancel.html.erb
@@ -9,7 +9,7 @@
         <%= t('page_titles.references_cancel_request') %>
       </h1>
 
-      <p class='govuk-body'>We’ll tell <%= @reference.name %> that they do not need to give a reference.</p>
+      <p class="govuk-body">We’ll tell <%= @reference.name %> that they do not need to give a reference.</p>
 
       <%= f.submit t('application_form.references.cancel_request.confirm'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 

--- a/app/views/candidate_interface/references/review/confirm_cancel.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_cancel.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.referee_cancel') %>
+<% content_for :title, t('page_titles.references_cancel_request') %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/references/review/confirm_destroy_referee.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_referee.html.erb
@@ -5,6 +5,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: candidate_interface_destroy_reference_path(@reference), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
+        <% if @reference.name %>
+          <span class="govuk-caption-xl"><%= @reference.name %></span>
+        <% end %>
         <%= t('page_titles.references_delete_referee') %>
       </h1>
 

--- a/app/views/candidate_interface/references/review/confirm_destroy_referee.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_referee.html.erb
@@ -1,14 +1,14 @@
-<% content_for :title, t('page_titles.referee_destroy') %>
+<% content_for :title, t('page_titles.references_delete_referee') %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: candidate_interface_destroy_reference_path(@reference), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
-        <%= t('page_titles.referee_destroy') %>
+        <%= t('page_titles.references_delete_referee') %>
       </h1>
 
-      <%= f.submit 'Yes I’m sure - delete this referee' , class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.references.delete_referee.confirm') , class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
         <%= govuk_link_to t('application_form.references.delete_referee.cancel'), candidate_interface_references_review_path %>

--- a/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: candidate_interface_destroy_reference_path(@reference), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @reference.name %></span>
         <%= t('page_titles.references_delete_reference') %>
       </h1>
 

--- a/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_reference.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, t('page_titles.references_delete') %>
+<% content_for :title, t('page_titles.references_delete_reference') %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: candidate_interface_destroy_reference_path(@reference), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
-        <%= t('page_titles.references_delete') %>
+        <%= t('page_titles.references_delete_reference') %>
       </h1>
 
       <%= f.submit t('application_form.references.delete_reference.confirm') , class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>

--- a/app/views/candidate_interface/references/review/confirm_destroy_reference_request.html.erb
+++ b/app/views/candidate_interface/references/review/confirm_destroy_reference_request.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: candidate_interface_destroy_reference_path(@reference), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @reference.name %></span>
         <%= t('page_titles.references_delete_request') %>
       </h1>
 

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, t('page_titles.referees') %>
+<% content_for :title, t('page_titles.references') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <h1 class="govuk-heading-xl">
-  <%= t('page_titles.referees') %>
+  <%= t('page_titles.references') %>
 </h1>
 
 <% unless @application_form.enough_references_have_been_provided? %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -6,15 +6,15 @@
 </h1>
 
 <% unless @application_form.enough_references_have_been_provided? %>
-  <div class='govuk-inset-text govuk-!-margin-top-0'>
-    <p class='govuk-body'>You need 2 references before you can submit your application.</p>
-    <p class='govuk-body'>You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
+  <div class="govuk-inset-text govuk-!-margin-top-0">
+    <p class="govuk-body">You need 2 references before you can submit your application.</p>
+    <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
     <%= link_to 'Add another referee', candidate_interface_references_start_path, class: 'govuk-button' %>
   </div>
 <% end %>
 
 <% if @references_given.present? %>
-  <div id='references_given'>
+  <div id="references_given">
     <h2 class="govuk-heading-m">References that have been given</h2>
     <%= render(
       CandidateInterface::ReferencesReviewComponent.new(references: @references_given, show_history: true)
@@ -23,14 +23,14 @@
 <% end %>
 
 <% if @references_waiting_to_be_sent.present? %>
-  <div id='references_waiting_to_be_sent'>
+  <div id="references_waiting_to_be_sent">
     <h2 class="govuk-heading-m">Requests that have not been sent</h2>
     <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_waiting_to_be_sent, show_history: true)) %>
   </div>
 <% end %>
 
 <% if @references_sent.present? %>
-  <div id='references_sent'>
+  <div id="references_sent">
     <h2 class="govuk-heading-m">Reference requests</h2>
     <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_sent, editable: false, show_history: true)) %>
   </div>

--- a/app/views/candidate_interface/references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/references/review/unsubmitted.html.erb
@@ -14,7 +14,6 @@
 
       <%= render CandidateInterface::UnsubmittedReferenceReviewComponent.new(reference: @reference) %>
 
-
       <%= f.govuk_radio_buttons_fieldset :submit_reference, legend: { text: "Are you ready to send a reference request to #{@reference.name}?", size: 'm' } do %>
           <%= f.govuk_radio_button :submit, 'yes', link_errors: true,  label: { text: 'Yes, send a reference request now' } %>
           <%= f.govuk_radio_button :submit, 'no', link_errors: true, label: { text: 'No, not at the moment' } %>

--- a/app/views/candidate_interface/references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/references/review/unsubmitted.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @submit_reference_form, url: candidate_interface_references_submit_path, class: 'govuk-!-margin-top-8' do |f| %>
+    <%= form_with model: @submit_reference_form, url: candidate_interface_references_submit_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/references/review/unsubmitted.html.erb
@@ -6,17 +6,15 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">
-          <%= @reference.name %>
-        </span>
+        <span class="govuk-caption-xl"><%= @reference.name %></span>
         <%= t('page_titles.references_unsubmitted_review') %>
       </h1>
 
       <%= render CandidateInterface::UnsubmittedReferenceReviewComponent.new(reference: @reference) %>
 
       <%= f.govuk_radio_buttons_fieldset :submit_reference, legend: { text: "Are you ready to send a reference request to #{@reference.name}?", size: 'm' } do %>
-          <%= f.govuk_radio_button :submit, 'yes', link_errors: true,  label: { text: 'Yes, send a reference request now' } %>
-          <%= f.govuk_radio_button :submit, 'no', link_errors: true, label: { text: 'No, not at the moment' } %>
+        <%= f.govuk_radio_button :submit, 'yes', link_errors: true,  label: { text: 'Yes, send a reference request now' } %>
+        <%= f.govuk_radio_button :submit, 'no', link_errors: true, label: { text: 'No, not at the moment' } %>
       <% end %>
 
       <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/references/review/unsubmitted.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_unsubmitted_review') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_unsubmitted_review'), @submit_reference_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/references/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/type/_shared_form.html.erb
@@ -1,13 +1,11 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: t('page_titles.references_type'), size: 'xl' } do %>
-  <div class="govuk-!-margin-top-7">
-    <%= f.govuk_radio_button :referee_type, 'academic', link_errors: true, label: { text: 'Academic' }, hint: { text: t("application_form.references.referee_type.hint_text.academic") } %>
-    <%= f.govuk_radio_button :referee_type, 'professional', label: { text: 'Professional' }, hint: { text: t("application_form.references.referee_type.hint_text.professional") } %>
-    <%= f.govuk_radio_button :referee_type, 'school-based', label: { text: 'School-based' }, hint: { text: t("application_form.references.referee_type.hint_text.school_based") } %>
-    <%= f.govuk_radio_divider %>
-    <%= f.govuk_radio_button :referee_type, 'character', label: { text: 'Character' }, hint: { text: t("application_form.references.referee_type.hint_text.character") } %>
-  </div>
+<%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: t('page_titles.references_type'), size: 'xl', tag: 'h1' } do %>
+  <%= f.govuk_radio_button :referee_type, 'academic', link_errors: true, label: { text: 'Academic' }, hint: { text: t("application_form.references.referee_type.hint_text.academic") } %>
+  <%= f.govuk_radio_button :referee_type, 'professional', label: { text: 'Professional' }, hint: { text: t("application_form.references.referee_type.hint_text.professional") } %>
+  <%= f.govuk_radio_button :referee_type, 'school-based', label: { text: 'School-based' }, hint: { text: t("application_form.references.referee_type.hint_text.school_based") } %>
+  <%= f.govuk_radio_divider %>
+  <%= f.govuk_radio_button :referee_type, 'character', label: { text: 'Character' }, hint: { text: t("application_form.references.referee_type.hint_text.character") } %>
 <% end %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/type/_shared_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: t('page_titles.referee_type'), size: 'xl' } do %>
+<%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: t('page_titles.references_type'), size: 'xl' } do %>
   <div class="govuk-!-margin-top-7">
     <%= f.govuk_radio_button :referee_type, 'academic', link_errors: true, label: { text: 'Academic' }, hint: { text: t("application_form.references.referee_type.hint_text.academic") } %>
     <%= f.govuk_radio_button :referee_type, 'professional', label: { text: 'Professional' }, hint: { text: t("application_form.references.referee_type.hint_text.professional") } %>

--- a/app/views/candidate_interface/references/type/edit.html.erb
+++ b/app/views/candidate_interface/references/type/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.referee_type') %>
+<% content_for :title, t('page_titles.references_type') %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/references/type/edit.html.erb
+++ b/app/views/candidate_interface/references/type/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_type') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_type'), @reference_type_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/references/type/new.html.erb
+++ b/app/views/candidate_interface/references/type/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.referee_type') %>
+<% content_for :title, t('page_titles.references_type') %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/references/type/new.html.erb
+++ b/app/views/candidate_interface/references/type/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.references_type') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references_type'), @reference_type_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -417,6 +417,7 @@ en:
         label: What is the referee’s name?
       email_address:
         label: What is the referee’s email address?
+        hint_text: In most cases, this should be a work address.
       relationship:
         label: How do you know this referee and how long have you known them?
         hint_text:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -451,6 +451,10 @@ en:
         action: Send request again
       retry_request:
         action: Retry request
+      send_reminder:
+        action: Send a reminder to this referee
+        confirm: Yes I’m sure - send a reminder
+        cancel: No - I’ve changed my mind
       cancel_request:
         action: Cancel request
         confirm: Yes I’m sure - cancel this reference request

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
     references_relationship: How do you know this referee and how long have you known them?
     references_unsubmitted_review: Check your answers before sending your request
     references_candidate_name: What is your name?
+    references_send_request: Are you ready to send a reference request?
     references_retry_request: Retry reference request
     references_cancel_request: Are you sure you want to cancel this reference request?
     references_delete_request: Are you sure you want to delete this reference request?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,27 +109,23 @@ en:
     add_volunteering_role: Add role
     edit_volunteering_role: Edit role
     destroy_volunteering_role: Are you sure you want to delete this role?
-    referees: References
-    referees_choosing: Choosing your referees
-    referee_type: What kind of referee do you want to add?
-    referee_destroy: Are you sure you want to delete this referee?
-    referee_cancel: Are you sure you want to cancel this request for a reference?
-    references_cancel_request: Are you sure you want to cancel this reference request?
-    references_delete_request: Are you sure you want to delete this reference request?
-    references_delete: Are you sure you want to delete this reference?
-    add_referee: Details of referee
-    maximum_referees: You cannot add any more referees
-    give_a_reference:
-      confirmation: Your reference has been submitted
-      finish: Thank you
+    references: References
     references_start: Choose your referees
     references_name: What is the referee’s name?
     references_email_address: What is the referee’s email address?
+    references_type: What kind of referee do you want to add?
     references_relationship: How do you know this referee and how long have you known them?
     references_unsubmitted_review: Check your answers before sending your request
     references_candidate_name: What is your name?
-    references_reminder: Would you like to send a reminder to this referee?
-    retry_reference_request: Retry reference request
+    references_retry_request: Retry reference request
+    references_cancel_request: Are you sure you want to cancel this reference request?
+    references_delete_request: Are you sure you want to delete this reference request?
+    references_delete_referee: Are you sure you want to delete this referee?
+    references_delete_reference: Are you sure you want to delete this reference?
+    references_send_reminder: Would you like to send a reminder to this referee?
+    give_a_reference:
+      confirmation: Your reference has been submitted
+      finish: Thank you
     providers: Courses on this service
     view_and_respond_to_offer: Details of offer
     api_docs:


### PR DESCRIPTION
## Context

* Fixes missing hint text (form builder gem was upgraded while this was still being developed, so a few `hint_text` values were not updated)
* Tidies up some localisation strings
* Use label localisations for labels, page title localisations for page titles
* Use `govuk_email_field` for referee email, ensure this is not client side validated
* Use `"` for HTML attributes
* Review page captions and headings, using new form builder methods in place of previous workarounds.
* Add missing page titles
* Ensure validated page titles are prefixed with ‘Error: ’
* Remove unnecessary top margin on referee ‘check your answers’ page

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Probably easiest to review each commit individually.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
