### PR TITLE
Include reference type in reference component output

### DIFF
--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -5,6 +5,7 @@ module ProviderInterface
     delegate :feedback,
              :name,
              :email_address,
+             :referee_type,
              :relationship,
              :relationship_confirmation,
              :relationship_correction,
@@ -21,6 +22,7 @@ module ProviderInterface
       [
         name_row,
         email_address_row,
+        reference_type_row,
         relationship_row,
         relationship_confirmation_row,
         relationship_correction_row,
@@ -43,6 +45,13 @@ module ProviderInterface
       {
         key: 'Email address',
         value: mail_to(email_address, email_address, class: 'govuk-link'),
+      }
+    end
+
+    def reference_type_row
+      {
+        key: 'Type of reference',
+        value: referee_type.capitalize,
       }
     end
 

--- a/spec/components/provider_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/reference_with_feedback_component_spec.rb
@@ -19,27 +19,33 @@ RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
       expect(row[:value]).to include(reference.email_address)
     end
 
-    it 'contains a relationship row' do
+    it 'contains a type of reference row' do
       row = component.rows.third
+      expect(row[:key]).to eq('Type of reference')
+      expect(row[:value]).to include(reference.referee_type.capitalize)
+    end
+
+    it 'contains a relationship row' do
+      row = component.rows.fourth
       expect(row[:key]).to eq('Relationship between candidate and referee')
       expect(row[:value]).to eq(reference.relationship)
     end
 
     context 'referee relationship confirmation' do
       it 'contains a confirmation row' do
-        expect(component.rows.fourth[:key]).to eq('Relationship confirmed by referee?')
+        expect(component.rows.fifth[:key]).to eq('Relationship confirmed by referee?')
       end
 
       it 'affirms the referee relationship when uncorrected' do
-        expect(component.rows.fourth[:value]).to eq('Yes')
+        expect(component.rows.fifth[:value]).to eq('Yes')
       end
 
       it 'contains a correction as the row value when corrected' do
         reference.relationship_correction = 'This is not correct'
 
-        expect(component.rows.fourth[:value]).to eq('No')
+        expect(component.rows.fifth[:value]).to eq('No')
 
-        correction_row = component.rows.fifth
+        correction_row = component.rows[5]
 
         expect(correction_row[:key]).to eq('Relationship amended by referee')
         expect(correction_row[:value]).to eq('This is not correct')
@@ -47,8 +53,8 @@ RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
     end
 
     context 'safeguarding' do
-      let(:safeguarding_row) { component.rows[4] }
-      let(:safeguarding_concerns_row) { component.rows[5] }
+      let(:safeguarding_row) { component.rows[5] }
+      let(:safeguarding_concerns_row) { component.rows[6] }
 
       it 'contains a safeguarding row' do
         expect(safeguarding_row[:key]).to eq(


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds `Type of reference` row to reference component which displays on the application details page.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/100635324-4d171980-3328-11eb-88cf-f05f14532f15.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/kaRshQ5H/2791-display-the-type-of-reference-to-providers-in-manage
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
