### PR TITLE
Use built-in word_count for feedback form validation

### DIFF
--- a/app/forms/provider_interface/rejected_by_default_feedback_form.rb
+++ b/app/forms/provider_interface/rejected_by_default_feedback_form.rb
@@ -4,11 +4,6 @@ module ProviderInterface
 
     attr_accessor :rejection_reason
     validates :rejection_reason, presence: true
-
-    validate :rejection_reason do |record|
-      if record.rejection_reason && record.rejection_reason.scan(/\w+/).length > 200
-        record.errors.add(:rejection_reason, :too_long)
-      end
-    end
+    validates :rejection_reason, word_count: { maximum: 200 }
   end
 end


### PR DESCRIPTION
## Context

The text area and the backend disagree when counting the number of words. Using the built-in `word_count` validator seems to fix this.

## Changes proposed in this pull request

Use the built-in `word_count` validator. Its count is consistent with `split(/\s+/)`, rather than `scan(/\w+/)`.

```
[5] pry(main)> 'Sing, o dearest one... it\'s wonderful...'.split(/\s+/)
=> ["Sing,", "o", "dearest", "one...", "it's", "wonderful..."]
```

```
[6] pry(main)> 'Sing, o dearest one... it\'s wonderful...'.scan(/\w+/)
=> ["Sing", "o", "dearest", "one", "it", "s", "wonderful"]
```

I actually prefer `scan(/\w+/)` but don't fancy updating the built-in validator and the govuk component. 

## Guidance to review

Easiest review ever.

## Link to Trello card

https://trello.com/c/6RZWDB9F

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
