### PR TITLE
Improve export speed

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -2,6 +2,7 @@
 # can initially apply to 3 different courses, represented by an Application Choice.
 class ApplicationForm < ApplicationRecord
   audited
+  has_associated_audits
 
   include Chased
 

--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ApplicationReferencesExport
     def data_for_export
-      application_forms = ApplicationForm.includes(:application_references)
+      application_forms = ApplicationForm.includes(:application_references, :application_choices)
 
       data_for_export = application_forms.map do |af|
         output = {

--- a/app/services/support_interface/applications_export.rb
+++ b/app/services/support_interface/applications_export.rb
@@ -1,24 +1,18 @@
 module SupportInterface
   class ApplicationsExport
     def applications
-      # Load the ApplicationForm audits into memory first, which is faster.
-      # Avoid the overhead of object creation and storage using #pluck.
-      audits = Audited::Audit.where(action: 'update', auditable_type: 'ApplicationForm')
-        .order(created_at: :desc).pluck(:auditable_id, :audited_changes, :created_at).to_a
-
       applications_of_interest = ApplicationForm.includes(
         :candidate,
-        :application_choices, # required to avoid an n+1 query when calculating ProcessState
+      ).preload(
+        :application_choices,
+        :associated_audits,
+        :audits,
       ).where(
         'candidates.hide_in_reporting' => false,
       )
 
       applications_of_interest.map do |application_form|
-        # Preload every associated audit for this application
-        associated_audits = Audited::Audit.where(
-          associated_type: 'ApplicationForm',
-          associated_id: application_form.id,
-        ).order(created_at: :desc).pluck(:auditable_type, :created_at).to_a
+        associated_audits = application_form.associated_audits.sort_by(&:created_at).reverse
 
         output = {
           support_reference: application_form.support_reference,
@@ -28,13 +22,17 @@ module SupportInterface
           first_signed_in_at: application_form.created_at,
           submitted_form_at: application_form.submitted_at,
           form_updated_at: application_form.updated_at,
-          courses_last_updated_at: associated_audits.find { |a| a[0] == 'ApplicationChoice' }&.dig(1),
-          qualifications_last_updated_at: associated_audits.find { |a| a[0] == 'ApplicationQualification' }&.dig(1),
-          work_history_last_updated_at: associated_audits.find { |a| a[0] == 'ApplicationExperience' }&.dig(1),
-          references_last_updated_at: associated_audits.find { |a| a[0] == 'ApplicationReference' }&.dig(1),
+          courses_last_updated_at: associated_audits.find { |audit| audit.auditable_type == 'ApplicationChoice' }&.created_at,
+          qualifications_last_updated_at: associated_audits.find { |audit| audit.auditable_type == 'ApplicationQualification' }&.created_at,
+          work_history_last_updated_at: associated_audits.find { |audit| audit.auditable_type == 'ApplicationExperience' }&.created_at,
+          references_last_updated_at: associated_audits.find { |audit| audit.auditable_type == 'ApplicationReference' }&.created_at,
         }
 
-        this_application_audits = audits.select { |a| a[0] == application_form.id }
+        this_application_audits = application_form
+          .audits
+          .select { |audit| audit.action == 'update' }
+          .sort_by(&:created_at)
+          .reverse
 
         %w[
           address_line1
@@ -62,7 +60,7 @@ module SupportInterface
         ].each do |column|
           # these are sorted by audit date, so the first time a given field appears
           # in the audit set is the last time it was touched
-          value = this_application_audits.find { |audit| audit[1].key?(column) }&.dig(2)
+          value = this_application_audits.find { |audit| audit.audited_changes.key?(column) }&.created_at
           output[:"#{column}_last_updated_at"] = value
         end
 

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -36,7 +36,7 @@ module SupportInterface
 
     def form_started_and_not_submitted
       [
-        @application_choice.application_form.audits.where(action: :update).minimum(:created_at),
+        @application_choice.application_form.audits.select { |audit| audit.action == 'update' }.sort_by(&:created_at).last&.created_at,
         @application_choice.created_at,
       ].compact.min
     end

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -36,7 +36,7 @@ module SupportInterface
 
     def form_started_and_not_submitted
       [
-        @application_choice.application_form.audits.select { |audit| audit.action == 'update' }.sort_by(&:created_at).last&.created_at,
+        @application_choice.application_form.audits.select { |audit| audit.action == 'update' }.max_by(&:created_at)&.created_at,
         @application_choice.created_at,
       ].compact.min
     end

--- a/app/services/support_interface/candidate_journey_tracking_export.rb
+++ b/app/services/support_interface/candidate_journey_tracking_export.rb
@@ -32,7 +32,7 @@ module SupportInterface
             :candidate,
             :audits,
             :chasers_sent,
-            { application_references: %i[audits] },
+            { application_references: %i[audits chasers_sent] },
           ],
         )
         .joins(:application_form)

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -1,7 +1,8 @@
 module SupportInterface
   class TADProviderStatsExport
     def call
