### PR TITLE
Update other qualification paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,15 +305,13 @@ Rails.application.routes.draw do
       scope '/other-qualifications' do
         get '/' => 'other_qualifications/type#new', as: :other_qualification_type
         post '/' => 'other_qualifications/type#create'
+        get '/type/edit/:id' => 'other_qualifications/type#edit', as: :edit_other_qualification_type
+        patch '/type/edit/:id' => 'other_qualifications/type#update'
 
-        get '/edit-type/:id' => 'other_qualifications/type#edit', as: :edit_other_qualification_type
-        patch '/edit-type/:id' => 'other_qualifications/type#update'
-
-        get '/new' => 'other_qualifications/details#new', as: :other_qualification_details
-        patch '/new' => 'other_qualifications/details#create'
-
-        get '/edit-details/:id' => 'other_qualifications/details#edit', as: :edit_other_qualification_details
-        patch '/edit-details/:id' => 'other_qualifications/details#update'
+        get '/details' => 'other_qualifications/details#new', as: :other_qualification_details
+        patch '/details' => 'other_qualifications/details#create'
+        get '/details/edit/:id' => 'other_qualifications/details#edit', as: :edit_other_qualification_details
+        patch '/details/edit/:id' => 'other_qualifications/details#update'
 
         get '/review' => 'other_qualifications/review#show', as: :review_other_qualifications
         patch '/review' => 'other_qualifications/review#complete', as: :complete_other_qualifications


### PR DESCRIPTION
## Context

Paths used for other qualifications don’t use the format we use elsewhere (i.e. `/edit-details` instead of `/edit/details`).

## Changes proposed in this pull request

Updates routes for other qualification type and details.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EmpbwjXY

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
