### PR TITLE
Only count courses in current cycle on provider start page

### DIFF
--- a/app/controllers/provider_interface/start_page_controller.rb
+++ b/app/controllers/provider_interface/start_page_controller.rb
@@ -6,7 +6,7 @@ module ProviderInterface
     layout 'base'
 
     def show
-      courses = Course.includes(:provider).open_on_apply
+      courses = Course.current_cycle.includes(:provider).open_on_apply
       @course_count = courses.count
       @provider_count = courses.map(&:provider).uniq.count
 


### PR DESCRIPTION
We forgot to scope this to the current cycle so it was overreporting the number of courses available on Apply.

## Context

https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1605529948417600