### PR TITLE
Only allow sign-ups from education.gov.uk emails addresses on qa etc.

### DIFF
--- a/app/forms/candidate_interface/sign_up_form.rb
+++ b/app/forms/candidate_interface/sign_up_form.rb
@@ -31,6 +31,7 @@ module CandidateInterface
 
     def candidate_email_address_has_access
       if HostingEnvironment.dfe_signup_only? &&
+          email_address.present? &&
           !email_address.match(/education\.gov\.uk$/)
         errors.add(:email_address, :dfe_signup_only)
       end

--- a/app/forms/candidate_interface/sign_up_form.rb
+++ b/app/forms/candidate_interface/sign_up_form.rb
@@ -6,6 +6,7 @@ module CandidateInterface
     validates :email_address, :accept_ts_and_cs, presence: true
     validates :email_address, length: { maximum: 100 }
 
+    validates :candidate_email_address_has_access
     validate :candidate_email_address_is_valid
 
     def initialize(params = {})
@@ -27,6 +28,13 @@ module CandidateInterface
     end
 
   private
+
+    def candidate_email_address_has_access
+      if HostingEnvironment.dfe_signup_only? &&
+          !email_address.match(/education\.gov\.uk$/)
+        errors.add(:email_address, :dfe_signup_only)
+      end
+    end
 
     def candidate_email_address_is_valid
       if candidate && candidate.invalid?

--- a/app/forms/candidate_interface/sign_up_form.rb
+++ b/app/forms/candidate_interface/sign_up_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     validates :email_address, :accept_ts_and_cs, presence: true
     validates :email_address, length: { maximum: 100 }
 
-    validates :candidate_email_address_has_access
+    validate :candidate_email_address_has_access
     validate :candidate_email_address_is_valid
 
     def initialize(params = {})

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,5 +1,6 @@
 module HostingEnvironment
   TEST_ENVIRONMENTS = %w[development test qa review].freeze
+  PRODUCTION_URL = 'https://apply-for-teacher-training.service.gov.uk'.freeze
 
   def self.application_url
     if Rails.env.production?

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -56,6 +56,10 @@ module HostingEnvironment
     environment_name == 'qa'
   end
 
+  def self.staging?
+    environment_name == 'staging'
+  end
+
   def self.production?
     environment_name == 'production'
   end
@@ -70,5 +74,9 @@ module HostingEnvironment
 
   def self.test_environment?
     TEST_ENVIRONMENTS.include?(HostingEnvironment.environment_name)
+  end
+
+  def self.dfe_signup_only?
+    review? || qa? || staging?
   end
 end

--- a/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
+++ b/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
@@ -4,9 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h2 class="govuk-heading-xl">
+    <h1 class="govuk-heading-xl">
       <%= t('page_titles.external_sign_up_forbidden') %>
-    </h2>
+    </h1>
     <p class="govuk-body">
       This is the <%= HostingEnvironment.environment_name %> version of the Apply for teacher training service.
       DfE use it for testing and development.

--- a/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
+++ b/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, t('page_titles.external_sign_up_forbidden') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_sign_up_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
+++ b/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, t('page_titles.external_sign_up_forbidden') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h2 class="govuk-heading-xl">
+      <%= t('page_titles.external_sign_up_forbidden') %>
+    </h2>
+    <p class="govuk-body">
+      This is the <%= HostingEnvironment.environment_name %> version of the Apply
+      for teacher training service that is used for testing and development.
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to(
+        'Sign into Apply for teacher training',
+        HostingEnvironment::PRODUCTION_URL,
+      ) %>
+    </p>
+  </div>
+</div>

--- a/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
+++ b/app/views/candidate_interface/sign_up/external_sign_up_forbidden.html.erb
@@ -8,8 +8,8 @@
       <%= t('page_titles.external_sign_up_forbidden') %>
     </h2>
     <p class="govuk-body">
