### PR TITLE
Refactor English GCSEs

### DIFF
--- a/adr/0016-structured-gcse-grades.md
+++ b/adr/0016-structured-gcse-grades.md
@@ -1,0 +1,70 @@
+# 16. Structured GCSE grades
+
+Date: 2020-11-18
+
+## Status
+
+Accepted
+
+## Context
+
+Since the service launched in November, candidates have been able to enter details about their academic and other 
+relevant qualifications using free text answers for most questions.
+
+We’ve seen that free-text answers can often lead to candidates submitting applications with spelling errors, which may 
+reduce their chances of being offered an interview.
+
+There is also some complexity around entering GCSE standard equivalent qualifications; there are a number of different 
+English GCSE exams, and science GCSEs can be awarded in a number of different ways.
+
+There are two key differences between English and Science GCSEs
+- for English GCSEs they have different certificates and are considered separate qualifications (eg. English Language and English Literature)
+- a candidate can enter an 'other English GCSE' qualification and give it a name, eg. Cockney Rhyming Slang. 
+
+We considered two different options for how we store this data in the database 
+- as separate records, one for each GCSE qualification
+- as a single record with the different qualifications stored in a JSON blob in a `structured_grades` column
+
+Part of the reason for this problem is that the English GCSE form is a single page but is gathering information about 
+multiple qualifications.
+
+### Separate records
+
+#### Pros
+- The database structure more closely reflects the domain structure of having multiple records for multiple 
+qualifications
+
+#### Cons
+- Increased code complexity. The `ApplicationForm` would need to have multiple English GCSEs, and anywhere that uses 
+the English GCSE data would need to be refactored to handle multiple GCSEs. The grade controller would also have to build 
+the `EnglishGCSEGradeForm` from multiple qualifications
+- No obvious way to store the name of "other English GCSEs" eg. Cockney Rhyming Slang. One idea was to introduce a new
+field to capture this data
+
+### JSON blob in a single record
+
+#### Pros
+- The logic for serialising and deserialising the GCSEs to JSON can be encapsulated inside the form object. 
+So it has a smaller footprint and impact on the codebase
+- Using a JSON blob we can easily store the name of "other English GCSEs" eg. Cockney Rhyming Slang
+
+```
+{
+    subject: 'english',
+    structured_grades: { 'English Language': 'E', 'English Literature': 'E', 'Cockney Rhyming Slang: 'A*'},
+    level: 'gcse'
+}
+```
+
+#### Cons
+- Database structure doesn't reflect domain structure
+
+## Decision
+
+We decided to go for the JSON blob approach
+
+- Within the candidate interface, whenever we reference English GCSEs we always discuss them together, rather than 
+one at a time, so there is little reason to treat them as separate from that point of view
+- We didn't feel that domain logic should necessarily dictate the structure of information in the database, if
+  it meant introducing extra code complexity
+ 

--- a/adr/0016-structured-gcse-grades.md
+++ b/adr/0016-structured-gcse-grades.md
@@ -8,7 +8,7 @@ Accepted
 
 ## Context
 
-Since the service launched in November, candidates have been able to enter details about their academic and other 
+Since the service launched, candidates have been able to enter details about their academic and other 
 relevant qualifications using free text answers for most questions.
 
 We’ve seen that free-text answers can often lead to candidates submitting applications with spelling errors, which may 

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -66,14 +66,14 @@ module CandidateInterface
 
     def present_grades
       if application_qualification.subject == ApplicationQualification::SCIENCE_TRIPLE_AWARD
-        grades = application_qualification.grades
+        grades = application_qualification.structured_grades
         [
           "#{grades['biology']} (Biology)",
           "#{grades['chemistry']} (Chemistry)",
           "#{grades['physics']} (Physics)",
         ]
-      elsif application_qualification.subject == 'english' && application_qualification.grades
-        grades = JSON.parse(application_qualification.grades)
+      elsif application_qualification.subject == 'english' && application_qualification.structured_grades
+        grades = JSON.parse(application_qualification.structured_grades)
         grades.map { |k, v,| "#{v} (#{k.humanize.titleize})" }
       else
         application_qualification.grade

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     attr_accessor :grade,
                   :qualification,
                   :other_grade,
-                  :grades,
+                  :structured_grades,
                   :english_gcses,
                   :english_single_award,
                   :grade_english_single,
@@ -27,8 +27,8 @@ module CandidateInterface
     validates :grade, presence: true, on: :grade
     validates :other_grade, presence: true, if: :grade_is_other?
     validate :validate_grade_format, on: :grade, unless: :is_multiple_gcse? || :new_record?
-    validate :validate_grades, unless: :new_record?, on: :grades, if: :is_multiple_gcse?
-    validate :gcse_selected, on: :grades, if: :is_multiple_gcse?
+    validate :validate_grades, unless: :new_record?, on: :structured_grades, if: :is_multiple_gcse?
+    validate :gcse_selected, on: :structured_grades, if: :is_multiple_gcse?
 
     class << self
       def build_from_qualification(qualification)
@@ -49,8 +49,8 @@ module CandidateInterface
           qualification: qualification,
         }
 
