### PR TITLE
Multiple English GCSEs API changes

### DIFF
--- a/app/components/gcse_qualification_cards_component.html.erb
+++ b/app/components/gcse_qualification_cards_component.html.erb
@@ -45,7 +45,9 @@
                 <%= qualification.award_year %>
                 </dd>
                 <dt class="app-qualification__key">Grade</dt>
-                <dd class="app-qualification__value"><%= qualification.grade %></dd>
+                <% grade_details(qualification).each do |grade| %>
+                  <dd class="app-qualification__value govuk-!-margin-bottom-0"><%= grade %></dd>
+                <% end %>
               </dl>
             <% end %>
           </div>

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -54,7 +54,7 @@ class GcseQualificationCardsComponent < ViewComponent::Base
         "#{grades['chemistry']} (Chemistry)",
         "#{grades['physics']} (Physics)",
       ]
-    elsif qualification.subject == 'english' && qualification.structured_grades
+    elsif qualification.structured_grades
       grades = JSON.parse(qualification.structured_grades)
       grades.map { |k, v,| "#{v} (#{k.humanize.titleize})" }
     else

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -45,4 +45,20 @@ class GcseQualificationCardsComponent < ViewComponent::Base
       "UK NARIC statement #{qualification.naric_reference} says this is comparable to a #{qualification.comparable_uk_qualification}."
     end
   end
+
+  def grade_details(qualification)
+    if qualification.subject == ApplicationQualification::SCIENCE_TRIPLE_AWARD
+      grades = qualification.structured_grades
+      [
+        "#{grades['biology']} (Biology)",
+        "#{grades['chemistry']} (Chemistry)",
+        "#{grades['physics']} (Physics)",
+      ]
+    elsif qualification.subject == 'english' && qualification.structured_grades
+      grades = JSON.parse(qualification.structured_grades)
+      grades.map { |k, v,| "#{v} (#{k.humanize.titleize})" }
+    else
+      [qualification.grade]
+    end
+  end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -193,19 +193,21 @@ module VendorAPI
     end
 
     def parse_structured_gcses(gcses)
-      multiple_english_gcse = gcses.find { |gcse| gcse[:subject] == 'english' && gcse[:structured_grades].present? }
+      multiple_gcses = gcses.select { |gcse| gcse[:subject] != 'science triple award' && gcse[:structured_grades].present? }
 
-      if multiple_english_gcse
-        structured_english_grades = JSON.parse(multiple_english_gcse[:structured_grades])
+      if multiple_gcses.any?
+        multiple_gcses.each do |multiple_gcse|
+          structured_grades = JSON.parse(multiple_gcse[:structured_grades])
 
-        structured_english_grades.each do |k, v|
-          new_separated_gcse = multiple_english_gcse.dup
-          new_separated_gcse.subject = k.humanize
-          new_separated_gcse.grade = v
-          gcses << new_separated_gcse
+          structured_grades.each do |k, v|
+            new_separated_gcse = multiple_gcse.dup
+            new_separated_gcse.subject = k.humanize
+            new_separated_gcse.grade = v
+            gcses << new_separated_gcse
+          end
+
+          gcses.delete_if { |gcse| gcse == multiple_gcse }
         end
-
-        gcses.delete_if { |gcse| gcse == multiple_english_gcse }
       end
       gcses
     end

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 19th November 2020
+
+- The `Qualification` object now supports multiple types of English GCSEs (eg. English Language, English Studies Double 
+Award). Candidates may have multiple English GCSEs. Each GCSE is provided as a separate `Qualification`. The title of 
+the GCSE is given in the `subject` field. 
+
 ### 16th November 2020
 - The `Qualification` `grade` field will now be populated with GCSE Science triple award information
   in the following format, where present:

--- a/spec/components/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/gcse_qualification_cards_component_spec.rb
@@ -160,4 +160,52 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
       expect(cards.next.text).to include 'Science'
     end
   end
+
+  describe 'rendering multiple English GCSEs' do
+    let(:application_form) do
+      create(
+        :application_form,
+        application_qualifications: [
+          create(:gcse_qualification, subject: 'english', structured_grades: '{"english_language":"E","english_literature":"E","Cockney Rhyming Slang":"A*"}', award_year: 2006),
+        ],
+      )
+    end
+
+    it 'renders grades for multiple English GCSEs' do
+      result = render_inline(described_class.new(application_form))
+
+      card = result.css('.app-card--outline')
+
+      expect(card.text).to include 'E (English Language)'
+      expect(card.text).to include 'E (English Literature)'
+      expect(card.text).to include 'A* (Cockney Rhyming Slang)'
+    end
+  end
+
+  describe 'rendering multiple Science GCSEs' do
+    science_triple_awards = {
+      biology: 'A',
+      chemistry: 'B',
+      physics: 'C',
+    }
+
+    let(:application_form) do
+      create(
+        :application_form,
+        application_qualifications: [
+          create(:gcse_qualification, subject: 'science triple award', structured_grades: science_triple_awards, award_year: 2006),
+        ],
+      )
+    end
+
+    it 'renders grades for multiple English GCSEs' do
+      result = render_inline(described_class.new(application_form))
+
+      card = result.css('.app-card--outline')
+
+      expect(card.text).to include 'A (Biology)'
+      expect(card.text).to include 'B (Chemistry)'
+      expect(card.text).to include 'C (Physics)'
+    end
+  end
 end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -469,6 +469,42 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       expect(qualification[:grade]).to eq 'ABC'
     end
+
+    it 'parses English GCSE structured grades' do
+      create(
+        :gcse_qualification,
+        subject: 'english',
+        grade: nil,
+        structured_grades: '{"english_language":"E","english_literature":"E","Cockney Rhyming Slang":"A*"}',
+        award_year: 2006,
+        predicted_grade: false,
+        application_form: application_choice.application_form,
+      )
+
+      english_language = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :gcses,
+      ).find { |q| q[:subject] == 'English language' }
+
+      expect(english_language[:grade]).to eq 'E'
+
+      english_literature = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :gcses,
+      ).find { |q| q[:subject] == 'English literature' }
+
+      expect(english_literature[:grade]).to eq 'E'
+
+      rhyming_slang = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :gcses,
+      ).find { |q| q[:subject] == 'Cockney rhyming slang' }
+
+      expect(rhyming_slang[:grade]).to eq 'A*'
+    end
   end
 
   describe 'attributes.offer' do


### PR DESCRIPTION
## Context

We recently added support for multiple English GCSEs. This PR makes the necessary changes to the support interface and the Provendor API

## Changes proposed in this pull request

Change in Support interface
![image (12)](https://user-images.githubusercontent.com/33458055/99697234-75c92480-2a87-11eb-80f8-7129af252634.png)

## Guidance to review

Do we need any further info on the release notes?

## Link to Trello card

https://trello.com/c/7HdxBomI/2559-make-english-gcse-info-available-in-provendor-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
