### PR TITLE
Remove autocomplete complete from GCSE Maths grade form

### DIFF
--- a/app/forms/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_details_form.rb
@@ -72,11 +72,17 @@ module CandidateInterface
     def validate_grade_format
       return if qualification.qualification_type.nil? || qualification.qualification_type == 'other_uk' || qualification.qualification_type == 'non_uk'
 
-      qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
+      if qualification.qualification_type == 'gcse' && qualification.subject == 'maths'
+        errors.add(:grade, :invalid) unless SINGLE_GCSE_GRADES.include?(sanitize(grade))
+      else
+        qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
 
-      if qualification_rexp && grade.match(qualification_rexp)
-        errors.add(:grade, :invalid)
+        errors.add(:grade, :invalid) if qualification_rexp && grade.match(qualification_rexp)
       end
+    end
+
+    def sanitize(grade)
+      grade.delete(' ').upcase if grade
     end
 
     def invalid_grades
@@ -116,7 +122,7 @@ module CandidateInterface
       when 'unknown'
         'Unknown'
       else
-        grade
+        sanitize(grade)
       end
     end
   end

--- a/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
@@ -19,20 +19,7 @@
       <% else %>
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
-        <% if autocomplete_grades? %>
-          <div class="govuk-!-width-one-third">
-            <%= f.govuk_collection_select(
-                  :grade,
-                  CandidateInterface::GcseQualificationDetailsForm.all_grade_drop_down_options,
-                  :value,
-                  :option,
-                  label: { text: 'Grade', size: 'm' },
-                  hint: { text: 'For example, ‘C’ or ‘4’' },
-                  ) %>
-          </div>
-        <% else %>
-          <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
-        <% end %>
+        <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
       <% end %>
 
       <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -56,10 +56,10 @@ module CandidateHelper
     candidate_fills_in_their_degree
 
     click_link 'Maths GCSE or equivalent'
-    candidate_fills_in_a_gcse
+    candidate_fills_in_a_gcse('maths')
 
     click_link 'English GCSE or equivalent'
-    candidate_fills_in_a_gcse
+    candidate_fills_in_a_gcse('english')
 
     click_link 'Science GCSE or equivalent'
     candidate_explains_a_missing_gcse
@@ -348,10 +348,10 @@ module CandidateHelper
     visit candidate_interface_application_form_path
   end
 
-  def candidate_fills_in_a_gcse
+  def candidate_fills_in_a_gcse(subject)
     choose('GCSE')
     click_button 'Save and continue'
-    select 'B', from: 'Grade'
+    subject == 'maths' ? fill_in('Please specify your grade', with: 'B') : select('B', from: 'Grade')
     click_button 'Save and continue'
     fill_in 'Enter year', with: '1990'
     click_button 'Save and continue'

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'Candidate entering GCSE details' do
     expect(page).to have_content 'Maths GCSE or equivalent'
 
     expect(page).to have_content 'GCSE'
-    expect(page).to have_content 'AA'
+    expect(page).to have_content 'A'
     expect(page).to have_content '1990'
   end
 
@@ -133,7 +133,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_fill_in_the_grade
-    select 'AA', from: 'Grade'
+    fill_in 'Please specify your grade', with: 'A'
   end
 
   def when_i_fill_in_the_year
@@ -149,7 +149,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def then_i_see_the_gcse_grade_entered
-    expect(page).to have_selector("input[value='AA']")
+    expect(page).to have_selector("input[value='A']")
   end
 
   def then_i_see_the_gcse_year_entered

--- a/spec/system/candidate_interface/signup_and_signin/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     click_on 'Maths GCSE or equivalent'
     choose('GCSE')
     click_button 'Save and continue'
-    select 'AA', from: 'Grade'
+    fill_in 'Please specify your grade', with: 'A'
     click_button 'Save and continue'
     fill_in 'Enter year', with: '1990'
     click_button 'Save and continue'

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -90,10 +90,10 @@ RSpec.feature 'International candidate submits the application' do
     candidate_fills_in_their_degree
 
     click_link 'Maths GCSE or equivalent'
-    candidate_fills_in_a_gcse
+    candidate_fills_in_a_gcse('maths')
 
     click_link 'English GCSE or equivalent'
-    candidate_fills_in_a_gcse
+    candidate_fills_in_a_gcse('english')
 
     click_link 'Science GCSE or equivalent'
     candidate_explains_a_missing_gcse


### PR DESCRIPTION
## Context

In [Design spike: GCSE grade options](https://trello.com/c/RjrKbnr0/), we revised how we are using auto selects for GCSE grades. Maths still need to have autocomplete removed from the grade form.

## Changes proposed in this pull request

- Remove the autocomplete
- Add extra validation checks now that grade is entered manually
- Fix broken specs
- 🏖️ 

## Guidance for review
Fill out a GCSE Maths qualification (`/candidate/application/gcse/maths/grade`) and note the lack of _auto-completeness_ when you reach the grade form.

## Link to Trello card

https://trello.com/c/r829S9jB/2558-remove-autocomplete-for-maths-gcse-grades-and-use-the-same-approach-as-that-used-for-science-gcse-grades

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
