### PR TITLE
Support: add filtering by candidate and application choice IDs

### DIFF
--- a/app/components/filter_component.html.erb
+++ b/app/components/filter_component.html.erb
@@ -50,7 +50,7 @@
                   <%= filter[:heading] %>
                 </legend>
                 <% if filter[:type] == :search %>
-                  <input class="govuk-input" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" aria-labelledby="filter-legend-<%= filter[:name] %>" >
+                  <input class="govuk-input <%= filter[:css_classes] %>" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" aria-labelledby="filter-legend-<%= filter[:name] %>" >
 
                 <% elsif filter[:type] == :checkboxes %>
                     <% filter[:options].each do |option| %>

--- a/app/components/support_interface/applications_table_component.html.erb
+++ b/app/components/support_interface/applications_table_component.html.erb
@@ -1,3 +1,7 @@
-<% application_forms.each do |application_form| %>
-  <%= render SupportInterface::ApplicationCardComponent.new(application_form: application_form) %>
+<% if application_forms.any? %>
+  <% application_forms.each do |application_form| %>
+    <%= render SupportInterface::ApplicationCardComponent.new(application_form: application_form) %>
+  <% end %>
+<% else %>
+  <p class="govuk-body">No applications found</p>
 <% end %>

--- a/app/components/support_interface/candidates_table_component.html.erb
+++ b/app/components/support_interface/candidates_table_component.html.erb
@@ -1,21 +1,25 @@
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Candidate</th>
-      <th scope="col" class="govuk-table__header">Status of latest application</th>
-      <th scope="col" class="govuk-table__header">Last updated</th>
-    </tr>
-  </thead>
-
-  <tbody class="govuk-table__body">
-    <% table_rows.each do |table_row| %>
-      <tr class="govuk-table__row" data-qa="candidate-<%= table_row[:candidate_id] %>">
-        <td class="govuk-table__cell">
-          <%= table_row[:candidate_link] %> <%= table_row[:apply_again] ? '(Apply again)' : '' %>
-        </td>
-        <td class="govuk-table__cell"><%= t "candidate_flow_application_states.#{table_row[:process_state]}.name" %></td>
-        <td class="govuk-table__cell"><%= table_row[:updated_at] %></td>
+<% if table_rows.any? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Candidate</th>
+        <th scope="col" class="govuk-table__header">Status of latest application</th>
+        <th scope="col" class="govuk-table__header">Last updated</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% table_rows.each do |table_row| %>
+        <tr class="govuk-table__row" data-qa="candidate-<%= table_row[:candidate_id] %>">
+          <td class="govuk-table__cell">
+            <%= table_row[:candidate_link] %> <%= table_row[:apply_again] ? '(Apply again)' : '' %>
+          </td>
+          <td class="govuk-table__cell"><%= t "candidate_flow_application_states.#{table_row[:process_state]}.name" %></td>
+          <td class="govuk-table__cell"><%= table_row[:updated_at] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="govuk-body">No candidates found</p>
+<% end %>

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -8,8 +8,13 @@ module SupportInterface
         .order(updated_at: :desc)
         .page(params[:page] || 1).per(30)
 
-      if params[:q]
+      if params[:q].present?
         @candidates = @candidates.where('CONCAT(email_address) ILIKE ?', "%#{params[:q]}%")
+      end
+
+      if params[:candidate_number].present?
+        candidate_number = params[:candidate_number].tr('^0-9', '')
+        @candidates = @candidates.where(id: candidate_number)
       end
 
       @filter = SupportInterface::CandidatesFilter.new(params: params)

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -33,7 +33,7 @@ module SupportInterface
     end
 
     def filters
-      @filters ||= [search_filter] + [search_by_application_choice_filter] + [year_filter] + [phase_filter]
+      @filters ||= [search_filter, search_by_application_choice_filter, year_filter, phase_filter]
     end
 
   private

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -17,6 +17,10 @@ module SupportInterface
         application_forms = application_forms.where("CONCAT(application_forms.first_name, ' ', application_forms.last_name, ' ', candidates.email_address, ' ', application_forms.support_reference) ILIKE ?", "%#{applied_filters[:q]}%")
       end
 
