### PR TITLE
Update the decline reference journey

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -117,18 +117,16 @@ module RefereeInterface
     end
 
     def confirm_feedback_refusal
-      @refuse_feedback_form = RefuseFeedbackForm.new(refuse_feedback_params)
+      @refuse_feedback_form = RefuseFeedbackForm.new(choice: choice_params)
+      @application = reference.application_form
 
-      if @refuse_feedback_form.valid?
-        if @refuse_feedback_form.referee_has_confirmed_they_wont_a_reference?
-          @refuse_feedback_form.save(reference)
-          redirect_to referee_interface_thank_you_path(token: @token_param)
-        else
-          redirect_to referee_interface_reference_relationship_path(token: @token_param)
-        end
+      render :refuse_feedback and return unless @refuse_feedback_form.valid?
+
+      if @refuse_feedback_form.referee_has_confirmed_they_wont_a_reference?
+        @refuse_feedback_form.save(reference)
+        redirect_to referee_interface_thank_you_path(token: @token_param)
       else
-        track_validation_error(@refuse_feedback_form)
-        render :refuse_feedback
+        redirect_to referee_interface_reference_relationship_path(token: @token_param)
       end
     end
 
@@ -182,9 +180,8 @@ module RefereeInterface
             .permit(:any_safeguarding_concerns, :safeguarding_concerns)
     end
 
-    def refuse_feedback_params
-      params.require(:referee_interface_refuse_feedback_form)
-            .permit(:choice)
+    def choice_params
+      params.dig(:referee_interface_refuse_feedback_form, :choice)
     end
   end
 end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -112,21 +112,29 @@ module RefereeInterface
     end
 
     def refuse_feedback
+      @refuse_feedback_form = RefuseFeedbackForm.new
       @application = reference.application_form
-      @reference = reference
     end
 
     def confirm_feedback_refusal
-      reference.update!(feedback_status: 'feedback_refused')
+      @refuse_feedback_form = RefuseFeedbackForm.new(refuse_feedback_params)
 
-      send_slack_notification
-
-      SendNewRefereeRequestEmail.call(reference: @reference, reason: :refused)
-
-      redirect_to referee_interface_confirmation_path(token: @token_param)
+      if @refuse_feedback_form.valid?
+        if @refuse_feedback_form.referee_has_confirmed_they_wont_a_reference?
+          @refuse_feedback_form.save(reference)
+          redirect_to referee_interface_thank_you_path(token: @token_param)
+        else
+          redirect_to referee_interface_reference_relationship_path(token: @token_param)
+        end
+      else
+        track_validation_error(@refuse_feedback_form)
+        render :refuse_feedback
+      end
     end
 
     def finish; end
+
+    def thank_you; end
 
   private
 
@@ -160,13 +168,6 @@ module RefereeInterface
       render 'errors/not_found', status: :not_found
     end
 
-    def send_slack_notification
-      message = ":sadparrot: A referee declined to give feedback for #{reference.application_form.first_name}’s application"
-      url = helpers.support_interface_application_form_url(reference.application_form)
-
-      SlackNotificationWorker.perform_async(message, url)
-    end
-
     def questionnaire_params
       params.require(:referee_interface_questionnaire_form).permit(*QuestionnaireForm::FORM_KEYS)
     end
@@ -179,6 +180,11 @@ module RefereeInterface
     def safeguarding_params
       params.require(:referee_interface_reference_safeguarding_form)
             .permit(:any_safeguarding_concerns, :safeguarding_concerns)
+    end
+
+    def refuse_feedback_params
+      params.require(:referee_interface_refuse_feedback_form)
+            .permit(:choice)
     end
   end
 end

