### PR TITLE
Fix bug that stops import from ucas

### DIFF
--- a/app/services/ucas_matching/file_download_check.rb
+++ b/app/services/ucas_matching/file_download_check.rb
@@ -1,0 +1,31 @@
+module UCASMatching
+  class FileDownloadCheck < OkComputer::Check
+    LAST_SUCCESSFUL_SYNC = 'last-successful-ucas-matching-file-download'.freeze
+
+    def self.set_last_sync(date)
+      Redis.current.set(LAST_SUCCESSFUL_SYNC, date)
+    end
+
+    def self.clear_last_sync
+      Redis.current.del(LAST_SUCCESSFUL_SYNC)
+    end
+
+    def self.last_sync
+      Redis.current.get(LAST_SUCCESSFUL_SYNC)
+    end
+
+    def check
+      last_date = self.class.last_sync
+
+      if last_date.nil?
+        mark_failure
+        mark_message 'Cannot find the time when the last UCAS file download took place'
+      elsif Time.zone.now > Time.zone.parse(last_date).next_weekday
+        mark_failure
+        mark_message 'There was no UCAS file download taking place yesterday'
+      else
+        mark_message 'There was a succesful UCAS file download that has taken place since the last weekday'
+      end
+    end
+  end
+end

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -42,6 +42,7 @@ module UCASMatching
         Rails.logger.info "Skipping file with ID #{movit_file.fetch('id')} - we’ve already processed it"
         return
       else
+        UCASMatching::FileDownloadCheck.set_last_sync(Time.zone.now)
         Rails.logger.info "Downloading file with ID #{movit_file.fetch('id')}"
       end
 

--- a/app/services/ucas_matching/process_matching_data.rb
+++ b/app/services/ucas_matching/process_matching_data.rb
@@ -70,7 +70,7 @@ module UCASMatching
     end
 
     def files_in_ucas_movit_folder
-      response = JSON.parse(HTTP.auth(auth_string).get("#{UCASAPI.base_url}/folders/#{UCASAPI.download_folder}/files"))
+      response = JSON.parse(HTTP.auth(auth_string).get("#{UCASAPI.base_url}/folders/#{UCASAPI.download_folder}/files?sortField=uploadStamp&sortDirection=descending"))
       response.fetch('items')
     end
 

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -34,5 +34,6 @@ OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
 OkComputer::Registry.register 'find_sync', FindSyncCheck.new
 OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
+OkComputer::Registry.register 'ucas_matching_file_download', UCASMatching::FileDownloadCheck.new
 
 OkComputer.make_optional %w[version]

--- a/spec/services/ucas_matching/file_download_check_spec.rb
+++ b/spec/services/ucas_matching/file_download_check_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe UCASMatching::FileDownloadCheck do
+  describe '#check' do
+    it 'succeeds if a download has taken before the weekend' do
+      Timecop.freeze(2020, 12, 7, 0, 0) do # Monday
+        UCASMatching::FileDownloadCheck.set_last_sync(3.days.ago) # Friday
+
+        expect(UCASMatching::FileDownloadCheck.new.check).to eql('There was a succesful UCAS file download that has taken place since the last weekday')
+      end
+    end
+
+    it 'succeeds if a download has taken place on the previous weekday' do
+      Timecop.freeze(2020, 12, 4, 0, 0) do # Friday
+        UCASMatching::FileDownloadCheck.set_last_sync(1.day.ago) # Thursday
+
+        expect(UCASMatching::FileDownloadCheck.new.check).to eql('There was a succesful UCAS file download that has taken place since the last weekday')
+      end
+    end
+
+    it 'fails if the file has never been downloaded' do
+      UCASMatching::FileDownloadCheck.clear_last_sync
+
+      expect(UCASMatching::FileDownloadCheck.new.check).to eql('Cannot find the time when the last UCAS file download took place')
+    end
+
+    it 'fails if the download has not happened since the last weekday' do
+      UCASMatching::FileDownloadCheck.set_last_sync(Time.zone.now.prev_weekday - 1.day)
+
+      expect(UCASMatching::FileDownloadCheck.new.check).to eql('There was no UCAS file download taking place yesterday')
+    end
+  end
+end

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     and_there_is_a_previously_matched_candidate_with_no_changes
     and_ucas_has_uploaded_a_file_to_our_shared_folder
 
-    when_the_daily_download_runs
+    a_file_download_check_is_logged { when_the_daily_download_runs }
     then_we_have_received_a_slack_message
 
     when_i_visit_the_ucas_matches_page_in_support
@@ -106,6 +106,12 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     UCASMatching::ProcessMatchingData.new.perform
   rescue UCASMatching::APIError => e
     @latest_exception = e
+  end
+
+  def a_file_download_check_is_logged(&block)
+    allow(UCASMatching::FileDownloadCheck).to receive(:set_last_sync)
+    block.call
+    expect(UCASMatching::FileDownloadCheck).to have_received(:set_last_sync)
   end
 
   def then_we_have_received_a_slack_message

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
         body: { access_token: '123456789' }.to_json,
       )
 
-    stub_request(:get, 'https://transfer.ucasenvironments.com/api/v1/folders/691078359/files')
+    stub_request(:get, 'https://transfer.ucasenvironments.com/api/v1/folders/691078359/files?sortField=uploadStamp&sortDirection=descending')
       .with(
         headers: {
           'Authorization' => 'Bearer 123456789',


### PR DESCRIPTION
## Context

The Movit API returns the 25 oldest files, which means that 5 weeks after turning on the sync, this process stopped working.

## Changes proposed in this pull request

Update request to sort files in descending order by the `uploadStamp` field so that latest files are always retrieved

Add a healthcheck as suggested in the card to check when the last upload took place and mark the process as failed if no upload has taken place in the previous weekday

## Link to Trello card

https://trello.com/c/ziLTnhqD/2960-fix-bug-that-stops-import-from-ucas

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
