### PR TITLE
Allow user to enter multiple Science GCSEs

### DIFF
--- a/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
+++ b/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
@@ -7,7 +7,7 @@
     <% if scottish_national_5? %>
       <%= t('gcse_edit_grade.guidance.triple_scottish_national_science') %>
     <% elsif gcse? || gce_o_level? %>
-      <%= t('gcse_edit_grade.guidance.triple_gcse_science') %>
+      <%= t('gcse_edit_grade.guidance.o_level_triple_gcse_science') %>
     <% end %>
   </p>
 <% end %>

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -58,10 +58,23 @@ module CandidateInterface
     def grade_row
       {
         key: 'Grade',
-        value: application_qualification.grade || t('gcse_summary.not_specified'),
+        value: present_grades || t('gcse_summary.not_specified'),
         action: "grade for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: grade_edit_path,
       }
+    end
+
+    def present_grades
+      if application_qualification.subject == ApplicationQualification::SCIENCE_TRIPLE_AWARD
+        grades = application_qualification.grades
+        [
+          "#{grades['biology']} (Biology)",
+          "#{grades['chemistry']} (Chemistry)",
+          "#{grades['physics']} (Physics)",
+        ]
+      else
+        application_qualification.grade
+      end
     end
 
     def missing_qualification_row

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -1,39 +1,65 @@
 module CandidateInterface
   class Gcse::Science::GradeController < Gcse::DetailsController
     include Gcse::GradeControllerConcern
-
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
 
     def edit
-      @application_qualification = details_form
-      @qualification_type = details_form.qualification.qualification_type
+      @gcse_grade_form = science_gcse_grade_form
+      @qualification_type = gcse_science_qualification.qualification_type
+
+      render view_path
     end
 
     def update
-      @qualification_type = details_form.qualification.qualification_type
+      @gcse_grade_form = science_gcse_grade_form.assign_values(science_details_params)
 
-      details_form.grade = details_params[:grade]
-      details_form.other_grade = details_params[:other_grade]
-
-      @application_qualification = details_form.save_grade
-
-      if @application_qualification
+      if @gcse_grade_form.save
         update_gcse_completed(false)
-        redirect_to next_gcse_path
+        redirect_to next_path
       else
-        @application_qualification = details_form
-        track_validation_error(@application_qualification)
-
-        render :edit
+        track_validation_error(@gcse_grade_form)
+        render view_path
       end
     end
 
   private
 
-    # Required by the GradeControllerConcern
+    def view_path
+      if gcse_qualification? && FeatureFlag.active?(:science_gcse_awards)
+        'candidate_interface/gcse/science/grade/awards_edit'
+      else
+        'candidate_interface/gcse/science/grade/edit'
+      end
+    end
+
+    def next_path
+      if science_gcse_grade_form.award_year.nil?
+        candidate_interface_gcse_details_edit_year_path(subject: @subject)
+      else
+        candidate_interface_gcse_review_path(subject: @subject)
+      end
+    end
+
+    def gcse_qualification?
+      gcse_science_qualification.qualification_type == 'gcse'
+    end
+
     def set_subject
