### PR TITLE
Amend HESAITTData disability field documentation

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+### 13th November 2020
+
+Documentation has been amended to indicate that `disability` is an array and not a string
+
 ### 9th November 2020
 
 New attributes:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -1068,10 +1068,14 @@ components:
           - "2"
           - "3"
         disability:
-          type: string
           nullable: true
-          description: The candidate’s disability as [a 2-digit HESA code for Disability](https://www.hesa.ac.uk/collection/c19053/e/disable)
-          example: "00"
+          type: array
+          items:
+            type: string
+          description: The candidate's disabilities as an array of [2-digit HESA codes for Disability](https://www.hesa.ac.uk/collection/c19053/e/disable)
+          example:
+            - "00"
+            - "51"
           enum:
           - "00"
           - "08"


### PR DESCRIPTION
## Context

Amend HESAITTData disability field documentation to indicate that field is an array and not a string

## Link to Trello card

https://trello.com/c/bZRoY1Xx/2879-api-docs-say-hesa-disability-data-is-an-string-when-actually-its-an-array

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
