### PR TITLE
Update guidance around 5 years work history

### DIFF
--- a/app/forms/candidate_interface/work_explanation_form.rb
+++ b/app/forms/candidate_interface/work_explanation_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     attr_accessor :work_history_explanation
 
     validates :work_history_explanation, presence: true
-    validates :work_history_explanation, word_count: { maximum: 600 }
+    validates :work_history_explanation, word_count: { maximum: 400 }
 
     def self.build_from_application(application_form)
       new(

--- a/app/views/candidate_interface/work_history/explanation/show.html.erb
+++ b/app/views/candidate_interface/work_history/explanation/show.html.erb
@@ -6,16 +6,10 @@
     <%= form_with model: @work_explanation_form, url: candidate_interface_work_history_explanation_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_area :work_history_explanation, label: { text: t('application_form.work_history.explanation.label'), tag: 'h1', size: 'xl' }, max_words: 600, rows: 20 do %>
+      <%= f.govuk_text_area :work_history_explanation, label: { text: t('application_form.work_history.explanation.label'), tag: 'h1', size: 'xl' }, max_words: 400, rows: 5 do %>
         <p class="govuk-body">
-          If you are returning to work for the first time in 5 or more years,
-          please give details. For example, explain your parental or caring
-          responsibilities (or any other reason why you have not been employed).
-        </p>
-        <p class="govuk-body">
-          You can also include relevant work history from more than 5 years ago.
-          Providers will be interested in skills and experience you could
-          transfer to a school setting.
+          For example, parenting or caring responsibilities, unemployment,
+          travel, health, study or other personal reasons.
         </p>
       <% end %>
 

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -24,16 +24,9 @@
       </p>
 
       <div class="govuk-!-margin-top-6">
-        <%= f.govuk_radio_buttons_fieldset :work_history, legend: { size: 'm', text: 'How long have you been working?', tag: 'h2' } do %>
-          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5.label'), size: 's' }, hint: { text: t('application_form.work_history.less_than_5.hint_text') }, link_errors: true %>
-
-          <%= f.govuk_radio_button :work_history, :more_than_5, label: { text: t('application_form.work_history.more_than_5.label'), size: 's' }, hint: { text: t('application_form.work_history.more_than_5.hint_text') } %>
-
-          <%= f.govuk_radio_button :work_history, :more_than_5_with_breaks, label: { text: t('application_form.work_history.more_than_5_with_breaks.label'), size: 's' }, hint: { text: t('application_form.work_history.more_than_5_with_breaks.hint_text') } %>
-
-          <%= f.govuk_radio_divider %>
-
-          <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing.label'), size: 's' }, hint: { text: t('application_form.work_history.missing.hint_text') } %>
+        <%= f.govuk_radio_buttons_fieldset :work_history, legend: { size: 'm', text: 'Do you have any work history to add?', tag: 'h2' } do %>
+          <%= f.govuk_radio_button :work_history, :complete, label: { text: t('application_form.work_history.complete.label'), size: 's' }, hint: { text: t('application_form.work_history.complete.hint_text') }, link_errors: true %>
+          <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing.label'), size: 's' } %>
         <% end %>
 
         <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -11,7 +11,7 @@
       </h1>
 
       <p class="govuk-body">
-        Training providers need a complete picture of the last 5 years of your
+        Training providers need a complete picture of your
         work history, including time out of the workplace, to safeguard
         children.
       </p>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -90,18 +90,11 @@ en:
       review:
         button: Continue
     work_history:
-      less_than_5:
-        label: Less than 5 years
-        hint_text: Give us as much of your work history as you can. For example, if you are a recent graduate, tell us about your employment before, during and since leaving university.
-      more_than_5:
-        label: More than 5 years
-        hint_text: You can list your complete work history – or just the roles you think are relevant – going back further than 5 years if you wish.
-      more_than_5_with_breaks:
-        label: More than 5 years, but with breaks
+      complete:
+        label: Yes, I have a complete work history
         hint_text: You’ll be able to give details once you’ve entered your employment history. Please explain any break longer than a month.
       missing:
-        label: I have not worked in the last 5 years
-        hint_text: You’ll be able to explain why you’ve been out of the workplace.
+        label: No, I do not have any work history
       role:
         label: Job title
         review_label: Job title

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -82,7 +82,7 @@ FactoryBot.define do
       becoming_a_teacher { Faker::Lorem.paragraph_by_chars(number: 500) }
       subject_knowledge { Faker::Lorem.paragraph_by_chars(number: 300) }
       interview_preferences { Faker::Lorem.paragraph_by_chars(number: 100) }
-      work_history_explanation { Faker::Lorem.paragraph_by_chars(number: 600) }
+      work_history_explanation { Faker::Lorem.paragraph_by_chars(number: 400) }
       work_history_breaks { Faker::Lorem.paragraph_by_chars(number: 400) }
       volunteering_experience { [true, false, nil].sample }
       phase { :apply_1 }

--- a/spec/forms/candidate_interface/work_explanation_form_spec.rb
+++ b/spec/forms/candidate_interface/work_explanation_form_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe CandidateInterface::WorkExplanationForm, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:work_history_explanation) }
 