-      @subject = 'science'
+      @subject = ApplicationQualification::SCIENCE
+    end
+
+    def science_details_params
+      params.require(:candidate_interface_science_gcse_grade_form)
+            .permit(%i[gcse_science grade single_award_grade double_award_grade biology_grade chemistry_grade physics_grade])
+    end
+
+    def gcse_science_qualification
+      @gcse_science_qualification ||= current_application.qualification_in_subject(:gcse, @subject)
+    end
+
+    def science_gcse_grade_form
+      @science_gcse_grade_form ||= ScienceGcseGradeForm.build_from_qualification(gcse_science_qualification)
     end
   end
 end

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -1,0 +1,230 @@
+module CandidateInterface
+  class ScienceGcseGradeForm
+    include ActiveModel::Model
+    include ValidationUtils
+
+    attr_accessor :grade,
+                  :grades,
+                  :award_year,
+                  :qualification,
+                  :subject,
+                  :other_grade,
+                  :single_award_grade,
+                  :double_award_grade,
+                  :gcse_science,
+                  :biology_grade,
+                  :physics_grade,
+                  :chemistry_grade
+    validates :other_grade, presence: true, if: :grade_is_other?
+    validates :grade, length: { maximum: 6 }, unless: :international_gcses_flag_active?
+    validate :grade_length
+    validate :grade_format, unless: :new_record?
+    validate :triple_award_grade_format
+
+    class << self
+      def build_from_qualification(qualification)
+        if FeatureFlag.active?('international_gcses') && qualification.qualification_type == 'non_uk'
+          new(
+            grade: qualification.set_grade,
+            other_grade: qualification.set_other_grade,
+            qualification: qualification,
+          )
+        else
+          new(build_params_from(qualification))
+        end
+      end
+
+    private
+
+      def build_params_from(qualification)
+        params = {
+          gcse_science: qualification.subject,
+          subject: qualification.subject,
+          qualification: qualification,
+        }
+
+        case qualification.subject
+        when ApplicationQualification::SCIENCE_SINGLE_AWARD
+          params[:single_award_grade] = qualification.grade
+        when ApplicationQualification::SCIENCE_DOUBLE_AWARD
+          params[:double_award_grade] = qualification.grade
+        when ApplicationQualification::SCIENCE_TRIPLE_AWARD
+          grades = qualification.grades
+          return unless grades
+
+          params[:biology_grade] = grades['biology']
+          params[:chemistry_grade] = grades['chemistry']
+          params[:physics_grade] = grades['physics']
+        else
+          params[:grade] = qualification.grade
+        end
+
+        params
+      end
+    end
+
+    def save
+      unless valid?
+        log_validation_errors(errors.keys.first)
+        return false
+      end
+
+      qualification.update(
+        grade: set_grade,
+        grades: set_triple_award_grades,
+        subject: subject,
+      )
+    end
+
+    def assign_values(params)
+      self.gcse_science = params[:gcse_science]
+      self.grade = set_grade_from(params)
+      self.other_grade = params[:other_grade]
+      self.subject = params[:gcse_science] || ApplicationQualification::SCIENCE
+      self.biology_grade = params[:biology_grade]
+      self.chemistry_grade = params[:chemistry_grade]
+      self.physics_grade = params[:physics_grade]
+      self
+    end
+
+  private
+
+    def set_grade_from(params)
+      case params[:gcse_science]
+      when ApplicationQualification::SCIENCE_SINGLE_AWARD
+        params[:single_award_grade]
+      when ApplicationQualification::SCIENCE_DOUBLE_AWARD
+        params[:double_award_grade]
+      else
+        params[:grade]
+      end
+    end
+
+    def grade_format
+      return if
+        qualification.qualification_type.nil? ||
+          qualification.qualification_type == 'other_uk' ||
+          qualification.qualification_type == 'non_uk' ||
+          grade.nil? ||
+          triple_award?
+
+      if %w[gce_o_level scottish_national_5 gcse].include?(qualification.qualification_type) && subject == ApplicationQualification::SCIENCE
+        qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
+        errors.add(:grade, :invalid) if grade.match(qualification_rexp)
+      end
+
+      if gsce_qualification_type? && single_award?
+        self.single_award_grade = grade
+        errors.add(:single_award_grade, :invalid) unless SINGLE_GCSE_GRADES.include?(grade.strip.upcase)
+      end
+
+      if gsce_qualification_type? && double_award?
+        self.double_award_grade = grade
+        errors.add(:double_award_grade, :invalid) unless DOUBLE_GCSE_GRADES.include?(grade.delete(' ').upcase)
+      end
+    end
+
+    def triple_award_grade_format
+      return unless triple_award?
+
+      grade_hash = {
+        biology_grade: biology_grade,
+        chemistry_grade: chemistry_grade,
+        physics_grade: physics_grade,
+      }
+
+      grade_hash.each do |key, grade|
+        next if grade.blank?
+
+        public_send("#{key}=", grade)
+        errors.add(key, :invalid) unless SINGLE_GCSE_GRADES.include?(grade.strip.upcase)
+      end
+    end
+
+    def grade_length
+      errors.add(:grade, :blank) if grade.blank? && science?
+      errors.add(:single_award_grade, :blank) if grade.blank? && single_award?
+      errors.add(:double_award_grade, :blank) if grade.blank? && double_award?
+      errors.add(:biology_grade, :blank) if biology_grade.blank? && triple_award?
+      errors.add(:chemistry_grade, :blank) if chemistry_grade.blank? && triple_award?
+      errors.add(:physics_grade, :blank) if physics_grade.blank? && triple_award?
+    end
+
+    def invalid_grades
+      {
+        gcse: /[^1-9A-GU\*\s\-]/i,
+        gce_o_level: /[^A-EU\s\-]/i,
+        scottish_national_5: /[^A-D1-7\s\-]/i,
+      }
+    end
+
+    def log_validation_errors(field)
+      return unless errors.key?(field)
+
+      error_message = {
+        field: field.to_s,
+        error_messages: errors[field].join(' - '),
+        value: grade || grades,
+      }
+
+      Rails.logger.info("Validation error: #{error_message.inspect}")
+    end
+
+    def set_grade
+      return if triple_award?
+
+      case grade
+      when 'other'
+        other_grade
+      when 'not_applicable'
+        'N/A'
+      when 'unknown'
+        'Unknown'
+      else
+        grade
+      end
+    end
+
+    def set_triple_award_grades
+      if triple_award?
+        {
+          biology: biology_grade,
+          physics: physics_grade,
+          chemistry: chemistry_grade,
+        }
+      end
+    end
+
+    def international_gcses_flag_active?
+      FeatureFlag.active?('international_gcses')
+    end
+
+    def new_record?
+      qualification.nil?
+    end
+
+    def grade_is_other?
+      grade == 'other'
+    end
+
+    def triple_award?
+      subject == ApplicationQualification::SCIENCE_TRIPLE_AWARD
+    end
+
+    def double_award?
+      subject == ApplicationQualification::SCIENCE_DOUBLE_AWARD
+    end
+
+    def single_award?
+      subject == ApplicationQualification::SCIENCE_SINGLE_AWARD
+    end
+
+    def science?
+      subject == ApplicationQualification::SCIENCE
+    end
+
+    def gsce_qualification_type?
+      qualification.qualification_type == 'gcse'
+    end
+  end
+end

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -115,12 +115,12 @@ module CandidateInterface
 
       if gsce_qualification_type? && single_award?
         self.single_award_grade = grade
