### PR TITLE
Fix test data generation for oracle

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -132,14 +132,12 @@ class TestApplications
         @application_form.application_references.each { |reference| submit_reference!(reference) }
 
         states.zip(application_choices).each do |state, application_choice|
+          maybe_add_note(application_choice.reload)
           put_application_choice_in_state(application_choice.reload, state)
+          maybe_add_note(application_choice.reload)
         end
 
         FactoryBot.create(:ucas_match, application_form: @application_form) if rand < 0.5
-      end
-
-      application_choices.each do |application_choice|
-        rand(0..3).times { add_note(application_choice.reload) }
       end
 
       application_choices
@@ -296,13 +294,14 @@ class TestApplications
     choice.audits.last&.update_columns(created_at: time)
   end
 
-  def add_note(choice)
+  def maybe_add_note(choice)
+    return unless rand > 0.3
     previous_updated_at = choice.updated_at
 
     provider_user = choice.provider.provider_users.first
     provider_user ||= add_provider_user_to_provider(choice.provider)
     as_provider_user(choice) do
-      travel_to time + rand(-5..5).days
+      fast_forward
       FactoryBot.create(
         :note,
         application_choice: choice,

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -296,6 +296,7 @@ class TestApplications
 
   def maybe_add_note(choice)
     return unless rand > 0.3
+
     previous_updated_at = choice.updated_at
 
     provider_user = choice.provider.provider_users.first
@@ -358,7 +359,9 @@ class TestApplications
   def fast_forward
     return unless @time_budget.positive?
 
-    time_to_jump = [2, rand(1..@time_budget)].min
+    # We want to spread out actions that happen on an application over time. This ensures we don't use up
+    # the entire time budget in one go, and that we have a good chance of jumping forward a bit
+    time_to_jump = [rand(0..2), rand(1..@time_budget)].min
 
     @time_budget -= time_to_jump
     @time = time + time_to_jump.days

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -349,9 +349,15 @@ class TestApplications
   end
 
   def initialize_time(recruitment_cycle_year)
-    earliest_date = EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
-    current_cycle_end = recruitment_cycle_year == RecruitmentCycle.current_year ? nil : EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
-    latest_date = current_cycle_end.presence || Time.zone.now.to_date
+    in_current_cycle = recruitment_cycle_year == RecruitmentCycle.current_year
+    if in_current_cycle
+      earliest_date = 20.days.ago.to_date
+      latest_date = Time.zone.now.to_date
+    else
+      earliest_date = EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year][:apply_reopens]
+      latest_date = EndOfCycleTimetable::CYCLE_DATES[recruitment_cycle_year + 1][:apply_1_deadline]
+    end
+
     @time = rand(earliest_date..latest_date)
     @time_budget = [30, (latest_date.to_date - @time.to_date).to_i].min
   end

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -1,4 +1,7 @@
 class EndOfCycleTimetable
