### PR TITLE
Handle blank commitment when displaying work history

### DIFF
--- a/app/components/candidate_interface/work_history_review_component.rb
+++ b/app/components/candidate_interface/work_history_review_component.rb
@@ -141,6 +141,7 @@ module CandidateInterface
     end
 
     def working_pattern(work)
+      return if work.commitment.blank? && work.working_pattern.blank?
       return work.commitment.humanize if work.working_pattern.blank?
 
       "#{work.commitment.humanize}\n #{work.working_pattern}"

--- a/app/components/work_history_item_component.rb
+++ b/app/components/work_history_item_component.rb
@@ -59,7 +59,7 @@ private
   def working_pattern
     return item.working_pattern if item.is_a?(ApplicationVolunteeringExperience)
 
-    item.commitment.humanize
+    item.commitment&.humanize
   end
 
   def explained_absence_title


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
