### PR TITLE
Improve the referee's journey when their references aren't required

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -126,7 +126,13 @@ module RefereeInterface
       redirect_to referee_interface_confirmation_path(token: @token_param)
     end
 
-    def finish; end
+    def finish
+      @min_feedback_provided = reference
+        .application_form
+        .application_references
+        .minimum_feedback_provided?
+      @application_form = reference.application_form
+    end
 
   private
 

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -34,6 +34,8 @@ class ApplicationReference < ApplicationRecord
     never_asked: 'never_asked',
   }
 
+  scope :minimum_feedback_provided?, -> { where(feedback_status: 'feedback_provided').count >= 2 }
+
   def self.pending_feedback_or_failed
     where.not(feedback_status: %i[not_requested_yet feedback_provided])
   end

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -9,7 +9,7 @@ class SubmitReference
   def save!
     reference_feedback_provided!
     cancel_feedback_requested_references if enough_references_have_been_provided?
-    CandidateMailer.reference_received(@reference).deliver_later
+    CandidateMailer.reference_received(reference).deliver_later
     RefereeMailer.reference_confirmation_email(application_form, reference).deliver_later
   end
 

--- a/app/views/referee_interface/reference/finish.html.erb
+++ b/app/views/referee_interface/reference/finish.html.erb
@@ -6,10 +6,21 @@
       <%= t('page_titles.referee.finish') %>
     </h1>
 
+    <% if @min_feedback_provided %>
+      <p class="govuk-body">
+        You do not need to give a reference anymore.
+      </p>
+      <p class="govuk-body">
+        <%= @application_form.first_name %> <%= @application_form.last_name %> has received the 2 references needed to
+        apply for a teacher training course.
+      </p>
+    <% end %>
+
     <% if @reference.consent_to_be_contacted? %>
       <h2 class="govuk-heading-m">Our user research team will contact you shortly</h2>
     <% end %>
 
-    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <%= bat_contact_mail_to %>.</p>
+    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please
+      contact <%= bat_contact_mail_to %>.</p>
   </div>
 </div>

--- a/spec/system/referee_interface/referee_cannot_provide_reference_if_two_already_received_spec.rb
+++ b/spec/system/referee_interface/referee_cannot_provide_reference_if_two_already_received_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee is not required to submit a reference' do
+  include CandidateHelper
+
+  scenario 'Candidate has already received the minimum number of references' do
+    given_the_candidate_has_requested_three_references_and_i_am_the_third_referee
+    and_the_first_referee_has_responded_with_a_reference
+    and_the_second_referee_has_responded_with_a_reference
+    when_i_receive_an_email_with_a_reference_request
+    and_i_click_on_the_link_within_the_email
+    then_i_should_see_that_i_am_not_required_to_give_a_reference
+  end
+
+  def given_the_candidate_has_requested_three_references_and_i_am_the_third_referee
+    @first_reference = create(:reference, :feedback_requested, email_address: 'terri@example.com', name: 'Terri Tudor')
+    @second_reference = create(:reference, :feedback_requested, email_address: 'Bruce@Wayne.com', name: 'Bat Man')
+    @third_reference = create(:reference, :feedback_requested, email_address: 'Clark@Kent.com', name: 'Super Man')
+    @application = create(:completed_application_form,
+                          application_references: [
+                            @first_reference,
+                            @second_reference,
+                            @third_reference,
+                          ],
+                          candidate: current_candidate)
+  end
+
+  def and_the_first_referee_has_responded_with_a_reference
+    submit_reference(@first_reference)
+  end
+
+  def and_the_second_referee_has_responded_with_a_reference
+    submit_reference(@second_reference)
+  end
+
+  def submit_reference(reference)
+    reference.update!(
+      feedback: 'Lovable',
+      relationship_correction: '',
+      safeguarding_concerns: '',
+    )
+
+    SubmitReference.new(
+      reference: reference,
+    ).save!
+  end
+
+  def when_i_receive_an_email_with_a_reference_request
+    RefereeMailer.reference_request_email(@third_reference).deliver_now
+    open_email('Clark@Kent.com')
+  end
+
+  def and_i_click_on_the_link_within_the_email
+    click_sign_in_link(current_email)
+  end
+
+  def then_i_should_see_that_i_am_not_required_to_give_a_reference
+    expect(page).to have_content('Thank you')
+    expect(page).to have_content('You do not need to give a reference anymore.')
+  end
+end


### PR DESCRIPTION
## Context

Currently, when a referee attempts to give a reference and the candidate already has 2 references they are taken to a page that just says thank you. It does not give them any context as to why they cannot give a reference.

## Changes proposed in this pull request

- Copy added to the ‘Thank you’ page

## Guidance to review

- Sign in as a candidate and request three references
- Log into the support and click of the reference requested emails for that application
- When click on the link inside the third reference request email you should be redirected to the 'Thank you' page where you will see the additional guidance that was added

## Link to Trello card

https://trello.com/c/EHiwLtjp/2593-%F0%9F%92%942%EF%B8%8F%E2%83%A3-dev-improve-the-referees-journey-when-their-references-arent-required

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
