### PR TITLE
Make HTTP method and path helper usage consistent in the candidate namespace

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :becoming_a_teacher, section_path: candidate_interface_becoming_a_teacher_edit_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :becoming_a_teacher, section_path: candidate_interface_edit_becoming_a_teacher_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: becoming_a_teacher_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
         key: t('application_form.personal_statement.becoming_a_teacher.label'),
         value: @becoming_a_teacher_form.becoming_a_teacher,
         action: t('application_form.personal_statement.becoming_a_teacher.change_action'),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_becoming_a_teacher_edit_path,
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_becoming_a_teacher_path,
       }
     end
   end

--- a/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
@@ -7,7 +7,7 @@
     <div class="app-summary-card__actions">
       <ul class="app-summary-card__actions-list">
         <li class="app-summary-card__actions-list-item">
-          <%= link_to candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
+          <%= link_to candidate_interface_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
             Explain break <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
           <% end %>
         </li>
@@ -15,7 +15,7 @@
           or
         </li>
         <li class="app-summary-card__actions-list-item">
-          <%= link_to candidate_interface_work_history_new_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
+          <%= link_to candidate_interface_new_work_history_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
             add another job <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
           <% end %>
         </li>

--- a/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
@@ -7,7 +7,7 @@
     <div class="app-summary-card__actions">
       <ul class="app-summary-card__actions-list">
         <li class="app-summary-card__actions-list-item">
-          <%= link_to candidate_interface_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
+          <%= link_to candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
             Explain break <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
           <% end %>
         </li>

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -145,11 +145,11 @@ module CandidateInterface
     def grade_edit_path
       case subject
       when 'maths'
-        candidate_interface_gcse_maths_edit_grade_path
+        candidate_interface_edit_gcse_maths_grade_path
       when 'science'
-        candidate_interface_gcse_science_edit_grade_path
+        candidate_interface_edit_gcse_science_grade_path
       when 'english'
-        candidate_interface_gcse_english_edit_grade_path
+        candidate_interface_edit_gcse_english_grade_path
       end
     end
   end

--- a/app/components/candidate_interface/interview_preferences_review_component.html.erb
+++ b/app/components/candidate_interface/interview_preferences_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :interview_preferences, section_path: candidate_interface_interview_preferences_edit_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :interview_preferences, section_path: candidate_interface_edit_interview_preferences_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: interview_preferences_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/interview_preferences_review_component.rb
+++ b/app/components/candidate_interface/interview_preferences_review_component.rb
@@ -31,7 +31,7 @@ module CandidateInterface
         key: t('application_form.personal_statement.interview_preferences.key'),
         value: preferences,
         action: t('application_form.personal_statement.interview_preferences.change_action'),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_interview_preferences_edit_path,
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_interview_preferences_path,
       }
     end
   end

--- a/app/components/candidate_interface/personal_details_review_component.html.erb
+++ b/app/components/candidate_interface/personal_details_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :personal_details, section_path: candidate_interface_personal_details_edit_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :personal_details, section_path: candidate_interface_edit_personal_details_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/subject_knowledge_review_component.html.erb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :subject_knowledge, section_path: candidate_interface_subject_knowledge_edit_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :subject_knowledge, section_path: candidate_interface_edit_subject_knowledge_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: subject_knowledge_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/subject_knowledge_review_component.rb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
         key: t('application_form.personal_statement.subject_knowledge.key'),
         value: @subject_knowledge_form.subject_knowledge,
         action: t('application_form.personal_statement.subject_knowledge.change_action'),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_subject_knowledge_edit_path,
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_subject_knowledge_path,
       }
     end
   end

--- a/app/components/candidate_interface/training_with_a_disability_review_component.html.erb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :training_with_a_disability, section_path: candidate_interface_training_with_a_disability_edit_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::SectionMissingBannerComponent.new(section: :training_with_a_disability, section_path: candidate_interface_edit_training_with_a_disability_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: training_with_a_disability_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -32,7 +32,7 @@ module CandidateInterface
         key: t('application_form.training_with_a_disability.disclose_disability.label'),
         value: boolean_display_value(@training_with_a_disability_form.disclose_disability),
         action: t('application_form.training_with_a_disability.disclose_disability.change_action'),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path,
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_training_with_a_disability_path,
       }
     end
 
@@ -41,7 +41,7 @@ module CandidateInterface
         key: t('application_form.training_with_a_disability.disability_disclosure.review_label'),
         value: @training_with_a_disability_form.disability_disclosure,
         action: t('application_form.training_with_a_disability.disability_disclosure.change_action'),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path,
+        change_path: Rails.application.routes.url_helpers.candidate_interface_edit_training_with_a_disability_path,
       }
     end
 

--- a/app/controllers/candidate_interface/gcse/resolve_gcse_edit_path_concern.rb
+++ b/app/controllers/candidate_interface/gcse/resolve_gcse_edit_path_concern.rb
@@ -4,11 +4,11 @@ module CandidateInterface
       def resolve_gcse_edit_path(subject)
         case subject
         when 'maths'
-          Rails.application.routes.url_helpers.candidate_interface_gcse_maths_edit_grade_path
+          Rails.application.routes.url_helpers.candidate_interface_edit_gcse_maths_grade_path
         when 'science'
-          candidate_interface_gcse_science_edit_grade_path
+          candidate_interface_edit_gcse_science_grade_path
         when 'english'
-          candidate_interface_gcse_english_edit_grade_path
+          candidate_interface_edit_gcse_english_grade_path
         end
       end
     end

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -22,9 +22,9 @@ module CandidateInterface
         @wizard.clear_state!
 
         if @wizard.choice == 'same_type'
-          redirect_to candidate_interface_new_other_qualification_details_path(qualification_type: current_application.application_qualifications.last.qualification_type)
+          redirect_to candidate_interface_other_qualification_details_path(qualification_type: current_application.application_qualifications.last.qualification_type)
         elsif @wizard.choice == 'different_type'
-          redirect_to candidate_interface_new_other_qualification_type_path
+          redirect_to candidate_interface_other_qualification_type_path
         else
           redirect_to candidate_interface_review_other_qualifications_path
         end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class OtherQualifications::ReviewController < OtherQualifications::BaseController
     def show
-      redirect_to candidate_interface_new_other_qualification_type_path and return if current_application.application_qualifications.other.blank?
+      redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank?
 
       @application_form = current_application
     end

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
         next_step = @wizard.next_step
 
         if next_step.first == :details
-          redirect_to candidate_interface_new_other_qualification_details_path
+          redirect_to candidate_interface_other_qualification_details_path
         else
           track_validation_error(@wizard)
           render :new