+      if applied_filters[:application_choice_id].present?
+        application_forms = application_forms.joins(:application_choices).where('application_choices.id = ?', applied_filters[:application_choice_id])
+      end
+
       if applied_filters[:phase]
         application_forms = application_forms.where('phase IN (?)', applied_filters[:phase])
       end
@@ -29,7 +33,7 @@ module SupportInterface
     end
 
     def filters
-      @filters ||= [search_filter] + [year_filter] + [phase_filter]
+      @filters ||= [search_filter] + [search_by_application_choice_filter] + [year_filter] + [phase_filter]
     end
 
   private
@@ -57,6 +61,15 @@ module SupportInterface
         heading: 'Name, email or reference',
         value: applied_filters[:q],
         name: 'q',
+      }
+    end
+
+    def search_by_application_choice_filter
+      {
+        type: :search,
+        heading: 'Provider application ID',
+        value: applied_filters[:application_choice_id],
+        name: 'application_choice_id',
       }
     end
 

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -67,6 +67,7 @@ module SupportInterface
     def search_by_application_choice_filter
       {
         type: :search,
+        css_classes: 'govuk-input--width-5',
         heading: 'Provider application ID',
         value: applied_filters[:application_choice_id],
         name: 'application_choice_id',

--- a/app/models/support_interface/candidates_filter.rb
+++ b/app/models/support_interface/candidates_filter.rb
@@ -14,6 +14,12 @@ module SupportInterface
           value: applied_filters[:q],
           name: 'q',
         },
+        {
+          type: :search,
+          heading: 'Candidate ID',
+          value: applied_filters[:candidate_number],
+          name: 'candidate_number',
+        },
       ]
     end
   end

