### PR TITLE
Add Last action taken filter to UCAS Matches page

### DIFF
--- a/app/models/support_interface/ucas_matches_filter.rb
+++ b/app/models/support_interface/ucas_matches_filter.rb
@@ -16,11 +16,15 @@ module SupportInterface
         ucas_matches = ucas_matches.where(id: action_needed_ids)
       end
 
+      if applied_filters[:action_taken]
+        ucas_matches = ucas_matches.where(action_taken: applied_filters[:action_taken])
+      end
+
       ucas_matches
     end
 
     def filters
-      @filters ||= [year_filter] + [action_needed_filter]
+      @filters ||= [year_filter] + [action_needed_filter] + [action_taken_filter]
     end
 
   private
@@ -53,6 +57,25 @@ module SupportInterface
           checked: applied_filters[:action_needed]&.include?('yes'),
         }],
       }
+    end
+
+    def action_taken_filter
+      {
+        type: :checkboxes,
+        heading: 'Last action taken',
+        name: 'action_taken',
+        options: action_taken_options,
+      }
+    end
+
+    def action_taken_options
+      UCASMatch.distinct(:action_taken).pluck(:action_taken).compact.map do |action|
+        {
+          value: action,
+          label: action.humanize,
+          checked: applied_filters[:action_taken]&.include?(action),
+        }
+      end
     end
   end
 end

--- a/spec/system/support_interface/ucas_matches_spec.rb
+++ b/spec/system/support_interface/ucas_matches_spec.rb
@@ -47,6 +47,11 @@ RSpec.feature 'See UCAS matches' do
     and_when_i_click 'Confirm withdrawal from UCAS was requested'
 
     then_i_see_last_performed_action_is 'requested withdrawal from UCAS'
+
+    when_i_go_to_ucas_matches_page
+    and_when_i_filter_by_last_action_taken
+    then_i_only_see_matches_with_selected_action_taken
+    and_i_expect_the_relevant_action_taken_tags_to_be_visible
   end
 
   def given_i_am_a_support_user
@@ -210,5 +215,19 @@ RSpec.feature 'See UCAS matches' do
   def when_i_visit_the_page_again
     visit current_path
     given_i_am_a_support_user
+  end
+
+  def and_when_i_filter_by_last_action_taken
+    find(:css, '#action_taken-ucas_withdrawal_requested').set(true)
+    click_button('Apply filters')
+  end
+
+  def then_i_only_see_matches_with_selected_action_taken
+    expect(page).to have_content(@candidate2.email_address)
+    expect(page).not_to have_content(@candidate.email_address)
+  end
+
+  def and_i_expect_the_relevant_action_taken_tags_to_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: 'UCAS withdrawal requested')
   end
 end


### PR DESCRIPTION
## Context

Support users and UCAS engagement leads want to see the matches they acted on and what they did.

## Changes proposed in this pull request

<img width="654" alt="Screenshot 2020-12-07 at 09 58 22" src="https://user-images.githubusercontent.com/38078064/101336781-c788f180-3872-11eb-80a7-624c4cd7d273.png">

## Guidance to review

Thoughts on 'No action taken' welcome. Should we exclude it from the filter? It would break in staging because all actions_taken are nil.

## Link to Trello card

https://trello.com/c/J5t3X5sB/3095-filter-ucas-matches-by-last-action-taken

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
