### PR TITLE
Fix test related to provider access controls

### DIFF
--- a/spec/services/support_interface/provider_access_controls_stats_spec.rb
+++ b/spec/services/support_interface/provider_access_controls_stats_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe SupportInterface::ProviderAccessControlsStats, with_audited: true
 
       access_controls = described_class.new(provider)
 
-      expect(access_controls.user_permissions_changed_by).to eq [provider_user1.email_address, provider_user2.email_address]
+      expect(access_controls.user_permissions_changed_by).to match_array [provider_user1.email_address, provider_user2.email_address]
     end
 
     it 'returns an empty array if there have been no changes' do


### PR DESCRIPTION
Use match_array so that the expectation doesn't care about the order of
returned elements.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Flaky test.

## Changes proposed in this pull request
See diff.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Is the new expectation ok? Do we care about the order of the array?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
