### PR TITLE
Add guidance around additional reference requests being cancelled 

### DIFF
--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -1,6 +1,22 @@
 <% unless application_form.enough_references_have_been_provided? %>
   <div class="govuk-inset-text govuk-!-margin-top-0">
-    <% if enough_references_have_been_added? %>
+    <% if no_viable_references? %>
+
+      <h2 class="govuk-heading-m">Add a referee</h2>
+
+      <p class="govuk-body">You need 2 references before you can submit your application.</p>
+
+      <%= govuk_button_link_to 'Add a referee', candidate_interface_references_start_path %>
+
+    <% elsif one_viable_reference? %>
+
+      <h2 class="govuk-heading-m">Add a second referee</h2>
+
+      <p class="govuk-body">You need 2 references before you can submit your application.</p>
+
+      <%= govuk_button_link_to 'Add a second referee', candidate_interface_references_start_path %>
+
+    <% else  %>
 
       <h2 class="govuk-heading-m">Add another referee</h2>
 
@@ -9,22 +25,6 @@
       <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
 
       <%= govuk_button_link_to 'Add another referee', candidate_interface_references_start_path %>
-
-    <% elsif no_viable_references? %>
-
-      <h2 class="govuk-heading-m">Add a referee</h2>
-
-      <p class="govuk-body">You need 2 references before you can submit your application.</p>
-
-      <%= govuk_button_link_to 'Add a referee', candidate_interface_references_start_path %>
-
-    <% else %>
-
-      <h2 class="govuk-heading-m">Add a second referee</h2>
-
-      <p class="govuk-body">You need 2 references before you can submit your application.</p>
-
-      <%= govuk_button_link_to 'Add a second referee', candidate_interface_references_start_path %>
 
     <% end %>
   </div>

--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -1,0 +1,31 @@
+<% unless application_form.enough_references_have_been_provided? %>
+  <div class="govuk-inset-text govuk-!-margin-top-0">
+    <% if enough_references_have_been_added? %>
+
+      <h2 class='govuk-heading-m'>Add another referee</h2>
+
+      <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
+
+      <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
+
+      <%= link_to 'Add another referee', candidate_interface_references_start_path, class: 'govuk-button' %>
+
+    <% elsif no_viable_references? %>
+
+      <h2 class='govuk-heading-m'>Add a referee</h2>
+
+      <p class="govuk-body">You need 2 references before you can submit your application.</p>
+
+      <%= link_to 'Add a referee', candidate_interface_references_start_path, class: 'govuk-button' %>
+
+    <% else %>
+
+      <h2 class='govuk-heading-m'>Add a second referee</h2>
+
+      <p class="govuk-body">You need 2 references before you can submit your application.</p>
+
+      <%= link_to 'Add a second referee', candidate_interface_references_start_path, class: 'govuk-button' %>
+
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -2,29 +2,29 @@
   <div class="govuk-inset-text govuk-!-margin-top-0">
     <% if enough_references_have_been_added? %>
 
-      <h2 class='govuk-heading-m'>Add another referee</h2>
+      <h2 class="govuk-heading-m">Add another referee</h2>
 
       <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
 
       <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
 
-      <%= link_to 'Add another referee', candidate_interface_references_start_path, class: 'govuk-button' %>
+      <%= govuk_button_link_to 'Add another referee', candidate_interface_references_start_path %>
 
     <% elsif no_viable_references? %>
 
-      <h2 class='govuk-heading-m'>Add a referee</h2>
+      <h2 class="govuk-heading-m">Add a referee</h2>
 
       <p class="govuk-body">You need 2 references before you can submit your application.</p>
 
-      <%= link_to 'Add a referee', candidate_interface_references_start_path, class: 'govuk-button' %>
+      <%= govuk_button_link_to 'Add a referee', candidate_interface_references_start_path %>
 
     <% else %>
 
