### PR TITLE
Remove matchedstate from ucas matches

### DIFF
--- a/app/components/support_interface/ucas_matches_table_component.rb
+++ b/app/components/support_interface/ucas_matches_table_component.rb
@@ -11,7 +11,7 @@ module SupportInterface
     def table_rows
       matches.map do |match|
         {
-          status: render(TagComponent.new(text: match.matching_data_updated? ? 'Updated' : match.matching_state.humanize, type: match.processed? ? :green : :purple)),
+          status: render(TagComponent.new(text: match.matching_data_updated? ? 'Updated' : match.matching_state.humanize, type: match.resolved? ? :green : :purple)),
           action_needed: action_needed(match),
           match_link: govuk_link_to(match.candidate.email_address, support_interface_ucas_match_path(match)),
           last_update: match.updated_at.to_s(:govuk_date),

--- a/app/components/support_interface/ucas_matches_table_component.rb
+++ b/app/components/support_interface/ucas_matches_table_component.rb
@@ -11,7 +11,7 @@ module SupportInterface
     def table_rows
       matches.map do |match|
         {
-          status: render(TagComponent.new(text: match.matching_data_updated? ? 'Updated' : match.matching_state.humanize, type: match.resolved? ? :green : :purple)),
+          status: render(TagComponent.new(text: match.action_taken&.humanize || 'No action taken', type: match.resolved? ? :green : :purple)),
           action_needed: action_needed(match),
           match_link: govuk_link_to(match.candidate.email_address, support_interface_ucas_match_path(match)),
           last_update: match.updated_at.to_s(:govuk_date),

--- a/app/controllers/support_interface/ucas_matches_controller.rb
+++ b/app/controllers/support_interface/ucas_matches_controller.rb
@@ -54,12 +54,5 @@ module SupportInterface
       flash[:success] = 'The date of requesting withdrawal from UCAS was recorded'
       redirect_to support_interface_ucas_match_path(match)
     end
-
-    def process_match
-      match = UCASMatch.find(params[:id])
-      match.update!(matching_state: :processed)
-      flash[:success] = 'Match marked as processed'
-      redirect_to support_interface_ucas_match_path(match)
-    end
   end
 end

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -3,11 +3,6 @@ class UCASMatch < ApplicationRecord
 
   belongs_to :candidate
 
-  enum matching_state: {
-    matching_data_updated: 'matching_data_updated',
-    new_match: 'new_match',
-  }
-
   enum action_taken: {
     initial_emails_sent: 'initial_emails_sent',
     reminder_emails_sent: 'reminder_emails_sent',

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -6,7 +6,6 @@ class UCASMatch < ApplicationRecord
   enum matching_state: {
     matching_data_updated: 'matching_data_updated',
     new_match: 'new_match',
-    processed: 'processed',
   }
 
   enum action_taken: {
@@ -31,8 +30,6 @@ class UCASMatch < ApplicationRecord
   end
 
   def action_needed?
-    return false if processed?
-
     return false if resolved?
 
     return false unless dual_application_or_dual_acceptance?

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -98,11 +98,9 @@ module UCASMatching
 
           if match.persisted?
             Rails.logger.info "Found a match for candidate ID #{candidate_id}, updating matching data"
-            match.matching_state = 'matching_data_updated'
             updated_matches += 1
           else
             Rails.logger.info "Found a match for candidate ID #{candidate_id}, creating new matching record"
-            match.matching_state = 'new_match'
             new_matches += 1
           end
 

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -7,7 +7,7 @@
 <%= render SupportInterface::UCASMatchActionComponent.new(@match) %>
 
 <% application = @match.candidate.application_forms.first %>
-<% status = [render(TagComponent.new(text: @match.matching_state.humanize, type: @match.processed? ? :green : :purple))] %>
+<% status = [render(TagComponent.new(text: @match.matching_state.humanize, type: @match.resolved? ? :green : :purple))] %>
 <% status << render(TagComponent.new(text: @match.action_taken.humanize, type: :purple)) if @match.action_taken.present? %>
 <% if @match.invalid_matching_data? %>
   <% status << render(TagComponent.new(text: "Invalid data", type: :red)) %>

--- a/app/views/support_interface/ucas_matches/show.html.erb
+++ b/app/views/support_interface/ucas_matches/show.html.erb
@@ -7,8 +7,7 @@
 <%= render SupportInterface::UCASMatchActionComponent.new(@match) %>
 
 <% application = @match.candidate.application_forms.first %>
-<% status = [render(TagComponent.new(text: @match.matching_state.humanize, type: @match.resolved? ? :green : :purple))] %>
-<% status << render(TagComponent.new(text: @match.action_taken.humanize, type: :purple)) if @match.action_taken.present? %>
+<% status = [render(TagComponent.new(text: @match.action_taken&.humanize || 'New match', type: @match.resolved? ? :green : :purple))] %>
 <% if @match.invalid_matching_data? %>
   <% status << render(TagComponent.new(text: "Invalid data", type: :red)) %>
 <% elsif @match.action_needed? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -655,7 +655,6 @@ Rails.application.routes.draw do
       post '/send-initial-emails' => 'ucas_matches#send_initial_emails', as: :send_initial_emails
       post '/send-reminder-email' => 'ucas_matches#send_reminder_email', as: :send_reminder_email
       post '/record-ucas-withdrawal-requested' => 'ucas_matches#record_ucas_withdrawal_requested', as: :record_ucas_withdrawal_requested
-      post '/process-match' => 'ucas_matches#process_match', as: :process_match
     end
 
     get '/application_choices/:application_choice_id' => 'application_choices#show', as: :application_choice

--- a/spec/components/support_interface/application_summary_component_spec.rb
+++ b/spec/components/support_interface/application_summary_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SupportInterface::ApplicationSummaryComponent do
     it 'includes a link to a UCAS match if present' do
       candidate = create(:candidate)
       application_form = create(:application_form, candidate: candidate)
-      create(:ucas_match, candidate: candidate, matching_state: 'new_match')
+      create(:ucas_match, candidate: candidate)
 
       result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SupportInterface::UCASMatchActionComponent do
   context 'when there is no dual application or dual acceptance' do
     it 'renders `No action required`' do
-      ucas_match_without_dual_applications = create(:ucas_match, matching_state: 'new_match', scheme: 'U', ucas_status: :rejected)
+      ucas_match_without_dual_applications = create(:ucas_match, scheme: 'U', ucas_status: :rejected)
       allow(ucas_match_without_dual_applications).to receive(:dual_application_or_dual_acceptance?).and_return(false)
 
       result = render_inline(described_class.new(ucas_match_without_dual_applications))
@@ -13,7 +13,7 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
 
   context 'when there is a dual application or dual acceptance' do
     it 'renders correct information for a new match' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', scheme: 'U', candidate_last_contacted_at: nil)
+      ucas_match = create(:ucas_match, scheme: 'U', candidate_last_contacted_at: nil)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       result = render_inline(described_class.new(ucas_match))
@@ -27,7 +27,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information after sending the initial emails' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
                             scheme: 'U',
                             action_taken: 'initial_emails_sent',
                             candidate_last_contacted_at: Time.zone.now - 1.day)
@@ -43,7 +42,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information when reminder emails need to be send' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
                             scheme: 'U',
                             action_taken: 'initial_emails_sent',
                             candidate_last_contacted_at: Time.zone.now - 7.days)
@@ -61,7 +59,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information after sending the reminder emails' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
                             scheme: 'U',
                             action_taken: 'reminder_emails_sent',
                             candidate_last_contacted_at: Time.zone.now - 1.day)
@@ -77,7 +74,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information when withdrawal from UCAS needs to be requested' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
                             scheme: 'U',
                             action_taken: 'reminder_emails_sent',
                             candidate_last_contacted_at: Time.zone.now - 16.days)
