### PR TITLE
Remove autocomplete from IELTS Grade field and update spec

### DIFF
--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -14,12 +14,6 @@ module CandidateInterface
       validate :award_year_is_a_valid_year
       validate :band_score_is_a_valid_score
 
-      def self.band_score_drop_down_options
-        empty_option = [BandScore.new('', '')]
-        scores = IeltsQualification::VALID_SCORES.map { |s| BandScore.new(s, s) }
-        empty_option + scores
-      end
-
       def save
         return false unless valid?
 

--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -21,7 +21,7 @@ module CandidateInterface
 
         ielts = IeltsQualification.new(
           trf_number: trf_number,
-          band_score: band_score,
+          band_score: sanitize(band_score),
           award_year: award_year,
         )
         UpdateEnglishProficiency.new(
@@ -47,8 +47,18 @@ module CandidateInterface
       end
 
       def band_score_is_a_valid_score
-        unless band_score.in? IeltsQualification::VALID_SCORES
+        unless sanitize(band_score).in? IeltsQualification::VALID_SCORES
           errors.add(:band_score, :invalid)
+        end
+      end
+
+      def sanitize(band_score)
+        if band_score.nil?
+          nil
+        elsif band_score.length == 1
+          "#{band_score}.0"
+        else
+          band_score
         end
       end
 

--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -2,7 +2,8 @@
   :trf_number,
   label: { text: 'Test report form (TRF) number', size: 'm' },
   hint: { text: 'For example, 02GB0674SOOM599A' },
-  spellcheck: false) %>
+  spellcheck: false,
+  width: 20) %>
 
 <%= f.govuk_text_field(
   :band_score,

--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -4,14 +4,10 @@
   hint: { text: 'For example, 02GB0674SOOM599A' },
   spellcheck: false) %>
 
-<%= f.govuk_collection_select(
+<%= f.govuk_text_field(
   :band_score,
-  CandidateInterface::EnglishForeignLanguage::IeltsForm.band_score_drop_down_options,
-  :value,
-  :option,
   label: { text: 'Overall band score', size: 'm' },
-  hint: { text: 'For example, 7.5' },
-  form_group: { classes: 'govuk-form-group--ielts-band-score' }) %>
+  hint: { text: 'For example, 7.5' }) %>
 
 <%= f.govuk_text_field(
   :award_year,

--- a/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/_form_fields.html.erb
@@ -7,7 +7,8 @@
 <%= f.govuk_text_field(
   :band_score,
   label: { text: 'Overall band score', size: 'm' },
-  hint: { text: 'For example, 7.5' }) %>
+  hint: { text: 'For example, 7.5' },
+  width: 4) %>
 
 <%= f.govuk_text_field(
   :award_year,

--- a/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @ielts_form, url: candidate_interface_edit_ielts_path, method: :patch) do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class='govuk-heading-xl class='govuk-heading-xl''>
+      <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
         <%= t('page_titles.efl.ielts') %>
       </h1>

--- a/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/edit.html.erb
@@ -3,12 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-xl class='govuk-heading-xl''>
-      <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
-      <%= t('page_titles.efl.ielts') %>
-    </h1>
-
     <%= form_with(model: @ielts_form, url: candidate_interface_edit_ielts_path, method: :patch) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class='govuk-heading-xl class='govuk-heading-xl''>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <%= t('page_titles.efl.ielts') %>
+      </h1>
       <%= render 'form_fields', { f: f } %>
     <% end %>
 

--- a/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @ielts_form, url: candidate_interface_ielts_path) do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class='govuk-heading-xl class='govuk-heading-xl''>
+      <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
         <%= t('page_titles.efl.ielts') %>
       </h1>

--- a/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/ielts/new.html.erb
@@ -3,12 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-xl class='govuk-heading-xl''>
-      <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
-      <%= t('page_titles.efl.ielts') %>
-    </h1>
-
     <%= form_with(model: @ielts_form, url: candidate_interface_ielts_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class='govuk-heading-xl class='govuk-heading-xl''>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <%= t('page_titles.efl.ielts') %>
+      </h1>
       <%= render 'form_fields', { f: f } %>
     <% end %>
 

--- a/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
@@ -2,7 +2,8 @@
   :registration_number,
   label: { text: 'TOEFL registration number', size: 'm' },
   hint: { text: 'For example, 0000 0000 2500 2147' },
-  spellcheck: false) %>
+  spellcheck: false,
+  width: 20) %>
 
 <%= f.govuk_text_field(
   :total_score,

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -714,6 +714,7 @@ en:
               blank: Enter your TRF number
             band_score:
               blank: Enter your overall band score
+              invalid: Enter an overall band score in the correct format
             award_year:
               blank: Enter year the assessment was done
               invalid: Enter a real year

--- a/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsForm, type: :mod
       expect(form).not_to be_valid
       expect(form.errors.full_messages) .to eq ['Award year Enter a real year']
     end
+
+    context 'user inputs single digit band_score' do
+      let(:valid_form_2) do
+        described_class.new(
+          trf_number: '12345',
+          band_score: '6',
+          award_year: 2000,
+        )
+      end
+
+      it 'is valid with valid attributes' do
+        expect(valid_form).to be_valid
+      end
+    end
   end
 
   describe '#save' do
@@ -53,6 +67,28 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsForm, type: :mod
       expect(qualification.trf_number).to eq '12345'
       expect(qualification.band_score).to eq '6.5'
       expect(qualification.award_year).to eq 2000
+    end
+
+    context 'user inputs single digit band_score' do
+      let(:valid_form_2) do
+        described_class.new(
+          trf_number: '12345',
+          band_score: '6',
+          award_year: 2000,
+        )
+      end
+
+      it 'saves a sanitized grade' do
+        application_form = create(:application_form)
+        valid_form_2.application_form = application_form
+
+        valid_form_2.save
+
+        expect(application_form.english_proficiency.qualification_status).to eq 'has_qualification'
+        qualification = application_form.english_proficiency.efl_qualification
+
+        expect(qualification.band_score).to eq '6.0'
+      end
     end
 
     context 'application_form already has an EnglishProficiency record' do

--- a/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
+++ b/spec/system/candidate_interface/entering_details/your_ielts_results_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Your IELTS result' do
 
   def when_i_provide_my_ielts_details
     fill_in 'Test report form (TRF) number', with: '123456'
-    select '7.5', from: 'Overall band score'
+    fill_in 'Overall band score', with: '7.5'
     fill_in 'When did you complete the assessment?', with: '1999'
     click_button 'Save and continue'
   end


### PR DESCRIPTION
#3093  Context

To comply with accessibility standards autocomplete drop down needs to be removed from the grade field on the IELTS page. 

## Changes proposed in this pull request

Field type has been changed and method called to map array of grades has been  removed from form model. However, array still exists as it is used for back end validation. Users now  have free text field which will validate against correct values.

![image](https://user-images.githubusercontent.com/62567622/99532271-f0b51100-299b-11eb-9200-af049adae041.png)
![image](https://user-images.githubusercontent.com/62567622/99532291-f7438880-299b-11eb-9f41-274aebe0f68a.png)
![image](https://user-images.githubusercontent.com/62567622/99532324-01fe1d80-299c-11eb-91cf-4fc80f402b05.png)
![image](https://user-images.githubusercontent.com/62567622/99532341-07f3fe80-299c-11eb-8327-4ffc80205d7a.png)

## Guidance to review

Check that solution matches expected behaviour.

## Link to Trello card

https://trello.com/c/Q9aOtnL0/2504-remove-autocomplete-for-ielts-band-score-and-use-same-approach-as-that-used-for-gcse-grades

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
