### PR TITLE
Fix Bug in carried over application Application Review

### DIFF
--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -9,7 +9,7 @@ class SubmitApplication
   def call
     application_form.update!(submitted_at: Time.zone.now)
 
-    application_choices.each do |application_choice|
+    application_choices.includes(%i[course_option provider]).each do |application_choice|
       SendApplicationToProvider.call(application_choice)
     end
 

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -22,12 +22,20 @@
       <% if @application_form.previous_application_form.application_choices.rejected.any?  %>
         <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
       <% end %>
-
-      <%= render(
-        CandidateInterface::ApplicationFormApplyAgainCourseChoiceComponent.new(
-          completed: @application_form_presenter.course_choices_completed?,
-        )
-      ) %>
+      <% if @application_form.apply_1? %>
+        <%= render(
+          CandidateInterface::ApplicationFormCourseChoicesComponent.new(
+            choices_are_present: @application_form_presenter.application_choices_added?,
+            completed: @application_form_presenter.course_choices_completed?,
+          )
+        ) %>
+      <% else %>
+        <%= render(
+          CandidateInterface::ApplicationFormApplyAgainCourseChoiceComponent.new(
+            completed: @application_form_presenter.course_choices_completed?,
+          )
+        ) %>
+      <% end %>
     <% else %>
       <%= render(
         CandidateInterface::ApplicationFormCourseChoicesComponent.new(

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -123,7 +123,9 @@ module CandidateHelper
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
     course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider, start_date: Date.new(2020, 9, 1))
+    course2 = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Drama', code: '2397', provider: @provider, start_date: Date.new(2020, 9, 1))
     create(:course_option, site: site, course: course)
+    create(:course_option, site: site, course: course2)
   end
 
   def candidate_fills_in_course_choices

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -31,10 +31,15 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
     when_i_view_courses
     then_i_can_see_that_i_need_to_select_courses
 
-    and_i_select_a_course
+    when_i_add_a_course
+    and_i_complete_the_section
+    and_i_visit_the_course_choices_section
+    then_i_see_the_course_choice_review_page
+
+    when_i_add_another_course
     and_i_complete_the_section
     and_i_submit_my_application
-    and_my_application_is_awaiting_provider_decision
+    then_my_application_is_awaiting_provider_decision
   end
 
   def given_i_am_signed_in_as_a_candidate
@@ -131,7 +136,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
     expect(page).to have_content 'You can apply for up to 3 courses'
   end
 
-  def and_i_select_a_course
+  def when_i_add_a_course
     given_courses_exist
 
     click_link 'Continue'
@@ -148,6 +153,30 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
     expect(page).to have_content 'You can choose 2 more courses'
   end
 
+  def and_i_visit_the_course_choices_section
+    click_link 'Choose your courses'
+  end
+
+  def then_i_see_the_course_choice_review_page
+    expect(page).to have_current_path candidate_interface_course_choices_review_path
+  end
+
+  def when_i_add_another_course
+    click_link 'Add another course'
+
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+
+    select 'Gorse SCITT (1N1)'
+    click_button 'Continue'
+
+    choose 'Drama (2397)'
+    click_button 'Continue'
+
+    expect(page).to have_content 'You’ve added Drama (2397) to your application'
+    expect(page).to have_content 'You can choose 1 more course'
+  end
+
   def and_i_complete_the_section
     choose 'No, not at the moment'
     click_button 'Continue'
@@ -159,7 +188,7 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
     @new_application_form = candidate_submits_application
   end
 
-  def and_my_application_is_awaiting_provider_decision
+  def then_my_application_is_awaiting_provider_decision
     application_choice = @new_application_form.application_choices.first
     expect(application_choice.status).to eq 'awaiting_provider_decision'
   end

--- a/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_between_cycles_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def then_i_can_add_course_choices
-    expect(page).to have_content('Choose your course Incomplete')
-    click_link 'Choose your course'
+    expect(page).to have_content('Choose your courses Incomplete')
+    click_link 'Choose your courses'
     expect(page).to have_content 'You can apply for up to 3 courses'
   end
 end

--- a/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_spec.rb
+++ b/spec/system/candidate_interface/apply_again/carry_over_unsuccessful_application_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe 'Candidate can carry over unsuccessful application to a new recru
   end
 
   def and_i_can_see_that_no_courses_are_selected
-    expect(page).to have_content('Choose your course Incomplete')
-    click_link 'Choose your course'
+    expect(page).to have_content('Choose your courses Incomplete')
+    click_link 'Choose your courses'
     expect(page).to have_content 'You can apply for up to 3 courses'
   end
 


### PR DESCRIPTION
## Context

When a user completes the course choices section after carrying over an application there is a bug which prevents
user from adding more than one course choice if the section is completed. This is due to the incorrect component
being rendered on the review screen. 

## Changes proposed in this pull request

Changes in this PR address this by refactoring the show view to show the correct component if the user has a previous application. Specs updated to mirror situation.

## Guidance to review

Check test coverage

## Link to Trello card

https://trello.com/c/dewnmCtC/2578-%F0%9F%8C%90-bug-candidate-is-not-able-to-add-additional-course-choice-from-review-screen-if-they-have-an-application-from-a-previous-cycle

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
