### PR TITLE
Add feedback prompts - Non-JS solution

### DIFF
--- a/app/components/candidate_interface/application_feedback_component.html.erb
+++ b/app/components/candidate_interface/application_feedback_component.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-width-container govuk-!-margin-top-6">
     <div class="app-feedback__container">
       <h2 class="app-feedback__container-title">
-        Are there any issues with this section?
+        <%= t('application_feedback_component.title') %>
       </h2>
 
       <ul class="app-feedback__list">
@@ -16,7 +16,7 @@
             ),
             class: 'app-feedback__list-item app-feedback__button',
             method: :post do |f| %>
-              <%= f.govuk_submit 'Yes' %>
+              <%= f.govuk_submit t('application_feedback_component.issues.submit') %>
           <% end %>
 
           <%= form_with url: candidate_interface_application_feedback_path(
@@ -28,7 +28,7 @@
             ),
             class: 'app-feedback__list-item app-feedback__button govuk-!-margin-left-1',
             method: :post,  remote: true do |f| %>
-              <%= f.govuk_submit 'No' %>
+              <%= f.govuk_submit t('application_feedback_component.no_issues.submit') %>
           <% end %>
         </li>
       </ul>

--- a/app/components/candidate_interface/application_feedback_component.html.erb
+++ b/app/components/candidate_interface/application_feedback_component.html.erb
@@ -1,0 +1,37 @@
+<% if FeatureFlag.active?(:feedback_prompts) %>
+  <div class="govuk-width-container govuk-!-margin-top-6">
+    <div class="app-feedback__container">
+      <h2 class="app-feedback__container-title">
+        Are there any issues with this section?
+      </h2>
+
+      <ul class="app-feedback__list">
+        <li class="app-feedback__list-item">
+          <%= form_with url: candidate_interface_application_feedback_path(
+              issues: true,
+              section: section,
+              path: path,
+              page_title: page_title,
+              id_in_path: id_in_path
+            ),
+            class: 'app-feedback__list-item app-feedback__button',
+            method: :post do |f| %>
+              <%= f.govuk_submit 'Yes' %>
+          <% end %>
+
+          <%= form_with url: candidate_interface_application_feedback_path(
+              issues: false,
+              section: section,
+              path: path,
+              page_title: page_title,
+              id_in_path: id_in_path
+            ),
+            class: 'app-feedback__list-item app-feedback__button govuk-!-margin-left-1',
+            method: :post,  remote: true do |f| %>
+              <%= f.govuk_submit 'No' %>
+          <% end %>
+        </li>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/application_feedback_component.rb
+++ b/app/components/candidate_interface/application_feedback_component.rb
@@ -1,0 +1,14 @@
+module CandidateInterface
+  class ApplicationFeedbackComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :section, :path, :page_title, :id_in_path
+
+    def initialize(section:, path:, page_title:, id_in_path: nil)
+      @section = section
+      @path = path
+      @page_title = page_title
+      @id_in_path = id_in_path
+    end
+  end
+end

--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -36,7 +36,14 @@ module CandidateInterface
       end
     end
 
-    def thank_you; end
+    def thank_you
+      @application_feedback = current_application.application_feedback.last
+      @previous_path = if @application_feedback.id_in_path
+                         Rails.application.routes.url_helpers.send(@application_feedback.path, @application_feedback.id_in_path)
+                       else
+                         Rails.application.routes.url_helpers.send(@application_feedback.path)
+                       end
+    end
 
   private
 
@@ -46,6 +53,7 @@ module CandidateInterface
         path: params[:path],
         page_title: params[:page_title],
         issues: params[:issues],
+        id_in_path: params[:id_in_path],
       }
     end
 

--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -1,0 +1,52 @@
+module CandidateInterface
+  class ApplicationFeedbackController < CandidateInterfaceController
+    def create
+      @application_feedback_form = CandidateInterface::ApplicationFeedbackForm.new(create_params)
+
+      if @application_feedback_form.save(current_application)
+        if @application_feedback_form.has_issues?
+          redirect_to candidate_interface_edit_application_feedback_path(
+            current_application.application_feedback.last.id,
+          )
+        else
+          redirect_to candidate_interface_application_feedback_thank_you_path
+        end
+      else
+        track_validation_error(@references_relationship_form)
+        flash[:warning] = add_errors_to_flash_message
+
+        redirect_to previous_path
+      end
+    end
+
+    def edit; end
+
+    def update; end
+
+    def thank_you; end
+
+  private
+
+    def create_params
+      {
+        section: params[:section],
+        path: params[:path],
+        page_title: params[:page_title],
+        issues: params[:issues],
+      }
+    end
+
+    def previous_path
+      request.env['HTTP_REFERER']
+    end
+
+    def add_errors_to_flash_message
+      @application_feedback_form
+      .errors
+      .messages
+      .values
+      .flatten
+      .join('\n')
+    end
+  end
+end

--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -19,9 +19,22 @@ module CandidateInterface
       end
     end
 
