### PR TITLE
Add candidate_id to submitted app choices export

### DIFF
--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -20,6 +20,7 @@ module SupportInterface
             offer_response: offer_response_interpretation(choice: choice),
             offer_response_at: choice.accepted_at || choice.declined_at,
             rejection_reason: choice.rejection_reason,
+            candidate_id: application_form.candidate_id,
           }
         end
       end

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -4,6 +4,7 @@ module SupportInterface
       relevant_applications.flat_map do |application_form|
         application_form.application_choices.map do |choice|
           {
+            candidate_id: application_form.candidate_id,
             recruitment_cycle_year: application_form.recruitment_cycle_year,
             support_reference: application_form.support_reference,
             phase: application_form.phase,
@@ -20,7 +21,6 @@ module SupportInterface
             offer_response: offer_response_interpretation(choice: choice),
             offer_response_at: choice.accepted_at || choice.declined_at,
             rejection_reason: choice.rejection_reason,
-            candidate_id: application_form.candidate_id,
           }
         end
       end

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           offer_response: nil,
           offer_response_at: nil,
           rejection_reason: nil,
+          candidate_id: submitted_form.candidate_id,
         },
         {
           recruitment_cycle_year: submitted_form.recruitment_cycle_year,
@@ -46,6 +47,7 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           offer_response: nil,
           offer_response_at: nil,
           rejection_reason: nil,
+          candidate_id: submitted_form.candidate_id,
         },
       )
     end

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
 
       expect(choices).to contain_exactly(
         {
+          candidate_id: submitted_form.candidate_id,
           recruitment_cycle_year: submitted_form.recruitment_cycle_year,
           support_reference: submitted_form.support_reference,
           phase: submitted_form.phase,
@@ -28,9 +29,9 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           offer_response: nil,
           offer_response_at: nil,
           rejection_reason: nil,
-          candidate_id: submitted_form.candidate_id,
         },
         {
+          candidate_id: submitted_form.candidate_id,
           recruitment_cycle_year: submitted_form.recruitment_cycle_year,
           support_reference: submitted_form.support_reference,
           phase: submitted_form.phase,
@@ -47,7 +48,6 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           offer_response: nil,
           offer_response_at: nil,
           rejection_reason: nil,
-          candidate_id: submitted_form.candidate_id,
         },
       )
     end


### PR DESCRIPTION
## Context

As a PA I need to know which candidates made applications so that I can track repeat apply again applications.

## Changes proposed in this pull request

- Add `candidate_id` to query and update specs.

## Guidance to review

- Should be possible to test the review application to ensure that the new column is there.

## Link to Trello card

https://trello.com/c/I5AhddN4/2496-add-candidate-id-to-submitted-application-choices-data-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