--- a/app/controllers/candidate_interface/personal_details/languages_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/languages_controller.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       before_action :redirect_to_dashboard_if_submitted
 
       def new
-        @languages_form = LanguagesForm.build_from_application(current_application)
+        @languages_form = LanguagesForm.new
       end
 
       def create

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
 
       if @work_experience_form.save(current_application)
         if @work_experience_form.add_another_job == 'true'
-          redirect_to candidate_interface_work_history_new_path
+          redirect_to candidate_interface_new_work_history_path
         else
           redirect_to candidate_interface_work_history_show_path
         end

--- a/app/controllers/candidate_interface/work_history/length_controller.rb
+++ b/app/controllers/candidate_interface/work_history/length_controller.rb
@@ -13,7 +13,7 @@ module CandidateInterface
         if @work_details_form.work_history == 'missing'
           redirect_to candidate_interface_work_history_explanation_path
         else
-          redirect_to candidate_interface_work_history_new_path
+          redirect_to candidate_interface_new_work_history_path
         end
       else
         track_validation_error(@work_details_form)

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -155,7 +155,7 @@ module CandidateInterface
       if other_qualifications_completed? || other_qualifications_added?
         Rails.application.routes.url_helpers.candidate_interface_review_other_qualifications_path
       else
-        Rails.application.routes.url_helpers.candidate_interface_new_other_qualification_type_path
+        Rails.application.routes.url_helpers.candidate_interface_other_qualification_type_path
       end
     end
 

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -36,7 +36,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.name.label'),
         value: @personal_details_form.name,
         action: ('name' if @editable),
-        change_path: candidate_interface_personal_details_edit_path,
+        change_path: candidate_interface_edit_personal_details_path,
       }
     end
 
@@ -45,7 +45,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.date_of_birth.label'),
         value: @personal_details_form.date_of_birth.to_s(:govuk_date),
         action: ('date of birth' if @editable),
-        change_path: candidate_interface_personal_details_edit_path,
+        change_path: candidate_interface_edit_personal_details_path,
       }
     end
 

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_path do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if @contact_details_form.uk? %>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if @contact_details_form.uk? %>

--- a/app/views/candidate_interface/contact_details/address_type/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_type_path do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_type_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('page_titles.where_do_you_live'), size: 'xl' } do %>

--- a/app/views/candidate_interface/contact_details/address_type/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_type_path do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_type_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('page_titles.where_do_you_live'), size: 'xl' } do %>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_base_path do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_base_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_base_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -9,5 +9,5 @@
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                         path: candidate_interface_contact_details_complete_path,
-                                        request_method: :post,
+                                        request_method: :patch,
                                         field_name: :contact_details_completed)) %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @disabilities, url: candidate_interface_update_equality_and_diversity_disabilities_path, method: :post do |f| %>
+    <%= form_with model: @disabilities, url: candidate_interface_edit_equality_and_diversity_disabilities_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_check_boxes_fieldset :disabilities, multiple: false, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.disabilities.title'), size: 'xl' } do %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @disability_status, url: candidate_interface_update_equality_and_diversity_disability_status_path, method: :post do |f| %>
+    <%= form_with model: @disability_status, url: candidate_interface_edit_equality_and_diversity_disability_status_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :disability_status, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.disability_status.title'), size: 'xl' } do %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @ethnic_background, url: candidate_interface_update_equality_and_diversity_ethnic_background_path, method: :post do |f| %>
+    <%= form_with model: @ethnic_background, url: candidate_interface_edit_equality_and_diversity_ethnic_background_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :ethnic_background, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: ethnic_background_title(@ethnic_group), size: 'xl' } do %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @ethnic_group, url: candidate_interface_update_equality_and_diversity_ethnic_group_path, method: :post do |f| %>
+    <%= form_with model: @ethnic_group, url: candidate_interface_edit_equality_and_diversity_ethnic_group_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :ethnic_group, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.ethnic_group.title'), size: 'xl' } do %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @sex, url: candidate_interface_edit_equality_and_diversity_sex_path, method: :post do |f| %>
+    <%= form_with model: @sex, url: candidate_interface_edit_equality_and_diversity_sex_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :sex, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.sex.title'), size: 'xl' } do %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @sex, url: candidate_interface_update_equality_and_diversity_sex_path, method: :post do |f| %>
+    <%= form_with model: @sex, url: candidate_interface_edit_equality_and_diversity_sex_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :sex, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.sex.title'), size: 'xl' } do %>

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_english_edit_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_english_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>

--- a/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_english_edit_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_english_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('multiple_gcse_edit_grade.page_title')%></h1>

--- a/app/views/candidate_interface/gcse/institution_country/edit.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @institution_country, url: candidate_interface_gcse_details_edit_institution_country_path, method: :post do |f| %>
+    <%= form_with model: @institution_country, url: candidate_interface_gcse_details_edit_institution_country_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>

--- a/app/views/candidate_interface/gcse/institution_country/edit.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @institution_country, url: candidate_interface_gcse_details_update_institution_country_path, method: :post do |f| %>
+    <%= form_with model: @institution_country, url: candidate_interface_gcse_details_edit_institution_country_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>

--- a/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_maths_edit_grade_path, method: :patch do |f| %>
+    <%= form_with model: @application_qualification, url: candidate_interface_edit_gcse_maths_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @naric_reference_form, url: candidate_interface_gcse_details_edit_naric_reference_path, method: :post do |f| %>
+    <%= form_with model: @naric_reference_form, url: candidate_interface_gcse_details_edit_naric_reference_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric_reference/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @naric_reference_form, url: candidate_interface_gcse_details_update_naric_reference_path, method: :post do |f| %>
+    <%= form_with model: @naric_reference_form, url: candidate_interface_gcse_details_edit_naric_reference_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -7,5 +7,5 @@
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                        path: candidate_interface_gcse_complete_path,
-                                       request_method: :post,
+                                       request_method: :patch,
                                        field_name: @field_name)) %>

--- a/app/views/candidate_interface/gcse/science/grade/awards_edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/awards_edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_science_edit_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_science_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @gcse_grade_form, url: candidate_interface_gcse_science_edit_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_science_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_type_path, method: :post do |f| %>
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_edit_type_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/gcse/year/edit.html.erb
+++ b/app/views/candidate_interface/gcse/year/edit.html.erb
@@ -3,7 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_year_path, method: :patch do |f| %>
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_edit_year_path do |f| %>
+
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_year.page_title', subject: @subject) %></h1>
 

