### PR TITLE
Add the find feedback page

### DIFF
--- a/app/controllers/candidate_interface/find_feedback_controller.rb
+++ b/app/controllers/candidate_interface/find_feedback_controller.rb
@@ -1,9 +1,33 @@
 module CandidateInterface
   class FindFeedbackController < CandidateInterfaceController
+    skip_before_action :authenticate_candidate!
+
     def new
       @find_feedback_form = CandidateInterface::FindFeedbackForm.new(
         path: params[:path],
         original_controller: params[:original_controller],
+      )
+    end
+
+    def create
+      @find_feedback_form = CandidateInterface::FindFeedbackForm.new(feedback_params)
+
+      if @find_feedback_form.save || @find_feedback_form.user_is_a_bot?
+        redirect_to candidate_interface_find_feedback_thank_you_path
+      else
+        track_validation_error(@find_feedback_form)
+
+        render :new
+      end
+    end
+
+    def thank_you; end
+
+  private
+
+    def feedback_params
+      params.require(:candidate_interface_find_feedback_form).permit(
+        :path, :original_controller, :hidden_feedback_field, :feedback, :email_address
       )
     end
   end

--- a/app/controllers/candidate_interface/find_feedback_controller.rb
+++ b/app/controllers/candidate_interface/find_feedback_controller.rb
@@ -1,0 +1,10 @@
+module CandidateInterface
+  class FindFeedbackController < CandidateInterfaceController
+    def new
+      @find_feedback_form = CandidateInterface::FindFeedbackForm.new(
+        path: params[:path],
+        original_controller: params[:original_controller],
+      )
+    end
+  end
+end

--- a/app/controllers/candidate_interface/find_feedback_controller.rb
+++ b/app/controllers/candidate_interface/find_feedback_controller.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     def new
       @find_feedback_form = CandidateInterface::FindFeedbackForm.new(
         path: params[:path],
-        original_controller: params[:original_controller],
+        find_controller: params[:find_controller],
       )
     end
 
@@ -27,7 +27,7 @@ module CandidateInterface
 
     def feedback_params
       params.require(:candidate_interface_find_feedback_form).permit(
-        :path, :original_controller, :hidden_feedback_field, :feedback, :email_address
+        :path, :find_controller, :hidden_feedback_field, :feedback, :email_address
       )
     end
   end

--- a/app/forms/candidate_interface/find_feedback_form.rb
+++ b/app/forms/candidate_interface/find_feedback_form.rb
@@ -19,5 +19,9 @@ module CandidateInterface
         email_address: email_address,
       )
     end
+
+    def user_is_a_bot?
+      errors.key?(:hidden_feedback_field)
+    end
   end
 end

--- a/app/forms/candidate_interface/find_feedback_form.rb
+++ b/app/forms/candidate_interface/find_feedback_form.rb
@@ -2,10 +2,10 @@ module CandidateInterface
   class FindFeedbackForm
     include ActiveModel::Model
 
-    attr_accessor :path, :original_controller, :feedback,
+    attr_accessor :path, :find_controller, :feedback,
                   :email_address, :hidden_feedback_field
 
-    validates :path, :original_controller, :feedback, presence: true
+    validates :path, :find_controller, :feedback, presence: true
     validates :hidden_feedback_field, absence: true
     validates :email_address, email_address: true, allow_blank: true
 
@@ -14,7 +14,7 @@ module CandidateInterface
 
       FindFeedback.create!(
         path: path,
-        original_controller: original_controller,
+        find_controller: find_controller,
         feedback: feedback,
         email_address: email_address,
       )

--- a/app/forms/candidate_interface/find_feedback_form.rb
+++ b/app/forms/candidate_interface/find_feedback_form.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  class FindFeedbackForm
+    include ActiveModel::Model
+
+    attr_accessor :path, :original_controller, :feedback,
+                  :email_address, :hidden_feedback_field
+
+    validates :path, :original_controller, :feedback, presence: true
+    validates :hidden_feedback_field, absence: true
+    validates :email_address, email_address: true, allow_blank: true
+
+    def save
+      return false unless valid?
+
+      FindFeedback.create!(
+        path: path,
+        original_controller: original_controller,
+        feedback: feedback,
+        email_address: email_address,
+      )
+    end
+  end
+end

