### PR TITLE
Add govuk error summaries and track validation errors where missing

### DIFF
--- a/app/controllers/candidate_interface/degrees/completion_status_controller.rb
+++ b/app/controllers/candidate_interface/degrees/completion_status_controller.rb
@@ -10,6 +10,7 @@ module CandidateInterface
         if @completion_status_form.save(current_degree)
           redirect_to candidate_interface_degree_grade_path
         else
+          track_validation_error(@completion_status_form)
           render :new
         end
       end
@@ -26,7 +27,7 @@ module CandidateInterface
           redirect_to candidate_interface_degrees_review_path
         else
           track_validation_error(@completion_status_form)
-          render :new
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/degrees/grade_controller.rb
+++ b/app/controllers/candidate_interface/degrees/grade_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
         if @degree_grade_form.save
           redirect_to candidate_interface_degree_year_path(current_degree)
         else
+          track_validation_error(@degree_grade_form)
           render :new
         end
       end
@@ -32,7 +33,7 @@ module CandidateInterface
           redirect_to candidate_interface_degrees_review_path
         else
           track_validation_error(@degree_grade_form)
-          render :new
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/degrees/institution_controller.rb
+++ b/app/controllers/candidate_interface/degrees/institution_controller.rb
@@ -17,6 +17,7 @@ module CandidateInterface
             redirect_to candidate_interface_degree_completion_status_path
           end
         else
+          track_validation_error(@degree_institution_form)
           render :new
         end
       end

--- a/app/controllers/candidate_interface/degrees/naric_statement_controller.rb
+++ b/app/controllers/candidate_interface/degrees/naric_statement_controller.rb
@@ -11,6 +11,7 @@ module CandidateInterface
         if @degree_naric_statement_form.save
           redirect_to candidate_interface_degree_completion_status_path
         else
+          track_validation_error(@degree_naric_statement_form)
           render :new
         end
       end

--- a/app/controllers/candidate_interface/degrees/subject_controller.rb
+++ b/app/controllers/candidate_interface/degrees/subject_controller.rb
@@ -12,6 +12,7 @@ module CandidateInterface
         if @degree_subject_form.save
           redirect_to candidate_interface_degree_institution_path(current_degree)
         else
+          track_validation_error(@degree_subject_form)
           render :new
         end
       end

--- a/app/controllers/candidate_interface/degrees/type_controller.rb
+++ b/app/controllers/candidate_interface/degrees/type_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
             @degree_type_form.degree,
           )
         else
+          track_validation_error(@degree_type_form)
           conditionally_render_new_degree_type_form
         end
       end

--- a/app/controllers/candidate_interface/degrees/year_controller.rb
+++ b/app/controllers/candidate_interface/degrees/year_controller.rb
@@ -11,6 +11,7 @@ module CandidateInterface
         if @degree_year_form.save
           redirect_to candidate_interface_degrees_review_path
         else
+          track_validation_error(@degree_type_form)
           render :new
         end
       end
@@ -27,7 +28,7 @@ module CandidateInterface
           redirect_to candidate_interface_degrees_review_path
         else
           track_validation_error(@degree_year_form)
-          render :new
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
         if @ielts_form.save
           redirect_to candidate_interface_english_foreign_language_review_path
         else
+          track_validation_error(@ielts_form)
           render :new
         end
       end
@@ -32,7 +33,8 @@ module CandidateInterface
         if @ielts_form.save
           redirect_to candidate_interface_english_foreign_language_review_path
         else
-          render :new
+          track_validation_error(@ielts_form)
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
         if @other_qualification_form.save
           redirect_to candidate_interface_english_foreign_language_review_path
         else
+          track_validation_error(@other_qualification_form)
           render :new
         end
       end
@@ -32,7 +33,8 @@ module CandidateInterface
         if @other_qualification_form.save
           redirect_to candidate_interface_english_foreign_language_review_path
         else
-          render :new
+          track_validation_error(@other_qualification_form)
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
@@ -13,6 +13,7 @@ module CandidateInterface
         if @start_form.save
           redirect_to @start_form.next_path
         else
+          track_validation_error(@start_form)
           render :new
         end
       end
