### PR TITLE
Applying for the same course twice bug

### DIFF
--- a/app/controllers/candidate_interface/find_course_selections_controller.rb
+++ b/app/controllers/candidate_interface/find_course_selections_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
       course = Course.find(params[:course_id])
 
       course_selection = CourseSelectionForm.new(course, course_selection_params[:confirm])
-      if !course_selection.confirm
+      if !course_selection.confirm || current_application.contains_course?(course)
         redirect_to candidate_interface_course_choices_index_path
         return
       end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -12,6 +12,7 @@ class ApplicationChoice < ApplicationRecord
   has_one :accredited_provider, through: :course, class_name: 'Provider'
 
   has_many :notes, dependent: :destroy
+  validates :course_option, uniqueness: { scope: :application_form_id }
 
   audited associated_with: :application_form
 

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -107,4 +107,10 @@ RSpec.describe ApplicationChoice, type: :model do
       end
     end
   end
+
+  describe 'validations' do
+    subject(:application_choice) { create(:application_choice) }
+
+    it { is_expected.to validate_uniqueness_of(:course_option).scoped_to(:application_form_id) }
+  end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_course_twice_with_back_button_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_course_twice_with_back_button_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate arrives from Find with provider and course params' do
+  include CandidateHelper
+
+  scenario 'The candidate cannot add course twice with back button' do
+    given_the_pilot_is_open
+    given_i_am_signed_in
+
+    # Single site course
+    and_i_have_less_than_3_application_options
+    and_the_course_i_selected_only_has_one_site
+    when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
+    when_i_say_yes
+    then_i_should_see_the_courses_review_page
+    and_i_expect_to_have_one_application_choice_for_this_course
+
+    when_i_click_the_back_button
+
+    then_i_should_see_the_confirm_selection_page
+    when_i_say_yes
+    then_i_should_see_the_courses_review_page
+    and_i_expect_to_have_one_application_choice_for_this_course
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_less_than_3_application_options
+    application_form = create(:application_form, candidate: @candidate)
+    create(:application_choice, application_form: application_form)
+  end
+
+  def and_the_course_i_selected_only_has_one_site
+    @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
+    @site = create(:site, provider: @course.provider)
+    create(:course_option, site: @site, course: @course)
+  end
+
+  def when_i_arrive_at_the_apply_from_find_page_with_the_single_site_course_params
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def when_i_say_yes
+    choose 'Yes'
+    click_on 'Continue'
+  end
+
+  def then_i_should_see_the_courses_review_page
+    expect(page).to have_current_path(candidate_interface_course_choices_review_path)
+  end
+
+  def and_i_expect_to_have_one_application_choice_for_this_course
+    expect(page).to have_css('.app-summary-card__header', text: 'Potions', count: 1)
+  end
+
+  def when_i_click_the_back_button
+    visit candidate_interface_course_confirm_selection_path(@course.id)
+  end
+
+  def then_i_should_see_the_confirm_selection_page
+    expect(page).to have_current_path(candidate_interface_course_confirm_selection_path(@course.id))
+  end
+end


### PR DESCRIPTION
## Context

When a user arrives on the `confirm_selection` page from Find and confirms to add a course, they can at that point use the back button to go back and complete the journey again which lets them join the same course twice.

## Changes proposed in this pull request

Add validation to the `application_choice` model and to the `find_course_selections_controller`.

## Link to Trello card

https://trello.com/c/RfVH10aE/2491-dev-bug-users-can-apply-for-the-same-course-twice-when-using-the-back-button


