### PR TITLE
Refactor OtherQualificationWizard

### DIFF
--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  class OtherQualificationTypeForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :qualification_type
+    attribute :other_uk_qualification_type
+    attribute :non_uk_qualification_type
+
+    validates :qualification_type, presence: true
+    validates :qualification_type, inclusion: { in: ['A level', 'AS level', 'GCSE', 'Other', 'non_uk'], allow_blank: false }
+    validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == 'Other' && FeatureFlag.active?('international_other_qualifications') }
+    validates :non_uk_qualification_type, presence: true, if: -> { qualification_type == 'non_uk' }
+  end
+end

--- a/spec/forms/candidate_interface/other_qualification_wizard_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_wizard_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe CandidateInterface::OtherQualificationWizard, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:qualification_type) }
+    # it { is_expected.to validate_presence_of(:qualification_type) }
     it { is_expected.to validate_presence_of(:award_year).on(:details) }
-    it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
-    it { is_expected.to validate_length_of(:subject).is_at_most(255) }
-    it { is_expected.to validate_length_of(:grade).is_at_most(255) }
+    # it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(255).on(:details) }
+    it { is_expected.to validate_length_of(:grade).is_at_most(255).on(:details) }
 
     describe 'subject' do
       it 'validates presence except for non-uk and other qualifications' do


### PR DESCRIPTION
## Context

After converting the candidate interface other qualification forms to use a wizard that defers saving changes until the last step we identified a few areas that could be refactored to reduce complexity and make it easier to apply the same change to other parts of the candidate interface.

At present this is a DRAFT PR - it's not ready to merge but raised here to get feedback about whether the proposed changes are worthwhile.

## Changes proposed in this pull request

The `OtherQualificationWizard` class is quite big despite being just a two step form. So our goals was to reduce the size and complexity of this class. To attempt to do that I've extracted `OtherQualificationsTypeForm` from the wizard to encapsulate the attributes and validations for the first of the two steps (with a view to adding an `OtherQualificationsDetailForm` for the second step).

The wizard responsibilities are:
- page flow rules (what's the current and next step)
- persisting the uncommitted state of the wizard (collecting form input and storing in Redis) until reaching the final step when it's stored in the database.

The form responsibilities are:
- declaring the attributes that are mapped to each form
- validation rules
  
## Guidance to review

- I've kept the interface between controller and wizard as it was because the controller needs to use the wizard to define the flow between pages so it made more sense to encapsulate the sub-forms within the wizard rather than vice versa. For now the wizard remains the object that the front-end views are mapped to.
- Both the form and wizard classes import `ActiveModel::Model` because they don't really have any purpose without having 'attributes'. This is the main reason I suppose that the original implementation didn't split the two. The form(s) are basically nested form objects in the wizard - this is similar(ish) to the pattern that we've adopted in https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/forms/provider_interface/provider_relationship_permissions_setup_wizard.rb

## Link to Trello card

https://trello.com/c/YWtsBdnu/2506-refactor-other-qualifications-wizard-implementation

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
