### PR TITLE
Rename GCSE ‘naric-reference’ to ‘naric’

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -17,7 +17,7 @@ module CandidateInterface
         [
           qualification_row,
           country_row,
-          naric_statment_row,
+          naric_statement_row,
           naric_reference_row,
           comparable_uk_qualification_row,
           grade_row,
@@ -107,14 +107,14 @@ module CandidateInterface
       }
     end
 
-    def naric_statment_row
+    def naric_statement_row
       return nil unless application_qualification.qualification_type == 'non_uk'
 
       {
         key: t('application_form.gcse.naric_statement.review_label'),
         value: application_qualification.naric_reference ? 'Yes' : 'No',
         action: t('application_form.gcse.naric_statement.change_action'),
-        change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_naric_path(subject: subject),
       }
     end
 
@@ -126,7 +126,7 @@ module CandidateInterface
         key: t('application_form.gcse.naric_reference.review_label'),
         value: application_qualification.naric_reference,
         action: t('application_form.gcse.naric_reference.change_action'),
-        change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_naric_path(subject: subject),
       }
     end
 
@@ -138,7 +138,7 @@ module CandidateInterface
         key: t('application_form.gcse.comparable_uk_qualification.review_label'),
         value: application_qualification.comparable_uk_qualification,
         action: t('application_form.gcse.comparable_uk_qualification.change_action'),
-        change_path: candidate_interface_gcse_details_edit_naric_reference_path(subject: subject),
+        change_path: candidate_interface_gcse_details_edit_naric_path(subject: subject),
       }
     end
 

--- a/app/controllers/candidate_interface/gcse/institution_country_controller.rb
+++ b/app/controllers/candidate_interface/gcse/institution_country_controller.rb
@@ -41,7 +41,7 @@ module CandidateInterface
         current_application.qualification_in_subject(:gcse, subject_param),
       )
       if @details_form.qualification.grade.nil?
-        candidate_interface_gcse_details_edit_naric_reference_path
+        candidate_interface_gcse_details_edit_naric_path
       else
         candidate_interface_gcse_review_path
       end

--- a/app/controllers/candidate_interface/gcse/naric_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_controller.rb
@@ -43,7 +43,7 @@ module CandidateInterface
 
     def naric_params
       params.require(:candidate_interface_gcse_naric_form)
-        .permit(:naric_reference_choice, :naric_reference, :comparable_uk_qualification)
+        .permit(:have_naric_reference, :naric_reference, :comparable_uk_qualification)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/naric_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_controller.rb
@@ -1,24 +1,24 @@
 module CandidateInterface
-  class Gcse::NaricReferenceController < Gcse::DetailsController
+  class Gcse::NaricController < Gcse::DetailsController
     include Gcse::ResolveGcseEditPathConcern
 
     before_action :redirect_to_dashboard_if_submitted, :set_subject
 
     def edit
-      @naric_reference_form = find_or_build_qualification_form
+      @naric_form = find_or_build_qualification_form
     end
 
     def update
-      @naric_reference_form = find_or_build_qualification_form
+      @naric_form = find_or_build_qualification_form
 
-      @naric_reference_form.set_attributes(naric_reference_params)
+      @naric_form.set_attributes(naric_params)
 
-      if @naric_reference_form.save(@current_qualification)
+      if @naric_form.save(@current_qualification)
         update_gcse_completed(false)
 
         redirect_to next_gcse_path
       else
-        track_validation_error(@naric_reference_form)
+        track_validation_error(@naric_form)
         render :edit
       end
     end
@@ -27,7 +27,7 @@ module CandidateInterface
 
     def find_or_build_qualification_form
       @current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
-      NaricReferenceForm.build_from_qualification(@current_qualification)
+      GcseNaricForm.build_from_qualification(@current_qualification)
     end
 
     def next_gcse_path
@@ -41,8 +41,8 @@ module CandidateInterface
       end
     end
 
