### PR TITLE
Format govuk_date_and_time and govuk_time according to the style guide

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -5,5 +5,26 @@ Date::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
 Time::DATE_FORMATS[:month_and_year] = '%B %Y'
 Date::DATE_FORMATS[:month_and_year] = '%B %Y'
 
-Time::DATE_FORMATS[:govuk_date_and_time] = '%e %B %Y at %l:%M%P'
-Time::DATE_FORMATS[:govuk_time] = '%l:%M%P'
+Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
+  format = if time >= time.midday && time <= time.midday.end_of_minute
+             '%e %B %Y at %l%P (midday)'
+           elsif time >= time.midnight && time <= time.midnight.end_of_minute
+             '%e %B %Y at %l%P (midnight)'
+           else
+             '%e %B %Y at %l:%M%P'
+           end
+
+  time.strftime(format)
+end
+
+Time::DATE_FORMATS[:govuk_time] = lambda do |time|
+  format = if time >= time.midday && time <= time.midday.end_of_minute
+             '%l%P (midday)'
+           elsif time >= time.midnight && time <= time.midnight.end_of_minute
+             '%l%P (midnight)'
+           else
+             '%l:%M%P'
+           end
+
+  time.strftime(format)
+end

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
         result = render_inline(described_class.new(ucas_match))
 
         expect(result.text).to include('No action required')
-        expect(result.text).to include(' We requested withdrawal from UCAS on the 18 October 2020 at 12:00p')
+        expect(result.text).to include(' We requested withdrawal from UCAS on the 18 October 2020 at 12pm (midday)')
       end
     end
 

--- a/spec/config/initializers/date_formats_spec.rb
+++ b/spec/config/initializers/date_formats_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Time::DATE_FORMATS' do
+  describe ':govuk_date_and_time, :govuk_time formats' do
+    it 'formats time to indicate midday' do
+      date_and_time = Time.zone.local(2020, 12, 25, 12, 0, 59)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq('25 December 2020 at 12pm (midday)')
+      expect(date_and_time.to_s(:govuk_time)).to eq('12pm (midday)')
+    end
+
+    it 'formats time to indicate midnight' do
+      date_and_time = Time.zone.local(2020, 12, 25, 0, 0, 59)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq('25 December 2020 at 12am (midnight)')
+      expect(date_and_time.to_s(:govuk_time)).to eq('12am (midnight)')
+    end
+
+    it 'formats time with minutes otherwise' do
+      date_and_time = Time.zone.local(2020, 12, 25, 12, 1, 0)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq('25 December 2020 at 12:01pm')
+      expect(date_and_time.to_s(:govuk_time)).to eq('12:01pm')
+    end
+  end
+end


### PR DESCRIPTION


## Context

According to the GOVUK style guide we should indicate midday or midnight when presenting dates.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request


Introduces conditional formatting of `:govuk_date_and_time` and `:govuk_time` to handle this.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/9JYg9qnW/3103-govuk-helper-format-times-across-the-service-to-follow-govuk-styles
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