-      <h2 class='govuk-heading-m'>Add a second referee</h2>
+      <h2 class="govuk-heading-m">Add a second referee</h2>
 
       <p class="govuk-body">You need 2 references before you can submit your application.</p>
 
-      <%= link_to 'Add a second referee', candidate_interface_references_start_path, class: 'govuk-button' %>
+      <%= govuk_button_link_to 'Add a second referee', candidate_interface_references_start_path %>
 
     <% end %>
   </div>

--- a/app/components/candidate_interface/add_reference_component.rb
+++ b/app/components/candidate_interface/add_reference_component.rb
@@ -8,12 +8,12 @@ module CandidateInterface
       @application_form = application_form
     end
 
-    def enough_references_have_been_added?
-      viable_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
-    end
-
     def no_viable_references?
       viable_references.count.zero?
+    end
+
+    def one_viable_reference?
+      viable_references.one?
     end
 
   private

--- a/app/components/candidate_interface/add_reference_component.rb
+++ b/app/components/candidate_interface/add_reference_component.rb
@@ -1,0 +1,29 @@
+module CandidateInterface
+  class AddReferenceComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :application_form
+
+    def initialize(application_form)
+      @application_form = application_form
+    end
+
+    def enough_references_have_been_added?
+      viable_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+    end
+
+    def no_viable_references?
+      viable_references.count.zero?
+    end
+
+  private
+
+    def viable_references
+      application_form.application_references.select do |reference|
+        reference.not_requested_yet? ||
+          reference.feedback_requested? ||
+          reference.feedback_provided?
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -5,13 +5,7 @@
   <%= t('page_titles.references') %>
 </h1>
 
-<% unless @application_form.enough_references_have_been_provided? %>
-  <div class="govuk-inset-text govuk-!-margin-top-0">
-    <p class="govuk-body">You need 2 references before you can submit your application.</p>
-    <p class="govuk-body">You can add as many referees as you like to increase the chances of getting 2 references quickly.</p>
-    <%= link_to 'Add another referee', candidate_interface_references_start_path, class: 'govuk-button' %>
-  </div>
-<% end %>
+<%= render CandidateInterface::AddReferenceComponent.new(@application_form) %>
 
 <% if @references_given.present? %>
   <div id="references_given">

