### PR TITLE
Use standard intro for application_rejected_all_rejected email

### DIFF
--- a/app/views/candidate_mailer/application_rejected_all_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_rejected.text.erb
@@ -1,12 +1,4 @@
-Dear <%= @application_form.first_name %>,
-
-# Application outcome
-
-<% if @application_choice.rejected_by_default %>
-  <%= @course.provider.name %> did not respond to your application for <%= @course.name_and_code %> in time.
-<% else %>
-  <%= @course.provider.name %> has decided not to progress your teacher training application for <%= @course.name_and_code %> on this occasion.
-<% end %>
+<%= render 'application_rejected_intro' %>
 
 # You can apply again
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -364,6 +364,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       )
       expect(email.body).to include('Apply again:')
       expect(email.body).not_to include('Review your feedback and apply again:')
+      expect(email.body).to include('They gave the following feedback')
     end
 
     it 'has the correct subject and content for rejection by default' do
@@ -372,15 +373,18 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect(email.subject).to eq 'Your application was unsuccessful but you can apply again'
       expect(email.body).to include('Dear Fred,')
       expect(email.body).to include(
-        'Bilberry College did not respond to your application for Mathematics (M101) in time.',
+        'Your application for Mathematics (M101) has been automatically rejected because Bilberry College did not respond in time.',
       )
+      expect(email.body).not_to include('They gave the following feedback')
     end
 
     it 'has the correct content when rejection reason is given' do
-      email = send_email(rejected_by_default: true, rejection_reason: 'Not clever enough')
+      email = send_email(rejection_reason: 'Not clever enough')
 
       expect(email.body).not_to include('Apply again:')
       expect(email.body).to include('Review your feedback and apply again:')
+      expect(email.body).to include('They gave the following feedback')
+      expect(email.body).to include('Not clever enough')
     end
   end
 


### PR DESCRIPTION

## Context

The `application_rejected_all_rejected` email is missing the reason for rejection and guidance to contact the provider to ask any questions.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Give this email the same intro as the other application rejected
emails. This results in:

- a minor change to the reject-by-default copy
- the addition of a reason for rejection

---
### Before
![Screenshot_20201120_122928](https://user-images.githubusercontent.com/519250/99800301-0ce7b800-2b2c-11eb-8a58-a607d3bb1ca9.png)

---
### After
![Screenshot_20201120_122847](https://user-images.githubusercontent.com/519250/99800249-f4779d80-2b2b-11eb-85ab-925dd520aae4.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Mailer preview: https://apply-for-te-2544-bug-m-grdufg.herokuapp.com/rails/mailers/candidate_mailer/application_rejected_all_rejected
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/j1gwHHEx
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
