### PR TITLE
Do not include diversity information in HESA export if user does not have permission to view it

### DIFF
--- a/app/controllers/provider_interface/applications_exports_controller.rb
+++ b/app/controllers/provider_interface/applications_exports_controller.rb
@@ -5,10 +5,7 @@ module ProviderInterface
     def export
       respond_to do |format|
         format.csv do
-          csv_data = HesaDataExport.new(
-            provider_ids: current_provider_user.providers.map(&:id),
-            actor: current_provider_user,
-          ).call
+          csv_data = HesaDataExport.new(actor: current_provider_user).call
           send_data csv_data, disposition: 'attachment', filename: csv_filename
         end
       end

--- a/app/controllers/provider_interface/applications_exports_controller.rb
+++ b/app/controllers/provider_interface/applications_exports_controller.rb
@@ -5,7 +5,10 @@ module ProviderInterface
     def export
       respond_to do |format|
         format.csv do
-          csv_data = HesaDataExport.new(provider_ids: current_provider_user.providers.map(&:id)).call
+          csv_data = HesaDataExport.new(
+            provider_ids: current_provider_user.providers.map(&:id),
+            actor: current_provider_user,
+          ).call
           send_data csv_data, disposition: 'attachment', filename: csv_filename
         end
       end

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class HesaDataExport
-    def initialize(provider_ids:, actor:)
-      @provider_ids = provider_ids
+    def initialize(actor:)
+      @provider_ids = actor.providers.map(&:id)
       @auth = ProviderAuthorisation.new(actor: actor)
     end
 

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -6,18 +6,21 @@ module ProviderInterface
     end
 
     def call
-      applications = ApplicationChoice
+      applications_join = ApplicationChoice
         .includes(
           :course,
           :provider,
           :site,
           course_option: { course: %i[provider accredited_provider] },
           application_form: %i[candidate application_qualifications],
-        ).where(
+        )
+
+      applications =
+        applications_join.where('providers.id': @provider_ids)
+        .or(applications_join.where('courses_course_options.accredited_provider_id': @provider_ids))
+        .where(
           'candidates.hide_in_reporting' => false,
           'status' => ApplicationStateChange::ACCEPTED_STATES,
-          'providers.id' => @provider_ids,
-          'application_forms.recruitment_cycle_year' => RecruitmentCycle.current_year,
         )
 
       rows = []

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -1,7 +1,8 @@
 module ProviderInterface
   class HesaDataExport
-    def initialize(provider_ids:)
+    def initialize(provider_ids:, actor:)
       @provider_ids = provider_ids
+      @auth = ProviderAuthorisation.new(actor: actor)
     end
 
     def call
@@ -79,6 +80,8 @@ module ProviderInterface
 
     def diversity_information(application)
       return { 'sex' => 'no data', 'disabilities' => 'no data', 'ethnicity' => 'no data' } if application.application_form.equality_and_diversity.blank?
