### PR TITLE
Content changes to the reference request email to soften the tone

### DIFF
--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @reference.name %>,
 
-# Please give a reference for <%= @candidate_name %>
+# Can you give <%= @candidate_name %> a reference?
 
 <%= @candidate_name %> put us in touch with you to get a reference for their teacher training application.
 
-Give a reference as soon as possible by filling in this short form (it does not take long):
+Please give a reference as soon as possible by filling in this short form (it does not take long):
 
 <%= referee_interface_reference_relationship_url(token: @unhashed_token) %>
 

--- a/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_requests_a_reference_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature 'Candidate requests a reference' do
   def and_an_email_is_sent_to_the_referee
     open_email(@reference.email_address)
     expect(current_email).to have_content "Dear #{@reference.name},"
-    expect(current_email).to have_content "Please give a reference for #{@application_form.reload.full_name}"
+    expect(current_email).to have_content "Can you give #{@application_form.reload.full_name} a reference?"
   end
 
   def when_i_have_added_a_second_reference


### PR DESCRIPTION
## Context

Referees aren't a fan of the tone of our reference request email.

## Changes proposed in this pull request

- Content changes to soften the tone 

Before 

![image](https://user-images.githubusercontent.com/42515961/100807549-7029f200-342a-11eb-8a9d-49a84d4bec57.png)

After

![image](https://user-images.githubusercontent.com/42515961/100807615-918ade00-342a-11eb-8a1c-0bd2905ad097.png)

## Guidance to review

Changes can be found here:
https://docs.google.com/document/d/1rTUWQtLam4DyPkiEcfodFgg9JeLShbAVhlj4t-QjcVQ/edit

## Link to Trello card

https://trello.com/c/LqEJyAXN/2598-reference-request-emails-content-changes-to-soften-the-tone

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
