### PR TITLE
Review remaining HTML fieldset elements in candidate interface

### DIFF
--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -7,18 +7,13 @@
       <%= f.govuk_error_summary %>
 
       <% if @contact_details_form.uk? %>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-            <h1 class="govuk-fieldset__heading">
-              <%= t('page_titles.address') %>
-            </h1>
-          </legend>
+        <%= f.govuk_fieldset legend: { text: t('page_titles.address'), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_text_field :address_line1, label: ->{ safe_join([t('application_form.contact_details.address_line1.label'), ' ', tag.span(t('application_form.contact_details.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
           <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
           <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
           <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
           <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
-        </fieldset>
+        <% end %>
       <% else %>
         <%= f.govuk_text_area :international_address, label: { text: t('page_titles.address'), size: 'xl' }, autocomplete: 'address' %>
       <% end %>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -6,40 +6,35 @@
     <%= form_with model: @training_with_a_disability_form, url: candidate_interface_training_with_a_disability_update_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.training_with_a_disability') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.training_with_a_disability') %>
+      </h1>
 
-        <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
-        <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
-        <p class="govuk-body">Examples of support could be:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>organising equipment like a hearing loop or an adapted keyboard</li>
-          <li>putting you in touch with support staff if you have a mental health condition</li>
-          <li>making sure classrooms are wheelchair accessible</li>
-        </ul>
-        <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <%= govuk_link_to 'Access to Work', 'https://www.gov.uk/access-to-work' %>. This could include a grant to help cover the costs of practical support in the workplace.</p>
-        <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
-        <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>. Training providers must not:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-          <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
-          <li>reject your application because you’re disabled</li>
-        </ul>
+      <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
+      <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
+      <p class="govuk-body">Examples of support could be:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>organising equipment like a hearing loop or an adapted keyboard</li>
+        <li>putting you in touch with support staff if you have a mental health condition</li>
+        <li>making sure classrooms are wheelchair accessible</li>
+      </ul>
+      <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <%= govuk_link_to 'Access to Work', 'https://www.gov.uk/access-to-work' %>. This could include a grant to help cover the costs of practical support in the workplace.</p>
+      <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
+      <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>. Training providers must not:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
+        <li>reject your application because you’re disabled</li>
+      </ul>
 
-        <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { size: 'm', text: t('application_form.training_with_a_disability.disclose_disability.label') } do %>
-          <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') } do %>
-            <%= f.govuk_text_area :disability_disclosure, rows: 8, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label'), size: 's' }, max_words: 400 %>
-          <% end %>
-
-          <%= f.govuk_radio_button :disclose_disability, 'no', label: { text: t('application_form.training_with_a_disability.disclose_disability.no') } %>
-
+      <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { size: 'm', text: t('application_form.training_with_a_disability.disclose_disability.label') } do %>
+        <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') } do %>
+          <%= f.govuk_text_area :disability_disclosure, rows: 8, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label'), size: 's' }, max_words: 400 %>
         <% end %>
 
-        <%= f.govuk_submit t('application_form.training_with_a_disability.complete_form_button') %>
-      </fieldset>
+        <%= f.govuk_radio_button :disclose_disability, 'no', label: { text: t('application_form.training_with_a_disability.disclose_disability.no') } %>
+      <% end %>
+
+      <%= f.govuk_submit t('application_form.training_with_a_disability.complete_form_button') %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Context

* Removes unnecessary `fieldset` element wrapping the training with a disability section
* Use `govuk_fieldset` helper to generate fieldset for contact address (am happy that this change no longer adds a margin below the legend) 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
