### PR TITLE
Docs: hide state counts for application state

### DIFF
--- a/app/components/state_explanation_component.html.erb
+++ b/app/components/state_explanation_component.html.erb
@@ -1,6 +1,6 @@
 <section class="app-section app-section--with-top-border">
   <h3 class="govuk-heading-m govuk-!-margin-bottom-1" id="<%= state_name %>"><%= human_state_name %></h3>
-  <% if development_details %>
+  <% if development_details && machine == ApplicationStateChange %>
     <p class="govuk-body-l"><%= govuk_link_to pluralize(machine.state_count(state_name), 'application'), support_interface_applications_path, class: 'govuk-link--no-visited-state' %> currently in this state</p>
   <% end %>
   <div class="govuk-grid-row">

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -84,10 +84,6 @@ class ProcessState
     'candidate_flow_'
   end
 
-  def self.state_count(_)
-    '?'
-  end
-
 private
 
   attr_reader :application_form


### PR DESCRIPTION
## Context

Currently we show a "?" because we can't easily calculate how many people are in each state. The question mark is confusing, we'd better not show it.

## Changes proposed in this pull request

Remove the thing.