-    def edit; end
+    def edit
+      @application_feedback = current_application.application_feedback.find(params[:id])
+      @application_feedback_form = CandidateInterface::ApplicationFeedbackForm.new
+    end
 
-    def update; end
+    def update
+      @application_feedback = current_application.application_feedback.find(params[:id])
+      @application_feedback_form = CandidateInterface::ApplicationFeedbackForm.new(update_params)
+
+      if @application_feedback_form.update(@application_feedback)
+        redirect_to candidate_interface_application_feedback_thank_you_path
+      else
+        track_validation_error(@application_feedback_form)
+        render :edit
+      end
+    end
 
     def thank_you; end
 
@@ -34,6 +47,13 @@ module CandidateInterface
         page_title: params[:page_title],
         issues: params[:issues],
       }
+    end
+
+    def update_params
+      params.require(:candidate_interface_application_feedback_form).permit(
+        :does_not_understand_section, :need_more_information, :answer_does_not_fit_format,
+        :other_feedback, :consent_to_be_contacted
+      )
     end
 
     def previous_path

--- a/app/forms/candidate_interface/application_feedback_form.rb
+++ b/app/forms/candidate_interface/application_feedback_form.rb
@@ -2,14 +2,18 @@ module CandidateInterface
   class ApplicationFeedbackForm
     include ActiveModel::Model
 
-    attr_accessor :issues, :section, :path, :page_title, :id_in_path
+    attr_accessor :issues, :section, :path, :page_title, :id_in_path, :does_not_understand_section,
+                  :need_more_information, :answer_does_not_fit_format, :other_feedback,
+                  :consent_to_be_contacted
 
-    validates :issues, :section, :path, :page_title, presence: true
+    validates :issues, :section, :path, :page_title, presence: true, on: :save
+
+    validates :consent_to_be_contacted, presence: true, on: :update
 
     validate :path_is_valid, if: -> { path.present? }
 
     def save(application_form)
-      return false unless valid?
+      return false unless valid?(:save)
 
       application_form.application_feedback.create!(
         issues: has_issues?,
@@ -17,6 +21,18 @@ module CandidateInterface
         path: path,
         page_title: page_title,
         id_in_path: id_in_path,
+      )
+    end
+
+    def update(application_feedback)
+      return false unless valid?(:update)
+
+      application_feedback.update!(
+        does_not_understand_section: does_not_understand_section ? true : false,
+        need_more_information: need_more_information ? true : false,
+        answer_does_not_fit_format: answer_does_not_fit_format ? true : false,
+        other_feedback: other_feedback,
+        consent_to_be_contacted: consent_to_be_contacted == 'true',
       )
     end
 

--- a/app/forms/candidate_interface/application_feedback_form.rb
+++ b/app/forms/candidate_interface/application_feedback_form.rb
@@ -1,0 +1,37 @@
+module CandidateInterface
+  class ApplicationFeedbackForm
+    include ActiveModel::Model
+
+    attr_accessor :issues, :section, :path, :page_title, :id_in_path
+
+    validates :issues, :section, :path, :page_title, presence: true
+
+    validate :path_is_valid, if: -> { path.present? }
+
+    def save(application_form)
+      return false unless valid?
+
+      application_form.application_feedback.create!(
+        issues: has_issues?,
+        section: section,
+        path: path,
+        page_title: page_title,
+        id_in_path: id_in_path,
+      )
+    end
+
+    def has_issues?
+      issues == 'true'
+    end
+
+  private
+
+    def path_is_valid
+      errors.add(:path, :invalid) if valid_paths.exclude?(path)
+    end
+
+    def valid_paths
+      Rails.application.routes.named_routes.helper_names
+    end
+  end
+end

