### PR TITLE
Set BLAZER_DATABASE_URL to read only Database URL

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -448,6 +448,7 @@
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
         "storageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'str'), '-', '')]",
         "databaseServerName": "[concat(variables('resourceNamePrefix'), '-psql')]",
+        "replicaServerConnectionString": "[concat('postgres://', parameters('databaseUsername'), ':', parameters('databasePassword'), '@', variables('databaseServerName'), '-replica.postgres.database.azure.com:5432/', parameters('databaseName'))]",
         "useCustomDomains": "[greater(length(parameters('customDomains')), 0)]",
         "databaseReplicaExists": "[bool(parameters('databaseReplicaExists'))]",
         "rubyAuthHosts": "[parameters('authorisedHosts')]",
@@ -645,6 +646,10 @@
                             {
                                 "name": "DB_DATABASE",
                                 "value": "[parameters('databaseName')]"
+                            },
+                            { 
+                                "name": "BLAZER_DATABASE_URL",
+                                "value": "[variables('replicaServerConnectionString')]"
                             },
                             {
                                 "name": "SECRET_KEY_BASE",
@@ -1161,6 +1166,9 @@
                     },
                     "isReadReplica": {
                         "value": true
+                    },
+                    "readReplicaExists": {
+                        "value": "[variables('databaseReplicaExists')]"
                     },
                     "storageAutoGrow": {
                         "value": "[parameters('databaseStorageAutoGrow')]"


### PR DESCRIPTION
## Context

Set `BLAZER_DATABASE_URL` 's value to the read replica server

## Changes proposed in this pull request

Set `BLAZER_DATABASE_URL` 's value to the read replica server

## Guidance to review

## Link to Trello card

https://trello.com/c/EnBhaj5K/2666-create-read-replica-postgres-server-for-reports-analytics

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
