### PR TITLE
Don’t show ‘No results found’ message when suggesting values

### DIFF
--- a/app/frontend/packs/helpers.js
+++ b/app/frontend/packs/helpers.js
@@ -21,7 +21,7 @@ export const accessibleAutocompleteFromSource = (input, autocompleteContainer, a
     id: input.id,
     name: input.name,
     source,
-    showNoOptionsFound: true,
+    showNoOptionsFound: false,
     defaultValue: input.value,
     ...autocompleteOptions
   });


### PR DESCRIPTION
## Context

Where we use the `accessible-autocomplete` library to enhance an input so that we can suggest values, we currently show a ‘No results found’ message. This might indicate to candidates that their answer might not be valid, when in fact we allow any free text answer.

## Changes proposed in this pull request

Change the `showNoOptionsFound` option used in `accessibleAutocompleteFromSource` (which is exclusively used for autosuggests) to `false`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/HJEWwB8n/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
