### PR TITLE
Do not spellcheck reference numbers

### DIFF
--- a/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/_form_fields.html.erb
@@ -4,7 +4,8 @@
     <%= f.govuk_text_field(
       :naric_reference,
       label: { text: t('application_form.degree.naric_reference.label'), size: 's' },
-      hint: { text: t('application_form.degree.naric_reference.hint_text') }
+      hint: { text: t('application_form.degree.naric_reference.hint_text') },
+      spellcheck: false
     ) %>
     <%= f.govuk_radio_buttons_fieldset(
       :comparable_uk_degree,

--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -1,7 +1,8 @@
 <%= f.govuk_text_field(
   :trf_number,
   label: { text: 'Test report form (TRF) number', size: 'm' },
-  hint: { text: 'For example, 02GB0674SOOM599A' }) %>
+  hint: { text: 'For example, 02GB0674SOOM599A' },
+  spellcheck: false) %>
 
 <%= f.govuk_collection_select(
   :band_score,

--- a/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
@@ -1,7 +1,8 @@
 <%= f.govuk_text_field(
   :registration_number,
   label: { text: 'TOEFL registration number', size: 'm' },
-  hint: { text: 'For example, 0000 0000 2500 2147' }) %>
+  hint: { text: 'For example, 0000 0000 2500 2147' },
+  spellcheck: false) %>
 
 <%= f.govuk_text_field(
   :total_score,

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -13,7 +13,7 @@
       <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
       <%= f.govuk_radio_buttons_fieldset :naric_details, legend: { text: t('application_form.gcse.naric_statement.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :naric_reference_choice, 'Yes', label: { text: 'Yes' } do %>
-          <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20 %>
+          <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
           <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('application_form.gcse.comparable_uk_qualification.label'), size: 's'}, hint: { text: t('application_form.gcse.comparable_uk_qualification.hint_text') } do %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') } %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel') } %>


### PR DESCRIPTION
## Context

We shouldn’t spellcheck reference numbers. This follows on from #3352, which removed spell checking for fields that ask for an email address. 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/FR7zw3cP/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
