### PR TITLE
Allow support users to add a course in support post-submission

### DIFF
--- a/app/controllers/support_interface/add_course_controller.rb
+++ b/app/controllers/support_interface/add_course_controller.rb
@@ -1,0 +1,24 @@
+module SupportInterface
+  class AddCourseController < SupportInterfaceController
+    def new
+      @pick_course = SupportInterface::AddCourseForm.new(application_form_id: params[:application_form_id])
+    end
+
+    def create
+      @pick_course = SupportInterface::AddCourseForm.new(course_params)
+
+      if @pick_course.save
+        redirect_to support_interface_application_form_path
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def course_params
+      params.require(:support_interface_add_course_form)
+            .permit(:application_form_id, :course_option_id)
+    end
+  end
+end

--- a/app/forms/support_interface/add_course_form.rb
+++ b/app/forms/support_interface/add_course_form.rb
@@ -1,0 +1,49 @@
+module SupportInterface
+  class AddCourseForm
+    include ActiveModel::Model
+
+    attr_accessor :course_option_id, :application_form_id, :candidate_id
+
+    validates :course_option_id, presence: true
+    validates :application_form_id, presence: true
+
+    DropdownOption = Struct.new(:id, :name)
+
+    def radio_available_courses
+      @radio_available_courses ||= begin
+        courses.order(:name)
+      end
+    end
+
+    def dropdown_available_courses
+      @dropdown_available_courses ||= courses.map { |course|
+        # YUCK
+
+        course.course_options.map do |course_option|
+          DropdownOption.new(course_option.id, "#{course.name} (#{course.code}) – #{course.provider&.name} - #{course_option.site.name}")
+        end
+      }.flatten.sort_by(&:name)
+    end
+
+    def courses
+      @courses ||= Course.current_cycle.includes(:provider, { course_options: [:site] }).open_on_apply
+    end
+
+    def save
+      return false unless valid?
+
+      SupportInterface::AddCourseChoiceAfterSubmission.new(
+        application_form: application_form,
+        course_option: course_option,
+      ).call
+    end
+
+    def application_form
+      @application_form ||= ApplicationForm.find(application_form_id)
+    end
+
+    def course_option
+      @course_option ||= CourseOption.find(course_option_id)
+    end
+  end
+end

--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -2,10 +2,12 @@ require.context("govuk-frontend/govuk/assets");
 
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
 import initApiTokenProviderAutocomplete from "./api-token-autocomplete";
-import "../styles/application-support.scss";
 import filter from "./components/paginated_filter";
+import initCoursesAutocomplete from "./courses-autocomplete";
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
+import "../styles/application-support.scss";
 
 govUKFrontendInitAll();
+initCoursesAutocomplete();
 initApiTokenProviderAutocomplete();
 filter();

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -74,6 +74,10 @@ class Course < ApplicationRecord
     "#{name} (#{code}) – #{accredited_provider&.name}"
   end
 
+  def name_code_and_training_provider
+    "#{name} (#{code}) – #{provider&.name}"
+  end
+
   def name_code_and_age_range
     "#{name} (#{code}) – #{age_range}"
   end

--- a/app/views/support_interface/add_course/new.html.erb
+++ b/app/views/support_interface/add_course/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, 'Add a course to a submitted application' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+            model: @pick_course,
+            url:   support_interface_add_course_for_candidate_path,
+            id:    'pick-course-form',
+        ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_select(
+              :course_option_id,
+              select_course_options(@pick_course.dropdown_available_courses),
+              :id,
+              :name,
+              label:   { text: "Search for a course", size: 'xl' },
+              options: { selected: nil },
+          ) %>
+      <%= f.hidden_field :application_form_id, value: @pick_course.application_form_id %>
+      <%= f.govuk_submit "Submit" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -23,6 +23,7 @@
   <% @application_form.application_choices.includes(:course, :provider, :site, :offered_course_option).each do |application_choice| %>
     <%= render SupportInterface::ApplicationChoiceComponent.new(application_choice) %>
   <% end %>
+  <%= govuk_button_link_to 'Add a course', support_interface_add_course_for_candidate_path, form_class: 'govuk-!-display-inline-block' %>
 <% end %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -678,8 +678,10 @@ Rails.application.routes.draw do
 
     scope path: '/applications/:application_form_id' do
       get '/' => 'application_forms#show', as: :application_form
+      get '/add-course' => 'add_course#new', as: :add_course_for_candidate
       get '/audit' => 'application_forms#audit', as: :application_form_audit
       get '/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
+      post '/add-course' => 'add_course#create', as: :create_course_for_candidate
       post '/comments' => 'application_forms/comments#create', as: :application_form_comments
 
       get '/applicant_details' => 'application_forms/applicant_details#edit', as: :application_form_edit_applicant_details


### PR DESCRIPTION
## Context

We've had some support queries come through where candidates have requested adding an additional course to their application post-submission.

This is something that ideally, should be able to be done through the support interface.

## Changes proposed in this pull request
- Add button to add a course to candidate's application page 
- Add a new form and autocomplete to allow support users to search for and add a course to an application.

## Guidance to review

- This is a first pass so keen to get feedback on the design. Will add tests once design agreed.

![add_a_course](https://user-images.githubusercontent.com/5256922/101155815-8fd63b80-361f-11eb-8a76-7951eb20cda9.gif)

## Link to Trello card

https://trello.com/c/yZ7Ahqvp/2621-dev-%F0%9F%8F%88-allow-support-users-to-add-a-course-in-support-post-submission

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
