### PR TITLE
Avoid storing latitude/longitude for addresses outside UK

### DIFF
--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -7,8 +7,24 @@ class GeocodeApplicationAddressWorker
     return unless Geocoder.config.api_key
 
     application_form = ApplicationForm.find(application_form_id)
-    application_form.latitude, application_form.longitude = application_form.geocode
+    coordinates = application_form.geocode
+    application_form.latitude, application_form.longitude = outside_uk?(coordinates) ? [nil, nil] : coordinates
 
     application_form.save!
+  end
+
+private
+
+  SOUTHERLY_LIMIT = 49.51
+  NORTHERLY_LIMIT = 60.51
+  WESTERLY_LIMIT = -8.638
+  EASTERLY_LIMIT = 1.46
+
+  def outside_uk?(coordinates)
+    latitude, longitude = coordinates
+    latitude < SOUTHERLY_LIMIT ||
+      latitude > NORTHERLY_LIMIT ||
+      longitude < WESTERLY_LIMIT ||
+      longitude > EASTERLY_LIMIT
   end
 end

--- a/spec/workers/geocode_application_address_worker_spec.rb
+++ b/spec/workers/geocode_application_address_worker_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe GeocodeApplicationAddressWorker do
         expect(application.latitude).to eq(51.499399)
         expect(application.longitude).to eq(-0.124808)
       end
+
+      it 'does not use coordinates returned by the geocoder if they are outside UK bounding box' do
+        application = create(:application_form)
+        allow(application).to receive(:geocode).and_return([13.7244416, 100.35291])
+        allow(ApplicationForm).to receive(:find).with(application.id).and_return(application)
+
+        described_class.new.perform(application.id)
+
+        expect(application.latitude).to be_nil
+        expect(application.longitude).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

There are a few international candidate addresses in the system disguised as UK ones. They follow a pattern: `address_line1-4` specify an international address but they have a UK postcode. Such addresses skew location distance stats because they are typically a long way from the course they are applying to.

We support international addresses so they can be input but we need to know that they are so that we can avoid geocoding them.

## Changes proposed in this pull request

Check geo-located coordinates to see whether they fall outside the bounding box for the UK. Store nil latitude/longitude values for such disguised international addresses.

Data source:
https://en.wikipedia.org/wiki/List_of_extreme_points_of_the_United_Kingdom

## Guidance to review

- Does this change make sense?
- Do we need to factor the logic out into a separate service?
- Is there a smarter way to do this check?

## Link to Trello card

https://trello.com/c/txBLFAYG/2674-inaccurate-geocoding-results

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
