### PR TITLE
Trigger smoke tests using workflow_dispatch event

### DIFF
--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -377,20 +377,25 @@ jobs:
               containerName: ${{ format('{0}-{1}', variables.containerInstanceNamePrefix,'clk') }}
 
           - powershell: |
-              $uri = "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training-tests/dispatches"
-
-              $body = @{
-               "event_type" = "Deploy ${{ parameters.environment }}"
+              $requestBody = @{
+                ref = "refs/heads/master"
+                inputs = @{
+                  environment = "${{ parameters.environment }}"
+                }
               } | ConvertTo-Json
 
-              $header = @{
-               "Accept" = "application/vnd.github.everest-preview+json"
+              $authHeaders = @{
+               "Accept" = "application/vnd.github.v3+json"
                "Authorization" = "token $($env:GITHUB_TOKEN)"
               }
 
-              Invoke-WebRequest -Method POST -Header $header -Body $body -Uri $uri
+              Invoke-RestMethod `
+              -Method Post `
+              -Headers $authHeaders `
+              -Body $requestBody `
+              -Uri "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training-tests/actions/workflows/smoke-tests.yml/dispatches"
             displayName: 'Trigger smoke tests on GitHub'
             continueOnError: true
-            condition: and(succeeded(), eq(variables['buildCancelled'], false))
+            condition: and(succeeded(), eq(variables['buildCancelled'], false), not(eq('${{ parameters.environment }}', 'devops')))
             env:
               GITHUB_TOKEN: $(smokeTestsGitHubToken)


### PR DESCRIPTION
Smoke tests workflow was refactored to reuse one file
and work on the workflow_dispatch trigger.

**Merge** once [smoke-test-pr](https://github.com/DFE-Digital/apply-for-teacher-training-tests/pull/32) is merged.

## Context

[smoke-test-pr](https://github.com/DFE-Digital/apply-for-teacher-training-tests/pull/32)

## Changes proposed in this pull request

Use workflow_dispatch trigger to invoke smoke test run.

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
