### PR TITLE
Resolve dual applications flow

### DIFF
--- a/app/components/support_interface/ucas_match_action_component.html.erb
+++ b/app/components/support_interface/ucas_match_action_component.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-inset-text govuk-!-margin-top-0">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
+        <%= inset_text_header %>
+      </h2>
+      <p class="govuk-body">
+        <%= action_details %>
+      </p>
+      <% if @match.action_needed? %>
+        <%= form_with url: button[:path], method: :post do |f| %>
+          <%= f.submit button[:text], class: 'govuk-button' %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -13,6 +13,12 @@ module SupportInterface
         button_text: 'Confirm reminder emails were sent',
         form_path: :support_interface_record_reminder_emails_sent_path,
       },
+      request_withdrawal_from_ucas: {
+        description: 'Request withdrawal from UCAS',
+        button_text: 'Confirm withdrawal from UCAS was requested',
+        form_path: :support_interface_record_ucas_withdrawal_requested_path,
+        instructions: "We need to contact UCAS. Please send an encrypted file with the candidate's duplicate application details to Harry Haines (h.haines@ucas.ac.uk) and Lizzy Carter (l.carter@ucas.ac.uk) from UCAS to ask them to remove the candidate from UTT.",
+      },
     }.freeze
 
     def initialize(match)
@@ -45,6 +51,8 @@ module SupportInterface
         :send_initial_emails
       elsif @match.initial_emails_sent? && @match.need_to_send_reminder_emails?
         :send_reminder_emails
+      elsif @match.reminder_emails_sent? && @match.need_to_request_withdrawal_from_ucas?
+        :request_withdrawal_from_ucas
       end
     end
 
@@ -53,7 +61,11 @@ module SupportInterface
     end
 
     def required_action_details
-      "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>.".html_safe
+      contact_info = ACTIONS[next_action][:instructions] ||
+        "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>."
+      support_manual_info = "<br><br>Please refer to <a class='govuk-link' href='https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4'>Dual-running user support manual</a> for more information about the current process."
+
+      contact_info.concat(support_manual_info).html_safe
     end
 
     def last_action_details
@@ -61,6 +73,8 @@ module SupportInterface
                       'sent the initial emails'
                     elsif @match.reminder_emails_sent?
                       'sent the reminder emails'
+                    elsif @match.ucas_withdrawal_requested?
+                      'requested for the candidate to be removed from UCAS'
                     end
 
       "We #{last_action} on the #{@match.candidate_last_contacted_at.to_s(:govuk_date_and_time)}"

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -8,6 +8,11 @@ module SupportInterface
         button_text: 'Confirm initial emails were sent',
         form_path: :support_interface_record_initial_emails_sent_path,
       },
+      send_reminder_emails: {
+        description: 'Send reminder emails',
+        button_text: 'Confirm reminder emails were sent',
+        form_path: :support_interface_record_reminder_emails_sent_path,
+      },
     }.freeze
 
     def initialize(match)
@@ -38,6 +43,8 @@ module SupportInterface
     def next_action
       if @match.candidate_last_contacted_at.nil?
         :send_initial_emails
+      elsif @match.initial_emails_sent? && @match.need_to_send_reminder_emails?
+        :send_reminder_emails
       end
     end
 
@@ -52,6 +59,8 @@ module SupportInterface
     def last_action_details
       last_action = if @match.initial_emails_sent?
                       'sent the initial emails'
+                    elsif @match.reminder_emails_sent?
+                      'sent the reminder emails'
                     end
 
       "We #{last_action} on the #{@match.candidate_last_contacted_at.to_s(:govuk_date_and_time)}"

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -19,6 +19,12 @@ module SupportInterface
         form_path: :support_interface_record_ucas_withdrawal_requested_path,
         instructions: "We need to contact UCAS. Please send an encrypted file with the candidate's duplicate application details to Harry Haines (h.haines@ucas.ac.uk) and Lizzy Carter (l.carter@ucas.ac.uk) from UCAS to ask them to remove the candidate from UTT.",
       },
+      confirm_withdrawal_from_ucas: {
+        description: 'Confirm withdrawal from UCAS',
+        button_text: 'Confirm the application was withdrawn from UCAS',
+        form_path: :support_interface_process_match_path,
+        instructions: "We need to ensure that UCAS have removed the candidate's duplicate application from UTT.",
+      },
     }.freeze
 
     def initialize(match)
@@ -53,6 +59,8 @@ module SupportInterface
         :send_reminder_emails
       elsif @match.reminder_emails_sent? && @match.need_to_request_withdrawal_from_ucas?
         :request_withdrawal_from_ucas
+      elsif @match.ucas_withdrawal_requested? && @match.need_to_confirm_withdrawal_from_ucas?
+        :confirm_withdrawal_from_ucas
       end
     end
 
@@ -73,6 +81,8 @@ module SupportInterface
                       'sent the initial emails'
                     elsif @match.reminder_emails_sent?
                       'sent the reminder emails'
