### PR TITLE
Fix for candidate journey tracker export

### DIFF
--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -160,7 +160,7 @@ module SupportInterface
           }
         end
 
-      @received_reference_timings.sort_by { |times| times[:received_at] }
+      @received_reference_timings.sort_by { |times| times[:received_at] || Time.zone.now }
     end
 
     def earliest_update_audit_for(model, attributes)

--- a/spec/services/support_interface/candidate_journey_tracker_spec.rb
+++ b/spec/services/support_interface/candidate_journey_tracker_spec.rb
@@ -142,6 +142,22 @@ RSpec.describe SupportInterface::CandidateJourneyTracker, with_audited: true do
       end
       expect(described_class.new(application_choice).reference_2_received).to eq(now + 2.days)
     end
+
+    context 'when audit entries are not present', with_audited: false do
+      it 'returns nil for the time when the second reference was received' do
+        application_form = create(:application_form)
+        application_choice = create(:application_choice, status: :unsubmitted, application_form: application_form)
+        application_reference1 = create(:reference, :feedback_requested, application_form: application_form)
+        application_reference2 = create(:reference, :feedback_requested, application_form: application_form)
+        Timecop.freeze(now + 1.day) do
+          application_reference1.update!(feedback_status: 'feedback_provided')
+        end
+        Timecop.freeze(now + 2.days) do
+          application_reference2.update!(feedback_status: 'feedback_provided')
+        end
+        expect(described_class.new(application_choice).reference_2_received).to be_nil
+      end
+    end
   end
 
   describe '#reference_reminder_email_sent' do


### PR DESCRIPTION
## Context

This report is broken in production.

https://sentry.io/organizations/dfe-bat/issues/2067746769/?environment=production&project=1765973&query=is%3Aunresolved

This is due to missing audit entries that this report depends on to work out the `received_at` value for provided references.

## Changes proposed in this pull request

This is a workaround that adds some defensive code to handle missing audit entries. Follow up investigation needed to find out why they are missing.

## Guidance to review

Does this look like a reasonable workaround? Is there anything else we can do to handle missing audit entries?

## Link to Trello card

https://trello.com/c/ZmyAYz38/2652-fix-and-investigate-why-candidate-journey-tracker-export-is-broken

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