--- a/app/forms/candidate_interface/find_feedback_form.rb
+++ b/app/forms/candidate_interface/find_feedback_form.rb
@@ -20,6 +20,17 @@ module CandidateInterface
       )
     end
 
+    def arrived_from_page
+      case find_controller
+      when 'courses'
+        'course'
+      when 'results'
+        'results'
+      else
+        'unknown'
+      end
+    end
+
     def user_is_a_bot?
       errors.key?(:hidden_feedback_field)
     end

--- a/app/models/find_feedback.rb
+++ b/app/models/find_feedback.rb
@@ -1,0 +1,3 @@
+class FindFeedback < ApplicationRecord
+  self.table_name = 'find_feedback'
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -34,6 +34,7 @@ class FeatureFlag
     [:structured_reasons_for_rejection, 'Allows providers to give specific reasons for rejecting an application', 'Steve Laing'],
     [:sync_from_public_teacher_training_api, 'Pull data from the public Teacher training API as well as the old "Find" API', 'Duncan Brown'],
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
+    [:find_feedback, 'Candidate can provide feedback on the Find service', 'David Gisbey'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/find_feedback/new.html.erb
+++ b/app/views/candidate_interface/find_feedback/new.html.erb
@@ -12,11 +12,18 @@
       <%= f.hidden_field :path %>
       <%= f.hidden_field :find_controller %>
 
+
+      <p class="govuk-body">
+         We use your feedback to make our service easier to use.
+         We don’t check responses every day, and cannot respond to comments. If you need support, please
+         <%= govuk_link_to "contact us by email", "mailto:becomingateacher@digital.education.gov.uk" %>.
+      </p>
+
       <div class="govuk-visually-hidden">
         <%= f.govuk_text_field :hidden_feedback_field, label: { text: t('find_feedback.hidden_feedback_field.label'), size: 'm' } %>
       </div>
 
-      <%= f.govuk_text_area :feedback, label: { text: t('find_feedback.feedback.label'), size: 'm' }, rows: 5, max_words: 300 %>
+      <%= f.govuk_text_area :feedback, label: { text: t("find_feedback.feedback.label.#{@find_feedback_form.arrived_from_page}"), size: 'm' }, rows: 5, max_words: 300 %>
 
       <%= f.govuk_text_field :email_address,
                               label: { text: t('find_feedback.email_address.label'), size: 'm' },

--- a/app/views/candidate_interface/find_feedback/new.html.erb
+++ b/app/views/candidate_interface/find_feedback/new.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.find_feedback'), @find_feedback_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @find_feedback_form, url: candidate_interface_find_feedback_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.find_feedback') %>
+      </h1>
+
+      <%= f.hidden_field :path %>
+      <%= f.hidden_field :original_controller %>
+
+      <div class="govuk-visually-hidden">
+        <%= f.govuk_text_field :hidden_feedback_field, label: { text: t('find_feedback.hidden_feedback_field.label'), size: 'm' } %>
+      </div>
+
+      <%= f.govuk_text_area :feedback, label: { text: t('find_feedback.feedback.label'), size: 'm' }, rows: 5, max_words: 300 %>
+
+      <%= f.govuk_text_field :email_address,
+                              label: { text: t('find_feedback.email_address.label'), size: 'm' },
+                              hint: { text: t('find_feedback.email_address.hint_text') },
+                              width: 20 %>
+
+      <%= f.govuk_submit t('find_feedback.submit') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/find_feedback/new.html.erb
+++ b/app/views/candidate_interface/find_feedback/new.html.erb
@@ -10,7 +10,7 @@
       </h1>
 
       <%= f.hidden_field :path %>
-      <%= f.hidden_field :original_controller %>
+      <%= f.hidden_field :find_controller %>
 
       <div class="govuk-visually-hidden">
         <%= f.govuk_text_field :hidden_feedback_field, label: { text: t('find_feedback.hidden_feedback_field.label'), size: 'm' } %>

--- a/app/views/candidate_interface/find_feedback/thank_you.html.erb
+++ b/app/views/candidate_interface/find_feedback/thank_you.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.application_feedback_thank_you') %>
+</h1>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -997,6 +997,14 @@ en:
               blank: Issues cannot blank
             consent_to_be_contacted:
               blank: Can we contact you about your feedback?
