### PR TITLE
Provide more representative references for test applications

### DIFF
--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -121,24 +121,14 @@ RSpec.describe TestApplications do
   end
 
   describe 'reference completion' do
-    it 'completes all references for unsubmitted_with_completed_references applications' do
+    it 'generates a representative collection of references' do
       courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[unsubmitted_with_completed_references], courses_to_apply_to: courses_we_want).first
+      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], courses_to_apply_to: courses_we_want).first
 
       references = application_choice.application_form.application_references
 
-      expect(references.all?(&:feedback_provided?)).to be true
-    end
-
-    it 'completes all references for other types of application' do
-      courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
-
-      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision offer], courses_to_apply_to: courses_we_want).first
-
-      references = application_choice.application_form.application_references
-
-      expect(references.all?(&:feedback_provided?)).to be true
+      expect(references.map(&:feedback_status)).to match_array(%w[not_requested_yet feedback_refused feedback_provided feedback_provided cancelled])
     end
 
     it 'does not complete any references for unsubmitted applications' do
@@ -148,7 +138,7 @@ RSpec.describe TestApplications do
 
       references = application_choice.application_form.application_references
 
-      expect(references.all?(&:feedback_requested?)).to be true
+      expect(references.map(&:feedback_status)).to match_array(%w[not_requested_yet feedback_requested feedback_requested feedback_requested feedback_requested])
     end
   end
 end


### PR DESCRIPTION
## Context

Working on an issue where there are too many references for some applications. Our test data for references isn't very realistic at the moment.

## Changes proposed in this pull request

This provides every application with the following references:

- 1 unrequested reference
- 1 reference declined by the referee
- 2 references where feedback is provided
- 1 reference that is automatically cancelled because there are already 2 references with feedback

![image](https://user-images.githubusercontent.com/233676/99252033-40fa6a80-2806-11eb-8403-c115da08d872.png)

## Guidance to review

Check out the test data.

## Link to Trello card

https://trello.com/c/9FgC13b6

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