-        errors.add(:single_award_grade, :invalid) unless SINGLE_GCSE_GRADES.include?(grade.strip.upcase)
+        errors.add(:single_award_grade, :invalid) unless SINGLE_GCSE_GRADES.include?(sanitize(grade))
       end
 
       if gsce_qualification_type? && double_award?
         self.double_award_grade = grade
-        errors.add(:double_award_grade, :invalid) unless DOUBLE_GCSE_GRADES.include?(grade.delete(' ').upcase)
+        errors.add(:double_award_grade, :invalid) unless DOUBLE_GCSE_GRADES.include?(sanitize(grade))
       end
     end
 
@@ -137,7 +137,7 @@ module CandidateInterface
         next if grade.blank?
 
         public_send("#{key}=", grade)
-        errors.add(key, :invalid) unless SINGLE_GCSE_GRADES.include?(grade.strip.upcase)
+        errors.add(key, :invalid) unless SINGLE_GCSE_GRADES.include?(sanitize(grade))
       end
     end
 
@@ -181,18 +181,22 @@ module CandidateInterface
       when 'unknown'
         'Unknown'
       else
-        grade
+        sanitize(grade)
       end
     end
 
     def set_triple_award_grades
       if triple_award?
         {
-          biology: biology_grade,
-          physics: physics_grade,
-          chemistry: chemistry_grade,
+          biology: sanitize(biology_grade),
+          physics: sanitize(physics_grade),
+          chemistry: sanitize(chemistry_grade),
         }
       end
+    end
+
+    def sanitize(grade)
+      grade.delete(' ').upcase if grade
     end
 
     def international_gcses_flag_active?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -86,6 +86,16 @@ class ApplicationForm < ApplicationRecord
   end
 
   def qualification_in_subject(level, subject)
+    if subject.to_s == ApplicationQualification::SCIENCE
+      # A Science GCSE may have any one of the following subject variants
+      subject = [
+        ApplicationQualification::SCIENCE,
+        ApplicationQualification::SCIENCE_SINGLE_AWARD,
+        ApplicationQualification::SCIENCE_DOUBLE_AWARD,
+        ApplicationQualification::SCIENCE_TRIPLE_AWARD,
+      ]
+    end
+
     application_qualifications
       .where(level: level, subject: subject)
       .order(created_at: 'asc')

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -22,6 +22,12 @@ class ApplicationQualification < ApplicationRecord
     award_year
   ].freeze
 
+  # Science GCSE may have any of the following subject variants
+  SCIENCE = 'science'.freeze
+  SCIENCE_SINGLE_AWARD = 'science single award'.freeze
+  SCIENCE_DOUBLE_AWARD = 'science double award'.freeze
+  SCIENCE_TRIPLE_AWARD = 'science triple award'.freeze
+
   belongs_to :application_form, touch: true
 
   scope :degrees, -> { where level: 'degree' }

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -30,6 +30,7 @@ class FeatureFlag
     [:export_hesa_data, 'Providers can export applications including HESA data.', 'Steve Laing'],
     [:feedback_form, 'New simplified feedback form to replace old multi-page satisfaction survey.', 'Steve Hook'],
     [:feedback_prompts, 'Candidates can give feedback while completing their application form', 'David Gisbey'],
