### PR TITLE
Filter UCAS matches by Action needed

### DIFF
--- a/app/models/support_interface/ucas_matches_filter.rb
+++ b/app/models/support_interface/ucas_matches_filter.rb
@@ -11,11 +11,16 @@ module SupportInterface
         ucas_matches = ucas_matches.where('recruitment_cycle_year IN (?)', applied_filters[:years])
       end
 
+      if applied_filters[:action_needed]&.include?('yes')
+        action_needed_ids = ucas_matches.select(&:action_needed?).map(&:id)
+        ucas_matches = ucas_matches.where(id: action_needed_ids)
+      end
+
       ucas_matches
     end
 
     def filters
-      [year_filter]
+      @filters ||= [year_filter] + [action_needed_filter]
     end
 
   private
@@ -34,6 +39,19 @@ module SupportInterface
         heading: 'Recruitment cycle year',
         name: 'years',
         options: cycle_options,
+      }
+    end
+
+    def action_needed_filter
+      {
+        type: :checkboxes,
+        heading: 'Action needed',
+        name: 'action_needed',
+        options: [{
+          value: 'yes',
+          label: 'Yes',
+          checked: applied_filters[:action_needed]&.include?('yes'),
+        }],
       }
     end
   end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -20,6 +20,10 @@ RSpec.feature 'See UCAS matches' do
     then_i_should_see_ucas_match_summary
 
     when_i_go_to_ucas_matches_page
+    when_i_filter_by_action_needed
+    then_i_only_see_matches_that_need_action
+    and_i_expect_the_relevant_action_needed_tags_to_be_visible
+
     when_i_follow_the_link_to_ucas_match_for_a_candidate_which_needs_an_action
     then_i_see_what_action_is_needed
     and_when_i_confirm_i_took_the_action
@@ -128,6 +132,20 @@ RSpec.feature 'See UCAS matches' do
     end
 
     expect(page).to have_content('This applicant has applied to the same course on both services.')
+  end
+
+  def when_i_filter_by_action_needed
+    find(:css, '#action_needed-yes').set(true)
+    click_button('Apply filters')
+  end
+
+  def then_i_only_see_matches_that_need_action
+    expect(page).to have_content(@candidate2.email_address)
+    expect(page).not_to have_content(@candidate.email_address)
+  end
+
+  def and_i_expect_the_relevant_action_needed_tags_to_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: 'Yes')
   end
 
   def when_i_follow_the_link_to_ucas_match_for_a_candidate_which_needs_an_action


### PR DESCRIPTION
## Context

With the increasing number of UCAS matches support agents need to be able to quickly see which ones require their actions.

## Changes proposed in this pull request

<img width="676" alt="Screenshot 2020-11-12 at 13 32 03" src="https://user-images.githubusercontent.com/38078064/98948840-ddfb9180-24ee-11eb-8ecb-bd8bdd22443d.png">


## Guidance to review

- visit `/support/ucas-matches`
- apply filters

## Link to Trello card

https://trello.com/c/B81XXk56/3010-filter-ucas-matches-by-action-needed-flag

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