--- a/app/views/candidate_interface/gcse/year/edit.html.erb
+++ b/app/views/candidate_interface/gcse/year/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_edit_year_path do |f| %>
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_edit_year_path, method: :patch do |f| %>
 
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_year.page_title', subject: @subject) %></h1>

--- a/app/views/candidate_interface/other_qualifications/details/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: candidate_interface_edit_other_qualification_details_path do |f| %>
+    <%= form_with model: @wizard, url: candidate_interface_edit_other_qualification_details_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: candidate_interface_create_other_qualification_details_path do |f| %>
+    <%= form_with model: @wizard, url: candidate_interface_other_qualification_details_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -11,7 +11,7 @@
 
 <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_new_other_qualification_type_path, class: 'govuk-button--secondary' %>
+<%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_other_qualification_type_path, class: 'govuk-button--secondary' %>
 
 <%= form_with model: @application_form, url: candidate_interface_complete_other_qualifications_path do |f| %>
   <div class='govuk-form-group'>

--- a/app/views/candidate_interface/other_qualifications/type/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: candidate_interface_edit_other_qualification_type_path do |f| %>
+    <%= form_with model: @wizard, url: candidate_interface_edit_other_qualification_type_path, method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f } %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @wizard, url: candidate_interface_create_other_qualification_type_path do |f| %>
+    <%= form_with model: @wizard, url: candidate_interface_other_qualification_type_path do |f| %>
       <%= render partial: 'shared_form', locals: { f: f } %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/base/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_update_path do |f| %>
+    <%= form_with model: @personal_details_form, url: candidate_interface_edit_personal_details_path, method: :patch do |f| %>
     <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/base/new.html.erb
+++ b/app/views/candidate_interface/personal_details/base/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_path do |f| %>
+    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_path, method: :patch do |f| %>
     <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/base/new.html.erb
+++ b/app/views/candidate_interface/personal_details/base/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_create_path do |f| %>
+    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_path do |f| %>
     <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/languages/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/languages/_shared_form.html.erb
@@ -1,23 +1,21 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @languages_form, url: candidate_interface_languages_path do |f| %>
-      <%= f.govuk_error_summary %>
+    <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.languages') %>
-      </h1>
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.languages') %>
+    </h1>
 
-      <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label'), tag: 'span' } do %>
-        <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
-        <% end %>
-
-        <%= f.govuk_radio_button :english_main_language, 'no', label: { text: 'No' } do %>
-          <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
-        <% end %>
+    <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label'), tag: 'span' } do %>
+      <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' }, link_errors: true do %>
+        <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
       <% end %>
 
-      <%= f.govuk_submit 'Save and continue' %>
+      <%= f.govuk_radio_button :english_main_language, 'no', label: { text: 'No' } do %>
+        <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
+      <% end %>
     <% end %>
+
+    <%= f.govuk_submit 'Save and continue' %>
   </div>
 </div>

--- a/app/views/candidate_interface/personal_details/languages/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/languages/edit.html.erb
@@ -1,4 +1,6 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.languages'), @languages_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
-<%= render partial: 'shared_form' %>
+<%= form_with model: @languages_form, url: candidate_interface_edit_languages_path, method: :patch do |f| %>
+  <%= render partial: 'shared_form', locals: { f: f } %>
+<% end %>

--- a/app/views/candidate_interface/personal_details/languages/new.html.erb
+++ b/app/views/candidate_interface/personal_details/languages/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.languages'), @languages_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_nationalities_path, 'Back') %>
 
-<%= form_with model: @languages_form, url: candidate_interface_languages_path do |f| %>
+<%= form_with model: @languages_form, url: candidate_interface_languages_path, method: :patch do |f| %>
   <%= render partial: 'shared_form',  locals: { f: f } %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/languages/new.html.erb
+++ b/app/views/candidate_interface/personal_details/languages/new.html.erb
@@ -1,4 +1,6 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.languages'), @languages_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_nationalities_path, 'Back') %>
 
-<%= render partial: 'shared_form' %>
+<%= form_with model: @languages_form, url: candidate_interface_languages_path do |f| %>
+  <%= render partial: 'shared_form',  locals: { f: f } %>
+<% end %>

--- a/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @nationalities_form, url: candidate_interface_edit_nationalities_path, class: 'app-nationality' do |f| %>
+    <%= form_with model: @nationalities_form, url: candidate_interface_edit_nationalities_path, class: 'app-nationality', method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/nationalities/new.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @nationalities_form, url: candidate_interface_nationalities_path, class: 'app-nationality' do |f| %>
+    <%= form_with model: @nationalities_form, url: candidate_interface_nationalities_path, class: 'app-nationality', method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/nationalities/new.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.nationalities'), @nationalities_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_new_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/personal_details/review/show.html.erb
+++ b/app/views/candidate_interface/personal_details/review/show.html.erb
@@ -13,5 +13,5 @@
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                         path: candidate_interface_personal_details_complete_path,
-                                        request_method: :post,
+                                        request_method: :patch,
                                         field_name: :personal_details_completed)) %>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_edit_right_to_work_or_study_path do |f| %>
+    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_edit_right_to_work_or_study_path, method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/new.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_right_to_work_or_study_path do |f| %>
+    <%= form_with model: @right_to_work_or_study_form, url: candidate_interface_right_to_work_or_study_path, method: :patch do |f| %>
       <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_edit_becoming_a_teacher_path do |f| %>
+    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_edit_becoming_a_teacher_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_becoming_a_teacher_update_path do |f| %>
+    <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_edit_becoming_a_teacher_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/show.html.erb
@@ -17,5 +17,5 @@
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                         path: candidate_interface_becoming_a_teacher_complete_path,
-                                        request_method: :post,
+                                        request_method: :patch,
                                         field_name: :becoming_a_teacher_completed)) %>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @interview_preferences_form, url: candidate_interface_interview_preferences_update_path do |f| %>
+    <%= form_with model: @interview_preferences_form, url: candidate_interface_edit_interview_preferences_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @interview_preferences_form, url: candidate_interface_edit_interview_preferences_path do |f| %>
+    <%= form_with model: @interview_preferences_form, url: candidate_interface_edit_interview_preferences_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -14,7 +14,7 @@
         <%=
           govuk_link_to(
             'health condition or disability',
-            candidate_interface_training_with_a_disability_edit_path,
+            candidate_interface_edit_training_with_a_disability_path,
           )
         %>.
       </p>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/show.html.erb
@@ -9,5 +9,5 @@
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                         path: candidate_interface_interview_preferences_complete_path,
-                                        request_method: :post,
+                                        request_method: :patch,
                                         field_name: :interview_preferences_completed)) %>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @subject_knowledge_form, url: candidate_interface_subject_knowledge_update_path do |f| %>
