### PR TITLE
Update Dealine Approaching task view heading

### DIFF
--- a/app/helpers/task_view_helper.rb
+++ b/app/helpers/task_view_helper.rb
@@ -2,7 +2,7 @@ module TaskViewHelper
   def task_view_header(choice)
     case choice&.task_view_group
     when 1 then 'Deferred offers: review and confirm'
-    when 2 then 'Deadline approaching: respond to candidate'
+    when 2 then 'Reject by Default date approaching'
     when 3 then 'Give feedback: you did not respond in time'
     when 4 then 'Ready for review'
     when 5 then 'Offers pending conditions (previous cycle)'


### PR DESCRIPTION
## Context

Research found the 'Deadline approaching' task view heading was confusing to users.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Task view heading _Deadline approaching: respond to the candidate_ changed to _Reject by Default date approaching_.

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/93511/100737045-8f456700-33cb-11eb-919f-f2dd1459606d.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
