### PR TITLE
Fix provider permissions export: Ignore changes to permissions that were not done by a ProviderUser

### DIFF
--- a/app/services/support_interface/provider_access_controls_stats.rb
+++ b/app/services/support_interface/provider_access_controls_stats.rb
@@ -16,7 +16,7 @@ module SupportInterface
     end
 
     def user_permissions_audits
-      @_user_permissions_audits ||= Audited::Audit.where(action: 'update', auditable: @provider.provider_permissions)
+      @_user_permissions_audits ||= Audited::Audit.where(action: 'update', auditable: @provider.provider_permissions, user_type: 'ProviderUser')
     end
 
     def user_permissions_last_changed_at
@@ -44,7 +44,7 @@ module SupportInterface
     end
 
     def org_training_provider_permission_audits
-      @_org_permissions_audits ||= Audited::Audit.where(action: 'update', auditable: @provider.training_provider_permissions)
+      @_org_permissions_audits ||= Audited::Audit.where(action: 'update', auditable: @provider.training_provider_permissions, user_type: 'ProviderUser')
     end
 
     def org_permissions_last_changed_at


### PR DESCRIPTION
## Context
Some audits exist that are not attached to a user with an email address, so the export was failing. This change ensures we only get updates from ProviderUsers who definitely have an email address. Export was failing on QA: https://sentry.io/organizations/dfe-bat/issues/2020421538/?referrer=slack

## Guidance to review
Straightforward, any other edge cases I might have missed?

## Link to Trello card
https://trello.com/c/A5wsjz7z/2919-create-downloadable-csvs-for-access-control-performance-analysis

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
