### PR TITLE
Add a start_date attribute to the API Course object

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -124,6 +124,7 @@ module VendorAPI
         site_code: course_option.site.code,
         course_code: course_option.course.code,
         study_mode: course_option.study_mode,
+        start_date: course_option.course.start_date.strftime('%Y-%m'),
       }
     end
 

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,10 @@
+### 9th November 2020
+
+New attributes:
+
+- `Course` now has a `start_date` attribute giving the month and year the
+  course begins
+
 ### 23rd October 2020
 
 New attributes:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -667,6 +667,11 @@ components:
           enum:
           - full_time
           - part_time
+        start_date:
+          type: string
+          description: |
+            ISO8601 month and year indicating when this course starts. Including this field in a POST has no effect because courses are unambiguously identified by the rest of the properties in this object.
+          example: '2021-01'
     Offer:
       type: object
       additionalProperties: false

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -125,7 +125,7 @@ module CandidateHelper
   def given_courses_exist
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
-    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider)
+    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider, start_date: Date.new(2020, 9, 1))
     create(:course_option, site: site, course: course)
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -53,6 +53,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
           site_code: '-',
           course_code: '2XT2',
           study_mode: 'full_time',
+          start_date: '2020-09',
         },
         candidate: {
           id: "C#{@current_candidate.id}",


### PR DESCRIPTION
## Context

This is to support SRS vendors. It enables them to handle courses which
run in the same academic year as the recruitment cycle that feeds them —
for example, a course in January 2021 will be open for applications from
October 2020, ie the 2021 recruitment cycle.

## Changes proposed in this pull request

Add the property to the `Course` object in the API. Update the docs.

## Link to Trello card

https://trello.com/c/LyspoB3J/2995-include-course-start-date-in-the-course-object-in-api-responses

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
