### PR TITLE
 Cancel references for cancelled test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -103,7 +103,7 @@ class TestApplications
         return application_choices
       end
 
-      if states.include? :cancelled
+      if states == [:cancelled]
         # The cancelled state doesn't exist anymore in the current system,
         # so we have to set this manually.
         @application_form.application_choices.each do |application_choice|
@@ -111,6 +111,11 @@ class TestApplications
             status: 'cancelled',
           )
         end
+
+        @application_form.application_references.each do |reference|
+          CancelReferee.new.call(reference: reference)
+        end
+
         return
       end
 

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -30,5 +30,7 @@ RSpec.describe GenerateTestApplications do
 
     # there is at least one unsubmitted application to a full course
     expect(ApplicationChoice.where(status: 'unsubmitted').map(&:course_option).select(&:no_vacancies?)).not_to be_empty
+
+    expect(ApplicationChoice.cancelled.first.application_form.application_references.feedback_requested).to be_empty
   end
 end


### PR DESCRIPTION
## Context

The `DetectInvariants` checker checks if there are requested references that belong to application choices that haven't been submitted yet. This is impossible because you can't submit applications without all references being either cancelled, declined or with feedback.

However, in QA/Sandbox we also have application choices in the cancelled state. This state has been removed, but it still exists on prod and so we need it as test data too. This is currently raising an error:

https://sentry.io/organizations/dfe-bat/issues/1990257169

For this application:

https://qa.apply-for-teacher-training.service.gov.uk/support/applications/4240

I've manually cancelled the references on this test application.

## Changes proposed in this pull request

Cancel references when cancelling the application.

## Guidance to review

Per commit.

## Link to Trello card

https://trello.com/c/9FgC13b6