+  CURRENT_YEAR_FOR_SCHEDULE = 2021
+
+  # These dates are configuration for when the previous cycle ends and the next cycle starts
   # The 2020 dates are made up so we can generate sensible test data
   CYCLE_DATES = {
     2020 => {
@@ -92,7 +95,7 @@ class EndOfCycleTimetable
 
   def self.schedules
     {
-      real: CYCLE_DATES[2021],
+      real: CYCLE_DATES[CURRENT_YEAR_FOR_SCHEDULE],
 
       today_is_mid_cycle: {
         apply_1_deadline: 1.day.from_now.to_date,

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -1,5 +1,4 @@
 class EndOfCycleTimetable
-
   # The 2020 dates are made up so we can generate sensible test data
   CYCLE_DATES = {
     2020 => {
@@ -18,7 +17,7 @@ class EndOfCycleTimetable
       find_reopens: Date.new(2020, 10, 6),
       apply_reopens: Date.new(2020, 10, 13),
     },
-  }
+  }.freeze
 
   def self.between_cycles?(phase)
     phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?

--- a/app/services/end_of_cycle_timetable.rb
+++ b/app/services/end_of_cycle_timetable.rb
@@ -1,4 +1,25 @@
 class EndOfCycleTimetable
+
+  # The 2020 dates are made up so we can generate sensible test data
+  CYCLE_DATES = {
+    2020 => {
+      apply_1_deadline: Date.new(2019, 8, 24),
+      stop_applications_to_unavailable_course_options: Date.new(2019, 9, 7),
+      apply_2_deadline: Date.new(2019, 9, 18),
+      find_closes: Date.new(2019, 10, 3),
+      find_reopens: Date.new(2019, 10, 6),
+      apply_reopens: Date.new(2019, 10, 13),
+    },
+    2021 => {
+      apply_1_deadline: Date.new(2020, 8, 24),
+      stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
+      apply_2_deadline: Date.new(2020, 9, 18),
+      find_closes: Date.new(2020, 10, 3),
+      find_reopens: Date.new(2020, 10, 6),
+      apply_reopens: Date.new(2020, 10, 13),
+    },
+  }
+
   def self.between_cycles?(phase)
     phase == 'apply_1' ? between_cycles_apply_1? : between_cycles_apply_2?
   end
@@ -72,14 +93,7 @@ class EndOfCycleTimetable
 
   def self.schedules
     {
-      real: {
-        apply_1_deadline: Date.new(2020, 8, 24),
-        stop_applications_to_unavailable_course_options: Date.new(2020, 9, 7),
-        apply_2_deadline: Date.new(2020, 9, 18),
-        find_closes: Date.new(2020, 10, 3),
-        find_reopens: Date.new(2020, 10, 6),
-        apply_reopens: Date.new(2020, 10, 13),
-      },
+      real: CYCLE_DATES[2021],
 
       today_is_mid_cycle: {
         apply_1_deadline: 1.day.from_now.to_date,

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe TestApplications do
     candidate = application_form.candidate
 
     expect(candidate.created_at).to eq candidate.last_signed_in_at
-    expect(days_between_ignoring_time_of_day(application_choice.created_at, candidate.created_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_form.submitted_at, application_choice.created_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_choice.offered_at, application_choice.sent_to_provider_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_choice.accepted_at, application_choice.offered_at)).to be >= 1
+    expect(candidate.created_at <= application_choice.created_at).to be_truthy
+    expect(application_choice.created_at <= application_form.submitted_at).to be_truthy
+    expect(application_choice.sent_to_provider_at <= application_choice.offered_at).to be_truthy
+    expect(application_choice.offered_at <= application_choice.accepted_at).to be_truthy
   end
 
   it 'creates a realistic timeline for an offered application' do
@@ -34,9 +34,9 @@ RSpec.describe TestApplications do
 
     application_form = application_choice.application_form
     candidate = application_form.candidate
-    expect(days_between_ignoring_time_of_day(application_choice.created_at, candidate.created_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_form.submitted_at, application_choice.created_at)).to be >= 1
-    expect(days_between_ignoring_time_of_day(application_choice.offered_at, application_choice.sent_to_provider_at)).to be >= 1
+    expect(candidate.created_at <= application_choice.created_at).to be_truthy
+    expect(application_choice.created_at <= application_form.submitted_at).to be_truthy
+    expect(application_choice.sent_to_provider_at <= application_choice.offered_at).to be_truthy
   end
 
   it 'attributes actions to candidates', with_audited: true do

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe TestApplications do
     candidate = application_form.candidate
 
     expect(candidate.created_at).to eq candidate.last_signed_in_at
-    expect(candidate.created_at <= application_choice.created_at).to be_truthy
-    expect(application_choice.created_at <= application_form.submitted_at).to be_truthy
-    expect(application_choice.sent_to_provider_at <= application_choice.offered_at).to be_truthy
-    expect(application_choice.offered_at <= application_choice.accepted_at).to be_truthy
+    expect(candidate.created_at <= application_choice.created_at).to be true
+    expect(application_choice.created_at <= application_form.submitted_at).to be true
+    expect(application_choice.sent_to_provider_at <= application_choice.offered_at).to be true
+    expect(application_choice.offered_at <= application_choice.accepted_at).to be true
   end
 
   it 'creates a realistic timeline for an offered application' do
@@ -34,9 +34,9 @@ RSpec.describe TestApplications do
 
     application_form = application_choice.application_form
     candidate = application_form.candidate
-    expect(candidate.created_at <= application_choice.created_at).to be_truthy
-    expect(application_choice.created_at <= application_form.submitted_at).to be_truthy
-    expect(application_choice.sent_to_provider_at <= application_choice.offered_at).to be_truthy
+    expect(candidate.created_at <= application_choice.created_at).to be true
+    expect(application_choice.created_at <= application_form.submitted_at).to be true
+    expect(application_choice.sent_to_provider_at <= application_choice.offered_at).to be true
   end
 
   it 'attributes actions to candidates', with_audited: true do

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TestApplications do
     expect(choices.count).to eq(2)
   end
 
-  it 'creates a realistic timeline for an recruited application' do
+  it 'creates a realistic timeline for a recruited application' do
     courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
     application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first


### PR DESCRIPTION
## Context
Oracle reported that some test data that was being generated in Sandbox had timestamps from the future (for e.g. updated_at), which is unrealistic and upsets things on their side.

## Changes proposed in this pull request
Update the test application generator so that its time travel functionality stays in the past. (The issue was that the generator's time could go further in time than the current date, and set unrealistic timestamps)

## Guidance to review
Each commit separately

## Link to Trello card
https://trello.com/c/Ma0Erlkt/2944-fix-test-data-generation-for-oracle

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
