### PR TITLE
Merge Slack message for application submission

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -22,7 +22,7 @@ class StateChangeNotifier
 
     provider_name = application_choice.course.provider.name
     course_name = application_choice.course.name_and_code
-    applicant = application_choice.application_form.first_name
+    candidate_name = application_choice.application_form.first_name
     application_form = application_choice.application_form
 
     case event
@@ -39,25 +39,25 @@ class StateChangeNotifier
       text = ":broken_heart: #{applicant}’s application has just been rejected by default"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :offer_accepted
-      text = ":handshake: #{applicant} has accepted #{provider_name}’s offer"
+      text = ":handshake: #{candidate_name} has accepted #{provider_name}’s offer"
       url = helpers.support_interface_application_form_url(application_form)
     when :offer_declined
-      text = ":no_good: #{applicant} has declined #{provider_name}’s offer"
+      text = ":no_good: #{candidate_name} has declined #{provider_name}’s offer"
       url = helpers.support_interface_application_form_url(application_form)
     when :withdraw
-      text = ":runner: #{applicant} has withdrawn their application for #{course_name} at #{provider_name}"
+      text = ":runner: #{candidate_name} has withdrawn their application for #{course_name} at #{provider_name}"
       url = helpers.support_interface_application_form_url(application_form)
     when :withdraw_offer
-      text = ":no_good: #{provider_name} has just withdrawn #{applicant}’s offer"
+      text = ":no_good: #{provider_name} has just withdrawn #{candidate_name}’s offer"
       url = helpers.support_interface_application_form_url(application_form)
     when :defer_offer
-      text = ":double_vertical_bar: #{provider_name} has just deferred #{applicant}’s offer"
+      text = ":double_vertical_bar: #{provider_name} has just deferred #{candidate_name}’s offer"
       url = helpers.support_interface_application_form_url(application_form)
     when :reinstate_offer_conditions_met
-      text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{applicant} (conditions met)"
+      text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{candidate_name} (conditions met)"
       url = helpers.support_interface_application_form_url(application_form)
     when :reinstate_offer_pending_conditions
-      text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{applicant} (pending conditions)"
+      text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{candidate_name} (pending conditions)"
       url = helpers.support_interface_application_form_url(application_form)
     else
       raise 'StateChangeNotifier: unsupported state transition event'

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -17,6 +17,13 @@ class StateChangeNotifier
     send(text, url)
   end
 
+  def self.submit_application(application_form)
+    message = ":rocket: #{application_form.first_name}’s application has been sent to #{application_form.application_choices.map(&:provider).map(&:name).to_sentence}"
+    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
+
+    send(message, url)
+  end
+
   def self.call(event, application_choice: nil)
     helpers = Rails.application.routes.url_helpers
 

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -1,6 +1,5 @@
 class StateChangeNotifier
   def self.sign_up(candidate)
-    helpers = Rails.application.routes.url_helpers
     candidate_number = Candidate.where(hide_in_reporting: false).count
 
     return unless (candidate_number % 25).zero?
@@ -19,14 +18,12 @@ class StateChangeNotifier
 
   def self.submit_application(application_form)
     message = ":rocket: #{application_form.first_name}’s application has been sent to #{application_form.application_choices.map(&:provider).map(&:name).to_sentence}"
-    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
+    url = helpers.support_interface_application_form_url(application_form)
 
     send(message, url)
   end
 
   def self.call(event, application_choice: nil)
-    helpers = Rails.application.routes.url_helpers
-
     provider_name = application_choice.course.provider.name
     course_name = application_choice.course.name_and_code
     candidate_name = application_choice.application_form.first_name
@@ -34,41 +31,32 @@ class StateChangeNotifier
 
     case event
     when :make_an_offer
-      text = ":love_letter: #{provider_name} has just made an offer to #{applicant}’s application"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      text = ":love_letter: #{provider_name} has just made an offer to #{candidate_name}’s application"
     when :change_an_offer
-      text = ":love_letter: #{provider_name} has just changed an offer for #{applicant}’s application"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      text = ":love_letter: #{provider_name} has just changed an offer for #{candidate_name}’s application"
     when :reject_application
-      text = ":broken_heart: #{provider_name} has just rejected #{applicant}’s application"
-      url = helpers.support_interface_application_form_url(application_form)
+      text = ":broken_heart: #{provider_name} has just rejected #{candidate_name}’s application"
     when :reject_application_by_default
-      text = ":broken_heart: #{applicant}’s application has just been rejected by default"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      text = ":broken_heart: #{candidate_name}’s application to #{provider_name} has just been rejected by default"
     when :offer_accepted
       text = ":handshake: #{candidate_name} has accepted #{provider_name}’s offer"
-      url = helpers.support_interface_application_form_url(application_form)
     when :offer_declined
       text = ":no_good: #{candidate_name} has declined #{provider_name}’s offer"
-      url = helpers.support_interface_application_form_url(application_form)
     when :withdraw
       text = ":runner: #{candidate_name} has withdrawn their application for #{course_name} at #{provider_name}"
