### PR TITLE
Use heading for when reference no longer needed

### DIFF
--- a/app/views/referee_interface/reference/finish.html.erb
+++ b/app/views/referee_interface/reference/finish.html.erb
@@ -7,20 +7,22 @@
     </h1>
 
     <% if @reference_cancelled %>
+      <h2 class="govuk-heading-m">
+        You do not need to give a reference anymore
+      </h2>
       <p class="govuk-body">
-        You do not need to give a reference anymore.
-      </p>
-      <p class="govuk-body">
-        <%= @application_form.first_name %> <%= @application_form.last_name %> has received the 2 references needed to
-        apply for a teacher training course.
+        <%= @application_form.first_name %> <%= @application_form.last_name %> has received the 2 references needed to apply for a teacher training course.
       </p>
     <% end %>
 
     <% if @reference.consent_to_be_contacted? %>
-      <h2 class="govuk-heading-m">Our user research team will contact you shortly</h2>
+      <h2 class="govuk-heading-m">
+        Our user research team will contact you shortly
+      </h2>
     <% end %>
 
-    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please
-      contact <%= bat_contact_mail_to %>.</p>
+    <p class="govuk-body">
+      If you have any questions about the Apply for teacher training service, please contact <%= bat_contact_mail_to %>.
+    </p>
   </div>
 </div>

--- a/spec/system/referee_interface/referee_cannot_provide_reference_if_two_already_received_spec.rb
+++ b/spec/system/referee_interface/referee_cannot_provide_reference_if_two_already_received_spec.rb
@@ -67,6 +67,6 @@ RSpec.feature 'Referee is not required to submit a reference' do
 
   def then_i_should_see_that_i_am_not_required_to_give_a_reference
     expect(page).to have_content('Thank you')
-    expect(page).to have_content('You do not need to give a reference anymore.')
+    expect(page).to have_content('You do not need to give a reference anymore')
   end
 end


### PR DESCRIPTION
## Context

* Puts ‘You do not need to give a reference anymore’ into a heading (to match what we do for ‘Our user research team will contact you shortly’)
* Consistent line wrapping