### PR TITLE
Increase pagination from 15 to 30 items per page

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -30,7 +30,7 @@ module ProviderInterface
         application_choices: with_includes.where(id: application_choices),
       )
 
-      @application_choices = application_choices.page(params[:page] || 1).per(15)
+      @application_choices = application_choices.page(params[:page] || 1).per(30)
     end
 
     def show

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -6,7 +6,7 @@ module SupportInterface
       @candidates = Candidate
         .includes(application_forms: :application_choices)
         .order(updated_at: :desc)
-        .page(params[:page] || 1).per(15)
+        .page(params[:page] || 1).per(30)
 
       if params[:q]
         @candidates = @candidates.where('CONCAT(email_address) ILIKE ?', "%#{params[:q]}%")

--- a/app/controllers/support_interface/email_log_controller.rb
+++ b/app/controllers/support_interface/email_log_controller.rb
@@ -6,7 +6,7 @@ module SupportInterface
       @emails = Email
         .order(id: :desc)
         .includes(:application_form)
-        .page(params[:page] || 1).per(15)
+        .page(params[:page] || 1).per(30)
 
       if params[:q]
         @emails = @emails.where("CONCAT('to', ' ', subject, ' ', notify_reference, ' ', body) ILIKE ?", "%#{params[:q]}%")

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -3,7 +3,7 @@ module SupportInterface
     def index
       @provider_users = ProviderUser
         .includes(providers: %i[training_provider_permissions ratifying_provider_permissions])
-        .page(params[:page] || 1).per(15)
+        .page(params[:page] || 1).per(30)
 
       if params[:q]
         @provider_users = @provider_users.where("CONCAT(first_name, ' ', last_name, ' ', email_address) ILIKE ?", "%#{params[:q]}%")

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -6,7 +6,7 @@ module SupportInterface
       @providers = Provider.where(sync_courses: true)
         .includes(:sites, :courses, :provider_agreements, :provider_users)
         .order(:name)
-        .page(params[:page] || 1).per(15)
+        .page(params[:page] || 1).per(30)
 
       if params[:q]
         @providers = @providers.where("CONCAT(name, ' ', code) ILIKE ?", "%#{params[:q]}%")
@@ -19,7 +19,7 @@ module SupportInterface
       @providers = Provider
         .where(sync_courses: false)
         .order(:name)
-        .page(params[:page] || 1).per(15)
+        .page(params[:page] || 1).per(30)
 
       if params[:q]
         @providers = @providers.where("CONCAT(name, ' ', code) ILIKE ?", "%#{params[:q]}%")

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -4,7 +4,7 @@ module SupportInterface
       @filter = SupportInterface::UCASMatchesFilter.new(params: params)
       @matches = @filter.filter_records(UCASMatch.includes(:candidate))
         .order(updated_at: :desc)
-        .page(params[:page] || 1).per(15)
+        .page(params[:page] || 1).per(30)
     end
 
     def show

--- a/app/controllers/support_interface/vendor_api_requests_controller.rb
+++ b/app/controllers/support_interface/vendor_api_requests_controller.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class VendorAPIRequestsController < SupportInterfaceController
     def index
       @filter = SupportInterface::VendorAPIRequestsFilter.new(params: params)
-      @vendor_api_requests = VendorAPIRequest.includes(:provider).order(created_at: :desc).page(params[:page] || 1).per(15)
+      @vendor_api_requests = VendorAPIRequest.includes(:provider).order(created_at: :desc).page(params[:page] || 1).per(30)
 
       if params[:q]
         @vendor_api_requests = @vendor_api_requests.where("CONCAT(request_path, ' ', request_body, ' ', response_body) ILIKE ?", "%#{params[:q]}%")

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -11,7 +11,7 @@ module SupportInterface
         .joins(:candidate)
         .includes(:candidate, :application_choices)
         .order(updated_at: :desc)
-        .page(applied_filters[:page] || 1).per(15)
+        .page(applied_filters[:page] || 1).per(30)
 
       if applied_filters[:q]
         application_forms = application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address, ' ', application_forms.support_reference) ILIKE ?", "%#{applied_filters[:q]}%")

--- a/spec/system/provider_interface/provider_applications_pagination_spec.rb
+++ b/spec/system/provider_interface/provider_applications_pagination_spec.rb
@@ -7,13 +7,13 @@ RSpec.feature 'Providers should be able to sort applications' do
   scenario 'viewing applications one page at a time' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
-    and_my_organisation_has_fewer_than_15_applications
+    and_my_organisation_has_fewer_than_30_applications
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_provider_applications_page
     then_i_should_not_see_a_paginator
 
-    given_my_organisation_has_more_than_15_applications
+    given_my_organisation_has_more_than_30_applications
     when_i_visit_the_provider_applications_page
     then_i_should_see_a_paginator
 
@@ -30,7 +30,7 @@ RSpec.feature 'Providers should be able to sort applications' do
     provider_user_exists_in_apply_database
   end
 
-  def and_my_organisation_has_fewer_than_15_applications
+  def and_my_organisation_has_fewer_than_30_applications
     current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
 
     @course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
@@ -59,10 +59,10 @@ RSpec.feature 'Providers should be able to sort applications' do
     expect(page).not_to have_content('Showing 1 to')
   end
 
-  def given_my_organisation_has_more_than_15_applications
+  def given_my_organisation_has_more_than_30_applications
     create_list(
       :application_choice,
-      15,
+      30,
       :awaiting_provider_decision,
       course_option: @course_option_one,
       application_form: create(:application_form),
@@ -91,7 +91,7 @@ RSpec.feature 'Providers should be able to sort applications' do
   def then_i_should_see_a_paginator_for_page_2
     expect(page).to have_link('Previous')
     expect(page).to have_link('1')
-    expect(page).to have_content('Showing 16 to')
+    expect(page).to have_content('Showing 31 to')
   end
 
   def then_i_should_not_see_a_paginator


### PR DESCRIPTION
## Context

Increase pagination from 15 to 30 items per page as requested by the interactions designer.

## Changes proposed in this pull request

<img width="480" alt="Screenshot 2020-11-17 at 10 57 30" src="https://user-images.githubusercontent.com/38078064/99382000-c4c65c80-28c3-11eb-8957-79c6c2370667.png">


## Guidance to review

🚢 

## Link to Trello card

https://trello.com/c/KvcoXL0w/3038-increase-pagination-from-15-to-30-items-per-page
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
