### PR TITLE
Experiment with documenting the TAD CSV

### DIFF
--- a/app/components/data_set_attribute_component.html.erb
+++ b/app/components/data_set_attribute_component.html.erb
@@ -1,0 +1,35 @@
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <code><%= column_name %></code><br/>
+    </dt>
+
+    <dd class="govuk-summary-list__value">
+      <p class="app-data-set-documentation--datatype">
+        <%= type_description %>
+      </p>
+
+      <p class="govuk-body">
+        <%= description %>
+      </p>
+
+      <% if has_example? %>
+        <p class="govuk-body">
+          Example: <code><%= example %></code>
+        </p>
+      <% end %>
+
+      <% if column['enum'] %>
+        <p class="govuk-body">
+          Possible values:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <% column['enum'].each do |item| %>
+            <li><code><%= item.inspect %></code></li>
+          <% end %>
+        </ul>
+      <% end %>
+    </dd>
+  </div>
+</dl>

--- a/app/components/data_set_attribute_component.rb
+++ b/app/components/data_set_attribute_component.rb
@@ -1,0 +1,34 @@
+class DataSetAttributeComponent < ViewComponent::Base
+  include MarkdownHelper
+
+  attr_reader :column_name, :column
+
+  def initialize(column_name:, column:)
+    @column_name = column_name
+    @column = column
+  end
+
+  def type_description
+    desc = [column['type']]
+    desc << ', ISO 8601 date with time and timezone' if column['format'] == 'date-time'
+    desc << ', date YYYY-MM-DD' if column['format'] == 'date'
+
+    if column['type'] == 'string' && column['max_length'].present?
+      desc << " (limited to #{column['max_length']} characters)"
+    end
+
+    desc.join
+  end
+
+  def description
+    markdown_to_html(column['description'])
+  end
+
+  def example
+    column['example'].is_a?(Array) ? column['example'].join('|').inspect : column['example'].inspect
+  end
+
+  def has_example?
+    column['example']
+  end
+end

--- a/app/controllers/support_interface/data_exports_controller.rb
+++ b/app/controllers/support_interface/data_exports_controller.rb
@@ -25,5 +25,9 @@ module SupportInterface
       data_export.update!(audit_comment: 'File downloaded')
       send_data data_export.data, filename: data_export.filename, disposition: :attachment
     end
+
+    def data_set_documentation
+      @export_type = DataExport::EXPORT_TYPES.fetch(params.fetch(:export_type_id).to_sym)
+    end
   end
 end

