### PR TITLE
Add unique index to application choices

### DIFF
--- a/db/migrate/20201123174522_add_unique_index_to_application_choices.rb
+++ b/db/migrate/20201123174522_add_unique_index_to_application_choices.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToApplicationChoices < ActiveRecord::Migration[6.0]
+  def change
+    add_index :application_choices,
+              %i[application_form_id course_option_id],
+              unique: true, name: 'index_course_option_to_application_form_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_132410) do
     t.datetime "offer_deferred_at"
     t.string "status_before_deferral"
     t.datetime "reject_by_default_feedback_sent_at"
+    t.index ["application_form_id", "course_option_id"], name: "index_course_option_to_application_form_id", unique: true
     t.index ["application_form_id"], name: "index_application_choices_on_application_form_id"
     t.index ["course_option_id"], name: "index_application_choices_on_course_option_id"
   end

--- a/spec/system/provider_interface/provider_applications_pagination_spec.rb
+++ b/spec/system/provider_interface/provider_applications_pagination_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Providers should be able to sort applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
+  let(:provider) { create(:provider, :with_signed_agreement, code: 'ABC') }
+
   scenario 'viewing applications one page at a time' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
@@ -31,11 +33,9 @@ RSpec.feature 'Providers should be able to sort applications' do
   end
 
   def and_my_organisation_has_fewer_than_30_applications
-    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
-
-    @course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
-    @course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
-    @course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+    @course_option_one = course_option_for_provider(provider: provider, course: create(:course, name: 'Alchemy', provider: provider))
+    @course_option_two = course_option_for_provider(provider: provider, course: create(:course, name: 'Divination', provider: provider))
+    @course_option_three = course_option_for_provider(provider: provider, course: create(:course, name: 'English', provider: provider))
 
     create(:application_choice, :awaiting_provider_decision, course_option: @course_option_one, status: 'withdrawn', application_form:
            create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
@@ -60,14 +60,13 @@ RSpec.feature 'Providers should be able to sort applications' do
   end
 
   def given_my_organisation_has_more_than_30_applications
-    create_list(
-      :application_choice,
-      30,
-      :awaiting_provider_decision,
-      course_option: @course_option_one,
-      application_form: create(:application_form),
-      updated_at: 1.day.ago,
-    )
+    30.times do |_n|
+      create(:application_choice,
+             :awaiting_provider_decision,
+             course_option: course_option_for_provider(provider: provider, course: create(:course, name: 'Alchemy', provider: provider)),
+             application_form: create(:application_form),
+             updated_at: 1.day.ago)
+    end
   end
 
   def then_i_should_see_a_paginator

--- a/spec/system/provider_interface/provider_applications_pagination_spec.rb
+++ b/spec/system/provider_interface/provider_applications_pagination_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Providers should be able to sort applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  let(:provider) { create(:provider, :with_signed_agreement, code: 'ABC') }
-
   scenario 'viewing applications one page at a time' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
@@ -33,9 +31,10 @@ RSpec.feature 'Providers should be able to sort applications' do
   end
 
   def and_my_organisation_has_fewer_than_30_applications
-    @course_option_one = course_option_for_provider(provider: provider, course: create(:course, name: 'Alchemy', provider: provider))
-    @course_option_two = course_option_for_provider(provider: provider, course: create(:course, name: 'Divination', provider: provider))
-    @course_option_three = course_option_for_provider(provider: provider, course: create(:course, name: 'English', provider: provider))
+    @provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    @course_option_one = course_option_for_provider(provider: @provider, course: create(:course, name: 'Alchemy', provider: @provider))
+    @course_option_two = course_option_for_provider(provider: @provider, course: create(:course, name: 'Divination', provider: @provider))
+    @course_option_three = course_option_for_provider(provider: @provider, course: create(:course, name: 'English', provider: @provider))
 
     create(:application_choice, :awaiting_provider_decision, course_option: @course_option_one, status: 'withdrawn', application_form:
            create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
@@ -63,7 +62,7 @@ RSpec.feature 'Providers should be able to sort applications' do
     30.times do |_n|
       create(:application_choice,
              :awaiting_provider_decision,
-             course_option: course_option_for_provider(provider: provider, course: create(:course, name: 'Alchemy', provider: provider)),
+             course_option: course_option_for_provider(provider: @provider, course: create(:course, name: 'Alchemy', provider: @provider)),
              application_form: create(:application_form),
              updated_at: 1.day.ago)
     end


### PR DESCRIPTION
## Context

This index is required to allow us to add a new validation to the `application_choices` model. 

```
validates :course_option, uniqueness: { scope: :application_form_id }
```

## Changes proposed in this pull request

This PR add the new index. [A separate PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/3493) adds the validation to the model. These two PRs should be released separately to ensure this migration is run before the code is deployed.

## Guidance to review


## Link to Trello card

https://trello.com/c/RfVH10aE/2491-dev-bug-users-can-apply-for-the-same-course-twice-when-using-the-back-button

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency

