### PR TITLE
Locations export: Return nil for award year and qualification type is there is no degree

### DIFF
--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -39,11 +39,11 @@ module SupportInterface
     end
 
     def return_lastest_degree_type(application_form)
-      latest_degree(application_form).qualification_type
+      latest_degree(application_form)&.qualification_type
     end
 
     def return_lastest_degree_award_year(application_form)
-      latest_degree(application_form).award_year
+      latest_degree(application_form)&.award_year
     end
 
     def latest_degree(application_form)


### PR DESCRIPTION
## Context

I just shipped a bug in the export where it breaks when returning award year if no degree is found on an application form


## Changes proposed in this pull request

- Return nil for the column's if there is no degree.

## Link to Trello card

https://trello.com/c/yeZRKLYE/2530-dev-locations-persona-data

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