+    <%= form_with model: @subject_knowledge_form, url: candidate_interface_edit_subject_knowledge_path do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.subject_knowledge') %>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @subject_knowledge_form, url: candidate_interface_edit_subject_knowledge_path do |f| %>
+    <%= form_with model: @subject_knowledge_form, url: candidate_interface_edit_subject_knowledge_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.subject_knowledge') %>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/show.html.erb
@@ -9,5 +9,5 @@
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                         path: candidate_interface_subject_knowledge_complete_path,
-                                        request_method: :post,
+                                        request_method: :patch,
                                         field_name: :subject_knowledge_completed)) %>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_training_with_a_disability_update_path do |f| %>
+    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_edit_training_with_a_disability_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_edit_training_with_a_disability_path do |f| %>
+    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_edit_training_with_a_disability_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -9,5 +9,5 @@
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                         path: candidate_interface_training_with_a_disability_complete_path,
-                                        request_method: :post,
+                                        request_method: :patch,
                                         field_name: :training_with_a_disability_completed)) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -80,7 +80,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.personal_details'),
             completed: @application_form_presenter.personal_details_completed?,
-            path: all_sections_completed ? candidate_interface_personal_details_show_path : candidate_interface_personal_details_new_path
+            path: all_sections_completed ? candidate_interface_personal_details_show_path : candidate_interface_personal_details_path
           )
         ) %>
       </li>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -206,7 +206,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.becoming_a_teacher'),
             completed: @application_form_presenter.becoming_a_teacher_completed?,
-            path: @application_form_presenter.becoming_a_teacher_valid? ? candidate_interface_becoming_a_teacher_show_path : candidate_interface_becoming_a_teacher_edit_path
+            path: @application_form_presenter.becoming_a_teacher_valid? ? candidate_interface_becoming_a_teacher_show_path : candidate_interface_edit_becoming_a_teacher_path
           )
         ) %>
       </li>
@@ -215,7 +215,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.subject_knowledge'),
             completed: @application_form_presenter.subject_knowledge_completed?,
-            path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_subject_knowledge_edit_path
+            path: @application_form_presenter.subject_knowledge_valid? ? candidate_interface_subject_knowledge_show_path : candidate_interface_edit_subject_knowledge_path
           )
         ) %>
       </li>
@@ -224,7 +224,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.interview_preferences'),
             completed: @application_form_presenter.interview_preferences_completed?,
-            path: @application_form_presenter.interview_preferences_valid? ? candidate_interface_interview_preferences_show_path : candidate_interface_interview_preferences_edit_path
+            path: @application_form_presenter.interview_preferences_valid? ? candidate_interface_interview_preferences_show_path : candidate_interface_edit_interview_preferences_path
           )
         ) %>
       </li>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -116,7 +116,7 @@
           TaskListItemComponent.new(
             text: t('page_titles.training_with_a_disability'),
             completed: @application_form_presenter.training_with_a_disability_completed?,
-            path: @application_form_presenter.training_with_a_disability_valid? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path
+            path: @application_form_presenter.training_with_a_disability_valid? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_edit_training_with_a_disability_path
           )
         ) %>
       </li>

--- a/app/views/candidate_interface/volunteering/base/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @volunteering_role, url: candidate_interface_edit_volunteering_role_path do |f| %>
+    <%= form_with model: @volunteering_role, url: candidate_interface_edit_volunteering_role_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/volunteering/base/new.html.erb
+++ b/app/views/candidate_interface/volunteering/base/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @volunteering_role, url: candidate_interface_create_volunteering_role_path do |f| %>
+    <%= form_with model: @volunteering_role, url: candidate_interface_new_volunteering_role_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/work_history/break/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/work_history/break/confirm_destroy.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_destroy_work_history_break_path(@work_break), method: :post do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_destroy_work_history_break_path(@work_break), method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl">Work history</span>
         <%= t('page_titles.destroy_work_history_break') %>

--- a/app/views/candidate_interface/work_history/break/edit.html.erb
+++ b/app/views/candidate_interface/work_history/break/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_edit_work_history_break_path, method: :post do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_edit_work_history_break_path, method: :patch do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/break/new.html.erb
+++ b/app/views/candidate_interface/work_history/break/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_new_work_history_break_path do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_work_history_break_path do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/break/new.html.erb
+++ b/app/views/candidate_interface/work_history/break/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_work_history_break_path do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_new_work_history_break_path do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_experience_form, url: candidate_interface_work_history_create_path do |f| %>
+    <%= form_with model: @work_experience_form, url: candidate_interface_new_work_history_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -8,9 +8,9 @@
 <%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form)) %>
 
 <% if @application_form.application_work_experiences.any? %>
-  <%= govuk_button_link_to t('application_form.work_history.another.button'), candidate_interface_work_history_new_path, class: 'govuk-button--secondary' %>
+  <%= govuk_button_link_to t('application_form.work_history.another.button'), candidate_interface_new_work_history_path, class: 'govuk-button--secondary' %>
 <% else %>
-  <%= govuk_button_link_to t('application_form.work_history.add.button'), candidate_interface_work_history_new_path, class: 'govuk-button--secondary' %>
+  <%= govuk_button_link_to t('application_form.work_history.add.button'), candidate_interface_new_work_history_path, class: 'govuk-button--secondary' %>
 <% end %>
 
 <%= form_with model: @application_form, url: candidate_interface_work_history_complete_path do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,17 +299,17 @@ Rails.application.routes.draw do
       end
 
       scope '/other-qualifications' do
-        get '/' => 'other_qualifications/type#new', as: :new_other_qualification_type
-        post '/' => 'other_qualifications/type#create', as: :create_other_qualification_type
+        get '/' => 'other_qualifications/type#new', as: :other_qualification_type
+        post '/' => 'other_qualifications/type#create'
 
         get '/edit-type/:id' => 'other_qualifications/type#edit', as: :edit_other_qualification_type
-        post '/edit-type/:id' => 'other_qualifications/type#update'
+        patch '/edit-type/:id' => 'other_qualifications/type#update'
 
-        get '/new' => 'other_qualifications/details#new', as: :new_other_qualification_details
-        post '/new' => 'other_qualifications/details#create', as: :create_other_qualification_details
+        get '/new' => 'other_qualifications/details#new', as: :other_qualification_details
+        patch '/new' => 'other_qualifications/details#create'
 
         get '/edit-details/:id' => 'other_qualifications/details#edit', as: :edit_other_qualification_details
