### PR TITLE
Add columns to work history export

### DIFF
--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -21,8 +21,8 @@ module SupportInterface
     def data_for_export
       applications = ApplicationForm
                          .where.not(date_of_birth: nil)
-                         .select(:id, :candidate_id, :submitted_at, :date_of_birth)
-                         .includes(:application_qualifications, :application_work_experiences, :application_work_history_breaks)
+                         .select(:id, :candidate_id, :submitted_at, :date_of_birth, :work_history_completed)
+                         .includes(:application_qualifications, :application_work_experiences, :application_work_history_breaks, :application_choices)
                          .order(submitted_at: :desc).uniq(&:candidate_id)
 
       data_for_export = applications.map do |application_form|
@@ -48,6 +48,8 @@ module SupportInterface
           'Number of unexplained breaks' => unexplained_breaks.length,
           'Number of unexplained breaks in last 5 years' => unexplained_breaks_in_last_five_years,
           'Number of unexplained breaks that coincide with studying for a degree' => unexplained_breaks_that_coincide_with_degrees,
+          'Work history completed' => application_form.work_history_completed,
+          'Course choice statuses' => application_form.application_choices.map(&:status),
         }
         output
       end

--- a/spec/services/support_interface/unexplained_breaks_in_work_history_export_spec.rb
+++ b/spec/services/support_interface/unexplained_breaks_in_work_history_export_spec.rb
@@ -43,6 +43,28 @@ RSpec.describe SupportInterface::UnexplainedBreaksInWorkHistoryExport do
              start_date: Date.new(2015, 10, 19),
              end_date: Date.new(2020, 10, 30))
 
+      candidate_four = create(:candidate)
+      create(:completed_application_form,
+             candidate: candidate_four,
+             date_of_birth: Date.new(1994, 7, 8),
+             submitted_at: Date.new(2019, 1, 1))
+      application_form_four = create(:application_form,
+                                     candidate: candidate_four,
+                                     date_of_birth: Date.new(1994, 7, 8),
+                                     submitted_at: Date.new(2020, 10, 30),
+                                     work_history_completed: false)
+      create(:application_qualification,
+             application_form: application_form_four,
+             level: 'degree',
+             start_year: 2012,
+             award_year: 2015)
+      create(:application_work_experience,
+             application_form: application_form_four,
+             start_date: Date.new(2015, 10, 19),
+             end_date: Date.new(2020, 10, 30))
+      create(:application_choice, application_form: application_form_four, status: :cancelled)
+      create(:application_choice, application_form: application_form_four, status: :recruited)
+
       expect(described_class.new.data_for_export).to contain_exactly(
         {
           'Candidate id' => candidate_one.id,
@@ -52,6 +74,8 @@ RSpec.describe SupportInterface::UnexplainedBreaksInWorkHistoryExport do
           'Number of unexplained breaks' => 1,
           'Number of unexplained breaks in last 5 years' => 1,
           'Number of unexplained breaks that coincide with studying for a degree' => 0,
+          'Work history completed' => true,
+          'Course choice statuses' => [],
         },
         {
           'Candidate id' => candidate_two.id,
@@ -61,6 +85,8 @@ RSpec.describe SupportInterface::UnexplainedBreaksInWorkHistoryExport do
           'Number of unexplained breaks' => 1,
           'Number of unexplained breaks in last 5 years' => 0,
           'Number of unexplained breaks that coincide with studying for a degree' => 0,
+          'Work history completed' => true,
+          'Course choice statuses' => [],
         },
         {
           'Candidate id' => candidate_three.id,
@@ -70,6 +96,19 @@ RSpec.describe SupportInterface::UnexplainedBreaksInWorkHistoryExport do
           'Number of unexplained breaks' => 1,
           'Number of unexplained breaks in last 5 years' => 0,
           'Number of unexplained breaks that coincide with studying for a degree' => 1,
+          'Work history completed' => true,
+          'Course choice statuses' => [],
+        },
+        {
+          'Candidate id' => candidate_four.id,
+          'Application id' => application_form_four.id,
+          'Start of working life' => Date.new(2012, 7, 1),
+          'Total unexplained time (months)' => 40,
+          'Number of unexplained breaks' => 1,
+          'Number of unexplained breaks in last 5 years' => 0,
+          'Number of unexplained breaks that coincide with studying for a degree' => 1,
+          'Work history completed' => false,
+          'Course choice statuses' => %w[cancelled recruited],
         },
       )
     end


### PR DESCRIPTION
## Context

At the moment the work history export looks at all applications, rather than only submitted applications. So we are unable to tell if there are gaps in the work history because the candidate hasn't completed filling in the form yet.

## Changes proposed in this pull request

Add two new columns to the data export

- Status (unsubmitted/accepted/awaiting provider decision etc.)
- Work history section marked as complete Y/N

## Guidance to review

Could this export be made more performant?

## Link to Trello card

https://trello.com/c/nVZ96WPO/2603-add-more-info-to-work-history-export

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