+                    elsif @match.processed? && @match.ucas_withdrawal_requested?
+                      'confirmed that the candidate was withdrawn from UCAS. We contacted UCAS to request removal from UTT'
                     elsif @match.ucas_withdrawal_requested?
                       'requested for the candidate to be removed from UCAS'
                     end

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -3,27 +3,33 @@ module SupportInterface
     include ViewHelper
 
     ACTIONS = {
-      send_initial_emails: {
+      initial_emails_sent: {
         description: 'Send initial emails',
         button_text: 'Confirm initial emails were sent',
         form_path: :support_interface_record_initial_emails_sent_path,
+        instructions: "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>.",
+        past_tense_description: 'sent the initial emails',
       },
-      send_reminder_emails: {
+      reminder_emails_sent: {
         description: 'Send reminder emails',
         button_text: 'Confirm reminder emails were sent',
         form_path: :support_interface_record_reminder_emails_sent_path,
+        instructions: "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>.",
+        past_tense_description: 'sent the reminder emails',
       },
-      request_withdrawal_from_ucas: {
+      ucas_withdrawal_requested: {
         description: 'Request withdrawal from UCAS',
         button_text: 'Confirm withdrawal from UCAS was requested',
         form_path: :support_interface_record_ucas_withdrawal_requested_path,
         instructions: "We need to contact UCAS. Please send an encrypted file with the candidate's duplicate application details to Harry Haines (h.haines@ucas.ac.uk) and Lizzy Carter (l.carter@ucas.ac.uk) from UCAS to ask them to remove the candidate from UTT.",
+        past_tense_description: 'requested withdrawal from UCAS',
       },
-      confirm_withdrawal_from_ucas: {
+      confirmed_withdrawal_from_ucas: {
         description: 'Confirm withdrawal from UCAS',
         button_text: 'Confirm the application was withdrawn from UCAS',
         form_path: :support_interface_process_match_path,
         instructions: "We need to ensure that UCAS have removed the candidate's duplicate application from UTT.",
+        past_tense_description: 'confirmed that the candidate was withdrawn from UCAS. We contacted UCAS to request removal from UTT',
       },
     }.freeze
 
@@ -44,6 +50,7 @@ module SupportInterface
     end
 
     def button
+      next_action = @match.next_action
       {
         text: ACTIONS[next_action][:button_text],
         path: Rails.application.routes.url_helpers.send(ACTIONS[next_action][:form_path], @match),
@@ -52,40 +59,20 @@ module SupportInterface
 
   private
 
-    def next_action
-      if @match.candidate_last_contacted_at.nil?
-        :send_initial_emails
-      elsif @match.initial_emails_sent? && @match.need_to_send_reminder_emails?
-        :send_reminder_emails
-      elsif @match.reminder_emails_sent? && @match.need_to_request_withdrawal_from_ucas?
-        :request_withdrawal_from_ucas
-      elsif @match.ucas_withdrawal_requested?
-        :confirm_withdrawal_from_ucas
-      end
-    end
-
     def type_of_action
-      "<strong class='govuk-tag govuk-tag--yellow app-tag'>Action needed</strong> #{ACTIONS[next_action][:description]}".html_safe
+      "<strong class='govuk-tag govuk-tag--yellow app-tag'>Action needed</strong> #{ACTIONS[@match.next_action][:description]}".html_safe
     end
 
     def required_action_details
-      instructions = ACTIONS[next_action][:instructions] ||
-        "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>."
+      instructions = ACTIONS[@match.next_action][:instructions]
       support_manual_info = "<br><br>Please refer to <a class='govuk-link' href='https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4'>Dual-running user support manual</a> for more information about the current process."
 
       instructions.concat(support_manual_info).html_safe
     end
 
     def last_action_details
-      last_action = if @match.initial_emails_sent?
-                      'sent the initial emails'
-                    elsif @match.reminder_emails_sent?
-                      'sent the reminder emails'
-                    elsif @match.processed? && @match.ucas_withdrawal_requested?
-                      'confirmed that the candidate was withdrawn from UCAS. We contacted UCAS to request removal from UTT'
-                    end
-
-      "We #{last_action} on the #{@match.candidate_last_contacted_at.to_s(:govuk_date_and_time)}"
+      last_action = @match.last_action
+      "We #{ACTIONS[last_action][:past_tense_description]} on the #{@match.candidate_last_contacted_at.to_s(:govuk_date_and_time)}"
     end
   end
 end

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -59,7 +59,7 @@ module SupportInterface
         :send_reminder_emails
       elsif @match.reminder_emails_sent? && @match.need_to_request_withdrawal_from_ucas?
         :request_withdrawal_from_ucas
-      elsif @match.ucas_withdrawal_requested? && @match.need_to_confirm_withdrawal_from_ucas?
+      elsif @match.ucas_withdrawal_requested?
         :confirm_withdrawal_from_ucas
       end
     end
@@ -69,11 +69,11 @@ module SupportInterface
     end
 
     def required_action_details
-      contact_info = ACTIONS[next_action][:instructions] ||
+      instructions = ACTIONS[next_action][:instructions] ||
         "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>."
       support_manual_info = "<br><br>Please refer to <a class='govuk-link' href='https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4'>Dual-running user support manual</a> for more information about the current process."
 
-      contact_info.concat(support_manual_info).html_safe
+      instructions.concat(support_manual_info).html_safe
     end
 
     def last_action_details
@@ -83,8 +83,6 @@ module SupportInterface
                       'sent the reminder emails'
                     elsif @match.processed? && @match.ucas_withdrawal_requested?
                       'confirmed that the candidate was withdrawn from UCAS. We contacted UCAS to request removal from UTT'
-                    elsif @match.ucas_withdrawal_requested?
-                      'requested for the candidate to be removed from UCAS'
                     end
 
       "We #{last_action} on the #{@match.candidate_last_contacted_at.to_s(:govuk_date_and_time)}"

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -38,7 +38,7 @@ module SupportInterface
     end
 
     def inset_text_header
-      return 'No action required' if !@match.dual_application_or_dual_acceptance? || !@match.action_needed?
+      return 'No action required' unless @match.action_needed?
 
       type_of_action
     end

--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -1,0 +1,60 @@
+module SupportInterface
+  class UCASMatchActionComponent < ViewComponent::Base
+    include ViewHelper
+
+    ACTIONS = {
+      send_initial_emails: {
+        description: 'Send initial emails',
+        button_text: 'Confirm initial emails were sent',
+        form_path: :support_interface_record_initial_emails_sent_path,
+      },
+    }.freeze
+
+    def initialize(match)
+      @match = match
+    end
+
+    def inset_text_header
+      return 'No action required' if !@match.dual_application_or_dual_acceptance? || !@match.action_needed?
+
+      type_of_action
+    end
+
+    def action_details
+      return '' unless @match.dual_application_or_dual_acceptance?
+
+      @match.action_needed? ? required_action_details : last_action_details
+    end
+
+    def button
+      {
+        text: ACTIONS[next_action][:button_text],
+        path: Rails.application.routes.url_helpers.send(ACTIONS[next_action][:form_path], @match),
+      }
+    end
+
+  private
+
+    def next_action
+      if @match.candidate_last_contacted_at.nil?
+        :send_initial_emails
+      end
+    end
+
+    def type_of_action
+      "<strong class='govuk-tag govuk-tag--yellow app-tag'>Action needed</strong> #{ACTIONS[next_action][:description]}".html_safe
+    end
+
+    def required_action_details
+      "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>.".html_safe
+    end
+
+    def last_action_details
+      last_action = if @match.initial_emails_sent?
+                      'sent the initial emails'
+                    end
+
+      "We #{last_action} on the #{@match.candidate_last_contacted_at.to_s(:govuk_date_and_time)}"
+    end
+  end
+end

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -15,26 +15,20 @@ module SupportInterface
       @match = UCASMatch.find(params[:id])
     end
 
+    def record_initial_emails_sent
+      match = UCASMatch.find(params[:id])
+      match.update!(
+        candidate_last_contacted_at: Time.zone.now,
+        action_taken: 'initial_emails_sent',
+      )
+      flash[:success] = 'The date of the initial emails was recorded'
+      redirect_to support_interface_ucas_match_path(match)
+    end
+
     def process_match
       match = UCASMatch.find(params[:id])
       match.update!(matching_state: :processed)
       flash[:success] = 'Match marked as processed'
-      redirect_to support_interface_ucas_match_path(match)
-    end
-
-    def record_initial_emails_sent
-      match = UCASMatch.find(params[:id])
-
-      if match.update!(
-        action_taken: 'initial_emails_sent',
-        candidate_last_contacted_at: Time.zone.now,
-      )
-        flash[:success] = 'The date of the initial emails was recorded'
-      else
-        flash[:warning] = 'There was a problem and the date of the initial emails was not recorded'
-
-      end
-
       redirect_to support_interface_ucas_match_path(match)
     end
   end

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -25,6 +25,16 @@ module SupportInterface
       redirect_to support_interface_ucas_match_path(match)
     end
 
+    def record_reminder_emails_sent
+      match = UCASMatch.find(params[:id])
+      match.update!(
+        candidate_last_contacted_at: Time.zone.now,
+        action_taken: 'reminder_emails_sent',
+      )
+      flash[:success] = 'The date of the reminder emails was recorded'
+      redirect_to support_interface_ucas_match_path(match)
+    end
+
     def process_match
       match = UCASMatch.find(params[:id])
       match.update!(matching_state: :processed)

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -35,6 +35,16 @@ module SupportInterface
       redirect_to support_interface_ucas_match_path(match)
     end
 
+    def record_ucas_withdrawal_requested
+      match = UCASMatch.find(params[:id])
+      match.update!(
+        candidate_last_contacted_at: Time.zone.now,
+        action_taken: 'ucas_withdrawal_requested',
+      )
+      flash[:success] = 'The date of requesting withdrawal from UCAS was recorded'
+      redirect_to support_interface_ucas_match_path(match)
+    end
+
     def process_match
       match = UCASMatch.find(params[:id])
       match.update!(matching_state: :processed)

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -57,6 +57,26 @@ class UCASMatch < ApplicationRecord
     Time.zone.today >= request_withdrawal_from_ucas_date
   end
 
+  def next_action
+    if candidate_last_contacted_at.nil?
+      :initial_emails_sent
+    elsif initial_emails_sent? && need_to_send_reminder_emails?
+      :reminder_emails_sent
+    elsif reminder_emails_sent? && need_to_request_withdrawal_from_ucas?
+      :ucas_withdrawal_requested
+    elsif ucas_withdrawal_requested?
+      :confirmed_withdrawal_from_ucas
+    end
+  end
+
+  def last_action
+    return nil if action_taken.nil?
+
+    return :confirmed_withdrawal_from_ucas if processed? && ucas_withdrawal_requested?
+
+    action_taken.to_sym
+  end
+
 private
 
   def application_for_the_same_course_in_progress_on_both_services?

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -11,12 +11,15 @@ class UCASMatch < ApplicationRecord
 
   enum action_taken: {
     initial_emails_sent: 'initial_emails_sent',
+    reminder_emails_sent: 'reminder_emails_sent',
   }
 
   def action_needed?
     return false if processed?
 
     return need_to_send_reminder_emails? if initial_emails_sent?
+
+    return need_to_request_withdrawal_from_ucas? if reminder_emails_sent?
 
     dual_application_or_dual_acceptance?
   end
@@ -42,6 +45,13 @@ class UCASMatch < ApplicationRecord
 
     send_reminder_emails_date = 5.business_days.after(candidate_last_contacted_at).to_date
     Time.zone.today >= send_reminder_emails_date
+  end
+
+  def need_to_request_withdrawal_from_ucas?
+    return false unless reminder_emails_sent?
+
+    request_withdrawal_from_ucas_date = 10.business_days.after(candidate_last_contacted_at).to_date
+    Time.zone.today >= request_withdrawal_from_ucas_date
   end
 
 private

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -12,6 +12,7 @@ class UCASMatch < ApplicationRecord
   enum action_taken: {
     initial_emails_sent: 'initial_emails_sent',
     reminder_emails_sent: 'reminder_emails_sent',
+    ucas_withdrawal_requested: 'ucas_withdrawal_requested',
   }
 
   def action_needed?
@@ -20,6 +21,8 @@ class UCASMatch < ApplicationRecord
     return need_to_send_reminder_emails? if initial_emails_sent?
 
     return need_to_request_withdrawal_from_ucas? if reminder_emails_sent?
+
+    return need_to_confirm_withdrawal_from_ucas? if ucas_withdrawal_requested?
 
     dual_application_or_dual_acceptance?
   end
@@ -52,6 +55,13 @@ class UCASMatch < ApplicationRecord
 
     request_withdrawal_from_ucas_date = 10.business_days.after(candidate_last_contacted_at).to_date
     Time.zone.today >= request_withdrawal_from_ucas_date
+  end
+
+  def need_to_confirm_withdrawal_from_ucas?
+    return false unless ucas_withdrawal_requested?
+
+    confirm_withdrawal_from_ucas_date = 5.business_days.after(candidate_last_contacted_at).to_date
+    Time.zone.today >= confirm_withdrawal_from_ucas_date
   end
 
 private

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -18,11 +18,11 @@ class UCASMatch < ApplicationRecord
   def action_needed?
     return false if processed?
 
+    return true if ucas_withdrawal_requested?
+
     return need_to_send_reminder_emails? if initial_emails_sent?
 
     return need_to_request_withdrawal_from_ucas? if reminder_emails_sent?
-
-    return need_to_confirm_withdrawal_from_ucas? if ucas_withdrawal_requested?
 
     dual_application_or_dual_acceptance?
   end
@@ -55,13 +55,6 @@ class UCASMatch < ApplicationRecord
 
     request_withdrawal_from_ucas_date = 10.business_days.after(candidate_last_contacted_at).to_date
     Time.zone.today >= request_withdrawal_from_ucas_date
-  end
-
-  def need_to_confirm_withdrawal_from_ucas?
-    return false unless ucas_withdrawal_requested?
-
-    confirm_withdrawal_from_ucas_date = 5.business_days.after(candidate_last_contacted_at).to_date
-    Time.zone.today >= confirm_withdrawal_from_ucas_date
   end
 
 private

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -18,13 +18,15 @@ class UCASMatch < ApplicationRecord
   def action_needed?
     return false if processed?
 
+    return false unless dual_application_or_dual_acceptance?
+
     return true if ucas_withdrawal_requested?
 
     return need_to_send_reminder_emails? if initial_emails_sent?
 
     return need_to_request_withdrawal_from_ucas? if reminder_emails_sent?
 
-    dual_application_or_dual_acceptance?
+    true
   end
 
   def dual_application_or_dual_acceptance?

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -2,37 +2,11 @@
 
 <%= render 'ucas_match_navigation', title: 'Details', match: @match %>
 
-<% if @match.action_needed? || @match.initial_emails_sent? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <div class="govuk-inset-text govuk-!-margin-top-0">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
-          <%= @match.action_needed? ? "Action needed: send initial email" :  'No action required' %>
-        </h2>
-        <% if @match.initial_emails_sent? %>
-          <p class="govuk-body">
-            We sent the initial emails to the candidate and the providers on <%= @match.candidate_last_contacted_at.to_s(:govuk_date_and_time) %>.
-          </p>
-        <% else %>
-          <p class="govuk-body">
-            We need to contact the candidate and the provider.
-            Use an appropriate templates from <%= govuk_link_to 'this document', "https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE" %>.
-          </p>
-          <p class="govuk-body">
-            Please refer to <%= govuk_link_to 'Dual-running user support manual', "https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4" %> for more information about the current process.
-          </p>
-          <%= form_with url: support_interface_record_initial_emails_sent_path(@match), method: :post do |f| %>
-            <%= f.submit 'Confirm initial emails were sent', class: 'govuk-button' %>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
-  </div>
-<% end %>
-
 <h2 class='govuk-heading-l'>UCAS match</h2>
-<% application = @match.candidate.application_forms.first %>
 
+<%= render SupportInterface::UCASMatchActionComponent.new(@match) %>
+
+<% application = @match.candidate.application_forms.first %>
 <% status = [render(TagComponent.new(text: @match.matching_state.humanize, type: @match.processed? ? :green : :purple))] %>
 <% status << render(TagComponent.new(text: @match.action_taken.humanize, type: :purple)) if @match.action_taken.present? %>
 <% if @match.invalid_matching_data? %>

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -25,14 +25,6 @@
   'Application on Apply' => govuk_link_to('View application', support_interface_application_form_path(application)),
 }) %>
 
-<p class="govuk-body">
-  <% unless @match.processed? %>
-    <%= form_with url: support_interface_process_match_path(@match), method: :post do |f| %>
-      <%= f.govuk_submit 'Mark as processed' %>
-    <% end %>
-  <% end %>
-</p>
-
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Course choices</h2>
 <%= render SupportInterface::UCASMatchTableComponent.new(@match) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -660,6 +660,7 @@ Rails.application.routes.draw do
       get '/audit' => 'ucas_matches#audit', as: :ucas_match_audit
       post '/record-initial-emails-sent' => 'ucas_matches#record_initial_emails_sent', as: :record_initial_emails_sent
       post '/record-reminder-emails-sent' => 'ucas_matches#record_reminder_emails_sent', as: :record_reminder_emails_sent
+      post '/record-ucas-withdrawal-requested' => 'ucas_matches#record_ucas_withdrawal_requested', as: :record_ucas_withdrawal_requested
       post '/process-match' => 'ucas_matches#process_match', as: :process_match
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -659,6 +659,7 @@ Rails.application.routes.draw do
       get '/' => 'ucas_matches#show', as: :ucas_match
       get '/audit' => 'ucas_matches#audit', as: :ucas_match_audit
       post '/record-initial-emails-sent' => 'ucas_matches#record_initial_emails_sent', as: :record_initial_emails_sent
+      post '/record-reminder-emails-sent' => 'ucas_matches#record_reminder_emails_sent', as: :record_reminder_emails_sent
       post '/process-match' => 'ucas_matches#process_match', as: :process_match
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -658,7 +658,7 @@ Rails.application.routes.draw do
     scope path: '/ucas-matches/:id' do
       get '/' => 'ucas_matches#show', as: :ucas_match
       get '/audit' => 'ucas_matches#audit', as: :ucas_match_audit
-      post '/initial-emails' => 'ucas_matches#record_initial_emails_sent', as: :record_initial_emails_sent
+      post '/record-initial-emails-sent' => 'ucas_matches#record_initial_emails_sent', as: :record_initial_emails_sent
       post '/process-match' => 'ucas_matches#process_match', as: :process_match
     end
 

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -73,5 +73,39 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
         expect(result.text).to include('We sent the reminder emails on the 18 October 2020')
       end
     end
+
+    it 'renders correct information when withdrawal from UCAS needs to be requested' do
+      Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
+        ucas_match = create(:ucas_match,
+                            matching_state: 'new_match',
+                            scheme: 'U',
+                            action_taken: 'reminder_emails_sent',
+                            candidate_last_contacted_at: Time.zone.now - 16.days)
+        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+
+        result = render_inline(described_class.new(ucas_match))
+
+        expect(result.text).to include('Action needed Request withdrawal from UCAS')
+        expect(result.css('input').attr('value').value).to include('Confirm withdrawal from UCAS was requested')
+        expect(result.css('form').attr('action').value).to include('/record-ucas-withdrawal-requested')
+        expect(result.text).to include('We need to contact UCAS')
+      end
+    end
+
+    it 'renders correct information after requesting withdrawal from UCAS' do
+      Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
+        ucas_match = create(:ucas_match,
+                            matching_state: 'new_match',
+                            scheme: 'U',
+                            action_taken: 'ucas_withdrawal_requested',
+                            candidate_last_contacted_at: Time.zone.now - 1.day)
+        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+
+        result = render_inline(described_class.new(ucas_match))
+
+        expect(result.text).to include('No action required')
+        expect(result.text).to include('We requested for the candidate to be removed from UCAS on the 18 October 2020')
+      end
+    end
   end
 end

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::UCASMatchActionComponent do
+  context 'when there is no dual application or dual acceptance' do
+    it 'renders `No action required`' do
+      ucas_match_without_dual_applications = create(:ucas_match, matching_state: 'new_match', scheme: 'U', ucas_status: :rejected)
+      allow(ucas_match_without_dual_applications).to receive(:dual_application_or_dual_acceptance?).and_return(false)
+
+      result = render_inline(described_class.new(ucas_match_without_dual_applications))
+      expect(result.text).to include('No action required')
+    end
+  end
+
+  context 'when there is a dual application or dual acceptance' do
+    it 'renders correct information for a new match' do
+      ucas_match = create(:ucas_match, matching_state: 'new_match', scheme: 'U', candidate_last_contacted_at: nil)
+      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+
+      result = render_inline(described_class.new(ucas_match))
+
+      expect(result.text).to include('Action needed Send initial emails')
+      expect(result.css('input').attr('value').value).to include('Confirm initial emails were sent')
+      expect(result.css('form').attr('action').value).to include('/record-initial-emails-sent')
+      expect(result.text).to include('We need to contact the candidate and the provider.')
+    end
+
+    it 'renders correct information after sending the initial emails' do
+      Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
+        ucas_match = create(:ucas_match,
+                            matching_state: 'new_match',
+                            scheme: 'U',
+                            action_taken: 'initial_emails_sent',
+                            candidate_last_contacted_at: Time.zone.now - 1.day)
+        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+
+        result = render_inline(described_class.new(ucas_match))
+
+        expect(result.text).to include('No action required')
+        expect(result.text).to include('We sent the initial emails on the 18 October 2020')
+      end
+    end
+  end
+end

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -103,22 +103,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
 
         result = render_inline(described_class.new(ucas_match))
 
-        expect(result.text).to include('No action required')
-        expect(result.text).to include('We requested for the candidate to be removed from UCAS on the 18 October 2020')
-      end
-    end
-
-    it 'renders correct information when withdrawal from UCAS needs to be confirmed' do
-      Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
-        ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
-                            scheme: 'U',
-                            action_taken: 'ucas_withdrawal_requested',
-                            candidate_last_contacted_at: Time.zone.now - 8.days)
-        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
-
-        result = render_inline(described_class.new(ucas_match))
-
         expect(result.text).to include('Action needed Confirm withdrawal from UCAS')
         expect(result.css('input').attr('value').value).to include('Confirm the application was withdrawn from UCAS')
         expect(result.css('form').attr('action').value).to include('/process-match')

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -45,20 +45,6 @@ RSpec.describe UCASMatch do
       expect(ucas_match.action_needed?).to eq(true)
     end
 
-    it 'returns false if we requested withdrawal from UCAS and we don not need to confirm yet' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
-      allow(ucas_match).to receive(:need_to_confirm_withdrawal_from_ucas?).and_return(false)
-
-      expect(ucas_match.action_needed?).to eq(false)
-    end
-
-    it 'returns true if we requested withdrawal from UCAS and it is time to confirm withdrawal from UCAS' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
-      allow(ucas_match).to receive(:need_to_confirm_withdrawal_from_ucas?).and_return(true)
-
-      expect(ucas_match.action_needed?).to eq(true)
-    end
-
     it 'returns true if we requested withdrawal from UCAS' do
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
 
@@ -216,35 +202,6 @@ RSpec.describe UCASMatch do
 
       Timecop.travel(10.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_request_withdrawal_from_ucas?).to eq(true)
-      end
-    end
-  end
-
-  describe '#need_to_confirm_withdrawal_from_ucas?' do
-    it 'returns false if last action taken in not ucas withdrawal requested' do
-      emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
-
-      Timecop.travel(1.business_days.after(emails_sent_at)) do
-        expect(ucas_match.need_to_confirm_withdrawal_from_ucas?).to eq(false)
-      end
-    end
-
-    it 'returns false if ucas withdrawal was requested and we don not need to confirm withdrawal from ucas yet' do
-      emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
-
-      Timecop.travel(1.business_days.after(emails_sent_at)) do
-        expect(ucas_match.need_to_confirm_withdrawal_from_ucas?).to eq(false)
-      end
-    end
-
-    it 'returns true if ucas withdrawal was requested and it is time to confirm withdrawal from ucas' do
-      emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
-
-      Timecop.travel(5.business_days.after(emails_sent_at)) do
-        expect(ucas_match.need_to_confirm_withdrawal_from_ucas?).to eq(true)
       end
     end
   end

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe UCASMatch do
     it 'returns false if initial emails were sent and we don not need to send the reminders yet' do
       initial_emails_sent_at = Time.zone.now
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
+      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       Timecop.travel(1.business_days.after(initial_emails_sent_at)) do
         expect(ucas_match.action_needed?).to eq(false)
@@ -25,6 +26,7 @@ RSpec.describe UCASMatch do
     it 'returns true if initial emails were sent and it is time to send reminder emails' do
       initial_emails_sent_at = Time.zone.now
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
+      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       Timecop.travel(5.business_days.after(initial_emails_sent_at)) do
         expect(ucas_match.action_needed?).to eq(true)
@@ -33,6 +35,7 @@ RSpec.describe UCASMatch do
 
     it 'returns false if reminder emails were sent and we don not need to request withdrawal from UCAS yet' do
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
+      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
       allow(ucas_match).to receive(:need_to_request_withdrawal_from_ucas?).and_return(false)
 
       expect(ucas_match.action_needed?).to eq(false)
@@ -40,6 +43,7 @@ RSpec.describe UCASMatch do
 
     it 'returns true if reminder emails were sent and it is time to request withdrawal from UCAS' do
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
+      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
       allow(ucas_match).to receive(:need_to_request_withdrawal_from_ucas?).and_return(true)
 
       expect(ucas_match.action_needed?).to eq(true)
@@ -47,6 +51,7 @@ RSpec.describe UCASMatch do
 
     it 'returns true if we requested withdrawal from UCAS' do
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
+      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       expect(ucas_match.action_needed?).to eq(true)
     end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.feature 'See UCAS matches' do
   include DfESignInHelpers
 
+  around do |example|
+    Timecop.freeze(Date.new(2020, 11, 2)) do
+      example.run
+    end
+  end
+
   scenario 'Support agent visits UCAS matches pages' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
@@ -21,9 +27,15 @@ RSpec.feature 'See UCAS matches' do
 
     when_i_go_to_ucas_matches_page
     when_i_follow_the_link_to_ucas_match_for_a_candidate_which_needs_an_action
-    then_i_see_what_action_is_needed
-    and_when_i_confirm_i_took_the_action
-    then_i_see_last_performed_action
+    then_i_see_that_i_need_to 'Send initial emails'
+    and_when_i_click 'Confirm initial emails were sent'
+    then_i_see_last_performed_action_is 'sent the initial emails'
+
+    given_five_working_days_passed
+    when_i_visit_the_page_again
+    then_i_see_that_i_need_to 'Send reminder emails'
+    and_when_i_click 'Confirm reminder emails were sent'
+    then_i_see_last_performed_action_is 'sent the reminder emails'
   end
 
   def given_i_am_a_support_user
@@ -134,17 +146,28 @@ RSpec.feature 'See UCAS matches' do
     click_link @candidate2.email_address
   end
 
-  def then_i_see_what_action_is_needed
-    expect(page).to have_text 'Action needed: send initial email'
-    expect(page).to have_text 'We need to contact the candidate and the provider'
+  def then_i_see_that_i_need_to(action_to_take)
+    expect(page).to have_text "Action needed #{action_to_take}"
   end
 
-  def and_when_i_confirm_i_took_the_action
-    click_button 'Confirm initial emails were sent'
+  def and_when_i_click(button_text)
+    click_button button_text
   end
 
-  def then_i_see_last_performed_action
+  def then_i_see_last_performed_action_is(action)
     expect(page).to have_content 'No action required'
-    expect(page).to have_content 'We sent the initial emails to the candidate and the providers'
+    expect(page).to have_content "We #{action}"
+  end
+
+  def given_five_working_days_passed
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 11, 9, 12, 0, 0))
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def when_i_visit_the_page_again
+    visit current_path
+    given_i_am_a_support_user
   end
 end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -42,6 +42,13 @@ RSpec.feature 'See UCAS matches' do
     then_i_see_that_i_need_to 'Request withdrawal from UCAS'
     and_when_i_click 'Confirm withdrawal from UCAS was requested'
     then_i_see_last_performed_action_is 'requested for the candidate to be removed from UCAS'
