### PR TITLE
Fix offer accepted confirmation email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -271,9 +271,9 @@ class CandidateMailer < ApplicationMailer
 
   def offer_accepted(application_choice)
     @application_form = application_choice.application_form
-    @course_name_and_code = application_choice.course_option.course.name_and_code
-    @provider_name = application_choice.course_option.provider.name
-    @start_date = application_choice.course_option.course.start_date.to_s(:month_and_year)
+    @course_name_and_code = application_choice.offered_option.course.name_and_code
+    @provider_name = application_choice.offered_option.provider.name
+    @start_date = application_choice.offered_option.course.start_date.to_s(:month_and_year)
 
     email_for_candidate(
       @application_form,


### PR DESCRIPTION
## Context

We're presenting the course_option not the offered_option in the offer accepted email that candidates receive.

## Changes proposed in this pull request

- Use the offered_option

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
