### PR TITLE
Add task to backfill geocoding of candidate addresses

### DIFF
--- a/lib/tasks/geocode.rake
+++ b/lib/tasks/geocode.rake
@@ -1,8 +1,15 @@
 namespace :geocode do
   desc 'Geocode candidate addresses'
   task candidate_addresses: :environment do
+    number_of_threads = 10
+    db_connection_pool_size = number_of_threads + 1
+
     if Geocoder.config.api_key.blank?
       raise 'You need to set a GOOGLE_MAPS_API_KEY'
+    end
+
+    if ENV['RAILS_MAX_THREADS'].to_i < db_connection_pool_size
+      raise "Set a connection pool size of at least #{db_connection_pool_size} by setting the RAILS_MAX_THREADS env var"
     end
 
     Benchmark.bm do |x|

--- a/lib/tasks/geocode.rake
+++ b/lib/tasks/geocode.rake
@@ -1,0 +1,25 @@
+namespace :geocode do
+  desc 'Geocode candidate addresses'
+  task candidate_addresses: :environment do
+    if Geocoder.config.api_key.blank?
+      raise 'You need to set a GOOGLE_MAPS_API_KEY'
+    end
+
+    Benchmark.bm do |x|
+      x.report do
+        ApplicationForm.where.not(address_line1: nil).find_in_batches do |application_batch|
+          application_batch.each_slice(10) do |slice|
+            threads = slice.map do |application|
+              Thread.new do
+                application.latitude, application.longitude = application.geocode
+                application.save!
+              end
+            end
+            threads.each(&:join)
+            sleep(0.25)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to analyse distances between candidates and the sites they choose to train at to improve location-related functionality in the service.

Building on https://github.com/DFE-Digital/apply-for-teacher-training/pull/3510, this change deals with back-filling address coordinates for existing application forms.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
A rake task which:

- Retrieves application forms with addresses present, in batches of 1000
- Concurrently geocodes 10 at a time
- Sleeps for 0.25s between each set of 10


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Geocoding API request limit appears to be 50 requests per second (source: https://developers.google.com/maps/documentation/geocoding/usage-and-billing)
- I've used threads to speed this up a bit. I'm thinking here that 10 concurrent requests with a 0.25s sleep between each slice of ten should mean we stay under the 50 rps limit. Does that sound about right?
- I've run this locally and checked a sample of the coordinates with Google Maps. Coordinates appear to be consistent with addresses.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/6A8t8vVY
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