-        post '/edit-details/:id' => 'other_qualifications/details#update'
+        patch '/edit-details/:id' => 'other_qualifications/details#update'
 
         get '/review' => 'other_qualifications/review#show', as: :review_other_qualifications
         patch '/review' => 'other_qualifications/review#complete', as: :complete_other_qualifications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,10 +193,10 @@ Rails.application.routes.draw do
         post '/' => 'volunteering/experience#submit'
 
         get '/new' => 'volunteering/base#new', as: :new_volunteering_role
-        post '/new' => 'volunteering/base#create', as: :create_volunteering_role
+        post '/new' => 'volunteering/base#create'
 
         get '/edit/:id' => 'volunteering/base#edit', as: :edit_volunteering_role
-        post '/edit/:id' => 'volunteering/base#update'
+        patch '/edit/:id' => 'volunteering/base#update'
 
         get '/review' => 'volunteering/review#show', as: :review_volunteering
         patch '/review' => 'volunteering/review#complete', as: :complete_volunteering

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,13 +146,13 @@ Rails.application.routes.draw do
         post '/' => 'gcse/type#update'
 
         get '/country' => 'gcse/institution_country#edit', as: :gcse_details_edit_institution_country
-        post '/country' => 'gcse/institution_country#update'
+        patch '/country' => 'gcse/institution_country#update'
 
         get '/naric-reference' => 'gcse/naric_reference#edit', as: :gcse_details_edit_naric_reference
-        post '/naric-reference' => 'gcse/naric_reference#update'
+        patch '/naric-reference' => 'gcse/naric_reference#update'
 
         get '/year' => 'gcse/year#edit', as: :gcse_details_edit_year
-        post '/year' => 'gcse/year#update'
+        patch '/year' => 'gcse/year#update'
 
         get '/review' => 'gcse/review#show', as: :gcse_review
         patch '/complete' => 'gcse/review#complete', as: :gcse_complete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -402,15 +402,15 @@ Rails.application.routes.draw do
         get '/' => 'equality_and_diversity#start', as: :start_equality_and_diversity
         post '/' => 'equality_and_diversity#choice'
         get '/sex' => 'equality_and_diversity#edit_sex', as: :edit_equality_and_diversity_sex
-        post '/sex' => 'equality_and_diversity#update_sex', as: :update_equality_and_diversity_sex
+        post '/sex' => 'equality_and_diversity#update_sex'
         get '/disability-status' => 'equality_and_diversity#edit_disability_status', as: :edit_equality_and_diversity_disability_status
-        post '/disability-status' => 'equality_and_diversity#update_disability_status', as: :update_equality_and_diversity_disability_status
+        patch '/disability-status' => 'equality_and_diversity#update_disability_status'
         get '/disabilities' => 'equality_and_diversity#edit_disabilities', as: :edit_equality_and_diversity_disabilities
-        post '/disabilities' => 'equality_and_diversity#update_disabilities', as: :update_equality_and_diversity_disabilities
+        patch '/disabilities' => 'equality_and_diversity#update_disabilities'
         get '/ethnic-group' => 'equality_and_diversity#edit_ethnic_group', as: :edit_equality_and_diversity_ethnic_group
-        post '/ethnic-group' => 'equality_and_diversity#update_ethnic_group', as: :update_equality_and_diversity_ethnic_group
+        patch '/ethnic-group' => 'equality_and_diversity#update_ethnic_group'
         get '/ethnic-background' => 'equality_and_diversity#edit_ethnic_background', as: :edit_equality_and_diversity_ethnic_background
-        post '/ethnic-background' => 'equality_and_diversity#update_ethnic_background', as: :update_equality_and_diversity_ethnic_background
+        patch '/ethnic-background' => 'equality_and_diversity#update_ethnic_background'
         get '/review' => 'equality_and_diversity#review', as: :review_equality_and_diversity
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,31 +89,31 @@ Rails.application.routes.draw do
         get '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#edit', as: :edit_right_to_work_or_study
         patch '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#update'
         get '/review' => 'personal_details/review#show', as: :personal_details_show
-        post '/review' => 'personal_details/review#complete', as: :personal_details_complete
+        patch '/review' => 'personal_details/review#complete', as: :personal_details_complete
       end
 
       scope '/personal-statement' do
         get '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#edit', as: :edit_becoming_a_teacher
         post '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#update'
         get '/becoming-a-teacher/review' => 'personal_statement/becoming_a_teacher#show', as: :becoming_a_teacher_show
-        post '/becoming-a-teacher/complete' => 'personal_statement/becoming_a_teacher#complete', as: :becoming_a_teacher_complete
+        patch '/becoming-a-teacher/complete' => 'personal_statement/becoming_a_teacher#complete', as: :becoming_a_teacher_complete
 
         get '/subject-knowledge' => 'personal_statement/subject_knowledge#edit', as: :edit_subject_knowledge
         post '/subject-knowledge' => 'personal_statement/subject_knowledge#update'
         get '/subject-knowledge/review' => 'personal_statement/subject_knowledge#show', as: :subject_knowledge_show
-        post '/subject-knowledge/complete' => 'personal_statement/subject_knowledge#complete', as: :subject_knowledge_complete
+        patch '/subject-knowledge/complete' => 'personal_statement/subject_knowledge#complete', as: :subject_knowledge_complete
 
         get '/interview-preferences' => 'personal_statement/interview_preferences#edit', as: :edit_interview_preferences
         post '/interview-preferences' => 'personal_statement/interview_preferences#update'
         get '/interview-preferences/review' => 'personal_statement/interview_preferences#show', as: :interview_preferences_show
-        post '/interview-preferences/complete' => 'personal_statement/interview_preferences#complete', as: :interview_preferences_complete
+        patch '/interview-preferences/complete' => 'personal_statement/interview_preferences#complete', as: :interview_preferences_complete
       end
 
       scope '/training-with-a-disability' do
         get '/' => 'training_with_a_disability#edit', as: :edit_training_with_a_disability
         post '/' => 'training_with_a_disability#update'
         get '/review' => 'training_with_a_disability#show', as: :training_with_a_disability_show
-        post '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
+        patch '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
       end
 
       scope '/contact-details' do
@@ -127,7 +127,7 @@ Rails.application.routes.draw do
         post '/address' => 'contact_details/address#update'
 
         get '/review' => 'contact_details/review#show', as: :contact_details_review
-        post '/complete' => 'contact_details/review#complete', as: :contact_details_complete
+        patch '/complete' => 'contact_details/review#complete', as: :contact_details_complete
       end
 
       scope '/gcse' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,8 +110,8 @@ Rails.application.routes.draw do
       end
 
       scope '/training-with-a-disability' do
