### PR TITLE
Add messaging for more than 2 complete references

### DIFF
--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -1,68 +1,75 @@
-<% references.each do |reference| %>
-  <%= render(SummaryCardComponent.new(
-    rows: reference_rows(reference),
-    editable: editable && editable?(reference),
-    ignore_editable: ignore_editable_for,
-  )) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
-      <div class="app-summary-card__actions">
-        <ul class="app-summary-card__actions-list">
-          <% if reference.feedback_requested? %>
-            <div class="app-summary-card__actions">
-              <%= link_to candidate_interface_confirm_cancel_reference_path(reference.id), class: 'govuk-link' do %>
-                <%= t('application_form.references.cancel_request.action') %>
-                <span class="govuk-visually-hidden"> <%= reference.name %></span>
-              <% end %>
-            </div>
-          <% elsif can_retry?(reference) %>
-            <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_references_retry_request_path(reference.id), class: 'govuk-link' do %>
-                <%= t('application_form.references.retry_request.action') %>
-                <span class="govuk-visually-hidden"> to <%= reference.name %></span>
-              <% end %>
-            </li>
-          <% end %>
+<div class="<%= container_class %>">
+  <% if too_many_complete_references? %>
+    <p class='app-review-warning__primary-message'><%= t('application_form.references.review.more_than_two') %></p>
+    <p class='govuk-body'><%= too_many_references_error %></p>
+  <% end %>
 
-          <% if reference.not_requested_yet? %>
-            <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_confirm_destroy_referee_path(reference), class: 'govuk-link' do %>
-                <%= t('application_form.references.delete_referee.action') %>
-                <span class="govuk-visually-hidden"> <%= reference.name %></span>
-              <% end %>
-            </li>
-          <% elsif reference.feedback_provided? %>
-            <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_confirm_destroy_reference_path(reference), class: 'govuk-link' do %>
-                <%= t('application_form.references.delete_reference.action') %>
-                <span class="govuk-visually-hidden"> <%= reference.name %></span>
-              <% end %>
-            </li>
-          <% elsif request_can_be_deleted?(reference) %>
-            <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_confirm_destroy_reference_request_path(reference), class: 'govuk-link' do %>
-                <%= t('application_form.references.delete_request.action') %>
-                <span class="govuk-visually-hidden"> <%= reference.name %></span>
-              <% end %>
-            </li>
-          <% end %>
+  <% references.each do |reference| %>
+    <%= render(SummaryCardComponent.new(
+      rows: reference_rows(reference),
+      editable: editable && editable?(reference),
+      ignore_editable: ignore_editable_for,
+    )) do %>
+      <%= render(SummaryCardHeaderComponent.new(title: card_title(reference))) do %>
+        <div class="app-summary-card__actions">
+          <ul class="app-summary-card__actions-list">
+            <% if reference.feedback_requested? %>
+              <div class="app-summary-card__actions">
+                <%= link_to candidate_interface_confirm_cancel_reference_path(reference.id), class: 'govuk-link' do %>
+                  <%= t('application_form.references.cancel_request.action') %>
+                  <span class="govuk-visually-hidden"> <%= reference.name %></span>
+                <% end %>
+              </div>
+            <% elsif can_retry?(reference) %>
+              <li class="app-summary-card__actions-list-item">
+                <%= link_to candidate_interface_references_retry_request_path(reference.id), class: 'govuk-link' do %>
+                  <%= t('application_form.references.retry_request.action') %>
+                  <span class="govuk-visually-hidden"> to <%= reference.name %></span>
+                <% end %>
+              </li>
+            <% end %>
 