+        candidate_interface/find_feedback_form:
+          attributes:
+            path:
+              blank: Path cannot be blank
+            original_controller:
+              blank: Original controller cannot be blank
+            feedback:
+              blank: How we can improve the service?
         candidate_interface/withdrawal_feedback_form:
           attributes:
             feedback:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1001,8 +1001,8 @@ en:
           attributes:
             path:
               blank: Path cannot be blank
-            original_controller:
-              blank: Original controller cannot be blank
+            find_controller:
+              blank: Find controller cannot be blank
             feedback:
               blank: How we can improve the service?
         candidate_interface/withdrawal_feedback_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,6 +133,7 @@ en:
     references_send_reminder: Would you like to send a reminder to this referee?
     application_feedback: How can we improve %{section} section?
     application_feedback_thank_you: Thank you for your feedback
+    find_feedback: Help us improve this service
     referee:
       refuse_feedback: Decline to give a reference
       relationship: Confirm how you know %{full_name}

--- a/config/locales/find_feedback.yml
+++ b/config/locales/find_feedback.yml
@@ -1,0 +1,10 @@
+en:
+  find_feedback:
+    hidden_feedback_field:
+      label: Do not fill in. To catch bots
+    feedback:
+      label: How can we improve this service?
+    email_address:
+      label: Email address (optional)
+      hint_text: We may contact you to ask you some questions about your feedback
+    submit: Submit feedback

--- a/config/locales/find_feedback.yml
+++ b/config/locales/find_feedback.yml
@@ -3,7 +3,10 @@ en:
     hidden_feedback_field:
       label: Do not fill in. To catch bots
     feedback:
-      label: How can we improve this service?
+      label:
+        course: How can we improve the information about this course?
+        results: How can we improve these search results?
+        unknown:  How can we improve this service?
     email_address:
       label: Email address (optional)
       hint_text: We may contact you to ask you some questions about your feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,12 @@ Rails.application.routes.draw do
 
     get '/interstitial', to: 'after_sign_in#interstitial', as: :interstitial
 
+    scope '/find-feedback' do
+      get '/' => 'find_feedback#new', as: :find_feedback
+      post '/' => 'find_feedback#create'
+      get '/thank-you' => 'find_feedback#thank_you', as: :find_feedback_thank_you
+    end
+
     scope '/application' do
       get '/prefill', to: 'prefill_application_form#new'
       post '/prefill', to: 'prefill_application_form#create'

--- a/spec/forms/candidate_interface/find_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/find_feedback_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateInterface::FindFeedbackForm, type: :model do
   let(:form) do
     described_class.new(
       path: '/course/T92/X130',
-      original_controller: 'courses',
+      find_controller: 'courses',
       feedback: 'Make it better.',
       email_address: 'email@gmail.com',
       hidden_feedback_field: nil,
@@ -13,14 +13,14 @@ RSpec.describe CandidateInterface::FindFeedbackForm, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:path) }
-    it { is_expected.to validate_presence_of(:original_controller) }
+    it { is_expected.to validate_presence_of(:find_controller) }
     it { is_expected.to validate_presence_of(:feedback) }
 
     describe '#hidden_feedback_field_is_blank' do
       it 'validates that #hidden_feedback_field is blank' do
         invalid_form = described_class.new(
           path: '/course/T92/X130',
-          original_controller: 'courses',
+          find_controller: 'courses',
           feedback: 'Make it better.',
           email_address: 'email@gmail.com',
           hidden_feedback_field: 'I am a bot',
@@ -44,7 +44,7 @@ RSpec.describe CandidateInterface::FindFeedbackForm, type: :model do
 
       expect(FindFeedback.count).to eq 1
       expect(feedback.path).to eq form.path
-      expect(feedback.original_controller).to eq form.original_controller
+      expect(feedback.find_controller).to eq form.find_controller
       expect(feedback.feedback).to eq form.feedback
       expect(feedback.email_address).to eq form.email_address
     end

--- a/spec/forms/candidate_interface/find_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/find_feedback_form_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::FindFeedbackForm, type: :model do
+  let(:form) do
+    described_class.new(
+      path: '/course/T92/X130',
+      original_controller: 'courses',
+      feedback: 'Make it better.',
+      email_address: 'email@gmail.com',
+      hidden_feedback_field: nil,
+    )
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:path) }
+    it { is_expected.to validate_presence_of(:original_controller) }
+    it { is_expected.to validate_presence_of(:feedback) }
+
+    describe '#hidden_feedback_field_is_blank' do
+      it 'validates that #hidden_feedback_field is blank' do
+        invalid_form = described_class.new(
+          path: '/course/T92/X130',
+          original_controller: 'courses',
+          feedback: 'Make it better.',
+          email_address: 'email@gmail.com',
+          hidden_feedback_field: 'I am a bot',
+        )
+
+        invalid_form.save
+
+        expect(invalid_form.errors[:hidden_feedback_field]).to be_present
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      expect(described_class.new.save).to eq(false)
+    end
+
+    it 'creates a new FindFeedback object if valid' do
+      form.save
+      feedback = FindFeedback.last
+
+      expect(FindFeedback.count).to eq 1
+      expect(feedback.path).to eq form.path
+      expect(feedback.original_controller).to eq form.original_controller
+      expect(feedback.feedback).to eq form.feedback
+      expect(feedback.email_address).to eq form.email_address
+    end
+  end
+end