-        if qualification.grades
-          grades = JSON.parse(qualification.grades)
+        if qualification.structured_grades
+          grades = JSON.parse(qualification.structured_grades)
           english_gcses = []
 
           if grades.keys.include? 'english_single_award'
@@ -144,11 +144,11 @@ module CandidateInterface
     end
 
     def save_grades
-      if !valid?(:grades)
-        log_validation_errors(:grades)
+      if !valid?(:structured_grades)
+        log_validation_errors(:structured_grades)
         return false
       end
-      qualification.update(grades: build_grades_json, grade: nil)
+      qualification.update(structured_grades: build_grades_json, grade: nil)
     end
 
     def save_grade
@@ -156,7 +156,7 @@ module CandidateInterface
         log_validation_errors(:grade)
         return false
       end
-      qualification.update(grade: set_grade, grades: nil)
+      qualification.update(grade: set_grade, structured_grades: nil)
     end
 
   private

--- a/app/forms/candidate_interface/science_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/science_gcse_grade_form.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     include ValidationUtils
 
     attr_accessor :grade,
-                  :grades,
+                  :structured_grades,
                   :award_year,
                   :qualification,
                   :subject,
@@ -48,7 +48,7 @@ module CandidateInterface
         when ApplicationQualification::SCIENCE_DOUBLE_AWARD
           params[:double_award_grade] = qualification.grade
         when ApplicationQualification::SCIENCE_TRIPLE_AWARD
-          grades = qualification.grades
+          grades = qualification.structured_grades
           return unless grades
 
           params[:biology_grade] = grades['biology']
@@ -70,7 +70,7 @@ module CandidateInterface
 
       qualification.update(
         grade: set_grade,
-        grades: set_triple_award_grades,
+        structured_grades: set_triple_award_grades,
         subject: subject,
       )
     end
@@ -163,7 +163,7 @@ module CandidateInterface
       error_message = {
         field: field.to_s,
         error_messages: errors[field].join(' - '),
-        value: grade || grades,
+        value: grade || structured_grades,
       }
 
       Rails.logger.info("Validation error: #{error_message.inspect}")

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -227,7 +227,7 @@ module VendorAPI
         end
       end
 
-      grades = qualification.grades
+      grades = qualification.structured_grades
 
       # We need to serialize 'grades' to the 'grade' field
       # in the specified order

--- a/db/migrate/20201118140921_update_grades_to_structured_grades.rb
+++ b/db/migrate/20201118140921_update_grades_to_structured_grades.rb
@@ -1,0 +1,5 @@
+class UpdateGradesToStructuredGrades < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :application_qualifications, :grades, :structured_grades
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_114518) do
+ActiveRecord::Schema.define(version: 2020_11_18_140921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_114518) do
     t.string "comparable_uk_degree"
     t.string "non_uk_qualification_type"
     t.string "comparable_uk_qualification"
-    t.jsonb "grades"
+    t.jsonb "structured_grades"
     t.index ["application_form_id"], name: "index_application_qualifications_on_application_form_id"
     t.index ["grade_hesa_code"], name: "qualifications_by_grade_hesa_code"
     t.index ["institution_hesa_code"], name: "qualifications_by_institution_hesa_code"

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
           qualification_type: 'gcse',
           level: 'gcse',
           grade: nil,
-          grades: { physics: 'A', chemistry: 'B', biology: 'C' },
+          structured_grades: { physics: 'A', chemistry: 'B', biology: 'C' },
           subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
         )
 
@@ -124,7 +124,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
           qualification_type: 'gcse',
           level: 'gcse',
           grade: nil,
-          grades: '{"english":"E","english_literature":"D","Cockney Rhyming Slang":"A*"}',
+          structured_grades: '{"english":"E","english_literature":"D","Cockney Rhyming Slang":"A*"}',
           subject: 'english',
         )
 

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         details_form.save
         qualification.reload
 
-        expect(qualification.grades).to eq({
+        expect(qualification.structured_grades).to eq({
           'biology' => 'A*',
           'chemistry' => 'A*',
           'physics' => 'A*',
@@ -328,7 +328,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           qualification.reload
 
           expect(qualification.grade).to eq(nil)
-          expect(qualification.grades).to eq({ 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' })
+          expect(qualification.structured_grades).to eq({ 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' })
         end
       end
 
@@ -338,7 +338,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           qualification = ApplicationQualification.create(
             level: 'gcse',
             grade: nil,
-            grades: { 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' },
+            structured_grades: { 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' },
             subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
             application_form: application_form,
           )
@@ -351,7 +351,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           qualification.reload
 
           expect(qualification.grade).to eq('A')
-          expect(qualification.grades).to eq(nil)
+          expect(qualification.structured_grades).to eq(nil)
         end
       end
     end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :gcse_qualification,
         grade: nil,
         subject: 'science triple award',
-        grades: science_triple_awards,
+        structured_grades: science_triple_awards,
         application_form: application_choice.application_form,
       )
 


### PR DESCRIPTION
## Context

With the move to multiple English GCSEs there was some discussion around how to store the information in the database.

## Changes proposed in this pull request

This PR adds an ADR to document that discussion. It also renames the `grades` column to `structured_grades` to make the contents less surprising.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/sLBZws9B/2548-refactor-english-gcses

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