+    [:science_gcse_awards, 'New UI layout for science GCSE', 'Toby Retallick'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/gcse/science/grade/awards_edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/awards_edit.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @gcse_grade_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_science_edit_grade_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
+
+      <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
+      <%= f.govuk_radio_buttons_fieldset :gcse_science, legend: {text: "Select the GCSEs you did and include your grade"} do %>
+        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_SINGLE_AWARD, label: {text: "Single award"}, hint: {text: t('gcse_edit_grade.hint.science.one_grade')}, link_errors: true) do %>
+          <%= f.govuk_text_field :single_award_grade, label: {text: "Grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
+        <% end %>
+        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_DOUBLE_AWARD, label: {text: "Double award"}, hint: {text: t('gcse_edit_grade.hint.science.combined_grade')}) do %>
+          <%= f.govuk_text_field :double_award_grade, label: {text: "Grade"}, hint: {text: t('gcse_edit_grade.hint.science.gcse_double_award')}, width: 4 %>
+        <% end %>
+        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_TRIPLE_AWARD, label: {text: "Triple award"}, hint: {text: t('gcse_edit_grade.hint.science.subject_per_grade')}) do %>
+          <%= f.govuk_text_field :biology_grade, label: {text: "Biology grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
+          <%= f.govuk_text_field :chemistry_grade, label: {text: "Chemistry grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
+          <%= f.govuk_text_field :physics_grade, label: {text: "Physics grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
+        <% end %>
+      <% end %>
+      <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -1,14 +1,14 @@
-<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @application_qualification.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('gcse_edit_grade.page_title', subject: @subject), @gcse_grade_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_science_edit_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_science_edit_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
+      <% if FeatureFlag.active?('international_gcses') && @qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
@@ -18,21 +18,7 @@
         <% end %>
       <% else %>
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
-
-        <% if autocomplete_grades? %>
-          <div class="govuk-!-width-one-third">
-            <%= f.govuk_collection_select(
-                  :grade,
-                  CandidateInterface::GcseQualificationDetailsForm.all_grade_drop_down_options,
-                  :value,
-                  :option,
-                  label: { text: 'Grade', size: 'm' },
-                  hint: { text: 'For example, ‘C’ or ‘4’' },
-                  ) %>
-          </div>
-        <% else %>
-          <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
-        <% end %>
+        <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
       <% end %>
 
       <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>

--- a/app/views/referee_interface/reference/safeguarding.html.erb
+++ b/app/views/referee_interface/reference/safeguarding.html.erb
@@ -11,7 +11,7 @@
           <%= f.govuk_radio_button :any_safeguarding_concerns, :yes, label: { text: 'Yes' } do %>
             <%= f.govuk_text_area :safeguarding_concerns, label: { text: "Tell us why you think #{@application.full_name} should not work with children"}, max_words: 150, rows: 5 %>
           <% end %>
-        <div>
+        </div>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -818,6 +818,33 @@ en:
               in_future: Enter a year before %{date}
             other_grade:
               blank: Enter your grade
+        candidate_interface/science_gcse_grade_form:
+          attributes:
+            single_award_grade:
+              blank: Enter your science single award grade
+              invalid: Enter a real science single award grade
+            double_award_grade:
+              blank: Enter your science double award grade
+              invalid: Enter a real science double award grade
+            grade:
+              blank: Enter your science grade
+              invalid: Enter a real science grade
+              too_long: Grade must be %{count} characters or fewer
+            biology_grade:
+              invalid: Enter a real Biology grade
+              blank: Enter your Biology grade
+            chemistry_grade:
+              invalid: Enter a real Chemistry grade
+              blank: Enter your Chemistry grade
+            physics_grade:
+              invalid: Enter a real Physics grade
+              blank: Enter your Physics grade
+            award_year:
+              blank: Enter the year you gained your qualification
+              invalid: Enter a real year
+              in_future: Enter a year before %{date}
+            other_grade:
+              blank: Enter your grade
         candidate_interface/gcse_qualification_type_form:
           attributes:
             qualification_type:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -821,24 +821,24 @@ en:
         candidate_interface/science_gcse_grade_form:
           attributes:
             single_award_grade:
-              blank: Enter your science single award grade
-              invalid: Enter a real science single award grade
+              blank: Enter your single award grade
+              invalid: Enter a real single award grade
             double_award_grade:
-              blank: Enter your science double award grade
-              invalid: Enter a real science double award grade
+              blank: Enter your double award grade
+              invalid: Enter a real double award grade
             grade:
               blank: Enter your science grade
               invalid: Enter a real science grade
               too_long: Grade must be %{count} characters or fewer
             biology_grade:
-              invalid: Enter a real Biology grade
-              blank: Enter your Biology grade
+              blank: Enter your biology grade
+              invalid: Enter a real biology grade
             chemistry_grade:
-              invalid: Enter a real Chemistry grade
-              blank: Enter your Chemistry grade
+              blank: Enter your chemistry grade
+              invalid: Enter a real chemistry grade
             physics_grade:
-              invalid: Enter a real Physics grade
-              blank: Enter your Physics grade
+              blank: Enter your physics grade
+              invalid: Enter a real physics grade
             award_year:
               blank: Enter the year you gained your qualification
               invalid: Enter a real year

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -22,8 +22,12 @@ en:
     hint:
       science:
         gcse: For example, ‘A*A*A*’, ‘AA’, ‘B’, ‘999’, ‘88’, ‘7’
+        gcse_double_award: For example, ‘CD’ or ‘4-3’
         gce_o_level: For example, ‘ABC’, ‘AA’, ‘B’
         scottish_national_5: For example, ‘A*A*A*’, ‘ABC’, ‘A’, ‘777’, ‘654’, ‘6’
+        one_grade: You have one science grade
+        combined_grade: You have a combined science grade
+        subject_per_grade: You have a grade for each subject
       other:
         gcse: For example, ‘C’ or ‘4’
         gce_o_level: For example, ‘C’

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -11,7 +11,7 @@ en:
         Providers expect you to have a grade C or 4 (or the equivalent) in order
         to train. If you do not have this, contact your provider to discuss your
         options. You might be able to retake an exam or do an equivalence test.
-      triple_gcse_science: If you have a combined or triple GCSE in science, enter your total grade.
+      o_level_triple_gcse_science: If you have a combined or triple O Level in science, enter your total grade.
       triple_scottish_national_science: If you studied three science subjects separately or took a general science qualification, enter your total grade.
       english_literature_only:
         summary: If you have %{type} in English Literature only

--- a/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
         result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
 
-        expect(result.text).to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
         result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
 
-        expect(result.text).to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
       end
     end

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -85,4 +85,34 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.text).not_to match(/Country\s+#{@qualification.institution_country}/)
     end
   end
+
+  context 'with the science_gcse_awards flag on' do
+    context 'when the candidate has entered a triple science GCSE award' do
+      it 'displays each science subject and associated grade' do
+        FeatureFlag.activate(:science_gcse_awards)
+
+        application_form = build :application_form
+        @qualification = application_qualification = build(
+          :application_qualification,
+          application_form: application_form,
+          qualification_type: 'gcse',
+          level: 'gcse',
+          grade: nil,
+          grades: { physics: 'A', chemistry: 'B', biology: 'C' },
+          subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
+        )
+
+        result = render_inline(
+          described_class.new(
+            application_form: application_form,
+            application_qualification: application_qualification,
+            subject: 'science',
+          ),
+        )
+
+        expect(result.css('.govuk-summary-list__key')[1].text).to include('Grade')
+        expect(result.css('.govuk-summary-list__value')[1].text).to include('C (Biology)B (Chemistry)A (Physics)')
+      end
+    end
+  end
 end

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -1,0 +1,371 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
+  describe 'validations' do
+    before { FeatureFlag.deactivate(:international_gcses) }
+
+    it { is_expected.to validate_length_of(:grade).is_at_most(6) }
+
+    context 'when grade is "other"' do
+      let(:form) { subject }
+
+      before { allow(form).to receive(:grade_is_other?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:other_grade) }
+    end
+
+    context 'when qualification type is GCSE' do
+      context 'single award' do
+        let(:qualification) do
+          FactoryBot.build_stubbed(
+            :application_qualification,
+            subject: 'science single award',
+            qualification_type: 'gcse',
+            level: 'gcse',
+          )
+        end
+        let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+
+        it 'returns no errors if grade is valid' do
+          mistyped_grades = %w[a b c]
+          valid_grades = SINGLE_GCSE_GRADES + mistyped_grades
+
+          valid_grades.each do |grade|
+            form.grade = grade
+            form.validate
+
+            expect(form.errors[:single_award_grade]).to be_empty
+          end
+        end
+
+        it 'returns validation error if grade is blank' do
+          form.validate
+
+          expect(form.errors[:single_award_grade]).to include('Enter your science single award grade')
+        end
+
+        it 'return validation error if grade is invalid' do
+          invalid_grades = %w[012 XYZ T 54%]
+
+          invalid_grades.each do |grade|
+            form.grade = grade
+            form.validate
+
+            expect(form.errors[:single_award_grade]).to include('Enter a real science single award grade')
+          end
+        end
+
+        it 'logs validation errors if grade is invalid' do
+          allow(Rails.logger).to receive(:info)
+          form.grade = 'XYZ'
+
+          form.save
+
+          expect(Rails.logger).to have_received(:info).with(
+            'Validation error: {:field=>"single_award_grade", :error_messages=>"Enter a real science single award grade", :value=>"XYZ"}',
+          )
+        end
+      end
+
+      context 'double award' do
+        let(:qualification) do
+          FactoryBot.build_stubbed(
+            :application_qualification,
+            subject: 'science double award',
+            qualification_type: 'gcse',
+            level: 'gcse',
+          )
+        end
+        let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+
+        it 'returns no errors if grade is valid' do
+          mistyped_grades = ['A a', 'A    a', 'b b']
+          valid_grades = DOUBLE_GCSE_GRADES + mistyped_grades
+
+          valid_grades.each do |grade|
+            form.grade = grade
+            form.validate
+
+            expect(form.errors[:double_award_grade]).to be_empty
+          end
+        end
+
+        it 'returns validation error if grade is blank' do
+          form.validate
+
+          expect(form.errors[:double_award_grade]).to include('Enter your science double award grade')
+        end
+
+        it 'return validation error if grade is invalid' do
+          invalid_grades = %w[012 XYZ T 54%]
+
+          invalid_grades.each do |grade|
+            form.grade = grade
+            form.validate
+
+            expect(form.errors[:double_award_grade]).to include('Enter a real science double award grade')
+          end
+        end
+
+        it 'logs validation errors if grade is invalid' do
+          allow(Rails.logger).to receive(:info)
+          form.grade = 'XYZ'
+
+          form.save
+
+          expect(Rails.logger).to have_received(:info).with(
+            'Validation error: {:field=>"double_award_grade", :error_messages=>"Enter a real science double award grade", :value=>"XYZ"}',
+          )
+        end
+      end
+
+      context 'triple award' do
+        let(:qualification) do
+          FactoryBot.build_stubbed(
+            :application_qualification,
+            qualification_type: 'gcse',
+            level: 'gcse',
+          )
+        end
+        let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+
+        it 'returns no errors if all grades are valid' do
+          form.subject = ApplicationQualification::SCIENCE_TRIPLE_AWARD
+
+          mistyped_grades = %w[a b c]
+          valid_grades = SINGLE_GCSE_GRADES + mistyped_grades
+
+          valid_grades.each do |grade|
+            form.biology_grade = grade
+            form.chemistry_grade = grade
+            form.physics_grade = grade
+            form.validate
+
+            expect(form.errors[:biology_grade]).to be_empty
+            expect(form.errors[:chemistry_grade]).to be_empty
+            expect(form.errors[:physics_grade]).to be_empty
+          end
+        end
+
+        it 'returns validation error if grade is blank' do
+          form.subject = ApplicationQualification::SCIENCE_TRIPLE_AWARD
+          form.validate
+
+          expect(form.errors[:biology_grade]).to include('Enter your Biology grade')
+          expect(form.errors[:chemistry_grade]).to include('Enter your Chemistry grade')
+          expect(form.errors[:physics_grade]).to include('Enter your Physics grade')
+        end
+
+        it 'return validation error if one or more grades are invalid' do
+          form.subject = ApplicationQualification::SCIENCE_TRIPLE_AWARD
+
+          invalid_grades = %w[XYZ]
+
+          invalid_grades.each do |invalid_grade|
+            form.biology_grade = invalid_grade
+            form.chemistry_grade = 'A'
+            form.physics_grade = 'A'
+
+            form.validate
+
+            expect(form.errors[:biology_grade]).to include('Enter a real Biology grade')
+          end
+        end
+      end
+    end
+
+    context 'when qualification type is GCE O LEVEL' do
+      let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse', subject: 'science') }
+      let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+
+      it 'returns no errors if grade is valid' do
+        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
+
+        valid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to be_empty
+        end
+      end
+
+      it 'return validation error if grade is invalid' do
+        invalid_grades = %w[123 A* XYZ]
+
+        invalid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to include('Enter a real science grade')
+        end
+      end
+    end
+
+    context 'when qualification type is Scottish National 5' do
+      let(:form) { CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification) }
+      let(:qualification) do
+        FactoryBot.build_stubbed(:application_qualification,
+                                 qualification_type: 'scottish_national_5',
+                                 level: 'gcse',
+                                 subject: 'science')
+      end
+
+      it 'returns no errors if grade is valid' do
+        valid_grades = ['AAA', 'AAB', '765', 'CBD', 'aaa', 'C B D', 'C-B-D']
+
+        valid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to be_empty
+        end
+      end
+
+      it 'return validation error if grade is invalid' do
+        invalid_grades = %w[89 AE A*]
+
+        invalid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to include('Enter a real science grade')
+        end
+      end
+    end
+  end
+
+  context 'when saving qualification details' do
+    qualification = ApplicationQualification.new
+    form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+    describe '#save' do
+      it 'return false if not valid' do
+        expect(form.save).to eq(false)
+      end
+
+      it 'updates qualification details if valid' do
+        application_form = create(:application_form)
+        qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
+        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+        details_form.grade = 'AB'
+
+        details_form.save
+        qualification.reload
+
+        expect(qualification.grade).to eq('AB')
+      end
+
+      it 'sets grade to other_grade if candidate selected "other"' do
+        application_form = create(:application_form)
+        qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
+        details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+        details_form.grade = 'other'
+        details_form.other_grade = 'D'
+
+        details_form.save
+        qualification.reload
+
+        expect(qualification.grade).to eq('D')
+      end
+
+      context 'updating a GCSE  qualification from single to triple award' do
+        it "clears 'grade' and populates 'grades'" do
+          application_form = create(:application_form)
+          qualification = ApplicationQualification.create(
+            level: 'gcse',
+            grade: 'A',
+            subject: ApplicationQualification::SCIENCE_SINGLE_AWARD,
+            application_form: application_form,
+          )
+          details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+          details_form.subject = ApplicationQualification::SCIENCE_TRIPLE_AWARD
+          details_form.biology_grade = 'B'
+          details_form.chemistry_grade = 'B'
+          details_form.physics_grade = 'B'
+
+          details_form.save
+          qualification.reload
+
+          expect(qualification.grade).to eq(nil)
+          expect(qualification.grades).to eq({ 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' })
+        end
+      end
+
+      context 'updating a GCSE qualification from triple to single award' do
+        it "clears 'grades' and populates 'grade'" do
+          application_form = create(:application_form)
+          qualification = ApplicationQualification.create(
+            level: 'gcse',
+            grade: nil,
+            grades: { 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' },
+            subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
+            application_form: application_form,
+          )
+          details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+          details_form.subject = ApplicationQualification::SCIENCE_SINGLE_AWARD
+          details_form.grade = 'AA'
+
+          details_form.save
+          qualification.reload
+
+          expect(qualification.grade).to eq('AA')
+          expect(qualification.grades).to eq(nil)
+        end
+      end
+    end
+
+    describe '.build_from_qualification' do
+      context 'with the international_gcses feature flag off' do
+        let(:data) do
+          {
+            grade: 'other',
+          }
+        end
+
+        it 'creates an object based on the provided ApplicationForm' do
+          qualification = ApplicationQualification.new(data)
+          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form).to have_attributes(data)
+        end
+      end
+
+      context 'with the international_gcses feature flag on, the qualification_type is non_uk and grade is not_applicable' do
+        it 'sets grade to not_applicable and other grade to nil' do
+          FeatureFlag.activate('international_gcses')
+          qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'n/a')
+          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form.grade).to eq 'not_applicable'
+          expect(gcse_details_form.other_grade).to eq nil
+        end
+      end
+
+      context 'with the international_gcses feature flag on and grade is unknown' do
+        it 'sets grade to not_applicable and other grade to nil' do
+          FeatureFlag.activate('international_gcses')
+          qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'unknown')
+          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form.grade).to eq 'unknown'
+          expect(gcse_details_form.other_grade).to eq nil
+        end
+      end
+
+      context 'with the international_gcses feature flag on and grade is another value' do
+        it 'sets grade to other and other grade to grades value' do
+          FeatureFlag.activate('international_gcses')
+          qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'D')
+          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
+
+          expect(gcse_details_form.grade).to eq 'other'
+          expect(gcse_details_form.other_grade).to eq 'D'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_gcse_science_award_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_science_award_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Candidate entering GCSE Science details' do
   end
 
   def then_i_see_the_grade_blank_error
