### PR TITLE
Fix bug with withdrawal feedback page not rendering

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -67,7 +67,7 @@ module CandidateInterface
         @provider = @application_choice.provider
         @course = @application_choice.course
 
-        render :feedback
+        render :withdrawal_feedback
       end
     end
 

--- a/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
+++ b/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
@@ -1,25 +1,23 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.decisions.withdrawal_feedback'),  @withdrawal_feedback_form.errors.any?) %>
 
-<div class="govuk-grid-row">
-    <%= form_with(
-      model: @withdrawal_feedback_form,
-      url: candidate_interface_confirm_withdrawal_feedback_path
-    ) do |f| %>
-    <%= f.govuk_error_summary %>
+<%= form_with(
+  model: @withdrawal_feedback_form,
+  url: candidate_interface_confirm_withdrawal_feedback_path
+) do |f| %>
+  <%= f.govuk_error_summary %>
 
-    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
+  <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
+    <h1 class="govuk-panel__title">
+      <%= t('page_titles.decisions.withdrawal_feedback') %>
+    </h1>
 
-      <h1 class="govuk-panel__title">
-        <%= t('page_titles.decisions.withdrawal_feedback') %>
-      </h1>
-
-      <div class="govuk-panel__body">
-        We will let <%= @provider.name %> know that you have withdrawn your application for <%= @course.name_and_code %>
-      </div>
+    <div class="govuk-panel__body">
+      We will let <%= @provider.name %> know that you have withdrawn your application for <%= @course.name_and_code %>
     </div>
+  </div>
 
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      
       <%= f.govuk_radio_buttons_fieldset :withdrawal_reason, legend: { text: CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION } do %>
         <%= f.govuk_radio_button :feedback, 'yes', link_errors: true, label: { text: t('decisions.withdrawal_feedback.feedback.yes.label') } do %>
           <%= f.govuk_text_area :explanation, label: { text: t('decisions.withdrawal_feedback.explanation.label') }, hint: { text: t('decisions.withdrawal_feedback.explanation.hint') } %>
@@ -35,6 +33,6 @@
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
+++ b/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
@@ -1,32 +1,34 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.decisions.withdrawal_feedback'),  @withdrawal_feedback_form.errors.any?) %>
 
-<div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
-  <h1 class="govuk-panel__title">
-    <%= t('page_titles.decisions.withdrawal_feedback') %>
-  </h1>
-
-  <div class="govuk-panel__body">
-    We will let <%= @provider.name %> know that you have withdrawn your application for <%= @course.name_and_code %>
-  </div>
-</div>
-
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @withdrawal_feedback_form,
       url: candidate_interface_confirm_withdrawal_feedback_path
     ) do |f| %>
     <%= f.govuk_error_summary %>
 
+    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
+
+      <h1 class="govuk-panel__title">
+        <%= t('page_titles.decisions.withdrawal_feedback') %>
+      </h1>
+
+      <div class="govuk-panel__body">
+        We will let <%= @provider.name %> know that you have withdrawn your application for <%= @course.name_and_code %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      
       <%= f.govuk_radio_buttons_fieldset :withdrawal_reason, legend: { text: CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION } do %>
-        <%= f.govuk_radio_button :feedback, 'yes', label: { text: t('decisions.withdrawal_feedback.feedback.yes.label') } do %>
+        <%= f.govuk_radio_button :feedback, 'yes', link_errors: true, label: { text: t('decisions.withdrawal_feedback.feedback.yes.label') } do %>
           <%= f.govuk_text_area :explanation, label: { text: t('decisions.withdrawal_feedback.explanation.label') }, hint: { text: t('decisions.withdrawal_feedback.explanation.hint') } %>
         <% end %>
         <%= f.govuk_radio_button :feedback, 'no', label: { text: t('decisions.withdrawal_feedback.feedback.no.label') } %>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :can_be_contacted, legend: { text: CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION }, hint: { text: t('decisions.withdrawal_feedback.can_be_contacted.hint') } do %>
-        <%= f.govuk_radio_button :consent_to_be_contacted, 'yes', label: { text: t('decisions.withdrawal_feedback.consent_to_be_contacted.yes.label') } do %>
+        <%= f.govuk_radio_button :consent_to_be_contacted,'yes', link_errors: true, label: { text: t('decisions.withdrawal_feedback.consent_to_be_contacted.yes.label') } do %>
           <%= f.govuk_text_area :contact_details, label: { text: t('decisions.withdrawal_feedback.contact_details.label') } %>
         <% end %>
         <%= f.govuk_radio_button :consent_to_be_contacted, 'no', label: { text: t('decisions.withdrawal_feedback.consent_to_be_contacted.no.label') } %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -995,6 +995,12 @@ en:
               blank: Issues cannot blank
             consent_to_be_contacted:
               blank: Can we contact you about your feedback?
+        candidate_interface/withdrawal_feedback_form:
+          attributes:
+            feedback:
+              blank: Will you give a reason for withdrawing your course choice?
+            consent_to_be_contacted:
+              blank: Can we contact you about your feedback?
         referee_interface/reference_relationship_form:
           attributes:
             relationship_confirmation:

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_withdraws_spec.rb
@@ -29,6 +29,10 @@ RSpec.feature 'A candidate withdraws her application' do
     and_a_slack_notification_is_sent
     and_the_provider_has_received_an_email
 
+    when_i_submit_the_questionnaire_without_choosing_options
+    then_i_am_told_i_need_to_choose_whether_i_want_to_provide_feedback
+    and_i_am_asked_if_i_can_be_contacted_about_my_feeedback
+
     when_i_fill_in_my_feedback
     and_i_click_continue
     then_i_see_my_application_dashboard
@@ -105,6 +109,18 @@ RSpec.feature 'A candidate withdraws her application' do
   def and_the_provider_has_received_an_email
     open_email(@provider_user.email_address)
     expect(current_email.subject).to have_content "#{@application_choice.application_form.full_name} (#{@application_choice.application_form.support_reference}) withdrew their application"
+  end
+
+  def when_i_submit_the_questionnaire_without_choosing_options
+    click_button 'Continue'
+  end
+
+  def then_i_am_told_i_need_to_choose_whether_i_want_to_provide_feedback
+    expect(page).to have_content 'Will you give a reason for withdrawing your course choice?'
+  end
+
+  def and_i_am_asked_if_i_can_be_contacted_about_my_feeedback
+    expect(page).to have_content 'Can we contact you about your feedback?'
   end
 
   def when_i_fill_in_my_feedback


### PR DESCRIPTION
## Context

If a candidate chooses not to provide any withdrawal feedback then they get an error, as the view being called to render doesn't exist.

## Changes proposed in this pull request

- Call the correct view in the controller action
- Display the correct error messages 
- Link errors correctly 
- Add a test

![image](https://user-images.githubusercontent.com/42515961/100338138-1eb7d800-2fd0-11eb-9f83-74ef90a2c78c.png)

## Link to Trello card

https://trello.com/c/ka7QcU1A/2586-rails-error-shown-if-submit-withdrawal-feedback-form-without-answering-any-questions-template-is-missing


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