@@ -95,7 +91,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information after requesting withdrawal from UCAS' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
                             scheme: 'U',
                             action_taken: 'ucas_withdrawal_requested',
                             candidate_last_contacted_at: Time.zone.now - 1.day)

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information after UCAS resolution of a match' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'processed',
                             scheme: 'U',
                             action_taken: 'resolved_on_ucas',
                             candidate_last_contacted_at: Time.zone.now - 1.day)
@@ -127,7 +126,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information after Apply resolution of a match' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'processed',
                             scheme: 'U',
                             action_taken: 'resolved_on_apply',
                             candidate_last_contacted_at: Time.zone.now - 1.day)
@@ -143,7 +141,6 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
     it 'renders correct information after the manual resolution of a match' do
       Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
         ucas_match = create(:ucas_match,
-                            matching_state: 'processed',
                             scheme: 'U',
                             action_taken: 'manually_resolved',
                             candidate_last_contacted_at: Time.zone.now - 1.day)

--- a/spec/components/support_interface/ucas_matches_table_component_spec.rb
+++ b/spec/components/support_interface/ucas_matches_table_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::UCASMatchesTableComponent do
   let(:today) { Time.zone.local(2020, 1, 7, 12, 0, 0) }
-  let(:ucas_match) { create(:ucas_match, matching_state: 'new_match') }
+  let(:ucas_match) { create(:ucas_match) }
 
   around do |example|
     Timecop.freeze(today) do
