### PR TITLE
Fix application status value in E&D report

### DIFF
--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -29,7 +29,6 @@ module SupportInterface
 
     def application_forms
       ApplicationForm
-        .select(:submitted_at, :recruitment_cycle_year, :equality_and_diversity, :created_at, :updated_at)
         .includes(:application_choices)
         .where.not(equality_and_diversity: nil)
     end

--- a/spec/services/support_interface/equality_and_diversity_export_spec.rb
+++ b/spec/services/support_interface/equality_and_diversity_export_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
       application_form_one = create(:completed_application_form, equality_and_diversity: two_disabilities)
       application_form_two = create(:completed_application_form, equality_and_diversity: one_disability)
       create(:completed_application_form, equality_and_diversity: nil)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form_two)
 
       expect(described_class.new.data_for_export).to contain_exactly(
         {
@@ -36,7 +37,7 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           'Ethnic background' => application_form_two.equality_and_diversity['ethnic_background'],
           'Ethnic group' => application_form_two.equality_and_diversity['ethnic_group'],
           'Disability 1' => application_form_two.equality_and_diversity['disabilities'].first,
-          'Application status' => 'Have not started form',
+          'Application status' => 'Awaiting decisions from providers',
         },
       )
     end


### PR DESCRIPTION
## Context

Application status is always returning `Have not started form` because the query uses a `select` which prevents `application_choices` from being loaded. `ProcessState` interprets this as 'form not started'.

## Changes proposed in this pull request

- [x] Update spec to reproduce issue
- [x] Remove `select` from active record query so that `application_choices` can be returned.

## Guidance to review

- It should be possible to test in the review app. You should see an _Application status_ 'column' in the results with various values.

## Link to Trello card

https://trello.com/c/Fwc2Dj0t/2573-ed-data-extract-bug

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