@@ -27,7 +28,8 @@ module CandidateInterface
         if @start_form.save
           redirect_to @start_form.next_path
         else
-          render :new
+          track_validation_error(@start_form)
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
         if @toefl_form.save
           redirect_to candidate_interface_english_foreign_language_review_path
         else
+          track_validation_error(@toefl_form)
           render :new
         end
       end
@@ -32,7 +33,8 @@ module CandidateInterface
         if @toefl_form.save
           redirect_to candidate_interface_english_foreign_language_review_path
         else
-          render :new
+          track_validation_error(@toefl_form)
+          render :edit
         end
       end
 

--- a/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
@@ -13,6 +13,7 @@ module CandidateInterface
         if @type_form.save
           redirect_to @type_form.next_form_path
         else
+          track_validation_error(@type_form)
           render :new
         end
       end

--- a/app/controllers/candidate_interface/prefill_application_form_controller.rb
+++ b/app/controllers/candidate_interface/prefill_application_form_controller.rb
@@ -6,14 +6,18 @@ module CandidateInterface
 
     def create
       @prefill_application_or_not_form = PrefillApplicationOrNotForm.new(prefill_application_or_not_params)
-      render :new and return unless @prefill_application_or_not_form.valid?
 
-      if @prefill_application_or_not_form.prefill?
-        prefill_candidate_application_form
-        flash[:info] = 'This application has been prefilled with example data'
-        redirect_to candidate_interface_application_form_path
+      if @prefill_application_or_not_form.valid?
+        if @prefill_application_or_not_form.prefill?
+          prefill_candidate_application_form
+          flash[:info] = 'This application has been prefilled with example data'
+          redirect_to candidate_interface_application_form_path
+        else
+          redirect_to candidate_interface_before_you_start_path
+        end
       else
-        redirect_to candidate_interface_before_you_start_path
+        track_validation_error(@prefill_application_or_not_form)
+        render :new
       end
     end
 

--- a/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
+++ b/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
@@ -16,6 +16,8 @@
       model: @withdrawal_feedback_form,
       url: candidate_interface_confirm_withdrawal_feedback_path
     ) do |f| %>
+    <%= f.govuk_error_summary %>
+
       <%= f.govuk_radio_buttons_fieldset :withdrawal_reason, legend: { text: CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION } do %>
         <%= f.govuk_radio_button :feedback, 'yes', label: { text: t('decisions.withdrawal_feedback.feedback.yes.label') } do %>
           <%= f.govuk_text_area :explanation, label: { text: t('decisions.withdrawal_feedback.explanation.label') }, hint: { text: t('decisions.withdrawal_feedback.explanation.hint') } %>

--- a/app/views/candidate_interface/degrees/completion_status/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/completion_status/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <%= f.govuk_radio_buttons_fieldset :degree_completed, legend: { tag: 'h1', size: 'xl', text: t('page_titles.degree_completion_status') } do %>
   <%= f.govuk_radio_button :degree_completed, 'yes', label: { text: 'Yes' } %>
   <%= f.govuk_radio_button :degree_completed, 'no', label: { text: 'No' } %>

--- a/app/views/candidate_interface/degrees/grade/edit.html.erb
+++ b/app/views/candidate_interface/degrees/grade/edit.html.erb
@@ -4,6 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree_grade_form, url: candidate_interface_edit_degree_grade_path(@degree_grade_form.degree), method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= @page_title %>
       </h1>

--- a/app/views/candidate_interface/degrees/grade/new.html.erb
+++ b/app/views/candidate_interface/degrees/grade/new.html.erb
@@ -4,6 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree_grade_form, url: candidate_interface_degree_grade_path(@degree_grade_form.degree) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= @page_title %>
       </h1>

--- a/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/institution/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <% if @degree_institution_form.international? %>
 
   <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/degrees/naric_statement/edit.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/edit.html.erb
@@ -8,6 +8,8 @@
       url: candidate_interface_edit_degree_naric_statement_path(@degree_naric_statement_form.degree),
       method: :patch
     ) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.degree_naric_statement') %>
       </h1>

