### PR TITLE
Update the candidate tracker and application reference export to include references' requested_at times

### DIFF
--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -14,6 +14,7 @@ module SupportInterface
         af.application_references.map.with_index(1) do |reference, index|
           output["Ref #{index} type"] = reference.referee_type
           output["Ref #{index} state"] = reference.feedback_status
+          output["Ref #{index} requested at"] = reference.requested_at
         end
 
         output

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -23,12 +23,16 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
           'Application state' => ProcessState.new(application_form_one).state,
           'Ref 1 type' => application_form_one.application_references[0].referee_type,
           'Ref 1 state' => application_form_one.application_references[0].feedback_status,
+          'Ref 1 requested at' => application_form_one.application_references[0].requested_at,
           'Ref 2 type' => application_form_one.application_references[1].referee_type,
           'Ref 2 state' => application_form_one.application_references[1].feedback_status,
+          'Ref 2 requested at' => application_form_one.application_references[0].requested_at,
           'Ref 3 type' => application_form_one.application_references[2].referee_type,
           'Ref 3 state' => application_form_one.application_references[2].feedback_status,
+          'Ref 3 requested at' => application_form_one.application_references[0].requested_at,
           'Ref 4 type' => application_form_one.application_references[3].referee_type,
           'Ref 4 state' => application_form_one.application_references[3].feedback_status,
+          'Ref 4 requested at' => application_form_one.application_references[0].requested_at,
         },
         {
           'Recruitment cycle year' => application_form_two.recruitment_cycle_year,
@@ -37,6 +41,7 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
           'Application state' => ProcessState.new(application_form_two).state,
           'Ref 1 type' => application_form_two.application_references[0].referee_type,
           'Ref 1 state' => application_form_two.application_references[0].feedback_status,
+          'Ref 1 requested at' => application_form_one.application_references[0].requested_at,
         },
       )
     end


### PR DESCRIPTION
## Context

The CandidateTrackerExport and the ApplicationReferenceExport need received references requested_at timings so analysis has can be done on the average amount of time it takes for references to be returned.

## Changes proposed in this pull request

- Update the CandidateJourneyTracker to include reference_1_requested_at & reference_2_requested_at
- Update the ApplicationReferenceExport to include requested_at

## Guidance to review

The work on the CnadidateJourneyTracker is complicated slightly by the fact that reference_1_received and reference_1_requested_at should always be from the same reference, so sorting by the oldest requested_at_date doesn't work.
 
## Link to Trello card

https://trello.com/c/oTAqdpTF/2591-data-export-add-request-date-for-references-application-references-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
