### PR TITLE
Try to fix issues with data export

### DIFF
--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -1,9 +1,11 @@
 module SupportInterface
   class ApplicationChoicesExport
     def application_choices
-      relevant_applications.flat_map do |application_form|
-        application_form.application_choices.map do |choice|
-          {
+      results = []
+
+      relevant_applications.find_each(batch_size: 100) do |application_form|
+        application_form.application_choices.each do |choice|
+          results << {
             candidate_id: application_form.candidate_id,
             recruitment_cycle_year: application_form.recruitment_cycle_year,
             support_reference: application_form.support_reference,
@@ -24,6 +26,8 @@ module SupportInterface
           }
         end
       end
+
+      results
     end
 
     alias_method :data_for_export, :application_choices

--- a/app/services/support_interface/applications_export.rb
+++ b/app/services/support_interface/applications_export.rb
@@ -11,7 +11,9 @@ module SupportInterface
         'candidates.hide_in_reporting' => false,
       )
 
-      applications_of_interest.map do |application_form|
+      results = []
+
+      applications_of_interest.find_each(batch_size: 100) do |application_form|
         associated_audits = application_form.associated_audits.sort_by(&:created_at).reverse
 
         output = {
@@ -64,8 +66,10 @@ module SupportInterface
           output[:"#{column}_last_updated_at"] = value
         end
 
-        output
+        results << output
       end
+
+      results
     end
 
     alias_method :data_for_export, :applications

--- a/app/workers/data_exporter.rb
+++ b/app/workers/data_exporter.rb
@@ -14,6 +14,7 @@ class DataExporter
         importer_class.constantize.new.data_for_export,
       )
     rescue StandardError => e
+      Rails.logger.info "Export generation failed: `#{e.message}`"
       data_export.update!(audit_comment: "Export generation failed: `#{e.message}`")
       raise
     end
@@ -25,6 +26,7 @@ class DataExporter
       data: csv_data,
       completed_at: Time.zone.now,
     )
+
     Rails.logger.info 'Finished writing CSV. Sidekiq done'
   end
 


### PR DESCRIPTION
## Context

Some data exports are failing silently - they just stop doing their thing and aren't logging anything. My suspicion is that we're loading too many records into memory and that destroys the worker somehow.

## Changes proposed in this pull request

Use `find_each` to load at most a 100 items into memory every time. Also adds some fixes for the logging.

I've tested this manually on production by replacing the class in the console and running that.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/C7NyIXm9/2574-bug

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