+
+      return { 'sex' => 'confidential', 'disabilities' => 'confidential', 'ethnicity' => 'confidential' } unless @auth.can_view_diversity_information?(course: application.course)
 
       {
         'sex' => application.application_form.equality_and_diversity['hesa_sex'] || 'not specified',

--- a/app/views/provider_interface/applications_exports/new.html.erb
+++ b/app/views/provider_interface/applications_exports/new.html.erb
@@ -3,20 +3,20 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      Click ‘Download’ to download application data for the current cycle (<%= RecruitmentCycle.current_cycle_name %>). This only relates to accepted applications - ones that you’ve made an offer on, and the candidate has accepted.
+      The export will include all candidates who have accepted an offer.
     </p>
     <p class="govuk-body">
-      The file includes the data sets that higher education institutions (HEIs) are required to send to the Higher Education Statistics Agency (HESA) as part of their statutory reporting obligations.
+      Higher education institutions will need the data when reporting to the Higher Education Statistics Agency (HESA).
     </p>
-    <p class="govuk-inset-text">
-      Diversity information will be marked confidential if you do not have permission to view it.
+    <p class="govuk-body">
+      Diversity information will only be included if you have permission to view it.
     </p>
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: provider_interface_applications_export_path(format: :csv), method: :get do |f| %>
+    <%= form_with url: provider_interface_applications_export_path(format: :csv), method: :get do %>
       <button class="govuk-button" data-module="govuk-button">
-        Download
+        Export data
       </button>
     <% end %>
   </div>

--- a/app/views/provider_interface/applications_exports/new.html.erb
+++ b/app/views/provider_interface/applications_exports/new.html.erb
@@ -8,6 +8,9 @@
     <p class="govuk-body">
       The file includes the data sets that higher education institutions (HEIs) are required to send to the Higher Education Statistics Agency (HESA) as part of their statutory reporting obligations.
     </p>
+    <p class="govuk-inset-text">
+      Diversity information will be marked confidential if you do not have permission to view it.
+    </p>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -2,11 +2,18 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::HesaDataExport do
   describe '#call' do
-    let(:accredited_provider) { create(:provider) }
+    let(:accredited_provider) do
+      provider_permissions = create(
+        :provider_relationship_permissions,
+        ratifying_provider_can_view_diversity_information: true,
+      )
+      provider_permissions.ratifying_provider
+    end
     let(:provider_ids) { @course.provider.id }
     let(:hesa_disabilities) { [53, 55, 54] }
+    let(:provider_user) { create(:provider_user, :with_view_diversity_information, providers: [accredited_provider]) }
 
-    subject(:export_data) { described_class.new(provider_ids: provider_ids).call }
+    subject(:export_data) { described_class.new(provider_ids: provider_ids, actor: provider_user).call }
 
     before do
       @course = create(:course, study_mode: 'full_time', subject_codes: %w[F3 X9], accredited_provider: accredited_provider)
@@ -83,6 +90,19 @@ RSpec.describe ProviderInterface::HesaDataExport do
       it 'exports this value' do
         exported_data = CSV.parse(export_data, headers: true)
         expect(exported_data.first['disabilities']).to eq('55')
+      end
+    end
+
+    context 'when user does not have permission to view diversity information' do
+      let(:provider_user) { create(:provider_user, providers: [accredited_provider]) }
+
+      it 'shows diversity information as confidential' do
+        exported_data = CSV.parse(export_data, headers: true)
+        row = exported_data.first
+
+        expect(row['sex']).to eq('confidential')
+        expect(row['disabilities']).to eq('confidential')
+        expect(row['ethnicity']).to eq('confidential')
       end
     end
   end

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::HesaDataExport do
   describe '#call' do
-    let(:provider_relationship) { create(:provider_relationship_permissions) }
+    let(:provider_relationship) { create(:provider_relationship_permissions, ratifying_provider_can_view_diversity_information: true) }
     let(:training_provider) { provider_relationship.training_provider }
     let(:accredited_provider) { provider_relationship.ratifying_provider }
     let(:provider_user) { create(:provider_user, :with_view_diversity_information, providers: [training_provider]) }
@@ -10,6 +10,41 @@ RSpec.describe ProviderInterface::HesaDataExport do
     let(:hesa_disabilities) { [53, 55, 54] }
 
     subject(:export_data) { described_class.new(actor: provider_user).call }
+
+    shared_examples_for 'a full HESA export' do
+      it 'includes candidate and HESA data' do
+        exported_data = CSV.parse(export_data, headers: true)
+        row = exported_data.first
+
+        expect(row['id']).to eq(@application_with_offer.application_form.support_reference)
+        expect(row['status']).to eq(@application_with_offer.status)
+        expect(row['first name']).to eq(@application_with_offer.application_form.first_name)
+        expect(row['last name']).to eq(@application_with_offer.application_form.last_name)
+        expect(row['date of birth']).to eq(@application_with_offer.application_form.date_of_birth.to_s)
+        expect(row['nationality']).to eq(@application_with_offer.application_form.first_nationality)
+        expect(row['domicile']).to eq(@application_with_offer.application_form.country)
+        expect(row['email address']).to eq(@application_with_offer.application_form.candidate.email_address)
+        expect(row['recruitment cycle']).to eq(@application_with_offer.application_form.recruitment_cycle_year.to_s)
+        expect(row['provider code']).to eq(@application_with_offer.provider.code)
+        expect(row['accredited body']).to eq(@application_with_offer.course.accredited_provider.name)
+        expect(row['course code']).to eq(@course.code)
+        expect(row['site code']).to eq(@application_with_offer.site.code)
+        expect(row['study mode']).to eq('01')
+        expect(row['SBJCA']).to eq('100425 101277')
+        expect(row['QLAIM']).to eq('021')
+        expect(row['FIRSTDEG']).to eq('1')
+        expect(row['DEGTYPE']).to eq('007')
+        expect(row['DEGSBJ']).to eq('100100')
+        expect(row['DEGCLSS']).to eq('02')
+        expect(row['institution country']).to eq('GB')
+        expect(row['DEGSTDT']).to eq('2010')
+        expect(row['DEGENDDT']).to eq('2013')
+        expect(row['institution details']).to eq('0001')
+        expect(row['sex']).to eq('1')
+        expect(row['disabilities']).to eq('53 55 54')
+        expect(row['ethnicity']).to eq('15')
+      end
+    end
 
     before do
       @course = create(:course, study_mode: 'full_time', subject_codes: %w[F3 X9], provider: training_provider, accredited_provider: accredited_provider)
@@ -47,38 +82,7 @@ RSpec.describe ProviderInterface::HesaDataExport do
       ])
     end
 