--- a/app/models/support_interface/candidates_filter.rb
+++ b/app/models/support_interface/candidates_filter.rb
@@ -16,6 +16,7 @@ module SupportInterface
         },
         {
           type: :search,
+          css_classes: 'govuk-input--width-5',
           heading: 'Candidate ID',
           value: applied_filters[:candidate_number],
           name: 'candidate_number',

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature 'See applications' do
     and_i_visit_the_support_page
     then_i_should_see_the_latest_applications
 
+    when_i_search_by_application_choice_id
+    then_i_see_only_the_associated_application
+    and_i_clear_filters
+
     when_i_search_for_an_application
     then_i_see_only_that_application
 
@@ -21,9 +25,9 @@ RSpec.feature 'See applications' do
   end
 
   def and_there_are_applications_in_the_system
-    @completed_application = create(:completed_application_form)
-    @unsubmitted_application = create(:application_form)
-    @application_with_reference = create(:completed_application_form)
+    @completed_application = create(:completed_application_form, first_name: 'Bill', last_name: 'Nugent')
+    @unsubmitted_application = create(:application_form, first_name: 'Calpurnia', last_name: 'Salazar')
+    @application_with_reference = create(:completed_application_form, first_name: 'Forrest', last_name: 'Cronenberg', application_choices_count: 1)
   end
 
   def and_i_visit_the_support_page
@@ -34,6 +38,21 @@ RSpec.feature 'See applications' do
     expect(page).to have_content @completed_application.full_name
     expect(page).to have_content @application_with_reference.full_name
     expect(page).to have_content @unsubmitted_application.full_name
+  end
+
+  def when_i_search_by_application_choice_id
+    fill_in :application_choice_id, with: @application_with_reference.application_choices.first.id
+    click_on 'Apply filters'
+  end
+
+  def then_i_see_only_the_associated_application
+    expect(page).to have_content @application_with_reference.full_name
+    expect(page).not_to have_content @unsubmitted_application.full_name
+    expect(page).not_to have_content @completed_application.full_name
+  end
+
+  def and_i_clear_filters
+    click_on 'Clear'
   end
 
   def when_i_search_for_an_application

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -16,6 +16,10 @@ RSpec.feature 'See applications' do
     when_i_search_for_an_application
     then_i_see_only_that_application
 
+    when_my_search_returns_nothing
+    then_i_see_a_message_saying_there_are_no_applications
+    and_i_clear_filters
+
     when_i_follow_the_link_to_applications
     then_i_should_see_the_application_references
   end
@@ -64,6 +68,15 @@ RSpec.feature 'See applications' do
     expect(page).to have_content @completed_application.candidate.email_address
     expect(page).not_to have_content @application_with_reference.candidate.email_address
     expect(page).not_to have_content @unsubmitted_application.candidate.email_address
+  end
+
+  def when_my_search_returns_nothing
+    fill_in :q, with: 'STRING THAT WILL NEVER MATCH'
+    click_on 'Apply filters'
+  end
+
+  def then_i_see_a_message_saying_there_are_no_applications
+    expect(page).to have_content 'No applications found'
   end
 
   def when_i_follow_the_link_to_applications

--- a/spec/system/support_interface/see_candidates_spec.rb
+++ b/spec/system/support_interface/see_candidates_spec.rb
@@ -11,6 +11,11 @@ RSpec.feature 'See candidates' do
 
     when_i_search_for_a_candidate
     then_i_see_that_candidate
+    and_i_clear_filters
+
+    when_i_search_for_a_candidate_by_id_from_a_vendor
+    then_i_see_that_candidate_too
+    and_i_clear_filters
 
     when_i_click_on_a_candidate_with_no_applications
     then_i_see_the_candidate_details
@@ -51,9 +56,22 @@ RSpec.feature 'See candidates' do
     click_on 'Apply filters'
   end
 
+  def when_i_search_for_a_candidate_by_id_from_a_vendor
+    fill_in :candidate_number, with: "C#{@candidate_with_a_submitted_application.id}"
+    click_on 'Apply filters'
+  end
+
   def then_i_see_that_candidate
     expect(page).to have_content('Never signed in')
     expect(page).not_to have_content('Sign up email bounced')
+  end
+
+  def then_i_see_that_candidate_too
+    expect(page).to have_content(@candidate_with_a_submitted_application.email_address)
+  end
+
+  def and_i_clear_filters
+    click_on 'Clear'
   end
 
   def when_i_click_on_a_candidate_with_no_applications

--- a/spec/system/support_interface/see_candidates_spec.rb
+++ b/spec/system/support_interface/see_candidates_spec.rb
@@ -17,6 +17,10 @@ RSpec.feature 'See candidates' do
     then_i_see_that_candidate_too
     and_i_clear_filters
 
+    when_my_search_returns_nothing
+    then_i_see_a_message_saying_there_are_no_applications
+    and_i_clear_filters
+
     when_i_click_on_a_candidate_with_no_applications
     then_i_see_the_candidate_details
 
@@ -72,6 +76,15 @@ RSpec.feature 'See candidates' do
 
   def and_i_clear_filters
     click_on 'Clear'
+  end
+
+  def when_my_search_returns_nothing
+    fill_in :q, with: 'NOT A REAL EMAIL'
+    click_on 'Apply filters'
+  end
+
+  def then_i_see_a_message_saying_there_are_no_applications
+    expect(page).to have_content('No candidates found')
   end
 
   def when_i_click_on_a_candidate_with_no_applications


### PR DESCRIPTION
## Context

It's long been a bit weird that you can't get directly to an application choice in support seeing as providers who contact us deal exclusively in application choice IDs.

It's also a bit weird that we send vendors candidate IDs in the form `CXXX` eg `C123` with no way to trace those back to applications except by hacking the `support/candidates/:id` URL.

It's *also* a shame we don't have an empty state for the support applications list. When the filters return nothing, we show a blank list instead of a message.

## Changes proposed in this pull request

Fix all of the above.

### Search by application choice ID

"Provider application ID" because it's what providers use.

<img width="1061" alt="Screenshot 2020-11-25 at 22 56 09" src="https://user-images.githubusercontent.com/642279/100289791-a15d7a80-2f71-11eb-9fe1-a5777fcf3d48.png">

### Search by candidate ID

This input treats `C123` and `123` the same

<img width="1048" alt="Screenshot 2020-11-25 at 22 55 22" src="https://user-images.githubusercontent.com/642279/100289811-b33f1d80-2f71-11eb-931a-9cb16acbe233.png">

### Empty state

<img width="1071" alt="Screenshot 2020-11-25 at 22 55 42" src="https://user-images.githubusercontent.com/642279/100289830-bfc37600-2f71-11eb-8a39-69d00a4296a0.png">

## Guidance to review

Code hopefully straightforward. Any improvement on field names?

## Link to Trello card

N/A, memories of support

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