-          <% if can_send?(reference) %>
-            <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_references_new_request_path(reference.id), class: 'govuk-link' do %>
-                <%= t('application_form.references.send_request.action') %>
-                <span class="govuk-visually-hidden"> <%= reference.name %></span>
-              <% end %>
-            </li>
-          <% elsif can_resend?(reference) %>
-            <li class="app-summary-card__actions-list-item">
-              <%= link_to candidate_interface_references_new_request_path(reference.id), class: 'govuk-link' do %>
-                <%= t('application_form.references.resend_request.action') %>
-                <span class="govuk-visually-hidden"> to <%= reference.name %></span>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
+            <% if reference.not_requested_yet? %>
+              <li class="app-summary-card__actions-list-item">
+                <%= link_to candidate_interface_confirm_destroy_referee_path(reference), class: 'govuk-link' do %>
+                  <%= t('application_form.references.delete_referee.action') %>
+                  <span class="govuk-visually-hidden"> <%= reference.name %></span>
+                <% end %>
+              </li>
+            <% elsif reference.feedback_provided? %>
+              <li class="app-summary-card__actions-list-item">
+                <%= link_to candidate_interface_confirm_destroy_reference_path(reference), class: 'govuk-link' do %>
+                  <%= t('application_form.references.delete_reference.action') %>
+                  <span class="govuk-visually-hidden"> <%= reference.name %></span>
+                <% end %>
+              </li>
+            <% elsif request_can_be_deleted?(reference) %>
+              <li class="app-summary-card__actions-list-item">
+                <%= link_to candidate_interface_confirm_destroy_reference_request_path(reference), class: 'govuk-link' do %>
+                  <%= t('application_form.references.delete_request.action') %>
+                  <span class="govuk-visually-hidden"> <%= reference.name %></span>
+                <% end %>
+              </li>
+            <% end %>
+
+            <% if can_send?(reference) %>
+              <li class="app-summary-card__actions-list-item">
+                <%= link_to candidate_interface_references_new_request_path(reference.id), class: 'govuk-link' do %>
+                  <%= t('application_form.references.send_request.action') %>
+                  <span class="govuk-visually-hidden"> <%= reference.name %></span>
+                <% end %>
+              </li>
+            <% elsif can_resend?(reference) %>
+              <li class="app-summary-card__actions-list-item">
+                <%= link_to candidate_interface_references_new_request_path(reference.id), class: 'govuk-link' do %>
+                  <%= t('application_form.references.resend_request.action') %>
+                  <span class="govuk-visually-hidden"> to <%= reference.name %></span>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -1,7 +1,7 @@
 <div class="<%= container_class %>">
   <% if too_many_complete_references? %>
-    <p class='app-review-warning__primary-message'><%= t('application_form.references.review.more_than_two') %></p>
-    <p class='govuk-body'><%= too_many_references_error %></p>
+    <p class="app-inset-text__title"><%= t('application_form.references.review.more_than_two') %></p>
+    <p class="govuk-body"><%= too_many_references_error %></p>
   <% end %>
 
   <% references.each do |reference| %>

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -58,7 +58,7 @@ module CandidateInterface
 
     def container_class
       if too_many_complete_references?
-        is_errored ? 'app-review-warning app-review-warning--error' : 'app-review-warning'
+        "govuk-inset-text app-inset-text--narrow-border app-inset-text--#{is_errored ? 'error' : 'important'}"
       end
     end
 

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -1,11 +1,12 @@
 module CandidateInterface
   class ReferencesReviewComponent < ViewComponent::Base
-    attr_reader :references, :editable, :show_history
+    attr_reader :references, :editable, :show_history, :is_errored
 
-    def initialize(references:, editable: true, show_history: false)
+    def initialize(references:, editable: true, show_history: false, is_errored: false)
       @references = references
       @editable = editable
       @show_history = show_history
+      @is_errored = is_errored
     end
 
     def card_title(reference)
@@ -49,6 +50,23 @@ module CandidateInterface
 
     def ignore_editable_for
       %w[History]
+    end
+
+    def too_many_complete_references?
+      references.select(&:feedback_provided?).size > ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+    end
+
+    def container_class
+      if too_many_complete_references?
+        is_errored ? 'app-review-warning app-review-warning--error' : 'app-review-warning'
+      end
+    end
+
+    def too_many_references_error
+      return if references.blank?
+
+      number_to_delete = references.size - ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+      "Delete #{number_to_delete} #{'reference'.pluralize(number_to_delete)}. You can only include 2 with your application"
     end
 
   private

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -9,8 +9,7 @@ module CandidateInterface
         @references_waiting_to_be_sent = current_application.application_references.includes(:application_form).not_requested_yet
         @references_sent = current_application.application_references.includes(:application_form).pending_feedback_or_failed
 
