### PR TITLE
Send slack notifications with a number of matches which need action 

### DIFF
--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -117,7 +117,7 @@ module UCASMatching
       existing_matches_string = "#{existing_matches} #{'match'.pluralize(existing_matches)}"
 
       message = ":dfe: :ucas: Hello, this is the Apply/UCAS matching robot. I’ve just received a new file from UCAS. It contained #{new_matches_string}, #{updated_matches_string}, and #{existing_matches_string} we’ve already seen."
-      url = Rails.application.routes.url_helpers.support_interface_ucas_matches_url
+      url = Rails.application.routes.url_helpers.support_interface_ucas_matches_url(years: RecruitmentCycle.current_year)
       SlackNotificationWorker.perform_async(message, url)
     end
   end

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -119,6 +119,16 @@ module UCASMatching
       message = ":dfe: :ucas: Hello, this is the Apply/UCAS matching robot. I’ve just received a new file from UCAS. It contained #{new_matches_string}, #{updated_matches_string}, and #{existing_matches_string} we’ve already seen."
       url = Rails.application.routes.url_helpers.support_interface_ucas_matches_url(years: RecruitmentCycle.current_year)
       SlackNotificationWorker.perform_async(message, url)
+
+      send_action_needed_slack_notification
+    end
+
+    def send_action_needed_slack_notification
+      action_needed_matches = UCASMatch.select(&:action_needed?).count
+      action_needed_matches_string = ":dfe: :ucas: We have #{action_needed_matches} #{'match'.pluralize(action_needed_matches)} requiring action."
+      action_needed_message = action_needed_matches.zero? ? ':relaxed: No matches require an action' : action_needed_matches_string
+      action_needed_url = Rails.application.routes.url_helpers.support_interface_ucas_matches_url(action_needed: 'yes')
+      SlackNotificationWorker.perform_async(action_needed_message, action_needed_url)
     end
   end
 end

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -112,6 +112,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def then_we_have_received_a_slack_message
     expect_slack_message_with_text('It contained 1 new match, 1 updated match, and 1 match we’ve already seen.')
+    expect_slack_message_with_text('We have 1 match requiring action.')
   end
 
   def when_i_visit_the_ucas_matches_page_in_support


### PR DESCRIPTION
## Context
```
As a busy support agent,
I need to know if there are UCAS matches that require my action,
so I don't waste my time checking matches page if there is nothing for me to do
```
## Changes proposed in this pull request

Adds a slack notification with a number of UCAS matches which are flagged as "Action needed".
It link to UCAS matches page with filter `Action needed: Yes` filter applied.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/lGgZl1zD/3015-send-slack-notifications-when-ucas-matches-need-action

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
