### PR TITLE
Notify providers and candidates when a ucas match is resolved

### DIFF
--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -24,12 +24,11 @@ module SupportInterface
         instructions: 'We need to contact UCAS. Please send the trackable applicant key and the candidate’s duplicate application details to Harry Haines (h.haines@ucas.ac.uk) and Lizzy Carter (l.carter@ucas.ac.uk) from UCAS to ask them to remove the candidate from UTT.',
         past_tense_description: 'requested withdrawal from UCAS',
       },
-      confirmed_withdrawal_from_ucas: {
-        description: 'Confirm withdrawal from UCAS',
-        button_text: 'Confirm the application was withdrawn from UCAS',
-        form_path: :support_interface_process_match_path,
-        instructions: 'We need to ensure that UCAS have removed the candidate’s duplicate application from UTT.',
-        past_tense_description: 'confirmed that the candidate was withdrawn from UCAS. We contacted UCAS to request removal from UTT',
+      resolved_on_ucas: {
+        past_tense_description: 'confirmed that the candidate was withdrawn from UCAS',
+      },
+      resolved_on_apply: {
+        past_tense_description: 'confirmed that the candidate was withdrawn from Apply',
       },
     }.freeze
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -352,6 +352,17 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_resolved_on_apply_email(application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.offered_option.course.name_and_code
+    @provider_name = application_choice.offered_option.provider.name
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.ucas_match.resolved_on_apply.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -341,6 +341,17 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_resolved_on_ucas_email(application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.offered_option.course.name_and_code
+    @provider_name = application_choice.offered_option.provider.name
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.ucas_match.resolved_on_ucas.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -113,6 +113,17 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_resolved_on_ucas_email(provider_user, application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course.name_and_code
+
+    email_for_provider(
+      provider_user,
+      @application_form,
+      subject: I18n.t!('provider_mailer.ucas_match.resolved_on_ucas.subject'),
+    )
+  end
+
 private
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -124,6 +124,17 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_resolved_on_apply_email(provider_user, application_choice)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course.name_and_code
+
+    email_for_provider(
+      provider_user,
+      @application_form,
+      subject: I18n.t!('provider_mailer.ucas_match.resolved_on_apply.subject'),
+    )
+  end
+
 private
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -13,6 +13,7 @@ class UCASMatch < ApplicationRecord
     initial_emails_sent: 'initial_emails_sent',
     reminder_emails_sent: 'reminder_emails_sent',
     ucas_withdrawal_requested: 'ucas_withdrawal_requested',
+    resolved_on_ucas: 'resolved_on_ucas',
   }
 
   def trackable_applicant_key

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -32,13 +32,15 @@ class UCASMatch < ApplicationRecord
   def action_needed?
     return false if processed?
 
-    return false unless dual_application_or_dual_acceptance?
+    return false if resolved?
 
-    return true if ucas_withdrawal_requested?
+    return false unless dual_application_or_dual_acceptance?
 
     return need_to_send_reminder_emails? if initial_emails_sent?
 
     return need_to_request_withdrawal_from_ucas? if reminder_emails_sent?
+
+    return false if ucas_withdrawal_requested?
 
     true
   end
@@ -84,15 +86,11 @@ class UCASMatch < ApplicationRecord
       :reminder_emails_sent
     elsif reminder_emails_sent? && need_to_request_withdrawal_from_ucas?
       :ucas_withdrawal_requested
-    elsif ucas_withdrawal_requested?
-      :confirmed_withdrawal_from_ucas
     end
   end
 
   def last_action
     return nil if action_taken.nil?
-
-    return :confirmed_withdrawal_from_ucas if processed? && ucas_withdrawal_requested?
 
     action_taken.to_sym
   end

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -98,27 +98,29 @@ class UCASMatch < ApplicationRecord
   end
 
   def application_choices_for_same_course_on_both_services
-    ucas_matched_applications.select(&:both_scheme?).map(&:application_choice)
+    duplicate_course_applications.map(&:application_choice)
   end
 
-  def ucas_withdrawal?
-    ucas_matched_applications.select(&:both_scheme?) &&
-      ucas_matched_applications.select(&:application_withdrawn_on_ucas?).any?
+  def duplicate_applications_withdrawn_from_ucas?
+    duplicate_course_applications.any? && duplicate_course_applications.all?(&:application_withdrawn_on_ucas?)
   end
 
-  def apply_withdrawal?
-    ucas_matched_applications.select(&:both_scheme?) &&
-      ucas_matched_applications.select(&:application_withdrawn_on_apply?).any?
+  def duplicate_applications_withdrawn_from_apply?
+    duplicate_course_applications.any? && duplicate_course_applications.all?(&:application_withdrawn_on_apply?)
   end
 
   def application_for_the_same_course_in_progress_on_both_services?
-    application_for_the_same_course_on_both_services = ucas_matched_applications.select(&:both_scheme?)
-
-    application_for_the_same_course_on_both_services.map(&:application_in_progress_on_ucas?).any? &&
-      application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
+    duplicate_course_applications.map(&:application_in_progress_on_ucas?).any? &&
+      duplicate_course_applications.map(&:application_in_progress_on_apply?).any?
   end
 
   def calculate_action_date(action, effective_date)
     TimeLimitCalculator.new(rule: action, effective_date: effective_date).call.fetch(:time_in_future).to_date
+  end
+
+private
+
+  def duplicate_course_applications
+    ucas_matched_applications.select(&:both_scheme?)
   end
 end

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -17,6 +17,14 @@ class UCASMatch < ApplicationRecord
     resolved_on_ucas: 'resolved_on_ucas',
   }
 
+  def ready_to_resolve?
+    action_taken.present? && !action_needed? && !resolved?
+  end
+
+  def resolved?
+    %w[resolved_on_apply resolved_on_ucas].include?(action_taken)
+  end
+
   def trackable_applicant_key
     ucas_matched_applications.first.trackable_applicant_key
   end
@@ -91,6 +99,11 @@ class UCASMatch < ApplicationRecord
 
   def application_choices_for_same_course_on_both_services
     ucas_matched_applications.select(&:both_scheme?).map(&:application_choice)
+  end
+
+  def ucas_withdrawal?
+    ucas_matched_applications.select(&:both_scheme?) &&
+      ucas_matched_applications.select(&:application_withdrawn_on_ucas?).any?
   end
 
   def application_for_the_same_course_in_progress_on_both_services?

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -13,6 +13,7 @@ class UCASMatch < ApplicationRecord
     initial_emails_sent: 'initial_emails_sent',
     reminder_emails_sent: 'reminder_emails_sent',
     ucas_withdrawal_requested: 'ucas_withdrawal_requested',
+    resolved_on_apply: 'resolved_on_apply',
     resolved_on_ucas: 'resolved_on_ucas',
   }
 

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -106,6 +106,11 @@ class UCASMatch < ApplicationRecord
       ucas_matched_applications.select(&:application_withdrawn_on_ucas?).any?
   end
 
