### PR TITLE
Fix provider permissions list component

### DIFF
--- a/app/components/associated_providers_permissions_list_component.html.erb
+++ b/app/components/associated_providers_permissions_list_component.html.erb
@@ -1,49 +1,49 @@
-<% if training_providers_that_can(permission_name).any? %>
+<% if training_providers_for_which_this_provider_can(permission_name).any? %>
   <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
     <p class="govuk-body govuk-!-margin-bottom-1">
       Applies to courses run by:
     </p>
     <ul class="govuk-list">
-      <% training_providers_that_can(permission_name).each do |provider| %>
+      <% training_providers_for_which_this_provider_can(permission_name).each do |provider| %>
         <li><%= render IconComponent.new(type: 'check') %> <%= provider.name %></li>
       <% end %>
     </ul>
   </div>
 <% end %>
 
-<% if training_providers_that_cannot(permission_name).any? %>
+<% if training_providers_for_which_this_provider_cannot(permission_name).any? %>
   <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
     <p class="govuk-body govuk-!-margin-bottom-1">
       Does not apply to courses run by:
     </p>
     <ul class="govuk-list">
-      <% training_providers_that_cannot(permission_name).each do |provider| %>
+      <% training_providers_for_which_this_provider_cannot(permission_name).each do |provider| %>
         <li><%= render IconComponent.new(type: 'cross') %> <%= provider.name %></li>
       <% end %>
     </ul>
   </div>
 <% end %>
 
-<% if ratifying_providers_that_can(permission_name).any? %>
+<% if ratifying_providers_for_which_this_provider_can(permission_name).any? %>
   <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
     <p class="govuk-body govuk-!-margin-bottom-1">
       Applies to courses ratified by:
     </p>
     <ul class="govuk-list">
-      <% ratifying_providers_that_can(permission_name).each do |provider| %>
+      <% ratifying_providers_for_which_this_provider_can(permission_name).each do |provider| %>
         <li><%= render IconComponent.new(type: 'check') %> <%= provider.name %></li>
       <% end %>
     </ul>
   </div>
 <% end %>
 
-<% if ratifying_providers_that_cannot(permission_name).any? %>
+<% if ratifying_providers_for_which_this_provider_cannot(permission_name).any? %>
   <div class="govuk-!-margin-left-5 govuk-!-margin-top-2">
     <p class="govuk-body govuk-!-margin-bottom-1">
       Does not apply to courses ratified by:
     </p>
     <ul class="govuk-list">
-      <% ratifying_providers_that_cannot(permission_name).each do |provider| %>
+      <% ratifying_providers_for_which_this_provider_cannot(permission_name).each do |provider| %>
         <li><%= render IconComponent.new(type: 'cross') %> <%= provider.name %></li>
       <% end %>
     </ul>

--- a/app/components/associated_providers_permissions_list_component.rb
+++ b/app/components/associated_providers_permissions_list_component.rb
@@ -13,9 +13,7 @@ class AssociatedProvidersPermissionsListComponent < ViewComponent::Base
   end
 
   def training_providers_that_cannot(permission_name)
-    @provider.ratifying_provider_permissions.map { |permission_relationship|
-      permission_relationship.training_provider unless permission_relationship.send("training_provider_can_#{permission_name}?")
-    }.compact
+    @provider.ratifying_provider_permissions.map(&:training_provider) - training_providers_that_can(permission_name)
   end
 
   def ratifying_providers_that_can(permission_name)
@@ -25,8 +23,6 @@ class AssociatedProvidersPermissionsListComponent < ViewComponent::Base
   end
 
   def ratifying_providers_that_cannot(permission_name)
-    @provider.training_provider_permissions.map { |permission_relationship|
-      permission_relationship.ratifying_provider unless permission_relationship.send("ratifying_provider_can_#{permission_name}?")
-    }.compact
+    @provider.training_provider_permissions.map(&:ratifying_provider) - ratifying_providers_that_can(permission_name)
   end
 end

--- a/app/components/associated_providers_permissions_list_component.rb
+++ b/app/components/associated_providers_permissions_list_component.rb
@@ -6,23 +6,23 @@ class AssociatedProvidersPermissionsListComponent < ViewComponent::Base
     @permission_name = permission_name
   end
 