-      Course.all
+      Course
+        .includes(:provider)
         .map { |c| course_to_row(c) }
         .sort_by { |r| r[:provider_code] }
     end

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
       application_form_two = create(:application_form)
       create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form_two)
 
-      expect(described_class.new.data_for_export).to contain_exactly(
+      data = Bullet.profile { described_class.new.data_for_export }
+
+      expect(data).to contain_exactly(
         {
           'Recruitment cycle year' => application_form_one.recruitment_cycle_year,
           'Support ref number' => application_form_one.support_reference,

--- a/spec/services/support_interface/applications_export_spec.rb
+++ b/spec/services/support_interface/applications_export_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe SupportInterface::ApplicationsExport, with_audited: true do
         create(:application_choice, :awaiting_provider_decision, application_form: application_form)
       end
 
-      row = described_class.new.applications.first
+      data = Bullet.profile { described_class.new.applications }
+
+      row = data.first
 
       expect(row[:signed_up_at].to_s).to start_with('2020-01-01')
       expect(row[:first_signed_in_at].to_s).to start_with('2020-01-02')

--- a/spec/services/support_interface/candidate_journey_tracking_export_spec.rb
+++ b/spec/services/support_interface/candidate_journey_tracking_export_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::CandidateJourneyTrackingExport, with_audited: true do
-  describe '#application_choices' do
+  describe '#data_for_export' do
     around do |example|
       Timecop.freeze(Time.zone.local(2020, 6, 30, 12, 0, 0)) { example.run }
     end
@@ -11,7 +11,7 @@ RSpec.describe SupportInterface::CandidateJourneyTrackingExport, with_audited: t
       create(:application_choice, status: :unsubmitted, application_form: unsubmitted_form)
       create(:completed_application_form, application_choices_count: 2)
 
-      choices = described_class.new.application_choices
+      choices = Bullet.profile { described_class.new.data_for_export }
       expect(choices.size).to eq(3)
 
       expect(choices[0][:form_not_started]).to eq('2020-06-30T12:00:00+01:00')

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::TADProviderStatsExport do
   include CourseOptionHelpers
 
-  subject(:exported_rows) { SupportInterface::TADProviderStatsExport.new.call }
+  subject(:exported_rows) { Bullet.profile { SupportInterface::TADProviderStatsExport.new.call } }
 
   describe 'calculating offers and acceptances' do
     states_excluded_from_tad_export = [:offer_deferred]


### PR DESCRIPTION
## Context

Our exports are slow because the queries are too big, and we have N+1 problems.

## Changes proposed in this pull request

Solve the issues and make sure they don't recur by using `Bullet.profile {}`, which raises an error if it sees an N+1 query (it's an outstanding mystery why bullet doesn't pick these up currently). 

I've only touched the reports that are regularly used by @Mikeemery2020.

## Guidance to review

Do the changes make sense?
