### PR TITLE
Renamed application section tweaks

### DIFF
--- a/app/components/interview_preferences_component.html.erb
+++ b/app/components/interview_preferences_component.html.erb
@@ -6,12 +6,12 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Interview needs</h2>
+    <h3 class="govuk-heading-m"><%= t('page_titles.interview_preferences') %></h3>
     <p class="govuk-body">Interviews usually take place over the course of a day. You’ll need to attend in person.</p>
     <p class="govuk-body">Training providers might not have much flexibility when setting a date and time for interview.</p>
     <p class="govuk-body">If there’s a reason why you need some flexibility you can tell us about it here.</p>
     <p class="govuk-body">For example:</p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+    <ul class="govuk-list govuk-list--bullet">
       <li>you have commitments such as employment or caring responsibilities</li>
       <li>you’ll be travelling a long way to get to the interview</li>
       <li>you’ll need some adjustments because you’re disabled</li>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -6,7 +6,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Equality and diversity</h2>
+    <h2 class="govuk-heading-m"><%= t('equality_and_diversity.title') %></h2>
     <p class="govuk-body">
       The equality and diversity questionnaire is optional and has no impact on the progress of your application.
     </p>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -8,7 +8,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Declaring any safeguarding issues</h2>
+    <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
     <p class="govuk-body">Teacher training providers need to check that it’s safe for you to work with children and young people.</p>
     <p class="govuk-body">As well as confirming your identity and your right to work in the UK, providers will check:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -6,7 +6,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Asking for support if you have a disability or other needs</h2>
+    <h2 class="govuk-heading-m">Ask for support if you have a disability or other needs</h2>
     <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
     <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
     <p class="govuk-body">Examples of support could be:</p>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -6,7 +6,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Ask for support if you have a disability or other needs</h2>
+    <h3 class="govuk-heading-m"><%= t('page_titles.training_with_a_disability') %></h3>
     <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
     <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
     <p class="govuk-body">Examples of support could be:</p>
@@ -16,7 +16,7 @@
       <li>making sure classrooms are wheelchair accessible</li>
     </ul>
     <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work" class="govuk-link">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
-    <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
+    <h4 class="govuk-heading-s">It’s against the law to discriminate</h4>
     <p class="govuk-body">If you’re disabled, <a href="/getintoteaching/train-to-teach-with-a-disability" class="govuk-link">it’s against the law to discriminate against you</a>. Training providers must not:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -4,7 +4,7 @@
     <span class="govuk-details__summary-text">View guidance given to candidate</span>
   </summary>
   <div class="govuk-details__text">
-    <h2 class="govuk-heading-m">Academic and other relevant qualifications</h2>
+    <h3 class="govuk-heading-m"><%= t('page_titles.other_qualification') %></h3>
     <p class="govuk-body">Your undergraduate degree confirms your eligibility to teach. Enter the details of your degree as they appear on your certificate, translating them into English if necessary.</p>
     <p class="govuk-body">You should also include any postgraduate degrees.</p>
     <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, t('page_titles.choosing_courses') %>
+<% content_for :title, t('page_titles.choose_courses') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.choosing_courses') %>
+      <%= t('page_titles.choose_courses') %>
     </h1>
     <% if @current_application.candidate_can_choose_single_course? %>
       <%= render 'guidance_apply_again' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
     add_another_degree: Add another degree
     work_history_explanation: Tell us why you’ve been out of the workplace
     destroy_degree: Are you sure you want to delete this degree?
-    choosing_courses: Choosing your courses
+    choose_courses: Choose your courses
     course: Course
     courses: Courses
     course_choices: Course choices
@@ -92,8 +92,8 @@ en:
     becoming_a_teacher: Why do you want to teach
     subject_knowledge: Your suitability to teach a subject or age group
     interview_preferences: Interview needs
-    training_with_a_disability: Asking for support if you’re disabled
-    suitability_to_work_with_children: Declaring any safeguarding issues
+    training_with_a_disability: Ask for support if you’re disabled
+    suitability_to_work_with_children: Declare any safeguarding issues
     recommendation: I would recommend this service to a friend or colleague
     complexity: I found this service unnecessarily complex
     ease_of_use: I thought this service was easy to use

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,6 @@ en:
     work_history_explanation: Tell us why you’ve been out of the workplace
     destroy_degree: Are you sure you want to delete this degree?
     choose_courses: Choose your courses
-    course: Course
     courses: Courses
     course_choices: Course choices
     course_choice: Course choice

--- a/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_disability_info_spec.rb
@@ -119,6 +119,6 @@ RSpec.feature 'Entering their disability information' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#asking-for-support-if-you-re-disabled-badge-id', text: 'Completed')
+    expect(page).to have_css('#ask-for-support-if-you-re-disabled-badge-id', text: 'Completed')
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -87,6 +87,6 @@ RSpec.feature 'Entering their suitability to work with children' do
   end
 
   def then_i_see_the_section_is_completed
-    expect(page).to have_css('#declaring-any-safeguarding-issues-badge-id', text: 'Completed')
+    expect(page).to have_css('#declare-any-safeguarding-issues-badge-id', text: 'Completed')
   end
 end


### PR DESCRIPTION
## Context

A few bits of fallout from renaming application sections.

## Changes proposed in this pull request

* Update section titles to be more active (‘ask’, ‘declare’, ‘choose’)
* Remove a deprecated page title (`page_titles.course`)
* Ensure the guidance previews shown to providers use the same page titles shown to candidate
* Use correct heading levels for headings within guidance previews shown to providers  

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
