### PR TITLE
Fix backlinks in the accept, decline and withdraw offer pages

### DIFF
--- a/app/views/candidate_interface/decisions/accept.html.erb
+++ b/app/views/candidate_interface/decisions/accept.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, 'Are you sure you want to accept this offer?' %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_offer_path(@application_choice), 'Back to application dashboard') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <h1 class="govuk-heading-xl govuk-heading-xl">
   Are you sure you want to accept this offer?

--- a/app/views/candidate_interface/decisions/decline.html.erb
+++ b/app/views/candidate_interface/decisions/decline.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, 'Are you sure you want to decline this offer?' %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_offer_path(@application_choice), 'Back to application dashboard') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('page_titles.withdraw_course_choice') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back to application dashboard') %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <h1 class="govuk-heading-xl govuk-heading-xl">
   Are you sure you want to withdraw this course choice?


### PR DESCRIPTION
## Context

The backlinks on the accept, decline and withdraw offer pages say 'Back to application dashboard when they should just say back. They are currently redirecting to the correct page (offer page), but it's misleading.

## Changes proposed in this pull request

Use the govuk_back_link_to method so the backlinks contain the correct information.

## Link to Trello card

https://trello.com/c/cAAKCSkL/1193-when-confirming-accept-decline-offer-the-back-link-should-go-back-to-the-offer-details-not-the-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
