### PR TITLE
Revert govuk-main-wrapper padding

### DIFF
--- a/app/components/candidate_interface/application_feedback_component.html.erb
+++ b/app/components/candidate_interface/application_feedback_component.html.erb
@@ -1,5 +1,5 @@
 <% if FeatureFlag.active?(:feedback_prompts) %>
-  <div class="govuk-width-container govuk-!-margin-top-6">
+  <div class="govuk-width-container">
     <div class="app-feedback__container">
       <p class="govuk-body-m govuk-!-margin-bottom-0 govuk-!-margin-top-4">
         <%= govuk_link_to(

--- a/app/frontend/styles/_feedback.scss
+++ b/app/frontend/styles/_feedback.scss
@@ -8,7 +8,3 @@
   padding: govuk-spacing(2) govuk-spacing(5);
   min-height: 80px;
 }
-
-.govuk-main-wrapper {
-  padding-bottom: 0;
-}


### PR DESCRIPTION
## Context

Removing bottom padding of `.govuk-main-wrapper` is breaking page layouts:

<img width="809" alt="Screenshot 2020-11-16 at 21 10 13" src="https://user-images.githubusercontent.com/813383/99308856-7cba2200-2850-11eb-9092-8b7811cb7103.png">
<img width="721" alt="Screenshot 2020-11-16 at 21 11 34" src="https://user-images.githubusercontent.com/813383/99308863-7e83e580-2850-11eb-9393-a08cba33d4bf.png">

## Changes proposed in this pull request

* Remove override for `.govuk-main-wrapper`
* Remove top margin on feedback component

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
