### PR TITLE
Add emojis to all Slack messages

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -35,16 +35,16 @@ class StateChangeNotifier
       text = ":rocket: #{applicant}’s application has been sent to #{provider_name}"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :make_an_offer
-      text = "#{provider_name} has just made an offer to #{applicant}’s application"
+      text = ":love_letter: #{provider_name} has just made an offer to #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :change_an_offer
-      text = "#{provider_name} has just changed an offer for #{applicant}’s application"
+      text = ":love_letter: #{provider_name} has just changed an offer for #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application
-      text = "#{provider_name} has just rejected #{applicant}’s application"
+      text = ":broken_heart: #{provider_name} has just rejected #{applicant}’s application"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application_by_default
-      text = "#{applicant}’s application has just been rejected by default"
+      text = ":broken_heart: #{applicant}’s application has just been rejected by default"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :offer_accepted
       text = ":handshake: #{applicant} has accepted #{provider_name}’s offer"

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe StateChangeNotifier do
       before { StateChangeNotifier.call(:make_an_offer, application_choice: application_choice) }
 
       it 'mentions applicant\'s first name and provider name' do
-        arg1 = "#{provider_name} has just made an offer to #{applicant}’s application"
+        arg1 = ":love_letter: #{provider_name} has just made an offer to #{applicant}’s application"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -60,7 +60,7 @@ RSpec.describe StateChangeNotifier do
       before { StateChangeNotifier.call(:change_an_offer, application_choice: application_choice) }
 
       it 'mentions applicant\'s first name and provider name' do
-        arg1 = "#{provider_name} has just changed an offer for #{applicant}’s application"
+        arg1 = ":love_letter: #{provider_name} has just changed an offer for #{applicant}’s application"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -74,7 +74,7 @@ RSpec.describe StateChangeNotifier do
       before { StateChangeNotifier.call(:reject_application, application_choice: application_choice) }
 
       it 'mentions applicant\'s first name and provider name' do
-        arg1 = "#{provider_name} has just rejected #{applicant}’s application"
+        arg1 = ":broken_heart: #{provider_name} has just rejected #{applicant}’s application"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 
@@ -88,7 +88,7 @@ RSpec.describe StateChangeNotifier do
       before { StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice) }
 
       it 'mentions applicant\'s first name' do
-        arg1 = "#{applicant}’s application has just been rejected by default"
+        arg1 = ":broken_heart: #{applicant}’s application has just been rejected by default"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 


### PR DESCRIPTION
## Context

Emojis make the Slack channel easy to scan.

## Changes proposed in this pull request

As per [this Slack thread](https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1604928358206500) add the appropriate emojis to the messages.

## Guidance to review

Ok?

## Link to Trello card

https://trello.com/c/mg0sTFiz/2495-improve-slack-messages-in-twdapplysupport

