### PR TITLE
Update the new provider sync service to grab lat, long & provider_type

### DIFF
--- a/app/services/teacher_training_public_api/sync_provider.rb
+++ b/app/services/teacher_training_public_api/sync_provider.rb
@@ -30,6 +30,9 @@ module TeacherTrainingPublicAPI
         sync_courses: sync_courses? || false,
         region_code: provider_from_api.region_code&.strip,
         name: provider_from_api.name,
+        provider_type: provider_from_api.provider_type,
+        latitude: provider_from_api.try(:latitude),
+        longitude: provider_from_api.try(:longitude),
       }
     end
 

--- a/spec/examples/teacher_training_api/single_provider_response.json
+++ b/spec/examples/teacher_training_api/single_provider_response.json
@@ -17,7 +17,9 @@
       "street_address_2": "1st floor, 86 Long Rd",
       "train_with_disability": "We are committed to supporting trainees with disabilities and other needs, so please let us and the accrediting provider know if you would like us to make any adjustments to support you.",
       "train_with_us": "We offer both primary and secondary training in a wide range of subjects and work with a collection of schools in the local area. We offer diverse teaching placements, ensuring trainees have experience in different types of school environments.",
-      "website": "http://www.teamworkstsa.org/home-page-s-c-i-t-t-teacher-training/"
+      "website": "http://www.teamworkstsa.org/home-page-s-c-i-t-t-teacher-training/",
+      "latitude": "51.498160",
+      "longitude": "-0.129900"
     },
     "relationships": {
       "locations": {


### PR DESCRIPTION
## Context

We need providers type, lat & long for data exports for Mike. Now we're using the public API i've done the work to add it to TTAPI. This is the work to persist these attrs during the provider sync.
 
## Changes proposed in this pull request

- Persist provide_type, latitude & longitude in the SyncProvider job.

## Guidance to review

I've used `try` as lat/long has not been deployed to the API yet.

Is this everything that needs to be done? 

## Link to Trello card

https://trello.com/c/YgubEbfX/2577-dev-use-the-v3-api-to-populate-the-latitude-and-longitude-for-providers

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
