### PR TITLE
Don't return dob if not filled in

### DIFF
--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -31,7 +31,7 @@ module SupportInterface
     end
 
     def return_age(application_form)
-      ((Time.zone.now.to_date - application_form.date_of_birth) / 365).floor
+      ((Time.zone.now.to_date - application_form.date_of_birth) / 365).floor if application_form.date_of_birth.present?
     end
 
     def application_state(application_form)


### PR DESCRIPTION
## Context

Another bug 🤦 

## Changes proposed in this pull request

Don't run age related logic if no d.o.b. if present

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yeZRKLYE/2530-dev-locations-persona-data

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
