### PR TITLE
Show phase banner within masthead on provider start page

### DIFF
--- a/app/components/phase_banner_component.html.erb
+++ b/app/components/phase_banner_component.html.erb
@@ -1,12 +1,14 @@
-<div class="govuk-width-container">
-  <div class="govuk-phase-banner <%= @no_border ? 'app-phase-banner--no-border' : '' %> govuk-!-display-none-print">
-    <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag <%= phase_tag_class %>">
-        <%= HostingEnvironment.phase %>
-      </strong>
-      <span class="govuk-phase-banner__text">
-        <%= text %>
-      </span>
-    </p>
+<div class="app-phase-banner<%= @no_border ? ' app-phase-banner--no-border' : '' %>">
+  <div class="govuk-width-container">
+    <div class="govuk-phase-banner govuk-!-display-none-print">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag <%= phase_tag_class %>">
+          <%= HostingEnvironment.phase %>
+        </strong>
+        <span class="govuk-phase-banner__text">
+          <%= text %>
+        </span>
+      </p>
+    </div>
   </div>
 </div>

--- a/app/frontend/styles/_phase-banner.scss
+++ b/app/frontend/styles/_phase-banner.scss
@@ -1,3 +1,26 @@
 .app-phase-banner--no-border {
-  border-bottom: 0;
+  .govuk-phase-banner {
+    border-bottom: 0;
+  }
+}
+
+.app-start-page {
+  .app-phase-banner {
+    background-color: $govuk-brand-colour;
+    margin-top: -(govuk-spacing(2));
+  }
+
+  .govuk-phase-banner {
+    border-bottom-color: govuk-colour("light-blue");
+  }
+
+  .govuk-phase-banner__text,
+  .govuk-link {
+    color: govuk-colour("white");
+  }
+
+  .govuk-tag {
+    background: govuk-colour("white");
+    color: $govuk-brand-colour;
+  }
 }

--- a/app/frontend/styles/provider/_masthead.scss
+++ b/app/frontend/styles/provider/_masthead.scss
@@ -1,6 +1,5 @@
 .app-masthead {
-  @include govuk-responsive-padding(6, "top");
-  @include govuk-responsive-padding(6, "bottom");
+  @include govuk-main-wrapper;
   color: govuk-colour("white");
   background-color: govuk-colour("blue");
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -21,7 +21,7 @@
                                  navigation_items: NavigationItems.for_provider_account_nav(try(:current_provider_user), controller, @provider_setup&.pending?))) %>
 
                                <% if controller.controller_name == 'start_page' %>
-                                 <%= render PhaseBannerComponent.new(no_border: true, feedback_link: ProviderInterface::FEEDBACK_LINK) %>
+                                 <%= render PhaseBannerComponent.new(feedback_link: ProviderInterface::FEEDBACK_LINK) %>
                                <% elsif controller.controller_name.in? %w[sessions content provider_agreements] %>
                                  <%= render PhaseBannerComponent.new(feedback_link: ProviderInterface::FEEDBACK_LINK) %>
                                <% else %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -35,7 +35,7 @@
     <% end %>
   </head>
 
-  <body class="govuk-template__body">
+  <body class="govuk-template__body <%= yield :body_class %>">
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -1,3 +1,4 @@
+<%= content_for :body_class, "app-start-page" %>
 <% content_for :browser_title, t('page_titles.application') %>
 
 <div class="app-masthead">


### PR DESCRIPTION
## Context

Register have [updated the phase banner so that it appears within the masthead on their start page](https://github.com/DFE-Digital/register-trainee-teachers/pull/227), and it’s 👌

## Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="1008" alt="Screenshot 2020-12-03 at 12 19 58" src="https://user-images.githubusercontent.com/813383/101017906-a1a5d900-3562-11eb-89c6-9b2b222fd1cd.png"> | <img width="1000" alt="Screenshot 2020-12-03 at 12 23 01" src="https://user-images.githubusercontent.com/813383/101017915-a5396000-3562-11eb-9b4c-4cfb7485e826.png"> |

Far less like a layer cake!

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