--- a/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Candidate providing feedback on Find' do
   end
 
   def given_i_arrive_from_find_with_valid_params_in_the_query_string
-    visit candidate_interface_find_feedback_path(original_controller: 'courses', path: '/course/T92/X130')
+    visit candidate_interface_find_feedback_path(find_controller: 'courses', path: '/course/T92/X130')
   end
 
   def and_the_find_feedback_flag_is_active

--- a/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
@@ -1,15 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe 'Candidate providing feedback on Find' do
+  include CandidateHelper
+
   scenario 'Candidate arrives from Find and provides feedback' do
-    given_i_arrive_from_find_with_valid_params_in_the_query_string
+    given_i_arrive_from_the_course_show_page
     and_the_find_feedback_flag_is_active
+
+    when_i_complete_and_submit_the_feedback_form_with_an_invalid_email_address
+    then_i_am_asked_to_provide_a_valid_email_address
+
+    when_i_provide_a_valid_email_address
+    then_i_am_thanked_for_my_feedback
+    and_my_feedback_on_the_course_page_has_been_persisted
+
+    given_i_arrive_from_the_results_page
 
     when_i_complete_and_submit_the_feedback_form
     then_i_am_thanked_for_my_feedback
+    and_my_feedback_on_the_results_page_has_been_persisted
+
+    given_i_arrive_without_query_string_params
+    and_i_submit_my_email_and_feedback
+    then_i_am_told_i_need_path_and_controller_params_to_give_feedback
+
+    given_i_arrive_from_the_course_show_page
+    and_i_fill_in_the_hidden_field_designed_to_catch_bots
+    then_i_am_thanked_for_my_feedback
   end
 
-  def given_i_arrive_from_find_with_valid_params_in_the_query_string
+  def given_i_arrive_from_the_course_show_page
     visit candidate_interface_find_feedback_path(find_controller: 'courses', path: '/course/T92/X130')
   end
 
@@ -17,14 +37,73 @@ RSpec.describe 'Candidate providing feedback on Find' do
     FeatureFlag.activate('find_feedback')
   end
 
-  def when_i_complete_and_submit_the_feedback_form
-    fill_in 'How can we improve this service?', with: 'Make it better.'
-    fill_in 'Email address (optional)', with: 'email@gmail.com'
+  def when_i_complete_and_submit_the_feedback_form_with_an_invalid_email_address
+    fill_in t('find_feedback.feedback.label.course'), with: 'Make it better.'
+    fill_in 'Email address (optional)', with: 'email'
 
+    click_button 'Submit feedback'
+  end
+
+  def then_i_am_asked_to_provide_a_valid_email_address
+    expect_validation_error 'Enter an email address in the correct format, like name@example.com'
+  end
+
+  def when_i_provide_a_valid_email_address
+    fill_in 'Email address (optional)', with: 'email@gmail.com'
     click_button 'Submit feedback'
   end
 
   def then_i_am_thanked_for_my_feedback
     expect(page).to have_content 'Thank you for your feedback'
