### PR TITLE
Correct conditional field label text and sizing for qualification types

### DIFF
--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -2,7 +2,7 @@
   <%= f.govuk_radio_button :uk_degree, 'yes', label: { text: t('application_form.degree.uk_degree.label') } do %>
     <%= f.govuk_text_field(
       :type_description,
-      label: { text: t('application_form.degree.qualification_type.label'), size: 'm' },
+      label: { text: t('application_form.degree.qualification_type.label'), size: 's' },
       hint: { text: t('application_form.degree.qualification_type.hint_text.undergraduate') }
     ) %>
     <%= tag.div(id: 'degree-type-autocomplete', data: { source: @degree_types }) %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -12,11 +12,11 @@
   <%= f.govuk_radio_button :qualification_type, 'AS level', label: { text: 'AS level' } %>
 
   <%= f.govuk_radio_button :qualification_type, 'Other', label: { text: 'Other UK qualification' } do %>
-    <%= f.govuk_text_field :other_uk_qualification_type, label: { text: 'Qualification name' } %>
+    <%= f.govuk_text_field :other_uk_qualification_type, label: { text: 'Qualification name', size: 's' } %>
     <%= tag.div(id: 'other-uk-qualifications-autocomplete', data: { source: OTHER_UK_QUALIFICATIONS }) %>
   <% end %>
   <%= f.govuk_radio_button :qualification_type, 'non_uk', label: { text: 'Non-UK qualification' } do %>
-    <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name' }, hint: { text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') } %>
+    <%= f.govuk_text_field :non_uk_qualification_type, label: { text: 'Qualification name', size: 's' }, hint: { text: t('application_form.other_qualification.qualification_type.non_uk.hint_text') } %>
   <% end %>
 <% end %>
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -265,9 +265,9 @@ en:
         non_uk: Non-UK qualification
         missing: I do not have this qualification yet
       other_uk:
-        label: Enter type of qualification
+        label: Qualification name
       non_uk:
-        label: Enter type of qualification
+        label: Qualification name
         hint_text: For example, High School Diploma, Higher Secondary School Certificate, Baccalauréat Général, Título de Bachiller
       missing_explanation:
         label: If you are working towards this qualification, give us details (optional)


### PR DESCRIPTION
## Context

We have a number of conditional fields available when entering qualifications. These fields should use the same label size. For GCSEs and other qualifications, we should also use the same label text, and consistently refer to qualification **name**, and not **type** within the conditional field.

## Changes proposed in this pull request

(Screenshots taken with JS-disabled to demonstrate the difference across all conditional fields)

| Before | After |
| - | - |
| ![degree-before](https://user-images.githubusercontent.com/813383/99391951-dbc07b00-28d2-11eb-899a-1a74875cc441.png) | ![degree-after](https://user-images.githubusercontent.com/813383/99391947-da8f4e00-28d2-11eb-911b-f73e542ea2c5.png) |
| ![gcse-before](https://user-images.githubusercontent.com/813383/99391955-dc591180-28d2-11eb-8287-02c6bfd61599.png) | ![gcse-after](https://user-images.githubusercontent.com/813383/99391952-dbc07b00-28d2-11eb-9a6f-933e3f565870.png) |
| ![other-before](https://user-images.githubusercontent.com/813383/99391957-de22d500-28d2-11eb-8472-0099d7eba317.png) | ![other-after](https://user-images.githubusercontent.com/813383/99391956-dcf1a800-28d2-11eb-81d4-9c1d51876ce5.png) |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
