### PR TITLE
Audit EFL changes

### DIFF
--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -1,4 +1,6 @@
 class EnglishProficiency < ApplicationRecord
+  audited associated_with: :application_form
+
   belongs_to :application_form
   belongs_to :efl_qualification, polymorphic: true, optional: true, dependent: :destroy
 


### PR DESCRIPTION


## Context
Noticed we aren't auditing EFL.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add auditing to the EnglishProficiency model to pick up 'English as a
foreign language' changes.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
na
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