+  end
+
+  def and_my_feedback_on_the_course_page_has_been_persisted
+    feedback = FindFeedback.last
+
+    expect(FindFeedback.count).to eq 1
+    expect(feedback.find_controller).to eq 'courses'
+    expect(feedback.path).to eq '/course/T92/X130'
+    expect(feedback.feedback).to eq 'Make it better.'
+  end
+
+  def given_i_arrive_from_the_results_page
+    visit candidate_interface_find_feedback_path(find_controller: 'results', path: 'results?l=2&subjects%5B%5D=31')
+  end
+
+  def when_i_complete_and_submit_the_feedback_form
+    fill_in t('find_feedback.feedback.label.results'), with: 'The pagination numbers are off.'
+    fill_in 'Email address (optional)', with: 'email@gmail.com'
+
+    click_button 'Submit feedback'
+  end
+
+  def and_my_feedback_on_the_results_page_has_been_persisted
+    feedback = FindFeedback.last
+
+    expect(FindFeedback.count).to eq 2
+    expect(feedback.find_controller).to eq 'results'
+    expect(feedback.path).to eq 'results?l=2&subjects%5B%5D=31'
+    expect(feedback.feedback).to eq 'The pagination numbers are off.'
+  end
+
+  def given_i_arrive_without_query_string_params
+    visit candidate_interface_find_feedback_path
+  end
+
+  def and_i_submit_my_email_and_feedback
+    fill_in t('find_feedback.feedback.label.unknown'), with: 'The pagination numbers are off.'
+    fill_in 'Email address (optional)', with: 'email@gmail.com'
+
+    click_button 'Submit feedback'
+  end
+
+  def then_i_am_told_i_need_path_and_controller_params_to_give_feedback
+    expect(page).to have_content 'Path cannot be blank'
+    expect(page).to have_content 'Find controller cannot be blank'
+  end
+
+  def and_i_fill_in_the_hidden_field_designed_to_catch_bots
+    fill_in 'Do not fill in. To catch bots', with: 'bleep bloop'
+    click_button 'Submit feedback'
   end
 end

--- a/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate providing feedback on Find' do
+  scenario 'Candidate arrives from Find and provides feedback' do
+    given_i_arrive_from_find_with_valid_params_in_the_query_string
+    and_the_find_feedback_flag_is_active
+
+    when_i_complete_and_submit_the_feedback_form
+    then_i_am_thanked_for_my_feedback
+  end
+
+  def given_i_arrive_from_find_with_valid_params_in_the_query_string
+    visit candidate_interface_find_feedback_path(original_controller: 'courses', path: '/course/T92/X130')
+  end
+
+  def and_the_find_feedback_flag_is_active
+    FeatureFlag.activate('find_feedback')
+  end
+
+  def when_i_complete_and_submit_the_feedback_form
+    fill_in 'How can we improve this service?', with: 'Make it better.'
+    fill_in 'Email address (optional)', with: 'email@gmail.com'
+
+    click_button 'Submit feedback'
+  end
+
+  def then_i_am_thanked_for_my_feedback
+    expect(page).to have_content 'Thank you for your feedback'
+  end
+end


### PR DESCRIPTION
## Context

In this PR https://github.com/DFE-Digital/find-teacher-training/pull/542 i added a feedback review component to the course show and results page on Find. They point to /candidate/find-feedback on Apply.

This PR adds the find feedback page where candidates can provide their feedback

## Changes proposed in this pull request

- Add a page where candidates can give their feedback
- Add a hidden field which if completed, doesn't persist the feedback to the DB to stop bot spam.
- Adds a thank you page

![image](https://user-images.githubusercontent.com/42515961/100801692-3e139280-3420-11eb-81b5-b1f1c3b61780.png)


![image](https://user-images.githubusercontent.com/42515961/100801740-4e2b7200-3420-11eb-95a9-662037e0ddc5.png)

## Guidance to review

It might be worth reviewing the two PRs so you can follow the flow end to end.

I think it's worth me going through this with @paulrobertlloyd as it may well need small tweaks.

## Link to Trello card

https://trello.com/c/DrnKcnnW/2466-%F0%9F%93%9D-%F0%9F%8F%88-dev-football-add-feedback-prompt-find

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
