### PR TITLE
Add distances to location export

### DIFF
--- a/app/helpers/geocode_helper.rb
+++ b/app/helpers/geocode_helper.rb
@@ -1,11 +1,29 @@
 module GeocodeHelper
-  def format_average_distance(start, destinations)
+  def format_distance(start, destination, with_units: true)
+    result = CandidateInterface::MeasureDistances.new.distance(
+      start,
+      destination,
+    )
+
+    format_number(result, with_units)
+  end
+
+  def format_average_distance(start, destinations, with_units: true)
     average = CandidateInterface::MeasureDistances.new.average_distance(
       start,
       destinations,
     )
-    return 'n/a' if average.blank?
 
-    "#{sprintf('%.1f', average)} miles"
+    format_number(average, with_units)
+  end
+
+private
+
+  def format_number(number, with_units)
+    return 'n/a' if number.blank? && with_units
+    return '' if number.blank?
+
+    rounded = sprintf('%.1f', number)
+    with_units ? "#{rounded} miles" : rounded
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -69,4 +69,8 @@ class Provider < ApplicationRecord
   def not_accepting_appplications_on_ucas?
     NOT_ACCEPTING_APPLICATIONS_ON_UCAS.include?(code)
   end
+
+  def geocoded?
+    latitude.present? && longitude.present?
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,6 @@
 class Site < ApplicationRecord
   belongs_to :provider
+  geocoded_by :full_address
 
   audited associated_with: :provider
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,5 @@
 class Site < ApplicationRecord
   belongs_to :provider
-  geocoded_by :full_address
 
   audited associated_with: :provider
 
@@ -25,5 +24,9 @@ class Site < ApplicationRecord
     else
       name
     end
+  end
+
+  def geocoded?
+    latitude.present? && longitude.present?
   end
 end

--- a/app/services/candidate_interface/measure_distances.rb
+++ b/app/services/candidate_interface/measure_distances.rb
@@ -21,7 +21,7 @@ module CandidateInterface
   private
 
     def has_coordinates?(model)
-      model && !model.latitude.nil? && !model.longitude.nil?
+      model && model.geocoded?
     end
   end
 end

--- a/app/services/candidate_interface/measure_distances.rb
+++ b/app/services/candidate_interface/measure_distances.rb
@@ -9,8 +9,6 @@ module CandidateInterface
       distances.sum(0.0) / distances.size
     end
 
-  private
-
     def distance(from, to)
       return nil unless has_coordinates?(from) && has_coordinates?(to)
 
@@ -20,8 +18,10 @@ module CandidateInterface
       )
     end
 
+  private
+
     def has_coordinates?(model)
-      !model.latitude.nil? && !model.longitude.nil?
+      model && !model.latitude.nil? && !model.longitude.nil?
     end
   end
 end

--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -1,5 +1,7 @@
 module SupportInterface
   class LocationsExport
+    include GeocodeHelper
+
     def data_for_export
       application_choices.find_each.map do |application_choice|
         application_form = application_choice.application_form
@@ -17,6 +19,8 @@ module SupportInterface
           'Degree completed' => return_lastest_degree_award_year(application_form),
           'Degree type' => return_lastest_degree_type(application_form),
           'Status' => application_state(application_form),
+          'Distance from site to candidate' => distance(application_choice),
+          'Average distance from all sites to candidate' => average_distance(application_form),
         }
       end
     end
@@ -52,6 +56,21 @@ module SupportInterface
       return nil if degrees_with_award_year.blank?
 
       degrees_with_award_year.max_by(&:award_year)
+    end
+
+    def distance(application_choice)
+      format_distance(
+        application_choice.application_form,
+        application_choice&.site, with_units: false
+      )
+    end
+
+    def average_distance(application_form)
+      format_average_distance(
+        application_form,
+        application_form.application_choices.map(&:site),
+        with_units: false,
+      )
     end
   end
 end

--- a/spec/helpers/geocode_helper_spec.rb
+++ b/spec/helpers/geocode_helper_spec.rb
@@ -10,12 +10,54 @@ RSpec.describe GeocodeHelper, type: :helper do
       expect(helper.format_average_distance(:start, :destinations)).to eq('12.3 miles')
     end
 