--- a/spec/components/candidate_interface/add_reference_component_spec.rb
+++ b/spec/components/candidate_interface/add_reference_component_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::AddReferenceComponent do
+  let(:application_form) { create(:application_form) }
+
+  context 'when the candidate has no viable references' do
+    it 'renders successfully' do
+      create(:reference, :feedback_refused, application_form: application_form)
+
+      result = render_inline(described_class.new(application_form))
+
+      expect(heading(result)).to eq 'Add a referee'
+      expect(link_text(result)).to eq 'Add a referee'
+      expect(href(result)).to eq '/candidate/application/references/start'
+      expect(body_text(result)).to eq 'You need 2 references before you can submit your application.'
+    end
+  end
+
+  context 'when the candidate has one viable reference' do
+    it 'renders successfully' do
+      create(:reference, :feedback_refused, application_form: application_form)
+      create(:reference, :not_requested_yet, application_form: application_form)
+
+      result = render_inline(described_class.new(application_form))
+
+      expect(heading(result)).to eq 'Add a second referee'
+      expect(link_text(result)).to eq 'Add a second referee'
+      expect(href(result)).to eq '/candidate/application/references/start'
+      expect(body_text(result)).to eq 'You need 2 references before you can submit your application.'
+    end
+  end
+
+  context 'when the candidate has two or more viable references' do
+    it 'renders successfully' do
+      create(:reference, :feedback_requested, application_form: application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
+
+      result = render_inline(described_class.new(application_form))
+
+      expected_first_para = 'You can add more referees to increase the chances of getting 2 references quickly.'
+      expected_second_para = 'We’ll cancel any remaining requests when you’ve received 2 references.'
+
+      expect(heading(result)).to eq 'Add another referee'
+      expect(link_text(result)).to eq 'Add another referee'
+      expect(href(result)).to eq '/candidate/application/references/start'
+      expect(body_text(result)).to eq expected_first_para + expected_second_para
+    end
+  end
+
+  context 'when enough references have been provided' do
+    it 'does not render any content' do
+      create(:reference, :feedback_provided, application_form: application_form)
+      create(:reference, :feedback_provided, application_form: application_form)
+
+      result = render_inline(described_class.new(application_form))
+
+      expect(heading(result)).to be_empty
+      expect(link(result)).to be_empty
+      expect(body_text(result)).to be_empty
+    end
+  end
+
+private
+
+  def heading(result)
+    result.css('h2').text.strip
+  end
+
+  def link(result)
+    result.css('a')
+  end
+
+  def link_text(result)
+    result.css('a').first.text
+  end
+
+  def href(result)
+    result.css('a').first.attributes['href'].value
+  end
+
+  def body_text(result)
+    result.css('.govuk-body').text
+  end
+end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -333,7 +333,7 @@ module CandidateHelper
     choose 'Yes, send a reference request now'
     click_button 'Save and continue'
 
-    click_link 'Add another referee'
+    click_link 'Add a second referee'
     click_link 'Continue'
     choose 'Professional'
     click_button 'Save and continue'

--- a/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_adding_referees_in_sandbox_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
     choose 'Yes, send a reference request now'
     click_button 'Save and continue'
 
-    click_link 'Add another referee'
+    click_link 'Add a second referee'
     click_link 'Continue'
     choose 'Professional'
     click_button 'Save and continue'

--- a/spec/system/candidate_interface/references/candidate_receives_feedback_from_their_reference_requests_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_receives_feedback_from_their_reference_requests_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'References' do
     choose 'Yes, send a reference request now'
     click_button 'Save and continue'
 
-    click_link 'Add another referee'
+    click_link 'Add a second referee'
     click_link 'Continue'
     choose 'Professional'
     click_button 'Save and continue'

--- a/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'Candidate applying again' do
   end
 
   def when_i_add_a_new_referee
-    click_link 'Add another referee'
+    click_link 'Add a second referee'
     click_link 'Continue'
     choose 'Academic'
     click_button 'Save and continue'


### PR DESCRIPTION
## Context

At the moment, when a candidate can request as many references as they want. However, when they receive 2 sets of feedback. We cancel all the other references with outstanding feedback(in both the awaiting reference and not requested yet states). 

We don't actually tell the candidate that this is going to happen.

This PR adds in this content (can be found in the Trello ticket)

## Changes proposed in this pull request

- Before

![image](https://user-images.githubusercontent.com/42515961/99677057-32fc5200-2a71-11eb-90a4-c0bc9f6452af.png)

- If **no** references are in the not_requested_yet, feedback_requested or feedback_provided state show

![image](https://user-images.githubusercontent.com/42515961/99679722-2b8a7800-2a74-11eb-840b-594a68e0fa9b.png)

-  If **one** references are in the not_requested_yet, feedback_requested or feedback_provided state show

![image](https://user-images.githubusercontent.com/42515961/99679816-465cec80-2a74-11eb-880c-85e1c12b54d3.png)


- If **more than one** 

![image](https://user-images.githubusercontent.com/42515961/99676996-1fe98200-2a71-11eb-83db-39143739a187.png)

- Does not render if 2 have been received 


## Guidance to review

Is the logic correct around what we consider a viable reference?

I understand that a cancelled reference can be re-requested so in that sense it could technically potentially be viable.

## Link to Trello card

https://trello.com/c/FOoQq16W/2532-%F0%9F%92%942%EF%B8%8F%E2%83%A3-dev-guidance-around-additional-reference-requests-being-cancelled-when-2-have-been-received

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
