### PR TITLE
Populate latitude and longitude on Site sync from Find

### DIFF
--- a/app/services/find_sync/sync_courses_from_find.rb
+++ b/app/services/find_sync/sync_courses_from_find.rb
@@ -58,6 +58,8 @@ module FindSync
         site.address_line3 = find_site.address3&.strip
         site.address_line4 = find_site.address4&.strip
         site.postcode = find_site.postcode&.strip
+        site.latitude = find_site.latitude
+        site.longitude = find_site.longitude
         site.save!
 
         find_site_status = site_statuses.find { |ss| ss.site.id == find_site.id }

--- a/spec/services/find_sync/sync_provider_from_find_spec.rb
+++ b/spec/services/find_sync/sync_provider_from_find_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe FindSync::SyncProviderFromFind, sidekiq: true do
         expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
         expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
         expect(course_option.site.postcode).to eq 'LS27 0LZ'
+        expect(course_option.site.latitude).to eq 53.745587
+        expect(course_option.site.longitude).to eq(-1.620208)
         expect(course_option.vacancy_status).to eq 'vacancies'
       end
 

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -62,6 +62,8 @@ module FindAPIHelper
                 'address3': 'Bruntcliffe Lane',
                 'address4': 'MORLEY, LEEDS',
                 'postcode': 'LS27 0LZ',
+                'longitude': -1.620208,
+                'latitude': 53.745587,
               },
             },
             {
@@ -190,6 +192,8 @@ module FindAPIHelper
                 'address3': 'Bruntcliffe Lane',
                 'address4': 'MORLEY, LEEDS',
                 'postcode': 'LS27 0LZ',
+                'longitude': -1.620208,
+                'latitude': 53.745587,
               },
             },
             {
@@ -307,6 +311,8 @@ module FindAPIHelper
               'address3': 'Bruntcliffe Lane',
               'address4': 'MORLEY, Leeds',
               'postcode': 'LS27 0LZ',
+              'longitude': -1.620208,
+              'latitude': 53.745587,
             },
           },
           {
@@ -320,6 +326,8 @@ module FindAPIHelper
               'address3': 'Another Lane',
               'address4': 'MORLEY, Leeds',
               'postcode': 'LS27 5HT',
+              'longitude': -1.62334,
+              'latitude': 53.745028,
             },
           },
           {
@@ -545,6 +553,8 @@ module FindAPIHelper
                 'address3': 'Bruntcliffe Lane',
                 'address4': 'MORLEY, LEEDS',
                 'postcode': 'LS27 0LZ',
+                'longitude': -1.620208,
+                'latitude': 53.745587,
               },
             },
             {


### PR DESCRIPTION
## Context

We want to add geographic location data to course sites. Following on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/3498 this PR adapts the code that sync sites to include latitude and longitude.

## Changes proposed in this pull request

- Extend `SyncCoursesFromFind`

## Guidance to review

- Do we need to extend our own API? Assuming not.
- The process of extending `FindAPIHelper` is a bit manual - would it make sense to use the VCR gem for this?

## Link to Trello card

https://trello.com/c/2uEjIOHm/2575-dev-use-the-v3-api-to-populate-the-latitude-and-longitude-for-sites

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