+    it 'returns a rounded string without units given a valid average' do
+      service = instance_double(CandidateInterface::MeasureDistances)
+      allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
+      allow(service).to receive(:average_distance).with(:start, :destinations).and_return(12.34567)
+
+      expect(helper.format_average_distance(:start, :destinations, with_units: false)).to eq('12.3')
+    end
+
     it 'returns "n/a" when no average is available' do
       service = instance_double(CandidateInterface::MeasureDistances)
       allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
       allow(service).to receive(:average_distance).with(:start, :destinations).and_return(nil)
 
       expect(helper.format_average_distance(:start, :destinations)).to eq('n/a')
+    end
+  end
+
+  describe '#format_distance' do
+    it 'returns a rounded string with units given a valid average' do
+      service = instance_double(CandidateInterface::MeasureDistances)
+      allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
+      allow(service).to receive(:distance).with(:start, :destinations).and_return(12.34567)
+
+      expect(helper.format_distance(:start, :destinations)).to eq('12.3 miles')
+    end
+
+    it 'returns a rounded string without units given a valid average' do
+      service = instance_double(CandidateInterface::MeasureDistances)
+      allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
+      allow(service).to receive(:distance).with(:start, :destinations).and_return(12.34567)
+
+      expect(helper.format_distance(:start, :destinations, with_units: false)).to eq('12.3')
+    end
+
+    it 'returns "n/a" when no average is available' do
+      service = instance_double(CandidateInterface::MeasureDistances)
+      allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
+      allow(service).to receive(:distance).with(:start, :destinations).and_return(nil)
+
+      expect(helper.format_distance(:start, :destinations)).to eq('n/a')
+    end
+
+    it 'returns "" when no average is available without units' do
+      service = instance_double(CandidateInterface::MeasureDistances)
+      allow(CandidateInterface::MeasureDistances).to receive(:new).and_return(service)
+      allow(service).to receive(:distance).with(:start, :destinations).and_return(nil)
+
+      expect(helper.format_distance(:start, :destinations, with_units: false)).to eq('')
     end
   end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Site, type: :model do
         address_line1: 'Gorse SCITT',
         address_line2: 'C/O The Bruntcliffe Academy',
         address_line3: 'Bruntcliffe Lane',
-        address_line4: 'MORLEY, lEEDS',
+        address_line4: 'MORLEY, LEEDS',
         postcode: 'LS27 0LZ',
       )
 
-      expect(site.full_address).to eq('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, lEEDS, LS27 0LZ')
+      expect(site.full_address).to eq('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, LEEDS, LS27 0LZ')
     end
 
     it 'ignores empty address lines when concatenating' do
@@ -28,11 +28,31 @@ RSpec.describe Site, type: :model do
         address_line1: '',
         address_line2: 'C/O The Bruntcliffe Academy',
         address_line3: '',
-        address_line4: 'MORLEY, lEEDS',
+        address_line4: 'MORLEY, LEEDS',
         postcode: 'LS27 0LZ',
       )
 
-      expect(site.full_address).to eq('C/O The Bruntcliffe Academy, MORLEY, lEEDS, LS27 0LZ')
+      expect(site.full_address).to eq('C/O The Bruntcliffe Academy, MORLEY, LEEDS, LS27 0LZ')
+    end
+  end
+
+  describe 'geocoded?' do
+    it 'returns true when latitude/longitude are specified' do
+      site = build(
+        :site,
+        latitude: '51.498024',
+        longitude: '0.129919',
+      )
+      expect(site.geocoded?).to be true
+    end
+
+    it 'returns false when latitude is nil' do
+      site = build(
+        :site,
+        latitude: nil,
+        longitude: '0.129919',
+      )
+      expect(site.geocoded?).to be false
     end
   end
 end

--- a/spec/services/candidate_interface/measure_distances_spec.rb
+++ b/spec/services/candidate_interface/measure_distances_spec.rb
@@ -1,6 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::MeasureDistances do
+  describe '#distance' do
+    it 'returns correct distance between geocoded destinations' do
+      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      destination = instance_double(Site, latitude: 51.6097184, longitude: -1.2482939)
+      expect(described_class.new.distance(start, destination)).to be_within(0.1).of(2.2)
+    end
+
+    it 'handles nil lat/lng values for `start` model' do
+      start = instance_double(ApplicationForm, latitude: nil, longitude: nil)
+      destination = instance_double(Site, latitude: 51.6097184, longitude: -1.2482939)
+      expect(described_class.new.distance(start, destination)).to be_nil
+    end
+
+    it 'handles nil lat/lng values for `destination` model' do
+      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      destination = instance_double(Site, latitude: nil, longitude: nil)
+      expect(described_class.new.distance(start, destination)).to be_nil
+    end
+
+    it 'handles nil `destination` model' do
+      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      expect(described_class.new.distance(start, nil)).to be_nil
+    end
+  end
+
   describe '#average_distance' do
     it 'returns correct average given multiple destinations' do
       start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)

--- a/spec/services/candidate_interface/measure_distances_spec.rb
+++ b/spec/services/candidate_interface/measure_distances_spec.rb
@@ -3,63 +3,63 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::MeasureDistances do
   describe '#distance' do
     it 'returns correct distance between geocoded destinations' do
-      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
-      destination = instance_double(Site, latitude: 51.6097184, longitude: -1.2482939)
+      start = build(:application_form, latitude: 51.5973506, longitude: -1.2967454)
+      destination = build(:site, latitude: 51.6097184, longitude: -1.2482939)
       expect(described_class.new.distance(start, destination)).to be_within(0.1).of(2.2)
     end
 
     it 'handles nil lat/lng values for `start` model' do
-      start = instance_double(ApplicationForm, latitude: nil, longitude: nil)
-      destination = instance_double(Site, latitude: 51.6097184, longitude: -1.2482939)
+      start = build(:application_form, latitude: nil, longitude: nil)
+      destination = build(:site, latitude: 51.6097184, longitude: -1.2482939)
       expect(described_class.new.distance(start, destination)).to be_nil
     end
 
     it 'handles nil lat/lng values for `destination` model' do
-      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
-      destination = instance_double(Site, latitude: nil, longitude: nil)
+      start = build(:application_form, latitude: 51.5973506, longitude: -1.2967454)
+      destination = build(:site, latitude: nil, longitude: nil)
       expect(described_class.new.distance(start, destination)).to be_nil
     end
 
     it 'handles nil `destination` model' do
-      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      start = build(:application_form, latitude: 51.5973506, longitude: -1.2967454)
       expect(described_class.new.distance(start, nil)).to be_nil
     end
   end
 
   describe '#average_distance' do
     it 'returns correct average given multiple destinations' do
-      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      start = build(:application_form, latitude: 51.5973506, longitude: -1.2967454)
       destinations = [
-        instance_double(Site, latitude: 51.6097184, longitude: -1.2482939),
-        instance_double(Site, latitude: 51.6072222, longitude: -1.2407998),
-        instance_double(Site, latitude: 51.605683, longitude: -1.2252001),
+        build(:site, latitude: 51.6097184, longitude: -1.2482939),
+        build(:site, latitude: 51.6072222, longitude: -1.2407998),
+        build(:site, latitude: 51.605683, longitude: -1.2252001),
       ]
       expect(described_class.new.average_distance(start, destinations)).to be_within(0.1).of(2.6)
     end
 
     it 'handles nil lat/lng values for `start` model' do
-      start = instance_double(ApplicationForm, latitude: nil, longitude: nil)
+      start = build(:application_form, latitude: nil, longitude: nil)
       destinations = [
-        instance_double(Site, latitude: 51.6097184, longitude: -1.2482939),
+        build(:site, latitude: 51.6097184, longitude: -1.2482939),
       ]
       expect(described_class.new.average_distance(start, destinations)).to be_nil
     end
 
     it 'handles nil lat/lng values for all of the `destinations`' do
-      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      start = build(:application_form, latitude: 51.5973506, longitude: -1.2967454)
       destinations = [
-        instance_double(Site, latitude: nil, longitude: nil),
-        instance_double(Site, latitude: nil, longitude: nil),
+        build(:site, latitude: nil, longitude: nil),
+        build(:site, latitude: nil, longitude: nil),
       ]
       expect(described_class.new.average_distance(start, destinations)).to be_nil
     end
 
     it 'handles nil lat/lng values for some of the `destinations`' do
