### PR TITLE
Refactor Apply Again checks

### DIFF
--- a/app/controllers/candidate_interface/submitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/submitted_application_form_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class SubmittedApplicationFormController < CandidateInterfaceController
     before_action :redirect_to_application_form_unless_submitted, except: %i[start_carry_over carry_over]
-    before_action :redirect_to_dashboard_unless_ended_without_success, only: [:apply_again]
 
     def review_submitted
       @application_form = current_application
@@ -19,9 +18,12 @@ module CandidateInterface
     end
 
     def apply_again
-      ApplyAgain.new(current_application).call
-      flash[:success] = 'Your new application is ready for editing'
-      redirect_to candidate_interface_before_you_start_path
+      if ApplyAgain.new(current_application).call
+        flash[:success] = 'Your new application is ready for editing'
+        redirect_to candidate_interface_before_you_start_path
+      else
+        redirect_to candidate_interface_application_complete_path
+      end
     end
 
     def start_carry_over
@@ -32,12 +34,6 @@ module CandidateInterface
       CarryOverApplication.new(current_application).call
       flash[:success] = 'Your application is ready for editing'
       redirect_to candidate_interface_before_you_start_path
-    end
-
-  private
-
-    def redirect_to_dashboard_unless_ended_without_success
-      redirect_to candidate_interface_application_complete_path unless current_application.ended_without_success?
     end
   end
 end

--- a/app/services/apply_again.rb
+++ b/app/services/apply_again.rb
@@ -4,6 +4,10 @@ class ApplyAgain
   end
 
   def call
-    DuplicateApplication.new(@application_form, target_phase: 'apply_2').duplicate
+    if @application_form.ended_without_success?
+      DuplicateApplication.new(@application_form, target_phase: 'apply_2').duplicate
+    else
+      false
+    end
   end
 end

--- a/spec/services/apply_again_spec.rb
+++ b/spec/services/apply_again_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ApplyAgain do
     Timecop.travel(-1.day) do
       @original_application_form ||= create(
         :completed_application_form,
-        application_choices_count: 3,
         work_experiences_count: 1,
         volunteering_experiences_count: 1,
         with_gcses: true,
@@ -15,9 +14,34 @@ RSpec.describe ApplyAgain do
       )
       create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @original_application_form)
       create(:reference, feedback_status: :feedback_refused, application_form: @original_application_form)
+      create(:application_choice, :with_rejection, application_form: @original_application_form)
     end
     @original_application_form
   end
 
   it_behaves_like 'duplicates application form', 'apply_2', RecruitmentCycle.current_year
+
+  describe '#call' do
+    context 'application_form.ended_without_success? returns true' do
+      it 'calls the DuplicateApplication service' do
+        application = instance_double(ApplicationForm, ended_without_success?: true)
+        duplication_service = instance_double(DuplicateApplication, duplicate: true)
+        allow(DuplicateApplication).to receive(:new)
+          .with(application, target_phase: 'apply_2')
+          .and_return(duplication_service)
+
+        described_class.new(application).call
+
+        expect(duplication_service).to have_received(:duplicate)
+      end
+    end
+
+    context 'application_form.ended_without_success? returns false' do
+      it 'returns false' do
+        application = instance_double(ApplicationForm, ended_without_success?: false)
+
+        expect(described_class.new(application).call).to eq false
+      end
+    end
+  end
 end

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples 'duplicates application form' do |expected_phase, expected
     expect(duplicate_application_form.phase).to eq expected_phase
   end
 
-  it "sets the recruitment_cycle_year to `#{expected_cycle}`", skip: true do
+  it "sets the recruitment_cycle_year to `#{expected_cycle}`" do
     expect(duplicate_application_form.recruitment_cycle_year).to eq expected_cycle
   end
 

--- a/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
     then_my_application_is_submitted_and_sent_to_the_provider
     and_i_receive_an_email_that_my_application_has_been_sent
     and_i_do_not_see_referee_related_guidance
+    and_i_cannot_apply_again_yet
   end
 
   def given_the_pilot_is_open
@@ -141,5 +142,11 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def and_i_do_not_see_referee_related_guidance
     expect(page).not_to have_content 'References'
+  end
+
+  def and_i_cannot_apply_again_yet
+    visit candidate_interface_start_apply_again_path
+    and_i_click_on_start_now
+    expect(page).to have_current_path candidate_interface_application_complete_path
   end
 end


### PR DESCRIPTION
We have code that checks that a candidate actually has an unsuccessful
current application before allowing them through the Apply Again
process. Move this code to from the controller into the actual service
that handles Apply Again, and add some tests for this behaviour.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Move the logical check from controller to service object.
- Add unit tests for the service object.
- Update a system spec to exercise this behaviour.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Is the testing adequate?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/gYsowIoQ/2672-2x-apply-again-bug
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
