### PR TITLE
Add average distance to site to the provider export

### DIFF
--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -1,11 +1,14 @@
 module SupportInterface
   class ProvidersExport
+    include GeocodeHelper
+
     def providers
       relevant_providers.map do |provider|
         {
-          name: provider.name,
-          code: provider.code,
-          agreement_accepted_at: provider.provider_agreements.where.not(accepted_at: nil).first&.accepted_at,
+          'name' => provider.name,
+          'code' => provider.code,
+          'agreement_accepted_at' => provider.provider_agreements.where.not(accepted_at: nil).first&.accepted_at,
+          'Average distance to site' => average_distance_to_site(provider),
         }
       end
     end
@@ -18,8 +21,18 @@ module SupportInterface
       Provider
         .includes(
           :provider_agreements,
+          :sites,
         )
         .where(sync_courses: true)
+        .order(:name)
+    end
+
+    def average_distance_to_site(provider)
+      format_average_distance(
+        provider,
+        provider.sites,
+        with_units: false,
+      )
     end
   end
 end

--- a/spec/services/support_interface/providers_export_spec.rb
+++ b/spec/services/support_interface/providers_export_spec.rb
@@ -4,10 +4,18 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
   describe '#providers' do
     it 'returns synced providers and the date they signed the data sharing agreement' do
       create(:provider, sync_courses: false)
-      provider_without_signed_dsa = create(:provider, sync_courses: true)
+      provider_without_signed_dsa = create(:provider, sync_courses: true, name: 'B', latitude: 51.498161, longitude: 0.129900)
+      create(:site, latitude: 51.482578, longitude: -0.007659, provider: provider_without_signed_dsa)
+      create(:site, latitude: 52.246868, longitude: 0.711190, provider: provider_without_signed_dsa)
+
       provider_with_signed_dsa = nil
       Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
-        provider_with_signed_dsa = create(:provider, :with_signed_agreement, sync_courses: true)
+        provider_with_signed_dsa = create(
+          :provider,
+          :with_signed_agreement,
+          sync_courses: true,
+          name: 'A',
+        )
       end
 
       providers = described_class.new.providers
@@ -15,14 +23,16 @@ RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
 
       expect(providers).to contain_exactly(
         {
-          name: provider_with_signed_dsa.name,
-          code: provider_with_signed_dsa.code,
-          agreement_accepted_at: Time.zone.local(2019, 10, 1, 12, 0, 0),
+          'name' => provider_with_signed_dsa.name,
+          'code' => provider_with_signed_dsa.code,
+          'agreement_accepted_at' => Time.zone.local(2019, 10, 1, 12, 0, 0),
+          'Average distance to site' => '',
         },
         {
-          name: provider_without_signed_dsa.name,
-          code: provider_without_signed_dsa.code,
-          agreement_accepted_at: nil,
+          'name' => provider_without_signed_dsa.name,
+          'code' => provider_without_signed_dsa.code,
+          'agreement_accepted_at' => nil,
+          'Average distance to site' => '31.7',
         },
       )
     end


### PR DESCRIPTION
## Context

As part of our work on locations, we need to be able to analyse how far away providers' are from their sites. 

This adds the ave distance to the ProvidersExport

## Changes proposed in this pull request

- Adds a column to the ProviderExport for the average distance to its sites.
- General reformatting of the export

## Link to Trello card

https://trello.com/c/pLw7nR2U/2596-%F0%9F%97%BA-dev-add-average-distance-to-sites-to-the-providers-data-export

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
