### PR TITLE
Make export work with blank award years

### DIFF
--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -47,7 +47,9 @@ module SupportInterface
     end
 
     def latest_degree(application_form)
-      return nil if application_form.application_qualifications.degree.blank?
+      degrees_with_award_year = application_form.application_qualifications.degree.select { |degree| degree.award_year.present? }
+
+      return nil if degrees_with_award_year.blank?
 
       application_form.application_qualifications.degree.max_by(&:award_year)
     end


### PR DESCRIPTION
## Context

If award year was blank it breaks.

## Changes proposed in this pull request

Reject application forms which have no award year before trying to max

## Link to Trello card

https://trello.com/c/yeZRKLYE/2530-dev-locations-persona-dat
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
