### PR TITLE
Add edit function to Support Int for candidate name

### DIFF
--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -40,6 +40,8 @@ module SupportInterface
       {
         key: 'Full name',
         value: "#{first_name} #{last_name}",
+        action: 'Change',
+        action_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }
     end
 

--- a/app/controllers/support_interface/application_forms/applicant_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/applicant_details_controller.rb
@@ -28,7 +28,7 @@ module SupportInterface
       def edit_application_params
         params.require(
           :support_interface_application_forms_edit_applicant_details_form,
-        ).permit(:phone_number, :audit_comment)
+        ).permit(:first_name, :last_name, :phone_number, :audit_comment)
       end
     end
   end

--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -3,21 +3,29 @@ module SupportInterface
     class EditApplicantDetailsForm
       include ActiveModel::Model
 
+      attr_accessor :first_name
+      attr_accessor :last_name
       attr_accessor :phone_number
       attr_accessor :audit_comment
       attr_reader :application_form
 
       validates :phone_number, presence: true, phone_number: true
+      validates :first_name, presence: true
+      validates :last_name, presence: true
 
       def initialize(application_form)
         @application_form = application_form
 
         super(
+          first_name: @application_form.first_name,
+          last_name: @application_form.last_name,
           phone_number: @application_form.phone_number
         )
       end
 
       def save!
+        @application_form.first_name = first_name
+        @application_form.last_name = last_name
         @application_form.phone_number = phone_number
         @application_form.audit_comment = audit_comment
         @application_form.save!

--- a/app/views/support_interface/application_forms/applicant_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/applicant_details/edit.html.erb
@@ -7,6 +7,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: 'Edit applicant details', size: 'l' } do %>
+        <%= f.govuk_text_field :first_name, label: { text: 'First Name' } %>
+        <%= f.govuk_text_field :last_name, label: { text: 'Last Name' } %>
         <%= f.govuk_text_field :phone_number, label: { text: 'Phone number' } %>
         <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
       <% end %>

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -9,10 +9,13 @@ RSpec.feature 'Editing application details' do
 
     when_i_visit_the_application_page
     and_i_click_the_change_link_next_to_the_phone_number
+    and_i_supply_a_new_first_name
+    and_i_supply_a_new_last_name
     and_i_supply_a_new_phone_number
     and_i_add_a_note_for_the_audit_log
 
     then_i_should_see_a_flash_message
+    and_i_should_see_the_new_name_in_full
     and_i_should_see_the_new_phone_number
     and_i_should_see_my_comment_in_the_audit_log
   end
@@ -30,13 +33,19 @@ RSpec.feature 'Editing application details' do
   end
 
   def and_i_click_the_change_link_next_to_the_phone_number
-    within('[data-qa="personal-details"]') do
-      click_on 'Change'
-    end
+    all('.govuk-summary-list__actions')[0].click_link 'Change'
   end
 
   def and_i_supply_a_new_phone_number
     fill_in 'support_interface_application_forms_edit_applicant_details_form[phone_number]', with: '0891 50 50 50'
+  end
+
+  def and_i_supply_a_new_first_name
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[first_name]', with: 'Steven'
+  end
+
+  def and_i_supply_a_new_last_name
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[last_name]', with: 'Seagal'
   end
 
   def and_i_add_a_note_for_the_audit_log
@@ -51,6 +60,10 @@ RSpec.feature 'Editing application details' do
 
   def and_i_should_see_the_new_phone_number
     expect(page).to have_content '0891 50 50 50'
+  end
+
+  def and_i_should_see_the_new_name_in_full
+    expect(page).to have_content 'Steven Seagal'
   end
 
   def and_i_should_see_my_comment_in_the_audit_log


### PR DESCRIPTION
## Context

This is to cut down the reliance on developers for support.

## Changes proposed in this pull request

This is built on top of the existing interface for changing candidate phone number, using the same logic.
![image](https://user-images.githubusercontent.com/62567622/100382562-82172980-3013-11eb-8a14-c5a997221881.png)
![image](https://user-images.githubusercontent.com/62567622/100382619-a70b9c80-3013-11eb-90d3-59008a2bdb4e.png)
![image](https://user-images.githubusercontent.com/62567622/100382648-b25ec800-3013-11eb-8c1b-66eb69c36c34.png)
![image](https://user-images.githubusercontent.com/62567622/100382685-c0ace400-3013-11eb-9eaf-28e158773abb.png)


## Guidance to review

Let me know if you believe this should be a separate view or if tests require more detail.

## Link to Trello card


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
