### PR TITLE
Add Sidekiq job ID and logging to data exports

### DIFF
--- a/app/workers/data_exporter.rb
+++ b/app/workers/data_exporter.rb
@@ -2,16 +2,23 @@ class DataExporter
   include Sidekiq::Worker
 
   def perform(importer_class, data_export_id)
+    RequestLocals.store[:debugging_info] = { data_export_id: data_export_id, importer_class: importer_class }
+
+    Rails.logger.info 'Sidekiq running. Loading data export record'
     data_export = DataExport.find(data_export_id)
 
+    Rails.logger.info 'Started CSV generation'
     csv_data = generate_csv(
       importer_class.constantize.new.data_for_export,
     )
+    Rails.logger.info 'Finished CSV generation'
 
+    Rails.logger.info 'Started writing CSV'
     data_export.update!(
       data: csv_data,
       completed_at: Time.zone.now,
     )
+    Rails.logger.info 'Finished writing CSV. Sidekiq done'
   end
 
 private


### PR DESCRIPTION
Some data exports mysteriously failed on production. It's not clear whether this happened because the job wasn't enqueued properly, whether it silently died when it ran, or for some some other reason.

Couldn't reproduce locally, so will start adding instrumentation until we know more about what happened here. This PR: 

- adds a sidekiq job ID to the data export. This might help us track down the job if something goes wrong — or at least assure us that it was enqueued.
- adds logging inside the Sidekiq worker so we can catch any silent failures

## Context

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1605518196399900