### PR TITLE
Add provider code to access controls export

### DIFF
--- a/app/services/support_interface/provider_access_controls_export.rb
+++ b/app/services/support_interface/provider_access_controls_export.rb
@@ -7,6 +7,7 @@ module SupportInterface
         access_controls = ProviderAccessControlsStats.new(provider)
         {
           name: provider.name,
+          code: provider.code,
           dsa_signer: access_controls.dsa_signer_email,
           last_user_permissions_change_at: access_controls.user_permissions_last_changed_at,
           total_user_permissions_changes: access_controls.total_user_permissions_changes,

--- a/app/services/support_interface/provider_access_controls_export.rb
+++ b/app/services/support_interface/provider_access_controls_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ProviderAccessControlsExport
     def data_for_export
-      providers = Provider.all
+      providers = Provider.where(sync_courses: true)
 
       providers.map do |provider|
         access_controls = ProviderAccessControlsStats.new(provider)

--- a/spec/services/support_interface/provider_access_controls_export_spec.rb
+++ b/spec/services/support_interface/provider_access_controls_export_spec.rb
@@ -2,10 +2,13 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: true do
   describe '#data_for_export' do
-    it 'returns access control data for providers' do
+    it 'returns access control data for synced providers' do
       Timecop.freeze(2020, 5, 1, 12, 0, 0) do
-        training_provider = create(:provider)
-        ratifying_provider = create(:provider)
+        training_provider = create(:provider, sync_courses: true)
+        ratifying_provider = create(:provider, sync_courses: true)
+
+        # Unsynced provider should not show up in the export
+        create(:provider)
 
         provider_user1 = create(
           :provider_user,

--- a/spec/services/support_interface/provider_access_controls_export_spec.rb
+++ b/spec/services/support_interface/provider_access_controls_export_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: tru
         expect(described_class.new.data_for_export).to match_array([
           {
             name: training_provider.name,
+            code: training_provider.code,
             dsa_signer: provider_user1.email_address,
             last_user_permissions_change_at: 1.day.ago,
             total_user_permissions_changes: 1,
@@ -71,6 +72,7 @@ RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: tru
           },
           {
             name: ratifying_provider.name,
+            code: ratifying_provider.code,
             dsa_signer: provider_user3.email_address,
             last_user_permissions_change_at: 2.days.ago,
             total_user_permissions_changes: 2,


### PR DESCRIPTION
## Context
Provider name is not enough to uniquely identify provider organisations in the access controls export. Add the code to each row so that they can be identified.

## Link to Trello card
https://trello.com/c/tJ1HAgt5/3073-add-provider-code-to-access-controls-export

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