+  def apply_withdrawal?
+    ucas_matched_applications.select(&:both_scheme?) &&
+      ucas_matched_applications.select(&:application_withdrawn_on_apply?).any?
+  end
+
   def application_for_the_same_course_in_progress_on_both_services?
     application_for_the_same_course_on_both_services = ucas_matched_applications.select(&:both_scheme?)
 

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -101,6 +101,10 @@ class UCASMatchedApplication
     ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym)
   end
 
+  def application_withdrawn_on_ucas?
+    mapped_ucas_status.eql?('withdrawn')
+  end
+
   def application_choice
     @application_choice ||= begin
       ApplicationChoice.includes(:application_form)

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -101,6 +101,10 @@ class UCASMatchedApplication
     ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym)
   end
 
+  def application_withdrawn_on_apply?
+    application_choice.status.eql?('withdrawn')
+  end
+
   def application_withdrawn_on_ucas?
     mapped_ucas_status.eql?('withdrawn')
   end

--- a/app/services/ucas_matches/resolve_on_apply.rb
+++ b/app/services/ucas_matches/resolve_on_apply.rb
@@ -1,0 +1,16 @@
+module UCASMatches
+  class ResolveOnApply
+    attr_reader :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      ucas_match.update!(action_taken: 'resolved_on_apply',
+                         candidate_last_contacted_at: Time.zone.now)
+
+      UCASMatches::SendResolvedOnApplyEmails.new(ucas_match).call
+    end
+  end
+end

--- a/app/services/ucas_matches/resolve_on_ucas.rb
+++ b/app/services/ucas_matches/resolve_on_ucas.rb
@@ -1,0 +1,16 @@
+module UCASMatches
+  class ResolveOnUCAS
+    attr_reader :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      ucas_match.update!(action_taken: 'resolved_on_ucas',
+                         candidate_last_contacted_at: Time.zone.now)
+
+      UCASMatches::SendResolvedOnUCASEmails.new(ucas_match).call
+    end
+  end
+end

--- a/app/services/ucas_matches/retrieve_for_application_choice.rb
+++ b/app/services/ucas_matches/retrieve_for_application_choice.rb
@@ -1,0 +1,17 @@
+module UCASMatches
+  class RetrieveForApplicationChoice
+    attr_accessor :candidate_id, :recruitment_cycle_year
+
+    def initialize(application_choice)
+      @candidate_id = application_choice.application_form.candidate.id
+      @recruitment_cycle_year = application_choice.recruitment_cycle
+    end
+
+    def call
+      UCASMatch.find_by(
+        candidate_id: candidate_id,
+        recruitment_cycle_year: recruitment_cycle_year,
+      )
+    end
+  end
+end

--- a/app/services/ucas_matches/send_resolved_on_apply_emails.rb
+++ b/app/services/ucas_matches/send_resolved_on_apply_emails.rb
@@ -1,0 +1,21 @@
+module UCASMatches
+  class SendResolvedOnApplyEmails
+    attr_reader :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      raise 'The application has not been resolved on Apply' if !ucas_match.resolved_on_apply?
+
+      application_choice = ucas_match.application_choices_for_same_course_on_both_services.first
+
+      CandidateMailer.ucas_match_resolved_on_apply_email(application_choice).deliver_later
+
+      NotificationsList.for(application_choice).each do |provider_user|
+        ProviderMailer.ucas_match_resolved_on_apply_email(provider_user, application_choice).deliver_later
+      end
+    end
+  end
+end

--- a/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
+++ b/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
@@ -7,7 +7,7 @@ module UCASMatches
     end
 
     def call
-      return false if !ucas_match.resolved_on_ucas?
+      raise 'The application has not been resolved on UCAS' if !ucas_match.resolved_on_ucas?
 
       application_choice = ucas_match.application_choices_for_same_course_on_both_services.first
 

--- a/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
+++ b/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
@@ -1,0 +1,21 @@
+module UCASMatches
+  class SendResolvedOnUCASEmails
+    attr_reader :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      return false if !ucas_match.resolved_on_ucas?
+
+      application_choice = ucas_match.application_choices_for_same_course_on_both_services.first
+
+      CandidateMailer.ucas_match_resolved_on_ucas_email(application_choice).deliver_later
+
+      NotificationsList.for(application_choice).each do |provider_user|
+        ProviderMailer.ucas_match_resolved_on_ucas_email(provider_user, application_choice).deliver_later
+      end
+    end
+  end
+end

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -105,6 +105,10 @@ module UCASMatching
             new_matches += 1
           end
 
