### PR TITLE
Add UCAS holidays to calendar

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -33,24 +33,26 @@ class TimeLimitConfig
     28
   end
 
-  RULES = {
-    reject_by_default: [
-      Rule.new(nil, nil, 40),
-      Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 20),
-    ],
-    decline_by_default: [
-      Rule.new(nil, nil, 10),
-    ],
-    chase_provider_before_rbd: [
-      Rule.new(nil, nil, 20),
-      Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 10),
-    ],
-    chase_candidate_before_dbd: [
-      Rule.new(nil, nil, 5),
-    ],
-  }.freeze
+  def self.rules
+    {
+      reject_by_default: [
+        Rule.new(nil, nil, 40),
+        Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 20),
+      ],
+      decline_by_default: [
+        Rule.new(nil, nil, 10),
+      ],
+      chase_provider_before_rbd: [
+        Rule.new(nil, nil, 20),
+        Rule.new(Time.zone.local(RecruitmentCycle.current_year, 7, 1), nil, 10),
+      ],
+      chase_candidate_before_dbd: [
+        Rule.new(nil, nil, 5),
+      ],
+    }
+  end
 
   def self.limits_for(rule)
-    RULES[rule.to_sym]
+    rules[rule.to_sym]
   end
 end

--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -2,7 +2,13 @@ Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).m
   BusinessTime::Config.holidays << holiday[:date]
 end
 
-(Date.new(2020, 3, 23)..Date.new(2020, 5, 28)).each do |date|
+UCAS_COVID_DATE_FREEZE = (Date.new(2020, 3, 23)..Date.new(2020, 5, 28)).freeze
+UCAS_WINTER_HOLIDAY_2020 = (Date.new(2020, 12, 20)..Date.new(2021, 1, 1)).freeze
+UCAS_SPRING_HOLIDAY_2021 = (Date.new(2021, 4, 2)..Date.new(2021, 4, 16)).freeze
+
+UCAS_HOLIDAYS = UCAS_COVID_DATE_FREEZE.to_a + UCAS_WINTER_HOLIDAY_2020.to_a + UCAS_SPRING_HOLIDAY_2021.to_a
+
+UCAS_HOLIDAYS.each do |date|
   BusinessTime::Config.holidays << date
 end
 

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SetRejectByDefault, skip: true do
+RSpec.describe SetRejectByDefault do
   describe '#call' do
     it 'does not update dates when nothing changes', with_audited: true do
       application_choice = create(:application_choice, sent_to_provider_at: Time.zone.now)
@@ -16,15 +16,18 @@ RSpec.describe SetRejectByDefault, skip: true do
       ['1 Jul 2019 9:00:00 AM BST',  '28 Aug 2019 0:00:00 AM BST', 'safely within BST'],
       ['4 Jan 2019 11:00:00 PM GMT', '2 Mar 2019 0:00:00 AM GMT',  'safely within GMT'],
       ['1 Jul 2020 11:00:00 PM BST', '30 Jul 2020 0:00:00 AM BST', 'during the 20-day summer period'],
+      ['21 Nov 2020 12:00:00 PM GMT', '2 Feb 2021 0:00:00 AM GMT', 'near the UCAS winter break'],
     ].freeze
 
     submitted_vs_rbd_dates.each do |submitted, correct_rbd, test_case|
       it "is correct when the application is delivered #{test_case}" do
-        choice = create(:application_choice, sent_to_provider_at: submitted)
+        Timecop.freeze(Time.zone.parse(submitted)) do
+          choice = create(:application_choice, sent_to_provider_at: Time.zone.now)
 
-        call_service(choice)
+          call_service(choice)
 
-        expect(choice.reload.reject_by_default_at).to be_within(1.second).of(Time.zone.parse(correct_rbd))
+          expect(choice.reload.reject_by_default_at).to be_within(1.second).of(Time.zone.parse(correct_rbd))
+        end
       end
     end
   end


### PR DESCRIPTION
## Context
UCAS have made us aware of their breaks in winter 2020 and spring 2021. Add these to the calendar to ensure RBD dates in apply are fair. Also fix RBD calculation tests

## Guidance to review
The ticket also mentions: 03 May 2021, 31 May 2021, 30 August 2021 (bank holidays) which I have checked are already in the calendar

## Link to Trello card
https://trello.com/c/kBLB4ot9/3043-fix-rbds-over-christmas-and-new-year

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
