### PR TITLE
Speed up tests a little bit

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,12 @@ Rails.application.configure do
 
     Bullet.raise = true # raise an error if n+1 query occurs
   end
+
+  if ENV['ENABLE_LOGGING']
+    puts 'Logging is enabled'
+  else
+    puts 'Logging is disabled. Run the tests with ENABLE_LOGGING=true to enable logging to log/test.log'
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,13 +13,15 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'simplecov'
-require 'simplecov-cobertura'
-SimpleCov.formatters = [
-  SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::CoberturaFormatter,
-]
-SimpleCov.start 'rails'
+if ENV['ENABLE_COVERAGE']
+  require 'simplecov'
+  require 'simplecov-cobertura'
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::CoberturaFormatter,
+  ]
+  SimpleCov.start 'rails'
+end
 
 require 'sidekiq/testing'
 require 'clockwork/test'


### PR DESCRIPTION
## Context

Our test suite is slow (4m).

## Changes proposed in this pull request

- Only run code coverage stats if `ENABLE_COVERAGE` is on
- Only log to `log/test.log` if `ENABLE_LOGGING` is on (this saves about 20s)

## Guidance to review

Ok?