-        @too_many_references = @references_given.size > ApplicationForm::MINIMUM_COMPLETE_REFERENCES
-        @too_many_references_error = too_many_references_error(@references_given, @too_many_references)
+        @too_many_references = @application_form.too_many_complete_references?
       end
 
       def unsubmitted
@@ -102,14 +101,6 @@ module CandidateInterface
 
       def redirect_to_start_path_if_candidate_has_no_references
         redirect_to candidate_interface_references_start_path if current_application.application_references.blank?
-      end
-
-      def too_many_references_error(references, too_many)
-        return if references.blank?
-        return unless too_many
-
-        number_to_delete = references.size - ApplicationForm::MINIMUM_COMPLETE_REFERENCES
-        "Delete #{number_to_delete} #{'reference'.pluralize(number_to_delete)}. You can only include 2 with your application"
       end
     end
   end

--- a/app/controllers/candidate_interface/references/review_controller.rb
+++ b/app/controllers/candidate_interface/references/review_controller.rb
@@ -8,6 +8,9 @@ module CandidateInterface
         @references_given = current_application.application_references.includes(:application_form).feedback_provided
         @references_waiting_to_be_sent = current_application.application_references.includes(:application_form).not_requested_yet
         @references_sent = current_application.application_references.includes(:application_form).pending_feedback_or_failed
+
+        @too_many_references = @references_given.size > ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+        @too_many_references_error = too_many_references_error(@references_given, @too_many_references)
       end
 
       def unsubmitted
@@ -99,6 +102,14 @@ module CandidateInterface
 
       def redirect_to_start_path_if_candidate_has_no_references
         redirect_to candidate_interface_references_start_path if current_application.application_references.blank?
+      end
+
+      def too_many_references_error(references, too_many)
+        return if references.blank?
+        return unless too_many
+
+        number_to_delete = references.size - ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+        "Delete #{number_to_delete} #{'reference'.pluralize(number_to_delete)}. You can only include 2 with your application"
       end
     end
   end

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -25,6 +25,7 @@ module CandidateInterface
       else
         @incomplete_sections = @application_form_presenter.incomplete_sections
         @application_choice_errors = @application_form_presenter.application_choice_errors
+        @reference_section_errors = @application_form_presenter.reference_section_errors
 
         render 'candidate_interface/unsubmitted_application_form/review' and return
       end

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -23,7 +23,7 @@ module CandidateInterface
       if @application_form_presenter.ready_to_submit?
         @further_information_form = FurtherInformationForm.new
       else
-        @errors = @application_form_presenter.section_errors
+        @incomplete_sections = @application_form_presenter.incomplete_sections
         @application_choice_errors = @application_form_presenter.application_choice_errors
 
         render 'candidate_interface/unsubmitted_application_form/review' and return

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -213,6 +213,10 @@ class ApplicationForm < ApplicationRecord
     application_references.size < MINIMUM_COMPLETE_REFERENCES
   end
 
+  def too_many_complete_references?
+    application_references.feedback_provided.size > MINIMUM_COMPLETE_REFERENCES
+  end
+
   def ready_to_be_sent_to_provider?
     !can_edit_after_submission? && enough_references_have_been_provided?
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -91,6 +91,14 @@ module CandidateInterface
       end
     end
 
+    def reference_section_errors
+      [].tap do |errors|
+        if @application_form.too_many_complete_references?
+          errors << OpenStruct.new(message: I18n.t('application_form.references.review.more_than_two'), anchor: '#references')
+        end
+      end
+    end
+
     def ready_to_submit?
       sections_with_completion.map(&:second).all? &&
         application_choice_errors.empty?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -101,7 +101,8 @@ module CandidateInterface
 
     def ready_to_submit?
       sections_with_completion.map(&:second).all? &&
