### PR TITLE
Make sure autoselect is disabled on autocompletes using showAllValues option

### DIFF
--- a/app/frontend/packs/api-token-autocomplete.js
+++ b/app/frontend/packs/api-token-autocomplete.js
@@ -9,8 +9,9 @@ const initApiTokenProviderAutocomplete = () => {
 
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: apiTokenProviderSelect,
-      showAllValues: true,
-      confirmOnBlur: false
+      autoselect: false,
+      confirmOnBlur: false,
+      showAllValues: true
     });
   } catch (err) {
     console.error("Could not enhance API token select:", err);

--- a/app/frontend/packs/api-token-autocomplete.js
+++ b/app/frontend/packs/api-token-autocomplete.js
@@ -3,12 +3,11 @@ import accessibleAutocomplete from "accessible-autocomplete";
 const initApiTokenProviderAutocomplete = () => {
   try {
     const id = "#vendor-api-token-provider-id-field.govuk-select";
-    const apiTokenProviderSelect = document.querySelector(id);
-
-    if (!apiTokenProviderSelect) return;
+    const selectElement = document.querySelector(id);
+    if (!selectElement) return;
 
     accessibleAutocomplete.enhanceSelectElement({
-      selectElement: apiTokenProviderSelect,
+      selectElement,
       autoselect: false,
       confirmOnBlur: false,
       showAllValues: true

--- a/app/frontend/packs/country-autocomplete.js
+++ b/app/frontend/packs/country-autocomplete.js
@@ -22,8 +22,9 @@ const initCountryAutocomplete = () => {
 
       accessibleAutocomplete.enhanceSelectElement({
         selectElement: select,
-        showAllValues: true,
-        confirmOnBlur: false
+        autoselect: false,
+        confirmOnBlur: false,
+        showAllValues: true
       });
     });
   } catch (err) {

--- a/app/frontend/packs/country-autocomplete.js
+++ b/app/frontend/packs/country-autocomplete.js
@@ -13,15 +13,15 @@ const initCountryAutocomplete = () => {
       "#candidate-interface-other-qualification-form-institution-country-field-error",
     ];
 
-    inputIds.forEach(inputId => {
-      const select = document.querySelector(inputId);
-      if (!select) { return; }
+    inputIds.forEach(id => {
+      const selectElement = document.querySelector(id);
+      if (!selectElement) return;
 
       // Replace "Select a country" with empty string
-      select.querySelector("[value='']").innerHTML = "";
+      selectElement.querySelector("[value='']").innerHTML = "";
 
       accessibleAutocomplete.enhanceSelectElement({
-        selectElement: select,
+        selectElement,
         autoselect: false,
         confirmOnBlur: false,
         showAllValues: true

--- a/app/frontend/packs/courses-autocomplete.js
+++ b/app/frontend/packs/courses-autocomplete.js
@@ -11,8 +11,9 @@ const initCoursesAutocomplete = () => {
 
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: coursesSelect,
-      showAllValues: true,
-      confirmOnBlur: false
+      autoselect: false,
+      confirmOnBlur: false,
+      showAllValues: true
     });
   } catch (err) {
     console.error("Could not enhance courses select:", err);

--- a/app/frontend/packs/courses-autocomplete.js
+++ b/app/frontend/packs/courses-autocomplete.js
@@ -3,14 +3,14 @@ import accessibleAutocomplete from "accessible-autocomplete";
 const initCoursesAutocomplete = () => {
   try {
     const id = "#pick-course-form .govuk-select";
-    const coursesSelect = document.querySelector(id);
-    if (!coursesSelect) return;
+    const selectElement = document.querySelector(id);
+    if (!selectElement) return;
 
     // Replace "Select a course" with empty string
-    coursesSelect.querySelector("[value='']").innerHTML = "";
+    selectElement.querySelector("[value='']").innerHTML = "";
 
     accessibleAutocomplete.enhanceSelectElement({
-      selectElement: coursesSelect,
+      selectElement,
       autoselect: false,
       confirmOnBlur: false,
       showAllValues: true

--- a/app/frontend/packs/gcse-grade-autocomplete.js
+++ b/app/frontend/packs/gcse-grade-autocomplete.js
@@ -12,12 +12,12 @@ const initGcseGradeAutocomplete = () => {
       if (!gradeSelect) return;
 
       accessibleAutocomplete.enhanceSelectElement({
-        autoselect: false,
-        defaultValue: '',
         selectElement: gradeSelect,
-        showAllValues: true,
-        showNoOptionsFound: true,
+        autoselect: false,
         confirmOnBlur: false,
+        defaultValue: '',
+        showAllValues: true,
+        showNoOptionsFound: true
       });
     });
   } catch (err) {

--- a/app/frontend/packs/gcse-grade-autocomplete.js
+++ b/app/frontend/packs/gcse-grade-autocomplete.js
@@ -8,14 +8,14 @@ const initGcseGradeAutocomplete = () => {
     ];
 
     ids.forEach(id => {
-      const gradeSelect = document.getElementById(id);
-      if (!gradeSelect) return;
+      const selectElement = document.getElementById(id);
+      if (!selectElement) return;
 
       accessibleAutocomplete.enhanceSelectElement({
-        selectElement: gradeSelect,
+        selectElement,
         autoselect: false,
         confirmOnBlur: false,
-        defaultValue: '',
+        defaultValue: "",
         showAllValues: true,
         showNoOptionsFound: true
       });

--- a/app/frontend/packs/ielts-band-score-autocomplete.js
+++ b/app/frontend/packs/ielts-band-score-autocomplete.js
@@ -12,11 +12,12 @@ const initIeltsBandScoreAutocomplete = () => {
       if (!bandScoreSelect) return;
 
       accessibleAutocomplete.enhanceSelectElement({
-        defaultValue: '',
         selectElement: bandScoreSelect,
+        autoselect: false,
+        confirmOnBlur: false,
+        defaultValue: '',
         showAllValues: true,
-        showNoOptionsFound: true,
-        confirmOnBlur: false
+        showNoOptionsFound: true
       });
 
       const accessibleAutocompleteWrapper = document.querySelector(".govuk-form-group--ielts-band-score .autocomplete__wrapper");

--- a/app/frontend/packs/ielts-band-score-autocomplete.js
+++ b/app/frontend/packs/ielts-band-score-autocomplete.js
@@ -8,14 +8,14 @@ const initIeltsBandScoreAutocomplete = () => {
     ]
 
     ids.forEach(id => {
-      const bandScoreSelect = document.querySelector(id);
-      if (!bandScoreSelect) return;
+      const selectElement = document.querySelector(id);
+      if (!selectElement) return;
 
       accessibleAutocomplete.enhanceSelectElement({
-        selectElement: bandScoreSelect,
+        selectElement,
         autoselect: false,
         confirmOnBlur: false,
-        defaultValue: '',
+        defaultValue: "",
         showAllValues: true,
         showNoOptionsFound: true
       });

--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -2,7 +2,7 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initNationalityAutocomplete = () => {
   try {
-    const nationalitySelects = [
+    const inputIds = [
       "#candidate-interface-nationalities-form-first-nationality-field",
       "#candidate-interface-nationalities-form-first-nationality-field-error",
       "#candidate-interface-nationalities-form-second-nationality-field",
@@ -13,25 +13,27 @@ const initNationalityAutocomplete = () => {
       "#candidate-interface-nationalities-form-other-nationality2-field-error",
       "#candidate-interface-nationalities-form-other-nationality3-field",
       "#candidate-interface-nationalities-form-other-nationality3-field-error",
-    ].forEach(id => {
-      const nationalitySelect = document.querySelector(id);
-      if (!nationalitySelect) return;
+    ];
 
-      const nationalitySelectValue = nationalitySelect.querySelector("[value='']");
+    inputIds.forEach(id => {
+      const selectElement = document.querySelector(id);
+      if (!selectElement) return;
 
-      if(!nationalitySelectValue) return;
+      const selectValue = selectElement.querySelector("[value='']");
+      if(!selectValue) return;
 
       // Replace "Select a nationality" with empty string
-      nationalitySelect.querySelector("[value='']").innerHTML = "";
+      selectElement.querySelector("[value='']").innerHTML = "";
 
       accessibleAutocomplete.enhanceSelectElement({
-        selectElement: nationalitySelect,
-        name: nationalitySelect.name,
+        selectElement,
+        name: selectElement.name,
         autoselect: false,
         confirmOnBlur: false,
         showAllValues: true
       });
-      nationalitySelect.name = "";
+
+      selectElement.name = "";
     });
   } catch (err) {
     console.error("Could not enhance nationality select:", err);

--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -27,8 +27,9 @@ const initNationalityAutocomplete = () => {
       accessibleAutocomplete.enhanceSelectElement({
         selectElement: nationalitySelect,
         name: nationalitySelect.name,
-        showAllValues: true,
-        confirmOnBlur: false
+        autoselect: false,
+        confirmOnBlur: false,
+        showAllValues: true
       });
       nationalitySelect.name = "";
     });

--- a/app/frontend/packs/providers-autocomplete.js
+++ b/app/frontend/packs/providers-autocomplete.js
@@ -3,14 +3,14 @@ import accessibleAutocomplete from "accessible-autocomplete";
 const initProvidersAutocomplete = () => {
   try {
     const id = "#pick-provider-form .govuk-select";
-    const providersSelect = document.querySelector(id);
-    if (!providersSelect) return;
+    const selectElement = document.querySelector(id);
+    if (!selectElement) return;
 
     // Replace "Select a provider" with empty string
-    providersSelect.querySelector("[value='']").innerHTML = "";
+    selectElement.querySelector("[value='']").innerHTML = "";
 
     accessibleAutocomplete.enhanceSelectElement({
-      selectElement: providersSelect,
+      selectElement,
       autoselect: false,
       confirmOnBlur: false,
       showAllValues: true

--- a/app/frontend/packs/providers-autocomplete.js
+++ b/app/frontend/packs/providers-autocomplete.js
@@ -11,8 +11,9 @@ const initProvidersAutocomplete = () => {
 
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: providersSelect,
-      showAllValues: true,
-      confirmOnBlur: false
+      autoselect: false,
+      confirmOnBlur: false,
+      showAllValues: true
     });
   } catch (err) {
     console.error("Could not enhance providers select:", err);


### PR DESCRIPTION
## Context

The service is using both `showAllValues` and `autoselect` - these should be mutually exclusive options as using them together will cause usability issues. `autoselect` should be false by default according to the docs, but in reality this is not the case.

## Changes proposed in this pull request

* Add `autoselect: false` to all autocompletes that have `showAllValues: true`
* Aligns the implementations where we enhance selects to use autocompletes to use the same variable names (`id`, `selectElement`, etc.( and order options after `selectElement` option alphabetically, etc.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ozg6Qw8s/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