-        get '/' => 'training_with_a_disability#edit', as: :training_with_a_disability_edit
-        post '/review' => 'training_with_a_disability#update', as: :training_with_a_disability_update
+        get '/' => 'training_with_a_disability#edit', as: :edit_training_with_a_disability
+        post '/' => 'training_with_a_disability#update'
         get '/review' => 'training_with_a_disability#show', as: :training_with_a_disability_show
         post '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,15 +168,15 @@ Rails.application.routes.draw do
         get '/explain-breaks' => 'work_history/breaks#edit', as: :work_history_breaks
         post '/explain-breaks' => 'work_history/breaks#update'
 
-        get '/explain-break/new' => 'work_history/break#new', as: :new_work_history_break
+        get '/explain-break/new' => 'work_history/break#new', as: :work_history_break
         post '/explain-break/new' => 'work_history/break#create'
         get '/explain-break/edit/:id' => 'work_history/break#edit', as: :edit_work_history_break
-        post '/explain-break/edit/:id' => 'work_history/break#update'
+        patch '/explain-break/edit/:id' => 'work_history/break#update'
         get '/explain-break/delete/:id' => 'work_history/break#confirm_destroy', as: :destroy_work_history_break
-        post '/explain-break/delete/:id' => 'work_history/break#destroy'
+        delete '/explain-break/delete/:id' => 'work_history/break#destroy'
 
-        get '/new' => 'work_history/edit#new', as: :work_history_new
-        post '/create' => 'work_history/edit#create', as: :work_history_create
+        get '/new' => 'work_history/edit#new', as: :new_work_history
+        post '/new' => 'work_history/edit#create'
 
         get '/edit/:id' => 'work_history/edit#edit', as: :work_history_edit
         post '/edit/:id' => 'work_history/edit#update'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,18 +93,18 @@ Rails.application.routes.draw do
       end
 
       scope '/personal-statement' do
-        get '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#edit', as: :becoming_a_teacher_edit
-        post '/becoming-a-teacher/review' => 'personal_statement/becoming_a_teacher#update', as: :becoming_a_teacher_update
+        get '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#edit', as: :edit_becoming_a_teacher
+        post '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#update'
         get '/becoming-a-teacher/review' => 'personal_statement/becoming_a_teacher#show', as: :becoming_a_teacher_show
         post '/becoming-a-teacher/complete' => 'personal_statement/becoming_a_teacher#complete', as: :becoming_a_teacher_complete
 
-        get '/subject-knowledge' => 'personal_statement/subject_knowledge#edit', as: :subject_knowledge_edit
-        post '/subject-knowledge/review' => 'personal_statement/subject_knowledge#update', as: :subject_knowledge_update
+        get '/subject-knowledge' => 'personal_statement/subject_knowledge#edit', as: :edit_subject_knowledge
+        post '/subject-knowledge' => 'personal_statement/subject_knowledge#update'
         get '/subject-knowledge/review' => 'personal_statement/subject_knowledge#show', as: :subject_knowledge_show
         post '/subject-knowledge/complete' => 'personal_statement/subject_knowledge#complete', as: :subject_knowledge_complete
 
-        get '/interview-preferences' => 'personal_statement/interview_preferences#edit', as: :interview_preferences_edit
-        post '/interview-preferences/review' => 'personal_statement/interview_preferences#update', as: :interview_preferences_update
+        get '/interview-preferences' => 'personal_statement/interview_preferences#edit', as: :edit_interview_preferences
+        post '/interview-preferences' => 'personal_statement/interview_preferences#update'
         get '/interview-preferences/review' => 'personal_statement/interview_preferences#show', as: :interview_preferences_show
         post '/interview-preferences/complete' => 'personal_statement/interview_preferences#complete', as: :interview_preferences_complete
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,19 +73,19 @@ Rails.application.routes.draw do
 
       scope '/personal-details' do
         get '/' => 'personal_details/base#new', as: :personal_details
-        post '/' => 'personal_details/base#create'
+        patch '/' => 'personal_details/base#create'
         get '/edit' => 'personal_details/base#edit', as: :edit_personal_details
         patch '/edit' => 'personal_details/base#update'
         get '/nationalities' => 'personal_details/nationalities#new', as: :nationalities
-        post '/nationalities' => 'personal_details/nationalities#create'
+        patch '/nationalities' => 'personal_details/nationalities#create'
         get '/nationalities/edit' => 'personal_details/nationalities#edit', as: :edit_nationalities
         patch '/nationalities/edit' => 'personal_details/nationalities#update'
-        get '/languages' => 'personal_details/languages#edit', as: :languages
-        post '/languages' => 'personal_details/languages#update'
+        get '/languages' => 'personal_details/languages#new', as: :languages
+        patch '/languages' => 'personal_details/languages#create'
         get '/languages/edit' => 'personal_details/languages#edit', as: :edit_languages
         patch '/languages/edit' => 'personal_details/languages#update'
         get '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#new', as: :right_to_work_or_study
-        post '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#create'
+        patch '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#create'
         get '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#edit', as: :edit_right_to_work_or_study
         patch '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#update'
         get '/review' => 'personal_details/review#show', as: :personal_details_show
@@ -94,37 +94,37 @@ Rails.application.routes.draw do
 
       scope '/personal-statement' do
         get '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#edit', as: :edit_becoming_a_teacher
-        post '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#update'
+        patch '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#update'
         get '/becoming-a-teacher/review' => 'personal_statement/becoming_a_teacher#show', as: :becoming_a_teacher_show
         patch '/becoming-a-teacher/complete' => 'personal_statement/becoming_a_teacher#complete', as: :becoming_a_teacher_complete
 
         get '/subject-knowledge' => 'personal_statement/subject_knowledge#edit', as: :edit_subject_knowledge
-        post '/subject-knowledge' => 'personal_statement/subject_knowledge#update'
+        patch '/subject-knowledge' => 'personal_statement/subject_knowledge#update'
         get '/subject-knowledge/review' => 'personal_statement/subject_knowledge#show', as: :subject_knowledge_show
         patch '/subject-knowledge/complete' => 'personal_statement/subject_knowledge#complete', as: :subject_knowledge_complete
 
         get '/interview-preferences' => 'personal_statement/interview_preferences#edit', as: :edit_interview_preferences
-        post '/interview-preferences' => 'personal_statement/interview_preferences#update'
+        patch '/interview-preferences' => 'personal_statement/interview_preferences#update'
         get '/interview-preferences/review' => 'personal_statement/interview_preferences#show', as: :interview_preferences_show
         patch '/interview-preferences/complete' => 'personal_statement/interview_preferences#complete', as: :interview_preferences_complete
       end
 
       scope '/training-with-a-disability' do
         get '/' => 'training_with_a_disability#edit', as: :edit_training_with_a_disability
