### PR TITLE
Fix flow that allows candidates to request too many references

### DIFF
--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -25,6 +25,7 @@ module CandidateInterface
 
     def can_send?(reference)
       reference.not_requested_yet? &&
+        !reference.application_form.enough_references_have_been_provided? &&
         CandidateInterface::Reference::SubmitRefereeForm.new(
           submit: 'yes',
           reference_id: reference.id,

--- a/spec/components/candidate_interface/references_review_component_spec.rb
+++ b/spec/components/candidate_interface/references_review_component_spec.rb
@@ -86,6 +86,20 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
     end
   end
 
+  context 'when reference state is "not_requested_yet" and enough references are available' do
+    it 'no send request link is available' do
+      application_form = create(:application_form)
+
+      result = render_inline(described_class.new(references: [
+        create(:reference, :not_requested_yet, application_form: application_form),
+        create(:reference, :feedback_provided, application_form: application_form),
+        create(:reference, :feedback_provided, application_form: application_form),
+      ]))
+
+      expect(result.text).not_to include 'Send request'
+    end
+  end
+
   context 'when reference state is "not_requested_yet" and the reference is incomplete' do
     let(:not_requested_yet) { create(:reference, :not_requested_yet, name: nil) }
 


### PR DESCRIPTION
## Context

When a candidate has a unrequested reference they will still be allowed to send this reference to the referee, even if they've already received 2 references.

## Changes proposed in this pull request

This hides the "Send request" button. A PR to refactor the references to make it consistent is upcoming.

## Guidance to review

Does this make sense? You can test it using the test applications from https://github.com/DFE-Digital/apply-for-teacher-training/pull/3416.

## Link to Trello card

https://trello.com/c/9FgC13b6

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
