### PR TITLE
Review account pages

### DIFF
--- a/app/views/candidate_interface/references/email_address/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/email_address/_shared_form.html.erb
@@ -13,6 +13,6 @@
   </div>
 <% end %>
 
-<%= f.govuk_email_field :email_address, label: { text: t('application_form.references.email_address.label'), size: 'xl', tag: 'h1' }, caption: { text: @reference.name, size: 'xl' }, hint: { text: t('application_form.references.email_address.hint_text') } %>
+<%= f.govuk_email_field :email_address, label: { text: t('application_form.references.email_address.label'), size: 'xl', tag: 'h1' }, caption: { text: @reference.name, size: 'xl' }, hint: { text: t('application_form.references.email_address.hint_text') }, spellcheck: false %>
 
 <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -3,15 +3,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.sign_in') %>
-    </h1>
-
-    <p class="govuk-body-l">Enter the email address you used to register with, and we will send you a link to sign in.</p>
-
     <%= form_with model: candidate, url: candidate_interface_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.sign_in') %>
+      </h1>
+
+      <p class="govuk-body-l">Enter the email address you used to register with, and we will send you a link to sign in.</p>
 
       <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -13,7 +13,7 @@
     <%= form_with model: candidate, url: candidate_interface_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
       <%= f.submit t('authentication.sign_up.button_continue'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -13,7 +13,7 @@
     <%= form_with model: candidate, url: candidate_interface_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, type: :email, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, width: 'two-thirds', autocomplete: 'email' %>
 
       <%= f.submit t('authentication.sign_up.button_continue'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -11,7 +11,7 @@
         <%= t('authentication.sign_up.heading') %>
       </h1>
 
-      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, type: :email, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email' %>
 
       <h2 class="govuk-heading-m">You will not need a password to use this service</h2>
       <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we’ll send you a link so you can return to your application.</p>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -11,7 +11,7 @@
         <%= t('authentication.sign_up.heading') %>
       </h1>
 
-      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
       <h2 class="govuk-heading-m">You will not need a password to use this service</h2>
       <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we’ll send you a link so you can return to your application.</p>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -14,7 +14,7 @@
       <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
       <h2 class="govuk-heading-m">You will not need a password to use this service</h2>
-      <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we’ll send you a link so you can return to your application.</p>
+      <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we will send you a link so you can return to your application.</p>
 
       <h2 class="govuk-heading-m">How we look after your data</h2>
       <p class="govuk-body">Your data will be looked after by the Department for Education and the training providers you apply to.</p>

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -2,15 +2,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Create an account or sign in
-    </h1>
-
     <%= form_with(
       model: @create_account_or_sign_in_form,
       url: candidate_interface_create_account_or_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]),
       method: :post,
     ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        Create an account or sign in
+      </h1>
+
       <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>
         <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' } do %>
           <%= f.govuk_email_field :email, label: { text: 'Email address', size: 's' }, hint: { text: 'Enter the email address you used to register, and we will send you a link to sign in.' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -13,7 +13,7 @@
     ) do |f| %>
       <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>
         <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' } do %>
-          <%= f.govuk_email_field :email, spellcheck: false %>
+          <%= f.govuk_email_field :email, label: { text: 'Email address', size: 's' }, hint: { text: 'Enter the email address you used to register, and we will send you a link to sign in.' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
         <% end %>
         <%= f.govuk_radio_button :existing_account, false, label: { text: 'No, I need to create an account' } %>
       <% end %>

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -13,7 +13,7 @@
     ) do |f| %>
       <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>
         <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' } do %>
-          <%= f.govuk_email_field :email %>
+          <%= f.govuk_email_field :email, spellcheck: false %>
         <% end %>
         <%= f.govuk_radio_button :existing_account, false, label: { text: 'No, I need to create an account' } %>
       <% end %>

--- a/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_details.html.erb
@@ -9,7 +9,7 @@
       <span class="govuk-caption-xl">Invite user</span>
       <h1 class="govuk-heading-xl">Basic details</h1>
 
-      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' } %>
+      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' }, spellcheck: false %>
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
 

--- a/app/views/provider_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/provider_interface/sessions/authentication_fallback.html.erb
@@ -19,7 +19,7 @@
     <%= form_with model: ProviderUser.new, url: provider_interface_sign_in_by_email_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' }, type: :email, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' }, width: 'two-thirds', autocomplete: 'email' %>
 
       <%= f.submit 'Continue', class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/app/views/provider_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/provider_interface/sessions/authentication_fallback.html.erb
@@ -19,7 +19,7 @@
     <%= form_with model: ProviderUser.new, url: provider_interface_sign_in_by_email_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' }, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
       <%= f.submit 'Continue', class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/app/views/support_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/support_interface/sessions/authentication_fallback.html.erb
@@ -15,7 +15,7 @@
     <%= form_with model: SupportUser.new, url: support_interface_sign_in_by_email_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' }, type: :email, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' }, width: 'two-thirds', autocomplete: 'email' %>
 
       <%= f.submit 'Continue', class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/app/views/support_interface/sessions/authentication_fallback.html.erb
+++ b/app/views/support_interface/sessions/authentication_fallback.html.erb
@@ -15,7 +15,7 @@
     <%= form_with model: SupportUser.new, url: support_interface_sign_in_by_email_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' }, width: 'two-thirds', autocomplete: 'email' %>
+      <%= f.govuk_email_field :email_address, label: { text: 'Email address', size: 'm' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
 
       <%= f.submit 'Continue', class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>


### PR DESCRIPTION
## Context

In the process of ensuring email fields don’t get spellchecked, found a few other bugs too 🙈

## Changes proposed in this pull request

* Don’t spellcheck email fields
* Add missing label, hint text and other attributes for sign in email field on sign in or create an account page
* Move error summary above title sign in page
* Add missing error summary on create account or sign in page
* Use `govuk_email_field` instead of `govuk_text_field`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/FR7zw3cP

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
