### PR TITLE
Remove banner style dependency from incomplete section component (follow up)

### DIFF
--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -21,12 +21,6 @@
 
 .app-banner--warning {
   border-color: govuk-colour("red");
-
-  &.app-banner--missing-section {
-    .app-banner__message p {
-      color: govuk-colour("red");
-    }
-  }
 }
 
 .app-banner__message {

--- a/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/review.html.erb
@@ -10,7 +10,7 @@
       <ul class="govuk-list govuk-error-summary__list">
         <% @errors.each do |section| %>
           <li>
-            <a href="<%= "#missing-#{section}-error" %>"><%= t("review_application.#{section}.incomplete", minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES) %></a>
+            <a href="<%= "#incomplete-#{section}-error" %>"><%= t("review_application.#{section}.incomplete", minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES) %></a>
           </li>
         <% end %>
 

--- a/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Candidate submits the application' do
 
   def then_i_should_see_all_sections_are_complete
     CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
-      expect(page).not_to have_selector "[data-qa='missing-#{section}']"
+      expect(page).not_to have_selector "[data-qa='incomplete-#{section}']"
     end
   end
 


### PR DESCRIPTION
## Context

In #3512 we updated the messages in the incomplete section component to use `app-inset-text` instead of a variation of `app-banner`. We also changed it so that `incomplete` keyword is used instead of `missing`.

However, the error messages in the summary at the top of the application review page were not updated, meaning they link to incomplete sections using `#missing-*`, not `#incomplete-*`.

## Changes proposed in this pull request

* Update links in in error summary to use `#incomplete-*` not `#missing-*`
* Remove a left over `.app-banner--missing-section` style
* Fix test for absence of incomplete application section (not sure how useful this test is… passed even after I changed the value in previous commit 🤔)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
