### PR TITLE
Code background on confirmation panels 

### DIFF
--- a/app/frontend/styles/_code.scss
+++ b/app/frontend/styles/_code.scss
@@ -3,6 +3,10 @@ code {
   font-family: monospace;
   padding: 2px 5px;
 
+  .govuk-panel--confirmation & {
+    background-color: transparent;
+  }
+
   a {
     text-decoration: none;
   }

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -6,7 +6,7 @@
   </h1>
 
   <div class="govuk-panel__body">
-      Your application number is <span id='application-ref'><%= @support_reference %></span>
+    Your application number is <span id="application-ref"><%= @support_reference %></span>
   </div>
 </div>
 

--- a/app/views/support_interface/api_tokens/create.html.erb
+++ b/app/views/support_interface/api_tokens/create.html.erb
@@ -1,11 +1,12 @@
-<% content_for :title, 'Token created' %>
-<% content_for :before_content, govuk_back_link_to(support_interface_api_tokens_path) %>
+<% content_for :browser_title, 'New API token generated' %>
 
-<div class="govuk-panel govuk-panel--confirmation">
+<div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
   <h1 class="govuk-panel__title">
-    ⚡️New API token generated
+    New API token generated
   </h1>
   <div class="govuk-panel__body">
-    Your token is<br> <code><%= @unhashed_token %></code>
+    Your token is<br><code><%= @unhashed_token %></code>
   </div>
 </div>
+
+<p class="govuk-body"><%= govuk_link_to 'Return to list of API tokens', support_interface_api_tokens_path %></p>


### PR DESCRIPTION
## Context

I previously added a solid grey background to `code`, but this doesn’t work on green confirmation  panels, so removed it.

Also update layout of this page to remove duplicated `h1`s and make back link more explicit.

## Changes proposed in this pull request

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/813383/100776190-24605400-33fc-11eb-8417-5a064be28f0b.png) | ![after](https://user-images.githubusercontent.com/813383/100776184-232f2700-33fc-11eb-9eca-75585066325e.png) |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