+
+    given_five_more_working_days_passed
+    when_i_visit_the_page_again
+    then_i_see_that_i_need_to 'Confirm withdrawal from UCAS'
+    and_when_i_click 'Confirm the application was withdrawn from UCAS'
+    then_i_see_last_performed_action_is 'confirmed that the candidate was withdrawn from UCAS'
+    and_then_the_match_is_processed
   end
 
   def given_i_am_a_support_user
@@ -179,8 +186,20 @@ RSpec.feature 'See UCAS matches' do
     Timecop.safe_mode = true
   end
 
+  def given_five_more_working_days_passed
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 11, 30, 12, 0, 0))
+  ensure
+    Timecop.safe_mode = true
+  end
+
   def when_i_visit_the_page_again
     visit current_path
     given_i_am_a_support_user
+  end
+
+  def and_then_the_match_is_processed
+    expect(page).to have_content 'Match marked as processed'
+    expect(page).to have_content 'Processed'
   end
 end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -41,10 +41,7 @@ RSpec.feature 'See UCAS matches' do
     when_i_visit_the_page_again
     then_i_see_that_i_need_to 'Request withdrawal from UCAS'
     and_when_i_click 'Confirm withdrawal from UCAS was requested'
-    then_i_see_last_performed_action_is 'requested for the candidate to be removed from UCAS'
 