-        application_choice_errors.empty?
+        application_choice_errors.empty? &&
+        reference_section_errors.empty?
     end
 
     def application_choices_added?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -39,7 +39,7 @@ module CandidateInterface
       ].compact
     end
 
-    def section_errors
+    def incomplete_sections
       sections_with_completion
         .reject(&:second)
         .map(&:first)

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,4 +1,4 @@
-<% missing_error = @errors && @errors.any? %>
+<% missing_error = @incomplete_sections && @incomplete_sections.any? %>
 <% application_choice_error = @application_choice_errors && @application_choice_errors.any? %>
 
 <section class="govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,5 +1,6 @@
 <% missing_error = @incomplete_sections && @incomplete_sections.any? %>
 <% application_choice_error = @application_choice_errors && @application_choice_errors.any? %>
+<% reference_section_error = @reference_section_errors && @reference_section_errors.any? %>
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.courses') %></h2>
@@ -23,7 +24,7 @@
  <% end %>
 </section>
 
-<section class="govuk-!-margin-bottom-8">
+<section class="govuk-!-margin-bottom-8" id="references">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.references') %></h2>
   <% if !application_form.enough_references_have_been_provided? && editable %>
     <%= render(
@@ -36,7 +37,13 @@
       ),
     ) %>
   <% else %>
-    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: application_form.application_references.includes(:application_form).feedback_provided, editable: false)) %>
+    <%= render(
+      CandidateInterface::ReferencesReviewComponent.new(
+      references: application_form.application_references.includes(:application_form).feedback_provided,
+      editable: false,
+      is_errored: reference_section_error
+      )
+    ) %>
   <% end %>
 </section>
 

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -1,11 +1,6 @@
-<% content_for :title, t('page_titles.references') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.references'), @too_many_references) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.references') %>
-</h1>
-
-<%= render CandidateInterface::AddReferenceComponent.new(@application_form) %>
 <% if @too_many_references %>
   <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
@@ -18,6 +13,12 @@
     </div>
   </div>
 <% end %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.references') %>
+</h1>
+
+<%= render CandidateInterface::AddReferenceComponent.new(@application_form) %>
 
 <% if @references_given.present? %>
   <div id="references_given">

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -6,13 +6,32 @@
 </h1>
 
 <%= render CandidateInterface::AddReferenceComponent.new(@application_form) %>
+<% if @too_many_references %>
+  <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
+    <h2 id="error-summary-title" class="govuk-error-summary__title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li><%= link_to t('application_form.references.review.too_many'), '#references_given' %></li>
+      </ul>
+    </div>
+  </div>
+<% end %>
 
 <% if @references_given.present? %>
   <div id="references_given">
     <h2 class="govuk-heading-m">References that have been given</h2>
-    <%= render(
-      CandidateInterface::ReferencesReviewComponent.new(references: @references_given, show_history: true)
-    ) %>
+    <% review_component = CandidateInterface::ReferencesReviewComponent.new(references: @references_given, show_history: true) %>
+    <% if @too_many_references %>
+      <div class="govuk-inset-text app-inset-text--error">
+        <p class="govuk-heading-s govuk-!-margin-bottom-2"><%= t('application_form.references.review.too_many') %></p>
+        <p class="govuk-body"><%= @too_many_references_error %></p>
+        <%= render(review_component) %>
+      </div>
+    <% else %>
+        <%= render(review_component) %>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -13,7 +13,7 @@
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
-        <li><%= link_to t('application_form.references.review.too_many'), '#references_given' %></li>
+        <li><%= link_to t('application_form.references.review.more_than_two'), '#references_given' %></li>
       </ul>
     </div>
   </div>
@@ -22,16 +22,7 @@
 <% if @references_given.present? %>
   <div id="references_given">
     <h2 class="govuk-heading-m">References that have been given</h2>
