### PR TITLE
Service to measure average distances

### DIFF
--- a/app/services/candidate_interface/measure_distances.rb
+++ b/app/services/candidate_interface/measure_distances.rb
@@ -3,15 +3,14 @@ module CandidateInterface
     def average_distance(start, destinations)
       return nil unless has_coordinates?(start)
 
-      distances = destinations.map do |destination|
-        distance(start, destination)
-      end.compact
+      distances = destinations.map { |destination| distance(start, destination) }.compact
       return nil if distances.blank?
 
       distances.sum(0.0) / distances.size
     end
 
   private
+
     def distance(from, to)
       return nil unless has_coordinates?(from) && has_coordinates?(to)
 

--- a/app/services/candidate_interface/measure_distances.rb
+++ b/app/services/candidate_interface/measure_distances.rb
@@ -1,0 +1,28 @@
+module CandidateInterface
+  class MeasureDistances
+    def average_distance(start, destinations)
+      return nil unless has_coordinates?(start)
+
+      distances = destinations.map do |destination|
+        distance(start, destination)
+      end.compact
+      return nil if distances.blank?
+
+      distances.sum(0.0) / distances.size
+    end
+
+  private
+    def distance(from, to)
+      return nil unless has_coordinates?(from) && has_coordinates?(to)
+
+      Geocoder::Calculations.distance_between(
+        [from.latitude, from.longitude],
+        [to.latitude, to.longitude],
+      )
+    end
+
+    def has_coordinates?(model)
+      !model.latitude.nil? && !model.longitude.nil?
+    end
+  end
+end

--- a/spec/services/candidate_interface/measure_distances_spec.rb
+++ b/spec/services/candidate_interface/measure_distances_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::MeasureDistances do
+  describe '#average_distance' do
+    it 'returns correct average given multiple destinations' do
+      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      destinations = [
+        instance_double(Site, latitude: 51.6097184, longitude: -1.2482939),
+        instance_double(Site, latitude: 51.6072222, longitude: -1.2407998),
+        instance_double(Site, latitude: 51.605683, longitude: -1.2252001),
+      ]
+      expect(described_class.new.average_distance(start, destinations)).to be_within(0.1).of(2.6)
+    end
+
+    it 'handles nil lat/lng values for `start` model' do
+      start = instance_double(ApplicationForm, latitude: nil, longitude: nil)
+      destinations = [
+        instance_double(Site, latitude: 51.6097184, longitude: -1.2482939),
+      ]
+      expect(described_class.new.average_distance(start, destinations)).to be_nil
+    end
+
+    it 'handles nil lat/lng values for all of the `destinations`' do
+      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      destinations = [
+        instance_double(Site, latitude: nil, longitude: nil),
+        instance_double(Site, latitude: nil, longitude: nil),
+      ]
+      expect(described_class.new.average_distance(start, destinations)).to be_nil
+    end
+
+    it 'handles nil lat/lng values for some of the `destinations`' do
+      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      destinations = [
+        instance_double(Site, latitude: nil, longitude: nil),
+        instance_double(Site, latitude: 51.6072222, longitude: -1.2407998),
+        instance_double(Site, latitude: 51.605683, longitude: -1.2252001),
+      ]
+      expect(described_class.new.average_distance(start, destinations)).to be_within(0.1).of(2.8)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We've been asked to build two data exports. One that measures the distance between candidates and their selected choice and one that measures the distance between Provider's main site and other sites.

## Changes proposed in this pull request

Because `Candidate`, `Provider` and `Site` all have the same location interface (`latitude` and `longitude` methods) this can be done with a service that takes a `start` model and an array of `destinations`. `start` and `destinations` can be any combination of `Candidate`, `Provider` or `Site`.

- [x] Create a new `MeasureDistances` service with an `average_distance` method.

I've added average distances for provider - sites and candidate - choices in the support interface in a follow-up PR https://github.com/DFE-Digital/apply-for-teacher-training/pull/3530.

## Guidance to review

- use the `geocoder` gem that we already using in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3510 (needs rebasing after that PR merges). The calculation is done based on an established algorithm using the given coordinates (it doesn't depend on any external APIs).
- can you think of a better name for this service?
- should we expose the average distance of candidate address to course choices and provider main site to other sites in the support interface to make it easier to check?

## Link to Trello card

https://trello.com/c/FObU2tvZ/2576-dev-create-a-service-which-measures-the-average-distance-between-one-coordinate-and-a-group-of-coordinates

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
