### PR TITLE
Fix link colour on app start page

### DIFF
--- a/app/frontend/styles/_phase-banner.scss
+++ b/app/frontend/styles/_phase-banner.scss
@@ -15,7 +15,7 @@
   }
 
   .govuk-phase-banner__text,
-  .govuk-link {
+  .govuk-phase-banner__text .govuk-link {
     color: govuk-colour("white");
   }
 


### PR DESCRIPTION
## Context

Imported overly aggressive link styling from Register, which turns all the links on the provider start page white – hiding most of them 😭

## Changes proposed in this pull request

Scopes link styling only to phase banner link. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
