### PR TITLE
Add logic to EAFL forms to validate against future dated awards

### DIFF
--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -41,8 +41,12 @@ module CandidateInterface
     private
 
       def award_year_is_a_valid_year
+        year_limit = Time.zone.today.year.to_i + 1
+
         if !valid_year?(award_year)
           errors.add(:award_year, :invalid)
+        elsif award_year.to_i >= year_limit
+          errors.add(:award_year, :in_the_future, date: year_limit)
         end
       end
 

--- a/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/ielts_form.rb
@@ -41,12 +41,10 @@ module CandidateInterface
     private
 
       def award_year_is_a_valid_year
-        year_limit = Time.zone.today.year.to_i + 1
-
         if !valid_year?(award_year)
           errors.add(:award_year, :invalid)
-        elsif award_year.to_i >= year_limit
-          errors.add(:award_year, :in_the_future, date: year_limit)
+        elsif future_year?(award_year)
+          errors.add(:award_year, :in_the_future)
         end
       end
 

--- a/app/forms/candidate_interface/english_foreign_language/other_efl_qualification_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/other_efl_qualification_form.rb
@@ -39,8 +39,12 @@ module CandidateInterface
     private
 
       def award_year_is_a_valid_year
+        year_limit = Time.zone.today.year.to_i + 1
+
         if !valid_year?(award_year)
           errors.add(:award_year, :invalid)
+        elsif award_year.to_i >= year_limit
+          errors.add(:award_year, :in_the_future, date: year_limit)
         end
       end
 

--- a/app/forms/candidate_interface/english_foreign_language/other_efl_qualification_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/other_efl_qualification_form.rb
@@ -39,12 +39,10 @@ module CandidateInterface
     private
 
       def award_year_is_a_valid_year
-        year_limit = Time.zone.today.year.to_i + 1
-
         if !valid_year?(award_year)
           errors.add(:award_year, :invalid)
-        elsif award_year.to_i >= year_limit
-          errors.add(:award_year, :in_the_future, date: year_limit)
+        elsif future_year?(award_year)
+          errors.add(:award_year, :in_the_future)
         end
       end
 

--- a/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
@@ -38,12 +38,10 @@ module CandidateInterface
     private
 
       def award_year_is_a_valid_year
-        year_limit = Time.zone.today.year.to_i + 1
-
         if !valid_year?(award_year)
           errors.add(:award_year, :invalid)
-        elsif award_year.to_i >= year_limit
-          errors.add(:award_year, :in_the_future, date: year_limit)
+        elsif future_year?(award_year)
+          errors.add(:award_year, :in_the_future)
         end
       end
 

--- a/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
+++ b/app/forms/candidate_interface/english_foreign_language/toefl_form.rb
@@ -38,8 +38,12 @@ module CandidateInterface
     private
 
       def award_year_is_a_valid_year
+        year_limit = Time.zone.today.year.to_i + 1
+
         if !valid_year?(award_year)
           errors.add(:award_year, :invalid)
+        elsif award_year.to_i >= year_limit
+          errors.add(:award_year, :in_the_future, date: year_limit)
         end
       end
 

--- a/app/forms/candidate_interface/other_qualification_wizard.rb
+++ b/app/forms/candidate_interface/other_qualification_wizard.rb
@@ -191,12 +191,10 @@ module CandidateInterface
     end
 
     def award_year_is_date_and_before_current_year
-      year_limit = Time.zone.today.year.to_i + 1
-
       if !valid_year?(award_year)
         errors.add(:award_year, :invalid)
-      elsif award_year.to_i >= year_limit
-        errors.add(:award_year, :in_the_future, date: year_limit)
+      elsif future_year?(award_year)
+        errors.add(:award_year, :in_the_future)
       end
     end
 

--- a/app/lib/validation_utils.rb
+++ b/app/lib/validation_utils.rb
@@ -4,6 +4,6 @@ module ValidationUtils
   end
 
   def future_year?(year)
-    year.to_i >= Time.zone.today.year
+    year.to_i > Time.zone.today.year
   end
 end

--- a/app/lib/validation_utils.rb
+++ b/app/lib/validation_utils.rb
@@ -2,4 +2,8 @@ module ValidationUtils
   def valid_year?(year)
     year.to_s.match?(/^[12]\d{3}$/)
   end
