### PR TITLE
[Do not merge] Convert international addresses into address fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'faker'
 gem 'view_component'
 
 gem 'uk_postcode'
+gem 'ruby_postal'
 
 gem 'business_time'
 gem 'holidays'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,6 +427,7 @@ GEM
       nokogiri
       rest-client
     ruby-progressbar (1.10.1)
+    ruby_postal (1.0.0)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -578,6 +579,7 @@ DEPENDENCIES
   rubocop-govuk
   ruby-graphviz
   ruby-jmeter
+  ruby_postal
   selenium-webdriver
   sentry-raven
   shoulda-matchers (~> 4.4)

--- a/app/services/provider_interface/international_address_line_converter.rb
+++ b/app/services/provider_interface/international_address_line_converter.rb
@@ -1,0 +1,119 @@
+require 'csv'
+require 'ruby_postal/parser'
+
+module ProviderInterface
+  class InternationalAddressLineConverter
+    # Read addresses file [application_form.id, international_address]
+    # Parse addresses
+    # Omit unparseable or invalid results
+    # Write addresses to file [application_form.id, address_line1, address_line2, address_line3, address_line4]
+
+    TRIBAL_MAX_ADDRESS_LENGTH = 50
+    MAX_ADDRESS_LINES = 4
+
+    def convert(address_file_name)
+      parsed_addresses = {}
+
+      raw_addresses = File.read(address_file_name).split("\n###\n").map(&:strip)
+      raw_addresses.each do |raw_address|
+        id, address = raw_address.split('||')
+        parsed_addresses[id] = Postal::Parser.parse_address(address.strip) if address.present?
+      end
+
+      converted_address_set = {}
+      parsed_addresses.each { |k, a| converted_address_set[k] = address_lines(a) }
+
+      CSV.open("#{address_file_name}.converted.csv", 'wb') do |csv|
+        csv << %w[id address_line1 address_line2 address_line3 address_line4]
+        converted_address_set.each do |id, address_lines|
+          if address_lines.blank?
+            Rails.logger.info "Address(#{id}) has no usable data."
+            next
+          end
+
+          if address_lines.present? && has_four_lines_or_less?(address_lines)
+            csv << [id] + address_lines
+          else
+            Rails.logger.info "Address (#{id}) has more than #{MAX_ADDRESS_LINES} lines."
+            Rails.logger.info address_lines
+          end
+        end
+      end
+
+      Rails.logger.info score(converted_address_set.values)
+    end
+
+    def import
+      CSV.read("#{address_file_name}.converted.csv", headers: true) do |row|
+        application_form = ApplicationForm.find_by_id(row['id'])
+
+        if application_form.address_line1.blank? && application_form.address_line2.blank? &&
+            application_form.address_line3.blank? && application_form.address_line4.blank?
+          application_form.update!(
+            address_line1: csv['address_line1'],
+            address_line2: csv['address_line2'],
+            address_line3: csv['address_line3'],
+            address_line4: csv['address_line4'],
+            international_address: nil,
+            audit_comment: 'Updating address fields from international address',
+          )
+        end
+      end
+    end
+
+    def address_lines(address)
+      address = Hash[address.map(&:values)]
+
+      lines = [
+        address.slice(:po_box, :unit, :level, :house, :house_number, :road).values.compact.join(' '),
+        address.slice(:suburb, :city_district, :city, :state_district, :state).values.compact.join(' '),
+        address[:postcode],
+      ].reject(&:blank?)
+
+      return lines if has_lines_of_acceptable_length?(lines)
+
+      split_lines = []
+      parts = []
+
+      lines.each do |line|
+        next if line.length <= TRIBAL_MAX_ADDRESS_LENGTH
+
+        line.split(' ').each do |word|
+          if (parts + [word]).join(' ').length > TRIBAL_MAX_ADDRESS_LENGTH
+            split_lines << parts.join(' ')
+            parts = [word]
+          else
+            parts << word
+          end
+        end
+      end
+
+      split_lines << parts.join(' ')
+      split_lines.reject(&:blank?)
+    end
+
+    def valid?(address)
+      has_four_lines_or_less?(address) && has_lines_of_acceptable_length?(address)
+    end
+
+    def has_four_lines_or_less?(address)
+      address.compact.count <= MAX_ADDRESS_LINES
+    end
+
+    def has_lines_of_acceptable_length?(address)
+      address.compact.all? { |a| a.length <= TRIBAL_MAX_ADDRESS_LENGTH }
+    end
+
+    def score(address_set)
+      passing = address_set.select { |a| valid?(a) }.count
+      too_many_lines = address_set.reject { |a| has_four_lines_or_less?(a) }.count
+      lines_too_long = address_set.reject { |a| has_lines_of_acceptable_length?(a) }.count
+      {
+        total_addresses: address_set.count,
+        passing_addresses: passing,
+        too_many_lines: too_many_lines,
+        lines_too_long: lines_too_long,
+      }
+    end
+  end
+end

--- a/spec/services/provider_interface/international_address_line_converter_spec.rb
+++ b/spec/services/provider_interface/international_address_line_converter_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::InternationalAddressLineConverter do
+  describe '#convert' do
+    let(:raw_data) do
+      <<-RAW.strip_heredoc
+        1213||
+        Saitama Prefecture,
+        Koshigaya city,
+        Sengendainishi 3-3
+        Pakutaun 10-301
+        ###
+        2234||
+        PIPELINE ROAD 1 CLOSE A HOUSE 18 RUMUAGHOLU NKPOLU OBIO AKPOR RIVERS STATE NIGERIA
+      RAW
+    end
+
+    let(:csv_buffer) { [] }
+
+    before do
+      allow(File).to receive(:read).and_return(raw_data)
+      allow(CSV).to receive(:open).and_yield(csv_buffer)
+
+      described_class.new.convert('test')
+    end
+
+    it 'produces CSV output' do
+      expect(csv_buffer.first).to eq(%w[id address_line1 address_line2 address_line3 address_line4])
+    end
+
+    it 'converts single lines of addresses to multiple lines' do
+      expect(csv_buffer[1]).to eq(['1213', 'saitama prefecture koshigaya city sengendainishi', '3-3 pakutaun'])
+    end
+
+    it 'splits long address lines to 50 chars or less' do
+      expect(csv_buffer[2]).to eq(['2234', 'rumuagholu nkpolu obio akpor rivers state nigeria', 'house 18 pipeline road 1 close a'])
+    end
+  end
+end


### PR DESCRIPTION

## Context

Data stored in `ApplicationForm#international_address` doesn't conform to any particular format and often contains unhelpful values which exceed line lengths acceptable to API consumers.
We'd like to tidy this data up into neat `address_line*` lines of no more than 50 chars.

The best fit for looking up address data was `ruby_postal` but this depends on 1.9GB of address data, so this task will be run locally and we'll update the application form data in the Rails console, there's no need to merge or deploy this PR, it's just here for peer review.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Attempts to sanitise data we store in the `ApplicationForm#international_address` field using `libpostal`.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/gz9VJ1wj/3093-resolve-international-non-uk-address-structures-for-api-integration

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