-        post '/' => 'training_with_a_disability#update'
+        patch '/' => 'training_with_a_disability#update'
         get '/review' => 'training_with_a_disability#show', as: :training_with_a_disability_show
         patch '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
       end
 
       scope '/contact-details' do
         get '/' => 'contact_details/base#edit', as: :contact_details_edit_base
-        post '/' => 'contact_details/base#update'
+        patch '/' => 'contact_details/base#update'
 
         get '/address_type' => 'contact_details/address_type#edit', as: :contact_details_edit_address_type
-        post '/address_type' => 'contact_details/address_type#update'
+        patch '/address_type' => 'contact_details/address_type#update'
 
         get '/address' => 'contact_details/address#edit', as: :contact_details_edit_address
-        post '/address' => 'contact_details/address#update'
+        patch '/address' => 'contact_details/address#update'
 
         get '/review' => 'contact_details/review#show', as: :contact_details_review
         patch '/complete' => 'contact_details/review#complete', as: :contact_details_complete
@@ -402,7 +402,7 @@ Rails.application.routes.draw do
         get '/' => 'equality_and_diversity#start', as: :start_equality_and_diversity
         post '/' => 'equality_and_diversity#choice'
         get '/sex' => 'equality_and_diversity#edit_sex', as: :edit_equality_and_diversity_sex
-        post '/sex' => 'equality_and_diversity#update_sex'
+        patch '/sex' => 'equality_and_diversity#update_sex'
         get '/disability-status' => 'equality_and_diversity#edit_disability_status', as: :edit_equality_and_diversity_disability_status
         patch '/disability-status' => 'equality_and_diversity#update_disability_status'
         get '/disabilities' => 'equality_and_diversity#edit_disabilities', as: :edit_equality_and_diversity_disabilities

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,22 +72,22 @@ Rails.application.routes.draw do
       post '/carry-over' => 'carry_over#create', as: :carry_over
 
       scope '/personal-details' do
-        get '/' => 'personal_details/base#new', as: :personal_details_new
-        post '/' => 'personal_details/base#create', as: :personal_details_create
-        get '/edit' => 'personal_details/base#edit', as: :personal_details_edit
-        post '/edit' => 'personal_details/base#update', as: :personal_details_update
+        get '/' => 'personal_details/base#new', as: :personal_details
+        post '/' => 'personal_details/base#create'
+        get '/edit' => 'personal_details/base#edit', as: :edit_personal_details
+        patch '/edit' => 'personal_details/base#update'
         get '/nationalities' => 'personal_details/nationalities#new', as: :nationalities
         post '/nationalities' => 'personal_details/nationalities#create'
         get '/nationalities/edit' => 'personal_details/nationalities#edit', as: :edit_nationalities
-        post '/nationalities/edit' => 'personal_details/nationalities#update'
+        patch '/nationalities/edit' => 'personal_details/nationalities#update'
         get '/languages' => 'personal_details/languages#edit', as: :languages
         post '/languages' => 'personal_details/languages#update'
         get '/languages/edit' => 'personal_details/languages#edit', as: :edit_languages
-        post '/languages/edit' => 'personal_details/languages#update'
+        patch '/languages/edit' => 'personal_details/languages#update'
         get '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#new', as: :right_to_work_or_study
         post '/right-to-work-or-study' => 'personal_details/right_to_work_or_study#create'
         get '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#edit', as: :edit_right_to_work_or_study
-        post '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#update'
+        patch '/right-to-work-or-study/edit' => 'personal_details/right_to_work_or_study#update'
         get '/review' => 'personal_details/review#show', as: :personal_details_show
         post '/review' => 'personal_details/review#complete', as: :personal_details_complete
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,30 +131,31 @@ Rails.application.routes.draw do
       end
 
       scope '/gcse' do
-        get '/maths/grade' => 'gcse/maths/grade#edit', as: :gcse_maths_edit_grade
-        get '/science/grade' => 'gcse/science/grade#edit', as: :gcse_science_edit_grade
-        get '/english/grade' => 'gcse/english/grade#edit', as: :gcse_english_edit_grade
-
+        get '/maths/grade' => 'gcse/maths/grade#edit', as: :edit_gcse_maths_grade
         patch '/maths/grade' => 'gcse/maths/grade#update'
+
+        get '/science/grade' => 'gcse/science/grade#edit', as: :edit_gcse_science_grade
         patch '/english/grade' => 'gcse/english/grade#update'
+
+        get '/english/grade' => 'gcse/english/grade#edit', as: :edit_gcse_english_grade
         patch '/science/grade' => 'gcse/science/grade#update'
       end
 
       scope '/gcse/:subject', constraints: { subject: /(maths|english|science)/ } do
         get '/' => 'gcse/type#edit', as: :gcse_details_edit_type
-        post '/' => 'gcse/type#update', as: :gcse_details_update_type
+        post '/' => 'gcse/type#update'
 
         get '/country' => 'gcse/institution_country#edit', as: :gcse_details_edit_institution_country
-        post '/country' => 'gcse/institution_country#update', as: :gcse_details_update_institution_country
+        post '/country' => 'gcse/institution_country#update'
 
         get '/naric-reference' => 'gcse/naric_reference#edit', as: :gcse_details_edit_naric_reference
-        post '/naric-reference' => 'gcse/naric_reference#update', as: :gcse_details_update_naric_reference
+        post '/naric-reference' => 'gcse/naric_reference#update'
 
         get '/year' => 'gcse/year#edit', as: :gcse_details_edit_year
-        patch '/year' => 'gcse/year#update', as: :gcse_details_update_year
+        post '/year' => 'gcse/year#update'
 
         get '/review' => 'gcse/review#show', as: :gcse_review
-        post '/complete' => 'gcse/review#complete', as: :gcse_complete
+        patch '/complete' => 'gcse/review#complete', as: :gcse_complete
       end
 
       scope '/work-history' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,13 +118,13 @@ Rails.application.routes.draw do
 
       scope '/contact-details' do
         get '/' => 'contact_details/base#edit', as: :contact_details_edit_base
-        post '/' => 'contact_details/base#update', as: :contact_details_update_base
+        post '/' => 'contact_details/base#update'
 
         get '/address_type' => 'contact_details/address_type#edit', as: :contact_details_edit_address_type
