### PR TITLE
Add Slack notification for RBD feedback

### DIFF
--- a/app/services/save_and_send_reject_by_default_feedback.rb
+++ b/app/services/save_and_send_reject_by_default_feedback.rb
@@ -14,5 +14,16 @@ class SaveAndSendRejectByDefaultFeedback
 
       CandidateMailer.feedback_received_for_application_rejected_by_default(application_choice).deliver_later
     end
+
+    notify_slack
+  end
+
+  def notify_slack
+    provider_name = application_choice.offered_course.provider.name
+    candidate_name = application_choice.application_form.first_name
+    message = ":telephone_receiver: #{provider_name} has sent feedback for #{candidate_name}’s RBD application"
+    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form)
+
+    SlackNotificationWorker.perform_async(message, url)
   end
 end

--- a/spec/services/save_and_send_reject_by_default_feedback_spec.rb
+++ b/spec/services/save_and_send_reject_by_default_feedback_spec.rb
@@ -30,4 +30,10 @@ RSpec.describe SaveAndSendRejectByDefaultFeedback, sidekiq: true do
 
     expect(CandidateMailer.deliveries.count).to be 1
   end
+
+  it 'sends a Slack notification' do
+    allow(SlackNotificationWorker).to receive(:perform_async)
+    service.call!
+    expect(SlackNotificationWorker).to have_received(:perform_async)
+  end
 end


### PR DESCRIPTION
## Context

We'd like to know if this feature is being used.

## Changes proposed in this pull request

Add a Slack notification to the relevant service.

## Guidance to review

Should be easy.

## Link to Trello card

https://trello.com/c/6RZWDB9F

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
