### PR TITLE
Add latitude and longitude to Providers

### DIFF
--- a/db/migrate/20201125094845_add_latitude_and_longitude_to_providers.rb
+++ b/db/migrate/20201125094845_add_latitude_and_longitude_to_providers.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToProviders < ActiveRecord::Migration[6.0]
+  def change
+    add_column :providers, :latitude, :float
+    add_column :providers, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_162533) do
+ActiveRecord::Schema.define(version: 2020_11_25_094845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -429,6 +429,8 @@ ActiveRecord::Schema.define(version: 2020_11_24_162533) do
     t.string "region_code"
     t.string "postcode"
     t.string "provider_type"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["code"], name: "index_providers_on_code", unique: true
   end
 


### PR DESCRIPTION
## Context

We need to know where providers are so that we can calculate distances and range in search queries.

## Changes proposed in this pull request

Add latitude and longitude, nullable, float columns to the providers table.

## Guidance to review

Follows the pattern from https://github.com/DFE-Digital/apply-for-teacher-training/pull/3498/files. NB. to other developers, there was a good discussion around why we choose to use a float type for these columns

## Link to Trello card

https://trello.com/c/YgubEbfX/2577-dev-use-the-v3-api-to-populate-the-latitude-and-longitude-for-providers

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
