### PR TITLE
Use the correct variable when maxing by award year

### DIFF
--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -51,7 +51,7 @@ module SupportInterface
 
       return nil if degrees_with_award_year.blank?
 
-      application_form.application_qualifications.degree.max_by(&:award_year)
+      degrees_with_award_year.max_by(&:award_year)
     end
   end
 end


### PR DESCRIPTION
## Context

I didn't use the defined variable 🤦. Sorry this is getting silly now.

## Changes proposed in this pull request

- use degrees_with_award_year when checking max 
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
