### PR TITLE
Add Application status to Equality & Diversity data export

### DIFF
--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -8,6 +8,7 @@ module SupportInterface
           'Sex' => application_form.equality_and_diversity['sex'],
           'Ethnic group' => application_form.equality_and_diversity['ethnic_group'],
           'Ethnic background' => application_form.equality_and_diversity['ethnic_background'],
+          'Application status' => I18n.t!("candidate_flow_application_states.#{ProcessState.new(application_form).state}.name"),
         }
 
         disabilities = application_form.equality_and_diversity['disabilities']
@@ -28,7 +29,8 @@ module SupportInterface
 
     def application_forms
       ApplicationForm
-        .select(:submitted_at, :recruitment_cycle_year, :equality_and_diversity)
+        .select(:submitted_at, :recruitment_cycle_year, :equality_and_diversity, :created_at, :updated_at)
+        .includes(:application_choices)
         .where.not(equality_and_diversity: nil)
     end
   end

--- a/spec/services/support_interface/equality_and_diversity_export_spec.rb
+++ b/spec/services/support_interface/equality_and_diversity_export_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           'Ethnic group' => application_form_one.equality_and_diversity['ethnic_group'],
           'Disability 1' => application_form_one.equality_and_diversity['disabilities'].first,
           'Disability 2' => application_form_one.equality_and_diversity['disabilities'].last,
+          'Application status' => 'Have not started form',
         },
         {
           'Month' => application_form_two.submitted_at&.strftime('%B'),
@@ -35,6 +36,7 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           'Ethnic background' => application_form_two.equality_and_diversity['ethnic_background'],
           'Ethnic group' => application_form_two.equality_and_diversity['ethnic_group'],
           'Disability 1' => application_form_two.equality_and_diversity['disabilities'].first,
+          'Application status' => 'Have not started form',
         },
       )
     end


### PR DESCRIPTION
## Context

As a PA I need to know the outcome of the applications of each respondent to the E&D survey so that I can report on this and potential pain-points/ options.

## Changes proposed in this pull request

- Add application status (using `ProcessStatus`) to response and update specs.
- Update query to avoid 1+n issue.

Sample response:
```
Month,Recruitment cycle year,Sex,Ethnic group,Ethnic background,Application status,Disability 1,Disability 2,Disability 3
October,2021,Prefer not to say,Mixed or multiple ethnic groups,Black Caribbean and White,Form started but unsubmitted,Blind,Deaf,Mental health condition
October,2021,male,Mixed or multiple ethnic groups,Black African and White,Form started but unsubmitted,Social or communication impairment,Mental health condition,Deaf
,2021,female,"Black, African, Black British or Caribbean",African,Form started but unsubmitted,Mental health condition,Blind,Physical disability or mobility issue
```

## Guidance to review

- Should be possible to test the review application to ensure that the new column is there.

## Link to Trello card

https://trello.com/c/QTzzTe8E/2499-add-application-status-to-ed-data-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
