### PR TITLE
Fix bug - editing 'other' qualifications

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -48,7 +48,8 @@ module CandidateInterface
       @intermediate_data_service = intermediate_data_service
       options = @intermediate_data_service.read.merge(options) if @intermediate_data_service
 
-      self.id ||= options[:id]
+      self.id ||= options[:id] || options['id']
+
       options = persistent_attributes(current_qualification).merge(options) if current_qualification
 
       super(options)


### PR DESCRIPTION
## Context

- When more than one non-UK qualification has been submitted, problems can occur when editing these. Editing one qualification actually edits the other.
- This is due to a type error and qualification id resolving to nil when reading from Redis

See bug report for full description https://trello.com/c/edEWlzAL/2599-%F0%9F%93%90-dev-structured-qualifications-clean-up-work

## Changes proposed in this pull request

Check for qualification id type (String) when reading from Redis

## Guidance to review

- Try and replicate the bug as described in the ticket
- Possibly this is a quick, hacky solution. Should this be made more robust @stevehook ?


## Link to Trello card

https://trello.com/c/edEWlzAL/2599-%F0%9F%93%90-dev-structured-qualifications-clean-up-work

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
