### PR TITLE
Amend UCAS matches "Action needed" flag

### DIFF
--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -31,8 +31,7 @@ class UCASMatch < ApplicationRecord
 
   def dual_application_or_dual_acceptance?
     application_for_the_same_course_in_progress_on_both_services? ||
-      application_accepted_on_ucas_and_in_progress_on_apply? ||
-      application_accepted_on_apply_and_in_progress_on_ucas?
+      application_accepted_on_ucas_and_accepted_on_apply?
   end
 
   def invalid_matching_data?
@@ -88,13 +87,8 @@ private
       application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
   end
 
-  def application_accepted_on_ucas_and_in_progress_on_apply?
+  def application_accepted_on_ucas_and_accepted_on_apply?
     ucas_matched_applications.map(&:application_accepted_on_ucas?).any? &&
-      ucas_matched_applications.map(&:application_in_progress_on_apply?).any?
-  end
-
-  def application_accepted_on_apply_and_in_progress_on_ucas?
-    ucas_matched_applications.map(&:application_accepted_on_apply?).any? &&
-      ucas_matched_applications.map(&:application_in_progress_on_ucas?).any?
+      ucas_matched_applications.map(&:application_accepted_on_apply?).any?
   end
 end

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -93,26 +93,13 @@ RSpec.describe UCASMatch do
       expect(ucas_match.dual_application_or_dual_acceptance?).to eq(false)
     end
 
-    it 'returns true if application is accepted on UCAS and in progress on Apply' do
-      course1 = application_form_awaiting_provider_decision.application_choices.first.course_option.course
-      ucas_matching_data = { 'Scheme' => 'U',
-                             'Offers' => '1',
-                             'Conditional firm' => '1',
-                             'Provider code' => course.provider.code.to_s }
-      apply_matching_data = { 'Scheme' => 'D',
-                              'Course code' => course1.code.to_s,
-                              'Provider code' => course1.provider.code.to_s,
-                              'Apply candidate ID' => candidate.id.to_s }
-      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
-
-      expect(ucas_match.dual_application_or_dual_acceptance?).to eq(true)
-    end
-
-    it 'returns true if application is accepted on Apply and in progress on UCAS' do
+    it 'returns true if application is accepted on UCAS and accepted on Apply' do
       application_choice = create(:application_choice, :with_accepted_offer)
       create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice])
       course1 = application_choice.course_option.course
       ucas_matching_data = { 'Scheme' => 'U',
+                             'Offers' => '1',
+                             'Conditional firm' => '1',
                              'Provider code' => course.provider.code.to_s }
       apply_matching_data = { 'Scheme' => 'D',
                               'Course code' => course1.code.to_s,


### PR DESCRIPTION
## Context

We only want to contact candidates who have accepted offers on both services. 
Applications in progress on both services will no longer be flagged.

We currently flag 3 scenarios:
- application for the same course in progress on both services
- application accepted on UCAS and in progress on Apply
- application accepted on apply and in progress on UCAS

We need to amend the last two scenarios to:
- application **accepted** on UCAS and **accepted** on Apply

## Changes proposed in this pull request

Change the logic in `dual_application_or_dual_acceptance?`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/xxHO3FFL/3009-amend-ucas-matches-action-needed-flag

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