-    <% review_component = CandidateInterface::ReferencesReviewComponent.new(references: @references_given, show_history: true) %>
-    <% if @too_many_references %>
-      <div class="govuk-inset-text app-inset-text--error">
-        <p class="govuk-heading-s govuk-!-margin-bottom-2"><%= t('application_form.references.review.too_many') %></p>
-        <p class="govuk-body"><%= @too_many_references_error %></p>
-        <%= render(review_component) %>
-      </div>
-    <% else %>
-        <%= render(review_component) %>
-    <% end %>
+    <%= render(CandidateInterface::ReferencesReviewComponent.new(references: @references_given, show_history: true, is_errored: @too_many_references)) %>
   </div>
 <% end %>
 

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -1,14 +1,14 @@
-<% content_for :title, title_with_error_prefix(t('review_application.title'), @errors && @errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('review_application.title'), @incomplete_sections && @incomplete_sections.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
-<% if @errors.present? || @application_choice_errors.present? %>
+<% if @incomplete_sections.present? || @application_choice_errors.present? %>
   <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
       There is a problem
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
-        <% @errors.each do |section| %>
+        <% @incomplete_sections.each do |section| %>
           <li>
             <a href="<%= "#missing-#{section}-error" %>"><%= t("review_application.#{section}.incomplete", minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES) %></a>
           </li>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, title_with_error_prefix(t('review_application.title'), @incomplete_sections && @incomplete_sections.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
-<% if @incomplete_sections.present? || @application_choice_errors.present? %>
+<% if @incomplete_sections.present? || @application_choice_errors.present? || @reference_section_errors.present? %>
   <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
       There is a problem
@@ -17,6 +17,10 @@
         <% @application_choice_errors.each do |error| %>
           <li><%= link_to error.message, error.anchor %></li>
         <% end %>
+
+        <% @reference_section_errors.each do |error| %>
+          <li><%= link_to error.message, error.anchor %></li>
+        <% end %>
       </ul>
     </div>
   </div>
@@ -26,7 +30,7 @@
   <%= t('review_application.heading') %>
 </h1>
 
-<%= render partial: 'candidate_interface/application_form/review', application_form: @application_form, editable: true %>
+<%= render partial: 'candidate_interface/application_form/review', locals: { application_form: @application_form, editable: true } %>
 
 <% unless EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
   <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -26,7 +26,7 @@
   <%= t('review_application.heading') %>
 </h1>
 
-<%= render 'candidate_interface/application_form/review', application_form: @application_form, editable: true %>
+<%= render partial: 'candidate_interface/application_form/review', application_form: @application_form, editable: true %>
 
 <% unless EndOfCycleTimetable.between_cycles?(@application_form.phase) %>
   <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -486,6 +486,8 @@ en:
         not_requested_yet: We’ll contact your referees after you submit your application.
         awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
         awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
+      review:
+        too_many: More than 2 references have been given
   activemodel:
     errors:
       models:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -487,7 +487,7 @@ en:
         awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
         awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
       review:
-        too_many: More than 2 references have been given
+        more_than_two: More than 2 references have been given
   activemodel:
     errors:
       models:

--- a/spec/components/candidate_interface/references_review_component_spec.rb
+++ b/spec/components/candidate_interface/references_review_component_spec.rb
@@ -72,14 +72,14 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
       it 'renders a warning' do
         result = render_inline(described_class.new(references: references))
         expect(result.text).to include 'Delete 2 references. You can only include 2 with your application'
-        expect(result.css('div.app-review-warning')).to be_present
-        expect(result.css('div.app-review-warning--error')).not_to be_present
+        expect(result.css('div.app-inset-text--important')).to be_present
+        expect(result.css('div.app-inset-text--error')).not_to be_present
       end
 
       it 'styles the warning as an error if rendered in an errored state' do
         result = render_inline(described_class.new(references: references, is_errored: true))
-        expect(result.css('div.app-review-warning')).to be_present
-        expect(result.css('div.app-review-warning--error')).to be_present
+        expect(result.css('div.app-inset-text--important')).not_to be_present
+        expect(result.css('div.app-inset-text--error')).to be_present
       end
     end
 
@@ -91,8 +91,8 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
       it 'does not render a warning' do
         result = render_inline(described_class.new(references: references, is_errored: true))
         expect(result.text).not_to include 'Delete 1 reference. You can only include 2 with your application'
-        expect(result.css('div.app-review-warning')).not_to be_present
-        expect(result.css('div.app-review-warning--error')).not_to be_present
+        expect(result.css('div.app-inset-text--important')).not_to be_present
+        expect(result.css('div.app-inset-text--error')).not_to be_present
       end
     end
   end

--- a/spec/components/candidate_interface/references_review_component_spec.rb
+++ b/spec/components/candidate_interface/references_review_component_spec.rb
@@ -58,6 +58,45 @@ RSpec.describe CandidateInterface::ReferencesReviewComponent, type: :component d
     expect(result.text).to include reference_two.email_address
   end
 
+  context 'handling too many complete references' do
+    context 'given more than 2 complete references' do
+      let(:references) do
+        [
+          create(:reference, :feedback_provided),
+          create(:reference, :feedback_provided),
+          create(:reference, :feedback_provided),
+          create(:reference, :feedback_provided),
+        ]
+      end
+
+      it 'renders a warning' do
+        result = render_inline(described_class.new(references: references))
+        expect(result.text).to include 'Delete 2 references. You can only include 2 with your application'
+        expect(result.css('div.app-review-warning')).to be_present
+        expect(result.css('div.app-review-warning--error')).not_to be_present
+      end
+
+      it 'styles the warning as an error if rendered in an errored state' do
+        result = render_inline(described_class.new(references: references, is_errored: true))
+        expect(result.css('div.app-review-warning')).to be_present
+        expect(result.css('div.app-review-warning--error')).to be_present
+      end
+    end
+
+    context 'given 2 complete references' do
+      let(:references) do
+        [create(:reference, :feedback_provided), create(:reference, :feedback_provided)]
+      end
+
+      it 'does not render a warning' do
+        result = render_inline(described_class.new(references: references, is_errored: true))
+        expect(result.text).not_to include 'Delete 1 reference. You can only include 2 with your application'
+        expect(result.css('div.app-review-warning')).not_to be_present
+        expect(result.css('div.app-review-warning--error')).not_to be_present
+      end
+    end
+  end
+
   context 'when reference state is "feedback_requested"' do
     let(:feedback_requested) { create(:reference, :feedback_requested) }
     let(:feedback_refused) { create(:reference, :feedback_refused) }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -239,6 +239,26 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#too_many_complete_references?' do
+    it 'returns true if there are more than 2 references' do
+      application_form = create :application_form
+      references = []
+      3.times { references << create(:reference, :feedback_provided) }
+      application_form.application_references = references
+
+      expect(application_form.too_many_complete_references?).to be true
+    end
+
+    it 'returns false if there are 2 or fewer references' do
+      application_form = create :application_form
+      expect(application_form.too_many_complete_references?).to be false
+      application_form.application_references << create(:reference)
+      expect(application_form.too_many_complete_references?).to be false
+      application_form.application_references << create(:reference)
+      expect(application_form.too_many_complete_references?).to be false
+    end
+  end
+
   describe '#equality_and_diversity_answers_provided?' do
     context 'when minimal expected attributes are present' do
       it 'is true' do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -541,6 +541,24 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#reference_section_errors' do
+    it 'returns an error if the application form has too many references' do
+      application_form = instance_double(ApplicationForm, too_many_complete_references?: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.reference_section_errors).to eq(
+        [OpenStruct.new(message: 'More than 2 references have been given', anchor: '#references')],
+      )
+    end
+
+    it 'returns an empty array  if the application form does not have too many references' do
+      application_form = instance_double(ApplicationForm, too_many_complete_references?: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.reference_section_errors).to eq []
+    end
+  end
+
   describe '#becoming_a_teacher_completed?' do
     it 'returns true if the becoming a teacher section is completed' do
       application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: true)

--- a/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
@@ -11,8 +11,15 @@ RSpec.feature 'References' do
     given_i_am_signed_in
     and_i_have_an_application_with_too_many_references
     then_i_see_errors_on_the_reference_review_page
+    and_i_see_a_warning_on_the_application_review_page
+
+    when_i_submit_the_application
+    then_i_see_an_error_on_the_application_review_page
+
     when_i_remove_a_reference
     then_i_no_longer_see_errors_on_the_reference_review_page
+    and_i_no_longer_see_a_warning_on_the_application_review_page
+    and_app_submission_no_longer_triggers_a_reference_section_error
   end
 
   def given_i_am_signed_in
@@ -27,8 +34,31 @@ RSpec.feature 'References' do
 
   def then_i_see_errors_on_the_reference_review_page
     visit candidate_interface_references_review_path
-    expect(page).to have_content 'More than 2 references have been given'
-    expect(page).to have_content 'Delete 1 reference. You can only include 2 with your application'
+    within('.app-review-warning--error') do
+      expect(page).to have_content 'More than 2 references have been given'
+      expect(page).to have_content 'Delete 1 reference. You can only include 2 with your application'
+    end
+  end
+
+  def and_i_see_a_warning_on_the_application_review_page
+    visit candidate_interface_application_review_path
+    within('#references > .app-review-warning') do
+      expect(page).to have_content 'More than 2 references have been given'
+    end
+  end
+
+  def when_i_submit_the_application
+    click_link 'Continue'
+  end
+
+  def then_i_see_an_error_on_the_application_review_page
+    within('.govuk-error-summary') do
+      expect(page).to have_content 'More than 2 references have been given'
+    end
+    within('#references > .app-review-warning--error') do
+      expect(page).to have_content 'More than 2 references have been given'
+      expect(page).to have_content 'Delete 1 reference. You can only include 2 with your application'
+    end
   end
 
   def when_i_remove_a_reference
@@ -37,7 +67,19 @@ RSpec.feature 'References' do
   end
 
   def then_i_no_longer_see_errors_on_the_reference_review_page
+    visit candidate_interface_references_review_path
     expect(page).not_to have_content 'More than 2 references have been given'
-    expect(page).not_to have_content 'Delete 1 reference. You can only include 2 with your application'
+  end
+
+  def and_i_no_longer_see_a_warning_on_the_application_review_page
+    visit candidate_interface_application_review_path
+    expect(page).not_to have_content 'More than 2 references have been given'
+  end
+
+  def and_app_submission_no_longer_triggers_a_reference_section_error
+    click_link 'Continue'
+    within('.govuk-error-summary') do
+      expect(page).not_to have_content 'More than 2 references have been given'
+    end
   end
 end

--- a/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'References' do
 
   def then_i_see_errors_on_the_reference_review_page
     visit candidate_interface_references_review_path
-    within('.app-review-warning--error') do
+    within('.app-inset-text--error') do
       expect(page).to have_content 'More than 2 references have been given'
       expect(page).to have_content 'Delete 1 reference. You can only include 2 with your application'
     end
@@ -40,7 +40,7 @@ RSpec.feature 'References' do
 
   def and_i_see_a_warning_on_the_application_review_page
     visit candidate_interface_application_review_path
-    within('#references > .app-review-warning') do
+    within('#references > .app-inset-text--important') do
       expect(page).to have_content 'More than 2 references have been given'
     end
   end
@@ -53,7 +53,7 @@ RSpec.feature 'References' do
     within('.govuk-error-summary') do
       expect(page).to have_content 'More than 2 references have been given'
     end
-    within('#references > .app-review-warning--error') do
+    within('#references > .app-inset-text--error') do
       expect(page).to have_content 'More than 2 references have been given'
       expect(page).to have_content 'Delete 1 reference. You can only include 2 with your application'
     end

--- a/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'References' do
+  include CandidateHelper
+
+  # We now take steps to prevent more than two references being provided. This
+  # wasn't the case historically, however, and a candidate might end up in the
+  # following state if they Apply Again from a previous application that had
+  # received more than 2 references.
+  scenario 'The candidate sees errors when they have too many references' do
+    given_i_am_signed_in
+    and_i_have_an_application_with_too_many_references
+    then_i_see_errors_on_the_reference_review_page
+    when_i_remove_a_reference
+    then_i_no_longer_see_errors_on_the_reference_review_page
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_application_with_too_many_references
+    @candidate.application_forms << create(:application_form)
+    create_list(:reference, 3, feedback_status: :feedback_provided, application_form: @candidate.current_application)
+  end
+
+  def then_i_see_errors_on_the_reference_review_page
+    visit candidate_interface_references_review_path
+    expect(page).to have_content 'More than 2 references have been given'
+    expect(page).to have_content 'Delete 1 reference. You can only include 2 with your application'
+  end
+
+  def when_i_remove_a_reference
+    all('a', text: 'Delete reference').first.click
+    click_on I18n.t('application_form.references.delete_reference.confirm')
+  end
+
+  def then_i_no_longer_see_errors_on_the_reference_review_page
+    expect(page).not_to have_content 'More than 2 references have been given'
+    expect(page).not_to have_content 'Delete 1 reference. You can only include 2 with your application'
+  end
+end

--- a/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature 'References' do
   # following state if they Apply Again from a previous application that had
   # received more than 2 references.
   scenario 'The candidate sees errors when they have too many references' do
-    given_i_am_signed_in
-    and_i_have_an_application_with_too_many_references
+    given_i_have_a_complete_application
+    and_it_has_too_many_references
     then_i_see_errors_on_the_reference_review_page
     and_i_see_a_warning_on_the_application_review_page
 
@@ -22,14 +22,12 @@ RSpec.feature 'References' do
     and_app_submission_no_longer_triggers_a_reference_section_error
   end
 
-  def given_i_am_signed_in
-    @candidate = create(:candidate)
-    login_as(@candidate)
+  def given_i_have_a_complete_application
+    candidate_completes_application_form
   end
 
-  def and_i_have_an_application_with_too_many_references
-    @candidate.application_forms << create(:application_form)
-    create_list(:reference, 3, feedback_status: :feedback_provided, application_form: @candidate.current_application)
+  def and_it_has_too_many_references
+    create_list(:reference, 3, feedback_status: :feedback_provided, application_form: @application)
   end
 
   def then_i_see_errors_on_the_reference_review_page
@@ -78,8 +76,7 @@ RSpec.feature 'References' do
 
   def and_app_submission_no_longer_triggers_a_reference_section_error
     click_link 'Continue'
-    within('.govuk-error-summary') do
-      expect(page).not_to have_content 'More than 2 references have been given'
-    end
+    expect(page).not_to have_content 'More than 2 references have been given'
+    expect(page).to have_current_path candidate_interface_start_equality_and_diversity_path
   end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Applications can get into a state where they have more than 2 references. We need to ask candidates to delete extra references, so that they can send it on to providers.


## Changes proposed in this pull request

- Reference review page updated to show an error when there are more than two refs in the `feedback_provided` state
- Application review page updated to:
  - show warning on the references section when in this state
  - show error on the references section on application submit

### Reference review page:
---
![Screenshot_20201204_091757](https://user-images.githubusercontent.com/519250/101145402-a07fb500-3611-11eb-8a4b-4d99532373a6.png)


### Application review page (warning):
---
![Screenshot_20201204_091856](https://user-images.githubusercontent.com/519250/101145473-bd1bed00-3611-11eb-9365-7b2f1bbc1ddd.png)



### Application review page (error):
---
![Screenshot_20201204_091928](https://user-images.githubusercontent.com/519250/101145525-d02ebd00-3611-11eb-9bfd-052e69cde305.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- In contrast to the card description, I've agreed with @paulrobertlloyd to try out the same messaging on both review pages to see how it looks, as the implementation is simpler.
- Per-commit review recommended.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/IIWPdP7w
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
