### PR TITLE
Update BTEC page

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -124,8 +124,7 @@ module CandidateInterface
     end
 
     def set_grade_autocomplete_data
-      qualification_type = @form.qualification_type_name
-      if qualification_type.in? OTHER_UK_QUALIFICATIONS
+      if @form.qualification_type == 'Other'
         @grade_autocomplete_data = OTHER_UK_QUALIFICATION_GRADES
       end
     end

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -23,7 +23,7 @@ module CandidateInterface
     validates :qualification_type, presence: true
 
     validates :award_year, presence: true
-    validates :subject, :grade, presence: true, if: -> { qualification_type != OtherQualificationTypeForm::NON_UK_TYPE && qualification_type != OtherQualificationTypeForm::OTHER_TYPE }
+    validates :subject, :grade, presence: true, if: -> {should_validate_grade?}
     validates :subject, :grade, length: { maximum: 255 }
     validates :institution_country, presence: true, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
     validates :institution_country, inclusion: { in: COUNTRIES }, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
@@ -178,6 +178,12 @@ module CandidateInterface
       ])
         self.grade = grade.delete(' ').upcase if grade
       end
+    end
+
+    def should_validate_grade?
+      (qualification_type != OtherQualificationTypeForm::NON_UK_TYPE &&
+          qualification_type != OtherQualificationTypeForm::OTHER_TYPE) ||
+          other_uk_qualification_type == 'BTEC'
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -121,6 +121,10 @@ module CandidateInterface
       @current_qualification ||= id.present? ? @current_application.application_qualifications.other.find(id) : nil
     end
 
+    def btec?
+      other_uk_qualification_type == 'BTEC'
+    end
+
   private
 
     def previous_qualification_is_of_same_type?(qualifications)
@@ -182,8 +186,7 @@ module CandidateInterface
 
     def should_validate_grade?
       (qualification_type != OtherQualificationTypeForm::NON_UK_TYPE &&
-          qualification_type != OtherQualificationTypeForm::OTHER_TYPE) ||
-        other_uk_qualification_type == 'BTEC'
+          qualification_type != OtherQualificationTypeForm::OTHER_TYPE) || btec?
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -23,7 +23,7 @@ module CandidateInterface
     validates :qualification_type, presence: true
 
     validates :award_year, presence: true
-    validates :subject, :grade, presence: true, if: -> {should_validate_grade?}
+    validates :subject, :grade, presence: true, if: -> { should_validate_grade? }
     validates :subject, :grade, length: { maximum: 255 }
     validates :institution_country, presence: true, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
     validates :institution_country, inclusion: { in: COUNTRIES }, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
@@ -183,7 +183,7 @@ module CandidateInterface
     def should_validate_grade?
       (qualification_type != OtherQualificationTypeForm::NON_UK_TYPE &&
           qualification_type != OtherQualificationTypeForm::OTHER_TYPE) ||
-          other_uk_qualification_type == 'BTEC'
+        other_uk_qualification_type == 'BTEC'
     end
   end
 end

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -7,8 +7,8 @@
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autocomplete-data', data: { source: subject_autocomplete_data }) if subject_autocomplete_data %>
     <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.other_qualification.grade.label'), tag: 'span' } do %>
-      <% OTHER_UK_QUALIFICATION_GRADES.each do |grade| %>
-        <%= f.govuk_radio_button :grade, grade, label: { text: grade.to_s }%>
+      <% OTHER_UK_QUALIFICATION_GRADES.each_with_index do |grade, i| %>
+        <%= f.govuk_radio_button :grade, grade, link_errors: i.zero?, label: { text: grade.to_s }%>
       <% end %>
     <% end %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -3,7 +3,7 @@
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>
-  <% elsif @form.other_uk_qualification_type == 'BTEC' %>
+  <% elsif @form.btec? %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autocomplete-data', data: { source: subject_autocomplete_data }) if subject_autocomplete_data %>
     <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.other_qualification.grade.label'), tag: 'span' } do %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -3,6 +3,15 @@
     <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t('application_form.other_qualification.institution_country.label'), size: 'm' } %>
     <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.optional_label'), size: 'm' }, width: 10 %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>
+  <% elsif @form.other_uk_qualification_type == 'BTEC' %>
+    <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
+    <%= tag.div(id: 'subject-autocomplete-data', data: { source: subject_autocomplete_data }) if subject_autocomplete_data %>
+    <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.other_qualification.grade.label'), tag: 'span' } do %>
+      <% OTHER_UK_QUALIFICATION_GRADES.each do |grade| %>
+        <%= f.govuk_radio_button :grade, grade, label: { text: grade.to_s }%>
+      <% end %>
+    <% end %>
+    <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>
   <% else %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autocomplete-data', data: { source: subject_autocomplete_data }) if subject_autocomplete_data %>

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
@@ -10,19 +10,15 @@ RSpec.feature 'Entering their other qualifications' do
     when_i_click_on_other_qualifications
     then_i_see_the_select_qualification_type_page
 
-    when_i_select_add_an_other_uk_qualification
-    and_i_fill_in_the_qualification_name_as_btec
-    and_i_click_continue
+    when_i_attempt_to_add_a_btec
     then_i_see_the_add_btec_qualifications_form
 
     when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
     and_i_submit_the_other_qualification_form
     then_i_see_validation_errors_for_my_qualification
 
-    when_i_select_a_grade
-    and_i_submit_the_other_qualification_form
-    then_i_see_the_other_qualification_review_page
-    and_i_should_see_my_qualifications
+    when_i_complete_the_form
+    then_i_see_my_btec_on_the_review_page
     and_my_other_uk_qualification_has_the_correct_format
   end
 