-      This is the <%= HostingEnvironment.environment_name %> version of the Apply
-      for teacher training service that is used for testing and development.
+      This is the <%= HostingEnvironment.environment_name %> version of the Apply for teacher training service.
+      DfE use it for testing and development.
     </p>
     <p class="govuk-body">
       <%= govuk_link_to(

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -8,6 +8,7 @@ en:
               blank: Enter your email address
               invalid: Enter an email address in the correct format, like name@example.com
               too_long: Email address must be %{count} characters or fewer
+              dfe_signup_only: Only DfE users can sign up in this test environment
             accept_ts_and_cs:
               blank: You must agree to the terms of use
   authentication:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     submitted_application: Your submitted application
     sign_up: Create an account
     sign_in: Sign in
+    external_sign_up_forbidden: Only DfE users can sign into this website
     sandbox: Use our sandbox to test Apply for teacher training
     check_your_email: Check your email
     not_found: Page not found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
     get '/sign-up', to: 'sign_up#new', as: :sign_up
     post '/sign-up', to: 'sign_up#create'
     get '/sign-up/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_up
+    get '/sign-up/external-sign-up-forbidden', to: 'sign_up#external_sign_up_forbidden', as: :external_sign_up_forbidden
 
     get '/sign-in', to: 'sign_in#new', as: :sign_in
     post '/sign-in', to: 'sign_in#create'

--- a/spec/forms/candidate_interface/sign_up_form_spec.rb
+++ b/spec/forms/candidate_interface/sign_up_form_spec.rb
@@ -18,18 +18,27 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
       expect(form.existing_candidate?).to eq(true)
     end
 
-    it 'returns false if it :accept_ts_and_cs is not true' do
+    it 'returns false if :accept_ts_and_cs is not true' do
       form = new_form(email: new_email, accept_ts_and_cs: false)
       expect(form.existing_candidate?).to eq(false)
       expect(form.save).to eq(false)
       expect(form.existing_candidate?).to eq(false)
     end
 
-    it 'returns false if it candidate email_address validations fail' do
-      form = new_form(email: 'foo', accept_ts_and_cs: false)
+    it 'returns false if candidate email_address validations fail' do
+      form = new_form(email: 'foo', accept_ts_and_cs: true)
       expect(form.existing_candidate?).to eq(false)
       expect(form.save).to eq(false)
       expect(form.errors[:email_address]).not_to be_empty
+    end
+
+    it 'returns false if candidate attempts to use a non-DfE email address on a test environment' do
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'qa' do
+        form = new_form(email: 'alice@example.com', accept_ts_and_cs: true)
+        expect(form.existing_candidate?).to eq(false)
+        expect(form.save).to eq(false)
+        expect(form.errors[:email_address]).not_to be_empty
+      end
     end
 
     it 'returns false if email_address belongs to existing candidate' do

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe HostingEnvironment do
+  describe '.dfe_signup_only?' do
+    %w[qa review staging].each do |environment|
+      it "returns true for `#{environment}`" do
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: environment do
+          expect(described_class.dfe_signup_only?).to eq(true)
+        end
+      end
+    end
+
+    %w[development test sandbox production].each do |environment|
+      it "returns false for `#{environment}`" do
+        ClimateControl.modify HOSTING_ENVIRONMENT_NAME: environment do
+          expect(described_class.dfe_signup_only?).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Candidate cannot sign up to a test environment (e.g. qa) without 
     then_i_see_an_access_forbidden_page
 
     given_i_have_a_dfe_email_address
-    when_i_go_to_sign_up
+    when_i_go_back_to_sign_up_again
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
   end
@@ -45,6 +45,10 @@ RSpec.feature 'Candidate cannot sign up to a test environment (e.g. qa) without 
 
     choose 'No, I need to create an account'
     click_button 'Continue'
+  end
+
+  def when_i_go_back_to_sign_up_again
+    click_link 'Back'
   end
 
   def then_i_see_an_access_forbidden_page

--- a/spec/system/candidate_interface/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate cannot sign up to a test environment (e.g. qa) without a DfE email address' do
+  include SignInHelper
+
+  around do |example|
+    ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'qa' do
+      example.run
+    end
+  end
+
+  scenario 'Candidate tries to sign up' do
+    given_the_pilot_is_open
+    and_the_international_personal_details_feature_is_active
+    and_i_am_a_candidate_without_an_account
+
+    when_i_go_to_sign_up
+    and_i_submit_my_email_address
+    then_i_see_an_error_message
+
+    given_i_have_a_dfe_email_address
+    when_i_go_to_sign_up
+    and_i_submit_my_email_address
+    then_i_receive_an_email_inviting_me_to_sign_up
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_international_personal_details_feature_is_active
+    FeatureFlag.activate('international_personal_details')
+  end
+
+  def and_i_am_a_candidate_without_an_account
+    @email = "#{SecureRandom.hex}@example.com"
+  end
+
+  def given_i_have_a_dfe_email_address
+    @email = "#{SecureRandom.hex}@education.gov.uk"
+  end
+
+  def when_i_go_to_sign_up
+    visit '/'
+
+    choose 'No, I need to create an account'
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_current_path(candidate_interface_sign_up_path)
+    expect(page).to have_content('Only DfE users can sign up in this test environment')
+  end
+
+  def and_i_submit_my_email_address
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    check t('authentication.sign_up.accept_terms_checkbox')
+    click_on t('authentication.sign_up.button_continue')
+  end
+
+  def then_i_receive_an_email_inviting_me_to_sign_up
+    open_email(@email)
+    expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
+  end
+end

--- a/spec/system/candidate_interface/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_to_test_environment_without_dfe_email_address_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Candidate cannot sign up to a test environment (e.g. qa) without 
 
     when_i_go_to_sign_up
     and_i_submit_my_email_address
-    then_i_see_an_error_message
+    then_i_see_an_access_forbidden_page
 
     given_i_have_a_dfe_email_address
     when_i_go_to_sign_up
@@ -47,9 +47,9 @@ RSpec.feature 'Candidate cannot sign up to a test environment (e.g. qa) without 
     click_button 'Continue'
   end
 
-  def then_i_see_an_error_message
-    expect(page).to have_current_path(candidate_interface_sign_up_path)
-    expect(page).to have_content('Only DfE users can sign up in this test environment')
+  def then_i_see_an_access_forbidden_page
+    expect(page).to have_current_path(candidate_interface_external_sign_up_forbidden_path)
+    expect(page).to have_content('Only DfE users can sign into this website')
   end
 
   def and_i_submit_my_email_address


### PR DESCRIPTION
## Context

We want to restrict use of test environments (qa, review apps and staging) to DfE uses (those with `education.gov.uk` email addresses).

## Changes proposed in this pull request

- [x] `HostEnvironment.dfe_signups_only?` helper
- [x] Add validation to the `SignUpForm` to prevent non-DfE sign-ups depending on environment.
- [x] System spec
- [x] Redirect to a page warning candidates that they can't sign-up without a DfE email address and link to production environment.

<img width="997" alt="image" src="https://user-images.githubusercontent.com/450843/98812104-cd2d1c00-2419-11eb-81f5-415781466b1e.png">


## Guidance to review

- Does the validation make sense? Originally it was meant to be displayed as a normal validation but now that we are redirecting to a special 'access forbidden' page it's no longer rendered as a validation error on the sign-up form itself. I've left it this way so that it gets captured by our validation error logging.
- Is the copy for the 'access forbidden' page correct?
- I needed a link to the production environment. I couldn't find an existing one in the codebase so I've added a constant to `HostingEnvironment`. Does this make sense or is there a simpler way? Should it be an env var?

## Link to Trello card

https://trello.com/c/M1IWxq2c/2481-only-allow-digitaleducationgovuk-signups-on-qa-staging-review-apps

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
