### PR TITLE
Add a 90% threshold to the word count message

### DIFF
--- a/app/views/candidate_interface/work_history/break/_form.html.erb
+++ b/app/views/candidate_interface/work_history/break/_form.html.erb
@@ -13,6 +13,6 @@
   <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: 'End of break', size: 'm', tag: 'span' } %>
 </div>
 
-<%= f.govuk_text_area :reason, label: { text: 'Enter reasons for break in work history', size: 'm' }, hint: { text: 'For example, parenting or caring responsibilities, unemployment, travel, health, study or other personal reasons' }, max_words: 400 %>
+<%= f.govuk_text_area :reason, label: { text: 'Enter reasons for break in work history', size: 'm' }, hint: { text: 'For example, parenting or caring responsibilities, unemployment, travel, health, study or other personal reasons' }, max_words: 400, threshold: 90 %>
 
 <%= f.govuk_submit 'Continue' %>


### PR DESCRIPTION
This removes the "You have 400 words remaining" message, and only shows the number of words remaining once a 90% threshold (40 words remaining or less) has been reached.

This is to avoid candidates feeling like they need to give a long explanation of their reasons for the break in work history.

## Screenshots

### Before

<img width="685" alt="Screenshot 2020-12-03 at 14 36 03" src="https://user-images.githubusercontent.com/30665/101042288-efc3d800-3574-11eb-91ee-bf8cb8e3510d.png">

### After

<img width="694" alt="Screenshot 2020-12-03 at 14 36 18" src="https://user-images.githubusercontent.com/30665/101042309-f5212280-3574-11eb-83ce-22307fb260a3.png">
