### PR TITLE
Add the candidate chaser emails to UCAS matching workflow

### DIFF
--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -11,10 +11,10 @@ module SupportInterface
         past_tense_description: 'sent the initial emails',
       },
       reminder_emails_sent: {
-        description: 'Send reminder emails',
-        button_text: 'Confirm reminder emails were sent',
-        form_path: :support_interface_record_reminder_emails_sent_path,
-        instructions: "We need to contact the candidate and the provider. Use the appropriate Zendesk macro. Alternatively, you can use the appropriate template from <a class='govuk-link' href='https://docs.google.com/document/d/1s5ql4jNUUr3QDPUQYWImkZR6o8upvutrjOEuoZ0qqTE'>this document</a>.",
+        description: 'Send a reminder email',
+        button_text: 'Send a reminder email',
+        form_path: :support_interface_send_reminder_email_path,
+        instructions: 'We need to contact the candidate again to remind them they need to take action.',
         past_tense_description: 'sent the reminder emails',
       },
       ucas_withdrawal_requested: {

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -29,13 +29,19 @@ module SupportInterface
       redirect_to support_interface_ucas_match_path(match)
     end
 
-    def record_reminder_emails_sent
+    def send_reminder_email
       match = UCASMatch.find(params[:id])
-      match.update!(
-        candidate_last_contacted_at: Time.zone.now,
-        action_taken: 'reminder_emails_sent',
-      )
-      flash[:success] = 'The date of the reminder emails was recorded'
+
+      if SupportInterface::SendUCASMatchReminderEmails.new(match).call
+        match.update!(
+          candidate_last_contacted_at: Time.zone.now,
+          action_taken: 'reminder_emails_sent',
+        )
+
+        flash[:success] = 'Reminder email was sent'
+      else
+        flash[:error] = 'Reminder email was not sent'
+      end
       redirect_to support_interface_ucas_match_path(match)
     end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -322,7 +322,7 @@ class CandidateMailer < ApplicationMailer
     @course_name_and_code = application_choice.course_option.course.name_and_code
     @provider_name = application_choice.course_option.course.provider.name
     @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
-    @request_ucas_withdrawal_date = TimeLimitCalculator.new(rule: :ucas_match_ucas_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
+    @request_ucas_withdrawal_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
 
     email_for_candidate(
       @application_form,
@@ -333,7 +333,7 @@ class CandidateMailer < ApplicationMailer
   def ucas_match_reminder_email_multiple_acceptances(ucas_match)
     @application_form = ucas_match.candidate.current_application
     @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
-    @request_ucas_withdrawal_date = TimeLimitCalculator.new(rule: :ucas_match_ucas_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
+    @request_ucas_withdrawal_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
 
     email_for_candidate(
       @application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -330,6 +330,17 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_reminder_email_multiple_acceptances(ucas_match)
+    @application_form = ucas_match.candidate.current_application
+    @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
+    @request_ucas_withdrawal_date = TimeLimitCalculator.new(rule: :ucas_match_ucas_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.ucas_match_reminder_email.multiple_acceptances.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -317,6 +317,19 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match)
+    @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course_option.course.name_and_code
+    @provider_name = application_choice.course_option.course.provider.name
+    @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
+    @request_ucas_withdrawal_date = TimeLimitCalculator.new(rule: :ucas_match_ucas_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.ucas_match_reminder_email.duplicate_applications.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -98,8 +98,6 @@ class UCASMatch < ApplicationRecord
       application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
   end
 
-private
-
   def calculate_action_date(action, effective_date)
     TimeLimitCalculator.new(rule: action, effective_date: effective_date).call.fetch(:time_in_future).to_date
   end

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -91,14 +91,14 @@ class UCASMatch < ApplicationRecord
     ucas_matched_applications.select(&:both_scheme?).map(&:application_choice)
   end
 
-private
-
   def application_for_the_same_course_in_progress_on_both_services?
     application_for_the_same_course_on_both_services = ucas_matched_applications.select(&:both_scheme?)
 
     application_for_the_same_course_on_both_services.map(&:application_in_progress_on_ucas?).any? &&
       application_for_the_same_course_on_both_services.map(&:application_in_progress_on_apply?).any?
   end
+
+private
 
   def calculate_action_date(action, effective_date)
     TimeLimitCalculator.new(rule: action, effective_date: effective_date).call.fetch(:time_in_future).to_date

--- a/app/services/support_interface/send_ucas_match_reminder_emails.rb
+++ b/app/services/support_interface/send_ucas_match_reminder_emails.rb
@@ -1,0 +1,34 @@
+module SupportInterface
+  class SendUCASMatchReminderEmails
+    attr_accessor :ucas_match
+
+    def initialize(ucas_match)
+      @ucas_match = ucas_match
+    end
+
+    def call
+      raise 'Reminder email was already sent' if ucas_match.reminder_emails_sent?
+
+      raise 'Cannot send reminder email before sending an initial one' unless ucas_match.initial_emails_sent?
+
+      # it's impossible for the candiate to have multiple acceptances and duplicate applications
+      # we will contact them about dual application in progress before they have a change to accept multiple offers
+
+      return send_duplicate_applications_candidate_reminder_email if ucas_match.application_for_the_same_course_in_progress_on_both_services?
+
+      send_multiple_acceptances_candidate_reminder_email if ucas_match.application_accepted_on_ucas_and_accepted_on_apply?
+    end
+
+  private
+
+    def send_multiple_acceptances_candidate_reminder_email
+      CandidateMailer.ucas_match_reminder_email_multiple_acceptances(ucas_match).deliver_later
+    end
+
+    def send_duplicate_applications_candidate_reminder_email
+      ucas_match.application_choices_for_same_course_on_both_services.each do |application_choice|
+        CandidateMailer.ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match).deliver_later
+      end
+    end
+  end
+end

--- a/app/views/candidate_mailer/ucas_match_reminder_email_duplicate_applications.text.erb
+++ b/app/views/candidate_mailer/ucas_match_reminder_email_duplicate_applications.text.erb
@@ -1,0 +1,19 @@
+Dear <%= @application_form.full_name %>
+
+Further to our email on <%= @initial_email_date %>, we’ve noticed you’ve applied to study <%= @course_name_and_code %> at <%= @provider_name %> on both DfE Apply for teacher training and UCAS Teacher Training Apply – which isn’t allowed.
+
+# What you need to do
+
+You need to withdraw the choice from one of the systems to ensure you’re not applying twice.
+
+It’s up to you which system you choose to progress the choice on. If you have additional UCAS Teacher Training choices, you may want to keep the choice on UCAS Teacher Training Track, so all your choices are in one place.
+
+# What happens if you don’t do anything?
+
+If you don’t withdraw your duplicate choice by <%= @request_ucas_withdrawal_date %> (5 working days), we will withdraw the choice from your UCAS Teacher Training application – meaning you’ll use DfE Apply for teacher training to progress this choice.
+
+If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/app/views/candidate_mailer/ucas_match_reminder_email_multiple_acceptances.text.erb
+++ b/app/views/candidate_mailer/ucas_match_reminder_email_multiple_acceptances.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @application_form.full_name %>
+
+It looks like you accepted offers on both Apply for teacher training and UCAS Teacher Training.
+
+Further to our email on <%= @initial_email_date %>, you need to withdraw the choice from one of the systems by <%= @request_ucas_withdrawal_date %>. Accepting offers on both services is not allowed, as outlined by the terms of use.
+
+For advice on choosing the right course for you, [talk to a teacher training adviser](https://register.getintoteaching.education.gov.uk/register?gclid=Cj0KCQjwoJX8BRCZARIsAEWBFMKTN_IOJaoNoGkn16TZ-4udi-dX6GTfxDPNVAafEX5ZrPh1_m3lpbQaAhDsEALw_wcB&gclsrc=aw.ds).
+
+If you think we made a mistake or have any questions, If you have any questions, get in touch with us by contacting  [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+Sincerely,
+
+The Department for Education & UCAS

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -86,3 +86,6 @@ en:
         subject: 'Action required: it looks like you submitted a duplicate application'
       multiple_acceptances:
         subject: 'Action required: it looks like you’ve accepted two offers'
+    ucas_match_reminder_email:
+      duplicate_applications:
+        subject: 'Action required: please withdraw one of your duplicate applications'

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -89,3 +89,5 @@ en:
     ucas_match_reminder_email:
       duplicate_applications:
         subject: 'Action required: please withdraw one of your duplicate applications'
+      multiple_acceptances:
+        subject: 'Action required: please withdraw one of your acceptances'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -688,7 +688,7 @@ Rails.application.routes.draw do
       get '/' => 'ucas_matches#show', as: :ucas_match
       get '/audit' => 'ucas_matches#audit', as: :ucas_match_audit
       post '/send-initial-emails' => 'ucas_matches#send_initial_emails', as: :send_initial_emails
-      post '/record-reminder-emails-sent' => 'ucas_matches#record_reminder_emails_sent', as: :record_reminder_emails_sent
+      post '/send-reminder-email' => 'ucas_matches#send_reminder_email', as: :send_reminder_email
       post '/record-ucas-withdrawal-requested' => 'ucas_matches#record_ucas_withdrawal_requested', as: :record_ucas_withdrawal_requested
       post '/process-match' => 'ucas_matches#process_match', as: :process_match
     end

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
 
         result = render_inline(described_class.new(ucas_match))
 
-        expect(result.text).to include('Action needed Send reminder emails')
-        expect(result.css('input').attr('value').value).to include('Confirm reminder emails were sent')
-        expect(result.css('form').attr('action').value).to include('/record-reminder-emails-sent')
-        expect(result.text).to include('We need to contact the candidate and the provider.')
+        expect(result.text).to include('Action needed Send a reminder email')
+        expect(result.css('input').attr('value').value).to include('Send a reminder email')
+        expect(result.css('form').attr('action').value).to include('/send-reminder-email')
+        expect(result.text).to include('We need to contact the candidate again')
       end
     end
 

--- a/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
@@ -48,7 +48,26 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     it 'sends an email containing the date that the application needs to be withdrawn by' do
+      expect(email.body).to include('30 November 2020')
+    end
+  end
 
+  describe '.ucas_match_reminder_email_multiple_acceptances' do
+    let(:email) { mailer.ucas_match_reminder_email_multiple_acceptances(ucas_match) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match_reminder_email.multiple_acceptances.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(email.body.encoded).to include("Dear #{application_form.full_name}")
+    end
+
+    it 'sends an email containing the date the initial email was sent' do
+      expect(email.body).to include('16 November 2020')
+    end
+
+    it 'sends an email containing the date that the application needs to be withdrawn by' do
       expect(email.body).to include('30 November 2020')
     end
   end

--- a/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer, type: :mailer do
+  include TestHelpers::MailerSetupHelper
+
+  around do |example|
+    Timecop.freeze(Date.new(2020, 11, 23)) do
+      example.run
+    end
+  end
+
+  subject(:mailer) { described_class }
+
+  let(:application_choice) { create(:application_choice) }
+  let(:application_form) { create(:completed_application_form, application_choices: [application_choice]) }
+  let(:ucas_match) do
+    create(:ucas_match,
+           application_form: application_form,
+           action_taken: 'initial_emails_sent',
+           candidate_last_contacted_at: 5.business_days.before(Time.zone.today))
+  end
+
+  describe '.ucas_match_reminder_email_duplicate_applications' do
+    let(:email) { mailer.ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match_reminder_email.duplicate_applications.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(email.body.encoded).to include("Dear #{application_form.full_name}")
+    end
+
+    it 'sends an email containing the course name and code in the body' do
+      course_name_and_code = application_choice.course.name_and_code
+
+      expect(email.body).to include(course_name_and_code)
+    end
+
+    it 'sends an email containing the provider name in the body' do
+      provider_name = application_choice.course.provider.name
+
+      expect(email.body).to include(provider_name)
+    end
+
+    it 'sends an email containing the date the initial email was sent' do
+      expect(email.body).to include('16 November 2020')
+    end
+
+    it 'sends an email containing the date that the application needs to be withdrawn by' do
+
+      expect(email.body).to include('30 November 2020')
+    end
+  end
+end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -426,6 +426,22 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.ucas_match_initial_email_multiple_acceptances(candidate)
   end
 
+  def ucas_match_reminder_email_duplicate_applications
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form,
+      course_option: course_option,
+    )
+    ucas_match = FactoryBot.build_stubbed(
+      :ucas_match,
+      application_form: application_choice.application_form,
+      action_taken: 'initial_emails_sent',
+      candidate_last_contacted_at: Time.zone.local(2019, 10, 14),
+    )
+
+    CandidateMailer.ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match)
+  end
+
 private
 
   def candidate

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -442,6 +442,16 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match)
   end
 
+  def ucas_match_reminder_email_multiple_acceptances
+    ucas_match = FactoryBot.build_stubbed(
+      :ucas_match,
+      action_taken: 'initial_emails_sent',
+      candidate_last_contacted_at: Time.zone.local(2019, 10, 14),
+    )
+
+    CandidateMailer.ucas_match_reminder_email_multiple_acceptances(ucas_match)
+  end
+
 private
 
   def candidate

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -286,4 +286,42 @@ RSpec.describe UCASMatch do
       expect(ucas_match.application_choices_for_same_course_on_both_services).to eq([:application_choice])
     end
   end
+
+  describe '#application_for_the_same_course_in_progress_on_both_services?' do
+    it 'returns true if candidate has application for the same course in progress on both UCAS and Apply' do
+      application_choice = create(:application_choice, status: :awaiting_provider_decision)
+      ucas_match = create(:ucas_match,
+                          matching_state: 'new_match',
+                          scheme: 'B',
+                          application_form: application_choice.application_form,
+                          ucas_status: :awaiting_provider_decision)
+
+      expect(ucas_match.application_for_the_same_course_in_progress_on_both_services?).to eq(true)
+    end
+
+    it 'returns false if dual application is not in progress on Apply' do
+      application_choice = create(:application_choice, :with_rejection)
+      ucas_match = create(:ucas_match,
+                          matching_state: 'new_match',
+                          scheme: 'B',
+                          application_form: application_choice.application_form)
+
+      expect(ucas_match.application_for_the_same_course_in_progress_on_both_services?).to eq(false)
+    end
+
+    it 'returns false if dual application is not in progress on UCAS' do
+      ucas_match = create(:ucas_match,
+                          matching_state: 'new_match',
+                          scheme: 'B',
+                          ucas_status: :withdrawn)
+
+      expect(ucas_match.application_for_the_same_course_in_progress_on_both_services?).to eq(false)
+    end
+
+    it 'returns false if there is no dual application' do
+      ucas_match = create(:ucas_match, matching_state: 'new_match', scheme: 'D')
+
+      expect(ucas_match.application_for_the_same_course_in_progress_on_both_services?).to eq(false)
+    end
+  end
 end

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -324,4 +324,24 @@ RSpec.describe UCASMatch do
       expect(ucas_match.application_for_the_same_course_in_progress_on_both_services?).to eq(false)
     end
   end
+
+  describe '#calculate_action_date' do
+    it 'returns the date when candidate has to withdraw one of their dual applications or acceptances by' do
+      ucas_match = create(:ucas_match)
+
+      expect(ucas_match.calculate_action_date(:ucas_match_candidate_withdrawal_request, Time.zone.local(2020, 11, 16))).to eq(Date.new(2020, 11, 30))
+    end
+
+    it 'returns the date when a reminder email has to be sent to a candidate' do
+      ucas_match = create(:ucas_match)
+
+      expect(ucas_match.calculate_action_date(:ucas_match_candidate_withdrawal_request_reminder, Time.zone.local(2020, 11, 16))).to eq(Date.new(2020, 11, 23))
+    end
+
+    it 'returns the date when UCAS will be asked to remove duplicate application or acceptances' do
+      ucas_match = create(:ucas_match)
+
+      expect(ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.local(2020, 11, 16))).to eq(Date.new(2020, 11, 23))
+    end
+  end
 end

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe UCASMatch do
       end
     end
 
-    it 'returns true if initial emails were sent and it is time to send reminder emails' do
+    it 'returns true if initial emails were sent and it is time to send a reminder email' do
       initial_emails_sent_at = Time.zone.now
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
@@ -178,7 +178,7 @@ RSpec.describe UCASMatch do
       end
     end
 
-    it 'returns true if initial emails were sent and it is time to send reminder emails' do
+    it 'returns true if initial emails were sent and it is time to send a reminder email' do
       emails_sent_at = Time.zone.now
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
@@ -224,7 +224,7 @@ RSpec.describe UCASMatch do
       expect(ucas_match.next_action).to eq(:initial_emails_sent)
     end
 
-    it 'returns :reminder_emails_sent if initial emails were sent and it time to send reminder emails' do
+    it 'returns :reminder_emails_sent if initial emails were sent and it time to send a reminder email' do
       ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: Time.zone.now - 6.days)
       allow(ucas_match).to receive(:need_to_send_reminder_emails?).and_return(true)
 

--- a/spec/services/support_interface/send_ucas_match_reminder_emails_spec.rb
+++ b/spec/services/support_interface/send_ucas_match_reminder_emails_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SendUCASMatchReminderEmails do
+  describe '#call' do
+    let(:application_choice) { create(:application_choice, :with_accepted_offer) }
+    let(:application_form) { create(:completed_application_form, application_choices: [application_choice]) }
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
+
+    it 'raises an error if a reminder email was already sent' do
+      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent')
+
+      expect {
+        SupportInterface::SendUCASMatchReminderEmails.new(ucas_match).call
+      }.to raise_error('Reminder email was already sent')
+    end
+
+    it 'raises an error when reminder email was not sent' do
+      ucas_match = create(:ucas_match, action_taken: nil)
+
+      expect {
+        SupportInterface::SendUCASMatchReminderEmails.new(ucas_match).call
+      }.to raise_error('Cannot send reminder email before sending an initial one')
+    end
+
+    context 'when the application has been accepted on both Apply and UCAS' do
+      it 'sends the candidate the reminder ucas match email for multiple acceptances' do
+        ucas_match = create(:ucas_match,
+                            matching_state: 'new_match',
+                            ucas_status: :pending_conditions,
+                            application_form: application_form,
+                            action_taken: 'initial_emails_sent',
+                            candidate_last_contacted_at: 6.business_days.before(Time.zone.now))
+        allow(ucas_match).to receive(:application_for_the_same_course_in_progress_on_both_services?).and_return(false)
+        allow(ucas_match).to receive(:application_accepted_on_ucas_and_accepted_on_apply?).and_return(true)
+
+        allow(CandidateMailer).to receive(:ucas_match_reminder_email_multiple_acceptances).and_return(mail)
+        described_class.new(ucas_match).call
+
+        expect(CandidateMailer).to have_received(:ucas_match_reminder_email_multiple_acceptances).with(ucas_match)
+      end
+    end
+
+    context 'when the candidate applied for the same course on both Apply and UCAS' do
+      it 'sends the candidate the reminder ucas match email for the duplicate application' do
+        ucas_match = create(:ucas_match,
+                            matching_state: 'new_match',
+                            scheme: 'B',
+                            application_form: application_form,
+                            action_taken: 'initial_emails_sent',
+                            candidate_last_contacted_at: 6.business_days.before(Time.zone.now))
+        allow(ucas_match).to receive(:application_for_the_same_course_in_progress_on_both_services?).and_return(true)
+        allow(ucas_match).to receive(:application_accepted_on_ucas_and_accepted_on_apply?).and_return(false)
+
+        allow(CandidateMailer).to receive(:ucas_match_reminder_email_duplicate_applications).and_return(mail)
+        described_class.new(ucas_match).call
+
+        expect(CandidateMailer).to have_received(:ucas_match_reminder_email_duplicate_applications).with(application_choice, ucas_match)
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-ucas_match_initial_email_duplicate_applications
       candidate_mailer-ucas_match_initial_email_multiple_acceptances
       candidate_mailer-ucas_match_reminder_email_duplicate_applications
+      candidate_mailer-ucas_match_reminder_email_multiple_acceptances
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-course_unavailable_notification
       candidate_mailer-ucas_match_initial_email_duplicate_applications
       candidate_mailer-ucas_match_initial_email_multiple_acceptances
+      candidate_mailer-ucas_match_reminder_email_duplicate_applications
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -37,8 +37,8 @@ RSpec.feature 'See UCAS matches' do
 
     given_five_working_days_passed
     when_i_visit_the_page_again
-    then_i_see_that_i_need_to 'Send reminder emails'
-    and_when_i_click 'Confirm reminder emails were sent'
+    then_i_see_that_i_need_to 'Send a reminder email'
+    and_when_i_click 'Send a reminder email'
     then_i_see_last_performed_action_is 'sent the reminder emails'
 
     given_five_more_working_days_passed


### PR DESCRIPTION
## Context

Replace marking reminder emails as sent with sending the reminder emails to the candidate in the Apply.

## Changes proposed in this pull request

- Duplicate applications
<img width="459" alt="Screenshot 2020-11-30 at 19 18 41" src="https://user-images.githubusercontent.com/38078064/100654230-6aa4ad00-3341-11eb-80fe-a1f1755dd360.png">

- Multiple acceptances
<img width="456" alt="Screenshot 2020-11-30 at 19 18 55" src="https://user-images.githubusercontent.com/38078064/100654246-709a8e00-3341-11eb-8898-be8874a4357e.png">

## Guidance to review

http://localhost:3000/rails/mailers/candidate_mailer/ucas_match_reminder_email_duplicate_applications
http://localhost:3000/rails/mailers/candidate_mailer/ucas_match_reminder_email_multiple_acceptances

## Link to Trello card

https://trello.com/c/kll4yxFr/3049-add-the-candidate-chaser-emails-to-the-in-app-matching-workflow

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
