### PR TITLE
Send initial emails to resolve dual applications

### DIFF
--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -5,9 +5,9 @@ module SupportInterface
     ACTIONS = {
       initial_emails_sent: {
         description: 'Send initial emails',
-        button_text: 'Confirm initial emails were sent',
-        form_path: :support_interface_record_initial_emails_sent_path,
-        instructions: "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>.",
+        button_text: 'Send emails',
+        form_path: :support_interface_send_initial_emails_path,
+        instructions: 'We need to contact the candidate and the provider.',
         past_tense_description: 'sent the initial emails',
       },
       reminder_emails_sent: {

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -15,13 +15,17 @@ module SupportInterface
       @match = UCASMatch.find(params[:id])
     end
 
-    def record_initial_emails_sent
+    def send_initial_emails
       match = UCASMatch.find(params[:id])
-      match.update!(
-        candidate_last_contacted_at: Time.zone.now,
-        action_taken: 'initial_emails_sent',
-      )
-      flash[:success] = 'The date of the initial emails was recorded'
+
+      if SupportInterface::SendUCASMatchInitialEmails.new(match)
+        match.update!(action_taken: 'initial_emails_sent',
+                      candidate_last_contacted_at: Time.zone.now)
+
+        flash[:success] = 'Initial emails sent'
+      else
+        flash[:error] = 'Initial emails were not sent'
+      end
       redirect_to support_interface_ucas_match_path(match)
     end
 

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -49,6 +49,15 @@ class TimeLimitConfig
       chase_candidate_before_dbd: [
         Rule.new(nil, nil, 5),
       ],
+      ucas_match_candidate_withdrawal_request: [
+        Rule.new(nil, nil, 10),
+      ],
+      ucas_match_candidate_withdrawal_request_reminder: [
+        Rule.new(nil, nil, 5),
+      ],
+      ucas_match_ucas_withdrawal_request: [
+        Rule.new(nil, nil, 10),
+      ],
     }
   end
 

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -56,7 +56,7 @@ class TimeLimitConfig
         Rule.new(nil, nil, 5),
       ],
       ucas_match_ucas_withdrawal_request: [
-        Rule.new(nil, nil, 10),
+        Rule.new(nil, nil, 5),
       ],
     }
   end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -299,7 +299,7 @@ class CandidateMailer < ApplicationMailer
     @application_form = application_choice.application_form
     @course_name_and_code = application_choice.course_option.course.name_and_code
     @provider_name = application_choice.course_option.course.provider.name