-    def naric_reference_params
-      params.require(:candidate_interface_naric_reference_form)
+    def naric_params
+      params.require(:candidate_interface_gcse_naric_form)
         .permit(:naric_reference_choice, :naric_reference, :comparable_uk_qualification)
     end
   end

--- a/app/forms/candidate_interface/gcse_naric_form.rb
+++ b/app/forms/candidate_interface/gcse_naric_form.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class NaricReferenceForm
+  class GcseNaricForm
     include ActiveModel::Model
 
     attr_accessor :naric_reference_choice, :naric_reference, :comparable_uk_qualification

--- a/app/forms/candidate_interface/gcse_naric_form.rb
+++ b/app/forms/candidate_interface/gcse_naric_form.rb
@@ -2,16 +2,16 @@ module CandidateInterface
   class GcseNaricForm
     include ActiveModel::Model
 
-    attr_accessor :naric_reference_choice, :naric_reference, :comparable_uk_qualification
+    attr_accessor :have_naric_reference, :naric_reference, :comparable_uk_qualification
 
-    validates :naric_reference_choice, presence: true
+    validates :have_naric_reference, presence: true
 
     validates :naric_reference, :comparable_uk_qualification, presence: true, if: :chose_to_provide_naric_reference?
 
     def self.build_from_qualification(qualification)
       new(
+        have_naric_reference: qualification.have_naric_reference,
         naric_reference: qualification.naric_reference,
-        naric_reference_choice: qualification.naric_reference_choice,
         comparable_uk_qualification: qualification.comparable_uk_qualification,
       )
     end
@@ -26,7 +26,7 @@ module CandidateInterface
     end
 
     def set_attributes(params)
-      @naric_reference_choice = params['naric_reference_choice']
+      @have_naric_reference = params['have_naric_reference']
       @naric_reference = chose_to_provide_naric_reference? ? params['naric_reference'] : nil
       @comparable_uk_qualification = chose_to_provide_naric_reference? ? params['comparable_uk_qualification'] : nil
     end
@@ -34,7 +34,7 @@ module CandidateInterface
   private
 
     def chose_to_provide_naric_reference?
-      naric_reference_choice == 'Yes'
+      have_naric_reference == 'Yes'
     end
   end
 end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -82,7 +82,7 @@ class ApplicationQualification < ApplicationRecord
     false
   end
 
-  def naric_reference_choice
+  def have_naric_reference
     if naric_reference.present?
       'Yes'
     elsif naric_reference.nil? && grade.present?

--- a/app/views/candidate_interface/gcse/naric/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :title, title_with_error_prefix(t("gcse_edit_naric_reference.page_title", subject: @subject.capitalize), @naric_reference_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t("gcse_edit_naric.page_title", subject: @subject.capitalize), @naric_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @naric_reference_form, url: candidate_interface_gcse_details_edit_naric_reference_path, method: :patch do |f| %>
+    <%= form_with model: @naric_form, url: candidate_interface_gcse_details_edit_naric_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        <%= t("gcse_edit_naric_reference.page_title", subject: @subject.capitalize) %>
+        <%= t("gcse_edit_naric.page_title", subject: @subject.capitalize) %>
       </h1>
 
       <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>

--- a/app/views/candidate_interface/gcse/naric/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric/edit.html.erb
@@ -12,7 +12,7 @@
 
       <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
       <%= f.govuk_radio_buttons_fieldset :naric_details, legend: { text: t('application_form.gcse.naric_statement.label'), tag: 'span' } do %>
-        <%= f.govuk_radio_button :naric_reference_choice, 'Yes', label: { text: 'Yes' } do %>
+        <%= f.govuk_radio_button :have_naric_reference, 'Yes', label: { text: 'Yes' } do %>
           <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
           <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('application_form.gcse.comparable_uk_qualification.label'), size: 's'}, hint: { text: t('application_form.gcse.comparable_uk_qualification.hint_text') } do %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') } %>
@@ -21,7 +21,7 @@
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.alevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.alevel') } %>
           <% end %>
         <% end %>
