### PR TITLE
Fix bug where max by is called on nil in the locations data export

### DIFF
--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -47,6 +47,8 @@ module SupportInterface
     end
 
     def latest_degree(application_form)
+      return nil if application_form.application_qualifications.degree.blank?
+
       application_form.application_qualifications.degree.max_by(&:award_year)
     end
   end


### PR DESCRIPTION
## Context

For some reason calling max_by on nil is breaking on qa, but does not break locally in the console.

## Changes proposed in this pull request

Have last degree return nil if no degrees are present.

## Guidance to review

Last one George i promise haha

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