@@ -11,7 +11,7 @@ RSpec.describe SupportInterface::UCASMatchesTableComponent do
   end
 
   it 'renders the status' do
-    expect(render_result.css('.govuk-tag').first.text.strip).to eq('New match')
+    expect(render_result.css('.govuk-tag').first.text.strip).to eq('No action taken')
   end
 
   it 'renders candidates email address' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :ucas_match do
     candidate { application_form.candidate }
-    matching_state { %w[new_match matching_data_updated processed].sample }
+    matching_state { %w[new_match matching_data_updated].sample }
     matching_data { nil }
     recruitment_cycle_year { application_form.recruitment_cycle_year }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :ucas_match do
     candidate { application_form.candidate }
-    matching_state { %w[new_match matching_data_updated].sample }
     matching_data { nil }
     recruitment_cycle_year { application_form.recruitment_cycle_year }
 

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe UCASMatch do
       expect(ucas_match.action_needed?).to eq(false)
     end
 
-    it 'returns false if ucas match is processed' do
-      ucas_match = create(:ucas_match, matching_state: 'processed')
+    it 'returns false if ucas match is resolved' do
+      ucas_match = create(:ucas_match, action_taken: 'resolved_on_ucas')
 
       expect(ucas_match.action_needed?).to eq(false)
     end
@@ -93,7 +93,7 @@ RSpec.describe UCASMatch do
 
   describe '#ready_to_resolve' do
     it 'returns true if no further action is required and the match is not resolved' do
-      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', matching_state: 'processed')
+      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested')
 
       expect(ucas_match.ready_to_resolve?).to eq(true)
     end
@@ -332,16 +332,16 @@ RSpec.describe UCASMatch do
       expect(ucas_match.last_action).to eq(:ucas_withdrawal_requested)
     end
 
-    it 'returns :resolved_on_ucas if the match was resolved on ucas' do
-      ucas_match = create(:ucas_match, matching_state: 'processed', action_taken: 'resolved_on_ucas')
-
-      expect(ucas_match.last_action).to eq(:resolved_on_ucas)
-    end
-
-    it 'returns :resolved_on_apply if the match was resolved on Apply' do
-      ucas_match = create(:ucas_match, matching_state: 'processed', action_taken: 'resolved_on_apply')
+    it 'returns :resolved_on_apply if the match was resolved on apply' do
+      ucas_match = create(:ucas_match, action_taken: 'resolved_on_apply')
 
       expect(ucas_match.last_action).to eq(:resolved_on_apply)
+    end
+
+    it 'returns :resolved_on_ucas if the match was resolved on ucas' do
+      ucas_match = create(:ucas_match, action_taken: 'resolved_on_ucas')
+
+      expect(ucas_match.last_action).to eq(:resolved_on_ucas)
     end
   end
 

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe UCASMatch do
 
     it 'returns false if initial emails were sent and we do not need to send the reminders yet' do
       initial_emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       Timecop.travel(1.business_days.after(initial_emails_sent_at)) do
@@ -37,7 +37,7 @@ RSpec.describe UCASMatch do
 
     it 'returns true if initial emails were sent and it is time to send a reminder email' do
       initial_emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       Timecop.travel(5.business_days.after(initial_emails_sent_at)) do
@@ -46,7 +46,7 @@ RSpec.describe UCASMatch do
     end
 
     it 'returns false if reminder emails were sent and we do not need to request withdrawal from UCAS yet' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
+      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
       allow(ucas_match).to receive(:need_to_request_withdrawal_from_ucas?).and_return(false)
 
@@ -54,7 +54,7 @@ RSpec.describe UCASMatch do
     end
 
     it 'returns true if reminder emails were sent and it is time to request withdrawal from UCAS' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
+      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
       allow(ucas_match).to receive(:need_to_request_withdrawal_from_ucas?).and_return(true)
 
@@ -62,21 +62,21 @@ RSpec.describe UCASMatch do
     end
 
     it 'returns false if we requested withdrawal from UCAS' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
+      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       expect(ucas_match.action_needed?).to eq(false)
     end
 
     it 'returns true if there is a dual application or dual acceptance' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match')