--- a/app/forms/referee_interface/refuse_feedback_form.rb
+++ b/app/forms/referee_interface/refuse_feedback_form.rb
@@ -1,0 +1,30 @@
+module RefereeInterface
+  class RefuseFeedbackForm
+    include ActiveModel::Model
+
+    attr_accessor :choice
+
+    validates :choice, presence: true
+
+    def save(reference)
+      return false unless valid?
+
+      reference.feedback_refused!
+      send_slack_notification(reference)
+      SendNewRefereeRequestEmail.call(reference: reference, reason: :refused)
+    end
+
+    def referee_has_confirmed_they_wont_a_reference?
+      choice == 'yes'
+    end
+
+  private
+
+    def send_slack_notification(reference)
+      message = ":sadparrot: A referee declined to give feedback for #{reference.application_form.first_name}’s application"
+      url = Rails.application.routes.url_helpers.support_interface_application_form_url(reference.application_form)
+
+      SlackNotificationWorker.perform_async(message, url)
+    end
+  end
+end

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -1,21 +1,28 @@
-<% content_for :title, t('page_titles.referee.refuse_feedback', full_name: @application.full_name) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.referee.refuse_feedback'), @refuse_feedback_form.errors.any?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.referee.refuse_feedback', full_name: @application.full_name) %>
-    </h1>
-
     <%= form_with(
-      model: @reference,
+      model: @refuse_feedback_form,
       url: referee_interface_refuse_feedback_path(token: @token_param),
       method: :patch
     ) do |f| %>
-      <%= f.govuk_submit t('referee.refuse_feedback.confirm') %>
-    <% end %>
+      <%= f.govuk_error_summary %>
 
-    <p class="govuk-body">
-      <%= govuk_link_to t('referee.refuse_feedback.cancel'), referee_interface_reference_feedback_path(token: @token_param) %>
-    </p>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.referee.refuse_feedback') %>
+      </h1>
+
+      <p class='govuk-body'>Teacher training courses can fill up quickly, and candidates need 2 references to apply.</p>
+
+      <p class='govuk-body'><%= @application.full_name %> will be able to submit the application quicker if you give a reference.</p>
+
+      <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name)  } do %>
+        <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }  %>
+        <%= f.govuk_radio_button :choice, 'no', label: { text: t('referee.refuse_feedback.choice.cancel') }  %>
+      <% end %>
+
+      <%= f.govuk_submit t('referee.refuse_feedback.continue') %>
+    <% end %>
   </div>
 </div>

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -13,9 +13,9 @@
         <%= t('page_titles.referee.refuse_feedback') %>
       </h1>
 
-      <p class='govuk-body'>Teacher training courses can fill up quickly, and candidates need 2 references to apply.</p>
+      <p class="govuk-body">Teacher training courses can fill up quickly, and candidates need 2 references to apply.</p>
 
-      <p class='govuk-body'><%= @application.full_name %> will be able to submit the application quicker if you give a reference.</p>
+      <p class="govuk-body"><%= @application.full_name %> will be able to submit the application quicker if you give a reference.</p>
 
       <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name)  } do %>
         <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }  %>

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.referee.relationship', full_name: @application.full_name), @relationship_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/referee_interface/reference/thank_you.html.erb
+++ b/app/views/referee_interface/reference/thank_you.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, t('page_titles.referee.finish') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.referee.finish') %>
+    </h1>
+
+    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <%= bat_contact_mail_to %>.</p>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1020,6 +1020,10 @@ en:
             feedback:
               blank: Enter your reference
               too_many_words: Your reference must be %{count} words or fewer
+        referee_interface/refuse_feedback_form:
+          attributes:
+            choice:
+              blank: Choose whether to decline this reference request
         candidate_interface/apply_on_ucas_or_apply_form:
           attributes:
             service:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,7 +134,7 @@ en:
     application_feedback: How can we improve %{section} section?
     application_feedback_thank_you: Thank you for your feedback
     referee:
-      refuse_feedback: Are you sure you will not give %{full_name} a reference?
+      refuse_feedback: You’ve declined to give a reference
       relationship: Confirm how you know %{full_name}
       safeguarding: Do you know of any reason why %{full_name} should not work with children?
       feedback: Your reference for %{full_name}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,7 +134,7 @@ en:
     application_feedback: How can we improve %{section} section?
     application_feedback_thank_you: Thank you for your feedback
     referee:
-      refuse_feedback: You’ve declined to give a reference
+      refuse_feedback: Decline to give a reference
       relationship: Confirm how you know %{full_name}
       safeguarding: Do you know of any reason why %{full_name} should not work with children?
       feedback: Your reference for %{full_name}

--- a/config/locales/referee.yml
+++ b/config/locales/referee.yml
@@ -1,8 +1,11 @@
 en:
   referee:
     refuse_feedback:
-      confirm: Yes – I’m sure
-      cancel: Cancel
+      choice:
+        label: Are you sure you do not want to give %{full_name} a reference?
+        confirm: Yes, I’m sure
+        cancel: No, I’ve changed my mind
+      continue: Continue
     relationship_confirmation:
       legend: Is this correct?
       'yes':

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -504,6 +504,8 @@ Rails.application.routes.draw do
 
     get '/refuse-feedback' => 'reference#refuse_feedback', as: :refuse_feedback
     patch '/refuse-feedback' => 'reference#confirm_feedback_refusal'
+
+    get '/thank-you' => 'reference#thank_you', as: :thank_you
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/spec/forms/referee_interface/refuse_feedback_form_spec.rb
+++ b/spec/forms/referee_interface/refuse_feedback_form_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::RefuseFeedbackForm do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:choice) }
+
+    describe '#save' do
+      let(:application_reference) { create(:reference, :feedback_requested) }
+
+      context 'when the form is invalid' do
+        it 'returns false' do
+          form = described_class.new
+
+          expect(form.save(application_reference)).to be(false)
+        end
+      end
+
+      context 'when the form is valid' do
+        it 'updates the reference to feedback_refused' do
+          form = described_class.new(choice: 'yes')
+          form.save(application_reference)
+
+          expect(application_reference.feedback_status).to eq('feedback_refused')
+        end
+      end
+    end
+  end
+end

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -9,10 +9,10 @@ RSpec.feature 'Refusing to give a reference' do
     then_i_receive_an_email_with_a_reference_request
 
     when_i_click_the_refuse_reference_link_in_the_email
-    and_i_say_that_i_do_actually_want_to_give_a_reference
-    then_i_see_the_reference_comment_page
+    and_choose_that_i_do_actually_want_to_give_a_reference
+    then_i_see_the_reference_relationship_page
 
-    when_i_click_the_refuse_reference_link_in_the_email
+    when_i_click_on_the_backlink
     and_i_confirm_that_i_wont_give_a_reference
     and_a_slack_notification_is_sent
     then_an_email_is_sent_to_the_candidate
@@ -36,20 +36,26 @@ RSpec.feature 'Refusing to give a reference' do
     current_email.click_link(refuse_feedback_url)
   end
 
-  def and_i_say_that_i_do_actually_want_to_give_a_reference
-    click_link 'Cancel'
+  def and_choose_that_i_do_actually_want_to_give_a_reference
+    choose 'No, I’ve changed my mind'
+    click_button 'Continue'
   end
 
-  def then_i_see_the_reference_comment_page
-    expect(page).to have_content("Your reference for #{@application.full_name}")
+  def then_i_see_the_reference_relationship_page
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+  end
+
+  def when_i_click_on_the_backlink
+    click_link 'Back'
+  end
+
+  def and_i_confirm_that_i_wont_give_a_reference
+    choose 'Yes, I’m sure'
+    click_button 'Continue'
   end
 
   def and_a_slack_notification_is_sent
     expect_slack_message_with_text ":sadparrot: A referee declined to give feedback for #{@application.first_name}’s application"
-  end
-
-  def and_i_confirm_that_i_wont_give_a_reference
-    click_button 'Yes – I’m sure'
   end
 
   def then_an_email_is_sent_to_the_candidate


### PR DESCRIPTION
## Context

Currently, when a referee clicks the link in the email to decline a reference they are taken to a Thank you page. 

If that's a mistake they have to get in touch. We want to enable referees to go into the referee flow and encourage them to think again about giving a reference.

(Plus it's reaaaaal ugly rn)

## Changes proposed in this pull request

- Add radio buttons and additional content to refuse feedback page

|Before|After|
|------------|------------|
| ![image](https://user-images.githubusercontent.com/42515961/100926665-b55a2c80-34db-11eb-9753-10e12e58adfd.png) | ![image](https://user-images.githubusercontent.com/42515961/100926544-86dc5180-34db-11eb-87eb-adcb912da7e0.png) |

- If they choose that they want to provide a reference send them to the confirm relationship page
- Ensure there's a backlink on that page so they can still go back and refuse to give a reference

- If they confirm they don't want to provide a reference redirect them to the thank you page

![image](https://user-images.githubusercontent.com/42515961/100926751-d3c02800-34db-11eb-9289-9d57107a4084.png)

## Guidance to review

This section of the code base is pretty horrible. I'm going to give it a bit of a refactor over Christmas.

## Link to Trello card

https://trello.com/c/IJzqtJI7/2592-%F0%9F%92%942%EF%B8%8F%E2%83%A3-dev-change-the-referee-declining-journey

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
