### PR TITLE
Extract logic about references into a single class

### DIFF
--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -1,7 +1,7 @@
 <% references.each do |reference| %>
   <%= render(SummaryCardComponent.new(
     rows: reference_rows(reference),
-    editable: editable && reference.editable?,
+    editable: editable && editable?(reference),
     ignore_editable: ignore_editable_for,
   )) do %>
     <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
@@ -37,7 +37,7 @@
                 <span class="govuk-visually-hidden"> <%= reference.name %></span>
               <% end %>
             </li>
-          <% elsif reference.request_can_be_deleted? %>
+          <% elsif request_can_be_deleted?(reference) %>
             <li class="app-summary-card__actions-list-item">
               <%= link_to candidate_interface_delete_reference_request_path(reference), class: 'govuk-link' do %>
                 <%= t('application_form.references.delete_request.action') %>

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -24,30 +24,15 @@ module CandidateInterface
     end
 
     def can_send?(reference)
-      reference.not_requested_yet? &&
-        !reference.application_form.enough_references_have_been_provided? &&
-        CandidateInterface::Reference::SubmitRefereeForm.new(
-          submit: 'yes',
-          reference_id: reference.id,
-        ).valid?
+      ReferenceActionsPolicy.new(reference).can_send?
     end
 
     def can_resend?(reference)
-      (reference.cancelled? || reference.cancelled_at_end_of_cycle?) &&
-        !reference.application_form.enough_references_have_been_provided? &&
-        CandidateInterface::Reference::SubmitRefereeForm.new(
-          submit: 'yes',
-          reference_id: reference.id,
-        ).valid?
+      ReferenceActionsPolicy.new(reference).can_resend?
     end
 
     def can_retry?(reference)
-      reference.email_bounced? &&
-        !reference.application_form.enough_references_have_been_provided? &&
-        CandidateInterface::Reference::SubmitRefereeForm.new(
-          submit: 'yes',
-          reference_id: reference.id,
-        ).valid?
+      ReferenceActionsPolicy.new(reference).can_retry?
     end
 
     def ignore_editable_for

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -35,6 +35,18 @@ module CandidateInterface
       ReferenceActionsPolicy.new(reference).can_retry?
     end
 
+    def editable?(reference)
+      ReferenceActionsPolicy.new(reference).editable?
+    end
+
+    def request_can_be_deleted?(reference)
+      ReferenceActionsPolicy.new(reference).request_can_be_deleted?
+    end
+
+    def can_send_reminder?(reference)
+      ReferenceActionsPolicy.new(reference).can_send_reminder?
+    end
+
     def ignore_editable_for
       %w[History]
     end
@@ -106,7 +118,7 @@ module CandidateInterface
         value: render(CandidateInterface::ReferenceHistoryComponent.new(reference)),
       }
 
-      if reference.can_send_reminder?
+      if can_send_reminder?(reference)
         row_attributes.merge!(
           action: t('application_form.references.send_reminder.action'),
           action_path: candidate_interface_references_new_reminder_path(reference),

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -116,19 +116,19 @@ module SupportInterface
       [
         {
           key: 'Can be edited?',
-          value: reference.editable? ? 'Yes' : 'No',
+          value: policy.editable? ? 'Yes' : 'No',
         },
         {
           key: 'Can be destroyed?',
-          value: reference.can_be_destroyed? ? 'Yes' : 'No',
+          value: policy.can_be_destroyed? ? 'Yes' : 'No',
         },
         {
           key: 'Can be deleted?',
-          value: reference.request_can_be_deleted? ? 'Yes' : 'No',
+          value: policy.request_can_be_deleted? ? 'Yes' : 'No',
         },
         {
           key: 'Can send reminder?',
-          value: reference.can_send_reminder? ? 'Yes' : 'No',
+          value: policy.can_send_reminder? ? 'Yes' : 'No',
         },
         {
           key: 'Can send?',

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -111,6 +111,8 @@ module SupportInterface
     end
 
     def possible_actions_row
+      policy = ReferenceActionsPolicy.new(reference)
+
       [
         {
           key: 'Editable by candidate',
@@ -127,6 +129,18 @@ module SupportInterface
         {
           key: 'Can send reminder?',
           value: reference.can_send_reminder? ? 'Yes' : 'No',
+        },
+        {
+          key: 'Can send?',
+          value: policy.can_send? ? 'Yes' : 'No',
+        },
+        {
+          key: 'Can resend?',
+          value: policy.can_resend? ? 'Yes' : 'No',
+        },
+        {
+          key: 'Can retry?',
+          value: policy.can_retry? ? 'Yes' : 'No',
         },
       ]
     end

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -26,6 +26,7 @@ module SupportInterface
         consent_row,
         feedback_row,
         history_row,
+        possible_actions_row,
       ].flatten.compact
     end
 
@@ -107,6 +108,27 @@ module SupportInterface
                                                to: reference.email_address,
                                              )),
       }