-        <%= f.govuk_radio_button :naric_reference_choice, 'No', label: { text: 'No' } do %>
+        <%= f.govuk_radio_button :have_naric_reference, 'No', label: { text: 'No' } do %>
           <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. Register with <%= govuk_link_to 'Get Into Teaching', 'https://register.getintoteaching.education.gov.uk/register' %> for help if you need to get one.</p>
         <% end %>
       <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -882,7 +882,7 @@ en:
             institution_country:
               blank: Enter the country you studied in
               inclusion: Select the country you studied in from the list
-        candidate_interface/naric_reference_form:
+        candidate_interface/gcse_naric_form:
           attributes:
             naric_reference_choice:
               blank: Select if you have a UK NARIC statement of comparability

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -884,7 +884,7 @@ en:
               inclusion: Select the country you studied in from the list
         candidate_interface/gcse_naric_form:
           attributes:
-            naric_reference_choice:
+            have_naric_reference:
               blank: Select if you have a UK NARIC statement of comparability
             naric_reference:
               blank: Enter your UK NARIC reference number

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -40,7 +40,7 @@ en:
     page_title: When was your %{subject} qualification awarded?
   gcse_edit_institution_country:
     page_title: In which country did you study for your %{subject} qualification?
-  gcse_edit_naric_reference:
+  gcse_edit_naric:
     page_title: How your %{subject} qualification compares to a UK qualification
   gcse_summary:
     page_titles:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,8 +149,8 @@ Rails.application.routes.draw do
         get '/country' => 'gcse/institution_country#edit', as: :gcse_details_edit_institution_country
         patch '/country' => 'gcse/institution_country#update'
 
-        get '/naric-reference' => 'gcse/naric_reference#edit', as: :gcse_details_edit_naric_reference
-        patch '/naric-reference' => 'gcse/naric_reference#update'
+        get '/naric' => 'gcse/naric#edit', as: :gcse_details_edit_naric
+        patch '/naric' => 'gcse/naric#update'
 
         get '/year' => 'gcse/year#edit', as: :gcse_details_edit_year
         patch '/year' => 'gcse/year#update'

--- a/spec/forms/candidate_interface/gcse_naric_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_naric_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::GcseNaricForm do
       }
     end
 
-    it { is_expected.to validate_presence_of(:naric_reference_choice) }
+    it { is_expected.to validate_presence_of(:have_naric_reference) }
 
     context 'validates naric_reference if they have chosen that they have one' do
       before { allow(form).to receive(:chose_to_provide_naric_reference?).and_return(true) }
@@ -32,7 +32,7 @@ RSpec.describe CandidateInterface::GcseNaricForm do
           qualification,
         )
 
-        expect(naric_form.naric_reference_choice).to eq 'Yes'
+        expect(naric_form.have_naric_reference).to eq 'Yes'
         expect(naric_form.naric_reference).to eq qualification.naric_reference
         expect(naric_form.comparable_uk_qualification).to eq qualification.comparable_uk_qualification
       end
@@ -41,9 +41,9 @@ RSpec.describe CandidateInterface::GcseNaricForm do
     describe '#save' do
       let(:form_data) do
         {
+          have_naric_reference: 'Yes',
           naric_reference: '12345',
           comparable_uk_qualification: 'GCSE (grades A*-C / 9-4)',
-          naric_reference_choice: 'Yes',
         }
       end
 

--- a/spec/forms/candidate_interface/gcse_naric_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_naric_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::NaricReferenceForm do
+RSpec.describe CandidateInterface::GcseNaricForm do
   describe 'validations' do
     let(:form) { subject }
 
@@ -28,13 +28,13 @@ RSpec.describe CandidateInterface::NaricReferenceForm do
     describe '#build_from_qualification' do
       it 'creates an object based on the provided ApplicationQualification' do
         qualification = ApplicationQualification.new(qualification_data)