--- a/app/views/candidate_interface/degrees/naric_statement/new.html.erb
+++ b/app/views/candidate_interface/degrees/naric_statement/new.html.erb
@@ -7,6 +7,8 @@
       model: @degree_naric_statement_form,
       url: candidate_interface_degree_naric_statement_path(@degree_naric_statement_form.degree)
     ) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.degree_naric_statement') %>
       </h1>

--- a/app/views/candidate_interface/degrees/subject/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/subject/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <%= f.govuk_text_field(
   :subject,
   label: { text: t('application_form.degree.subject.label'), size: 'xl' },

--- a/app/views/candidate_interface/degrees/type/add_another.html.erb
+++ b/app/views/candidate_interface/degrees/type/add_another.html.erb
@@ -4,6 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree_type_form, url: candidate_interface_new_degree_path do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.add_another_degree') %>
       </h1>

--- a/app/views/candidate_interface/degrees/type/edit.html.erb
+++ b/app/views/candidate_interface/degrees/type/edit.html.erb
@@ -8,6 +8,8 @@
       url: candidate_interface_edit_degree_type_path(@degree_type_form.degree),
       method: :patch
     ) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.edit_degree_type') %>
       </h1>

--- a/app/views/candidate_interface/degrees/type/new.html.erb
+++ b/app/views/candidate_interface/degrees/type/new.html.erb
@@ -4,6 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree_type_form, url: candidate_interface_new_degree_path do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.add_undergraduate_degree') %>
       </h1>

--- a/app/views/candidate_interface/degrees/year/edit.html.erb
+++ b/app/views/candidate_interface/degrees/year/edit.html.erb
@@ -4,6 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree_year_form, url: candidate_interface_edit_degree_year_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.when_did_you_study_for_your_degree') %>
       </h1>

--- a/app/views/candidate_interface/degrees/year/new.html.erb
+++ b/app/views/candidate_interface/degrees/year/new.html.erb
@@ -4,6 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree_year_form, url: candidate_interface_degree_year_path do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-xl">
         <%= t('page_titles.when_did_you_study_for_your_degree') %>
       </h1>

--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <%= f.govuk_text_field(
   :name,
   label: { text: 'Assessment name', size: 'm' },

--- a/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <%= f.govuk_radio_buttons_fieldset :qualification_status, legend: { size: 'm', text: 'Have you done an English as a foreign language assessment?', tag: 'span' } do %>
   <%= f.govuk_radio_button :qualification_status, 'has_qualification', label: { text: 'Yes' } %>
   <%= f.govuk_radio_button :qualification_status, 'qualification_not_needed', label: { text: 'No, English is not a foreign language to me' } %>

--- a/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/_form_fields.html.erb
@@ -1,3 +1,5 @@
+<%= f.govuk_error_summary %>
+
 <%= f.govuk_text_field(
   :registration_number,
   label: { text: 'TOEFL registration number', size: 'm' },

--- a/app/views/candidate_interface/english_foreign_language/type/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/type/new.html.erb
@@ -4,6 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @type_form, url: candidate_interface_english_foreign_language_type_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      
       <%= f.govuk_radio_buttons_fieldset :type,
         legend: { text: t('page_titles.efl.type'), size: 'xl' },
         caption: { text: t('page_titles.efl.start'), size: 'xl' } do %>

--- a/app/views/candidate_interface/prefill_application_form/new.html.erb
+++ b/app/views/candidate_interface/prefill_application_form/new.html.erb
@@ -11,6 +11,8 @@
       url: candidate_interface_prefill_path,
       method: :post,
     ) do |f| %>
+      <%= f.govuk_error_summary %>
+
       <%= f.govuk_radio_buttons_fieldset :prefill, legend: { text: 'What do you want to do?' } do %>
         <%= f.govuk_radio_button :prefill, false, label: { text: 'Start with a blank application form' }, link_errors: true %>
         <%= f.govuk_radio_button :prefill, true, label: { text: 'Start with the form filled in automatically' } %>


### PR DESCRIPTION
## Context

Recently, a few pages have been missing govuk error summaries so I thought I'd have a glance through our views. While doing this I thought I'd check the corresponding controllers and noticed that in some cases we aren't tracking validation errors

## Changes proposed in this pull request

- Add govuk_error_summary to views where it's missing
- Track validation errors when missing in the corresponding controllers

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