--- a/app/frontend/styles/_feedback.scss
+++ b/app/frontend/styles/_feedback.scss
@@ -1,0 +1,65 @@
+.app-feedback__button .govuk-button {
+  @include govuk-font(16);
+  margin: 0;
+  min-width: 80px;
+  background-color: #1d70b8;
+
+  @include govuk-media-query($from: mobile) {
+    white-space: nowrap;
+  }
+}
+
+.app-feedback__container {
+  @include govuk-clearfix;
+  align-items: center;
+  background-color: govuk-colour("light-grey");
+  box-sizing: border-box;
+  flex-wrap: wrap;
+  outline: 0;
+  padding: govuk-spacing(2) govuk-spacing(5);
+  min-height: 80px;
+  display: flex;
+}
+
+.app-feedback__container-title {
+  @include govuk-font(16, $weight: bold);
+  display: inline-block;
+  margin: govuk-spacing(2) 0;
+  margin-right: govuk-spacing(4);
+
+  &:focus {
+    outline: 0;
+  }
+}
+
+.app-feedback__list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  @include govuk-media-query($from: tablet) {
+    align-items: center;
+    display: flex;
+    flex: 1;
+  }
+}
+
+.app-feedback__list-item {
+  margin: govuk-spacing(2) 0;
+
+  @include govuk-media-query($from: mobile) {
+    display: inline-block;
+    margin-right: govuk-spacing(2);
+  }
+}
+
+.app-feedback__form {
+  @include govuk-responsive-padding(6, "top");
+  @include govuk-responsive-padding(6, "bottom");
+  border-top: $govuk-border-width solid govuk-colour("blue");
+  outline: 0;
+}
+
+.govuk-main-wrapper {
+  padding-bottom: 0;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -39,3 +39,4 @@ $govuk-breakpoints: (
 @import "_status-box";
 @import "_styled-content";
 @import "_summary-card";
+@import "_feedback";

--- a/app/models/application_feedback.rb
+++ b/app/models/application_feedback.rb
@@ -1,0 +1,5 @@
+class ApplicationFeedback < ApplicationRecord
+  self.table_name = 'application_feedback'
+
+  belongs_to :application_form, touch: true
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -19,6 +19,8 @@ class ApplicationForm < ApplicationRecord
   has_one :subsequent_application_form, class_name: 'ApplicationForm', foreign_key: 'previous_application_form_id', inverse_of: 'previous_application_form'
   has_one :english_proficiency
 
+  has_many :application_feedback
+
   scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.current_year) }
 
   MINIMUM_COMPLETE_REFERENCES = 2

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:international_other_qualifications, 'Candidates can provide details of Other international qualifications .', 'David Gisbey'],
     [:export_hesa_data, 'Providers can export applications including HESA data.', 'Steve Laing'],
     [:feedback_form, 'New simplified feedback form to replace old multi-page satisfaction survey.', 'Steve Hook'],
+    [:feedback_prompts, 'Candidates can give feedback while completing their application form', 'David Gisbey'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/application_feedback/edit.html.erb
+++ b/app/views/candidate_interface/application_feedback/edit.html.erb
@@ -17,12 +17,12 @@
 
       <%= f.govuk_text_area :other_feedback, label: { text: t('application_form.application_feedback.other_feedback.label'), size: 'm' }, rows: 5, max_words: 300 %>
 
-      <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, inline: true, legend: { text:  t('application_form.application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
-        <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: 'Yes' }  %>
-        <%= f.govuk_radio_button :consent_to_be_contacted, false, label: { text: 'No' } %>
+      <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, inline: true, legend: { text: t('application_form.application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
+        <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('application_form.application_feedback.consent_to_be_contacted.yes') }  %>
+        <%= f.govuk_radio_button :consent_to_be_contacted, false, label: { text:t('application_form.application_feedback.consent_to_be_contacted.no') } %>
       <% end %>
 
-      <%= f.govuk_submit 'Submit feedback' %>
+      <%= f.govuk_submit t('application_form.application_feedback.submit') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/application_feedback/edit.html.erb
+++ b/app/views/candidate_interface/application_feedback/edit.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.application_feedback'), @application_feedback_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_feedback_form, url: candidate_interface_edit_application_feedback_path(@application_feedback.id), method: :patch do |f| %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.application_feedback') %>
+      </h1>
+
+      <%= f.govuk_check_boxes_fieldset :issues, multiple: false, legend: { text: t('application_form.application_feedback.issues.label'), size: 'm' } do %>
+        <%= f.govuk_check_box :does_not_understand_section, true, multiple: false, label: { text: t('application_form.application_feedback.issues.does_not_understand_section') } %>
+        <%= f.govuk_check_box :need_more_information, true, multiple: false, label: { text: t('application_form.application_feedback.issues.need_more_information') } %>
+        <%= f.govuk_check_box :answer_does_not_fit_format, true, multiple: false, label: { text: t('application_form.application_feedback.issues.answer_does_not_fit_format') } %>
+      <% end %>
+
+      <%= f.govuk_text_area :other_feedback, label: { text: t('application_form.application_feedback.other_feedback.label'), size: 'm' }, rows: 5, max_words: 300 %>
+
+      <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, inline: true, legend: { text:  t('application_form.application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
+        <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: 'Yes' }  %>
+        <%= f.govuk_radio_button :consent_to_be_contacted, false, label: { text: 'No' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Submit feedback' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/application_feedback/thank_you.html.erb
+++ b/app/views/candidate_interface/application_feedback/thank_you.html.erb
@@ -2,5 +2,5 @@
   <%= t('page_titles.application_feedback_thank_you') %>
 </h1>
 <p class="govuk-body govuk-!-margin-bottom-9">
-  <%= govuk_link_to 'Go back to page you were previously on', @previous_path %>
+  <%= govuk_link_to t('application_form.application_feedback.thank_you.backlink'), @previous_path %>
 </p>

--- a/app/views/candidate_interface/application_feedback/thank_you.html.erb
+++ b/app/views/candidate_interface/application_feedback/thank_you.html.erb
@@ -1,0 +1,6 @@
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.application_feedback_thank_you') %>
+</h1>
+<p class="govuk-body govuk-!-margin-bottom-9">
+  <%= govuk_link_to 'Go back to page you were previously on', @previous_path %>
+</p>

--- a/app/views/candidate_interface/references/base/start.html.erb
+++ b/app/views/candidate_interface/references/base/start.html.erb
@@ -20,3 +20,11 @@
     <%= govuk_link_to 'Continue', candidate_interface_references_type_path, class: 'govuk-button' %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_start_path',
+    page_title: t('page_titles.references_start')
+  )
+) %>

--- a/app/views/candidate_interface/references/candidate_name/new.html.erb
+++ b/app/views/candidate_interface/references/candidate_name/new.html.erb
@@ -25,3 +25,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_new_candidate_name_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_candidate_name')
+  )
+) %>