-    given_five_more_working_days_passed
-    when_i_visit_the_page_again
     then_i_see_that_i_need_to 'Confirm withdrawal from UCAS'
     and_when_i_click 'Confirm the application was withdrawn from UCAS'
     then_i_see_last_performed_action_is 'confirmed that the candidate was withdrawn from UCAS'
@@ -182,13 +179,6 @@ RSpec.feature 'See UCAS matches' do
   def given_ten_more_working_days_passed
     Timecop.safe_mode = false
     Timecop.travel(Time.zone.local(2020, 11, 23, 12, 0, 0))
-  ensure
-    Timecop.safe_mode = true
-  end
-
-  def given_five_more_working_days_passed
-    Timecop.safe_mode = false
-    Timecop.travel(Time.zone.local(2020, 11, 30, 12, 0, 0))
   ensure
     Timecop.safe_mode = true
   end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -36,6 +36,12 @@ RSpec.feature 'See UCAS matches' do
     then_i_see_that_i_need_to 'Send reminder emails'
     and_when_i_click 'Confirm reminder emails were sent'
     then_i_see_last_performed_action_is 'sent the reminder emails'
+
+    given_ten_more_working_days_passed
+    when_i_visit_the_page_again
+    then_i_see_that_i_need_to 'Request withdrawal from UCAS'
+    and_when_i_click 'Confirm withdrawal from UCAS was requested'
+    then_i_see_last_performed_action_is 'requested for the candidate to be removed from UCAS'
   end
 
   def given_i_am_a_support_user