-  def training_providers_that_can(permission_name)
-    @provider.ratifying_provider_permissions.map { |permission_relationship|
-      permission_relationship.training_provider if permission_relationship.send("training_provider_can_#{permission_name}?")
+  def training_providers_for_which_this_provider_can(permission_name)
+    @_training_providers_for_which_this_provider_can ||= @provider.ratifying_provider_permissions.map { |permission_relationship|
+      permission_relationship.training_provider if permission_relationship.send("ratifying_provider_can_#{permission_name}?")
     }.compact
   end
 
-  def training_providers_that_cannot(permission_name)
-    @provider.ratifying_provider_permissions.map(&:training_provider) - training_providers_that_can(permission_name)
+  def training_providers_for_which_this_provider_cannot(permission_name)
+    @_training_providers_for_which_this_provider_cannot ||= @provider.ratifying_provider_permissions.map(&:training_provider) - training_providers_for_which_this_provider_can(permission_name)
   end
 
-  def ratifying_providers_that_can(permission_name)
-    @provider.training_provider_permissions.map { |permission_relationship|
-      permission_relationship.ratifying_provider if permission_relationship.send("ratifying_provider_can_#{permission_name}?")
+  def ratifying_providers_for_which_this_provider_can(permission_name)
+    @_ratifying_providers_for_which_this_provider_can ||= @provider.training_provider_permissions.map { |permission_relationship|
+      permission_relationship.ratifying_provider if permission_relationship.send("training_provider_can_#{permission_name}?")
     }.compact
   end
 
-  def ratifying_providers_that_cannot(permission_name)
-    @provider.training_provider_permissions.map(&:ratifying_provider) - ratifying_providers_that_can(permission_name)
+  def ratifying_providers_for_which_this_provider_cannot(permission_name)
+    @_ratifying_providers_for_which_this_provider_cannot ||= @provider.training_provider_permissions.map(&:ratifying_provider) - ratifying_providers_for_which_this_provider_can(permission_name)
   end
 end

--- a/spec/components/associated_providers_permissions_list_component_spec.rb
+++ b/spec/components/associated_providers_permissions_list_component_spec.rb
@@ -3,76 +3,72 @@ require 'rails_helper'
 RSpec.describe AssociatedProvidersPermissionsListComponent do
   let(:ratifying_provider) { create(:provider) }
   let(:training_provider) { create(:provider) }
-  let(:provider_relationship_permissions) do
-    create(:provider_relationship_permissions,
-           ratifying_provider: ratifying_provider,
-           training_provider: training_provider,
-           training_provider_can_make_decisions: true,
-           ratifying_provider_can_make_decisions: true)
+
+  context 'when viewing as a training provider' do
+    it 'renders which ratifying providers the permission applies to' do
+      create_provider_relationship_permissions
+
+      result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
+
+      expect(result.text).to include('Applies to courses ratified by:')
+      expect(result.css('li').text).to include(ratifying_provider.name.to_s)
+    end
+
+    it 'renders which ratifying providers the permission does not apply to' do
+      create_provider_relationship_permissions.update!(training_provider_can_make_decisions: false)
+
+      result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
+
+      expect(result.text).to include('Does not apply to courses ratified by:')
+      expect(result.css('li').text).to include(ratifying_provider.name.to_s)
+    end
+
+    it 'does not change based on what the ratifying provider can do' do
+      create_provider_relationship_permissions.update!(ratifying_provider_can_make_decisions: false)
+
+      result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
+
+      expect(result.text).to include('Applies to courses ratified by:')
+      expect(result.css('li').text).to include(ratifying_provider.name.to_s)
+    end
   end
 
-  it 'renders ratifying providers the permission also applies to' do
-    create(:provider_permissions,
-           provider: training_provider,
-           make_decisions: true)
-    provider_relationship_permissions
-    result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
+  context 'when viewing as a ratifying provider' do
+    it 'renders which training providers the permission applies to' do
+      create_provider_relationship_permissions
 
-    expect(result.text).to include('Applies to courses ratified by:')
-    expect(result.css('li').text).to include(ratifying_provider.name.to_s)
+      result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
+
+      expect(result.text).to include('Applies to courses run by:')
+      expect(result.css('li').text).to include(training_provider.name.to_s)
+    end
+
+    it 'renders which training providers the permission does not apply to' do
+      create_provider_relationship_permissions.update!(ratifying_provider_can_make_decisions: false)
+
+      result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
+
+      expect(result.text).to include('Does not apply to courses run by:')
+      expect(result.css('li').text).to include(training_provider.name.to_s)
+    end
+
+    it 'does not change based on what the training provider can do' do
+      create_provider_relationship_permissions.update!(training_provider_can_make_decisions: false)
+
+      result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
+
+      expect(result.text).to include('Applies to courses run by:')
+      expect(result.css('li').text).to include(training_provider.name.to_s)
+    end
   end
 
-  it 'renders training providers the permission also applies to' do
-    create(:provider_permissions,
-           provider: ratifying_provider,
-           make_decisions: true)
-    provider_relationship_permissions
-    result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
-
-    expect(result.text).to include('Applies to courses run by:')
-    expect(result.css('li').text).to include(training_provider.name.to_s)
-  end
-
-  it 'renders ratifying providers the permission does not apply to' do
-    create(:provider_permissions,
-           provider: training_provider,
-           make_decisions: false)
-    provider_relationship_permissions.update(training_provider_can_make_decisions: true, ratifying_provider_can_make_decisions: false)
-    result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
-
-    expect(result.text).to include('Does not apply to courses ratified by:')
-    expect(result.css('li').text).to include(ratifying_provider.name.to_s)
-  end
-
-  it 'renders training providers the permission does not apply to' do
-    create(:provider_permissions,
-           provider: ratifying_provider,
-           make_decisions: true)
-    provider_relationship_permissions.update!(training_provider_can_make_decisions: false, ratifying_provider_can_make_decisions: true)
-
-    result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
-
-    expect(result.text).to include('Does not apply to courses run by:')
-    expect(result.css('li').text).to include(training_provider.name.to_s)
-  end
-
-  it 'does not render associated training providers permissions if there are not any' do
-    create(:provider_permissions,
-           provider: training_provider,
-           make_decisions: true)
-    provider_relationship_permissions
-    result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
-
-    expect(result.text).not_to include('Applies to courses run by:')
-  end
-
-  it 'does not render associated ratifying providers permissions if there are not any' do
-    create(:provider_permissions,
-           provider: ratifying_provider,
-           make_decisions: false)
-    provider_relationship_permissions
-    result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
-
-    expect(result.text).not_to include('Applies to courses ratified by:')
+  def create_provider_relationship_permissions
+    create(
+      :provider_relationship_permissions,
+      ratifying_provider: ratifying_provider,
+      training_provider: training_provider,
+      training_provider_can_make_decisions: true,
+      ratifying_provider_can_make_decisions: true,
+    )
   end
 end

--- a/spec/components/associated_providers_permissions_list_component_spec.rb
+++ b/spec/components/associated_providers_permissions_list_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe AssociatedProvidersPermissionsListComponent do
   it 'renders ratifying providers the permission does not apply to' do
     create(:provider_permissions,
            provider: training_provider,
-           make_decisions: true)
+           make_decisions: false)
     provider_relationship_permissions.update(training_provider_can_make_decisions: true, ratifying_provider_can_make_decisions: false)
     result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
 
@@ -48,7 +48,7 @@ RSpec.describe AssociatedProvidersPermissionsListComponent do
     create(:provider_permissions,
            provider: ratifying_provider,
            make_decisions: true)
-    provider_relationship_permissions.update(training_provider_can_make_decisions: false, ratifying_provider_can_make_decisions: true)
+    provider_relationship_permissions.update!(training_provider_can_make_decisions: false, ratifying_provider_can_make_decisions: true)
 
     result = render_inline(described_class.new(provider: ratifying_provider, permission_name: 'make_decisions'))
 
@@ -59,7 +59,7 @@ RSpec.describe AssociatedProvidersPermissionsListComponent do
   it 'does not render associated training providers permissions if there are not any' do
     create(:provider_permissions,
            provider: training_provider,
-           make_decisions: false)
+           make_decisions: true)
     provider_relationship_permissions
     result = render_inline(described_class.new(provider: training_provider, permission_name: 'make_decisions'))
 


### PR DESCRIPTION
## Context
The provider permissions list component has been confusing users because it displays information in the wrong direction. 

The correct behaviour is:
For a given provider, show information about what permissions this provider has, and with which organisations. It should not care about what the other provider in the relationship can do, only that there is a relationship. 

## Changes proposed in this pull request
Switch around the check so that the correct side of permissions shows up.

Update the tests to clearly show that the component does not depend on any user permissions, and add contexts to split it up a bit.

## Guidance to review
Have a play with the review app to check the behaviour is what you'd expect

## Link to Trello card
https://trello.com/c/YBj2TDsT/3024-fix-does-not-apply-permissions-list-indicators

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