--- a/app/views/candidate_interface/references/email_address/edit.html.erb
+++ b/app/views/candidate_interface/references/email_address/edit.html.erb
@@ -13,3 +13,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_edit_email_address_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_email_address')
+  )
+) %>

--- a/app/views/candidate_interface/references/email_address/new.html.erb
+++ b/app/views/candidate_interface/references/email_address/new.html.erb
@@ -13,3 +13,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_email_address_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_email_address')
+  )
+) %>

--- a/app/views/candidate_interface/references/name/edit.html.erb
+++ b/app/views/candidate_interface/references/name/edit.html.erb
@@ -12,3 +12,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_edit_name_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_name')
+  )
+) %>

--- a/app/views/candidate_interface/references/name/new.html.erb
+++ b/app/views/candidate_interface/references/name/new.html.erb
@@ -12,3 +12,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_name_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_name')
+  )
+) %>

--- a/app/views/candidate_interface/references/relationship/edit.html.erb
+++ b/app/views/candidate_interface/references/relationship/edit.html.erb
@@ -12,3 +12,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_relationship_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_relationship')
+  )
+) %>

--- a/app/views/candidate_interface/references/relationship/new.html.erb
+++ b/app/views/candidate_interface/references/relationship/new.html.erb
@@ -12,3 +12,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_edit_relationship_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_relationship')
+  )
+) %>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -37,3 +37,11 @@
 <% end %>
 
 <%= govuk_link_to 'Continue', candidate_interface_application_form_path, class: 'govuk-button' %>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_review_path',
+    page_title: t('page_titles.references')
+  )
+) %>

--- a/app/views/candidate_interface/references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/references/review/unsubmitted.html.erb
@@ -24,3 +24,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+  CandidateInterface::ApplicationFeedbackComponent.new(
+    section: 'application_references',
+    path: 'candidate_interface_references_review_unsubmitted_path',
+    id_in_path: @reference.id,
+    page_title: t('page_titles.references_unsubmitted_review')
+  )
+) %>

--- a/app/views/candidate_interface/references/type/edit.html.erb
+++ b/app/views/candidate_interface/references/type/edit.html.erb
@@ -12,3 +12,13 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+    CandidateInterface::ApplicationFeedbackComponent.new(
+      section: 'application_references',
+      path: 'candidate_interface_references_edit_type_path',
+      id_in_path: @reference.id,
+      page_title: t('page_titles.references_type')
+    )
+  )
+%>

--- a/app/views/candidate_interface/references/type/new.html.erb
+++ b/app/views/candidate_interface/references/type/new.html.erb
@@ -12,3 +12,12 @@
     <% end %>
   </div>
 </div>
+
+<%= render(
+    CandidateInterface::ApplicationFeedbackComponent.new(
+      section: 'application_references',
+      path: 'candidate_interface_references_type_path',
+      page_title: t('page_titles.references_type')
+    )
+  )
+%>

--- a/config/locales/application_feedback_component.yml
+++ b/config/locales/application_feedback_component.yml
@@ -1,0 +1,7 @@
+en:
+  application_feedback_component:
+    title: Are there any issues with this section?
+    issues:
+      submit: 'Yes'
+    no_issues:
+      submit: 'No'

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -919,6 +919,17 @@ en:
               blank: Enter your first name
             last_name:
               blank: Enter your last name
+        candidate_interface/application_feedback_form:
+          attributes:
+            section:
+              blank: Section cannot be blank
+            path:
+              blank: Path cannot be blank
+              invalid: Path must be a valid endpoint
+            page_title:
+              blank: Page title cannot be blank
+            issues:
+              blank: Issues cannot blank
         referee_interface/reference_relationship_form:
           attributes:
             relationship_confirmation:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -501,6 +501,11 @@ en:
         label: Do you have any other feedback about this section?
       consent_to_be_contacted:
         label: Can we contact you about your feedback?
+        'yes': 'Yes'
+        'no': 'No'
+      thank_you:
+        backlink: Go back to page you were previously on
+      submit: Submit feedback
   activemodel:
     errors:
       models:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -491,6 +491,16 @@ en:
         not_requested_yet: We’ll contact your referees after you submit your application.
         awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
         awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
+    application_feedback:
+      issues:
+        label: What issues are there in this section?
+        does_not_understand_section: I do not understand this section
+        need_more_information: I do not have the information needed at the moment
+        answer_does_not_fit_format: My answers do not fit the format
+      other_feedback:
+        label: Do you have any other feedback about this section?
+      consent_to_be_contacted:
+        label: Can we contact you about your feedback?
   activemodel:
     errors:
       models:
@@ -930,6 +940,8 @@ en:
               blank: Page title cannot be blank
             issues:
               blank: Issues cannot blank
+            consent_to_be_contacted:
+              blank: Can we contact you about your feedback?
         referee_interface/reference_relationship_form:
           attributes:
             relationship_confirmation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
     references_delete_referee: Are you sure you want to delete this referee?
     references_delete_reference: Are you sure you want to delete this reference?
     references_send_reminder: Would you like to send a reminder to this referee?
+    application_feedback: Help us improve this service
     give_a_reference:
       confirmation: Your reference has been submitted
       finish: Thank you

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,7 @@ en:
     references_delete_reference: Are you sure you want to delete this reference?
     references_send_reminder: Would you like to send a reminder to this referee?
     application_feedback: Help us improve this service
+    application_feedback_thank_you: Thank you for your feedback
     give_a_reference:
       confirmation: Your reference has been submitted
       finish: Thank you

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -462,6 +462,10 @@ Rails.application.routes.draw do
 
         get '/thank-you' => 'satisfaction_survey#thank_you', as: :satisfaction_survey_thank_you
       end
+
+      scope '/application-feedback' do
+        post '/' => 'application_feedback#create', as: :application_feedback
+      end
     end
 
     get '*path', to: 'errors#not_found'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -465,6 +465,9 @@ Rails.application.routes.draw do
 
       scope '/application-feedback' do
         post '/' => 'application_feedback#create', as: :application_feedback
+        get '/edit/:id' => 'application_feedback#edit', as: :edit_application_feedback
+        patch '/edit/:id' => 'application_feedback#update'
+        get '/thank-you' => 'application_feedback#thank_you', as: :application_feedback_thank_you
       end
     end
 

--- a/db/migrate/20201110185731_add_id_in_params_to_application_feedback_table.rb
+++ b/db/migrate/20201110185731_add_id_in_params_to_application_feedback_table.rb
@@ -1,0 +1,5 @@
+class AddIdInParamsToApplicationFeedbackTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :application_feedback, :id_in_path, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_10_114210) do
+ActiveRecord::Schema.define(version: 2020_11_10_185731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2020_11_10_114210) do
     t.bigint "application_form_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "id_in_path"
     t.index ["application_form_id"], name: "index_application_feedback_on_application_form_id"
   end
 

--- a/spec/components/candidate_interface/application_feedback_component_spec.rb
+++ b/spec/components/candidate_interface/application_feedback_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::ApplicationFeedbackComponent do
   it 'renders successfully' do
     result = render_inline(
       described_class.new(
-        section: 'references',
+        section: 'application_references',
         path: 'candidate_interface_references_start_path',
         page_title: 'This is the references start page',
         id_in_path: '1',

--- a/spec/components/candidate_interface/application_feedback_component_spec.rb
+++ b/spec/components/candidate_interface/application_feedback_component_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplicationFeedbackComponent do
+  before { FeatureFlag.activate(:feedback_prompts) }
+
+  it 'renders successfully' do
+    result = render_inline(
+      described_class.new(
+        section: 'references',
+        path: 'candidate_interface_references_start_path',
+        page_title: 'This is the references start page',
+        id_in_path: '1',
+      ),
+    )
+
+    expected_base_url = '/candidate/application/application-feedback'
+    expected_issues_query_string = '?id_in_path=1&issues=true&page_title=This+is+the+references+start+page&path=candidate_interface_references_start_path&section=application_references'
+    expected_no_issues_query_string = '?id_in_path=1&issues=false&page_title=This+is+the+references+start+page&path=candidate_interface_references_start_path&section=application_references'
+
+    issues_query_string = result.css('.app-feedback__list-item')[1].attributes['action'].value
+    issues_form_action = result.css('.app-feedback__list-item')[1].attributes['method'].value
+
+    no_issues_form_url = result.css('.app-feedback__list-item')[2].attributes['action'].value
+    no_issues_form_action = result.css('.app-feedback__list-item')[2].attributes['method'].value
+
+    expect(issues_query_string).to eq expected_base_url + expected_issues_query_string
+    expect(issues_form_action).to eq 'post'
+    expect(no_issues_form_url).to eq expected_base_url + expected_no_issues_query_string
+    expect(no_issues_form_action).to eq 'post'
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -864,4 +864,18 @@ FactoryBot.define do
     grade { 10 }
     award_year { 2001 }
   end
+
+  factory :application_feedback do
+    application_form
+
+    section { 'application_reference' }
+    path { 'candidate_interface_references_edit_type_path' }
+    page_title { Faker::Lorem.paragraph(sentence_count: 1) }
+    issues { true }
+    does_not_understand_section { [true, false].sample }
+    need_more_information { [true, false].sample }
+    answer_does_not_fit_format { [true, false].sample }
+    other_feedback { Faker::Lorem.paragraph(sentence_count: 3) }
+    consent_to_be_contacted { true }
+  end
 end

--- a/spec/forms/candidate_interface/application_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/application_feedback_form_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
   let(:application_form) { create(:application_form) }
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:issues) }
-    it { is_expected.to validate_presence_of(:section) }
-    it { is_expected.to validate_presence_of(:path) }
-    it { is_expected.to validate_presence_of(:page_title) }
+    it { is_expected.to validate_presence_of(:issues).on(:save) }
+    it { is_expected.to validate_presence_of(:section).on(:save) }
+    it { is_expected.to validate_presence_of(:path).on(:save) }
+    it { is_expected.to validate_presence_of(:page_title).on(:save) }
+    it { is_expected.to validate_presence_of(:consent_to_be_contacted).on(:update) }
 
     describe '#path_is_valid' do
       it 'returns false if the path is not one of our endpoints' do
