### PR TITLE
Update degree review component logic to not abbreviate title for international degrees

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -38,7 +38,9 @@ module CandidateInterface
     attr_reader :application_form
 
     def degree_type_with_honours(degree)
-      if degree.grade&.include? 'honours'
+      if international?(degree)
+        degree.qualification_type
+      elsif degree.grade&.include? 'honours'
         "#{abbreviate_degree(degree.qualification_type)} (Hons)"
       else
         abbreviate_degree(degree.qualification_type)

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     let(:degree1) do
       build_stubbed(
         :degree_qualification,
-        qualification_type: 'BA',
+        qualification_type: 'Bachelor of Arts',
         subject: 'Woof',
         institution_name: 'University of Doge',
         institution_country: 'DE',
@@ -206,8 +206,14 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
         Rails.application.routes.url_helpers.candidate_interface_edit_degree_institution_path(degree1),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include(
-        "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",
+        "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
       )
+    end
+
+    it 'renders the unabbreviated value on the summary card title' do
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.app-summary-card__title').text).to include('Bachelor of Arts Woof')
     end
 
     context 'when a UK NARIC reference number has been provided' do
@@ -228,7 +234,7 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
           Rails.application.routes.url_helpers.candidate_interface_edit_degree_naric_statement_path(degree1),
         )
         expect(result.css('.govuk-summary-list__actions').text).to include(
-          "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",
+          "Change #{t('application_form.degree.qualification.change_action')} for Bachelor of Arts, Woof, University of Doge, 2008",
         )
       end
     end


### PR DESCRIPTION
## Context
The Summary titles of each card the the degree review section should be free text if international degrees. 

## Changes proposed in this pull request

I have updated the existing logic to validate further the degree type so that an unabbreviated title is rendered for international degrees.

## Guidance to review

Check that logic is sound and that spec covers new functionality.
Check in review app that desired behaviour is achieved.

## Link to Trello card

https://trello.com/c/Ae7E4bh2/2424-%F0%9F%8C%90-defect-only-abbreviate-degree-type-for-uk-degrees

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