-    okay_text = Faker::Lorem.sentence(word_count: 600)
-    long_text = Faker::Lorem.sentence(word_count: 601)
+    okay_text = Faker::Lorem.sentence(word_count: 400)
+    long_text = Faker::Lorem.sentence(word_count: 401)
 
     it { is_expected.to allow_value(okay_text).for(:work_history_explanation) }
     it { is_expected.not_to allow_value(long_text).for(:work_history_explanation) }

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -255,7 +255,7 @@ module CandidateHelper
   end
 
   def candidate_fills_in_work_experience
-    choose t('application_form.work_history.more_than_5.label')
+    choose t('application_form.work_history.complete.label')
     click_button 'Continue'
 
     with_options scope: 'application_form.work_history' do |locale|

--- a/spec/system/candidate_interface/entering_details/candidate_edits_work_history_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_work_history_after_completing_the_section_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Candidate deletes their work history' do
 
     when_i_visit_the_application_page
     and_i_click_on_work_history
-    and_i_choose_more_than_5_years
+    and_i_choose_complete
     and_i_fill_in_the_job_form
     and_i_mark_this_section_as_completed
     and_i_click_on_continue
@@ -59,8 +59,8 @@ RSpec.feature 'Candidate deletes their work history' do
     click_link t('page_titles.work_history')
   end
 
-  def and_i_choose_more_than_5_years
-    choose t('application_form.work_history.more_than_5.label')
+  def and_i_choose_complete
+    choose t('application_form.work_history.complete.label')
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_work_history_breaks_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     and_i_visit_the_site
 
     when_i_click_on_work_history
-    and_i_choose_i_have_work_for_more_than_5_years
+    and_i_choose_i_have_complete_work_history
     and_i_add_a_job_between_february_2015_to_august_2019
     and_i_add_another_job_between_november_2019_and_december_2019
     then_i_see_a_two_months_break_between_my_first_job_and_my_second_job
@@ -55,8 +55,8 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     click_link t('page_titles.work_history')
   end
 
-  def and_i_choose_i_have_work_for_more_than_5_years
-    choose t('application_form.work_history.more_than_5.label')
+  def and_i_choose_i_have_complete_work_history
+    choose t('application_form.work_history.complete.label')
 
     click_button 'Continue'
   end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_work_history_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Entering their work history' do
     when_i_omit_choosing_from_the_list_of_work_lengths
     then_i_should_see_work_history_length_validation_errors
 
-    when_i_choose_more_than_5_years
+    when_i_choose_complete
     then_i_should_see_the_job_form
 
     when_i_fill_in_the_job_form_with_incorrect_date_fields
@@ -27,7 +27,7 @@ RSpec.feature 'Entering their work history' do
     and_i_confirm
     then_i_should_see_a_list_of_work_lengths
 
-    when_i_choose_more_than_5_years
+    when_i_choose_complete
     and_i_fill_in_the_job_form # 5/2014 - 1/2019
     then_i_should_see_my_completed_job
 
@@ -59,7 +59,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def then_i_should_see_a_list_of_work_lengths
-    expect(page).to have_content(t('application_form.work_history.more_than_5.label'))
+    expect(page).to have_content(t('application_form.work_history.complete.label'))
   end
 
   def when_i_omit_choosing_from_the_list_of_work_lengths
@@ -70,8 +70,8 @@ RSpec.feature 'Entering their work history' do
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/work_history_form.attributes.work_history.blank')
   end
 
-  def when_i_choose_more_than_5_years
-    choose t('application_form.work_history.more_than_5.label')
+  def when_i_choose_complete
+    choose t('application_form.work_history.complete.label')
     click_button 'Continue'
   end
 


### PR DESCRIPTION
## Context

We need to remove references to 5 years of work history from the candidate facing guidance and content.

## Changes proposed in this pull request

- [x] On work history start page update the guidance to remove references to 5 years (as specified).
- [x] On work history start page change choices to simple complete or no work history.
- [x] Change guidance on work history explanation page to remove references to 5 years (as specified) and reduce size of text area.

<img width="708" alt="image" src="https://user-images.githubusercontent.com/450843/99514615-da9b5680-2983-11eb-9782-7a6f83db894f.png">

<img width="704" alt="image" src="https://user-images.githubusercontent.com/450843/99514456-afb10280-2983-11eb-8f58-6a3913da9463.png">

## Guidance to review

- Is the content correct?
- Is there anything missing?

## Link to Trello card

https://trello.com/c/12YzTgic/2526-dev-update-guidance-around-needing-5-years-of-work-history

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
