### PR TITLE
Add geocoding of candidate addresses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,9 @@ gem 'pdfkit'
 
 gem 'archive-zip'
 
+# Geocoding
+gem 'geocoder'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,7 @@ GEM
       ffi (>= 1.0.0)
       rake
     formatador (0.2.5)
+    geocoder (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_design_system_formbuilder (2.1.4)
@@ -538,6 +539,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  geocoder
   govuk_design_system_formbuilder (~> 2.1.4)
   govuk_markdown
   guard-rspec

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -333,7 +333,8 @@ private
       saved_change_to_address_line3? ||
       saved_change_to_address_line4? ||
       saved_change_to_country? ||
-      saved_change_to_postcode?
+      saved_change_to_postcode? ||
+      saved_change_to_address_type?
   end
 
   def withdrawn_course_choices

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -3,6 +3,7 @@
 class ApplicationForm < ApplicationRecord
   audited
   has_associated_audits
+  geocoded_by :address_formatted_for_geocoding
 
   include Chased
 
@@ -70,13 +71,9 @@ class ApplicationForm < ApplicationRecord
 
   attribute :recruitment_cycle_year, :integer, default: -> { RecruitmentCycle.current_year }
 
-  before_create lambda {
-    self.support_reference ||= GenerateSupportRef.call
-  }
-
-  after_save lambda {
-    application_choices.update_all(updated_at: Time.zone.now)
-  }
+  before_create -> { self.support_reference ||= GenerateSupportRef.call }
+  after_save -> { application_choices.update_all(updated_at: Time.zone.now) }
+  after_commit :geocode_address_if_required
 
   def submitted?
     submitted_at.present?
@@ -314,7 +311,30 @@ class ApplicationForm < ApplicationRecord
     application_references.feedback_provided.count >= MINIMUM_COMPLETE_REFERENCES
   end
 
+  def address_formatted_for_geocoding
+    full_address.compact.join(', ')
+  end
+
 private
+
+  def geocode_address_if_required
+    return unless address_changed?
+
+    if international?
+      update!(latitude: nil, longitude: nil)
+    else
+      GeocodeApplicationAddressWorker.perform_async(id)
+    end
+  end
+
+  def address_changed?
+    saved_change_to_address_line1? ||
+      saved_change_to_address_line2? ||
+      saved_change_to_address_line3? ||
+      saved_change_to_address_line4? ||
+      saved_change_to_country? ||
+      saved_change_to_postcode?
+  end
 
   def withdrawn_course_choices
     application_choices.includes(%i[provider course]).select { |choice| choice.course.withdrawn == true }

--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -1,6 +1,8 @@
 class GeocodeApplicationAddressWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :low_priority
+
   def perform(application_form_id)
     return unless Geocoder.config.api_key
 

--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -1,0 +1,12 @@
+class GeocodeApplicationAddressWorker
+  include Sidekiq::Worker
+
+  def perform(application_form_id)
+    return unless Geocoder.config.api_key
+
+    application_form = ApplicationForm.find(application_form_id)
+    application_form.latitude, application_form.longitude = application_form.geocode
+
+    application_form.save!
+  end
+end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,13 @@
+Geocoder.configure(
+  timeout: 3, # geocoding service timeout (secs)
+  lookup: :google, # name of geocoding service (symbol)
+  use_https: true, # use HTTPS for lookup requests? (if supported)
+  api_key: ENV['GOOGLE_MAPS_API_KEY'], # API key for geocoding service
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  always_raise: [Geocoder::InvalidApiKey, Geocoder::OverQueryLimitError],
+
+  units: :mi, # :km for kilometers or :mi for miles
+)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ApplicationForm do
       it 'clears existing coordinates if address changed to international' do
         allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
         application_form = create(:completed_application_form, latitude: 1.5, longitude: 0.2)
-        application_form.update!(address_type: :international, country: 'AF')
+        application_form.update!(address_type: :international)
 
         expect([application_form.latitude, application_form.longitude]).to eq [nil, nil]
         expect(GeocodeApplicationAddressWorker)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -6,6 +6,63 @@ RSpec.describe ApplicationForm do
     expect(application_form.support_reference).to be_present
   end
 
+  describe 'after_commit' do
+    describe '#geocode_address_if_required' do
+      it 'invokes geocoding of UK addresses on create' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
+        application_form = build(:completed_application_form)
+        application_form.save!
+
+        expect(GeocodeApplicationAddressWorker).to have_received(:perform_async).with(application_form.id)
+      end
+
+      it 'invokes geocoding of UK addresses on update' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
+        application_form = create(:completed_application_form)
+
+        address_attributes = %i[address_line1 address_line2 address_line3 address_line4 postcode country]
+        address_attributes.each do |address_attr|
+          application_form.update!(address_attr => 'foo')
+        end
+
+        expected_calls_to_worker = address_attributes.size + 1 # Each update plus the initial create
+        expect(GeocodeApplicationAddressWorker)
+          .to have_received(:perform_async)
+          .with(application_form.id)
+          .exactly(expected_calls_to_worker).times
+      end
+
+      it 'does not invoke geocoding for international addresses' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
+        application_form = build(:completed_application_form, :international_address)
+        application_form.save!
+
+        expect(GeocodeApplicationAddressWorker).not_to have_received(:perform_async).with(application_form.id)
+      end
+
+      it 'does not invoke geocoding if address fields have not been changed' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
+        application_form = build(:application_form)
+        application_form.save!
+        application_form.update!(phone_number: 111111)
+
+        expect(GeocodeApplicationAddressWorker).not_to have_received(:perform_async).with(application_form.id)
+      end
+
+      it 'clears existing coordinates if address changed to international' do
+        allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
+        application_form = create(:completed_application_form, latitude: 1.5, longitude: 0.2)
+        application_form.update!(address_type: :international, country: 'AF')
+
+        expect([application_form.latitude, application_form.longitude]).to eq [nil, nil]
+        expect(GeocodeApplicationAddressWorker)
+          .to have_received(:perform_async)
+          .with(application_form.id)
+          .exactly(1).times # The initial create only
+      end
+    end
+  end
+
   describe '#previous_application_form' do
     it 'refers to the previous application' do
       previous_application_form = create(:application_form)

--- a/spec/workers/geocode_application_address_worker_spec.rb
+++ b/spec/workers/geocode_application_address_worker_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe GeocodeApplicationAddressWorker do
+  describe '#perform' do
+    it 'does nothing if a Geocoder API key is not set' do
+      allow(Geocoder.config).to receive(:api_key).and_return(nil)
+      application = create(:application_form)
+      allow(application).to receive(:geocode)
+
+      described_class.new.perform(application.id)
+
+      expect(application).not_to have_received(:geocode)
+    end
+
+    context 'with an API key set' do
+      before { allow(Geocoder.config).to receive(:api_key).and_return('SOME_KEY') }
+
+      it 'saves coordinates returned by the geocoder' do
+        application = create(:application_form)
+        allow(application).to receive(:geocode).and_return([51.499399, -0.124808])
+        allow(ApplicationForm).to receive(:find).with(application.id).and_return(application)
+
+        described_class.new.perform(application.id)
+
+        expect(application.latitude).to eq(51.499399)
+        expect(application.longitude).to eq(-0.124808)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to analyse distances between candidates and the sites they choose to train at to improve location-related functionality in the service.

This change deals with geolocating candidate addresses.

## Changes proposed in this pull request
- Set up `geocoder` gem
- Add a callback to application forms that invokes a geocoding worker when certain conditions are met
- Implement a worker that invokes the geocoder and persists the returned coordinates.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Can be tested locally. Ensure Sidekiq is running and add/modify the address on an application form. 
- A valid UK address should be successfully geolocated. Inspect the form in the console - if a valid address was provided, latitude/longitude should be filled in.
- International addresses should not be geolocated (ie - blank lat/long).
- Changing a UK address to international address should clear the coordinates.
- Coordinates can be double checked by searching https://www.google.com/maps with a query in the form "(latitude),(longitude)"

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/6A8t8vVY
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
