### PR TITLE
Populate latitude and longitude on providers when syncing from Find

### DIFF
--- a/app/services/find_sync/sync_provider_from_find.rb
+++ b/app/services/find_sync/sync_provider_from_find.rb
@@ -53,6 +53,8 @@ module FindSync
         postcode: find_provider.postcode,
         name: find_provider.provider_name,
         provider_type: find_provider.courses.first&.provider_type,
+        latitude: find_provider.latitude,
+        longitude: find_provider.longitude,
       }
     end
 

--- a/app/services/find_sync/sync_provider_from_find.rb
+++ b/app/services/find_sync/sync_provider_from_find.rb
@@ -53,8 +53,8 @@ module FindSync
         postcode: find_provider.postcode,
         name: find_provider.provider_name,
         provider_type: find_provider.courses.first&.provider_type,
-        latitude: find_provider.latitude,
-        longitude: find_provider.longitude,
+        latitude: find_provider.try(:latitude),
+        longitude: find_provider.try(:longitude),
       }
     end
 

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -24,7 +24,9 @@ module FindAPIHelper
     funding_type: 'fee',
     age_range_in_years: '4 to 8',
     vac_status: 'full_time_vacancies',
-    content_status: 'published'
+    content_status: 'published',
+    latitude: '51.498024',
+    longitude: '0.129919'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -39,6 +41,8 @@ module FindAPIHelper
               'provider_code': provider_code,
               'region_code': region_code,
               'postcode': postcode,
+              'latitude': latitude,
+              'longitude': longitude,
             },
             'relationships': {
               'sites': {
@@ -158,7 +162,9 @@ module FindAPIHelper
     course_length: 'OneYear',
     region_code: 'north_west',
     age_range_in_years: '4 to 8',
-    content_status: 'published'
+    content_status: 'published',
+    latitude: '51.498024',
+    longitude: '0.129919'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -173,6 +179,8 @@ module FindAPIHelper
               'provider_code': provider_code,
               'region_code': region_code,
               'postcode': postcode,
+              'latitude': latitude,
+              'longitude': longitude,
             },
             'relationships': {
               'sites': {
@@ -280,8 +288,9 @@ module FindAPIHelper
     course_length: 'OneYear',
     region_code: 'north_west',
     age_range_in_years: '4 to 8',
-    content_status: 'published'
-
+    content_status: 'published',
+    latitude: '51.498024',
+    longitude: '0.129919'
   )
     response_hash = {
       status: 200,
@@ -296,6 +305,8 @@ module FindAPIHelper
             'region_code': region_code,
             'postcode': postcode,
             'provider_type': provider_type,
+            'latitude': latitude,
+            'longitude': longitude,
           },
           'relationships': {
             'sites': {
@@ -528,7 +539,9 @@ module FindAPIHelper
     vac_status: 'full_time_vacancies',
     qualifications: %w[PG PF],
     program_type: 'SD',
-    content_status: 'published'
+    content_status: 'published',
+    latitude: '51.498024',
+    longitude: '0.129919'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -543,6 +556,8 @@ module FindAPIHelper
               'provider_code': provider_code,
               'region_code': region_code,
               'postcode': postcode,
+              'latitude': latitude,
+              'longitude': longitude,
             },
             'relationships': {
               'sites': {


### PR DESCRIPTION
## Context

We want to add geographic location data to course providers. Following on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/3507 this PR adapts the code that sync providers to include latitude and longitude.

## Changes proposed in this pull request

- Extend `SyncProviderFromFind.`

## Guidance to review

This is very similar to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3503

## Link to Trello card

https://trello.com/c/YgubEbfX/2577-dev-use-the-v3-api-to-populate-the-latitude-and-longitude-for-providers

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
