### PR TITLE
Setup GOOGLE_MAPS_API_KEY env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ DFE_SIGN_IN_CLIENT_ID=
 DFE_SIGN_IN_SECRET=
 DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk
 BYPASS_DFE_SIGN_IN=true
+GOOGLE_MAPS_API_KEY=
 GOVUK_NOTIFY_CALLBACK_API_KEY=
 DSI_API_URL=https://test-api.signin.education.gov.uk
 DSI_API_SECRET=xxxxxxxxxxxx-xxxxx-xxxxxxxx-xxxxxxxx

--- a/azure/pipelines/release.yml
+++ b/azure/pipelines/release.yml
@@ -203,6 +203,7 @@ stages:
       logstashHost: '$(logstashHost)'
       logstashPort: '$(logstashPort)'
       logstashSsl: '$(logstashSsl)'
+      googleMapsAPIKey: '$(googleMapsAPIKey)'
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
       dfeSignInClientId: '$(dfeSignInClientId)'

--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -40,6 +40,7 @@ parameters:
   logstashHost:
   logstashPort:
   logstashSsl:
+  googleMapsAPIKey:
   govukNotifyAPIKey:
   findBaseUrl:
   dfeSignInClientId:
@@ -222,6 +223,7 @@ jobs:
                 -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
                 -warmupPingPath "${{parameters.warmupPingPath}}"
                 -warmupPingStatus "${{parameters.warmupPingStatus}}"
+                -googleMapsAPIKey "${{parameters.googleMapsAPIKey}}"
                 -govukNotifyAPIKey "${{parameters.govukNotifyAPIKey}}"
                 -basicAuthUsername "${{parameters.basicAuthUsername}}"
                 -basicAuthPassword "${{parameters.basicAuthPassword}}"

--- a/azure/template.json
+++ b/azure/template.json
@@ -184,6 +184,13 @@
                 "description": "The permitted status codes to indicate a successful app warmup."
             }
         },
+        "googleMapsAPIKey": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Google Maps API key, used for geocoding addresses"
+            }
+        },
         "govukNotifyAPIKey": {
             "type": "string",
             "metadata": {
@@ -648,6 +655,10 @@
                             {
                                 "name": "RAILS_SERVE_STATIC_FILES",
                                 "value": "[parameters('railsServeStaticFiles')]"
+                            },
+                            {
+                                "name": "GOOGLE_MAPS_API_KEY",
+                                "secureValue": "[parameters('googleMapsAPIKey')]"
                             },
                             {
                                 "name": "GOVUK_NOTIFY_API_KEY",


### PR DESCRIPTION
## Context
We need to make this API key available in prod and development as part of https://trello.com/c/6A8t8vVY
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Setup the env var in the deploy config. These instructions have been followed, including setting the value in the Production variable group.
- Add a reference to the env var in .env.example. I'll add some brief documentation about this in a later PR.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Do the config changes look ok?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/6A8t8vVY
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