--- a/app/exports/_common_columns.yml
+++ b/app/exports/_common_columns.yml
@@ -1,0 +1,212 @@
+extract_date:
+  type: string
+  format: date-time
+  description: Time when the report ran
+  example: 2019-06-13T10:44:31Z
+
+candidate_id:
+  type: string
+  description: The candidate’s ID in the Apply system
+  maxLength: 10
+  example: 5432
+
+application_choice_id:
+  type: string
+  description: The application choice's ID in the Apply system
+  maxLength: 10
+  example: 89876
+
+application_form_id:
+  type: string
+  description: The application form's ID in the Apply system
+  maxLength: 10
+  example: 4566
+
+phase:
+  type: string
+  description: |
+    The phase of this application. In the first phase, "Apply 1", the
+    candidate can choose up to 3 courses. If all of those choices are rejected,
+    declined, or withdrawn, the user can go into "Apply 2". This means
+    they can choose 1 course at a time.
+  enum:
+  - apply_1
+  - apply_2
+  example: apply_1
+
+# # Personal information
+first_name:
+  type: string
+  description: The candidate’s first name
+  maxLength: 60
+  example: Boris
+
+last_name:
+  type: string
+  description: The candidate’s last name
+  example: Brown
+  maxLength: 60
+
+date_of_birth:
+  type: string
+  format: date
+  description: The candidate’s date of birth
+  example: 1985-02-02
+
+email:
+  type: string
+  description: The candidate’s email address
+  maxLength: 100
+  example: boris.brown@example.com
+
+postcode:
+  type: string
+  description: The candidate’s postcode
+  maxLength: 8
+  example: SK2 6AA
+  nullable: true
+
+country:
+  type: string
+  maxLength: 2
+  description: The candidate’s country - ISO 3166-2 country code
+  pattern: "^[A-Z]{2}$"
+  example: GB
+
+nationality:
+  type: array
+  items:
+    type: string
+    pattern: "^[A-Z]{2}$"
+    example: NL
+  maxItems: 5
+  description: One or more ISO 3166-2 country codes
+  example:
+    - GB
+    - NL
+sex:
+  type: string
+  nullable: true
+  description: The candidate’s sex as a [1-digit HESA code for Sex](https://www.hesa.ac.uk/collection/c19053/e/sexid)
+  example: "1"
+  enum:
+  - "1"
+  - "2"
+  - "3"
+
+disability:
+  nullable: true
+  type: array
+  items:
+    type: string
+  description: The candidate's disabilities as an array of [2-digit HESA codes for Disability](https://www.hesa.ac.uk/collection/c19053/e/disable)
+  example:
+    - "00"
+    - "51"
+  enum:
+  - "00"
+  - "08"
+  - "51"
+  - "53"
+  - "54"
+  - "55"
+  - "56"
+  - "57"
+  - "58"
+  - "96"
+
+ethnicity:
+  type: string
+  nullable: true
+  description: The candidate’s ethnicity as [a 2-digit HESA code for Ethnicity](https://www.hesa.ac.uk/collection/c19053/e/ethnic)
+  example: "10"
+  enum:
+  - "10"
+  - "15"
+  - "21"
+  - "22"
+  - "29"
+  - "31"
+  - "32"
+  - "33"
+  - "34"
+  - "39"
+  - "41"
+  - "42"
+  - "43"
+  - "49"
+  - "50"
+  - "80"
+  - "90"
+  - "98"
+
+# # The candidate's degree
+degree_classification:
+  type: string
+
+degree_classification_hesa_code:
+  type: string
+
+# # Provider
+provider_code:
+  type: string
+  description: The provider’s code
+  example: 2FR
+  maxLength: 3
+
+provider_id:
+  type: string
+  description: The provider’s ID in Apply
+  example: 98765
+  maxLength: 10
+
+provider_name:
+  type: string
+  description: The provider’s name
+  example: "Hogwarts School of Witchcraft and Wizardry"
+  maxLength: 255
+
+accrediting_provider_code:
+  type: string
+  description: The accrediting provider’s code
+  example: 2FR
+  maxLength: 3
+
+accrediting_provider_id:
+  type: string
+  description: The accrediting provider’s ID in Apply
+  example: 98765
+  maxLength: 10
+
+accrediting_provider_name:
+  type: string
+  description: The accrediting provider’s name
+  example: "Hogwarts School of Witchcraft and Wizardry"
+  maxLength: 255
+
+course_level:
+  type: string
+
+program_type:
+  type: string
+  description: Not provided yet
+
+programme_outcome:
+  type: string
+  description: The description of the course
+
+course_name:
+  type: string
+  description: The course’s name
+  example: "Maths"
+  maxLength: 255
+
+course_code:
+  type: string
+  description: The course’s code
+  example: 3CVK
+  maxLength: 4
+
+nctl_subject:
+  type: array
+  maxLength: 255

--- a/app/exports/active_provider_user_permissions_export.yml
+++ b/app/exports/active_provider_user_permissions_export.yml
@@ -1,0 +1,43 @@
+custom_columns:
+  name:
+    type: string
+
+  email_address:
+    type: string
+
+  provider:
+    type: string
+
+  last_signed_in_at:
+    type: string
+    format: date-time
+
+  has_make_decisions:
+    type: string
+    enum:
+      - true
+      - false
+
+  has_view_safeguarding:
+    type: string
+    enum:
+      - true
+      - false
+
+  has_view_diversity:
+    type: string
+    enum:
+      - true
+      - false
+
+  has_manage_users:
+    type: string
+    enum:
+      - true
+      - false
+
+  has_manage_organisations:
+    type: string
+    enum:
+      - true
+      - false

--- a/app/exports/tad_export.yml
+++ b/app/exports/tad_export.yml
@@ -1,0 +1,49 @@
+common_columns:
+- extract_date
+- candidate_id
+- application_choice_id
+- application_form_id
+- phase
+- first_name
+- last_name
+- date_of_birth
+- email
+- postcode
+- country
+- nationality
+- sex
+- disability
+- ethnicity
+- degree_classification
+- degree_classification_hesa_code
+- provider_code
+- provider_id
+- provider_name
+- accrediting_provider_code
+- accrediting_provider_id
+- accrediting_provider_name
+- course_level
+- program_type
+- programme_outcome
+- course_name
+- course_code
+- nctl_subject
+
+custom_columns:
+  status:
+    type: string
+    description: |
+      The status of this application. Limited to a number of statuses because we
+      only expose applications that have been submitted.
+    enum:
+    - awaiting_provider_decision
+    - conditions_not_met
+    - declined
+    - declined_by_default
+    - offer
+    - pending_conditions
+    - recruited
+    - rejected
+    - rejected_by_default
+    - withdrawn
+    example: awaiting_provider_decision

--- a/app/frontend/styles/application-support.scss
+++ b/app/frontend/styles/application-support.scss
@@ -1,3 +1,9 @@
 @import "application";
 @import "support/all";
 @import "components/paginated_filter";
+
+.app-data-set-documentation--datatype {
+  color:  $govuk-secondary-text-colour;
+  margin: 0;
+  font-weight: normal;
+}

--- a/app/services/data_set_documentation.rb
+++ b/app/services/data_set_documentation.rb
@@ -1,0 +1,15 @@
+class DataSetDocumentation
+  def self.for(klass)
+    name = klass.name.demodulize.underscore
+
+    begin
+      spec = YAML.load_file(Rails.root.join("app/exports/#{name}.yml"))
+    rescue Errno::ENOENT
+      return false
+    end
+
+    common_columns = YAML.load_file(Rails.root.join('app/exports/_common_columns.yml'))
+    used_common_columns = common_columns.slice(*spec['common_columns'])
+    spec['custom_columns'].merge(used_common_columns)
+  end
+end

--- a/app/views/support_interface/data_exports/data_set_documentation.html.erb
+++ b/app/views/support_interface/data_exports/data_set_documentation.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, "Data set documentation for `#{@export_type.fetch(:name)}`" %>
+<% content_for :before_content, govuk_back_link_to(new_support_interface_data_export_path) %>
+
+<% DataSetDocumentation.for(@export_type.fetch(:class)).each do |column_name, column| %>
+  <%= render DataSetAttributeComponent.new(column_name: column_name, column: column) %>
+<% end %>

--- a/app/views/support_interface/data_exports/new.html.erb
+++ b/app/views/support_interface/data_exports/new.html.erb
@@ -22,6 +22,13 @@
       <div class="govuk-grid-column-two-thirds">
         <h3 class="govuk-heading-m"><%= export.fetch(:name) %></h3>
         <p class="govuk-body"><%= export.fetch(:description) %></p>
+
+        <% if DataSetDocumentation.for(export.fetch(:class)) %>
+          <p class="govuk-body">
+            <%= govuk_link_to "View documentation for #{export.fetch(:name)}", support_interface_data_set_documentation_path(id) %>
+          </p>
+        <% end %>
+
         <%= button_to "Generate #{export.fetch(:name)} export", support_interface_data_exports_path(export_type_id: id), class: 'govuk-button govuk-button--secondary' %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -746,6 +746,8 @@ Rails.application.routes.draw do
       get '/validation-errors/search' => 'validation_errors#search', as: :validation_error_search
       get '/validation-errors/summary' => 'validation_errors#summary', as: :validation_error_summary
 
+      get '/data-export/documentation/:export_type_id' => 'data_exports#data_set_documentation', as: :data_set_documentation
+
       resources :data_exports, path: '/data-exports' do
         member do
           get :download

--- a/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
+++ b/spec/services/support_interface/active_provider_user_permissions_export_spec.rb
@@ -1,72 +1,82 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ActiveProviderUserPermissionsExport do
+  around do |example|
+    Timecop.freeze(2020, 5, 1, 12, 0, 0) do
+      example.run
+    end
+  end
+
+  before do
+    @provider1 = create(:provider)
+    @provider2 = create(:provider)
+    @provider_user_with_permissions = create(
+      :provider_user,
+      :with_view_safeguarding_information,
+      :with_manage_organisations,
+      :with_manage_users,
+      :with_make_decisions,
+      :with_view_diversity_information,
+      providers: [@provider1],
+      last_signed_in_at: 5.days.ago,
+    )
+    @provider_user2 = create(:provider_user, providers: [@provider2], last_signed_in_at: 5.days.ago)
+    @provider_user3 = create(:provider_user, providers: [@provider1, @provider2], last_signed_in_at: 3.days.ago)
+    create(:provider_user, providers: [@provider1])
+  end
+
+  it_behaves_like 'a data export'
+
   describe '#data_for_export' do
     it 'returns provider_users and their permissions who have have signed in at least once' do
-      Timecop.freeze(2020, 5, 1, 12, 0, 0) do
-        provider1 = create(:provider)
-        provider2 = create(:provider)
-        provider_user_with_permissions = create(
-          :provider_user,
-          :with_view_safeguarding_information,
-          :with_manage_organisations,
-          :with_manage_users,
-          :with_make_decisions,
-          :with_view_diversity_information,
-          providers: [provider1],
+      expected_data = [
+        {
+          name: @provider_user_with_permissions.full_name,
+          email_address: @provider_user_with_permissions.email_address,
+          provider: @provider1.name,
           last_signed_in_at: 5.days.ago,
-        )
-        provider_user2 = create(:provider_user, providers: [provider2], last_signed_in_at: 5.days.ago)
-        provider_user3 = create(:provider_user, providers: [provider1, provider2], last_signed_in_at: 3.days.ago)
-        create(:provider_user, providers: [provider1])
+          has_make_decisions: true,
+          has_view_safeguarding: true,
+          has_view_diversity: true,
+          has_manage_users: true,
+          has_manage_organisations: true,
+        },
+        {
+          name: @provider_user2.full_name,
+          email_address: @provider_user2.email_address,
+          provider: @provider2.name,
+          last_signed_in_at: 5.days.ago,
+          has_make_decisions: false,
+          has_view_safeguarding: false,
+          has_view_diversity: false,
+          has_manage_users: false,
+          has_manage_organisations: false,
+        },
+        {
+          name: @provider_user3.full_name,
+          email_address: @provider_user3.email_address,
+          provider: @provider1.name,
+          last_signed_in_at: 3.days.ago,
+          has_make_decisions: false,
+          has_view_safeguarding: false,
+          has_view_diversity: false,
+          has_manage_users: false,
+          has_manage_organisations: false,
+        },
+        {
+          name: @provider_user3.full_name,
+          email_address: @provider_user3.email_address,
+          provider: @provider2.name,
+          last_signed_in_at: 3.days.ago,
+          has_make_decisions: false,
+          has_view_safeguarding: false,
+          has_view_diversity: false,
+          has_manage_users: false,
+          has_manage_organisations: false,
+        },
+      ]
 
-        expect(described_class.new.data_for_export).to match_array([
-          {
-            name: provider_user_with_permissions.full_name,
-            email_address: provider_user_with_permissions.email_address,
-            provider: provider1.name,
-            last_signed_in_at: 5.days.ago,
-            has_make_decisions: true,
-            has_view_safeguarding: true,
-            has_view_diversity: true,
-            has_manage_users: true,
-            has_manage_organisations: true,
-          },
-          {
-            name: provider_user2.full_name,
-            email_address: provider_user2.email_address,
-            provider: provider2.name,
-            last_signed_in_at: 5.days.ago,
-            has_make_decisions: false,
-            has_view_safeguarding: false,
-            has_view_diversity: false,
-            has_manage_users: false,
-            has_manage_organisations: false,
-          },
-          {
-            name: provider_user3.full_name,
-            email_address: provider_user3.email_address,
-            provider: provider1.name,
-            last_signed_in_at: 3.days.ago,
-            has_make_decisions: false,
-            has_view_safeguarding: false,
-            has_view_diversity: false,
-            has_manage_users: false,
-            has_manage_organisations: false,
-          },
-          {
-            name: provider_user3.full_name,
-            email_address: provider_user3.email_address,
-            provider: provider2.name,
-            last_signed_in_at: 3.days.ago,
-            has_make_decisions: false,
-            has_view_safeguarding: false,
-            has_view_diversity: false,
-            has_manage_users: false,
-            has_manage_organisations: false,
-          },
-        ])
-      end
+      expect(described_class.new.data_for_export).to match_array(expected_data)
     end
   end
 end

--- a/spec/services/support_interface/tad_export_spec.rb
+++ b/spec/services/support_interface/tad_export_spec.rb
@@ -1,13 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::TADExport do
+  before do
+    create(:submitted_application_choice, status: 'rejected', rejected_by_default: true)
+    create(:submitted_application_choice, status: 'declined', declined_by_default: true)
+    create(:submitted_application_choice, status: 'rejected')
+    create(:submitted_application_choice, status: 'declined')
+  end
+
+  it_behaves_like 'a data export'
+
   describe '#data_for_export' do
     it 'incorporates RDB and DBD into the status' do
-      create(:submitted_application_choice, status: 'rejected', rejected_by_default: true)
-      create(:submitted_application_choice, status: 'declined', declined_by_default: true)
-      create(:submitted_application_choice, status: 'rejected')
-      create(:submitted_application_choice, status: 'declined')
-
       result = described_class.new.data_for_export
 
       expect(result.map { |r| r[:status] }).to match_array(%w[rejected_by_default declined_by_default rejected declined])

--- a/spec/support/data_export_shared_example.rb
+++ b/spec/support/data_export_shared_example.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'a data export' do
+  it 'has documentation that describes all columns' do
+    create(:submitted_application_choice)
+
+    exported_columns = described_class.new.data_for_export.first.keys
+    documented_columns = DataSetDocumentation.for(described_class).keys.map(&:to_sym)
+
+    expect(exported_columns).to match_array(documented_columns)
+  end
+end

--- a/spec/system/support_interface/data_set_documentation_spec.rb
+++ b/spec/system/support_interface/data_set_documentation_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'Data set documentation' do
+  include DfESignInHelpers
+
+  scenario 'Support user visits the data set documentation' do
+    given_i_am_a_support_user
+    and_i_visit_the_new_data_exports_page
+    and_i_click_on_the_tad_export_documentation
+    then_i_see_the_data_set_documentation
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_i_visit_the_new_data_exports_page
+    visit new_support_interface_data_export_path
+  end
+
+  def and_i_click_on_the_tad_export_documentation
+    click_link 'View documentation for Applications for TAD'
+  end
+
+  def then_i_see_the_data_set_documentation
+    expect(page).to have_content 'extract_date'
+  end
+end


### PR DESCRIPTION
## Context

We're constantly creating new CSV exports, for TAD, UCAS, HESA (via providers) and analysts. The CSVs are currently not specified - we don't describe what each column means.

We also have an API, which is very well documented. Each property has a name, description, examples, enums and a type.

## Changes proposed in this pull request

This is an attempt at reusing some of the patterns from our API docs to expose a spec for the TAD export. The goal is that we describe all CSVs coming out of the system using the OpenAPI specification language. 

## Guidance to review

https://apply-for-te-tad-data-e-3wmbh9.herokuapp.com/support/performance/data-export/specifications/tad_applications

Does this idea make sense? There's a bunch to do here:

- [x] A test needs to be added that every column in the export is documented 
- [x] The views need some deduping and componentisation.
- [x] For common columns, we should fetch the API spec and CSV specs from a central source (this will make it easier to add specs for existing exports as well)

## Link to Trello card

https://trello.com/c/4ZXsk30A