-    expect(page).to have_content 'Enter your science single award grade'
+    expect(page).to have_content 'Enter your single award grade'
   end
 
   def and_i_enter_an_invalid_grade
@@ -87,7 +87,7 @@ RSpec.feature 'Candidate entering GCSE Science details' do
   end
 
   def then_i_see_the_grade_invalid_error
-    expect(page).to have_content('Enter a real science single award grade')
+    expect(page).to have_content('Enter a real single award grade')
   end
 
   def then_i_enter_a_valid_grade

--- a/spec/system/candidate_interface/candidate_entering_gcse_science_award_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_science_award_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate entering GCSE Science details' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their Science GCSE award' do
+    FeatureFlag.deactivate(:international_gcses)
+    # Activating the :science_gcse_awards FeatureFlag enables the new awards UI
+    FeatureFlag.activate(:science_gcse_awards)
+
+    given_i_am_signed_in
+    and_i_wish_to_apply_to_a_course_that_requires_gcse_science
+    and_i_visit_the_site
+
+    and_i_click_on_the_science_gcse_link
+    then_i_see_the_add_gcse_science_page
+
+    when_i_select_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_the_science_gcse_awards_grade_page
+
+    # enter single award
+    then_i_select_single_award
+    and_i_click_save_and_continue
+    then_i_see_the_grade_blank_error
+
+    and_i_enter_an_invalid_grade
+    and_i_click_save_and_continue
+    then_i_see_the_grade_invalid_error
+
+    and_i_enter_a_grade_that_is_too_long
+    and_i_click_save_and_continue
+    then_i_see_grade_too_long_error
+
+    then_i_enter_a_valid_grade
+    and_i_click_save_and_continue
+    then_i_see_the_grade_year_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_wish_to_apply_to_a_course_that_requires_gcse_science
+    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Science')
+    course_option = create(:course_option, course: course)
+    current_candidate.current_application.application_choices << create(:application_choice, course_option: course_option)
+  end
+
+  def and_i_click_on_the_science_gcse_link
+    click_on 'Science GCSE or equivalent'
+  end
+
+  def then_i_see_the_add_gcse_science_page
+    expect(page).to have_content 'Add science GCSE grade 4 (C) or above, or equivalent'
+  end
+
+  def when_i_select_gcse_option
+    choose('GCSE')
+  end
+
+  def and_i_click_save_and_continue
+    click_button 'Save and continue'
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_see_the_science_gcse_awards_grade_page
+    expect(page).to have_content t('gcse_edit_grade.page_title', subject: 'science')
+    expect(page).to have_content 'Select the GCSEs you did and include your grade'
+  end
+
+  def then_i_select_single_award
+    choose('Single award')
+  end
+
+  def then_i_see_the_grade_blank_error
+    expect(page).to have_content 'Enter your science single award grade'
+  end
+
+  def and_i_enter_an_invalid_grade
+    within find('#candidate-interface-science-gcse-grade-form-gcse-science-science-single-award-conditional') do
+      fill_in('Grade', with: 'SHIZZ')
+    end
+  end
+
+  def then_i_see_the_grade_invalid_error
+    expect(page).to have_content('Enter a real science single award grade')
+  end
+
+  def then_i_enter_a_valid_grade
+    within find('#candidate-interface-science-gcse-grade-form-gcse-science-science-single-award-conditional') do
+      fill_in('Grade', with: 'A')
+    end
+  end
+
+  def then_i_see_the_grade_year_page
+    expect(page).to have_content 'When was your science qualification awarded?'
+  end
+
+  def then_i_enter_a_valid_grade
+    within find('#candidate-interface-science-gcse-grade-form-gcse-science-science-single-award-conditional') do
+      fill_in('Grade', with: 'A')
+    end
+  end
+
+  def and_i_enter_a_grade_that_is_too_long
+    within find('#candidate-interface-science-gcse-grade-form-gcse-science-science-single-award-conditional') do
+      fill_in('Grade', with: 'SHIZZLE')
+    end
+  end
+
+  def then_i_see_grade_too_long_error
+    expect(page).to have_content('Grade must be 6 characters or fewer')
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_gcse_science_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_science_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate entering GCSE Science details' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their Science GCSE award' do
+    FeatureFlag.deactivate(:international_gcses)
+    # Activating the :science_gcse_awards feature flag enables the new awards UI
+    FeatureFlag.deactivate(:science_gcse_awards)
+
+    given_i_am_signed_in
+    and_i_wish_to_apply_to_a_course_that_requires_gcse_science
+    and_i_visit_the_site
+
+    and_i_click_on_the_science_gcse_link
+    then_i_see_the_add_gcse_science_page
+
+    when_i_select_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_the_science_gcse_grade_page
+
+    # enter grade
+    and_i_click_save_and_continue
+    then_i_see_the_grade_blank_error
+
+    and_i_enter_an_invalid_grade
+    and_i_click_save_and_continue
+    then_i_see_the_grade_invalid_error
+
+    and_i_enter_a_grade_that_is_too_long
+    and_i_click_save_and_continue
+    then_i_see_grade_too_long_error
+
+    then_i_enter_a_valid_grade
+    and_i_click_save_and_continue
+    then_i_see_the_grade_year_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_wish_to_apply_to_a_course_that_requires_gcse_science
+    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Science')
+    course_option = create(:course_option, course: course)
+    current_candidate.current_application.application_choices << create(:application_choice, course_option: course_option)
+  end
+
+  def and_i_click_on_the_science_gcse_link
+    click_on 'Science GCSE or equivalent'
+  end
+
+  def then_i_see_the_add_gcse_science_page
+    expect(page).to have_content 'Add science GCSE grade 4 (C) or above, or equivalent'
+    expect(page).not_to have_content 'If you have a combined or triple GCSE in science, enter your total grade.'
+  end
+
+  def when_i_select_gcse_option
+    choose('GCSE')
+  end
+
+  def and_i_click_save_and_continue
+    click_button 'Save and continue'
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_see_the_science_gcse_grade_page
+    expect(page).to have_content t('gcse_edit_grade.page_title', subject: 'science')
+    # If we did see this we would know that we were on the new Science GCSE awards page
+    expect(page).not_to have_content 'Select the GCSEs you did and include your grade'
+  end
+
+  def then_i_select_single_award
+    choose('Single award')
+  end
+
+  def then_i_see_the_grade_blank_error
+    expect(page).to have_content 'Enter your science grade'
+  end
+
+  def and_i_enter_an_invalid_grade
+    fill_in('candidate-interface-science-gcse-grade-form-grade-field-error', with: 'SHIZ')
+  end
+
+  def then_i_see_the_grade_invalid_error
+    expect(page).to have_content('Enter a real science grade')
+  end
+
+  def and_i_enter_a_grade_that_is_too_long
+    fill_in('candidate-interface-science-gcse-grade-form-grade-field-error', with: 'SHIZZLE')
+  end
+
+  def then_i_see_grade_too_long_error
+    expect(page).to have_content('Grade must be 6 characters or fewer')
+  end
+
+  def then_i_enter_a_valid_grade
+    fill_in('candidate-interface-science-gcse-grade-form-grade-field-error', with: 'A')
+  end
+
+  def then_i_see_the_grade_year_page
+    expect(page).to have_content 'When was your science qualification awarded?'
+  end
+end


