### PR TITLE
Prevent Apply Again unless application is unsuccessful

### DIFF
--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class SubmittedApplicationFormController < CandidateInterfaceController
     before_action :redirect_to_application_form_unless_submitted, except: %i[start_carry_over carry_over]
+    before_action :redirect_to_dashboard_unless_ended_without_success, only: [:apply_again]
 
     def review_submitted
       @application_form = current_application
@@ -31,6 +32,12 @@ module CandidateInterface
       CarryOverApplication.new(current_application).call
       flash[:success] = 'Your application is ready for editing'
       redirect_to candidate_interface_before_you_start_path
+    end
+
+  private
+
+    def redirect_to_dashboard_unless_ended_without_success
+      redirect_to candidate_interface_application_complete_path unless current_application.ended_without_success?
     end
   end
 end


### PR DESCRIPTION
## Context
https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1607033817105700
<!-- Why are you making this change? What might surprise someone about it? -->
Steps to repro bug:

- Start with a failed app
- Apply again normally
- Submit the app
- Navigate to path `/candidate/application/start-apply-again`
- Click through, a new app gets created

## Changes proposed in this pull request
See diff
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Is this the right check to make? Should we make this check in the service object instead?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/gYsowIoQ
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
