### PR TITLE
Add provider contact details to UCAS match

### DIFF
--- a/app/components/support_interface/ucas_match_table_component.html.erb
+++ b/app/components/support_interface/ucas_match_table_component.html.erb
@@ -14,7 +14,28 @@
     <% table_rows.each do |table_row| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= table_row[:course_code] %></td>
-        <td class="govuk-table__cell"><%= table_row[:course_details] %></td>
+        <td class="govuk-table__cell">
+          <%= table_row[:course_details] %>
+          <% if table_row[:course_provider_contacts].any? %>
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Contact details
+                </span>
+              </summary>
+              <div class="govuk-details__text govuk-!-padding-bottom-0">
+                <% table_row[:course_provider_contacts].each do |provider_contact| %>
+                  <dl class="app-provider_contacts_list govuk-!-margin-0 govuk-!-padding-bottom-2">
+                    <dt class="govuk-visually-hidden">Full name</dt>
+                    <dd class="govuk-heading-s govuk-!-margin-0"><%= provider_contact.full_name %></dd>
+                    <dt class="govuk-visually-hidden">email address</dt>
+                    <dd class="govuk-body govuk-!-margin-0"><%= provider_contact.email_address %></dd>
+                  </dl>
+                <% end %>
+              </div>
+            </details>
+          <% end %>
+        </td>
         <td class="govuk-table__cell">
           <% if table_row[:status_on_ucas] == 'N/A' %>
             N/A

--- a/app/components/support_interface/ucas_match_table_component.rb
+++ b/app/components/support_interface/ucas_match_table_component.rb
@@ -12,6 +12,7 @@ module SupportInterface
         row_data = {
           course_code: course_code(course),
           course_details: course_details(course),
+          course_provider_contacts: course_provider_contacts(course),
         }
 
         matched_applications_for_course(course).each do |ucas_matched_application|
@@ -57,6 +58,12 @@ module SupportInterface
 
     def course_details(course)
       "#{course.name} – #{course.provider&.name || 'Provider not on Apply'}"
+    end
+
+    def course_provider_contacts(course)
+      return [] if course.provider.blank?
+
+      course.provider.provider_users.select { |u| u.provider_permissions.map(&:manage_users).any? }
     end
   end
 end

--- a/spec/components/support_interface/ucas_match_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_table_component_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe SupportInterface::UCASMatchTableComponent do
     expect(result.css('td')[1].text).to include("#{course.name} – #{course.provider.name}")
   end
 
+  it 'renders course provider contact details for a course on Apply' do
+    provider_user = create(:provider_user, :with_manage_users, providers: [course.provider])
+    result = render_inline(described_class.new(ucas_match))
+
+    expect(result.css('td')[1].text).to include('Contact details')
+    expect(result.css('td')[1].text).to include(provider_user.full_name)
+    expect(result.css('td')[1].text).to include(provider_user.email_address)
+  end
+
   it 'renders course choice details for a course not on Apply' do
     result = render_inline(described_class.new(ucas_match_course_only_on_ucas))
 


### PR DESCRIPTION
## Context

Exposing provider user contact details so that support agents can easily get in touch with them as part of resolving dual applications.

## Changes proposed in this pull request

#### Before
<img width="1072" alt="before" src="https://user-images.githubusercontent.com/159200/99066798-76524e80-25a1-11eb-9173-8e080fa16353.png">

#### After
<img width="1019" alt="after-collapsed" src="https://user-images.githubusercontent.com/159200/99066103-579f8800-25a0-11eb-93f1-dcfecd251bd7.png">
Collapsed

<img width="1069" alt="after-expanded-amended" src="https://user-images.githubusercontent.com/159200/99269345-2af8a400-281e-11eb-9f55-76201ee0029a.png">
Expanded


## Guidance to review

Navigate to http://localhost:3000/support/ucas-matches and select a UCAS match.
You should be able to see this change under Course Choices

## Link to Trello card

https://trello.com/c/sg3H1Wp0/3016-add-provider-contact-details-to-ucas-match-pages

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