+          if match.ready_to_resolve? && match.ucas_withdrawal?
+            UCASMAtches::ResolveOnUCAS.new(ucas_match: match).call
+          end
+
           match.save!
         else
           Rails.logger.info "Found a match for candidate ID #{candidate_id}, but no changes to record"

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -105,7 +105,7 @@ module UCASMatching
             new_matches += 1
           end
 
-          if match.ready_to_resolve? && match.ucas_withdrawal?
+          if match.ready_to_resolve? && match.duplicate_applications_withdrawn_from_ucas?
             UCASMAtches::ResolveOnUCAS.new(ucas_match: match).call
           end
 

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -33,7 +33,7 @@ private
   def resolve_ucas_match(application_choice)
     match = UCASMatches::RetrieveForApplicationChoice.new(application_choice).call
 
-    if match && match.ready_to_resolve? && match.apply_withdrawal?
+    if match && match.ready_to_resolve? && match.duplicate_applications_withdrawn_from_apply?
       UCASMatches::ResolveOnApply.new(match).call
     end
   end

--- a/app/views/candidate_mailer/ucas_match_resolved_on_apply_email.text.erb
+++ b/app/views/candidate_mailer/ucas_match_resolved_on_apply_email.text.erb
@@ -1,0 +1,15 @@
+Dear <%= @application_form.full_name %>
+
+We’re writing to confirm your choice to study <%= @course_name_and_code %> at <%= @provider_name %> has been removed from your Apply for teacher training application.
+
+You should use [UCAS Teacher Training](https://teachertraining.track.ucas.com/track/Login.jsp) to continue your application for <%= @course_name_and_code %>.
+
+Any other courses you applied to have not been affected.
+
+We informed <%= @provider_name %> that the course choice was removed from your DfE Apply application.
+
+If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/app/views/candidate_mailer/ucas_match_resolved_on_ucas_email.text.erb
+++ b/app/views/candidate_mailer/ucas_match_resolved_on_ucas_email.text.erb
@@ -1,0 +1,15 @@
+Dear <%= @application_form.full_name %>
+
+We’ve written to you a couple of times as we noticed you applied to study  <%= @course_name_and_code %> at <%= @provider_name %> on both Apply for teacher training and UCAS Teacher Training Apply – which isn’t allowed.
+
+As you didn’t withdraw the choice, as requested, we have removed it from your UCAS application meaning you should use Apply for teacher training to track the progress of your application for [course name and code].
+
+Any other courses you applied to have not been affected.
+
+We informed <%= @provider_name %> that the course choice was removed from your UCAS application.
+
+If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/app/views/provider_mailer/ucas_match_resolved_on_apply_email.text.erb
+++ b/app/views/provider_mailer/ucas_match_resolved_on_apply_email.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @provider_user_name %>
+
+<%= @application_form.full_name %>’s duplicate application for <%= @course_name_and_code %> has been removed from their Apply for teacher training application.
+
+We’ve let the candidate know that they can continue their application for the course through UCAS Teacher Training.
+
+You do not have to do anything, but if you have any questions you can get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/app/views/provider_mailer/ucas_match_resolved_on_ucas_email.text.erb
+++ b/app/views/provider_mailer/ucas_match_resolved_on_ucas_email.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @provider_user_name %>
+
+<%= @application_form.full_name %>’s duplicate application for <%= @course_name_and_code %> has been removed from their UCAS application.
+
+We’ve let the candidate know that they can continue their application for the course through Apply for teacher training.
+
+You do not have to do anything, but if you have any questions you can get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -91,3 +91,6 @@ en:
         subject: 'Action required: please withdraw one of your duplicate applications'
       multiple_acceptances:
         subject: 'Action required: please withdraw one of your acceptances'
+    ucas_match:
+      resolved_on_ucas:
+        subject: Your application has been deleted from UTT

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -94,3 +94,5 @@ en:
     ucas_match:
       resolved_on_ucas:
         subject: Your application has been deleted from UTT
+      resolved_on_apply:
+        subject: Your application has been deleted from DfE Apply

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -22,3 +22,5 @@ en:
       initial_email:
         duplicate_applications:
           subject: "Duplicate applicant identified"
+      resolved_on_ucas:
+        subject: Duplicate applicant removed from UTT

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -24,3 +24,5 @@ en:
           subject: "Duplicate applicant identified"
       resolved_on_ucas:
         subject: Duplicate applicant removed from UTT
+      resolved_on_apply:
+        subject: Duplicate applicant removed from DfE Apply

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -103,43 +103,40 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
 
         result = render_inline(described_class.new(ucas_match))
 
-        expect(result.text).to include('Action needed Confirm withdrawal from UCAS')
-        expect(result.css('input').attr('value').value).to include('Confirm the application was withdrawn from UCAS')
-        expect(result.css('form').attr('action').value).to include('/process-match')
-        expect(result.text).to include('We need to ensure that UCAS have removed the candidate’s duplicate application from UTT.')
+        expect(result.text).to include('No action required')
+        expect(result.text).to include(' We requested withdrawal from UCAS on the 18 October 2020 at 12:00p')
       end
     end
 
-    it 'renders correct information after withdrawal from UCAS was confirmed by a support user' do
+    it 'renders correct information after UCAS resolution of a match' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
                             matching_state: 'processed',
                             scheme: 'U',
-                            action_taken: 'ucas_withdrawal_requested',
+                            action_taken: 'resolved_on_ucas',
                             candidate_last_contacted_at: Time.zone.now - 1.day)
         allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
         result = render_inline(described_class.new(ucas_match))
 
         expect(result.text).to include('No action required')
