### PR TITLE
Improve Sentry messaging when weird situations are detected 

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -36,7 +36,7 @@ class DetectInvariants
       .sort
 
     if applications_with_reference_weirdness.any?
-      urls = applications_with_reference_weirdness.map { |applicatio_form_id| helpers.support_interface_application_form_url(applicatio_form_id) }
+      urls = applications_with_reference_weirdness.map { |application_form_id| helpers.support_interface_application_form_url(application_form_id) }
 
       message = <<~MSG
         One or more references are still pending on these applications,
@@ -59,10 +59,10 @@ class DetectInvariants
       .sort
 
     if unauthorised_changes.any?
-      urls = unauthorised_changes.map { |applicatio_form_id| helpers.support_interface_application_form_url(applicatio_form_id) }
+      urls = unauthorised_changes.map { |application_form_id| helpers.support_interface_application_form_url(application_form_id) }
 
       message = <<~MSG
-        The following application forms have had unauthorised edits:
+        The following application forms have had edits by a candidate who is not the owner of the application:
 
         #{urls.join("\n")}
       MSG

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -23,7 +23,7 @@ class DetectInvariants
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(WeirdSituationDetected.new(message))
+      Raven.capture_exception(ApplicationInRemovedState.new(message))
     end
   end
 
@@ -45,7 +45,7 @@ class DetectInvariants
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(WeirdSituationDetected.new(message))
+      Raven.capture_exception(OutstandingReferencesOnSubmittedApplication.new(message))
     end
   end
 
@@ -67,11 +67,13 @@ class DetectInvariants
         #{urls.join("\n")}
       MSG
 
-      Raven.capture_exception(WeirdSituationDetected.new(message))
+      Raven.capture_exception(ApplicationEditedByWrongCandidate.new(message))
     end
   end
 
-  class WeirdSituationDetected < StandardError; end
+  class ApplicationInRemovedState < StandardError; end
+  class OutstandingReferencesOnSubmittedApplication < StandardError; end
+  class ApplicationEditedByWrongCandidate < StandardError; end
 
 private
 

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -14,11 +14,13 @@ class DetectInvariants
     end
 
     if choices_in_wrong_state.any?
+      urls = choices_in_wrong_state.map { |application_choice_id| helpers.support_interface_application_choice_url(application_choice_id) }
+
       message = <<~MSG
         One or more application choices are still in `awaiting_references` or
         `application_complete` state, but all these states have been removed:
 
-        #{choices_in_wrong_state.join("\n")}
+        #{urls.join("\n")}
       MSG
 
       Raven.capture_exception(WeirdSituationDetected.new(message))
@@ -34,10 +36,13 @@ class DetectInvariants
       .sort
 
     if applications_with_reference_weirdness.any?
+      urls = applications_with_reference_weirdness.map { |applicatio_form_id| helpers.support_interface_application_form_url(applicatio_form_id) }
+
       message = <<~MSG
         One or more references are still pending on these applications,
         even though they've already been submitted:
-        #{applications_with_reference_weirdness.join("\n")}
+
+        #{urls.join("\n")}
       MSG
 
       Raven.capture_exception(WeirdSituationDetected.new(message))
@@ -54,10 +59,12 @@ class DetectInvariants
       .sort
 
     if unauthorised_changes.any?
+      urls = unauthorised_changes.map { |applicatio_form_id| helpers.support_interface_application_form_url(applicatio_form_id) }
+
       message = <<~MSG
         The following application forms have had unauthorised edits:
 
-        #{unauthorised_changes.join("\n")}
+        #{urls.join("\n")}
       MSG
 
       Raven.capture_exception(WeirdSituationDetected.new(message))
@@ -65,4 +72,10 @@ class DetectInvariants
   end
 
   class WeirdSituationDetected < StandardError; end
+
+private
+
+  def helpers
+    Rails.application.routes.url_helpers
+  end
 end

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe DetectInvariants do
       expect(Raven).to have_received(:capture_exception).with(
         DetectInvariants::ApplicationEditedByWrongCandidate.new(
           <<~MSG,
-            The following application forms have had unauthorised edits:
+            The following application forms have had edits by a candidate who is not the owner of the application:
 
             http://localhost:3000/support/applications/#{suspect_form.id}
           MSG

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe DetectInvariants do
             One or more application choices are still in `awaiting_references` or
             `application_complete` state, but all these states have been removed:
 
-            #{application_choice_bad.id}
-            #{application_choice_bad_too.id}
+            http://localhost:3000/support/application_choices/#{application_choice_bad.id}
+            http://localhost:3000/support/application_choices/#{application_choice_bad_too.id}
           MSG
         ),
       )
@@ -45,7 +45,8 @@ RSpec.describe DetectInvariants do
           <<~MSG,
             One or more references are still pending on these applications,
             even though they've already been submitted:
-            #{weird_application_form.id}
+
+            http://localhost:3000/support/applications/#{weird_application_form.id}
           MSG
         ),
       )
@@ -76,7 +77,7 @@ RSpec.describe DetectInvariants do
           <<~MSG,
             The following application forms have had unauthorised edits:
 
-            #{suspect_form.id}
+            http://localhost:3000/support/applications/#{suspect_form.id}
           MSG
         ),
       )

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DetectInvariants do
       DetectInvariants.new.perform
 
       expect(Raven).to have_received(:capture_exception).with(
-        DetectInvariants::WeirdSituationDetected.new(
+        DetectInvariants::ApplicationInRemovedState.new(
           <<~MSG,
             One or more application choices are still in `awaiting_references` or
             `application_complete` state, but all these states have been removed:
@@ -41,7 +41,7 @@ RSpec.describe DetectInvariants do
       DetectInvariants.new.perform
 
       expect(Raven).to have_received(:capture_exception).with(
-        DetectInvariants::WeirdSituationDetected.new(
+        DetectInvariants::OutstandingReferencesOnSubmittedApplication.new(
           <<~MSG,
             One or more references are still pending on these applications,
             even though they've already been submitted:
@@ -73,7 +73,7 @@ RSpec.describe DetectInvariants do
       DetectInvariants.new.perform
 
       expect(Raven).to have_received(:capture_exception).with(
-        DetectInvariants::WeirdSituationDetected.new(
+        DetectInvariants::ApplicationEditedByWrongCandidate.new(
           <<~MSG,
             The following application forms have had unauthorised edits:
 


### PR DESCRIPTION
## Context

We raise Sentry errors when things occur that really shouldn't.

## Changes proposed in this pull request

 This makes them easier to debug.

## Guidance to review

Ok?

## Link to Trello card

https://trello.com/c/9FgC13b6

