### PR TITLE
Support: Redirect sign in page to candidates page if already signed in

### DIFF
--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -3,6 +3,8 @@ module SupportInterface
     skip_before_action :authenticate_support_user!, except: :destroy
 
     def new
+      redirect_to support_interface_path and return if current_support_user
+
       session['post_dfe_sign_in_path'] ||= support_interface_path
       if FeatureFlag.active?('dfe_sign_in_fallback')
         render :authentication_fallback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -793,8 +793,8 @@ Rails.application.routes.draw do
       end
     end
 
-    get '/sign-in' => 'sessions#new'
-    get '/sign-out' => 'sessions#destroy'
+    get '/sign-in' => 'sessions#new', as: :sign_in
+    get '/sign-out' => 'sessions#destroy', as: :sign_out
 
     post '/request-sign-in-by-email' => 'sessions#sign_in_by_email', as: :sign_in_by_email
     get '/sign-in/check-email', to: 'sessions#check_your_email', as: :check_your_email

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -42,9 +42,11 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
   end
 
   def and_i_should_not_see_support_menu
-    expect(page).not_to have_link 'Applications'
-    expect(page).not_to have_link 'APITokens'
-    expect(page).not_to have_link 'Vendors'
+    expect(page).not_to have_link 'Candidates'
+    expect(page).not_to have_link 'Providers'
+    expect(page).not_to have_link 'Performance'
+    expect(page).not_to have_link 'Settings'
+    expect(page).not_to have_link 'Documentation'
   end
 
   def when_i_sign_in_via_dfe_sign_in

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
     when_i_sign_in_via_dfe_sign_in
     and_i_should_not_have_received_an_email_about_the_new_login
+
+    when_i_visit_the_sign_in_page
+    then_i_should_be_redirected_to_the_support_interface_applications_path
+    and_i_should_see_my_email_address
   end
 
   def given_i_have_a_dfe_sign_in_account_and_support_authorisation
@@ -77,5 +81,13 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
   def and_i_should_not_have_received_an_email_about_the_new_login
     open_email('user@apply-support.com')
     expect(current_email).to be_nil
+  end
+
+  def when_i_visit_the_sign_in_page
+    visit support_interface_sign_in_path
+  end
+
+  def then_i_should_be_redirected_to_the_support_interface_applications_path
+    expect(page).to have_current_path support_interface_applications_path
   end
 end


### PR DESCRIPTION
## Context

If you are already signed in to the support console, the sign in page should redirect you to the default signed in page for this interface.

## Changes proposed in this pull request

Adds a redirect to `support_interface_path` if user visits sign-in page and `current_support_user` is true.

## Guidance to review

* Is this redirect in the right place? Tried a `before_action` like used in other interfaces, but different requirements here. 
* Does this need a test? Can somebody help me write one if it does?

## Link to Trello card

https://trello.com/c/eGZpDgHK/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
