### PR TITLE
Add data export for feedback provided by candidates while completing the application form 

### DIFF
--- a/app/models/application_feedback.rb
+++ b/app/models/application_feedback.rb
@@ -1,5 +1,6 @@
 class ApplicationFeedback < ApplicationRecord
   self.table_name = 'application_feedback'
   belongs_to :application_form, touch: true
+  has_one :candidate, through: :application_form
   serialize :section
 end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -25,6 +25,11 @@ class DataExport < ApplicationRecord
       description: 'This provides the compiled results of all the referee surveys.',
       class: SupportInterface::RefereeSurveyExport,
     },
+    candidate_application_feedback: {
+      name: 'Candidate application feedback',
+      description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
+      class: SupportInterface::CandidateApplicationFeedbackExport,
+    },
     candidate_survey: {
       name: 'Candidate survey',
       description: 'This provides the compiled results of all the multi-page candidate satisfaction surveys.',

--- a/app/services/support_interface/candidate_application_feedback_export.rb
+++ b/app/services/support_interface/candidate_application_feedback_export.rb
@@ -1,0 +1,30 @@
+module SupportInterface
+  class CandidateApplicationFeedbackExport
+    def data_for_export
+      application_feedback.map do |feedback|
+        {
+          'Name' => feedback.application_form.full_name,
+          'Recruitment cycle year' => feedback.application_form.recruitment_cycle_year,
+          'Email_address' => feedback.application_form.candidate.email_address,
+          'Phone number' => feedback.application_form.phone_number,
+          'Submitted at' => feedback.created_at.iso8601,
+          'Path' => feedback.path,
+          'Page title' => feedback.page_title,
+          'Understood the section' => !feedback.does_not_understand_section,
+          'Needed more information' => feedback.need_more_information,
+          'Answer does not fit the format' => feedback.answer_does_not_fit_format,
+          'Other feedback' => feedback.other_feedback,
+          'Consent to be contacted' => feedback.consent_to_be_contacted,
+        }
+      end
+    end
+
+  private
+
+    def application_feedback
+      ApplicationFeedback.all.includes(%i[application_form candidate]).sort_by do |feedback|
+        feedback.application_form.full_name
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/application_feedback/new.html.erb
+++ b/app/views/candidate_interface/application_feedback/new.html.erb
@@ -4,6 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_feedback_form, url: candidate_interface_application_feedback_path, method: :post do |f| %>
+     <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.application_feedback') %>

--- a/spec/services/support_interface/candidate_application_feedback_export_spec.rb
+++ b/spec/services/support_interface/candidate_application_feedback_export_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CandidateApplicationFeedbackExport do
+  describe '#data_for_export' do
+    it 'returns a hash of candidates satisfaction survey answers' do
+      application_form1 = create(:application_form, first_name: 'Theo')
+      application_form2 = create(:application_form, first_name: 'Vararu')
+      application_feedback1 = create(:application_feedback, application_form: application_form1)
+      application_feedback2 = create(:application_feedback, application_form: application_form2)
+      application_feedback3 = create(:application_feedback, application_form: application_form1)
+
+      expect(described_class.new.data_for_export).to eql([
+        expected_hash(application_feedback1),
+        expected_hash(application_feedback3),
+        expected_hash(application_feedback2),
+      ])
+    end
+  end
+
+private
+
+  def expected_hash(application_feedback)
+    {
+      'Name' => application_feedback.application_form.full_name,
+      'Recruitment cycle year' => application_feedback.application_form.recruitment_cycle_year,
+      'Email_address' => application_feedback.application_form.candidate.email_address,
+      'Phone number' => application_feedback.application_form.phone_number,
+      'Submitted at' => application_feedback.created_at.iso8601,
+      'Path' => application_feedback.path,
+      'Page title' => application_feedback.page_title,
+      'Understood the section' => !application_feedback.does_not_understand_section,
+      'Needed more information' => application_feedback.need_more_information,
+      'Answer does not fit the format' => application_feedback.answer_does_not_fit_format,
+      'Other feedback' => application_feedback.other_feedback,
+      'Consent to be contacted' => application_feedback.consent_to_be_contacted,
+    }
+  end
+end


### PR DESCRIPTION
## Context

Previous pr - #3403

Candidates are now able to provide feedback throughout the application form. This is an export for the feedback provided. 

## Changes proposed in this pull request

- Add an additional data export to the support section for candidates feedback

## Link to Trello card

https://trello.com/c/oMqauVfv/2503-%F0%9F%93%9D-dev-data-export-for-candidate-feeedback-prompts

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