### PR DESCRIPTION
## Context
As part of [🏈 Dev: Structured pre-degree qualifications](https://trello.com/c/ztwbkRly/1643-%F0%9F%8F%88-dev-structured-pre-degree-qualifications) we are updating pre-degree fields to use structure data.

## Changes proposed in this pull request
- Add a new flow to enable users to enter multiple Science GCSEs
- Update the review component to display Science triple awards (where present)

## Guidance for review
- Welcome initial comments on the work so far, especially where more refactoring is deemed _essential_ before shipping the first iteration
- I would imagine a **general clean up PR** may be required once this new flow (and the one for GSCE English) is shipped.
- See the _Todos_ section below for ticket status
- If you are viewing via the deployed Heroku app then you will need to activate the feature flag 'science gcse awards'

## Gif-o-rama

![multi_gcse_science](https://user-images.githubusercontent.com/5256922/98572910-15c7c680-22ae-11eb-8267-88db9d4bd62e.gif)

## Todos

- [x] User can enter single, double or triple award
- [x] Validation error occurs if fields are blank
- [x] Review component shows grades with correct format
- [x] New UI is populated with currently saved values when editing
- [x] Bug - some grade format validations no kicking in
- [x] Handle review and editing of Science GCSE created by original form
- [x] Add autocomplete - waiting to hear if this is still required
- [x] Agree API changes with ProVendor
- [x] Add feature specs and any missing test coverage - May want to create a new component and test validations here rather than within system spec
- [x] Refactor? - form is ugly, grade controller is still a bit fat. 

## Link to Trello card

https://trello.com/c/jJPtfRY3/1779-%F0%9F%8F%88-allow-candidates-to-enter-multiple-science-gcses

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
