### PR TITLE
Change original_controller to find_controller

### DIFF
--- a/db/migrate/20201203144318_change_original_controller_to_find_controller.rb
+++ b/db/migrate/20201203144318_change_original_controller_to_find_controller.rb
@@ -1,0 +1,5 @@
+class ChangeOriginalControllerToFindController < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :find_feedback, :original_controller, :find_controller
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_132605) do
+ActiveRecord::Schema.define(version: 2020_12_03_144318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -339,7 +339,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_132605) do
 
   create_table "find_feedback", force: :cascade do |t|
     t.string "path", null: false
-    t.string "original_controller", null: false
+    t.string "find_controller", null: false
     t.string "feedback", null: false
     t.string "email_address"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
## Context

As part of the work on candidates giving feedback on find here #3563 Toby noted that the field original_controller was not very explicit.
 
## Changes proposed in this pull request

- Change original_controller to find_controller in the db

## Guidance to review

I'll change the code in #3563 to use find_controller once this is merged.

## Link to Trello card

https://trello.com/c/WlerGBf0/2456-%F0%9F%93%9D-dev-collect-user-feedback-at-specific-drop-off-points-catch-all

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
