### PR TITLE
Update diversity info and permission guidance text

### DIFF
--- a/app/components/provider_interface/diversity_information_component.rb
+++ b/app/components/provider_interface/diversity_information_component.rb
@@ -10,7 +10,7 @@ module ProviderInterface
     end
 
     def message
-      return 'The candidate disclosed information in the equality and diversity questionnaire.' if diversity_information_declared?
+      return declared_diversity_information_message if diversity_information_declared?
 
       'No information shared'
     end
@@ -21,10 +21,10 @@ module ProviderInterface
 
     def details
       if [current_user_has_permission_to_view_diversity_information?, application_in_correct_state?].all?(false)
-        return "This will become available to users with permissions to `view diversity information` when #{offer_context} offer has been accepted"
+        return "Users with permission to see this information will only be able to do so after #{offer_context} offer has been accepted by the candidate."
       end
 
-      return "You will be able to view this when #{offer_context} offer has been accepted." if current_user_has_permission_to_view_diversity_information?
+      return "You’ll only be able to see this information after #{offer_context} offer has been accepted by the candidate." if current_user_has_permission_to_view_diversity_information?
 
       'This section is only available to users with permissions to `view diversity information`.' if application_in_correct_state?
     end
@@ -76,6 +76,10 @@ module ProviderInterface
 
     def equality_and_diversity
       @equality_and_diversity ||= application_choice.application_form.equality_and_diversity
+    end
+
+    def declared_diversity_information_message
+      'The candidate disclosed information in the optional equality and diversity questionnaire. This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs).'
     end
   end
 end

--- a/config/locales/provider_relationship_permissions.yml
+++ b/config/locales/provider_relationship_permissions.yml
@@ -2,4 +2,4 @@ en:
   provider_relationship_permissions:
     make_decisions: This allows an organisation to make offers, amend offers and rejection applications
     view_safeguarding_information: "This allows an organisation to see information disclosed in the ‘criminal convictions and professional misconduct’ section of the application"
-    view_diversity_information: "This allows an organisation to see information disclosed in the ‘equality and diversity’ section of the application"
+    view_diversity_information: "This allows an organisation to see information disclosed in the ‘equality and diversity’ questionnaire. This relates to the candidate’s sex, ethnicity and disability status"

--- a/spec/components/provider_interface/diversity_information_component_spec.rb
+++ b/spec/components/provider_interface/diversity_information_component_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
         it 'displays the correct diversity information' do
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).not_to include('The candidate disclosed information in the equality and diversity questionare.')
+          expect(result.text).not_to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
+          expect(result.text).not_to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
           expect(result.text).to include('Sex')
           expect(result.text).to include('Male')
           expect(result.text).to include('Ethnic group')
@@ -128,7 +129,8 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: false)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the equality and diversity questionnaire.')
+          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
+          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
           expect(result.text).to include('This section is only available to users with permissions to `view diversity information`.')
         end
       end
@@ -141,7 +143,8 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
           )
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the equality and diversity questionnaire.')
+          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
+          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
           expect(result.text).to include('This section is only available to users with permissions to `view diversity information`.')
         end
       end
@@ -162,8 +165,9 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: true)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the equality and diversity questionnaire.')
-          expect(result.text).to include('You will be able to view this when an offer has been accepted.')
+          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
+          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
+          expect(result.text).to include('You’ll only be able to see this information after an offer has been accepted by the candidate.')
         end
       end
 
@@ -173,8 +177,9 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: false)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the equality and diversity questionnaire.')
-          expect(result.text).to include('This will become available to users with permissions to `view diversity information` when an offer has been accepted')
+          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
+          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
+          expect(result.text).to include(' Users with permission to see this information will only be able to do so after an offer has been accepted by the candidate')
         end
       end
 
@@ -187,8 +192,9 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
 
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('The candidate disclosed information in the equality and diversity questionnaire.')
-          expect(result.text).to include('This will become available to users with permissions to `view diversity information` when an offer has been accepted')
+          expect(result.text).to include('The candidate disclosed information in the optional equality and diversity questionnaire.')
+          expect(result.text).to include('This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)')
+          expect(result.text).to include('Users with permission to see this information will only be able to do so after an offer has been accepted by the candidate')
         end
       end
     end
@@ -208,7 +214,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: true)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('You will be able to view this when your offer has been accepted.')
+          expect(result.text).to include('You’ll only be able to see this information after your offer has been accepted by the candidate')
         end
       end
 
@@ -218,7 +224,7 @@ RSpec.describe ProviderInterface::DiversityInformationComponent do
             .update!(view_diversity_information: false)
           result = render_inline(described_class.new(application_choice: application_choice, current_provider_user: provider_user))
 
-          expect(result.text).to include('This will become available to users with permissions to `view diversity information` when your offer has been accepted')
+          expect(result.text).to include('Users with permission to see this information will only be able to do so after your offer has been accepted by the candidate')
         end
       end
     end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -263,7 +263,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   def and_i_should_see_diversity_information_section
-    expect(page).to have_content 'The candidate disclosed information in the equality and diversity questionnaire.'
+    expect(page).to have_content 'The candidate disclosed information in the optional equality and diversity questionnaire.'
+    expect(page).to have_content 'This relates to their sex, ethnicity and disability status. We collect this data to help reduce discrimination on these grounds. (This is not the same as the information we request relating to the candidate’s disability, access and other needs)'
   end
 
   def and_i_should_see_a_link_to_download_as_pdf


### PR DESCRIPTION
## Context

Update text in diversity_information_component and in the permission setup flow

## Changes proposed in this pull request

#### Before 
<img width="693" alt="before-no-permissions" src="https://user-images.githubusercontent.com/159200/98922757-c1e5f900-24ca-11eb-8586-a293192647e2.png">
No permissions

<img width="681" alt="before-with-permissions" src="https://user-images.githubusercontent.com/159200/98922769-c6121680-24ca-11eb-85f9-53aea9167790.png">
With permissions

<img width="698" alt="who-can-view-div-info-before" src="https://user-images.githubusercontent.com/159200/98925799-5bfb7080-24ce-11eb-8dde-746303ca16d3.png">
Permission flow

#### After

<img width="769" alt="after-no-permissions" src="https://user-images.githubusercontent.com/159200/98922972-feb1f000-24ca-11eb-990d-c9fff9a45d49.png">
No permissions

<img width="707" alt="after-with-permissions" src="https://user-images.githubusercontent.com/159200/98922980-01144a00-24cb-11eb-85bf-cb5cffa6e68e.png">
With permissions

<img width="708" alt="who-can-view-div-info-after" src="https://user-images.githubusercontent.com/159200/98925828-64ec4200-24ce-11eb-855f-2bf067af27a0.png">
Permission flow

## Link to Trello card

https://trello.com/c/BrbI9u3P/2979-iterate-guidance-around-diversity-information-and-the-associated-permission

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
