### PR TITLE
Add GCSE Science Triple Award grades to Vendor API

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -207,13 +207,35 @@ module VendorAPI
         qualification_type: qualification.qualification_type,
         non_uk_qualification_type: qualification.non_uk_qualification_type,
         subject: qualification.subject,
-        grade: "#{qualification.grade}#{' (Predicted)' if qualification.predicted_grade}",
+        grade: grade_details(qualification),
         start_year: qualification.start_year,
         award_year: qualification.award_year,
         institution_details: institution_details(qualification),
         awarding_body: qualification.awarding_body,
         equivalency_details: composite_equivalency_details(qualification),
       }.merge HesaQualificationFieldsPresenter.new(qualification).to_hash
+    end
+
+    def grade_details(qualification)
+      grade = nil
+
+      if qualification.grade
+        if qualification.predicted_grade
+          grade = "#{qualification.grade} (Predicted)"
+        else
+          grade = qualification.grade
+        end
+      end
+
+      grades = qualification.grades
+
+      # We need to serialize 'grades' to the 'grade' field
+      # in the specified order
+      if qualification.subject == 'science triple award' && grades
+        grade = "#{grades['biology']}#{grades['chemistry']}#{grades['physics']}"
+      end
+
+      grade
     end
 
     def composite_equivalency_details(qualification)

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,8 @@
+### 16th November 2020
+- The `Qualification` `grade` field will now be populated with GCSE Science triple award information
+  in the following format, where present:
+  `[biology_grade][chemistry_grade][physics_grade]` e.g 'ABC'
+
 ### 13th November 2020
 
 Documentation has been amended to indicate that `disability` is an array and not a string

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -777,7 +777,10 @@ components:
           type: string
           maxLength: 256
           description: The grade awarded
-          example: "2:1"
+          example:
+          - 2:1 (University degree)
+          - A* (GSCE grade in a single subject)
+          - A*A*A (GCSE Science triple award, where grades are for Biology, Chemistry and Physics, respectively)
         start_year:
           type: string
           nullable: true

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -445,6 +445,30 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       expect(qualification[:non_uk_qualification_type]).to eq 'High School Diploma'
     end
+
+    it 'adds GCSE science triple award information' do
+      science_triple_awards = {
+        biology: 'A',
+        chemistry: 'B',
+        physics: 'C',
+      }
+
+      create(
+        :gcse_qualification,
+        grade: nil,
+        subject: 'science triple award',
+        grades: science_triple_awards,
+        application_form: application_choice.application_form,
+      )
+
+      qualification = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :gcses,
+      ).find { |q| q[:subject] == 'science triple award' }
+
+      expect(qualification[:grade]).to eq 'ABC'
+    end
   end
 
   describe 'attributes.offer' do


### PR DESCRIPTION
## Context

A candidate can now enter grades for their GCSE Science triple award. See [🏈 Allow candidates to enter multiple science GCSEs.](https://trello.com/c/jJPtfRY3/1779-%F0%9F%8F%88-allow-candidates-to-enter-multiple-science-gcses)

We need to make this info available in the ProVendor API

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- When a user has a GCSE Science Triple Award we serialize the ‘grades’ column (JSON blob) to the ‘grade’ field as a combined string, e.g. 'ABC' (the order is Biology grade, Chemistry grade then Physics grade)

## Guidance to review

- Does the [guidance added to vendor-api-v1.yml ](https://github.com/DFE-Digital/apply-for-teacher-training/pull/3415/files#diff-0412a6ac7e64144cf133eb0787d2f3da57ff826bcf21a6904a774f7ac3d36cc5R780-R783)make sense?

## Link to Trello card

https://trello.com/c/DbLecIGk/2539-make-gcse-triple-award-science-info-available-in-provendor-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