-        naric_reference_form = CandidateInterface::NaricReferenceForm.build_from_qualification(
+        naric_form = CandidateInterface::GcseNaricForm.build_from_qualification(
           qualification,
         )
 
-        expect(naric_reference_form.naric_reference_choice).to eq 'Yes'
-        expect(naric_reference_form.naric_reference).to eq qualification.naric_reference
-        expect(naric_reference_form.comparable_uk_qualification).to eq qualification.comparable_uk_qualification
+        expect(naric_form.naric_reference_choice).to eq 'Yes'
+        expect(naric_form.naric_reference).to eq qualification.naric_reference
+        expect(naric_form.comparable_uk_qualification).to eq qualification.comparable_uk_qualification
       end
     end
 
@@ -48,16 +48,16 @@ RSpec.describe CandidateInterface::NaricReferenceForm do
       end
 
       it 'returns false if not valid' do
-        naric_reference_form = CandidateInterface::NaricReferenceForm.new
+        naric_form = CandidateInterface::GcseNaricForm.new
 
-        expect(naric_reference_form.save(ApplicationQualification.new)).to eq(false)
+        expect(naric_form.save(ApplicationQualification.new)).to eq(false)
       end
 
       it 'updates the provided ApplicationQualification if valid' do
         qualification = create(:gcse_qualification)
-        naric_reference_form = CandidateInterface::NaricReferenceForm.new(form_data)
+        naric_form = CandidateInterface::GcseNaricForm.new(form_data)
 
-        expect(naric_reference_form.save(qualification)).to eq(true)
+        expect(naric_form.save(qualification)).to eq(true)
         expect(qualification.naric_reference).to eq form_data[:naric_reference]
         expect(qualification.comparable_uk_qualification).to eq form_data[:comparable_uk_qualification]
       end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -133,20 +133,20 @@ RSpec.describe ApplicationQualification, type: :model do
     end
   end
 
-  describe '#naric_reference_choice' do
+  describe '#have_naric_reference' do
     it 'returns No when naric reference is nil and grade is present' do
       qualification = build_stubbed(:application_qualification, naric_reference: nil, grade: 'c')
-      expect(qualification.naric_reference_choice).to eq('No')
+      expect(qualification.have_naric_reference).to eq('No')
     end
 
     it 'returns Yes when reference number provided' do
       qualification = build_stubbed(:application_qualification, naric_reference: '12345')
-      expect(qualification.naric_reference_choice).to eq('Yes')
+      expect(qualification.have_naric_reference).to eq('Yes')
     end
 
     it 'returns nil when field not submitted' do
       qualification = build_stubbed(:application_qualification, naric_reference: nil, grade: nil)
-      expect(qualification.naric_reference_choice).to eq(nil)
+      expect(qualification.have_naric_reference).to eq(nil)
     end
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_international_gcse_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def then_i_see_the_add_naric_reference_page
-    expect(page).to have_current_path candidate_interface_gcse_details_edit_naric_reference_path('maths')
+    expect(page).to have_current_path candidate_interface_gcse_details_edit_naric_path('maths')
   end
 
   def when_i_do_not_input_my_naric_reference_or_choose_an_equivalency; end
@@ -127,7 +127,7 @@ RSpec.feature 'Candidate entering Non UK GCSE equivalency details' do
   end
 
   def when_i_fill_in_my_naric_reference_and_choose_an_equivalency
-    fill_in 'candidate-interface-naric-reference-form-naric-reference-field-error', with: '12345'
+    fill_in 'candidate-interface-gcse-naric-form-naric-reference-field-error', with: '12345'
     choose 'GCSE (grades A*-C / 9-4)'
   end
 


### PR DESCRIPTION
## Context

GCSEs use `naric-reference`, degrees use `naric-statement`. Let’s just use `naric`. Follows on from #3538.

## Changes proposed in this pull request

* Renames GCSE NARIC folders, routes, paths and variables to use the `naric` keyword.
* Updates `naric_reference_choice` to `have_naric_reference` to match the same value used for degrees

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EmpbwjXY/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