+
+  def future_year?(year)
+    year.to_i >= Time.zone.today.year
+  end
 end

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/edit.html.erb
@@ -3,12 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-xl class='govuk-heading-xl''>
-      <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
-      <%= t('page_titles.efl.other') %>
-    </h1>
-
     <%= form_with(model: @other_qualification_form, url: candidate_interface_edit_other_efl_qualification_path, method: :patch) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class='govuk-heading-xl'>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <%= t('page_titles.efl.other') %>
+      </h1>
       <%= render 'form_fields', { f: f } %>
     <% end %>
 

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/new.html.erb
@@ -3,12 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-xl class='govuk-heading-xl''>
-      <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
-      <%= t('page_titles.efl.other') %>
-    </h1>
-
     <%= form_with(model: @other_qualification_form, url: candidate_interface_other_efl_qualification_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class='govuk-heading-xl'>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <%= t('page_titles.efl.other') %>
+      </h1>
       <%= render 'form_fields', { f: f } %>
     <% end %>
 

--- a/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
@@ -3,12 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-xl class='govuk-heading-xl''>
-      <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
-      <%= t('page_titles.efl.toefl') %>
-    </h1>
-
     <%= form_with(model: @toefl_form, url: candidate_interface_toefl_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class='govuk-heading-xl'>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <%= t('page_titles.efl.toefl') %>
+      </h1>
       <%= render 'form_fields', { f: f } %>
     <% end %>
 

--- a/app/views/candidate_interface/english_foreign_language/toefl/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/new.html.erb
@@ -3,12 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-xl class='govuk-heading-xl''>
-      <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
-      <%= t('page_titles.efl.toefl') %>
-    </h1>
-
     <%= form_with(model: @toefl_form, url: candidate_interface_toefl_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class='govuk-heading-xl'>
+        <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
+        <%= t('page_titles.efl.toefl') %>
+      </h1>
       <%= render 'form_fields', { f: f } %>
     <% end %>
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -705,7 +705,7 @@ en:
             award_year:
               blank: Enter year the assessment was done
               invalid: Enter a real year
-              in_the_future: Enter a year before %{date}
+              in_the_future: Assessment year must be this year or a previous year
         candidate_interface/english_foreign_language/other_efl_qualification_form:
           attributes:
             name:
@@ -715,7 +715,7 @@ en:
             award_year:
               blank: Enter year the assessment was done
               invalid: Enter a real year
-              in_the_future: Enter a year before %{date}
+              in_the_future: Assessment year must be this year or a previous year
         candidate_interface/english_foreign_language/toefl_form:
           attributes:
             registration_number:
@@ -726,7 +726,7 @@ en:
             award_year:
               blank: Enter year the assessment was done
               invalid: Enter a real year
-              in_the_future: Enter a year before %{date}
+              in_the_future: Assessment year must be this year or a previous year
         candidate_interface/other_qualification_wizard:
           attributes:
             non_uk_qualification_type:
@@ -752,7 +752,7 @@ en:
             award_year:
               blank: Enter the year the qualification was awarded
               invalid: Enter a real year
-              in_the_future: Enter a year before %{date}
+              in_the_future: Assessment year must be this year or a previous year
             choice:
               blank: Do you want to add another qualification?
         candidate_interface/work_experience_form:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -705,6 +705,7 @@ en:
             award_year:
               blank: Enter year the assessment was done
               invalid: Enter a real year
+              in_the_future: Enter a year before %{date}
         candidate_interface/english_foreign_language/other_efl_qualification_form:
           attributes:
             name:
@@ -714,6 +715,7 @@ en:
             award_year:
               blank: Enter year the assessment was done
               invalid: Enter a real year
+              in_the_future: Enter a year before %{date}
         candidate_interface/english_foreign_language/toefl_form:
           attributes:
             registration_number:
@@ -724,6 +726,7 @@ en:
             award_year:
               blank: Enter year the assessment was done
               invalid: Enter a real year
+              in_the_future: Enter a year before %{date}
         candidate_interface/other_qualification_wizard:
           attributes:
             non_uk_qualification_type:

--- a/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsForm, type: :mod
       form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ["Award year Enter a year before #{Time.zone.today.year.to_i + 1}"]
+      expect(form.errors.full_messages) .to eq ['Award year Assessment year must be this year or a previous year']
     end
 
     context 'user inputs single digit band_score' do

--- a/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/ielts_form_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::IeltsForm, type: :mod
       expect(form.errors.full_messages) .to eq ['Award year Enter a real year']
     end
 
+    it 'is is future year if given a future year' do
+      form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
+
+      expect(form).not_to be_valid
+      expect(form.errors.full_messages) .to eq ["Award year Enter a year before #{Time.zone.today.year.to_i + 1}"]
+    end
+
     context 'user inputs single digit band_score' do
       let(:valid_form_2) do
         described_class.new(

--- a/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
       form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ["Award year Enter a year before #{Time.zone.today.year.to_i + 1}"]
+      expect(form.errors.full_messages) .to eq ['Award year Assessment year must be this year or a previous year']
     end
   end
 

--- a/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
       expect(form).not_to be_valid
       expect(form.errors.full_messages) .to eq ['Award year Enter a real year']
     end
+
+    it 'is is future year if given a future year' do
+      form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
+
+      expect(form).not_to be_valid
+      expect(form.errors.full_messages) .to eq ["Award year Enter a year before #{Time.zone.today.year.to_i + 1}"]
+    end
   end
 
   describe '#save' do

--- a/spec/forms/candidate_interface/english_foreign_language/toefl_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/toefl_form_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflForm, type: :mod
       expect(form).not_to be_valid
       expect(form.errors.full_messages) .to eq ['Award year Enter a real year']
     end
+
+    it 'is is future year if given a future year' do
+      form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
+
+      expect(form).not_to be_valid
+      expect(form.errors.full_messages) .to eq ["Award year Enter a year before #{Time.zone.today.year.to_i + 1}"]
+    end
   end
 
   describe '#save' do

--- a/spec/forms/candidate_interface/english_foreign_language/toefl_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/toefl_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::ToeflForm, type: :mod
       form = valid_form.tap { |f| f.award_year = Time.zone.today.year.to_i + 1 }
 
       expect(form).not_to be_valid
-      expect(form.errors.full_messages) .to eq ["Award year Enter a year before #{Time.zone.today.year.to_i + 1}"]
+      expect(form.errors.full_messages) .to eq ['Award year Assessment year must be this year or a previous year']
     end
   end
 

--- a/spec/forms/candidate_interface/other_qualification_wizard_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_wizard_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe CandidateInterface::OtherQualificationWizard, type: :model do
           qualification.valid?(:details)
 
           expect(qualification.errors.full_messages_for(:award_year)).to eq(
-            ['Award year Enter a year before 2020'],
+            ['Award year Assessment year must be this year or a previous year'],
           )
         end
       end

--- a/spec/lib/validation_utils_spec.rb
+++ b/spec/lib/validation_utils_spec.rb
@@ -26,4 +26,24 @@ RSpec.describe ValidationUtils do
       expect(form.new).not_to be_valid_year(too_long_year)
     end
   end
+
+  describe '#future_year' do
+    let(:form) do
+      Class.new do
+        include ValidationUtils
+      end
+    end
+
+    it 'returns true if the year passed is greater than the current year' do
+      next_year = Time.zone.today.year.to_i + 1
+
+      expect(form.new.future_year?(next_year)).to eq true
+    end
+
+    it 'returns false if the year passed is before or equal to the current year' do
+      last_year = Time.zone.today.year.to_i
+
+      expect(form.new.future_year?(last_year)).to eq false
+    end
+  end
 end


### PR DESCRIPTION
## Context

Whilst fixing another bug on the IELTs form it was noticed that the form allowed the submittal of future dates.
On searching it was found that the other eafl forms contained this bug. 

## Changes proposed in this pull request

This fix updates the logic in the validation
method to include a year limit and throw a different validation error in accordance. Yml updated and new unit test
added to each form spec.
![image](https://user-images.githubusercontent.com/62567622/99796233-099cfe00-2b25-11eb-90ed-3a02b2641836.png)
![image](https://user-images.githubusercontent.com/62567622/99796248-128dcf80-2b25-11eb-8b8a-1fbd45870850.png)
![image](https://user-images.githubusercontent.com/62567622/99796327-305b3480-2b25-11eb-886b-4bac959012a2.png)

## Guidance to review

Dev - Check that Test coverage is sufficient.
UX/UI - Check that Error is displayed correctly, I notice that the TOEFL and Other EAFL don't seem to display error summaries should I also make this tweak?

## Link to Trello card

https://trello.com/c/27fRszKG/2568-bug-ielts-and-possibly-other-eafl-forms-validating-future-dates

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
