### PR TITLE
Bug fix - editing 'other' qualifications

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -48,8 +48,7 @@ module CandidateInterface
       @intermediate_data_service = intermediate_data_service
       options = @intermediate_data_service.read.merge(options) if @intermediate_data_service
 
-      self.id ||= options[:id] || options['id']
-
+      self.id ||= options[:id]
       options = persistent_attributes(current_qualification).merge(options) if current_qualification
 
       super(options)

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -13,6 +13,13 @@ module CandidateInterface
     attr_reader :next_step
     attr_accessor :editing, :id, :current_step
 
+    attr_accessor :subject
+    attr_accessor :institution_country
+    attr_accessor :choice
+    attr_accessor :award_year
+    attr_accessor :predicted_grade
+    attr_accessor :grade
+
     attr_accessor :qualification_type
     attr_accessor :other_uk_qualification_type
     attr_accessor :non_uk_qualification_type
@@ -25,7 +32,11 @@ module CandidateInterface
     def initialize(current_application = nil, intermediate_data_service = nil, options = nil)
       @current_application = current_application
       @intermediate_data_service = intermediate_data_service
-      options = @intermediate_data_service.read.merge(options.select { |_, value| value.present? }) if @intermediate_data_service
+      options = if @intermediate_data_service
+                  prepared_options = prepare(options)
+                  @intermediate_data_service.read.merge(prepared_options)
+                end
+
       super(options)
     end
 
@@ -57,6 +68,16 @@ module CandidateInterface
 
     def qualification_type_changed?
       id && ApplicationQualification.find(id)&.qualification_type != qualification_type
+    end
+
+    def prepare(options)
+      options.select { |_, value| value.present? }
+
+      if [A_LEVEL_TYPE, AS_LEVEL_TYPE, GCSE_TYPE].include?(options[:qualification_type])
+        options[:non_uk_qualification_type] = ''
+      end
+
+      options
     end
   end
 end

--- a/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
@@ -8,4 +8,32 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:qualification_type) }
   end
+
+  describe '#initialize' do
+    let(:current_application) { create(:application_form) }
+    let(:intermediate_data_service) do
+      Class.new {
+        def read
+          {
+            'qualification_type' => 'non_uk',
+            'non_uk_qualification_type' => 'German diploma',
+          }
+        end
+      }.new
+    end
+
+    context 'the qualification type is being updated from a non-uk qualification to a uk qualification' do
+      it 'assigns an empty string to the non_uk_qualification_type attribute' do
+        form = CandidateInterface::OtherQualificationTypeForm.new(
+          current_application,
+          intermediate_data_service,
+          qualification_type: 'GCSE',
+          non_uk_qualification_type: 'German diploma',
+        )
+
+        expect(form.qualification_type).to eq('GCSE')
+        expect(form.non_uk_qualification_type).to be_blank
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context
- It was thought the previous fix sufficed, but alas no. 
- See https://github.com/DFE-Digital/apply-for-teacher-training/pull/3596

## Changes proposed in this pull request
- This time we are ensuring that the qualification data and data from Redis are being merged correct when initialising form objects
- Test coverage added

## Guidance to review

- Please see if you can replicate the bug as described in the Trello ticket. 

## Link to Trello card

https://trello.com/c/BqTT5ptc/2675-bug-edit-other-qualifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