-      start = instance_double(ApplicationForm, latitude: 51.5973506, longitude: -1.2967454)
+      start = build(:application_form, latitude: 51.5973506, longitude: -1.2967454)
       destinations = [
-        instance_double(Site, latitude: nil, longitude: nil),
-        instance_double(Site, latitude: 51.6072222, longitude: -1.2407998),
-        instance_double(Site, latitude: 51.605683, longitude: -1.2252001),
+        build(:site, latitude: nil, longitude: nil),
+        build(:site, latitude: 51.6072222, longitude: -1.2407998),
+        build(:site, latitude: 51.605683, longitude: -1.2252001),
       ]
       expect(described_class.new.average_distance(start, destinations)).to be_within(0.1).of(2.8)
     end

--- a/spec/services/support_interface/locations_export_spec.rb
+++ b/spec/services/support_interface/locations_export_spec.rb
@@ -9,11 +9,17 @@ RSpec.describe SupportInterface::LocationsExport do
     end
 
     it 'returns a hash of location and application choice related data' do
-      application_form = create(:application_form, date_of_birth: Date.new(2000, 1, 1))
+      application_form = create(
+        :application_form,
+        date_of_birth: Date.new(2000, 1, 1),
+        latitude: 51.5973506,
+        longitude: -1.2967454,
+      )
       provider = create(:provider, provider_type: 'lead_school')
       accredited_provider = create(:provider, provider_type: 'scitt')
       course = create(:course, provider: provider, accredited_provider: accredited_provider, program_type: 'scitt_programme')
-      course_option = create(:course_option, course: course)
+      site = create(:site, latitude: 51.6097184, longitude: -1.2482939, provider: provider)
+      course_option = create(:course_option, course: course, site: site)
       application_choice = create(:application_choice, course_option: course_option, application_form: application_form, status: :awaiting_provider_decision)
       create(:degree_qualification, award_year: '2020', application_form: application_form, qualification_type: 'Bachelor of Theology')
       create(:degree_qualification, award_year: '2018', application_form: application_form)
@@ -40,6 +46,8 @@ private
       'Degree completed' => '2020',
       'Degree type' => 'Bachelor of Theology',
       'Status' => :awaiting_provider_decisions,
+      'Distance from site to candidate' => '2.2',
+      'Average distance from all sites to candidate' => '2.2',
     }
   end
 end


### PR DESCRIPTION
## Context

Performance Analysts need insight into distance between candidate course choices and registered address.
So that they can group candidates to inform the development of personas.

## Changes proposed in this pull request

This PR adds two new 'columns' to the location export:

* Distance from site to candidate
* Average distance from all sites to candidate

Example:

```
Candidate id,Support reference,Age,Candidate’s postcode,Provider’s postcode,Site’s postcode,Provider type,Accrediting provider type,Program type,Degree completed,Degree type,Status,Distance from site to candidate,Average distance from all sites to candidate
2,WA6198,30,ZL34 2HA,ST7 8AP,ST5 2QY,,,school_direct_training_programme,1997,Bachelor of Nursing,unsubmitted_in_progress,239.0,239.0
3,VZ4642,57,Y0 7BB,ST7 8AP,CW3 0JJ,,,school_direct_training_programme,1979,BSc/Education,unsubmitted_in_progress,27.6,27.6
4,BD9292,57,WP8N 6RJ,ST7 8AP,CW3 0JJ,,,school_direct_training_programme,1965,Bachelor of Librarianship,unsubmitted_in_progress,"",""
5,ZB6417,50,WP0 0WJ,,LS11 0LT,,,scitt_programme,1983,Master of Education,ended_without_success,"",""
6,YB8546,50,Z8J 5FE,,LS27 0PD,,,scitt_programme,2015,Bachelor of Administration,unsubmitted_in_progress,4198.4,4198.4
7,JP3873,46,T4 0NN,,LS12 5EU,,,scitt_programme,2000,BA with intercalated PGCE,awaiting_provider_decisions,105.0,104.6
7,JP3873,46,T4 0NN,,LS8 5DQ,,,scitt_programme,2000,BA with intercalated PGCE,awaiting_provider_decisions,106.8,104.6
7,JP3873,46,T4 0NN,,LS27 0PD,,,higher_education_programme,2000,BA with intercalated PGCE,awaiting_provider_decisions,102.1,104.6
```

## Guidance to review

This should work on review application given sites and applications with `latitude`/`longitude` values. If these are missing on either side then the value is blank in the report.

## Link to Trello card

https://trello.com/c/dgGd5DPZ/2589-dev-data-export-for-candidates-distance-from-course-choices

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