@@ -51,6 +52,34 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
       expect(feedback.path).to eq form.path
       expect(feedback.page_title).to eq form.page_title
       expect(feedback.id_in_path).to eq 1
+    end
+  end
+
+  describe '#update' do
+    let(:form) do
+      described_class.new(
+        need_more_information: 'true',
+        answer_does_not_fit_format: 'true',
+        other_feedback: 'This would be easier if i could read.',
+        consent_to_be_contacted: 'false',
+      )
+    end
+
+    it 'returns false if not valid' do
+      application_feedback = double
+      expect(described_class.new.save(application_feedback)).to eq(false)
+    end
+
+    it 'updates the ApplicationFeedback object and ensures booleans with missing values are set to false' do
+      feedback = create(:application_feedback, other_feedback: nil)
+
+      form.update(feedback)
+
+      expect(feedback.does_not_understand_section).to eq false
+      expect(feedback.need_more_information).to eq true
+      expect(feedback.answer_does_not_fit_format).to eq true
+      expect(feedback.other_feedback).to eq 'This would be easier if i could read.'
+      expect(feedback.consent_to_be_contacted).to eq false
     end
   end
 

--- a/spec/forms/candidate_interface/application_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/application_feedback_form_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
+  let(:form) do
+    described_class.new(
+      issues: 'true',
+      section: 'application_references',
+      path: 'candidate_interface_references_edit_type_path',
+      page_title: t('page_titles.references_type'),
+      id_in_path: '1',
+    )
+  end
+
+  let(:application_form) { create(:application_form) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:issues) }
+    it { is_expected.to validate_presence_of(:section) }
+    it { is_expected.to validate_presence_of(:path) }
+    it { is_expected.to validate_presence_of(:page_title) }
+
+    describe '#path_is_valid' do
+      it 'returns false if the path is not one of our endpoints' do
+        invalid_form = described_class.new(
+          issues: 'true',
+          section: 'application_references',
+          path: 'invalid_path',
+          page_title: t('page_titles.references_type'),
+        )
+
+        invalid_form.save(application_form)
+
+        expect(invalid_form.errors.full_messages_for(:path)).not_to be_empty
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      application_form = double
+      expect(described_class.new.save(application_form)).to eq(false)
+    end
+
+    it 'adds a new ApplicationFeedback object to the ApplicationForm if valid' do
+      form.save(application_form)
+      feedback = application_form.application_feedback.last
+
+      expect(application_form.application_feedback.count).to eq 1
+      expect(feedback.issues).to eq true
+      expect(feedback.section).to eq form.section
+      expect(feedback.path).to eq form.path
+      expect(feedback.page_title).to eq form.page_title
+      expect(feedback.id_in_path).to eq 1
+    end
+  end
+
+  describe '#has_issues?' do
+    it 'returns true when issues is "true"' do
+      expect(form.has_issues?).to eq true
+    end
+
+    it 'returns false when issues is not "true"' do
+      form = described_class.new(issues: 'false')
+      expect(form.has_issues?).to eq false
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
+++ b/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
@@ -19,10 +19,13 @@ RSpec.feature 'Candidate provides feedback throughout the application process' d
     when_i_click_go_back_to_previous_page
     then_i_see_the_references_start_page
 
-    when_i_click_continue
-    and_i_click_there_is_not_an_issue_with_the_section
+    when_i_choose_a_type
+    and_i_click_there_is_not_an_issue_with_the_name_section
     then_i_see_the_thank_you_page
     and_my_second_set_of_feedback_has_been_collected
+
+    when_i_click_go_back_to_previous_page
+    then_i_see_the_references_name_page
   end
 
   def given_i_am_signed_in
@@ -85,24 +88,31 @@ RSpec.feature 'Candidate provides feedback throughout the application process' d
     expect(@application.application_feedback.last.consent_to_be_contacted).to eq true
   end
 
-  def when_i_click_continue
+  def when_i_choose_a_type
     click_link 'Continue'
+    choose 'Academic'
+    click_button 'Save and continue'
   end
 
