### PR TITLE
Don’t capitalise 'candidate' on Sandbox start page

### DIFF
--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -47,7 +47,7 @@
 
     <%= render(
       GovUkStartButtonComponent.new(
-        title: "Continue as a Candidate",
+        title: "Continue as a candidate",
         href: candidate_interface_account_path,
       ),
     ) %>


### PR DESCRIPTION
## Context

This word isn't capitalised anywhere else