-      url = helpers.support_interface_application_form_url(application_form)
     when :withdraw_offer
       text = ":no_good: #{provider_name} has just withdrawn #{candidate_name}’s offer"
-      url = helpers.support_interface_application_form_url(application_form)
     when :defer_offer
       text = ":double_vertical_bar: #{provider_name} has just deferred #{candidate_name}’s offer"
-      url = helpers.support_interface_application_form_url(application_form)
     when :reinstate_offer_conditions_met
       text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{candidate_name} (conditions met)"
-      url = helpers.support_interface_application_form_url(application_form)
     when :reinstate_offer_pending_conditions
       text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{candidate_name} (pending conditions)"
-      url = helpers.support_interface_application_form_url(application_form)
     else
       raise 'StateChangeNotifier: unsupported state transition event'
     end
+
+    url = helpers.support_interface_application_form_url(application_form)
 
     send(text, url)
   end
@@ -80,5 +68,9 @@ class StateChangeNotifier
     end
 
     SlackNotificationWorker.perform_async(text, url)
+  end
+
+  def self.helpers
+    Rails.application.routes.url_helpers
   end
 end

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -31,9 +31,6 @@ class StateChangeNotifier
     when :submit_application
       text = "#{application_form.first_name} has just submitted their application"
       url = helpers.support_interface_application_form_url(application_form)
-    when :send_application_to_provider
-      text = ":rocket: #{applicant}’s application has been sent to #{provider_name}"
-      url = helpers.support_interface_application_form_url(application_form_id)
     when :make_an_offer
       text = ":love_letter: #{provider_name} has just made an offer to #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -28,9 +28,6 @@ class StateChangeNotifier
     end
 
     case event
-    when :submit_application
-      text = "#{application_form.first_name} has just submitted their application"
-      url = helpers.support_interface_application_form_url(application_form)
     when :make_an_offer
       text = ":love_letter: #{provider_name} has just made an offer to #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -23,7 +23,7 @@ class StateChangeNotifier
     provider_name = application_choice.course.provider.name
     course_name = application_choice.course.name_and_code
     applicant = application_choice.application_form.first_name
-    application_form_id = application_choice.application_form.id
+    application_form = application_choice.application_form
 
     case event
     when :make_an_offer
@@ -34,31 +34,31 @@ class StateChangeNotifier
       url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application
       text = ":broken_heart: #{provider_name} has just rejected #{applicant}’s application"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     when :reject_application_by_default
       text = ":broken_heart: #{applicant}’s application has just been rejected by default"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :offer_accepted
       text = ":handshake: #{applicant} has accepted #{provider_name}’s offer"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     when :offer_declined
       text = ":no_good: #{applicant} has declined #{provider_name}’s offer"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     when :withdraw
       text = ":runner: #{applicant} has withdrawn their application for #{course_name} at #{provider_name}"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     when :withdraw_offer
       text = ":no_good: #{provider_name} has just withdrawn #{applicant}’s offer"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     when :defer_offer
       text = ":double_vertical_bar: #{provider_name} has just deferred #{applicant}’s offer"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     when :reinstate_offer_conditions_met
       text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{applicant} (conditions met)"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     when :reinstate_offer_pending_conditions
       text = ":arrow_forward: #{provider_name} has just reinstated their offer to #{applicant} (pending conditions)"
-      url = helpers.support_interface_application_form_url(application_form_id)
+      url = helpers.support_interface_application_form_url(application_form)
     else
       raise 'StateChangeNotifier: unsupported state transition event'
     end

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -17,15 +17,13 @@ class StateChangeNotifier
     send(text, url)
   end
 
-  def self.call(event, application_choice: nil, application_form: nil)
+  def self.call(event, application_choice: nil)
     helpers = Rails.application.routes.url_helpers
 
-    if application_choice
-      provider_name = application_choice.course.provider.name
-      course_name = application_choice.course.name_and_code
-      applicant = application_choice.application_form.first_name
-      application_form_id = application_choice.application_form.id
-    end
+    provider_name = application_choice.course.provider.name
+    course_name = application_choice.course.name_and_code
+    applicant = application_choice.application_form.first_name
+    application_form_id = application_choice.application_form.id
 
     case event
     when :make_an_offer

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -22,7 +22,6 @@ class SendApplicationToProvider
       ApplicationStateChange.new(application_choice).send_to_provider!
     end
 
-    StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice)
     SendNewApplicationEmailToProvider.new(application_choice: application_choice).call
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -19,8 +19,6 @@ class SubmitApplication
       CandidateMailer.application_submitted(application_form).deliver_later
     end
 
-    message = ":rocket: #{application_form.first_name}’s application has been sent to #{application_choices.map(&:provider).map(&:name).to_sentence}"
-    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
-    SlackNotificationWorker.perform_async(message, url)
+      StateChangeNotifier.submit_application(application_form)
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -19,6 +19,6 @@ class SubmitApplication
       CandidateMailer.application_submitted(application_form).deliver_later
     end
 