-  def and_i_click_there_is_not_an_issue_with_the_section
+  def and_i_click_there_is_not_an_issue_with_the_name_section
     click_button 'No'
   end
 
   def and_my_second_set_of_feedback_has_been_collected
     expect(@application.application_feedback.count).to eq 2
     expect(@application.application_feedback.last.section).to eq 'application_references'
-    expect(@application.application_feedback.last.path).to eq 'candidate_interface_references_type_path'
-    expect(@application.application_feedback.last.page_title).to eq t('page_titles.references_type')
+    expect(@application.application_feedback.last.path).to eq 'candidate_interface_references_name_path'
+    expect(@application.application_feedback.last.page_title).to eq t('page_titles.references_name')
     expect(@application.application_feedback.last.issues).to eq false
     expect(@application.application_feedback.last.does_not_understand_section).to eq false
     expect(@application.application_feedback.last.need_more_information).to eq false
     expect(@application.application_feedback.last.answer_does_not_fit_format).to eq false
     expect(@application.application_feedback.last.other_feedback).to eq nil
     expect(@application.application_feedback.last.consent_to_be_contacted).to eq false
+    expect(@application.application_feedback.last.id_in_path).to eq @application.reload.application_references.last.id
+  end
+
+  def then_i_see_the_references_name_page
+    expect(page).to have_current_path candidate_interface_references_name_path(@application.application_references.last.id)
   end
 end

--- a/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
+++ b/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate provides feeback throughout the application process' do
+RSpec.feature 'Candidate provides feedback throughout the application process' do
   include CandidateHelper
 
   scenario 'Candidate without JS gives feedback while completing their applications' do
@@ -52,16 +52,16 @@ RSpec.feature 'Candidate provides feeback throughout the application process' do
   end
 
   def when_i_fill_in_my_feedback
-    check 'I do not understand this section'
-    check 'My answers do not fit the format'
-    fill_in :other_feedback, with: 'Me no understand.'
+    check t('application_form.application_feedback.issues.does_not_understand_section')
+    check t('application_form.application_feedback.issues.answer_does_not_fit_format')
+    fill_in t('application_form.application_feedback.other_feedback.label'), with: 'Me no understand.'
     choose 'Yes'
 
     click_button 'Submit feedback'
   end
 
   def then_i_see_the_thank_you_page
-    expect(page).to have_current_path candidate_interface_application_feedback_thanks_path
+    expect(page).to have_current_path candidate_interface_application_feedback_thank_you_path
   end
 
   def when_i_click_go_back_to_previous_page

--- a/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
+++ b/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'Candidate provides feedback throughout the application process' d
   end
 
   def and_i_click_there_is_an_issue_with_the_section
-    click_button 'Yes'
+    click_button t('application_feedback_component.issues.submit')
   end
 
   def then_i_see_the_references_section_feedback_page
@@ -58,9 +58,9 @@ RSpec.feature 'Candidate provides feedback throughout the application process' d
     check t('application_form.application_feedback.issues.does_not_understand_section')
     check t('application_form.application_feedback.issues.answer_does_not_fit_format')
     fill_in t('application_form.application_feedback.other_feedback.label'), with: 'Me no understand.'
-    choose 'Yes'
+    choose t('application_form.application_feedback.consent_to_be_contacted.yes')
 
-    click_button 'Submit feedback'
+    click_button t('application_form.application_feedback.submit')
   end
 
   def then_i_see_the_thank_you_page
@@ -68,7 +68,7 @@ RSpec.feature 'Candidate provides feedback throughout the application process' d
   end
 
   def when_i_click_go_back_to_previous_page
-    click_link 'Go back to page you were previously on'
+    click_link t('application_form.application_feedback.thank_you.backlink')
   end
 
   def then_i_see_the_references_start_page
@@ -95,7 +95,7 @@ RSpec.feature 'Candidate provides feedback throughout the application process' d
   end
 
   def and_i_click_there_is_not_an_issue_with_the_name_section
-    click_button 'No'
+    click_button t('application_feedback_component.no_issues.submit')
   end
 
   def and_my_second_set_of_feedback_has_been_collected

