### PR TITLE
Prevent unsendable references from being sent

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -131,6 +131,10 @@ module SupportInterface
           value: policy.can_send_reminder? ? 'Yes' : 'No',
         },
         {
+          key: 'Can request?',
+          value: policy.can_request? ? 'Yes' : 'No',
+        },
+        {
           key: 'Can send?',
           value: policy.can_send? ? 'Yes' : 'No',
         },

--- a/app/controllers/candidate_interface/references/candidate_name_controller.rb
+++ b/app/controllers/candidate_interface/references/candidate_name_controller.rb
@@ -16,8 +16,8 @@ module CandidateInterface
         )
 
         if @reference_candidate_name_form.save(@reference)
-          RequestReference.new.call(@reference, flash)
-
+          RequestReference.new.call(@reference)
+          flash[:success] = "Reference request sent to #{@reference.name}"
           redirect_to candidate_interface_references_review_path
         else
           track_validation_error(@reference_candidate_name_form)

--- a/app/controllers/candidate_interface/references/retry_request_controller.rb
+++ b/app/controllers/candidate_interface/references/retry_request_controller.rb
@@ -14,10 +14,8 @@ module CandidateInterface
         if @reference_email_address_form.valid?
           ActiveRecord::Base.transaction do
             @reference_email_address_form.save(@reference)
-            RequestReference.new.call(
-              @reference,
-              flash,
-            )
+            RequestReference.new.call(@reference)
+            flash[:success] = "Reference request sent to #{@reference.name}"
           end
           redirect_to candidate_interface_references_review_path
         else

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -25,7 +25,8 @@ module CandidateInterface
           if @submit_reference_form.send_request? && !@candidate_name_form.valid?
             redirect_to candidate_interface_references_new_candidate_name_path(@reference.id)
           elsif @submit_reference_form.send_request?
-            RequestReference.new.call(@reference, flash)
+            RequestReference.new.call(@reference)
+            flash[:success] = "Reference request sent to #{@reference.name}"
             redirect_to_review_page
           else
             redirect_to_review_page

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -85,7 +85,7 @@ class TestApplications
       # 4 will be requested
       4.times do
         reference = FactoryBot.create(:reference, :not_requested_yet, application_form: @application_form)
-        CandidateInterface::RequestReference.new.call(reference, {})
+        CandidateInterface::RequestReference.new.call(reference)
       end
 
       fast_forward

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -19,6 +19,10 @@ class ReferenceActionsPolicy
     reference.feedback_requested? && reference.reminder_sent_at.nil?
   end
 
+  def can_request?
+    can_send? || can_resend? || can_retry?
+  end
+
   def can_send?
     reference.not_requested_yet? &&
       needs_more_references? &&

--- a/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
@@ -173,7 +173,7 @@ RSpec.feature 'Candidate requests a reference' do
   end
 
   def then_i_see_a_page_not_found_page
-    expect(page).to have_content "Page not found"
+    expect(page).to have_content 'Page not found'
   end
 
   def when_i_manually_try_and_edit_my_references_type

--- a/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
@@ -38,8 +38,7 @@ RSpec.feature 'Candidate requests a reference' do
     and_the_reference_is_moved_to_the_requested_state
     and_an_email_is_sent_to_the_referee
     when_i_navigate_back_to_a_stale_confirmation_page
-    and_i_confirm_that_i_am_ready_to_send_a_reference_request
-    then_i_am_told_a_reference_has_already_been_sent
+    then_i_see_a_page_not_found_page
 
     when_i_manually_try_and_edit_my_references_type
     then_i_am_redirected_to_the_review_page
@@ -173,10 +172,8 @@ RSpec.feature 'Candidate requests a reference' do
     visit candidate_interface_references_new_request_path(@reference)
   end
 
-  def then_i_am_told_a_reference_has_already_been_sent
-    expect(page).to have_content "Reference request already sent to #{@reference.name}"
-    reference_requests = all_emails.select { |e| e.to.shift == @reference.email_address }
-    expect(reference_requests.count).to eq 1
+  def then_i_see_a_page_not_found_page
+    expect(page).to have_content "Page not found"
   end
 
   def when_i_manually_try_and_edit_my_references_type


### PR DESCRIPTION
## Context

It's currently possible to trick the system into sending references requests for any existing reference, even if it's already sent or if the application already enough references.

## Changes proposed in this pull request

Use the new policy object from #3423 to restrict the controller. 

## Guidance to review

Does the logic make sense?

## Link to Trello card

https://trello.com/c/9FgC13b6
