### PR TITLE
Let candidates proceed if they decide not to add another job

### DIFF
--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -14,18 +14,20 @@ module CandidateInterface
                                   start_date_year: start_date.year,
                                   end_date_month: end_date&.month || '',
                                   end_date_year: end_date&.year || '',
-                                  add_another_job: true,
+                                  add_another_job: 'no',
                                 )
                               else
-                                WorkExperienceForm.new(add_another_job: true)
+                                WorkExperienceForm.new(add_another_job: 'no')
                               end
     end
 
     def create
       @work_experience_form = WorkExperienceForm.new(work_experience_form_params)
 
-      if @work_experience_form.save(current_application)
-        if @work_experience_form.add_another_job == 'true'
+      if @work_experience_form.blank_form?
+        redirect_to candidate_interface_work_history_show_path
+      elsif @work_experience_form.save(current_application)
+        if @work_experience_form.add_another_job == 'yes'
           redirect_to candidate_interface_new_work_history_path
         else
           redirect_to candidate_interface_work_history_show_path
@@ -41,7 +43,7 @@ module CandidateInterface
       work_experience = current_application
         .application_work_experiences.find(work_experience_params[:id])
       @work_experience_form = WorkExperienceForm.build_from_experience(work_experience)
-      @work_experience_form.add_another_job = false
+      @work_experience_form.add_another_job = 'no'
     end
 
     def update

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -82,6 +82,8 @@ module CandidateInterface
       elsif qualification_type == OtherQualificationTypeForm::OTHER_TYPE
         self.other_uk_qualification_type ||= qualifications[-1].other_uk_qualification_type
       end
+
+      self.choice = 'no'
     end
 
     def qualification_type_name

--- a/app/forms/candidate_interface/work_experience_form.rb
+++ b/app/forms/candidate_interface/work_experience_form.rb
@@ -73,6 +73,14 @@ module CandidateInterface
       )
     end
 
+    def blank_form?
+      [
+        role, organisation, details, working_with_children, commitment,
+        working_pattern, start_date_day, start_date_month, start_date_year,
+        end_date_day, end_date_month, end_date_year
+      ].all?(&:blank?)
+    end
+
     def start_date
       valid_or_invalid_date(start_date_year, start_date_month)
     end

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -17,11 +17,9 @@
 
       <%= render 'form', f: f %>
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
       <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
-        <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>
-        <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, not at the moment' } %>
+        <%= f.govuk_radio_button :do_not_add_another_job, false, label: { text: 'Yes, I want to add another job' } %>
+        <%= f.govuk_radio_button :do_not_add_another_job, true, label: { text: 'No, not at the moment' } %>
       <% end %>
 
       <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -18,8 +18,8 @@
       <%= render 'form', f: f %>
 
       <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
-        <%= f.govuk_radio_button :do_not_add_another_job, false, label: { text: 'Yes, I want to add another job' } %>
-        <%= f.govuk_radio_button :do_not_add_another_job, true, label: { text: 'No, not at the moment' } %>
+        <%= f.govuk_radio_button :add_another_job, 'yes',  label: { text: 'Yes, I want to add another job' } %>
+        <%= f.govuk_radio_button :add_another_job, 'no', label: { text: 'No, not at the moment' } %>
       <% end %>
 
       <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -206,6 +206,94 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     end
   end
 
+  describe '#initialize_from_last_qualification' do
+    it 'sets choice' do
+      qualification = build_stubbed(
+        :application_qualification,
+      )
+
+      last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+        nil,
+        nil,
+      )
+
+      last_qualification.initialize_from_last_qualification([qualification])
+
+      expect(last_qualification.choice).to eq('no')
+    end
+
+    context 'blank qualifications' do
+      it 'returns nil' do
+        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new
+        expect(last_qualification.initialize_from_last_qualification([])).to be_nil
+      end
+    end
+
+    context 'previous qualification is same type' do
+      it 'sets institution_country and award_year' do
+        qualification_type = 'foo'
+
+        qualification = build_stubbed(
+          :application_qualification,
+          qualification_type: qualification_type,
+        )
+
+        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+          nil,
+          nil,
+          qualification_type: qualification_type,
+        )
+
+        last_qualification.initialize_from_last_qualification([qualification])
+
+        expect(last_qualification.institution_country).to eq(qualification.institution_country)
+        expect(last_qualification.award_year).to eq(qualification.award_year)
+      end
+    end
+
+    context 'qualification is non-uk' do
+      it 'sets non_uk_qualification_type' do
+        non_uk = 'non_uk'
+
+        qualification = build_stubbed(
+          :application_qualification,
+          qualification_type: non_uk,
+        )
+
+        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+          nil,
+          nil,
+          qualification_type: 'foo',
+        )
+
+        last_qualification.initialize_from_last_qualification([qualification])
+
+        expect(last_qualification.non_uk_qualification_type).to eq(qualification.non_uk_qualification_type)
+      end
+    end
+
+    context 'qualification is other' do
+      it 'sets other_uk_qualification_type' do
+        other = 'Other'
+
+        qualification = build_stubbed(
+          :application_qualification,
+          qualification_type: 'foo',
+        )
+
+        last_qualification = CandidateInterface::OtherQualificationDetailsForm.new(
+          nil,
+          nil,
+          qualification_type: other,
+        )
+
+        last_qualification.initialize_from_last_qualification([qualification])
+
+        expect(last_qualification.other_uk_qualification_type).to eq(qualification.other_uk_qualification_type)
+      end
+    end
+  end
+
   describe '#title' do
     context 'for a non-uk qualification' do
       it 'concatenates the non_uk_qualification_type and subject' do

--- a/spec/system/candidate_interface/entering_details/candidate_entering_blank_work_history_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_blank_work_history_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their work history' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their work history' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_work_history
+    then_i_should_see_a_list_of_work_lengths
+
+    when_i_choose_complete
+    then_i_should_see_the_job_form
+
+    when_i_leave_all_fields_blank_and_submit
+    then_i_should_be_redirected_to_work_history
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_work_history
+    click_link t('page_titles.work_history')
+  end
+
+  def then_i_should_see_a_list_of_work_lengths
+    expect(page).to have_content(t('application_form.work_history.complete.label'))
+  end
+
+  def when_i_choose_complete
+    choose t('application_form.work_history.complete.label')
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_the_job_form
+    expect(page).to have_content(t('page_titles.add_job'))
+  end
+
+  def when_i_leave_all_fields_blank_and_submit
+    click_button t('application_form.work_history.complete_form_button')
+  end
+
+  def then_i_should_be_redirected_to_work_history
+    expect(page).to have_content(t('page_titles.work_history'))
+  end
+end


### PR DESCRIPTION
## Context

Currently, if you add a job, choose to add another, but then change your mind, options for exiting out of this state are non-optimal.

## Changes proposed in this pull request

- Redirect to work history review page if candidate submits blank form
- ‘Add another job’ radio now defaults to false
- Horizontal line removed in new job form
- Adding another qualification radio button defaults to 'no'

## Guidance to review

- Create a job then choose to add another. When you submit the form (keeping all fields blank) you should be redirected back to the Work Experience review page.
- When adding another ‘Academic and other relevant qualification’ the ‘Do you want to add another qualification?’ radio button selection should now defaults to 'No, not at the moment' 

## Link to Trello card

https://trello.com/c/wbUacSal/1974-let-candidates-proceed-if-decide-not-to-add-another-qualification-or-job

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