--- a/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
+++ b/spec/system/candidate_interface/candidate_provides_feedback_throughout_the_application_process_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate provides feeback throughout the application process' do
+  include CandidateHelper
+
+  scenario 'Candidate without JS gives feedback while completing their applications' do
+    given_i_am_signed_in
+    and_the_feedback_prompts_flag_is_active
+
+    when_i_visit_the_site
+    and_i_click_on_the_references_section
+    and_i_click_there_is_an_issue_with_the_section
+    then_i_see_the_references_section_feedback_page
+
+    when_i_fill_in_my_feedback
+    then_i_see_the_thank_you_page
+    and_my_first_set_of_feedback_has_been_collected
+
+    when_i_click_go_back_to_previous_page
+    then_i_see_the_references_start_page
+
+    when_i_click_continue
+    and_i_click_there_is_not_an_issue_with_the_section
+    then_i_see_the_thank_you_page
+    and_my_second_set_of_feedback_has_been_collected
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+    @application = @candidate.current_application
+  end
+
+  def and_the_feedback_prompts_flag_is_active
+    FeatureFlag.activate(:feedback_prompts)
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_on_the_references_section
+    click_link 'Add your references'
+  end
+
+  def and_i_click_there_is_an_issue_with_the_section
+    click_button 'Yes'
+  end
+
+  def then_i_see_the_references_section_feedback_page
+    expect(page).to have_current_path candidate_interface_edit_application_feedback_path(@application.application_feedback.last.id)
+  end
+
+  def when_i_fill_in_my_feedback
+    check 'I do not understand this section'
+    check 'My answers do not fit the format'
+    fill_in :other_feedback, with: 'Me no understand.'
+    choose 'Yes'
+
+    click_button 'Submit feedback'
+  end
+
+  def then_i_see_the_thank_you_page
+    expect(page).to have_current_path candidate_interface_application_feedback_thanks_path
+  end
+
+  def when_i_click_go_back_to_previous_page
+    click_link 'Go back to page you were previously on'
+  end
+
+  def then_i_see_the_references_start_page
+    expect(page).to have_current_path candidate_interface_references_start_path
+  end
+
+  def and_my_first_set_of_feedback_has_been_collected
+    expect(@application.application_feedback.count).to eq 1
+    expect(@application.application_feedback.last.section).to eq 'application_references'
+    expect(@application.application_feedback.last.path).to eq 'candidate_interface_references_start_path'
+    expect(@application.application_feedback.last.page_title).to eq t('page_titles.references_start')
+    expect(@application.application_feedback.last.issues).to eq true
+    expect(@application.application_feedback.last.does_not_understand_section).to eq true
+    expect(@application.application_feedback.last.need_more_information).to eq false
+    expect(@application.application_feedback.last.answer_does_not_fit_format).to eq true
+    expect(@application.application_feedback.last.other_feedback).to eq 'Me no understand.'
+    expect(@application.application_feedback.last.consent_to_be_contacted).to eq true
+  end
+
+  def when_i_click_continue
+    click_link 'Continue'
+  end
+
+  def and_i_click_there_is_not_an_issue_with_the_section
+    click_button 'No'
+  end
+
+  def and_my_second_set_of_feedback_has_been_collected
+    expect(@application.application_feedback.count).to eq 2
+    expect(@application.application_feedback.last.section).to eq 'application_references'
+    expect(@application.application_feedback.last.path).to eq 'candidate_interface_references_type_path'
+    expect(@application.application_feedback.last.page_title).to eq t('page_titles.references_type')
+    expect(@application.application_feedback.last.issues).to eq false
+    expect(@application.application_feedback.last.does_not_understand_section).to eq false
+    expect(@application.application_feedback.last.need_more_information).to eq false
+    expect(@application.application_feedback.last.answer_does_not_fit_format).to eq false
+    expect(@application.application_feedback.last.other_feedback).to eq nil
+    expect(@application.application_feedback.last.consent_to_be_contacted).to eq false
+  end
+end


### PR DESCRIPTION
## Context

**The designs have now changed for this. This should be merged then the changes applied. It's behind a feature flag so it's safe to do so**

First of all apologies for the size of this PR. I realised it was going to be bigger than I thought fairly early on so I've tried to keep the commits clean.

```
As a service owner
I need to understand what issues users are having at specific points in the journey
So that I can address them

```
This PR adds the non-JavaScript solution. The desired behaviour is:

If a user clicks yes on the feedback prompt:
1. They are taken to a second page where they can provide details of their issue
2. Once submitted they see a thank you page with a link back to the section they were completing when they chose to provide feedback

if a user clicks no on the feedback prompt:
1. They are taken to the thank you page. The same as above re. the link

## Changes proposed in this pull request

- Adds a component for the feedback prompt 


![image](https://user-images.githubusercontent.com/42515961/98736836-45093100-239d-11eb-9e4c-4d4e3aaa68b7.png)

- Adds the feedback page 


![image](https://user-images.githubusercontent.com/42515961/98736907-5c481e80-239d-11eb-9d68-c8341f622b77.png)

- Adds the thank you page


![image](https://user-images.githubusercontent.com/42515961/98736956-708c1b80-239d-11eb-9b77-0df8d64f296c.png)

## GIF section that I've shamelessly stolen from Toby (excuse the low quality)

![feedback prompts](https://user-images.githubusercontent.com/42515961/98739312-02495800-23a1-11eb-90d8-63fd465494cc.gif)


## Guidance to review

Def review per commit.

I've purposely only added the component to the references section for now for two reasons:
1. To reduce the size of the PR
2. So that any changes needed can be applied before expanding the component throughout the application

Once this PR is merged, then I'll add the component to the following sections:

* Degree
* GCSEs
* Other qualifications
* Personal statement
* Subject knowledge

I'll then add a recursive test that uses the relevant tests to checks the component is rendering where it should be.

## Link to Trello card

https://trello.com/c/AvxRVqld/2465-%F0%9F%93%9D-dev-add-feedback-prompt-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)