@@ -42,18 +38,11 @@ RSpec.feature 'Entering their other qualifications' do
     expect(page).to have_current_path(candidate_interface_other_qualification_type_path)
   end
 
-  def when_i_select_add_an_other_uk_qualification
+  def when_i_attempt_to_add_a_btec
     choose 'Other'
-  end
-
-  def and_i_fill_in_the_qualification_name_as_btec
     fill_in 'candidate-interface-other-qualification-type-form-other-uk-qualification-type-field', with: 'BTEC'
-  end
-
-  def and_i_click_continue
     click_button 'Continue'
   end
-  alias_method :when_i_click_continue, :and_i_click_continue
 
   def then_i_see_the_add_btec_qualifications_form
     expect(page).to have_content('Add BTEC qualification')
@@ -72,15 +61,14 @@ RSpec.feature 'Entering their other qualifications' do
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/other_qualification_details_form.attributes.grade.blank')
   end
 
-  def when_i_select_a_grade
+  def when_i_complete_the_form
     choose 'Merit'
+    click_button t('application_form.other_qualification.base.button')
   end
 
-  def then_i_see_the_other_qualification_review_page
+  def then_i_see_my_btec_on_the_review_page
     expect(page).to have_current_path(candidate_interface_review_other_qualifications_path)
-  end
 
-  def and_i_should_see_my_qualifications
     expect(page).to have_content('BTEC')
     expect(page).to have_content('Music Theory')
     expect(page).to have_content('2015')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their other qualifications' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their BTEC qualification' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_other_qualifications
+    then_i_see_the_select_qualification_type_page
+
+    when_i_select_add_an_other_uk_qualification
+    and_i_fill_in_the_qualification_name_as_btec
+    and_i_click_continue
+    then_i_see_the_add_btec_qualifications_form
+
+    when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
+    and_i_submit_the_other_qualification_form
+    then_i_see_validation_errors_for_my_qualification
+
+    when_i_select_a_grade
+    and_i_submit_the_other_qualification_form
+    then_i_see_the_other_qualification_review_page
+    and_i_should_see_my_qualifications
+    and_my_other_uk_qualification_has_the_correct_format
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_other_qualifications
+    click_link t('page_titles.other_qualification')
+  end
+
+  def then_i_see_the_select_qualification_type_page
+    expect(page).to have_current_path(candidate_interface_other_qualification_type_path)
+  end
+
+  def when_i_select_add_an_other_uk_qualification
+    choose 'Other'
+  end
+
+  def and_i_fill_in_the_qualification_name_as_btec
+    fill_in 'candidate-interface-other-qualification-type-form-other-uk-qualification-type-field', with: 'BTEC'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+  alias_method :when_i_click_continue, :and_i_click_continue
+
+  def then_i_see_the_add_btec_qualifications_form
+    expect(page).to have_content('Add BTEC qualification')
+  end
+
+  def when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Music Theory'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
+  end
+
+  def and_i_submit_the_other_qualification_form
+    click_button t('application_form.other_qualification.base.button')
+  end
+
+  def then_i_see_validation_errors_for_my_qualification
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/other_qualification_details_form.attributes.grade.blank')
+  end
+
+  def when_i_select_a_grade
+    choose 'Merit'
+  end
+
+  def then_i_see_the_other_qualification_review_page
+    expect(page).to have_current_path(candidate_interface_review_other_qualifications_path)
+  end
+
+  def and_i_should_see_my_qualifications
+    expect(page).to have_content('BTEC')
+    expect(page).to have_content('Music Theory')
+    expect(page).to have_content('2015')
+    expect(page).to have_content('Merit')
+  end
+
+  def and_my_other_uk_qualification_has_the_correct_format
+    @application = current_candidate.current_application
+    expect(@application.application_qualifications.last.qualification_type).to eq 'Other'
+    expect(@application.application_qualifications.last.other_uk_qualification_type).to eq 'BTEC'
+    expect(@application.application_qualifications.last.subject).to eq 'Music Theory'
+  end
+end


### PR DESCRIPTION
## Context

BTEC qualifications currently have a free text field supported by an autocomplete. But the allowed grades are well defined so it would be clearer to use radio buttons here.

We can also use this list of grades as autocomplete values for other "Other UK qualifications". There is no autocomplete at the moment.

## Changes proposed in this pull request

BTEC before 
![image](https://user-images.githubusercontent.com/33458055/101064512-fd388c80-358b-11eb-8732-97cecd76b3f6.png)

BTEC after
![image](https://user-images.githubusercontent.com/33458055/101064840-54d6f800-358c-11eb-8c6d-4b53cfb5f1ac.png)

BTEC validation
![image](https://user-images.githubusercontent.com/33458055/101065659-51903c00-358d-11eb-9c50-aaf57ec85216.png)


Other UK qualifications before 
![image](https://user-images.githubusercontent.com/33458055/101065088-a1bace80-358c-11eb-9b11-615fdf809e7e.png)

Other UK qualifications after
![image](https://user-images.githubusercontent.com/33458055/101065258-d6c72100-358c-11eb-96d1-96ac3bd7dc51.png)

Note that the grade has been marked as optional. This was a separate change made in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3540


## Guidance to review

Have I missed any edge cases? Or disrupted any existing behaviour?

## Link to Trello card

https://trello.com/c/aEAhKbDE/2649-%F0%9F%93%90-dev-update-btec-page-to-have-structured-options-using-radio-options-for-the-grades

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
