### PR TITLE
Add referee guidance to application page for providers

### DIFF
--- a/app/views/provider_interface/application_choices/_references_context.html.erb
+++ b/app/views/provider_interface/application_choices/_references_context.html.erb
@@ -18,3 +18,35 @@
     </ul>
   </div>
 </details>
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View guidance given to referee
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p class="govuk-body">When giving your reference try to cover the following, but do not worry if there are areas you cannot comment on:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+      <li>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
+        <p class="govuk-body">Does the candidate think critically and have good numeracy and literacy skills?</p>
+      </li>
+      <li>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
+        <p class="govuk-body">Is the candidate emotionally resilient? Do they work well with others?</p>
+      </li>
+      <li>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
+        <p class="govuk-body">Can the candidate meet deadlines and manage their time?</p>
+      </li>
+      <li>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Suitability to work with children</h2>
+        <p class="govuk-body">Does the candidate care about the wellbeing of children?</p>
+      </li>
+      <li>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
+        <p class="govuk-body">What abilities would the candidate bring to teaching — for example, communication, creativity, project management?</p>
+      </li>
+    </ul>
+  </div>
+</details>


### PR DESCRIPTION
## Context
Providers have asked that we add a preview of the guidance given to referees when they provide a reference

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/30071178/99645499-35e24d00-2a47-11eb-9220-88966686da1c.png)

![image](https://user-images.githubusercontent.com/30071178/99645505-37ac1080-2a47-11eb-993e-70b5d736b1a6.png)

## Guidance to review
Is it worth using the component from the referee interface here instead? Downside of what I've done is that changes to the actual guidance won't automatically come up here

## Link to Trello card
https://trello.com/c/IPheGE55/3041-show-guidance-given-to-referees-within-manage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