-    it 'includes candidate and HESA data' do
-      exported_data = CSV.parse(export_data, headers: true)
-      row = exported_data.first
-
-      expect(row['id']).to eq(@application_with_offer.application_form.support_reference)
-      expect(row['status']).to eq(@application_with_offer.status)
-      expect(row['first name']).to eq(@application_with_offer.application_form.first_name)
-      expect(row['last name']).to eq(@application_with_offer.application_form.last_name)
-      expect(row['date of birth']).to eq(@application_with_offer.application_form.date_of_birth.to_s)
-      expect(row['nationality']).to eq(@application_with_offer.application_form.first_nationality)
-      expect(row['domicile']).to eq(@application_with_offer.application_form.country)
-      expect(row['email address']).to eq(@application_with_offer.application_form.candidate.email_address)
-      expect(row['recruitment cycle']).to eq(@application_with_offer.application_form.recruitment_cycle_year.to_s)
-      expect(row['provider code']).to eq(@application_with_offer.provider.code)
-      expect(row['accredited body']).to eq(@application_with_offer.course.accredited_provider.name)
-      expect(row['course code']).to eq(@course.code)
-      expect(row['site code']).to eq(@application_with_offer.site.code)
-      expect(row['study mode']).to eq('01')
-      expect(row['SBJCA']).to eq('100425 101277')
-      expect(row['QLAIM']).to eq('021')
-      expect(row['FIRSTDEG']).to eq('1')
-      expect(row['DEGTYPE']).to eq('007')
-      expect(row['DEGSBJ']).to eq('100100')
-      expect(row['DEGCLSS']).to eq('02')
-      expect(row['institution country']).to eq('GB')
-      expect(row['DEGSTDT']).to eq('2010')
-      expect(row['DEGENDDT']).to eq('2013')
-      expect(row['institution details']).to eq('0001')
-      expect(row['sex']).to eq('1')
-      expect(row['disabilities']).to eq('53 55 54')
-      expect(row['ethnicity']).to eq('15')
-    end
+    it_behaves_like 'a full HESA export'
 
     context 'when hesa disabilities is stored as string' do
       let(:hesa_disabilities) { '55' }
@@ -100,6 +104,12 @@ RSpec.describe ProviderInterface::HesaDataExport do
         expect(row['disabilities']).to eq('confidential')
         expect(row['ethnicity']).to eq('confidential')
       end
+    end
+
+    context 'when user is from the accredited provider' do
+      let(:provider_user) { create(:provider_user, :with_view_diversity_information, providers: [accredited_provider]) }
+
+      it_behaves_like 'a full HESA export'
     end
   end
 end

--- a/spec/system/provider_interface/export_applications_spec.rb
+++ b/spec/system/provider_interface/export_applications_spec.rb
@@ -37,9 +37,10 @@ RSpec.feature 'Export applications' do
   end
 
   def and_i_click_export_data
-    expect(page).to have_content('Click ‘Download’ to download application data for the current cycle')
+    expect(page).to have_content('The export will include all candidates who have accepted an offer.')
+    expect(page).to have_content('Diversity information will only be included if you have permission to view it.')
 
-    click_on 'Download'
+    click_button 'Export data'
   end
 
   def then_i_can_download_application_data_as_csv


### PR DESCRIPTION
## Context
Currently, diversity info is included in this export regardless of whether or not the provider user who generated it has permission to view that information.

## Changes proposed in this pull request
#### Added descriptive text about why `confidential` will show up in some reports
Content here updated as per discussion on card
![image](https://user-images.githubusercontent.com/30071178/99395746-c64e4f80-28d8-11eb-9465-43050742bfd0.png)


## Link to Trello card
https://trello.com/c/p36aFgu9/2982-restrict-diversity-information-in-hesa-export

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