-        expect(result.text).to include('We confirmed that the candidate was withdrawn from UCAS. We contacted UCAS to request removal from UTT on the 18 October 2020')
+        expect(result.text).to include('We confirmed that the candidate was withdrawn from UCAS on the 18 October 2020')
       end
     end
 
-    it 'renders correct information after UCAS matching data was updated automatically after requesting withdrawal' do
+    it 'renders correct information after Apply resolution of a match' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'matching_data_updated',
+                            matching_state: 'processed',
                             scheme: 'U',
-                            ucas_status: :withdrawn,
-                            action_taken: 'ucas_withdrawal_requested',
-                            candidate_last_contacted_at: Time.zone.now - 8.days)
-        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(false)
+                            action_taken: 'resolved_on_apply',
+                            candidate_last_contacted_at: Time.zone.now - 1.day)
+        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
         result = render_inline(described_class.new(ucas_match))
 
         expect(result.text).to include('No action required')
-        expect(result.text).not_to include('Confirm withdrawal from UCAS')
+        expect(result.text).to include('We confirmed that the candidate was withdrawn from Apply on the 18 October 2020')
       end
     end
   end

--- a/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
@@ -5,14 +5,45 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   subject(:mailer) { described_class }
 
+  let(:ucas_match) { create(:ucas_match) }
+  let(:application_form) { ucas_match.candidate.application_forms.first }
+  let(:application_choice) { application_form.application_choices.first }
+
   describe '.ucas_match_resolved_on_ucas_email' do
-    let(:ucas_match) { create(:ucas_match) }
-    let(:application_form) { ucas_match.candidate.application_forms.first }
-    let(:application_choice) { application_form.application_choices.first }
     let(:email) { mailer.ucas_match_resolved_on_ucas_email(application_choice) }
 
     it 'sends an email with the correct subject' do
       expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match.resolved_on_ucas.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(email.body.encoded).to include("Dear #{application_form.full_name}")