+      ucas_match = create(:ucas_match)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
 
       expect(ucas_match.action_needed?).to eq(true)
     end
 
     it 'returns false if there is no dual application or dual acceptance' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match')
+      ucas_match = create(:ucas_match)
       allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(false)
 
       expect(ucas_match.action_needed?).to eq(false)
@@ -149,14 +149,14 @@ RSpec.describe UCASMatch do
 
   describe '#dual_application_or_dual_acceptance?' do
     it 'returns true if a candidate applied for the same course on both services and both applications are still in progress' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [both_schemes_match])
+      ucas_match = create(:ucas_match, candidate: candidate, matching_data: [both_schemes_match])
 
       expect(ucas_match.dual_application_or_dual_acceptance?).to eq(true)
     end
 
     it 'returns false if a candidate applied for the same course on both services but at least one of them was unsucesfull' do
       both_schemes_match.merge!('Rejects' => '1')
-      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [both_schemes_match])
+      ucas_match = create(:ucas_match, candidate: candidate, matching_data: [both_schemes_match])
 
       expect(ucas_match.dual_application_or_dual_acceptance?).to eq(false)
     end
@@ -173,7 +173,7 @@ RSpec.describe UCASMatch do
                               'Course code' => course1.code.to_s,
                               'Provider code' => course1.provider.code.to_s,
                               'Apply candidate ID' => candidate.id.to_s }
-      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
+      ucas_match = create(:ucas_match, candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
 
       expect(ucas_match.dual_application_or_dual_acceptance?).to eq(true)
     end
@@ -189,7 +189,7 @@ RSpec.describe UCASMatch do
                               'Course code' => course1.code.to_s,
                               'Provider code' => course1.provider.code.to_s,
                               'Apply candidate ID' => candidate.id.to_s }
-      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
+      ucas_match = create(:ucas_match, candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
 
       expect(ucas_match.dual_application_or_dual_acceptance?).to eq(false)
     end
@@ -202,7 +202,7 @@ RSpec.describe UCASMatch do
                               'Course code' => course1.code.to_s,
                               'Provider code' => course1.provider.code.to_s,
                               'Apply candidate ID' => candidate.id.to_s }
-      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
+      ucas_match = create(:ucas_match, candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
 
       expect(ucas_match.dual_application_or_dual_acceptance?).to eq(false)
     end
@@ -221,7 +221,7 @@ RSpec.describe UCASMatch do
                               'Course code' => course1.code.to_s,
                               'Provider code' => course1.provider.code.to_s,
                               'Apply candidate ID' => candidate.id.to_s }
-      ucas_match = create(:ucas_match, matching_state: 'new_match', candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
+      ucas_match = create(:ucas_match, candidate: candidate, matching_data: [ucas_matching_data, apply_matching_data])
 
       expect(ucas_match.application_accepted_on_ucas_and_accepted_on_apply?).to eq(true)
     end
@@ -230,7 +230,7 @@ RSpec.describe UCASMatch do
   describe '#need_to_send_reminder_emails?' do
     it 'returns false if last action taken in not initial emails sent' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(1.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_send_reminder_emails?).to eq(false)
@@ -239,7 +239,7 @@ RSpec.describe UCASMatch do
 
     it 'returns false if initial emails were sent and we do not need to send the reminders yet' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(1.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_send_reminder_emails?).to eq(false)
@@ -248,7 +248,7 @@ RSpec.describe UCASMatch do
 
     it 'returns true if initial emails were sent and it is time to send a reminder email' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(5.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_send_reminder_emails?).to eq(true)
@@ -259,7 +259,7 @@ RSpec.describe UCASMatch do
   describe '#need_to_request_withdrawal_from_ucas?' do
     it 'returns false if last action taken in not reminder emails sent' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(1.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_request_withdrawal_from_ucas?).to eq(false)
@@ -268,7 +268,7 @@ RSpec.describe UCASMatch do
 
     it 'returns false if reminder emails were sent and we do not need to request withdrawal from ucas yet' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(1.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_request_withdrawal_from_ucas?).to eq(false)
@@ -277,7 +277,7 @@ RSpec.describe UCASMatch do
 
     it 'returns true if reminder emails were sent and it is time to request withdrawal from ucas' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(10.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_request_withdrawal_from_ucas?).to eq(true)
@@ -287,20 +287,20 @@ RSpec.describe UCASMatch do
 
   describe '#next_action' do
     it 'returns :initial_emails_sent if the candidate has never been contacted' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match')
+      ucas_match = create(:ucas_match)
 
       expect(ucas_match.next_action).to eq(:initial_emails_sent)
     end
 
-    it 'returns :reminder_emails_sent if initial emails were sent and it time to send a reminder email' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent', candidate_last_contacted_at: Time.zone.now - 6.days)
+    it 'returns :reminder_emails_sent if initial emails were sent and it time to send reminder emails' do
+      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: Time.zone.now - 6.days)
       allow(ucas_match).to receive(:need_to_send_reminder_emails?).and_return(true)
 
       expect(ucas_match.next_action).to eq(:reminder_emails_sent)
     end
 
     it 'returns :ucas_withdrawal_requested if reminder emails were sent and it time to request withdrawal from UCAS' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now - 16.days)
