### PR TITLE
Fix test that is flaky locally

### DIFF
--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_receives_rejection_email_spec.rb
@@ -4,11 +4,13 @@ RSpec.feature 'Receives rejection email' do
   include CandidateHelper
 
   around do |example|
+    original_time_zone = Time.zone
     Time.zone = 'Pacific Time (US & Canada)'
     date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 1, 13)
     Timecop.freeze(date_that_avoids_clocks_changing_by_ten_days) do
       example.run
     end
+    Time.zone = original_time_zone
   end
 
   scenario 'Receives rejection email' do

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_receives_rejection_email_spec.rb
@@ -4,13 +4,10 @@ RSpec.feature 'Receives rejection email' do
   include CandidateHelper
 
   around do |example|
-    original_time_zone = Time.zone
-    Time.zone = 'Pacific Time (US & Canada)'
     date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 1, 13)
     Timecop.freeze(date_that_avoids_clocks_changing_by_ten_days) do
       example.run
     end
-    Time.zone = original_time_zone
   end
 
   scenario 'Receives rejection email' do


### PR DESCRIPTION
## Context
Some tests have been failing locally for me due to the timezone being changed and not reset in a case. Not sure why this doesn't affect deployments though.

## Guidance to review
Is this change in timezone necessary? Can we just remove that instead?