@@ -162,6 +168,13 @@ RSpec.feature 'See UCAS matches' do
   def given_five_working_days_passed
     Timecop.safe_mode = false
     Timecop.travel(Time.zone.local(2020, 11, 9, 12, 0, 0))
+  ensure
+    Timecop.safe_mode = true
+  end
+
+  def given_ten_more_working_days_passed
+    Timecop.safe_mode = false
+    Timecop.travel(Time.zone.local(2020, 11, 23, 12, 0, 0))
   ensure
     Timecop.safe_mode = true
   end

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -19,8 +19,6 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
     when_i_click_on_a_match
     then_i_see_the_matching_info
-    when_i_mark_the_match_as_processed
-    then_the_match_is_processed
 
     when_the_daily_download_runs_again
     then_nothing_has_happened
@@ -142,15 +140,6 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     expect(page).to have_content '999213'
     expect(page).to have_content 'XX'
     expect(page).to have_content 'XYZ'
-  end
-
-  def when_i_mark_the_match_as_processed
-    click_on 'Mark as processed'
-  end
-
-  def then_the_match_is_processed
-    expect(page).to have_content 'Match marked as processed'
-    expect(page).to have_content 'Processed'
   end
 
   def when_the_daily_download_runs_again


### PR DESCRIPTION
## Context

