### PR TITLE
Prevent editing of references in applications that have enough references

### DIFF
--- a/app/controllers/candidate_interface/references/base_controller.rb
+++ b/app/controllers/candidate_interface/references/base_controller.rb
@@ -22,7 +22,8 @@ module CandidateInterface
       end
 
       def redirect_to_review_page_unless_reference_is_editable
-        redirect_to candidate_interface_references_review_path unless @reference.present? && @reference.not_requested_yet?
+        policy = ReferenceActionsPolicy.new(@reference)
+        redirect_to candidate_interface_references_review_path unless @reference.present? && policy.editable?
       end
     end
   end

--- a/app/controllers/candidate_interface/references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/email_address_controller.rb
@@ -1,7 +1,8 @@
 module CandidateInterface
   module References
     class EmailAddressController < BaseController
-      before_action :set_reference, :redirect_to_review_page_unless_reference_is_not_requested_or_email_bounced
+      before_action :set_reference
+      before_action :verify_email_is_editable
 
       def new
         @reference_email_address_form = Reference::RefereeEmailAddressForm.new
@@ -45,10 +46,11 @@ module CandidateInterface
           .merge!(reference_id: @reference.id)
       end
 
-      def redirect_to_review_page_unless_reference_is_not_requested_or_email_bounced
-        unless @reference.present? && (@reference.not_requested_yet? || @reference.email_bounced?)
-          redirect_to candidate_interface_references_review_path
-        end
+      def verify_email_is_editable
+        policy = ReferenceActionsPolicy.new(@reference)
+        return if policy.editable? || @reference.email_bounced?
+
+        redirect_to candidate_interface_references_review_path
       end
     end
   end

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -4,7 +4,7 @@ class ReferenceActionsPolicy
   end
 
   def editable?
-    reference.not_requested_yet?
+    reference.not_requested_yet? && needs_more_references?
   end
 
   def can_be_destroyed?

--- a/spec/services/reference_actions_policy_spec.rb
+++ b/spec/services/reference_actions_policy_spec.rb
@@ -2,13 +2,21 @@ require 'rails_helper'
 
 RSpec.describe ReferenceActionsPolicy do
   describe '#editable?' do
-    it 'returns true for `not_requested_yet`' do
+    it 'is editable when the reference has not been requested yet' do
       reference = build(:reference, :not_requested_yet)
 
       expect(policy(reference).editable?).to eq true
     end
 
-    it 'returns false for all other statuses' do
+    it 'is not editable when the application form has enough references' do
+      reference = create(:reference, :not_requested_yet)
+      create(:reference, :feedback_provided, application_form: reference.application_form)
+      create(:reference, :feedback_provided, application_form: reference.application_form)
+
+      expect(policy(reference).editable?).to eq false
+    end
+
+    it 'is not editable in any other other state' do
       reference = build(:reference, :feedback_provided)
 
       expect(policy(reference).editable?).to eq false

--- a/spec/system/candidate_interface/references/review_references_spec.rb
+++ b/spec/system/candidate_interface/references/review_references_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Review references' do
   include CandidateHelper
 
-  scenario 'the candidate has several references in different states' do
+  scenario 'Candidate submits and reviews references' do
     given_i_am_signed_in
 
     when_i_have_no_references_and_try_to_visit_the_review_page
@@ -18,7 +18,6 @@ RSpec.feature 'Review references' do
     when_enough_references_have_been_given
     then_the_references_section_is_complete
     and_i_can_review_my_references_before_submission
-    and_i_can_edit_a_reference
     and_i_can_delete_a_reference
     and_i_can_delete_a_reference_request
     and_i_can_cancel_a_sent_reference
@@ -89,7 +88,7 @@ RSpec.feature 'Review references' do
 
     within '#references_waiting_to_be_sent' do
       expect(page).to have_content @not_sent_reference.email_address
-      expect(page).to have_link 'Change'
+      expect(page).not_to have_link 'Change'
       expect(page).to have_link 'Delete referee'
     end
 
@@ -107,21 +106,6 @@ RSpec.feature 'Review references' do
       expect(all('.app-summary-card')[3]).not_to have_link 'Change'
       expect(all('.app-summary-card')[3]).to have_link 'Delete request'
     end
-  end
-
-  def and_i_can_edit_a_reference
-    within '#references_waiting_to_be_sent' do
-      click_change_link 'name'
-    end
-
-    fill_in 'candidate-interface-reference-referee-name-form-name-field', with: 'John Major'
-    click_button 'Save and continue'
-
-    within '#references_waiting_to_be_sent' do
-      expect(page).to have_content 'John Major'
-    end
-
-    expect(page).to have_current_path candidate_interface_references_review_path
   end
 
   def and_i_can_delete_a_reference


### PR DESCRIPTION
##  Context

Similar to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3418, we want to prevent candidates from editing references in applications that already have 2 references.

## Changes proposed in this pull request

Updated `editable?`, which _should_ be used across the app to determine editability.

## Guidance to review

Before:

![image](https://user-images.githubusercontent.com/233676/99277887-4c5d8e00-2826-11eb-80ff-0b8adad11c0d.png)

After:

![image](https://user-images.githubusercontent.com/233676/99277858-423b8f80-2826-11eb-9a97-7ea1b4287cdb.png)


## Link to Trello card

https://trello.com/c/9FgC13b6

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
