### PR TITLE
Format API grade example as a string, not an array

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 7th December 2020
+
+Documentation:
+
+- Clarify the format of the `grade` field in the spec and documentation
+
 ### 19th November 2020
 
 - The `Qualification` object now supports multiple types of English GCSEs (eg. English Language, English Studies Double 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -776,11 +776,8 @@ components:
         grade:
           type: string
           maxLength: 256
-          description: The grade awarded
-          example:
-          - 2:1 (University degree)
-          - A* (GSCE grade in a single subject)
-          - A*A*A (GCSE Science triple award, where grades are for Biology, Chemistry and Physics, respectively)
+          description: The grade awarded. e.g. "2:1" for university degrees, "A" for GCSE, "BA*" for double-award science, or "ABC" for triple-award science. For triple-award science, which is the only possible value with three grades, the grades are in the order Biology, Physics, Chemistry.
+          example: "AA*B"
         start_year:
           type: string
           nullable: true


### PR DESCRIPTION
## Context

Some parts of OpenAPI [do support multiple examples](https://swagger.io/docs/specification/adding-examples/) under an "examples:" key, but properties unfortunately don’t. The old code rendered an array in the docs which implied that clients should expect an array, and it also made the autogenerated JSON example incorrect.

Put the extra information in the description and leave a valid example in the example field.

Before

<img width="1325" alt="Screenshot 2020-12-04 at 16 59 19" src="https://user-images.githubusercontent.com/642279/101191802-160b7580-3652-11eb-9098-0b331b7b407b.png">

<img width="1094" alt="Screenshot 2020-12-04 at 20 46 20" src="https://user-images.githubusercontent.com/642279/101213179-e2d8de80-3671-11eb-816e-ccf077056205.png">

After

<img width="1041" alt="Screenshot 2020-12-04 at 16 59 10" src="https://user-images.githubusercontent.com/642279/101191808-186dcf80-3652-11eb-8ceb-2acc37acd37f.png">

<img width="1032" alt="Screenshot 2020-12-04 at 20 47 44" src="https://user-images.githubusercontent.com/642279/101213247-fd12bc80-3671-11eb-8862-ec004c0be6fa.png">

