### PR TITLE
Remove the full stop from the offer-accepted Slack message

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -47,7 +47,7 @@ class StateChangeNotifier
       declined_msg += declines.to_sentence
     end
 
-    message = ":handshake: #{[accepted_msg, withdrawn_msg, declined_msg].compact.to_sentence}."
+    message = ":handshake: #{[accepted_msg, withdrawn_msg, declined_msg].compact.to_sentence}"
     url = helpers.support_interface_application_form_url(accepted.application_form)
 
     send(message, url)

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe StateChangeNotifier do
 
     context 'when this is the only application choice' do
       it 'shows the correct message' do
-        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE).'
+        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE)'
         expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message, anything)
       end
     end
@@ -166,7 +166,7 @@ RSpec.describe StateChangeNotifier do
       end
 
       it 'shows the correct message' do
-        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and declined UCL’s offer for French (FFF).'
+        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and declined UCL’s offer for French (FFF)'
         expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message, anything)
       end
     end
@@ -179,7 +179,7 @@ RSpec.describe StateChangeNotifier do
       end
 
       it 'shows the correct message' do
-        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and withdrawn their application for French (FFF) at UCL.'
+        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and withdrawn their application for French (FFF) at UCL'
         expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message, anything)
       end
     end
@@ -198,7 +198,7 @@ RSpec.describe StateChangeNotifier do
       end
 
       it 'shows the correct message' do
-        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE), withdrawn their application for French (FFF) at UCL, and declined UCL’s offer for Maths (MMM).'
+        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE), withdrawn their application for French (FFF) at UCL, and declined UCL’s offer for Maths (MMM)'
         expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message, anything)
       end
     end
@@ -214,7 +214,7 @@ RSpec.describe StateChangeNotifier do
       end
 
       it 'shows the correct message' do
-        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and withdrawn their applications for French (FFF) at UCL and Maths (MMM) at UCL.'
+        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and withdrawn their applications for French (FFF) at UCL and Maths (MMM) at UCL'
         expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message, anything)
       end
     end
@@ -230,7 +230,7 @@ RSpec.describe StateChangeNotifier do
       end
 
       it 'shows the correct message' do
-        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and declined UCL’s offer for French (FFF) and UCL’s offer for Maths (MMM).'
+        expected_message = ':handshake: Leah has accepted UCL’s offer for English (EEE) and declined UCL’s offer for French (FFF) and UCL’s offer for Maths (MMM)'
         expect(SlackNotificationWorker).to have_received(:perform_async).with(expected_message, anything)
       end
     end


### PR DESCRIPTION
It's now different from all the other messages, which is quite annoying

## Context

<img width="795" alt="Screenshot 2020-11-19 at 15 29 24" src="https://user-images.githubusercontent.com/642279/99687038-1b769680-2a7c-11eb-8941-44ca33b3d739.png">