-        post '/address_type' => 'contact_details/address_type#update', as: :contact_details_update_address_type
+        post '/address_type' => 'contact_details/address_type#update'
 
         get '/address' => 'contact_details/address#edit', as: :contact_details_edit_address
-        post '/address' => 'contact_details/address#update', as: :contact_details_update_address
+        post '/address' => 'contact_details/address#update'
 
         get '/review' => 'contact_details/review#show', as: :contact_details_review
         post '/complete' => 'contact_details/review#complete', as: :contact_details_complete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,7 +168,7 @@ Rails.application.routes.draw do
         get '/explain-breaks' => 'work_history/breaks#edit', as: :work_history_breaks
         post '/explain-breaks' => 'work_history/breaks#update'
 
-        get '/explain-break/new' => 'work_history/break#new', as: :work_history_break
+        get '/explain-break/new' => 'work_history/break#new', as: :new_work_history_break
         post '/explain-break/new' => 'work_history/break#create'
         get '/explain-break/edit/:id' => 'work_history/break#edit', as: :edit_work_history_break
         patch '/explain-break/edit/:id' => 'work_history/break#update'

--- a/spec/components/candidate_interface/training_with_a_disability_review_component_spec.rb
+++ b/spec/components/candidate_interface/training_with_a_disability_review_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disclose_disability.label'))
       expect(result.css('.govuk-summary-list__value').text).to include('Yes')
-      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_edit_training_with_a_disability_path)
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disclose_disability.change_action')}")
     end
 
@@ -24,7 +24,7 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('I have difficulty climbing stairs')
-      expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
+      expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_edit_training_with_a_disability_path)
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disability_disclosure.change_action')}")
     end
   end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(personal_details_form: personal_details_form)).to include(
-        row_for(:name, 'Max Caulfield', candidate_interface_personal_details_edit_path),
-        row_for(:date_of_birth, '21 September 1995', candidate_interface_personal_details_edit_path),
+        row_for(:name, 'Max Caulfield', candidate_interface_edit_personal_details_path),
+        row_for(:date_of_birth, '21 September 1995', candidate_interface_edit_personal_details_path),
       )
     end
   end

--- a/spec/requests/candidate_interface/audit_trail_spec.rb
+++ b/spec/requests/candidate_interface/audit_trail_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Candidate interface - audit trail', type: :request, with_audited
     sign_in candidate
 
     expect {
-      post candidate_interface_personal_details_update_url(
+      post candidate_interface_personal_details_url(
         candidate_interface_personal_details_form: valid_attributes,
       )
     }.to(change { candidate.current_application.audits.count })

--- a/spec/requests/candidate_interface/audit_trail_spec.rb
+++ b/spec/requests/candidate_interface/audit_trail_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Candidate interface - audit trail', type: :request, with_audited
     sign_in candidate
 
     expect {
-      post candidate_interface_personal_details_url(
+      patch candidate_interface_personal_details_url(
         candidate_interface_personal_details_form: valid_attributes,
       )
     }.to(change { candidate.current_application.audits.count })

--- a/spec/requests/candidate_interface/validation_error_tracking_spec.rb
+++ b/spec/requests/candidate_interface/validation_error_tracking_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe 'Candidate interface - validation error tracking', type: :request
 
   it 'does NOT create validation error when request is valid' do
     expect {
-      post candidate_interface_contact_details_update_base_url(valid_attributes)
+      post candidate_interface_contact_details_edit_base_url(valid_attributes)
     }.not_to(change { ValidationError.count })
   end
 
   it 'creates validation error when request is invalid' do
     expect {
-      post candidate_interface_contact_details_update_base_url(invalid_attributes)
+      post candidate_interface_contact_details_edit_base_url(invalid_attributes)
     }.to(change { ValidationError.count }.by(1))
   end
 end

--- a/spec/requests/candidate_interface/validation_error_tracking_spec.rb
+++ b/spec/requests/candidate_interface/validation_error_tracking_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe 'Candidate interface - validation error tracking', type: :request
 
   it 'does NOT create validation error when request is valid' do
     expect {
-      post candidate_interface_contact_details_edit_base_url(valid_attributes)
+      patch candidate_interface_contact_details_edit_base_url(valid_attributes)
     }.not_to(change { ValidationError.count })
   end
 
   it 'creates validation error when request is invalid' do
     expect {
-      post candidate_interface_contact_details_edit_base_url(invalid_attributes)
+      patch candidate_interface_contact_details_edit_base_url(invalid_attributes)
     }.to(change { ValidationError.count }.by(1))
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_becoming_a_teacher_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('becoming_a_teacher')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_becoming_a_teacher_show_path)
+    expect(validation_error.request_path).to eq(candidate_interface_edit_becoming_a_teacher_path)
   end
 
   def and_i_fill_in_some_details_but_omit_some_required_details

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Entering their contact details' do
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('phone_number')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_contact_details_update_base_path)
+    expect(validation_error.request_path).to eq(candidate_interface_contact_details_edit_base_path)
   end
 
   def when_i_fill_in_my_phone_number

--- a/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
@@ -132,7 +132,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def then_i_see_the_add_grade_page
-    expect(page).to have_current_path candidate_interface_gcse_maths_edit_grade_path
+    expect(page).to have_current_path candidate_interface_edit_gcse_maths_grade_path
   end
 
   def then_i_see_the_review_page_with_correct_details

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def then_i_see_the_select_qualification_type_page
-    expect(page).to have_current_path(candidate_interface_new_other_qualification_type_path)
+    expect(page).to have_current_path(candidate_interface_other_qualification_type_path)
   end
 
   def when_i_select_add_a_level_qualification
@@ -223,7 +223,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def when_i_click_the_back_button
-    visit candidate_interface_new_other_qualification_details_path
+    visit candidate_interface_other_qualification_details_path
   end
 
   def and_update_the_subject

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_other_qualification_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Non-uk Other qualifications' do
   end
 
   def then_i_see_the_select_qualification_type_page
-    expect(page).to have_current_path(candidate_interface_new_other_qualification_type_path)
+    expect(page).to have_current_path(candidate_interface_other_qualification_type_path)
   end
 
   def when_i_do_not_select_any_type_option; end


### PR DESCRIPTION
## Context

At the moment our routes are a bit messy for two reasons:

1. We often POST when updating an object. We should use PATCH
2. We often two rails paths helpers for methods with the same raw path (new/create || edit/update) when we can just use one

## Changes proposed in this pull request

- Update POSTs to PATCHs where appropriate
- Use one ails paths helper if endpoints share a raw path 

## Guidance to review

This isn't as painful as it looks to review. If you review by commit  I've broken it down by scope.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