As a support agent,
I need to be able to record when I take actions in the process of resolving dual applications
So I can see when I need to take the next action

## Changes proposed in this pull request

Refactors existing "Send initial emails" action and adds the next actions until the dual application is resolved.
- when first flagged as "Action needed"
<kbd><img width="663" alt="Screenshot 2020-11-11 at 17 43 41" src="https://user-images.githubusercontent.com/38078064/98922319-38362b80-24ca-11eb-9478-b75fffb0a7b9.png"></kbd>
- After confirming initial emails were sent
<kbd><img width="661" alt="Screenshot 2020-11-11 at 14 43 12" src="https://user-images.githubusercontent.com/38078064/98837306-b5b25b00-243a-11eb-9e87-d33c091986a9.png"></kbd>
- After 5 working days
<kbd><img width="654" alt="Screenshot 2020-11-11 at 17 45 36" src="https://user-images.githubusercontent.com/38078064/98922262-281e4c00-24ca-11eb-92c4-6fe196727b52.png"></kbd>
- After confirming reminder emails were sent
<kbd><img width="656" alt="Screenshot 2020-11-11 at 14 45 10" src="https://user-images.githubusercontent.com/38078064/98837334-bba83c00-243a-11eb-9b28-11d45b2902a0.png"></kbd>
- After 10 working days
<kbd><img width="660" alt="Screenshot 2020-11-11 at 17 51 16" src="https://user-images.githubusercontent.com/38078064/98922178-1046c800-24ca-11eb-898e-d774a026276a.png"></kbd>
- After requesting withdrawal from UCAS
<kbd><img width="653" alt="Screenshot 2020-11-12 at 09 31 54" src="https://user-images.githubusercontent.com/38078064/98922121-002ee880-24ca-11eb-930c-21b40290a81f.png"></kbd>
- After confirming that the application was withdrawn from UCAS
<kbd><img width="667" alt="Screenshot 2020-11-11 at 14 48 23" src="https://user-images.githubusercontent.com/38078064/98837407-d37fc000-243a-11eb-95e3-f771b3b322fb.png"></kbd>

