### PR TITLE
Add relevant dates to the reference in support

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -44,20 +44,63 @@ module SupportInterface
     end
 
     def date_rows
-      [
+      return [] if reference.not_requested_yet?
+
+      dates = [
         {
           key: 'Requested on',
           value: reference.requested_at&.to_s(:govuk_date_and_time),
         },
-        {
+      ]
+
+      if reference.cancelled?
+        dates << {
+          key: 'Cancelled on',
+          value: reference.feedback_cancelled_at&.to_s(:govuk_date_and_time),
+        }
+      end
+
+      if reference.cancelled_at_end_of_cycle?
+        dates << {
+          key: 'Cancelled at end of cycle on',
+          value: reference.feedback_cancelled_at_end_of_cycle_at&.to_s(:govuk_date_and_time),
+        }
+      end
+
+      if reference.feedback_requested?
+        dates << {
           key: 'Chase on',
           value: reference.chase_referee_at&.to_s(:govuk_date_and_time),
-        },
-        {
+        }
+
+        dates << {
           key: 'Replace on',
           value: reference.replace_referee_at&.to_s(:govuk_date_and_time),
-        },
-      ].select { |row| row[:value] }
+        }
+      end
+
+      if reference.feedback_provided?
+        dates << {
+          key: 'Feedback provided on',
+          value: reference.feedback_provided_at&.to_s(:govuk_date_and_time),
+        }
+      end
+
+      if reference.feedback_refused?
+        dates << {
+          key: 'Declined on',
+          value: reference.feedback_refused_at&.to_s(:govuk_date_and_time),
+        }
+      end
+
+      if reference.email_bounced?
+        dates << {
+          key: 'Email bounced on',
+          value: reference.email_bounced_at&.to_s(:govuk_date_and_time),
+        }
+      end
+
+      dates
     end
 
     def name_row
@@ -100,6 +143,8 @@ module SupportInterface
     end
 
     def history_row
+      return if reference.not_requested_yet?
+
       {
         key: 'Email history',
         value: govuk_link_to('View history', support_interface_email_log_path(

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -93,4 +93,33 @@ class ApplicationReference < ApplicationRecord
 
     replace_referee_at < Time.zone.now
   end
+
+  def feedback_refused_at
+    state_changed_at(from: 'feedback_requested', to: 'feedback_refused')
+  end
+
+  def feedback_provided_at
+    state_changed_at(from: 'feedback_requested', to: 'feedback_provided')
+  end
+
+  def feedback_cancelled_at
+    state_changed_at(from: 'feedback_requested', to: 'cancelled')
+  end
+
+  def feedback_cancelled_at_end_of_cycle_at
+    state_changed_at(from: 'feedback_requested', to: 'cancelled_at_end_of_cycle')
+  end
+
+  def email_bounced_at
+    state_changed_at(from: 'feedback_requested', to: 'email_bounced')
+  end
+
+private
+
+  # We don't keep track of all state changes in separate database columns, so we have
+  # to interrogate the audit log for specific transitions. If we start using these
+  # more often, they should become a database column since this isn't very efficient.
+  def state_changed_at(from:, to:)
+    audits.find { |audit| audit.audited_changes['feedback_status'] == [from, to] }&.created_at
+  end
 end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -28,7 +28,7 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
 
 <% if @application_form.application_references.any? %>
-  <% @application_form.application_references.includes([:application_form]).each_with_index do |reference, i| %>
+  <% @application_form.application_references.includes([:application_form, :audits]).each_with_index do |reference, i| %>
     <%= render SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: i + 1) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Context

For each state, figure out the relevant dates and show them. Haven't tested it because the set up is very hard. It's resilient to errors though - if a date hasn't been found it will just display nothing.

## Changes proposed in this pull request

Before:

![image](https://user-images.githubusercontent.com/233676/99386552-913b0080-28ca-11eb-964e-980ab7362192.png)

After:

![image](https://user-images.githubusercontent.com/233676/99386559-94ce8780-28ca-11eb-97f0-686dbd313836.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/9FgC13b6
