### PR TITLE
Slack: consolidate offer-accepted message, comma off thousands

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -62,7 +62,7 @@ class StateChangeNotifier
   end
 
   def self.send(text, url)
-    if RequestStore.store[:disable_slack_messages]
+    if RequestStore.store[:disable_state_change_notifications]
       Rails.logger.info "Sending Slack messages disabled (message: `#{text}`)"
       return
     end
@@ -72,5 +72,11 @@ class StateChangeNotifier
 
   def self.helpers
     Rails.application.routes.url_helpers
+  end
+
+  def self.disable_notifications
+    RequestStore.store[:disable_state_change_notifications] = true
+    yield
+    RequestStore.store[:disable_state_change_notifications] = false
   end
 end

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -5,10 +5,13 @@ class StateChangeNotifier
     return unless (candidate_number % 25).zero?
 
     candidate_number_is_significant = (candidate_number % 100).zero?
+
+    human_readable_number = "#{ActiveSupport::NumberHelper.number_to_delimited(candidate_number)}#{candidate_number.ordinal}"
+
     text = if candidate_number_is_significant
-             ":ultrafastparrot: The #{candidate_number.ordinalize} candidate just signed up"
+             ":ultrafastparrot: The #{human_readable_number} candidate just signed up"
            else
-             ":sparkles: The #{candidate_number.ordinalize} candidate just signed up"
+             ":sparkles: The #{human_readable_number} candidate just signed up"
            end
 
     url = helpers.support_interface_candidate_url(candidate)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -114,7 +114,7 @@ class TestApplications
         return
       end
 
-      without_slack_message_sending do
+      StateChangeNotifier.disable_notifications do
         fast_forward
         SubmitApplication.new(@application_form).call
 
@@ -340,12 +340,6 @@ class TestApplications
     Audited.audit_class.as_user(provider_user(choice)) do
       yield
     end
-  end
-
-  def without_slack_message_sending
-    RequestStore.store[:disable_slack_messages] = true
-    yield
-    RequestStore.store[:disable_slack_messages] = false
   end
 
   def initialize_time(recruitment_cycle_year)

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -4,16 +4,23 @@ class AcceptOffer
   end
 
   def save!
+    declined = []
+    withdrawn = []
+
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).accept!
       @application_choice.update!(accepted_at: Time.zone.now)
 
-      other_application_choices_with_offers.each do |other_application_choice|
-        DeclineOffer.new(application_choice: other_application_choice).save!
-      end
+      StateChangeNotifier.disable_notifications do
+        other_application_choices_with_offers.each do |application_choice|
+          DeclineOffer.new(application_choice: application_choice).save!
+          declined << application_choice
+        end
 
-      application_choices_awaiting_provider_decision.each do |application_choices|
-        WithdrawApplication.new(application_choice: application_choices).save!
+        application_choices_awaiting_provider_decision.each do |application_choice|
+          WithdrawApplication.new(application_choice: application_choice).save!
+          withdrawn << application_choice
+        end
       end
     end
 
@@ -23,7 +30,7 @@ class AcceptOffer
 
     CandidateMailer.offer_accepted(@application_choice).deliver_later
 
-    StateChangeNotifier.call(:offer_accepted, application_choice: @application_choice)
+    StateChangeNotifier.accept_offer(accepted: @application_choice, declined: declined, withdrawn: withdrawn)
   end
 
 private

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -39,7 +39,7 @@ class GenerateTestApplications
     create recruitment_cycle_year: 2021, states: %i[conditions_not_met]
     create recruitment_cycle_year: 2021, states: %i[withdrawn]
 
-    without_slack_message_sending do
+    StateChangeNotifier.disable_notifications do
       RejectApplicationsByDefault.new.call
     end
   end
@@ -68,11 +68,5 @@ private
 
   def dev_support_user
     @dev_support_user ||= ProviderUser.find_by_dfe_sign_in_uid('dev-support')
-  end
-
-  def without_slack_message_sending
-    RequestStore.store[:disable_slack_messages] = true
-    yield
-    RequestStore.store[:disable_slack_messages] = false
   end
 end

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -99,6 +99,40 @@ RSpec.describe StateChangeNotifier do
     end
   end
 
+  describe '.sign_up' do
+    let(:candidate_count) { 0 }
+
+    before do
+      fake_relation = instance_double('ActiveRecord::Relation', count: candidate_count)
+      allow(Candidate).to receive(:where).and_return fake_relation
+      StateChangeNotifier.sign_up(create(:candidate))
+    end
+
+    context 'every 25th candidate' do
+      let(:candidate_count) { 25 }
+
+      it 'reports the sign up' do
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(/sparkles.+25th candidate/, anything)
+      end
+    end
+
+    context 'every 100th candidate' do
+      let(:candidate_count) { 100 }
+
+      it 'reports the sign up' do
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(/ultrafastparrot.+100th candidate/, anything)
+      end
+    end
+
+    context 'counts over 1000' do
+      let(:candidate_count) { 1500 }
+
+      it 'reports the sign up' do
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(/1,500th candidate/, anything)
+      end
+    end
+  end
+
   describe '.accept_offer' do
     let(:application_form) { create(:application_form, first_name: 'Leah') }
     let(:provider) { create(:provider, name: 'UCL') }

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -92,7 +92,15 @@ RSpec.feature 'Candidate accepts an offer' do
   end
 
   def then_a_slack_notification_is_sent
-    expect_slack_message_with_text "Harry has accepted #{@course_option.course.provider.name}’s offer"
+    accepted_course = @course_option.course
+    declined_course = @other_application_choice.course_option.course
+    withdrawn_course = @third_application_choice.course_option.course
+
+    expected_message = "Harry has accepted #{accepted_course.provider.name}’s offer for #{accepted_course.name_and_code}, " \
+      "withdrawn their application for #{withdrawn_course.name_and_code} at #{withdrawn_course.provider.name}, and " \
+      "declined #{declined_course.provider.name}’s offer for #{declined_course.name_and_code}"
+
+    expect_slack_message_with_text expected_message
   end
 
   def and_i_see_that_i_accepted_the_offer


### PR DESCRIPTION
## Context

We get up to three messages per offer acceptance in Slack, as the candidate might automatically decline and withdraw at the same time.

Also, numbers in the thousands are difficult to read without commas, and we'll soon hit 10,000 candidates (!).

## Changes proposed in this pull request

- Move the `without_slack_message_sending` method onto `StateChangeNotifier` where it belongs and give it a better name
- Consolidate the offer-accepted message
- Comma off thousands

I think `offer accepted` and `application sent to provider` are the only state changes entailing multiple messages, so I didn't make a generic `buffer_slack_messages` method. (That might be been usable in both cases but the messages would have been less readable without some fiddly extra work of the sort already in this PR but more unpleasantly generic).

## Guidance to review

Tests should prove it works 🤞

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
