### PR TITLE
Remove ‘international_gcses’ feature flag

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -94,7 +94,7 @@ module CandidateInterface
     end
 
     def country_row
-      return nil unless FeatureFlag.active?('international_gcses') && application_qualification.qualification_type == 'non_uk'
+      return nil unless application_qualification.qualification_type == 'non_uk'
 
       {
         key: 'Country',
@@ -105,7 +105,7 @@ module CandidateInterface
     end
 
     def naric_statment_row
-      return nil unless FeatureFlag.active?('international_gcses') && application_qualification.qualification_type == 'non_uk'
+      return nil unless application_qualification.qualification_type == 'non_uk'
 
       {
         key: t('application_form.gcse.naric_statement.review_label'),
@@ -116,8 +116,7 @@ module CandidateInterface
     end
 
     def naric_reference_row
-      return nil unless FeatureFlag.active?('international_gcses') &&
-        application_qualification.qualification_type == 'non_uk' &&
+      return nil unless application_qualification.qualification_type == 'non_uk' &&
         application_qualification.naric_reference
 
       {
@@ -129,8 +128,7 @@ module CandidateInterface
     end
 
     def comparable_uk_qualification_row
-      return nil unless FeatureFlag.active?('international_gcses') &&
-        application_qualification.qualification_type == 'non_uk' &&
+      return nil unless application_qualification.qualification_type == 'non_uk' &&
         application_qualification.naric_reference
 
       {

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Gcse::InstitutionCountryController < Gcse::DetailsController
-    before_action :redirect_to_dashboard_if_submitted, :set_subject, :render_404_if_flag_is_inactive
+    before_action :redirect_to_dashboard_if_submitted, :set_subject
 
     def edit
       @institution_country = find_or_build_qualification_form
@@ -22,10 +22,6 @@ module CandidateInterface
     end
 
   private
-
-    def render_404_if_flag_is_inactive
-      render_404 and return unless FeatureFlag.active?('international_gcses')
-    end
 
     def find_or_build_qualification_form
       @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)

--- a/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_reference_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class Gcse::NaricReferenceController < Gcse::DetailsController
     include Gcse::ResolveGcseEditPathConcern
 
-    before_action :redirect_to_dashboard_if_submitted, :set_subject, :render_404_if_flag_is_inactive
+    before_action :redirect_to_dashboard_if_submitted, :set_subject
 
     def edit
       @naric_reference_form = find_or_build_qualification_form
@@ -24,10 +24,6 @@ module CandidateInterface
     end
 
   private
-
-    def render_404_if_flag_is_inactive
-      render_404 and return unless FeatureFlag.active?('international_gcses')
-    end
 
     def find_or_build_qualification_form
       @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -69,8 +69,7 @@ module CandidateInterface
     end
 
     def new_non_uk_qualification?
-      FeatureFlag.active?('international_gcses') &&
-        @application_qualification.qualification_type == 'non_uk' &&
+      @application_qualification.qualification_type == 'non_uk' &&
         @details_form.qualification.institution_country.nil?
     end
   end

--- a/app/forms/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_details_form.rb
@@ -7,7 +7,6 @@ module CandidateInterface
     validates :grade, presence: true, on: :grade
     validates :other_grade, presence: true, if: :grade_is_other?
     validates :award_year, presence: true, on: :award_year
-    validates :grade, length: { maximum: 6 }, on: :grade, unless: :international_gcses_flag_active?
     validate :award_year_is_a_valid_date, if: :award_year, on: :award_year
     validate :validate_grade_format, unless: :new_record?, on: :grade
 
@@ -18,7 +17,7 @@ module CandidateInterface
     end
 
     def self.build_from_qualification(qualification)
-      if FeatureFlag.active?('international_gcses') && qualification.qualification_type == 'non_uk'
+      if qualification.qualification_type == 'non_uk'
         new(
           grade: qualification.set_grade,
           other_grade: qualification.set_other_grade,
@@ -119,10 +118,6 @@ module CandidateInterface
       else
         grade
       end
-    end
-
-    def international_gcses_flag_active?
-      FeatureFlag.active?('international_gcses')
     end
   end
 end

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -16,14 +16,13 @@ module CandidateInterface
                   :physics_grade,
                   :chemistry_grade
     validates :other_grade, presence: true, if: :grade_is_other?
-    validates :grade, length: { maximum: 6 }, unless: :international_gcses_flag_active?
     validate :grade_length
     validate :grade_format, unless: :new_record?
     validate :triple_award_grade_format
 
     class << self
       def build_from_qualification(qualification)
-        if FeatureFlag.active?('international_gcses') && qualification.qualification_type == 'non_uk'
+        if qualification.qualification_type == 'non_uk'
           new(
             grade: qualification.set_grade,
             other_grade: qualification.set_other_grade,
@@ -197,10 +196,6 @@ module CandidateInterface
 
     def sanitize(grade)
       grade.delete(' ').upcase if grade
-    end
-
-    def international_gcses_flag_active?
-      FeatureFlag.active?('international_gcses')
     end
 
     def new_record?

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,7 +26,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:providers_can_filter_by_recruitment_cycle, 'Allows provider users to filter applications by recruitment cycle', 'Michael Nacos'],
     [:efl_section, 'Allow candidates with nationalities other then British or Irish to specify their English as a Foreign Language experience', 'Malcolm Baig'],
-    [:international_gcses, 'Candidates can provide details of international GCSE equivalents.', 'George Holborn'],
     [:export_hesa_data, 'Providers can export applications including HESA data.', 'Steve Laing'],
     [:feedback_form, 'New simplified feedback form to replace old multi-page satisfaction survey.', 'Steve Hook'],
     [:feedback_prompts, 'Candidates can give feedback while completing their application form', 'David Gisbey'],

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
+      <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>

--- a/app/views/candidate_interface/gcse/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
+      <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>

--- a/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <% if FeatureFlag.active?('international_gcses') && @application_qualification.qualification.qualification_type == 'non_uk' %>
+      <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <% if FeatureFlag.active?('international_gcses') && @qualification_type == 'non_uk' %>
+      <% if @qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -19,10 +19,8 @@
             <% end %>
 
           <% elsif option.id == :non_uk %>
-            <% if FeatureFlag.active?('international_gcses') %>
-              <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
-                <% f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
-              <% end %>
+            <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
+              <% f.govuk_text_field :non_uk_qualification_type, label: { text: t('application_form.gcse.non_uk.label'), size: 's' }, hint: { text: t('application_form.gcse.non_uk.hint_text') } %>
             <% end %>
 
           <% elsif option.id == :missing %>

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -1,11 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
-  context 'with the international_gcses flag on' do
-    before do
-      FeatureFlag.activate('international_gcses')
-    end
-
+  context 'a non uk qualification' do
     it 'renders a non-uk GCSE equivalent qualification' do
       application_form = build :application_form
       @qualification = application_qualification = build(
@@ -64,7 +60,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
     end
   end
 
-  context 'with the international_gcses flag off' do
+  context 'a uk qualification' do
     it 'displays award year, qualification type and grade' do
       application_form = build :application_form
       @qualification = application_qualification = build(

--- a/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -2,11 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
   describe 'validations' do
-    before { FeatureFlag.deactivate(:international_gcses) }
-
     it { is_expected.to validate_presence_of(:grade).on(:grade) }
     it { is_expected.to validate_presence_of(:award_year).on(:award_year) }
-    it { is_expected.to validate_length_of(:grade).is_at_most(6).on(:grade) }
 
     context 'when grade is "other"' do
       let(:form) { subject }
@@ -175,25 +172,8 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
     end
 
     describe '.build_from_qualification' do
-      context 'with the international_gcses feature flag off' do
-        let(:data) do
-          {
-            grade: 'D',
-            award_year: '2012',
-          }
-        end
-
-        it 'creates an object based on the provided ApplicationForm' do
-          qualification = ApplicationQualification.new(data)
-          gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
-
-          expect(gcse_details_form).to have_attributes(data)
-        end
-      end
-
-      context 'with the international_gcses feature flag on, the qualification_type is non_uk and grade is not_applicable' do
+      context 'when the qualification_type is non_uk and grade is not_applicable' do
         it 'sets grade to not_applicable and other grade to nil' do
-          FeatureFlag.activate('international_gcses')
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'n/a')
           gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
 
@@ -202,9 +182,8 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
         end
       end
 
-      context 'with the international_gcses feature flag on and grade is unknown' do
+      context 'when the grade is unknown' do
         it 'sets grade to not_applicable and other grade to nil' do
-          FeatureFlag.activate('international_gcses')
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'unknown')
           gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
 
@@ -213,9 +192,8 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
         end
       end
 
-      context 'with the international_gcses feature flag on and grade is another value' do
+      context 'when grade is another value' do
         it 'sets grade to other and other grade to grades value' do
-          FeatureFlag.activate('international_gcses')
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'D')
           gcse_details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
 

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
   describe 'validations' do
-    before { FeatureFlag.deactivate(:international_gcses) }
-
-    it { is_expected.to validate_length_of(:grade).is_at_most(6) }
-
     context 'when grade is "other"' do
       let(:form) { subject }
 
@@ -361,24 +357,8 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
     end
 
     describe '.build_from_qualification' do
-      context 'with the international_gcses feature flag off' do
-        let(:data) do
-          {
-            grade: 'other',
-          }
-        end
-
-        it 'creates an object based on the provided ApplicationForm' do
-          qualification = ApplicationQualification.new(data)
-          gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
-
-          expect(gcse_details_form).to have_attributes(data)
-        end
-      end
-
-      context 'with the international_gcses feature flag on, the qualification_type is non_uk and grade is not_applicable' do
+      context 'when the qualification_type is non_uk and grade is not_applicable' do
         it 'sets grade to not_applicable and other grade to nil' do
-          FeatureFlag.activate('international_gcses')
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'n/a')
           gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
 
@@ -387,9 +367,8 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         end
       end
 
-      context 'with the international_gcses feature flag on and grade is unknown' do
+      context 'when the grade is unknown' do
         it 'sets grade to not_applicable and other grade to nil' do
-          FeatureFlag.activate('international_gcses')
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'unknown')
           gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
 
@@ -398,9 +377,8 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         end
       end
 
-      context 'with the international_gcses feature flag on and grade is another value' do
+      context 'when the grade is another value' do
         it 'sets grade to other and other grade to grades value' do
-          FeatureFlag.activate('international_gcses')
           qualification = build_stubbed(:gcse_qualification, qualification_type: 'non_uk', grade: 'D')
           gcse_details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_other_uk_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_other_uk_qualification_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Candidate entering GCSE details' do
   include CandidateHelper
 
   scenario 'Candidate specifies GCSE maths with "Other UK qualification" type' do
-    FeatureFlag.deactivate(:international_gcses)
-
     given_i_am_signed_in
     and_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
@@ -34,7 +32,8 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def and_i_fill_in_the_type_of_qualification
-    fill_in t('application_form.gcse.other_uk.label'), with: 'Scottish Baccalaureate'
+    find('#candidate-interface-gcse-qualification-type-form-other-uk-qualification-type-field')
+      .set('Scottish Baccalaureate')
   end
 
   def and_i_click_save_and_continue

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_award_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature 'Candidate entering GCSE Science details' do
   include CandidateHelper
 
   scenario 'Candidate submits their Science GCSE award' do
-    FeatureFlag.deactivate(:international_gcses)
     # Activating the :science_gcse_awards FeatureFlag enables the new awards UI
     FeatureFlag.activate(:science_gcse_awards)
 
@@ -27,10 +26,6 @@ RSpec.feature 'Candidate entering GCSE Science details' do
     and_i_enter_an_invalid_grade
     and_i_click_save_and_continue
     then_i_see_the_grade_invalid_error
-
-    and_i_enter_a_grade_that_is_too_long
-    and_i_click_save_and_continue
-    then_i_see_grade_too_long_error
 
     then_i_enter_a_valid_grade
     and_i_click_save_and_continue
@@ -104,15 +99,5 @@ RSpec.feature 'Candidate entering GCSE Science details' do
     within find('#candidate-interface-science-gcse-grade-form-gcse-science-science-single-award-conditional') do
       fill_in('Grade', with: 'A')
     end
-  end
-
-  def and_i_enter_a_grade_that_is_too_long
-    within find('#candidate-interface-science-gcse-grade-form-gcse-science-science-single-award-conditional') do
-      fill_in('Grade', with: 'SHIZZLE')
-    end
-  end
-
-  def then_i_see_grade_too_long_error
-    expect(page).to have_content('Grade must be 6 characters or fewer')
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_science_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature 'Candidate entering GCSE Science details' do
   include CandidateHelper
 
   scenario 'Candidate submits their Science GCSE award' do
-    FeatureFlag.deactivate(:international_gcses)
     # Activating the :science_gcse_awards feature flag enables the new awards UI
     FeatureFlag.deactivate(:science_gcse_awards)
 
@@ -26,10 +25,6 @@ RSpec.feature 'Candidate entering GCSE Science details' do
     and_i_enter_an_invalid_grade
     and_i_click_save_and_continue
     then_i_see_the_grade_invalid_error
-
-    and_i_enter_a_grade_that_is_too_long
-    and_i_click_save_and_continue
-    then_i_see_grade_too_long_error
 
     then_i_enter_a_valid_grade
     and_i_click_save_and_continue
@@ -87,14 +82,6 @@ RSpec.feature 'Candidate entering GCSE Science details' do
 
   def then_i_see_the_grade_invalid_error
     expect(page).to have_content('Enter a real science grade')
-  end
-
-  def and_i_enter_a_grade_that_is_too_long
-    fill_in('candidate-interface-science-gcse-grade-form-grade-field-error', with: 'SHIZZLE')
-  end
-
-  def then_i_see_grade_too_long_error
-    expect(page).to have_content('Grade must be 6 characters or fewer')
   end
 
   def then_i_enter_a_valid_grade

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Candidate entering GCSE details' do
   include CandidateHelper
 
   scenario 'Candidate submits their maths GCSE details and then update them' do
-    FeatureFlag.deactivate(:international_gcses)
-
     given_i_am_signed_in
 
     when_i_visit_the_candidate_application_page

--- a/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
 
   scenario 'Candidate submits their maths Non UK GCSE equivalency details and then updates them' do
     given_i_am_signed_in
-    and_the_international_gcses_flag_is_active
 
     when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
@@ -57,10 +56,6 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_international_gcses_flag_is_active
-    FeatureFlag.activate('international_gcses')
   end
 
   def given_i_am_not_signed_in; end


### PR DESCRIPTION
## Context

The ‘international gcses’ feature flag is no longer required as we're not going to roll back this feature.

## Changes proposed in this pull request

- remove ‘international gsces’ feature flag
- fix broken specs
- remove any redundant specs


## Guidance to review


## Link to Trello card

https://trello.com/c/B4H5LubI/2554-remove-international-gcse-flag

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
