### PR TITLE
Add region param to ApplicationForm geocoding

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -3,7 +3,7 @@
 class ApplicationForm < ApplicationRecord
   audited
   has_associated_audits
-  geocoded_by :address_formatted_for_geocoding
+  geocoded_by :address_formatted_for_geocoding, params: { region: 'uk' }
 
   include Chased
 


### PR DESCRIPTION
## Context

We are seeing some inaccurate geocoding results in the production system for candidate addresses. This seems to happen when the first line of an address matches a place name in North America. In such cases the rest of the address is sufficient to locate the correct coordinates but the API is biasing towards the incorrect match.

## Changes proposed in this pull request

Adding the `region` param tells the Google Maps Geocoding API to bias results to the UK. This
makes sense because we only geocode candidates who are UK based.

We will need to re-run the script that geocodes candidate addresses again after this is deployed.

Docs: https://developers.google.com/maps/documentation/geocoding/overview#RegionCodes

## Guidance to review

- No tests for this one since we don't test the geocoder gem.
- I can point to some addresses that didn't work in the production system if needed.

## Link to Trello card

https://trello.com/c/txBLFAYG/2674-inaccurate-geocoding-results

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
