### PR TITLE
Create postgre read replica server

### DIFF
--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -185,6 +185,19 @@ jobs:
                 Write-Host "##vso[task.setvariable variable=deploymentStartTime]$(Get-Date)"
                 Write-Host "##vso[task.setvariable variable=fullDeployment]$fullDeployment"
 
+          - task: AzureCLI@2
+            displayName: 'Check if read replica postgres server exists in $(resourceGroupName)'
+            env:
+              REPLICA_SERVER_NAME: ${{ format('{0}-psql-replica', variables.resourceGroupName) }}
+              RESOURCE_GROUP_NAME: $(resourceGroupName)
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              ScriptType: pscore
+              ScriptLocation: inlineScript
+              inlineScript: |
+                $replicaServer = az postgres server list --resource-group $env:RESOURCE_GROUP_NAME | ConvertFrom-Json | where name -eq $env:REPLICA_SERVER_NAME
+                Write-Host "##vso[task.setvariable variable=databaseReplicaExists]$($replicaServer -ne $null)"
+
           - task: AzureResourceGroupDeployment@2
             displayName: 'ARM Deployment - Create Or Update Resource Group action on $(resourceGroupName)'
             condition: and(eq(variables['buildCancelled'], false), or(eq(variables['fullDeployment'], true), eq(variables['overrideFullDeployment'], true) ))
@@ -218,6 +231,7 @@ jobs:
                 -databasePassword "${{parameters.databasePassword}}"
                 -databaseStorageAutoGrow "${{parameters.databaseStorageAutoGrow}}"
                 -databaseBackupRetentionDays "${{parameters.databaseBackupRetentionDays}}"
+                -databaseReplicaExists "$(databaseReplicaExists)"
                 -environment "${{parameters.environment}}"
                 -securityAlertEmail "${{parameters.securityAlertEmail}}"
                 -secretKeyBase "${{parameters.railsSecretKeyBase}}"

--- a/azure/template.json
+++ b/azure/template.json
@@ -154,6 +154,12 @@
                 "description": "Used to configure the number of days the database backups will be retained for."
             }
         },
+        "databaseReplicaExists": {
+            "type": "string",
+            "metadata": {
+                "description": "Does the database read replica already exists?"
+            }
+        },
         "securityAlertEmail": {
             "type": "string",
             "metadata": {
@@ -443,6 +449,7 @@
         "storageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'str'), '-', '')]",
         "databaseServerName": "[concat(variables('resourceNamePrefix'), '-psql')]",
         "useCustomDomains": "[greater(length(parameters('customDomains')), 0)]",
+        "databaseReplicaExists": "[bool(parameters('databaseReplicaExists'))]",
         "rubyAuthHosts": "[parameters('authorisedHosts')]",
         "defaultAvailabilityCheckHosts": "[if(variables('useCustomDomains'), createArray(concat('azcheck:', variables('appServiceName'), '.azurewebsites.net/check'), concat('check:', parameters('customDomains')[0].domainName, '/check')), createArray(concat('azcheck:', variables('appServiceName'), '.azurewebsites.net/check')))]",
         "availabilityCheckHosts": "[if(greater(length(parameters('customAvailabilityMonitors')), 0), concat(variables('defaultAvailabilityCheckHosts'), parameters('customAvailabilityMonitors')), variables('defaultAvailabilityCheckHosts'))]",
@@ -1110,6 +1117,7 @@
             "apiVersion": "2017-05-10",
             "name": "postgresql-server-configurations",
             "type": "Microsoft.Resources/deployments",
+            "condition": "[not(variables('databaseReplicaExists'))]",
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
@@ -1137,6 +1145,7 @@
             "apiVersion": "2017-05-10",
             "name": "postgresql-server-read-replica",
             "type": "Microsoft.Resources/deployments",
+            "condition": "[not(variables('databaseReplicaExists'))]",
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
@@ -1174,6 +1183,7 @@
             "apiVersion": "2017-05-10",
             "name": "postgresql-replica-server-firewall-rules",
             "type": "Microsoft.Resources/deployments",
+            "condition": "[not(variables('databaseReplicaExists'))]",
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
@@ -1186,6 +1196,12 @@
                     },
                     "allowAzureServicesAccess": {
                         "value": true
+                    },
+                    "firewallRuleNamePrefix": {
+                        "value": "AZURE_IP-"
+                    },
+                    "ipAddresses": {
+                        "value": "[reference('app-service-and-containers').outputs.appServiceIpAddresses.value]"
                     }
                 }
             },

--- a/azure/template.json
+++ b/azure/template.json
@@ -1102,7 +1102,95 @@
                 }
             },
             "dependsOn": [
+                "postgresql-server",
+                "postgresql-server-read-replica"
+            ]
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "postgresql-server-configurations",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server-configuration.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "serverName": {
+                        "value": "[variables('databaseServerName')]"
+                    },
+                    "configurations": {
+                        "value": [{
+                            "name": "azure.replication_support",
+                            "value": "REPLICA",
+                            "source": "user-override"
+                        }]
+                    }
+                }
+            },
+            "dependsOn": [
                 "postgresql-server"
+            ]
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "postgresql-server-read-replica",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
+                    "postgresServerName": {
+                        "value": "[variables('databaseServerName')]"
+                    },
+                    "isReadReplica": {
+                        "value": true
+                    },
+                    "storageAutoGrow": {
+                        "value": "[parameters('databaseStorageAutoGrow')]"
+                    },
+                    "backupRetentionDays": {
+                        "value": "[parameters('databaseBackupRetentionDays')]"
+                    },
+                    "storageAccountName": {
+                        "value": "[variables('storageAccountName')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "postgresql-server",
+                "postgresql-server-configurations",
+                "postgresql-database"
+            ]
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "postgresql-replica-server-firewall-rules",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'postgresql-server-firewall-rules.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "serverName": {
+                        "value": "[concat(variables('databaseServerName'), '-replica')]"
+                    },
+                    "allowAzureServicesAccess": {
+                        "value": true
+                    }
+                }
+            },
+            "dependsOn": [
+                "postgresql-server-read-replica"
             ]
         },
         {


### PR DESCRIPTION
## Context

It would be best to create a read replica server for reporting and analytics workloads.
This PR adds support to create a read replica database server.

## Changes proposed in this pull request

Change ARM template to create read replica postgres server.

## Guidance to review

To be merged once [this ](https://github.com/DFE-Digital/bat-platform-building-blocks/pull/73)upstream PR is merged

## Link to Trello card

https://trello.com/c/EnBhaj5K/2666-create-read-replica-postgres-server-for-reports-analytics

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
