### PR TITLE
Use correct form object when tracking validation error for degree year

### DIFF
--- a/app/controllers/candidate_interface/degrees/year_controller.rb
+++ b/app/controllers/candidate_interface/degrees/year_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
         if @degree_year_form.save
           redirect_to candidate_interface_degrees_review_path
         else
-          track_validation_error(@degree_type_form)
+          track_validation_error(@degree_year_form)
           render :new
         end
       end


### PR DESCRIPTION
## Context

We had this sentry error pop https://sentry.io/organizations/dfe-bat/issues/2062776465/?project=1765973&referrer=slack

It's caused by using the degree_type_form object here:

![image](https://user-images.githubusercontent.com/42515961/100594718-f5f65200-32f1-11eb-82d9-c0f12cc09628.png)

It should be using the degree_year_form.

## Changes proposed in this pull request

- Pass in the correct form object to the track_validation_error method.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