+    end
+
+    def possible_actions_row
+      [
+        {
+          key: 'Editable by candidate',
+          value: reference.editable? ? 'Yes' : 'No',
+        },
+        {
+          key: 'Can be destroyed?',
+          value: reference.can_be_destroyed? ? 'Yes' : 'No',
+        },
+        {
+          key: 'Request can be deleted?',
+          value: reference.request_can_be_deleted? ? 'Yes' : 'No',
+        },
+        {
+          key: 'Can send reminder?',
+          value: reference.can_send_reminder? ? 'Yes' : 'No',
+        },
+      ]
     end
 
     def consent_to_be_contacted_present

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -115,7 +115,7 @@ module SupportInterface
 
       [
         {
-          key: 'Editable by candidate',
+          key: 'Can be edited?',
           value: reference.editable? ? 'Yes' : 'No',
         },
         {
@@ -123,7 +123,7 @@ module SupportInterface
           value: reference.can_be_destroyed? ? 'Yes' : 'No',
         },
         {
-          key: 'Request can be deleted?',
+          key: 'Can be deleted?',
           value: reference.request_can_be_deleted? ? 'Yes' : 'No',
         },
         {

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -49,13 +49,17 @@ module CandidateInterface
       end
 
       def confirm_destroy_reference_request
-        unless @reference.present? && @reference.request_can_be_deleted?
+        policy = ReferenceActionsPolicy.new(@reference)
+
+        unless @reference.present? && policy.request_can_be_deleted?
           redirect_to_review_page
         end
       end
 
       def destroy
-        unless @reference.present? && (@reference.can_be_destroyed? || @reference.request_can_be_deleted?)
+        policy = ReferenceActionsPolicy.new(@reference)
+
+        unless @reference.present? && (policy.can_be_destroyed? || policy.request_can_be_deleted?)
           redirect_to_review_page and return
         end
 

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -93,20 +93,4 @@ class ApplicationReference < ApplicationRecord
 
     replace_referee_at < Time.zone.now
   end
-
-  def editable?
-    not_requested_yet?
-  end
-
-  def can_be_destroyed?
-    (not_requested_yet? || feedback_provided?) && !application_form.submitted?
-  end
-
-  def request_can_be_deleted?
-    (cancelled? || feedback_refused? || email_bounced?) && !application_form.submitted?
-  end
-
-  def can_send_reminder?
-    feedback_requested? && reminder_sent_at.nil?
-  end
 end

--- a/app/services/candidate_interface/send_reference_reminder.rb
+++ b/app/services/candidate_interface/send_reference_reminder.rb
@@ -13,7 +13,9 @@ module CandidateInterface
     end
 
     def call
-      if reference.can_send_reminder?
+      policy = ReferenceActionsPolicy.new(reference)
+
+      if policy.can_send_reminder?
         RefereeMailer.reference_request_chaser_email(application_form, reference).deliver_later
         reference.update!(reminder_sent_at: Time.zone.now)
         flash[:success] = "Reminder sent to #{referee_name}"

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -1,0 +1,36 @@
+class ReferenceActionsPolicy
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def can_send?
+    reference.not_requested_yet? &&
+      !reference.application_form.enough_references_have_been_provided? &&
+      CandidateInterface::Reference::SubmitRefereeForm.new(
+        submit: 'yes',
+        reference_id: reference.id,
+      ).valid?
+  end
+
+  def can_resend?
+    (reference.cancelled? || reference.cancelled_at_end_of_cycle?) &&
+      !reference.application_form.enough_references_have_been_provided? &&
+      CandidateInterface::Reference::SubmitRefereeForm.new(
+        submit: 'yes',
+        reference_id: reference.id,
+      ).valid?
+  end
+
+  def can_retry?
+    reference.email_bounced? &&
+      !reference.application_form.enough_references_have_been_provided? &&
+      CandidateInterface::Reference::SubmitRefereeForm.new(
+        submit: 'yes',
+        reference_id: reference.id,
+      ).valid?
+  end
+
+private
+
+  attr_reader :reference
+end

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -3,6 +3,22 @@ class ReferenceActionsPolicy
     @reference = reference
   end
 
+  def editable?
+    reference.not_requested_yet?
+  end
+
+  def can_be_destroyed?
+    (reference.not_requested_yet? || reference.feedback_provided?) && !reference.application_form.submitted?
+  end
+
+  def request_can_be_deleted?
+    (reference.cancelled? || reference.feedback_refused? || reference.email_bounced?) && !reference.application_form.submitted?
+  end
+
+  def can_send_reminder?
+    reference.feedback_requested? && reference.reminder_sent_at.nil?
+  end
+
   def can_send?
     reference.not_requested_yet? &&
       needs_more_references? &&

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -5,32 +5,34 @@ class ReferenceActionsPolicy
 
   def can_send?
     reference.not_requested_yet? &&
-      !reference.application_form.enough_references_have_been_provided? &&
-      CandidateInterface::Reference::SubmitRefereeForm.new(
-        submit: 'yes',
-        reference_id: reference.id,
-      ).valid?
+      needs_more_references? &&
+      valid_reference?
   end
 
   def can_resend?
     (reference.cancelled? || reference.cancelled_at_end_of_cycle?) &&
-      !reference.application_form.enough_references_have_been_provided? &&
-      CandidateInterface::Reference::SubmitRefereeForm.new(
-        submit: 'yes',
-        reference_id: reference.id,
-      ).valid?
+      needs_more_references? &&
+      valid_reference?
   end
 
   def can_retry?
     reference.email_bounced? &&
-      !reference.application_form.enough_references_have_been_provided? &&
-      CandidateInterface::Reference::SubmitRefereeForm.new(
-        submit: 'yes',
-        reference_id: reference.id,
-      ).valid?
+      needs_more_references? &&
+      valid_reference?
   end
 
 private
 
   attr_reader :reference
+
+  def needs_more_references?
+    !reference.application_form.enough_references_have_been_provided?
+  end
+
+  def valid_reference?
+    CandidateInterface::Reference::SubmitRefereeForm.new(
+      submit: 'yes',
+      reference_id: reference.id,
+    ).valid?
+  end
 end

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
   describe 'Cancel and reinstate links' do
     it 'Cancel link is present when the reference is feedback_requested' do
-      reference = build_stubbed(:reference, feedback_status: 'feedback_requested')
+      reference = create(:reference, feedback_status: 'feedback_requested')
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
@@ -12,7 +12,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
     end
 
     it 'Reinstate link is present when the reference is cancelled' do
-      reference = build_stubbed(:reference, feedback_status: 'cancelled')
+      reference = create(:reference, feedback_status: 'cancelled')
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
@@ -21,7 +21,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
     end
 
     it 'Reinstate link is present when the reference is refused' do
-      reference = build_stubbed(:reference, feedback_status: 'feedback_refused')
+      reference = create(:reference, feedback_status: 'feedback_refused')
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
@@ -32,7 +32,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
 
   describe 'title' do
     it 'includes the supplied reference number' do
-      reference = build_stubbed(:reference)
+      reference = create(:reference)
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
@@ -40,7 +40,7 @@ RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
     end
 
     it 'says if the reference is a replacement' do
-      reference = build_stubbed(:reference, replacement: true)
+      reference = create(:reference, replacement: true)
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -65,18 +65,6 @@ RSpec.describe ApplicationReference, type: :model do
     end
   end
 
-  describe '#editable?' do
-    it 'returns true for `not_requested_yet`' do
-      expect(described_class.new(feedback_status: :not_requested_yet).editable?).to be true
-    end
-
-    it 'returns false for all other statuses' do
-      ApplicationReference.feedback_statuses.keys.reject { |s| s == 'not_requested_yet' }.each do |status|
-        expect(described_class.new(feedback_status: status).editable?).to be false
-      end
-    end
-  end
-
   describe '#pending_feedback_or_failed' do
     it 'returns references in every state except not_requested_yet and feedback_provided' do
       expected_states = ApplicationReference.feedback_statuses.values - %w[not_requested_yet feedback_provided]
@@ -113,75 +101,6 @@ RSpec.describe ApplicationReference, type: :model do
         reference = build(:reference, requested_at: Time.zone.now - TimeLimitConfig.additional_reference_chase_calendar_days.days)
         expect(reference.next_automated_chase_at).to eq nil
       end
-    end
-  end
-
-  describe '#can_send_reminder?' do
-    it 'is true when state is feedback_requested and reminder_sent_at is nil' do
-      reference = build(:reference, :feedback_requested, reminder_sent_at: nil)
-      expect(reference.can_send_reminder?).to eq true
-    end
-
-    it 'is false when state is not feedback_requested' do
-      reference = build(:reference, :not_requested_yet, reminder_sent_at: nil)
-      expect(reference.can_send_reminder?).to eq false
-    end
-
-    it 'is false when reminder_sent_at is filled' do
-      reference = build(:reference, :feedback_requested, reminder_sent_at: Time.zone.now)
-      expect(reference.can_send_reminder?).to eq false
-    end
-  end
-
-  describe '#can_be_destroyed?' do
-    let(:unsubmitted_application_form) { build_stubbed(:application_form, submitted_at: nil) }
-    let(:valid_states) { %i[not_requested_yet feedback_provided] }
-    let(:invalid_states) { %i[cancelled cancelled_at_end_of_cycle email_bounced feedback_refused feedback_requested] }
-
-    it 'returns true when the reference is in a state that can be destroyed and the application form has not been submitted' do
-      valid_states.each do |state|
-        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
-        expect(reference.can_be_destroyed?).to eq true
-      end
-    end
-
-    it 'returns false when the reference is in a state that cannot be destroyed' do
-      invalid_states.each do |state|
-        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
-        expect(reference.can_be_destroyed?).to eq false
-      end
-    end
-
-    it 'is false when in a state that has been can be destroyed, but the the application form has been submitted' do
-      submitted_application_form = build_stubbed(:application_form, submitted_at: Time.zone.now)
-      reference = build(:reference, valid_states.sample, application_form: submitted_application_form)
-      expect(reference.can_be_destroyed?).to eq false
-    end
-  end
-
-  describe '#request_can_be_deleted?' do
-    let(:unsubmitted_application_form) { build_stubbed(:application_form, submitted_at: nil) }
-    let(:valid_states) { %i[cancelled email_bounced feedback_refused] }
-    let(:invalid_states) { %i[not_requested_yet feedback_provided cancelled_at_end_of_cycle feedback_requested] }
-
-    it 'returns true when the reference is in a state that can be deleted and the application form has not been submitted' do
-      valid_states.each do |state|
-        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
-        expect(reference.request_can_be_deleted?).to eq true
-      end
-    end
-
-    it 'returns false when the reference is in a state that cannot be deleted' do
-      invalid_states.each do |state|
-        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
-        expect(reference.request_can_be_deleted?).to eq false
-      end
-    end
-
-    it 'is false when in a state that has been can be deleted, but the the application form has been submitted' do
-      submitted_application_form = build_stubbed(:application_form, submitted_at: Time.zone.now)
-      reference = build(:reference, valid_states.sample, application_form: submitted_application_form)
-      expect(reference.request_can_be_deleted?).to eq false
     end
   end
 end

--- a/spec/services/reference_actions_policy_spec.rb
+++ b/spec/services/reference_actions_policy_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe ReferenceActionsPolicy do
+  describe '#editable?' do
+    it 'returns true for `not_requested_yet`' do
+      reference = build(:reference, :not_requested_yet)
+
+      expect(policy(reference).editable?).to eq true
+    end
+
+    it 'returns false for all other statuses' do
+      reference = build(:reference, :feedback_provided)
+
+      expect(policy(reference).editable?).to eq false
+    end
+  end
+
+  describe '#can_send_reminder?' do
+    it 'is true when state is feedback_requested and reminder_sent_at is nil' do
+      reference = build(:reference, :feedback_requested, reminder_sent_at: nil)
+      expect(policy(reference).can_send_reminder?).to eq true
+    end
+
+    it 'is false when state is not feedback_requested' do
+      reference = build(:reference, :not_requested_yet, reminder_sent_at: nil)
+      expect(policy(reference).can_send_reminder?).to eq false
+    end
+
+    it 'is false when reminder_sent_at is filled' do
+      reference = build(:reference, :feedback_requested, reminder_sent_at: Time.zone.now)
+      expect(policy(reference).can_send_reminder?).to eq false
+    end
+  end
+
+  describe '#can_be_destroyed?' do
+    let(:unsubmitted_application_form) { build_stubbed(:application_form, submitted_at: nil) }
+    let(:valid_states) { %i[not_requested_yet feedback_provided] }
+    let(:invalid_states) { %i[cancelled cancelled_at_end_of_cycle email_bounced feedback_refused feedback_requested] }
+
+    it 'returns true when the reference is in a state that can be destroyed and the application form has not been submitted' do
+      valid_states.each do |state|
+        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
+        expect(policy(reference).can_be_destroyed?).to eq true
+      end
+    end
+
+    it 'returns false when the reference is in a state that cannot be destroyed' do
+      invalid_states.each do |state|
+        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
+        expect(policy(reference).can_be_destroyed?).to eq false
+      end
+    end
+
+    it 'is false when in a state that has been can be destroyed, but the the application form has been submitted' do
+      submitted_application_form = build_stubbed(:application_form, submitted_at: Time.zone.now)
+      reference = build(:reference, valid_states.sample, application_form: submitted_application_form)
+      expect(policy(reference).can_be_destroyed?).to eq false
+    end
+  end
+
+  describe '#request_can_be_deleted?' do
+    let(:unsubmitted_application_form) { build_stubbed(:application_form, submitted_at: nil) }
+    let(:valid_states) { %i[cancelled email_bounced feedback_refused] }
+    let(:invalid_states) { %i[not_requested_yet feedback_provided cancelled_at_end_of_cycle feedback_requested] }
+
+    it 'returns true when the reference is in a state that can be deleted and the application form has not been submitted' do
+      valid_states.each do |state|
+        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
+        expect(policy(reference).request_can_be_deleted?).to eq true
+      end
+    end
+
+    it 'returns false when the reference is in a state that cannot be deleted' do
+      invalid_states.each do |state|
+        reference = build_stubbed(:reference, state, application_form: unsubmitted_application_form)
+        expect(policy(reference).request_can_be_deleted?).to eq false
+      end
+    end
+
+    it 'is false when in a state that has been can be deleted, but the the application form has been submitted' do
+      submitted_application_form = build_stubbed(:application_form, submitted_at: Time.zone.now)
+      reference = build(:reference, valid_states.sample, application_form: submitted_application_form)
+      expect(policy(reference).request_can_be_deleted?).to eq false
+    end
+  end
+
+  def policy(reference)
+    ReferenceActionsPolicy.new(reference)
+  end
+end


### PR DESCRIPTION
## Context

The references logic is fairly complicated and we're seeing a number of bugs. One of these was fixed in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3418. 

## Changes proposed in this pull request

To start solving the issues, this is a big refactor PR. The goal of it is to create a single class, ReferenceActionsPolicy, which can answer all questions about whether a reference can be deleted, destroyed (yes), sent, cancelled, reminded, retried and more.

This is limited to refactoring. For manual testing it also exposes the policy booleans to the support UI.

Next steps:

- Find where we duplicate logic from the policy class and replace it
- Update the `editable?` to disallow edits when there are enough references
- Use the policy object consistently in controllers so that it's impossible to request a reference by fiddling with the URL (https://github.com/DFE-Digital/apply-for-teacher-training/pull/3418 only does the view)

## Guidance to review

Does the end result make sense?

## Link to Trello card

https://trello.com/c/9FgC13b6

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
