### PR TITLE
Add validation string for right to work question

### DIFF
--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -565,6 +565,8 @@ en:
               too_many_words: Other languages spoken must be %{count} words or fewer
         candidate_interface/right_to_work_or_study_form:
           attributes:
+            right_to_work_or_study:
+              blank: Select if you have the right to work or study in the UK
             right_to_work_or_study_details:
               blank: Please provide details of your right to work or study in the UK.
               too_many_words: Other languages spoken must be %{count} words or fewer

--- a/spec/system/candidate_interface/entering_details/international_candidate_enters_their_personal_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/international_candidate_enters_their_personal_details_spec.rb
@@ -53,6 +53,9 @@ RSpec.feature 'Entering their personal details' do
     and_i_submit_the_form
     then_i_see_the_right_to_work_or_study_page
 
+    when_i_submit_the_form
+    then_i_see_a_validation_error
+
     when_i_choose_i_do_not_know
     and_i_submit_the_form
     then_i_see_the_personal_details_review_page
@@ -116,6 +119,7 @@ RSpec.feature 'Entering their personal details' do
   def and_i_submit_the_form
     click_button t('application_form.personal_details.complete_form_button')
   end
+  alias_method :when_i_submit_the_form, :and_i_submit_the_form
 
   def then_i_see_the_nationalites_page
     expect(page).to have_current_path candidate_interface_nationalities_path
@@ -211,6 +215,10 @@ RSpec.feature 'Entering their personal details' do
 
   def and_i_choose_yes
     choose 'Yes'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content 'Select if you have the right to work or study in the UK'
   end
 
   def when_i_choose_i_do_not_know


### PR DESCRIPTION
## Context

The validation error message was missing for blank answers to the right to work and study question.

## Changes proposed in this pull request

Just adds an error message for missing answers to the right to work and study question and extends the system spec.

<img width="868" alt="image" src="https://user-images.githubusercontent.com/450843/99977680-df557580-2d9c-11eb-94a2-800dd62c2f5a.png">

## Guidance to review

Should be possible to test this on the review app by editing personal details and specifying a country other than Britain and Ireland.

## Link to Trello card

https://trello.com/c/AI0PUEGY/2569-bug-missing-validation-for-blank-residency-answer

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