-    @date_to_withdraw_application_by = 10.business_days.after(Time.zone.today).to_s(:govuk_date)
+    @date_to_withdraw_application_by = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
 
     email_for_candidate(
       @application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -307,6 +307,16 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_initial_email_multiple_acceptances(candidate)
+    @application_form = candidate.application_forms.first
+    @date_to_withdraw_application_by = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.ucas_match_initial_email.multiple_acceptances.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -295,6 +295,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_initial_email_duplicate_applications(application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course_option.course.name_and_code
+    @provider_name = application_choice.course_option.course.provider.name
+    @date_to_withdraw_application_by = 10.business_days.after(Time.zone.today).to_s(:govuk_date)
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.ucas_match_initial_email.duplicate_applications.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -93,6 +93,17 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_initial_email_duplicate_applications(provider_user, application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course.name_and_code
+
+    email_for_provider(
+      provider_user,
+      @application_form,
+      subject: I18n.t!('provider_mailer.ucas_match.initial_email.duplicate_applications.subject'),
+    )
+  end
+
   def fallback_sign_in_email(provider_user, token)
     @token = token
 

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -38,6 +38,11 @@ class UCASMatch < ApplicationRecord
       application_accepted_on_ucas_and_accepted_on_apply?
   end
 
+  def application_accepted_on_ucas_and_accepted_on_apply?
+    ucas_matched_applications.map(&:application_accepted_on_ucas?).any? &&
+      ucas_matched_applications.map(&:application_accepted_on_apply?).any?
+  end
+
   def invalid_matching_data?
     !ucas_matched_applications.all?(&:valid_matching_data?)
   end
@@ -93,10 +98,5 @@ private
 
     application_for_the_same_course_on_both_services.map(&:application_in_progress_on_ucas?).any? &&
       application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
-  end
-
-  def application_accepted_on_ucas_and_accepted_on_apply?
-    ucas_matched_applications.map(&:application_accepted_on_ucas?).any? &&
-      ucas_matched_applications.map(&:application_accepted_on_apply?).any?
   end
 end

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -82,6 +82,10 @@ class UCASMatch < ApplicationRecord
     action_taken.to_sym
   end
 
+  def application_choices_for_same_course_on_both_services
+    ucas_matched_applications.select(&:both_scheme?).map(&:application_choice)
+  end
+
 private
 
   def application_for_the_same_course_in_progress_on_both_services?

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -56,15 +56,15 @@ class UCASMatch < ApplicationRecord
   def need_to_send_reminder_emails?
     return false unless initial_emails_sent?
 
-    send_reminder_emails_date = 5.business_days.after(candidate_last_contacted_at).to_date
-    Time.zone.today >= send_reminder_emails_date
+    candidate_withdrawal_request_reminder_date = calculate_action_date(:ucas_match_candidate_withdrawal_request_reminder, candidate_last_contacted_at)
+    Time.zone.today >= candidate_withdrawal_request_reminder_date
   end
 
   def need_to_request_withdrawal_from_ucas?
     return false unless reminder_emails_sent?
 
-    request_withdrawal_from_ucas_date = 10.business_days.after(candidate_last_contacted_at).to_date
-    Time.zone.today >= request_withdrawal_from_ucas_date
+    ucas_withdrawal_request_date = calculate_action_date(:ucas_match_ucas_withdrawal_request, candidate_last_contacted_at)
+    Time.zone.today >= ucas_withdrawal_request_date
   end
 
   def next_action
@@ -98,5 +98,9 @@ private
 
     application_for_the_same_course_on_both_services.map(&:application_in_progress_on_ucas?).any? &&
       application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
+  end
+
+  def calculate_action_date(action, effective_date)
+    TimeLimitCalculator.new(rule: action, effective_date: effective_date).call.fetch(:time_in_future).to_date
   end
 end

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -101,8 +101,6 @@ class UCASMatchedApplication
     ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym)
   end
 
-private
-
   def application_choice
     @application_choice ||= begin
       ApplicationChoice.includes(:application_form)
@@ -110,6 +108,8 @@ private
         .find_by(course_option: course.course_options)
     end
   end
+
+private
 
   def provider_not_on_apply?
     Provider.find_by(code: @matching_data['Provider code']).nil?

--- a/app/services/support_interface/send_ucas_match_initial_emails.rb
+++ b/app/services/support_interface/send_ucas_match_initial_emails.rb
@@ -1,0 +1,15 @@
+module SupportInterface
+  class SendUCASMatchInitialEmails
+    attr_reader :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      return SupportInterface::SendUCASMatchInitialEmailsMultipleAcceptances.new(ucas_match).call if ucas_match.application_accepted_on_ucas_and_accepted_on_apply?
+
+      SupportInterface::SendUCASMatchInitialEmailsDuplicateApplications.new(ucas_match).call if ucas_match.dual_application_or_dual_acceptance?
+    end
+  end
+end

--- a/app/services/support_interface/send_ucas_match_initial_emails_duplicate_applications.rb
+++ b/app/services/support_interface/send_ucas_match_initial_emails_duplicate_applications.rb
@@ -1,0 +1,21 @@
+module SupportInterface
+  class SendUCASMatchInitialEmailsDuplicateApplications
+    attr_reader :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      raise 'UCAS Match initial emails already sent' if ucas_match.initial_emails_sent?
+
+      application_choice = ucas_match.application_choices_for_same_course_on_both_services.first
+
+      CandidateMailer.ucas_match_initial_email_duplicate_applications(application_choice).deliver_later
+
+      NotificationsList.for(application_choice).each do |provider_user|
+        ProviderMailer.ucas_match_initial_email_duplicate_applications(provider_user, application_choice).deliver_later
+      end
+    end
+  end
+end

--- a/app/services/support_interface/send_ucas_match_initial_emails_multiple_acceptances.rb
+++ b/app/services/support_interface/send_ucas_match_initial_emails_multiple_acceptances.rb
@@ -1,0 +1,15 @@
+module SupportInterface
+  class SendUCASMatchInitialEmailsMultipleAcceptances
+    attr_reader :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      raise 'UCAS Match initial emails already sent' if ucas_match.initial_emails_sent?
+
+      CandidateMailer.ucas_match_initial_email_multiple_acceptances(ucas_match.candidate).deliver_later
+    end
+  end
+end

--- a/app/views/candidate_mailer/ucas_match_initial_email_duplicate_applications.text.erb
+++ b/app/views/candidate_mailer/ucas_match_initial_email_duplicate_applications.text.erb
@@ -1,0 +1,22 @@
+Dear <%= @application_form.full_name %>
+
+It looks like you submitted an application for <%= @course_name_and_code %> at <%= @provider_name %> on both DfE Apply for teacher training and UCAS Teacher Training Apply.
+
+This has been flagged to us, as well as to <%= @provider_name %>, as applying for the same course on both services is not allowed, as outlined by the terms of use.
+
+# Action required – withdraw your duplicate application
+
+To ensure your application progresses effectively, you need to withdraw the course choice from either DfE Apply for teacher training or UCAS Teacher Training by <%= @date_to_withdraw_application_by %>.
+
+It’s up to you which system you choose to progress the choice on. If you have additional UCAS Teacher Training choices, you may want to keep the choice on UCAS Teacher Training, so all your choices are in one place.
+
+# What happens if you don’t do anything?
+
+If you don’t withdraw your duplicate choice by <%= @date_to_withdraw_application_by %> (in 10 working days), we will withdraw the choice from your UCAS Teacher Training application – meaning you’ll use DfE Apply for teacher training to progress this choice.
+
+If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/app/views/candidate_mailer/ucas_match_initial_email_multiple_acceptances.text.erb
+++ b/app/views/candidate_mailer/ucas_match_initial_email_multiple_acceptances.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @application_form.first_name %>
+
+It looks like you accepted offers on both Apply for teacher training and UCAS Teacher Training.
+
+This has been flagged to us, as you can only accept one offer to start a teacher training programme in 2021. Accepting offers on both services is not allowed, as outlined by the terms of use.
+
+# Action required – withdraw your duplicate application
+
+To ensure your application progresses effectively, you need to withdraw the choice from either Apply for teacher training or UCAS Teacher Training by <%= @date_to_withdraw_application_by %>.
+
+For advice on choosing the right course for you, talk to a teacher training adviser.
+
+If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/app/views/provider_mailer/ucas_match_initial_email_duplicate_applications.text.erb
+++ b/app/views/provider_mailer/ucas_match_initial_email_duplicate_applications.text.erb
@@ -1,0 +1,20 @@
+Dear <%= @provider_user_name %>
+
+<%= @application_form.full_name %> has applied to <%= @course_name_and_code %> on both DfE Apply for teacher training and UCAS Teacher Training Apply.
+
+We’re letting you know so you recognise this is a duplicate and you do not process this application twice.
+
+# Next steps
+
+We’ve contacted the candidate and asked them to withdraw their application from one of the services within 10 working days. If they have not acted within 10 working days, their course choice will be deleted from their UCAS application.
+
+In the meantime, you can review the candidate’s application.
+
+We’ll send you an email once the duplicate application has been deleted.
+
+
+You do not have to do anything, but if you have any questions you can get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -84,3 +84,5 @@ en:
     ucas_match_initial_email:
       duplicate_applications:
         subject: 'Action required: it looks like you submitted a duplicate application'
+      multiple_acceptances:
+        subject: 'Action required: it looks like you’ve accepted two offers'

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -81,3 +81,6 @@ en:
         course_full: "%{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"
         location_full: "%{course_name} at %{provider_name} became full at %{location} while %{candidate_name} was awaiting references"
         study_mode_full: "%{study_mode} places for %{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"
+    ucas_match_initial_email:
+      duplicate_applications:
+        subject: 'Action required: it looks like you submitted a duplicate application'

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -18,3 +18,7 @@ en:
       subject: "Respond to %{candidate_name}’s (%{support_reference}) application"
     application_withdrawn:
       subject: "%{candidate_name} (%{support_reference}) withdrew their application"
+    ucas_match:
+      initial_email:
+        duplicate_applications:
+          subject: "Duplicate applicant identified"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -687,7 +687,7 @@ Rails.application.routes.draw do
     scope path: '/ucas-matches/:id' do
       get '/' => 'ucas_matches#show', as: :ucas_match
       get '/audit' => 'ucas_matches#audit', as: :ucas_match_audit
-      post '/record-initial-emails-sent' => 'ucas_matches#record_initial_emails_sent', as: :record_initial_emails_sent
+      post '/send-initial-emails' => 'ucas_matches#send_initial_emails', as: :send_initial_emails
       post '/record-reminder-emails-sent' => 'ucas_matches#record_reminder_emails_sent', as: :record_reminder_emails_sent
       post '/record-ucas-withdrawal-requested' => 'ucas_matches#record_ucas_withdrawal_requested', as: :record_ucas_withdrawal_requested
       post '/process-match' => 'ucas_matches#process_match', as: :process_match

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
       result = render_inline(described_class.new(ucas_match))
 
       expect(result.text).to include('Action needed Send initial emails')
-      expect(result.css('input').attr('value').value).to include('Confirm initial emails were sent')
-      expect(result.css('form').attr('action').value).to include('/record-initial-emails-sent')
+      expect(result.css('input').attr('value').value).to include('Send emails')
+      expect(result.css('form').attr('action').value).to include('/send-initial-emails')
       expect(result.text).to include('We need to contact the candidate and the provider.')
     end
 

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe TimeLimitConfig do
       expect(TimeLimitConfig.limits_for(:ucas_match_candidate_withdrawal_request_reminder).first.limit).to eq(5)
     end
 
-    it ':ucas_match_ucas_withdrawal_request returns a default limit of 10 days' do
-      expect(TimeLimitConfig.limits_for(:ucas_match_ucas_withdrawal_request).first.limit).to eq(10)
+    it ':ucas_match_ucas_withdrawal_request returns a default limit of 5 days' do
+      expect(TimeLimitConfig.limits_for(:ucas_match_ucas_withdrawal_request).first.limit).to eq(5)
     end
   end
 end

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -17,5 +17,17 @@ RSpec.describe TimeLimitConfig do
     it ':chase_candidate_before_dbd returns a default limit of 5 days' do
       expect(TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit).to eq(5)
     end
+
+    it ':ucas_match_candidate_withdrawal_request returns a default limit of 10 days' do
+      expect(TimeLimitConfig.limits_for(:ucas_match_candidate_withdrawal_request).first.limit).to eq(10)
+    end
+
+    it ':ucas_match_candidate_withdrawal_request_reminder returns a default limit of 5 days' do
+      expect(TimeLimitConfig.limits_for(:ucas_match_candidate_withdrawal_request_reminder).first.limit).to eq(5)
+    end
+
+    it ':ucas_match_ucas_withdrawal_request returns a default limit of 10 days' do
+      expect(TimeLimitConfig.limits_for(:ucas_match_ucas_withdrawal_request).first.limit).to eq(10)
+    end
   end
 end

--- a/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
@@ -43,4 +43,30 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect(email.body).to include(withdraw_application_date)
     end
   end
+
+  describe '.ucas_match_initial_email_multiple_acceptances' do
+    let(:ucas_match) { create(:ucas_match) }
+    let(:application_form) { ucas_match.candidate.application_forms.first }
+    let(:email) { mailer.ucas_match_initial_email_multiple_acceptances(ucas_match.candidate) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match_initial_email.multiple_acceptances.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(email.body.encoded).to include("Dear #{application_form.first_name}")
+    end
+
+    it 'sends an email containing the candidate name in the body' do
+      candidate_name = application_form.first_name
+
+      expect(email.body).to include(candidate_name)
+    end
+
+    it 'sends an email containing the date that the application needs to be withdrawn by' do
+      withdraw_application_date = 10.business_days.after(Time.zone.today).to_s(:govuk_date)
+
+      expect(email.body).to include(withdraw_application_date)
+    end
+  end
 end

--- a/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer, type: :mailer do
+  include TestHelpers::MailerSetupHelper
+
+  subject(:mailer) { described_class }
+
+  describe '.ucas_match_initial_email_duplicate_applications' do
+    let(:ucas_match) { create(:ucas_match) }
+    let(:application_form) { ucas_match.candidate.application_forms.first }
+    let(:application_choice) { application_form.application_choices.first }
+    let(:email) { mailer.ucas_match_initial_email_duplicate_applications(application_choice) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match_initial_email.duplicate_applications.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(email.body.encoded).to include("Dear #{application_form.full_name}")
+    end
+
+    it 'sends an email containing the course name and code in the body' do
+      course_name_and_code = application_choice.course.name_and_code
+
+      expect(email.body).to include(course_name_and_code)
+    end
+
+    it 'sends an email containing the candidate full name in the body' do
+      full_name = application_form.full_name
+
+      expect(email.body).to include(full_name)
+    end
+
+    it 'sends an email containing the provider name in the body' do
+      provider_name = application_choice.course.provider.name
+
+      expect(email.body).to include(provider_name)
+    end
+
+    it 'sends an email containing the date that the application needs to be withdrawn by' do
+      withdraw_application_date = 10.business_days.after(Time.zone.today).to_s(:govuk_date)
+
+      expect(email.body).to include(withdraw_application_date)
+    end
+  end
+end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -410,6 +410,16 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.reinstated_offer(application_choice)
   end
 
+  def ucas_match_initial_email_duplicate_applications
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form,
+      course_option: course_option,
+    )
+
+    CandidateMailer.ucas_match_initial_email_duplicate_applications(application_choice)
+  end
+
 private
 
   def candidate

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -420,6 +420,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.ucas_match_initial_email_duplicate_applications(application_choice)
   end
 
+  def ucas_match_initial_email_multiple_acceptances
+    candidate = FactoryBot.build_stubbed(:candidate, application_forms: [application_form])
+
+    CandidateMailer.ucas_match_initial_email_multiple_acceptances(candidate)
+  end
+
 private
 
   def candidate

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -38,6 +38,10 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.declined(provider_user, application_choice)
   end
 
+  def ucas_match_initial_email_duplicate_applications
+    ProviderMailer.ucas_match_initial_email_duplicate_applications(provider_user, application_choice)
+  end
+
   def fallback_sign_in_email
     ProviderMailer.fallback_sign_in_email(
       FactoryBot.build_stubbed(:provider_user),

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -150,4 +150,13 @@ RSpec.describe ProviderMailer, type: :mailer do
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')
   end
+
+  describe '.ucas_match_initial_email_duplicate_applications' do
+    it_behaves_like('a provider mail with subject and content', :ucas_match_initial_email_duplicate_applications,
+                    I18n.t!('provider_mailer.ucas_match.initial_email.duplicate_applications.subject',
+                            course_name_and_code: 'Computer Science (6IND)'),
+                    'provider name' => 'Dear Johny English',
+                    'candidate name' => 'Harry Potter',
+                    'course name and code' => 'Computer Science (6IND)')
+  end
 end

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UCASMatch do
       expect(ucas_match.action_needed?).to eq(false)
     end
 
-    it 'returns false if initial emails were sent and we don not need to send the reminders yet' do
+    it 'returns false if initial emails were sent and we do not need to send the reminders yet' do
       initial_emails_sent_at = Time.zone.now
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
@@ -137,6 +137,25 @@ RSpec.describe UCASMatch do
       ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
 
       expect(ucas_match.dual_application_or_dual_acceptance?).to eq(false)
+    end
+  end
+
+  describe '#application_accepted_on_ucas_and_accepted_on_apply?' do
+    it 'returns true if application is accepted on both UCAS and Apply' do
+      application_choice = create(:application_choice, :with_accepted_offer)
+      create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice])
+      course1 = application_choice.course_option.course
+      ucas_matching_data = { 'Scheme' => 'U',
+                             'Offers' => '1',
+                             'Conditional firm' => '1',
+                             'Provider code' => course.provider.code.to_s }
+      apply_matching_data = { 'Scheme' => 'D',
+                              'Course code' => course1.code.to_s,
+                              'Provider code' => course1.provider.code.to_s,
+                              'Apply candidate ID' => candidate.id.to_s }
+      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
+
+      expect(ucas_match.application_accepted_on_ucas_and_accepted_on_apply?).to eq(true)
     end
   end
 

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -257,4 +257,14 @@ RSpec.describe UCASMatch do
       expect(ucas_match.last_action).to eq(:confirmed_withdrawal_from_ucas)
     end
   end
+
+  describe '#ucas_matched_applications_on_both_services' do
+    it 'returns applications for the same course that exist on both services' do
+      ucas_match = create(:ucas_match)
+      matched_application = instance_double(UCASMatchedApplication, both_scheme?: true, application_choice: :application_choice)
+      allow(ucas_match).to receive(:ucas_matched_applications).and_return([matched_application])
+
+      expect(ucas_match.application_choices_for_same_course_on_both_services).to eq([:application_choice])
+    end
+  end
 end

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -291,4 +291,17 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_in_progress_on_apply?).to eq(false)
     end
   end
+
+  describe '#application_choice' do
+    it 'returns the application_choice related with the candidate and course option' do
+      ucas_matching_data =
+        { 'Scheme' => 'B',
+          'Course code' => course.code.to_s,
+          'Provider code' => course.provider.code.to_s,
+          'Apply candidate ID' => candidate2.id.to_s }
+      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+
+      expect(ucas_matching_application.application_choice).to eq(application_choice2)
+    end
+  end
 end

--- a/spec/services/support_interface/send_ucas_match_initial_emails_duplicate_applications_spec.rb
+++ b/spec/services/support_interface/send_ucas_match_initial_emails_duplicate_applications_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SendUCASMatchInitialEmailsDuplicateApplications do
+  describe '#call' do
+    let(:course) { create(:course, recruitment_cycle_year: 2020) }
+    let(:candidate) { create(:candidate) }
+    let(:course_option) { create(:course_option, course: course) }
+    let(:application_choice) { create(:application_choice, course_option: course_option) }
+    let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+    let(:ucas_match) { create(:ucas_match, recruitment_cycle_year: 2020, candidate: candidate, matching_data: [matching_data]) }
+    let(:provider_user) { create(:provider_user) }
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    context 'when the application has a ucas_match' do
+      describe 'when initial emails have not been sent' do
+        let(:ucas_match) { create(:ucas_match, action_taken: 'initial_emails_sent', candidate: candidate) }
+
+        it 'when the emails have already been sent it throws an exception' do
+          expect { described_class.new(ucas_match).call }.to raise_error('UCAS Match initial emails already sent')
+        end
+      end
+
+      describe 'when the initial emails have not been sent already' do
+        let(:matching_data) { { 'Scheme' => 'B', 'Course code' => course.code.to_s, 'Provider code' => course.provider.code.to_s, 'Apply candidate ID' => candidate.id.to_s } }
+
+        before do
+          application_form
+          create(:provider_permissions, provider_id: course.provider.id, provider_user_id: provider_user.id)
+          allow(CandidateMailer).to receive(:ucas_match_initial_email_duplicate_applications).and_return(mail)
+          allow(ProviderMailer).to receive(:ucas_match_initial_email_duplicate_applications).and_return(mail)
+          described_class.new(ucas_match).call
+        end
+
+        it 'sends the candidate the initial ucas_match email' do
+          expect(CandidateMailer).to have_received(:ucas_match_initial_email_duplicate_applications).with(application_choice)
+        end
+
+        it 'sends the provider the ucas_match email' do
+          expect(ProviderMailer).to have_received(:ucas_match_initial_email_duplicate_applications).with(provider_user, application_choice)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/send_ucas_match_initial_emails_multiple_acceptances_spec.rb
+++ b/spec/services/support_interface/send_ucas_match_initial_emails_multiple_acceptances_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SendUCASMatchInitialEmailsMultipleAcceptances do
+  describe '#call' do
+    let(:course) { create(:course, recruitment_cycle_year: 2020) }
+    let(:candidate) { create(:candidate) }
+    let(:course_option) { create(:course_option, course: course) }
+    let(:application_choice) { create(:application_choice, course_option: course_option) }
+    let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+    let(:ucas_match) { create(:ucas_match, recruitment_cycle_year: 2020, candidate: candidate, matching_data: [matching_data]) }
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    context 'when the application has been accepted on both apply and ucas' do
+      describe 'when initial emails have not been sent' do
+        let(:ucas_match) { create(:ucas_match, action_taken: 'initial_emails_sent', candidate: candidate) }
+
+        it 'when the emails have already been sent it throws an exception' do
+          expect { described_class.new(ucas_match).call }.to raise_error('UCAS Match initial emails already sent')
+        end
+      end
+
+      describe 'when the initial emails have not been sent already' do
+        let(:matching_data) { { 'Scheme' => 'B', 'Course code' => course.code.to_s, 'Provider code' => course.provider.code.to_s, 'Apply candidate ID' => candidate.id.to_s } }
+
+        before do
+          application_form
+          allow(CandidateMailer).to receive(:ucas_match_initial_email_multiple_acceptances).and_return(mail)
+          described_class.new(ucas_match).call
+        end
+
+        it 'sends the candidate the initial ucas_match email for multiple acceptances' do
+          expect(CandidateMailer).to have_received(:ucas_match_initial_email_multiple_acceptances).with(ucas_match.candidate)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/send_ucas_match_initial_emails_spec.rb
+++ b/spec/services/support_interface/send_ucas_match_initial_emails_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SendUCASMatchInitialEmails do
+  describe '#call' do
+    let(:ucas_match) { create(:ucas_match) }
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+    let(:multiple_acceptances_mailer) { instance_double(SupportInterface::SendUCASMatchInitialEmailsMultipleAcceptances, call: true) }
+    let(:duplicate_applications_mailer) { instance_double(SupportInterface::SendUCASMatchInitialEmailsDuplicateApplications, call: true) }
+
+    context 'when the application has been accepted on both UCAS and Apply' do
+      before do
+        allow(ucas_match).to receive(:application_accepted_on_ucas_and_accepted_on_apply?).and_return(true)
+        allow(SupportInterface::SendUCASMatchInitialEmailsMultipleAcceptances).to receive(:new).with(ucas_match).and_return(multiple_acceptances_mailer)
+      end
+
+      it 'sends the initial multiple acceptances ucas_match email' do
+        described_class.new(ucas_match).call
+
+        expect(SupportInterface::SendUCASMatchInitialEmailsMultipleAcceptances).to have_received(:new).with(ucas_match)
+      end
+    end
+
+    context 'when the applicant has applied to both UCAS and Apply' do
+      before do
+        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+        allow(SupportInterface::SendUCASMatchInitialEmailsDuplicateApplications).to receive(:new).with(ucas_match).and_return(duplicate_applications_mailer)
+      end
+
+      it 'sends the initial duplicate applications ucas_match email' do
+        described_class.new(ucas_match).call
+
+        expect(SupportInterface::SendUCASMatchInitialEmailsDuplicateApplications).to have_received(:new).with(ucas_match)
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'Docs' do
     emails_outside_of_states = %w[
       provider_mailer-account_created
       provider_mailer-fallback_sign_in_email
+      provider_mailer-ucas_match_initial_email_duplicate_applications
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification
       candidate_mailer-ucas_match_initial_email_duplicate_applications

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'Docs' do
       provider_mailer-fallback_sign_in_email
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification
+      candidate_mailer-ucas_match_initial_email_duplicate_applications
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-apply_again_call_to_action
       candidate_mailer-course_unavailable_notification
       candidate_mailer-ucas_match_initial_email_duplicate_applications
+      candidate_mailer-ucas_match_initial_email_multiple_acceptances
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'See UCAS matches' do
 
     when_i_follow_the_link_to_ucas_match_for_a_candidate_which_needs_an_action
     then_i_see_that_i_need_to 'Send initial emails'
-    and_when_i_click 'Confirm initial emails were sent'
+    and_when_i_click 'Send emails'
     then_i_see_last_performed_action_is 'sent the initial emails'
 
     given_five_working_days_passed

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'See UCAS matches' do
     and_when_i_click 'Confirm reminder emails were sent'
     then_i_see_last_performed_action_is 'sent the reminder emails'
 
-    given_ten_more_working_days_passed
+    given_five_more_working_days_passed
     when_i_visit_the_page_again
     then_i_see_that_i_need_to 'Request withdrawal from UCAS'
     and_when_i_click 'Confirm withdrawal from UCAS was requested'
@@ -203,9 +203,9 @@ RSpec.feature 'See UCAS matches' do
     Timecop.safe_mode = true
   end
 
-  def given_ten_more_working_days_passed
+  def given_five_more_working_days_passed
     Timecop.safe_mode = false
-    Timecop.travel(Time.zone.local(2020, 11, 23, 12, 0, 0))
+    Timecop.travel(Time.zone.local(2020, 11, 16, 12, 0, 0))
   ensure
     Timecop.safe_mode = true
   end


### PR DESCRIPTION
## Context

Replace marking initial emails to sent with sending initial emails to the candidate and provider in case of duplicate matches between UCAS and apply

## Changes proposed in this pull request

#### Duplicate applicant 
Provider email
<img width="1056" alt="ucas_match--duplicate--provider-email" src="https://user-images.githubusercontent.com/159200/99658888-fc660d80-2a57-11eb-9841-b13ead2e500f.png">

Candidate email  ❗ updated

<img width="797" alt="updated-candidate-duplication-application-initial-email" src="https://user-images.githubusercontent.com/159200/99797017-6351f800-2b26-11eb-92f4-279be33fed92.png">


### Multiple acceptances email (candidate)

<img width="962" alt="ucas-multiple-acceptances-match" src="https://user-images.githubusercontent.com/159200/99658894-fcfea400-2a57-11eb-91c9-4bc5a47f48bb.png">


## Link to Trello card

https://trello.com/c/SL6IT49j/3018-send-initial-emails-to-resolve-dual-applications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
