### PR TITLE
Add provider-sites & candidate-sites average distance to support UI

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -1,6 +1,7 @@
 module SupportInterface
   class ApplicationSummaryComponent < ViewComponent::Base
     include ViewHelper
+    include GeocodeHelper
 
     delegate :support_reference,
              :submitted_at,
@@ -22,6 +23,7 @@ module SupportInterface
         previous_application_row,
         subsequent_application_row,
         ucas_match_row,
+        average_distance_row,
       ].compact
     end
 
@@ -104,6 +106,16 @@ module SupportInterface
       {
         key: 'Subsequent application',
         value: govuk_link_to(application_form.subsequent_application_form.support_reference, support_interface_application_form_path(application_form.subsequent_application_form)),
+      }
+    end
+
+    def average_distance_row
+      {
+        key: 'Average distance to sites',
+        value: format_average_distance(
+          application_form,
+          application_form.application_choices.map(&:site),
+        ),
       }
     end
 

--- a/app/helpers/geocode_helper.rb
+++ b/app/helpers/geocode_helper.rb
@@ -1,0 +1,11 @@
+module GeocodeHelper
+  def format_average_distance(start, destinations)
+    average = CandidateInterface::MeasureDistances.new.average_distance(
+      start,
+      destinations,
+    )
+    return 'n/a' if average.blank?
+
+    "#{sprintf('%.1f', average)} miles"
+  end
+end

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -17,4 +17,5 @@
   'Code' => @provider.code,
   'Last updated' => @provider.updated_at.to_s(:govuk_date_and_time),
   'Data sharing agreement' => dsa,
+  'Average distance to sites' => format_average_distance(@provider, @provider.sites),
 })) %>

--- a/spec/helpers/geocode_helper_spec.rb
+++ b/spec/helpers/geocode_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe GeocodeHelper, type: :helper do
+  describe '#format_average_distance' do
+    it 'returns a rounded string with units given a valid average' do
+      service = instance_double(CandidateInterface::MeasureDistances)
+      allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
+      allow(service).to receive(:average_distance).with(:start, :destinations).and_return(12.34567)
+
+      expect(helper.format_average_distance(:start, :destinations)).to eq('12.3 miles')
+    end
+
+    it 'returns "n/a" when no average is available' do
+      service = instance_double(CandidateInterface::MeasureDistances)
+      allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
+      allow(service).to receive(:average_distance).with(:start, :destinations).and_return(nil)
+
+      expect(helper.format_average_distance(:start, :destinations)).to eq('n/a')
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is a follow-up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3517 to add the average distance between provider and their sites and the average distance between a candidate and the location of their chosen courses.

## Changes proposed in this pull request

<img width="868" alt="image" src="https://user-images.githubusercontent.com/450843/100435493-e975bd80-3095-11eb-89d9-8d718e286896.png">

<img width="997" alt="image" src="https://user-images.githubusercontent.com/450843/100435578-08744f80-3096-11eb-954b-802233972706.png">

## Guidance to review

- Is this useful?

## Link to Trello card

https://trello.com/c/FObU2tvZ/2576-dev-create-a-service-which-measures-the-average-distance-between-one-coordinate-and-a-group-of-coordinates

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