+      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now - 16.days)
       allow(ucas_match).to receive(:need_to_request_withdrawal_from_ucas?).and_return(true)
 
       expect(ucas_match.next_action).to eq(:ucas_withdrawal_requested)
@@ -309,25 +309,25 @@ RSpec.describe UCASMatch do
 
   describe '#last_action' do
     it 'returns nil if no action was taken' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match')
+      ucas_match = create(:ucas_match)
 
       expect(ucas_match.last_action).to eq(nil)
     end
 
     it 'returns :initial_emails_sent if initial emails were sent' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'initial_emails_sent')
+      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent')
 
       expect(ucas_match.last_action).to eq(:initial_emails_sent)
     end
 
     it 'returns :reminder_emails_sent if reminder emails were sent' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'reminder_emails_sent')
+      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent')
 
       expect(ucas_match.last_action).to eq(:reminder_emails_sent)
     end
 
     it 'returns :ucas_withdrawal_requested if ucas withdrawal was requested' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', action_taken: 'ucas_withdrawal_requested')
+      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested')
 
       expect(ucas_match.last_action).to eq(:ucas_withdrawal_requested)
     end
@@ -359,7 +359,6 @@ RSpec.describe UCASMatch do
     it 'returns true if candidate has application for the same course in progress on both UCAS and Apply' do
       application_choice = create(:application_choice, status: :awaiting_provider_decision)
       ucas_match = create(:ucas_match,
-                          matching_state: 'new_match',
                           scheme: 'B',
                           application_form: application_choice.application_form,
                           ucas_status: :awaiting_provider_decision)
@@ -370,7 +369,6 @@ RSpec.describe UCASMatch do
     it 'returns false if dual application is not in progress on Apply' do
       application_choice = create(:application_choice, :with_rejection)
       ucas_match = create(:ucas_match,
-                          matching_state: 'new_match',
                           scheme: 'B',
                           application_form: application_choice.application_form)
 
@@ -379,7 +377,6 @@ RSpec.describe UCASMatch do
 
     it 'returns false if dual application is not in progress on UCAS' do
       ucas_match = create(:ucas_match,
-                          matching_state: 'new_match',
                           scheme: 'B',
                           ucas_status: :withdrawn)
 
@@ -387,7 +384,7 @@ RSpec.describe UCASMatch do
     end
 
     it 'returns false if there is no dual application' do
-      ucas_match = create(:ucas_match, matching_state: 'new_match', scheme: 'D')
+      ucas_match = create(:ucas_match, scheme: 'D')
 
       expect(ucas_match.application_for_the_same_course_in_progress_on_both_services?).to eq(false)
     end

--- a/spec/services/support_interface/send_ucas_match_reminder_emails_spec.rb
+++ b/spec/services/support_interface/send_ucas_match_reminder_emails_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe SupportInterface::SendUCASMatchReminderEmails do
     context 'when the application has been accepted on both Apply and UCAS' do
       it 'sends the candidate the reminder ucas match email for multiple acceptances' do
         ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
                             ucas_status: :pending_conditions,
                             application_form: application_form,
                             action_taken: 'initial_emails_sent',
@@ -43,7 +42,6 @@ RSpec.describe SupportInterface::SendUCASMatchReminderEmails do
     context 'when the candidate applied for the same course on both Apply and UCAS' do
       it 'sends the candidate the reminder ucas match email for the duplicate application' do
         ucas_match = create(:ucas_match,
-                            matching_state: 'new_match',
                             scheme: 'B',
                             application_form: application_form,
                             action_taken: 'initial_emails_sent',

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -102,8 +102,8 @@ RSpec.feature 'See UCAS matches' do
         'Trackable applicant key' => trackable_applicant_id,
       }
 