+    end
+
+    it 'sends an email containing the course name and code in the body' do
+      course_name_and_code = application_choice.course.name_and_code
+
+      expect(email.body).to include(course_name_and_code)
+    end
+
+    it 'sends an email containing the candidate full name in the body' do
+      full_name = application_form.full_name
+
+      expect(email.body).to include(full_name)
+    end
+
+    it 'sends an email containing the provider name in the body' do
+      provider_name = application_choice.course.provider.name
+
+      expect(email.body).to include(provider_name)
+    end
+  end
+
+  describe '.ucas_match_resolved_on_apply_email' do
+    let(:email) { mailer.ucas_match_resolved_on_apply_email(application_choice) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match.resolved_on_apply.subject'))
     end
 
     it 'sends an email with the correct heading' do

--- a/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer, type: :mailer do
+  include TestHelpers::MailerSetupHelper
+
+  subject(:mailer) { described_class }
+
+  describe '.ucas_match_resolved_on_ucas_email' do
+    let(:ucas_match) { create(:ucas_match) }
+    let(:application_form) { ucas_match.candidate.application_forms.first }
+    let(:application_choice) { application_form.application_choices.first }
+    let(:email) { mailer.ucas_match_resolved_on_ucas_email(application_choice) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match.resolved_on_ucas.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(email.body.encoded).to include("Dear #{application_form.full_name}")
+    end
+
+    it 'sends an email containing the course name and code in the body' do
+      course_name_and_code = application_choice.course.name_and_code
+
+      expect(email.body).to include(course_name_and_code)
+    end
+
+    it 'sends an email containing the candidate full name in the body' do
+      full_name = application_form.full_name
+
+      expect(email.body).to include(full_name)
+    end
+
+    it 'sends an email containing the provider name in the body' do
+      provider_name = application_choice.course.provider.name
+
+      expect(email.body).to include(provider_name)
+    end
+  end
+end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -153,8 +153,13 @@ RSpec.describe ProviderMailer, type: :mailer do
 
   describe '.ucas_match_initial_email_duplicate_applications' do
     it_behaves_like('a provider mail with subject and content', :ucas_match_initial_email_duplicate_applications,
-                    I18n.t!('provider_mailer.ucas_match.initial_email.duplicate_applications.subject',
-                            course_name_and_code: 'Computer Science (6IND)'),
+                    I18n.t!('provider_mailer.ucas_match.initial_email.duplicate_applications.subject'),
+                    course_name_and_code: 'Computer Science (6IND)')
+  end
+
+  describe '.ucas_match_resolved_on_ucas_email' do
+    it_behaves_like('a provider mail with subject and content', :ucas_match_resolved_on_ucas_email,
+                    I18n.t('provider_mailer.ucas_match.resolved_on_ucas.subject'),
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -164,4 +164,12 @@ RSpec.describe ProviderMailer, type: :mailer do
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')
   end
+
+  describe '.ucas_match_resolved_on_apply_email' do
+    it_behaves_like('a provider mail with subject and content', :ucas_match_resolved_on_apply_email,
+                    I18n.t('provider_mailer.ucas_match.resolved_on_apply.subject'),
+                    'provider name' => 'Dear Johny English',
+                    'candidate name' => 'Harry Potter',
+                    'course name and code' => 'Computer Science (6IND)')
+  end
 end

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UCASMatch do
       end
     end
 
-    it 'returns false if reminder emails were sent and we don not need to request withdrawal from UCAS yet' do
+    it 'returns false if reminder emails were sent and we do not need to request withdrawal from UCAS yet' do
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
       allow(ucas_match).to receive(:need_to_request_withdrawal_from_ucas?).and_return(false)
@@ -68,6 +68,38 @@ RSpec.describe UCASMatch do
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(false)
 
       expect(ucas_match.action_needed?).to eq(false)
+    end
+  end
+
+  describe '#resolved?' do
+    it 'returns true if action_taken is resolved_on_apply or resolved_on_ucas' do
+      ucas_match = create(:ucas_match, action_taken: 'resolved_on_ucas')
+
+      expect(ucas_match.resolved?).to eq(true)
+    end
+  end
+
+  describe '#ready_to_resolve' do
+    it 'returns true if no further action is required and the match is not resolved' do
+      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', matching_state: 'processed')
+
+      expect(ucas_match.ready_to_resolve?).to eq(true)
+    end
+
+    it 'returns false if no further action is required and the match is resolved' do
+      ucas_match = create(:ucas_match, action_taken: 'resolved_on_ucas')
+
+      expect(ucas_match.ready_to_resolve?).to eq(false)
+    end
+  end
+
+  describe 'ucas_withdrawal?' do
+    it 'returns true if the application was on both services and withdrawn from UCAS' do
+      ucas_matching_data = { 'Scheme' => 'B',
+                             'Withdrawns' => '1' }
+      ucas_match = create(:ucas_match, matching_data: [ucas_matching_data])
+
+      expect(ucas_match.ucas_withdrawal?).to eq(true)
     end
   end
 
@@ -169,7 +201,7 @@ RSpec.describe UCASMatch do
       end
     end
 
-    it 'returns false if initial emails were sent and we don not need to send the reminders yet' do
+    it 'returns false if initial emails were sent and we do not need to send the reminders yet' do
       emails_sent_at = Time.zone.now
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
@@ -198,7 +230,7 @@ RSpec.describe UCASMatch do
       end
     end
 
-    it 'returns false if reminder emails were sent and we don not need to request withdrawal from ucas yet' do
+    it 'returns false if reminder emails were sent and we do not need to request withdrawal from ucas yet' do
       emails_sent_at = Time.zone.now
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: emails_sent_at)
 

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -103,6 +103,26 @@ RSpec.describe UCASMatch do
     end
   end
 
+  describe 'apply_withdrawal?' do
+    it 'returns true if the application was on both services and withdrawn from Apply' do
+      application_choice = create(:application_choice, status: 'withdrawn')
+      create(:application_form, candidate_id: candidate.id, application_choices: [application_choice])
+      course = application_choice.course_option.course
+
+      ucas_matching_data = { 'Scheme' => 'B',
+                             'Course code' => course.code.to_s,
+                             'Apply candidate ID' => candidate.id.to_s,
+                             'Provider code' => course.provider.code.to_s }
+      apply_matching_data = { 'Scheme' => 'B',
+                              'Course code' => course.code.to_s,
+                              'Apply candidate ID' => candidate.id.to_s,
+                              'Provider code' => course.provider.code.to_s }
+      ucas_match = create(:ucas_match, matching_data: [ucas_matching_data, apply_matching_data])
+
+      expect(ucas_match.apply_withdrawal?).to eq(true)
+    end
+  end
+
   describe '#dual_application_or_dual_acceptance?' do
     it 'returns true if a candidate applied for the same course on both services and both applications are still in progress' do
       ucas_matching_data = { 'Scheme' => 'B',

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe UCASMatch do
       expect(ucas_match.action_needed?).to eq(true)
     end
 
-    it 'returns true if we requested withdrawal from UCAS' do
+    it 'returns false if we requested withdrawal from UCAS' do
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
-      expect(ucas_match.action_needed?).to eq(true)
+      expect(ucas_match.action_needed?).to eq(false)
     end
 
     it 'returns true if there is a dual application or dual acceptance' do
@@ -299,12 +299,6 @@ RSpec.describe UCASMatch do
 
       expect(ucas_match.next_action).to eq(:ucas_withdrawal_requested)
     end
-
-    it 'returns :confirmed_withdrawal_from_ucas if withdrawal from UCAS was requested' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
-
-      expect(ucas_match.next_action).to eq(:confirmed_withdrawal_from_ucas)
-    end
   end
 
   describe '#last_action' do
@@ -332,10 +326,16 @@ RSpec.describe UCASMatch do
       expect(ucas_match.last_action).to eq(:ucas_withdrawal_requested)
     end
 
-    it 'returns :confirmed_withdrawal_from_ucas if reminder emails were sent and the match is processed' do
-      ucas_match = create(:ucas_match, matching_state: 'processed', action_taken: 'ucas_withdrawal_requested')
+    it 'returns :resolved_on_ucas if the match was resolved on ucas' do
+      ucas_match = create(:ucas_match, matching_state: 'processed', action_taken: 'resolved_on_ucas')
 
-      expect(ucas_match.last_action).to eq(:confirmed_withdrawal_from_ucas)
+      expect(ucas_match.last_action).to eq(:resolved_on_ucas)
+    end
+
+    it 'returns :resolved_on_apply if the match was resolved on Apply' do
+      ucas_match = create(:ucas_match, matching_state: 'processed', action_taken: 'resolved_on_apply')
+
+      expect(ucas_match.last_action).to eq(:resolved_on_apply)
     end
   end
 

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -320,4 +320,36 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_withdrawn_on_ucas?).to eq(false)
     end
   end
+
+  describe '#application_withdrawn_on_apply?' do
+    context 'when the application_choice status is set to withdrawn' do
+      let(:application_choice) { create(:application_choice, course_option: course_option, status: 'withdrawn') }
+
+      before do
+        application_choice
+      end
+
+      it 'retuns true' do
+        dfe_matching_data =
+          { 'Course code' => course.code.to_s,
+            'Provider code' => course.provider.code.to_s,
+            'Apply candidate ID' => candidate.id.to_s }
+        ucas_matching_application = UCASMatchedApplication.new(dfe_matching_data, recruitment_cycle_year)
+
+        expect(ucas_matching_application.application_withdrawn_on_apply?).to eq(true)
+      end
+    end
+
+    context 'when the application_choice status is not set to withdrawn' do
+      it 'retuns false' do
+        dfe_matching_data =
+          { 'Course code' => course.code.to_s,
+            'Provider code' => course.provider.code.to_s,
+            'Apply candidate ID' => candidate.id.to_s }
+        ucas_matching_application = UCASMatchedApplication.new(dfe_matching_data, recruitment_cycle_year)
+
+        expect(ucas_matching_application.application_withdrawn_on_apply?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe UCASMatchedApplication do
   end
 
   describe '#application_in_progress_on_ucas?' do
-    it 'retruns true if application is not in an unsucesfull state on UCAS' do
+    it 'returns true if application is not in an unsucesfull state on UCAS' do
       ucas_matching_data =
         { 'Scheme' => 'B',
           'Course code' => course.code.to_s,
@@ -141,7 +141,7 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_in_progress_on_ucas?).to eq(true)
     end
 
-    it 'retruns false if application is in unsucesfull state on UCAS' do
+    it 'returns false if application is in unsucesfull state on UCAS' do
       ucas_matching_data =
         { 'Scheme' => 'B',
           'Course code' => course.code.to_s,
@@ -161,14 +161,14 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_in_progress_on_ucas?).to eq(false)
     end
 
-    it 'retruns false the application is DfE scheme' do
+    it 'returns false the application is DfE scheme' do
       ucas_matching_data = { 'Scheme' => 'D' }
       ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
       expect(ucas_matching_application.application_in_progress_on_ucas?).to eq(false)
     end
 
-    it 'retruns false the provider is not on apply' do
+    it 'returns false the provider is not on apply' do
       ucas_matching_data = { 'Scheme' => 'U', 'Provider code' => 'WELSH PROVIDER CODE' }
       ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
@@ -177,7 +177,7 @@ RSpec.describe UCASMatchedApplication do
   end
 
   describe '#application_in_progress_on_apply?' do
-    it 'retruns true if application is not in an unsucesfull state on Apply' do
+    it 'returns true if application is not in an unsucesfull state on Apply' do
       ucas_matching_data =
         { 'Scheme' => 'B',
           'Course code' => course.code.to_s,
@@ -188,7 +188,7 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_in_progress_on_apply?).to eq(true)
     end
 
-    it 'retruns false if application is in unsucesfull state on Apply' do
+    it 'returns false if application is in unsucesfull state on Apply' do
       ucas_matching_data =
         { 'Scheme' => 'B',
           'Course code' => course.code.to_s,
@@ -199,7 +199,7 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_in_progress_on_apply?).to eq(false)
     end
 
-    it 'retruns false the application is UCAS scheme' do
+    it 'returns false the application is UCAS scheme' do
       ucas_matching_data = { 'Scheme' => 'U' }
       ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
@@ -208,7 +208,7 @@ RSpec.describe UCASMatchedApplication do
   end
 
   describe '#application_accepted_on_ucas?' do
-    it 'retruns true if application is in recruited state on UCAS' do
+    it 'returns true if application is in recruited state on UCAS' do
       ucas_matching_data =
         { 'Scheme' => 'U',
           'Course code' => course.code.to_s,
@@ -221,7 +221,7 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_accepted_on_ucas?).to eq(true)
     end
 
-    it 'retruns true if application is in pending_conditions state on UCAS' do
+    it 'returns true if application is in pending_conditions state on UCAS' do
       ucas_matching_data =
         { 'Scheme' => 'B',
           'Course code' => course.code.to_s,
@@ -234,7 +234,7 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_accepted_on_ucas?).to eq(true)
     end
 
-    it 'retruns false if application is in unsucesfull state on UCAS' do
+    it 'returns false if application is in unsucesfull state on UCAS' do
       ucas_matching_data =
         { 'Scheme' => 'U',
           'Course code' => course.code.to_s,
@@ -246,14 +246,14 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_accepted_on_ucas?).to eq(false)
     end
 
-    it 'retruns false the application is DfE scheme' do
+    it 'returns false when the application is DfE scheme' do
       ucas_matching_data = { 'Scheme' => 'D' }
       ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
       expect(ucas_matching_application.application_accepted_on_ucas?).to eq(false)
     end
 
-    it 'retruns false the provider is not on Apply' do
+    it 'returns false when the provider is not on Apply' do
       ucas_matching_data = { 'Scheme' => 'U', 'Provider code' => 'WELSH PROVIDER CODE' }
       ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
@@ -262,7 +262,7 @@ RSpec.describe UCASMatchedApplication do
   end
 
   describe '#application_accepted_on_apply?' do
-    it 'retruns true if application is accepted on Apply' do
+    it 'returns true if application is accepted on Apply' do
       ucas_matching_data =
         { 'Scheme' => 'D',
           'Course code' => course.code.to_s,
@@ -273,7 +273,7 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_in_progress_on_apply?).to eq(true)
     end
 
-    it 'retruns false if application is in unsucesfull state on Apply' do
+    it 'returns false if application is in unsucesfull state on Apply' do
       ucas_matching_data =
         { 'Scheme' => 'B',
           'Course code' => course.code.to_s,
@@ -284,7 +284,7 @@ RSpec.describe UCASMatchedApplication do
       expect(ucas_matching_application.application_in_progress_on_apply?).to eq(false)
     end
 
-    it 'retruns false the application is UCAS scheme' do
+    it 'returns false if the application is in UCAS scheme' do
       ucas_matching_data = { 'Scheme' => 'U' }
       ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
@@ -302,6 +302,22 @@ RSpec.describe UCASMatchedApplication do
       ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
 
       expect(ucas_matching_application.application_choice).to eq(application_choice2)
+    end
+  end
+
+  describe '#application_withdrawn_on_ucas?' do
+    it 'returns true if application has been withdrawn on UCAS' do
+      ucas_matching_data = { 'Withdrawns' => '1' }
+      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+
+      expect(ucas_matching_application.application_withdrawn_on_ucas?).to eq(true)
+    end
+
+    it 'returns false if application has not been withdrawn on UCAS' do
+      ucas_matching_data = { 'Withdrawns' => '' }
+      ucas_matching_application = UCASMatchedApplication.new(ucas_matching_data, recruitment_cycle_year)
+
+      expect(ucas_matching_application.application_withdrawn_on_ucas?).to eq(false)
     end
   end
 end

--- a/spec/services/ucas_matches/resolve_on_apply_spec.rb
+++ b/spec/services/ucas_matches/resolve_on_apply_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe UCASMatches::ResolveOnApply do
+  let(:ucas_match) { create(:ucas_match) }
+  let(:send_resolved_on_ucas_emails) { instance_double(UCASMatches::SendResolvedOnApplyEmails, call: true) }
+
+  context 'when the application has a ucas_match' do
+    before do
+      allow(ucas_match).to receive(:update!).with(hash_including(action_taken: 'resolved_on_apply'))
+      allow(UCASMatches::SendResolvedOnApplyEmails).to receive(:new).with(ucas_match).and_return(send_resolved_on_ucas_emails)
+
+      described_class.new(ucas_match).call
+    end
+
+    it 'sets the application as resolved on Apply and sends the relevant emails' do
+      expect(ucas_match).to have_received(:update!).with(hash_including(action_taken: 'resolved_on_apply'))
+
+      expect(UCASMatches::SendResolvedOnApplyEmails).to have_received(:new).with(ucas_match)
+    end
+  end
+end

--- a/spec/services/ucas_matches/resolve_on_ucas_spec.rb
+++ b/spec/services/ucas_matches/resolve_on_ucas_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe UCASMatches::ResolveOnUCAS do
+  let(:ucas_match) { create(:ucas_match) }
+  let(:send_resolved_on_ucas_emails) { instance_double(UCASMatches::SendResolvedOnUCASEmails, call: true) }
+
+  context 'when the application has a ucas_match' do
+    before do
+      allow(ucas_match).to receive(:update!).with(hash_including(action_taken: 'resolved_on_ucas'))
+      allow(UCASMatches::SendResolvedOnUCASEmails).to receive(:new).with(ucas_match)
+                                                                   .and_return(send_resolved_on_ucas_emails)
+      described_class.new(ucas_match).call
+    end
+
+    it 'sets the application as resolved on UCAS and sends the relevant emails' do
+      expect(ucas_match).to have_received(:update!).with(hash_including(action_taken: 'resolved_on_ucas'))
+
+      expect(UCASMatches::SendResolvedOnUCASEmails).to have_received(:new).with(ucas_match)
+    end
+  end
+end

--- a/spec/services/ucas_matches/send_resolved_on_apply_emails_spec.rb
+++ b/spec/services/ucas_matches/send_resolved_on_apply_emails_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe UCASMatches::SendResolvedOnApplyEmails do
+  let(:course) { create(:course, recruitment_cycle_year: 2020) }
+  let(:course_option) { create(:course_option, course: course) }
+  let(:candidate) { create(:candidate) }
+  let(:application_choice) { create(:application_choice, course_option: course_option) }
+  let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+  let(:provider_user) { create(:provider_user) }
+  let(:matching_data) { { 'Scheme' => 'B', 'Course code' => course.code.to_s, 'Provider code' => course.provider.code.to_s, 'Apply candidate ID' => candidate.id.to_s } }
+  let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+  context 'when the application has been resolved on apply' do
+    let(:ucas_match) { create(:ucas_match, recruitment_cycle_year: 2020, action_taken: 'resolved_on_apply', candidate: candidate, matching_data: [matching_data]) }
+
+    before do
+      application_form
+      create(:provider_permissions, provider_id: course.provider.id, provider_user_id: provider_user.id)
+      allow(CandidateMailer).to receive(:ucas_match_resolved_on_apply_email).and_return(mail)
+      allow(ProviderMailer).to receive(:ucas_match_resolved_on_apply_email).and_return(mail)
+      described_class.new(ucas_match).call
+    end
+
+    it 'sends the candidate the ucas_match_resolved_on_apply_email' do
+      expect(CandidateMailer).to have_received(:ucas_match_resolved_on_apply_email).with(application_choice)
+    end
+
+    it 'sends the provider the ucas_match_resolved_on_apply_email' do
+      expect(ProviderMailer).to have_received(:ucas_match_resolved_on_apply_email).with(provider_user, application_choice)
+    end
+  end
+end

--- a/spec/services/ucas_matches/send_resolved_on_ucas_emails_spec.rb
+++ b/spec/services/ucas_matches/send_resolved_on_ucas_emails_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe UCASMatches::SendResolvedOnUCASEmails do
+  let(:course) { create(:course, recruitment_cycle_year: 2020) }
+  let(:course_option) { create(:course_option, course: course) }
+  let(:candidate) { create(:candidate) }
+  let(:application_choice) { create(:application_choice, course_option: course_option) }
+  let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+  let(:provider_user) { create(:provider_user) }
+  let(:matching_data) { { 'Scheme' => 'B', 'Course code' => course.code.to_s, 'Provider code' => course.provider.code.to_s, 'Apply candidate ID' => candidate.id.to_s } }
+
+  let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+  context 'when the application has been resolved on ucas' do
+    let(:ucas_match) { create(:ucas_match, recruitment_cycle_year: 2020, action_taken: 'resolved_on_ucas', candidate: candidate, matching_data: [matching_data]) }
+
+    before do
+      application_form
+      create(:provider_permissions, provider_id: course.provider.id, provider_user_id: provider_user.id)
+
+      allow(CandidateMailer).to receive(:ucas_match_resolved_on_ucas_email).and_return(mail)
+      allow(ProviderMailer).to receive(:ucas_match_resolved_on_ucas_email).and_return(mail)
+      described_class.new(ucas_match).call
+    end
+
+    it 'sends the candidate the ucas_match_resolved_on_ucas_email' do
+      expect(CandidateMailer).to have_received(:ucas_match_resolved_on_ucas_email).with(application_choice)
+    end
+
+    it 'sends the provider the ucas_match_resolved_on_ucas_email' do
+      expect(ProviderMailer).to have_received(:ucas_match_resolved_on_ucas_email).with(provider_user, application_choice)
+    end
+  end
+end

--- a/spec/services/withdraw_application_spec.rb
+++ b/spec/services/withdraw_application_spec.rb
@@ -11,12 +11,44 @@ RSpec.describe WithdrawApplication do
     end
 
     it 'calls SetDeclineByDefault with the withdrawn application’s application_form' do
+      decline_by_default = instance_double(SetDeclineByDefault, call: nil)
       withdrawing_application = create(:application_choice, status: :awaiting_provider_decision)
-      allow(SetDeclineByDefault).to receive(:new).and_call_original
+      allow(SetDeclineByDefault).to receive(:new).and_return(decline_by_default)
 
       WithdrawApplication.new(application_choice: withdrawing_application).save!
 
       expect(SetDeclineByDefault).to have_received(:new).with(application_form: withdrawing_application.application_form)
+    end
+
+    describe 'retrieving a UCASMatch' do
+      let(:candidate) { create(:candidate) }
+      let(:ucas_match) { create(:ucas_match, candidate: candidate, action_taken: 'initial_emails_sent', matching_data: [ucas_matching_data, apply_matching_data]) }
+      let(:ucas_match_not_ready) { create(:ucas_match, candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data]) }
+      let(:ucas_matching_data) { { 'Scheme' => 'B', 'Course code' => course.code.to_s, 'Apply candidate ID' => candidate.id.to_s, 'Provider code' => course.provider.code.to_s } }
+      let(:apply_matching_data) { { 'Scheme' => 'B', 'Course code' => course.code.to_s, 'Apply candidate ID' => candidate.id.to_s, 'Provider code' => course.provider.code.to_s } }
+      let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
+      let(:course) { application_choice.course_option.course }
+
+      before do
+        create(:application_form, candidate_id: candidate.id, application_choices: [application_choice])
+      end
+
+      it 'when there is a not ready to resolve it does nothing' do
+        ucas_match_not_ready
+
+        WithdrawApplication.new(application_choice: application_choice).save!
+      end
+
+      it 'when there is a match ready to resolve it resolves it' do
+        ucas_match
+
+        resolve_on_apply = instance_double(UCASMatches::ResolveOnApply, call: nil)
+        allow(UCASMatches::ResolveOnApply).to receive(:new).and_return(resolve_on_apply)
+
+        WithdrawApplication.new(application_choice: application_choice).save!
+
+        expect(UCASMatches::ResolveOnApply).to have_received(:new)
+      end
     end
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -38,6 +38,8 @@ RSpec.feature 'Docs' do
       candidate_mailer-ucas_match_reminder_email_multiple_acceptances
       candidate_mailer-ucas_match_resolved_on_ucas_email
       provider_mailer-ucas_match_resolved_on_ucas_email
+      candidate_mailer-ucas_match_resolved_on_apply_email
+      provider_mailer-ucas_match_resolved_on_apply_email
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -36,6 +36,8 @@ RSpec.feature 'Docs' do
       candidate_mailer-ucas_match_initial_email_multiple_acceptances
       candidate_mailer-ucas_match_reminder_email_duplicate_applications
       candidate_mailer-ucas_match_reminder_email_multiple_acceptances
+      candidate_mailer-ucas_match_resolved_on_ucas_email
+      provider_mailer-ucas_match_resolved_on_ucas_email
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -46,10 +46,7 @@ RSpec.feature 'See UCAS matches' do
     then_i_see_that_i_need_to 'Request withdrawal from UCAS'
     and_when_i_click 'Confirm withdrawal from UCAS was requested'
 
-    then_i_see_that_i_need_to 'Confirm withdrawal from UCAS'
-    and_when_i_click 'Confirm the application was withdrawn from UCAS'
-    then_i_see_last_performed_action_is 'confirmed that the candidate was withdrawn from UCAS'
-    and_then_the_match_is_processed
+    then_i_see_last_performed_action_is 'requested withdrawal from UCAS'
   end
 
   def given_i_am_a_support_user
@@ -213,10 +210,5 @@ RSpec.feature 'See UCAS matches' do
   def when_i_visit_the_page_again
     visit current_path
     given_i_am_a_support_user
-  end
-
-  def and_then_the_match_is_processed
-    expect(page).to have_content 'Match marked as processed'
-    expect(page).to have_content 'Processed'
   end
 end


### PR DESCRIPTION
## Context

Emails notifying candidate and provider about a UCAS Match being resolved.

UCAS resolved match email trigerred when processing matching data 
Apply resolved match email trigerred when an application is withdrawn

## Link to Trello card

https://trello.com/c/jLEgGDIv/3047-%F0%9F%8F%88-notify-providers-and-candidates-when-a-ucas-match-is-resolved

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