Note: When the candidate withdraws from one of the services as requested, the status on Apply is updated automatically and the status on UCAS is updated daily after receiving new matching data.
When there is no longer a dual application we display "No action required" along with the information about last action taken. This reduces support agents workload.
<kbd><img width="772" alt="Screenshot 2020-11-11 at 13 13 45" src="https://user-images.githubusercontent.com/38078064/98838382-1c844400-243c-11eb-909a-0b8a1f957a1c.png"></kbd>

## Guidance to review
- generate test applications `http://localhost:5000/support/settings/tasks` (start the app with foreman) 
- got to `/support/ucas-matches`
- click on a match without "Action needed" tag. "No action required" should be shown

- click on a match with "Action needed" tag. 
- click the action button
- change the time in the console eg `UCASMatch.find(ID).update(candidate_last_contacted_at: Time.zone.now - 6.days)`
🔁 repeat last two steps until you get to the end of the flow

Notes:
Not a massive fan of the `need_to_send_reminder_emails?` / `need_to_request_withdrawal_from_ucas` / `need_to_confirm_withdrawal_from_ucas?` methods, so any suggestions on improving them welcome! 
I considered replacing them with `need_to_perform_next_action_after?(last_action, days_wait)` but doesn't seem very readable and I don't like the idea of passing the number of days from different places. Also looked into using `TimeLimitConfig`.

## Link to Trello card

https://trello.com/c/XRWaVD60/2933-action-ucas-matches

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