-    create(:ucas_match, matching_state: 'new_match', application_form: @application_form, matching_data: [ucas_matching_data, dfe_matching_data, invalid_dfe_matching_data])
-    create(:ucas_match, matching_state: 'matching_data_updated', scheme: 'B', ucas_status: :offer, application_form: @application_form2)
+    create(:ucas_match, application_form: @application_form, matching_data: [ucas_matching_data, dfe_matching_data, invalid_dfe_matching_data])
+    create(:ucas_match, scheme: 'B', ucas_status: :offer, application_form: @application_form2)
   end
 
   def when_i_go_to_ucas_matches_page
@@ -111,12 +111,12 @@ RSpec.feature 'See UCAS matches' do
   end
 
   def then_i_should_see_list_of_ucas_matches
-    expect(page).to have_content 'New match'
+    expect(page).to have_content 'No action taken'
     expect(page).to have_content @candidate.email_address
   end
 
   def and_i_should_see_which_ucas_matches_need_action
-    expect(page).to have_content 'Updated Action needed'
+    expect(page).to have_content 'No action taken Action needed'
     expect(page).to have_content 'Invalid data'
   end
 

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'See UCAS matches' do
 
     when_i_go_to_ucas_matches_page
     then_i_should_see_list_of_ucas_matches
-    and_i_should_which_ucas_matches_need_action
+    and_i_should_see_which_ucas_matches_need_action
 
     when_i_filter_by_recruitment_cycle
     then_i_only_see_applications_for_that_recruitment_cycle
@@ -115,7 +115,7 @@ RSpec.feature 'See UCAS matches' do
     expect(page).to have_content @candidate.email_address
   end
 
-  def and_i_should_which_ucas_matches_need_action
+  def and_i_should_see_which_ucas_matches_need_action
     expect(page).to have_content 'Updated Action needed'
     expect(page).to have_content 'Invalid data'
   end

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     when_i_visit_the_ucas_matches_page_in_support
     then_the_new_match_is_created
     and_the_existing_match_is_updated
-    and_the_unchanged_existing_match_is_left_alone
 
     when_i_click_on_a_match
     then_i_see_the_matching_info
@@ -44,7 +43,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     course_option3 = create(:course_option, course: course3)
     application_choice3 = create(:submitted_application_choice, course_option: course_option3)
     application_form = create(:completed_application_form, candidate: @previously_matched_changed, application_choices: [application_choice1, application_choice2, application_choice3])
-    create(:ucas_match, matching_state: 'processed', application_form: application_form, scheme: 'U', ucas_status: :offer)
+    create(:ucas_match, application_form: application_form, scheme: 'U', ucas_status: :offer)
   end
 
   def and_there_is_a_previously_matched_candidate_with_no_changes
@@ -54,7 +53,6 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     application_choice = create(:submitted_application_choice, course_option: course_option)
     application_form = create(:completed_application_form, candidate: @previously_matched_unchanged, application_choices: [application_choice])
     create(:ucas_match,
-           matching_state: 'processed',
            application_form: application_form,
            scheme: 'B',
            ucas_status: :offer,
@@ -132,11 +130,6 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
   def and_the_existing_match_is_updated
     expect(page).to have_content @previously_matched_changed.email_address
     expect(page).to have_content 'Updated'
-  end
-
-  def and_the_unchanged_existing_match_is_left_alone
-    expect(page).to have_content @previously_matched_unchanged.email_address
-    expect(page).to have_content 'Processed'
   end
 
   def when_i_click_on_a_match

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
     when_i_visit_the_ucas_matches_page_in_support
     then_the_new_match_is_created
-    and_the_existing_match_is_updated
 
     when_i_click_on_a_match
     then_i_see_the_matching_info
@@ -124,12 +123,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def then_the_new_match_is_created
     expect(page).to have_content @not_previously_matched.email_address
-    expect(page).to have_content 'New match'
-  end
-
-  def and_the_existing_match_is_updated
-    expect(page).to have_content @previously_matched_changed.email_address
-    expect(page).to have_content 'Updated'
+    expect(page).to have_content 'No action taken'
   end
 
   def when_i_click_on_a_match


### PR DESCRIPTION
Pending merge of #3552 as it relies on `UCASMatch#resolved?` introduced on that PR.

## Context

Removes matched_state from UCASMatch

## Link to Trello card

https://trello.com/c/NQYTn8V5/3048-remove-matchedstate-from-ucas-matches

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
