### PR TITLE
Change copy for Criminal convictions and professional misconduct

### DIFF
--- a/config/locales/safeguarding.yml
+++ b/config/locales/safeguarding.yml
@@ -4,10 +4,10 @@ en:
       has_safeguarding_issues_to_declare: The candidate has disclosed sensitive material related to safeguarding.
       not_answered_yet: Not answered yet.
       never_asked: Never asked.
-      no_safeguarding_issues_to_declare: No information shared.
+      no_safeguarding_issues_to_declare: The candidate has declared no criminal convictions or other safeguarding issues.
   support_interface:
     safeguarding_issues_component:
       has_safeguarding_issues_to_declare: The candidate has shared information related to safeguarding.
       not_answered_yet: Not answered yet.
       never_asked: Never asked.
-      no_safeguarding_issues_to_declare: No information shared.
+      no_safeguarding_issues_to_declare: The candidate has declared no criminal convictions or other safeguarding issues.

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
         safeguarding_issues: nil,
         safeguarding_issues_status: 'no_safeguarding_issues_to_declare',
       )
-      expect(result.text).to include('No information shared.')
+      expect(result.text).to include('The candidate has declared no criminal convictions or other safeguarding issues.')
     end
 
     it 'when the candidate has shared information related to safeguarding' do
@@ -137,7 +137,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
         safeguarding_issues: nil,
         safeguarding_issues_status: 'no_safeguarding_issues_to_declare',
       )
-      expect(result.text).to include('No information shared.')
+      expect(result.text).to include('The candidate has declared no criminal convictions or other safeguarding issues.')
     end
 
     it 'when the candidate has shared information related to safeguarding' do

--- a/spec/components/support_interface/safeguarding_issues_component_spec.rb
+++ b/spec/components/support_interface/safeguarding_issues_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SupportInterface::SafeguardingIssuesComponent do
     end
   end
 
-  context 'when the candidate has not shared information related to safeguarding' do
+  context 'when the candidate has no safeguarding issues to declare' do
     it 'displays the correct text' do
       application_form = build_stubbed(
         :application_form,
@@ -36,7 +36,7 @@ RSpec.describe SupportInterface::SafeguardingIssuesComponent do
       )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include('No information shared.')
+      expect(result.text).to include('The candidate has declared no criminal convictions or other safeguarding issues.')
     end
   end
 


### PR DESCRIPTION
## Context

I was not clear if the candidate did not respond to this question or they have no issues to declare.

## Changes proposed in this pull request

- Before
<kbd><img width="481" alt="Screenshot 2020-11-17 at 11 52 08" src="https://user-images.githubusercontent.com/38078064/99388373-67370d80-28cd-11eb-9ca8-3ee2352dbddb.png"></kbd>

- After
<kbd><img width="426" alt="Screenshot 2020-11-17 at 11 51 51" src="https://user-images.githubusercontent.com/38078064/99388386-6d2cee80-28cd-11eb-83c4-4d03cdc52063.png"></kbd>

## Guidance to review

- visit individual application page `http://localhost:3000/provider/applications/:id`

## Link to Trello card

https://trello.com/c/95j0NfEE/2956-change-text-in-criminal-convictions

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