-      StateChangeNotifier.submit_application(application_form)
+    StateChangeNotifier.submit_application(application_form)
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -18,5 +18,9 @@ class SubmitApplication
     else
       CandidateMailer.application_submitted(application_form).deliver_later
     end
+
+    message = ":rocket: #{application_form.first_name}’s application has been sent to #{application_choices.map(&:provider).map(&:name).to_sentence}"
+    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_form)
+    SlackNotificationWorker.perform_async(message, url)
   end
 end

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -14,20 +14,6 @@ RSpec.describe StateChangeNotifier do
 
     before { allow(SlackNotificationWorker).to receive(:perform_async) }
 
-    describe ':submit_application' do
-      before { StateChangeNotifier.call(:submit_application, application_form: application_form) }
-
-      it 'mentions applicant\'s first name' do
-        arg1 = "#{applicant} has just submitted their application"
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
-      end
-
-      it 'links the notification to the relevant support_interface application_form' do
-        arg2 = helpers.support_interface_application_form_url(application_form_id)
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
-      end
-    end
-
     describe ':make_an_offer' do
       before { StateChangeNotifier.call(:make_an_offer, application_choice: application_choice) }
 

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -28,20 +28,6 @@ RSpec.describe StateChangeNotifier do
       end
     end
 
-    describe ':send_application_to_provider' do
-      before { StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice) }
-
-      it 'mentions applicant\'s first name and provider name' do
-        arg1 = ":rocket: #{applicant}’s application has been sent to #{provider_name}"
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
-      end
-
-      it 'links the notification to the relevant support_interface application_form' do
-        arg2 = helpers.support_interface_application_form_url(application_form_id)
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
-      end
-    end
-
     describe ':make_an_offer' do
       before { StateChangeNotifier.call(:make_an_offer, application_choice: application_choice) }
 

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe StateChangeNotifier do
       before { StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice) }
 
       it 'mentions applicant\'s first name' do
-        arg1 = ":broken_heart: #{applicant}’s application has just been rejected by default"
+        arg1 = ":broken_heart: #{applicant}’s application to #{provider_name} has just been rejected by default"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -37,14 +37,6 @@ RSpec.describe SendApplicationToProvider do
     expect(application_choice.reject_by_default_days).to eq 20
   end
 
-  it 'sends a Slack notification' do
-    allow(SlackNotificationWorker).to receive(:perform_async)
-
-    SendApplicationToProvider.new(application_choice: application_choice).call
-
-    expect(SlackNotificationWorker).to have_received(:perform_async)
-  end
-
   it 'emails the provider’s provider users', sidekiq: true do
     user = create(:provider_user)
     application_choice.provider.provider_users = [user]

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -197,7 +197,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def and_a_slack_notification_is_sent
-    expect_slack_message_with_text 'Lando’s application has been sent to'
+    expect_slack_message_with_text 'Lando’s application has been sent to Gorse SCITT'
   end
 
   def when_i_click_on_track_your_application

--- a/spec/system/candidate_interface/references/submitting_an_application_spec.rb
+++ b/spec/system/candidate_interface/references/submitting_an_application_spec.rb
@@ -17,11 +17,6 @@ RSpec.feature 'Submitting an application' do
     and_i_submit_the_application
 
     then_i_can_see_my_application_has_been_successfully_submitted
-    and_its_in_the_right_state
-    and_i_receive_an_email_about_my_submitted_application
-    and_a_slack_notification_is_sent
-    and_i_can_review_my_application
-    and_i_do_not_see_references
   end
 
   def given_i_am_signed_in
@@ -90,33 +85,6 @@ RSpec.feature 'Submitting an application' do
     click_button 'Continue'
     choose 'No'
     click_button 'Send application'
-  end
-
-  def and_its_in_the_right_state
-    expect(application.application_choices).to all(be_awaiting_provider_decision)
-  end
-
-  def and_i_receive_an_email_about_my_submitted_application
-    open_email(current_candidate.email_address)
-
-    expect(current_email.subject).to include 'You’ve submitted your teacher training application'
-    expect(current_email.text).to include application.support_reference
-  end
-
-  def and_a_slack_notification_is_sent
-    expect_slack_message_with_text "#{application.first_name}’s application has been sent to #{provider.name}"
-  end
-
-  def and_i_can_review_my_application
-    visit candidate_interface_application_form_path
-    expect(page).to have_content 'Application dashboard'
-    expect(page).to have_content 'Application submitted'
-    expect(page).to have_link 'View application'
-  end
-
-  def and_i_do_not_see_references
-    expect(page).not_to have_content 'First referee'
-    expect(page).not_to have_content application.application_references.first.name
   end
 
 private


### PR DESCRIPTION
## Context

Currently we send a Slack message per application choice on submission, which clutters the support channel. 

## Changes proposed in this pull request

This merges it into a single message. Also deletes some duplicated tests and some refactoring on the Slack message code.

## Guidance to review

Looks okay?

## Link to Trello card

https://trello.com/c/mg0sTFiz

