### PR TITLE
Add undocumented search function to audit log 

### DIFF
--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -19,7 +19,7 @@ module SupportInterface
         audits = audits.where(auditable_type: params[:auditable_type])
       end
 
-      audits.includes(:user).order('id desc').page(params[:page] || 1).per(30)
+      audits.includes(:user).order('id desc').page(params[:page] || 1).per(60)
     end
 
     attr_reader :audited_thing

--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -15,6 +15,10 @@ module SupportInterface
                  standard_audits
                end
 
+      if params[:auditable_type]
+        audits = audits.where(auditable_type: params[:auditable_type])
+      end
+
       audits.includes(:user).order('id desc').page(params[:page] || 1).per(30)
     end
 


### PR DESCRIPTION
## Context

I need to search the application audit log for everything related to references. This is tricky because they're so large, and split over multiple pages.

## Changes proposed in this pull request

This allows you to filter any audit log by adding `auditable_type` in the URL:

http://localhost:3000/support/applications/514/audit?auditable_type=ApplicationReference

The UI (and tests) for this will be added in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3361.

Also increases the number of audits shown, to make searching even easier.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/9FgC13b6

