### PR TITLE
Do not allow render/redirect_to to be called twice in controller

### DIFF
--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -35,7 +35,7 @@ module CandidateInterface
     def complete
       @application_form = current_application
 
-      render :index if @application_form.application_choices.count.zero?
+      render :index and return if @application_form.application_choices.count.zero?
 
       if @application_form.update(application_form_params)
         redirect_to candidate_interface_application_form_path


### PR DESCRIPTION
## Context
Sentry told us that this has happened

## Changes proposed in this pull request
Return when rendering

## Guidance to review
One liner