### PR TITLE
Add edit functionality for date of birth to to support UI

### DIFF
--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -40,8 +40,8 @@ module SupportInterface
       {
         key: 'Full name',
         value: "#{first_name} #{last_name}",
-        action: 'Change',
-        action_path: support_interface_application_form_edit_applicant_details_path(application_form),
+        action: 'name',
+        change_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }
     end
 
@@ -56,8 +56,8 @@ module SupportInterface
       {
         key: 'Phone number',
         value: phone_number || MISSING,
-        action: 'Change',
-        action_path: support_interface_application_form_edit_applicant_details_path(application_form),
+        action: 'phone number',
+        change_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }
     end
 
@@ -90,8 +90,8 @@ module SupportInterface
       {
         key: 'Date of birth',
         value: application_form.date_of_birth ? application_form.date_of_birth.to_s(:govuk_date) : MISSING,
-        action: 'Change',
-        action_path: support_interface_application_form_edit_applicant_details_path(application_form),
+        action: 'date of birth',
+        change_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }
     end
 

--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -90,6 +90,8 @@ module SupportInterface
       {
         key: 'Date of birth',
         value: application_form.date_of_birth ? application_form.date_of_birth.to_s(:govuk_date) : MISSING,
+        action: 'Change',
+        action_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }
     end
 

--- a/app/controllers/support_interface/application_forms/applicant_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/applicant_details_controller.rb
@@ -13,7 +13,6 @@ module SupportInterface
         )
 
         @details.assign_attributes(edit_application_params)
-
         if @details.valid?
           @details.save!
           flash[:success] = 'Applicant details updated'
@@ -28,7 +27,19 @@ module SupportInterface
       def edit_application_params
         params.require(
           :support_interface_application_forms_edit_applicant_details_form,
-        ).permit(:first_name, :last_name, :phone_number, :audit_comment)
+        ).permit(:first_name, :last_name, :"date_of_birth(3i)", :"date_of_birth(2i)",
+                 :"date_of_birth(1i)", :phone_number, :audit_comment)
+          .transform_keys { |key| dob_field_to_attribute(key) }
+          .transform_values(&:strip)
+      end
+
+      def dob_field_to_attribute(key)
+        case key
+        when 'date_of_birth(3i)' then 'day'
+        when 'date_of_birth(2i)' then 'month'
+        when 'date_of_birth(1i)' then 'year'
+        else key
+        end
       end
     end
   end

--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -2,6 +2,7 @@ module SupportInterface
   module ApplicationForms
     class EditApplicantDetailsForm
       include ActiveModel::Model
+      include ValidationUtils
 
       attr_accessor :first_name
       attr_accessor :last_name
@@ -10,10 +11,17 @@ module SupportInterface
       attr_accessor :audit_comment
       attr_reader :application_form
 
-      validates :first_name, presence: true
-      validates :last_name, presence: true
+      validates :first_name, :last_name, presence: true
+      validates :first_name, :last_name,
+                length: { maximum: 60 }
+
       validates :date_of_birth, presence: true
+      validate :date_of_birth_valid
+      validate :date_of_birth_not_in_future
+      validate :date_of_birth_is_within_lower_age_limit
+
       validates :phone_number, presence: true, phone_number: true
+      validates :audit_comment, presence: true
 
       def initialize(application_form)
         @application_form = application_form
@@ -39,7 +47,27 @@ module SupportInterface
 
       def date_of_birth
         date_args = [year, month, day].map(&:to_i)
-        Date.new(*date_args)
+
+        if valid_year?(year) && Date.valid_date?(*date_args)
+          Date.new(*date_args)
+        else
+          Struct.new(:day, :month, :year).new(day, month, year)
+        end
+      end
+
+      def date_of_birth_valid
+        errors.add(:date_of_birth, :invalid) unless date_of_birth.is_a?(Date)
+      end
+
+      def date_of_birth_not_in_future
+        errors.add(:date_of_birth, :future) if date_of_birth.is_a?(Date) && date_of_birth > Time.zone.today
+      end
+
+      def date_of_birth_is_within_lower_age_limit
+        return unless date_of_birth.is_a?(Date) && date_of_birth < Time.zone.today
+
+        age_limit = Time.zone.today - 16.years
+        errors.add(:date_of_birth, :below_lower_age_limit, date: age_limit.to_s(:govuk_date)) if date_of_birth > age_limit
       end
     end
   end

--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -5,13 +5,15 @@ module SupportInterface
 
       attr_accessor :first_name
       attr_accessor :last_name
+      attr_accessor :day, :month, :year
       attr_accessor :phone_number
       attr_accessor :audit_comment
       attr_reader :application_form
 
-      validates :phone_number, presence: true, phone_number: true
       validates :first_name, presence: true
       validates :last_name, presence: true
+      validates :date_of_birth, presence: true
+      validates :phone_number, presence: true, phone_number: true
 
       def initialize(application_form)
         @application_form = application_form
@@ -19,6 +21,9 @@ module SupportInterface
         super(
           first_name: @application_form.first_name,
           last_name: @application_form.last_name,
+          day: @application_form.date_of_birth&.day,
+          month: @application_form.date_of_birth&.month,
+          year: @application_form.date_of_birth&.year,
           phone_number: @application_form.phone_number
         )
       end
@@ -26,9 +31,15 @@ module SupportInterface
       def save!
         @application_form.first_name = first_name
         @application_form.last_name = last_name
+        @application_form.date_of_birth = date_of_birth
         @application_form.phone_number = phone_number
         @application_form.audit_comment = audit_comment
         @application_form.save!
+      end
+
+      def date_of_birth
+        date_args = [year, month, day].map(&:to_i)
+        Date.new(*date_args)
       end
     end
   end

--- a/app/views/support_interface/application_forms/applicant_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/applicant_details/edit.html.erb
@@ -7,8 +7,9 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: 'Edit applicant details', size: 'l' } do %>
-        <%= f.govuk_text_field :first_name, label: { text: 'First Name' } %>
-        <%= f.govuk_text_field :last_name, label: { text: 'Last Name' } %>
+        <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
+        <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
+        <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: 'Date of birth', size: 's' } %>
         <%= f.govuk_text_field :phone_number, label: { text: 'Phone number' } %>
         <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
       <% end %>

--- a/app/views/support_interface/application_forms/applicant_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/applicant_details/edit.html.erb
@@ -7,11 +7,11 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: { text: 'Edit applicant details', size: 'l' } do %>
-        <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
-        <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
-        <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: 'Date of birth', size: 's' } %>
-        <%= f.govuk_text_field :phone_number, label: { text: 'Phone number' } %>
-        <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
+        <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.first_name.hint_text') }, autocomplete: 'given-name' %>
+        <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.last_name.hint_text') }, autocomplete: 'family-name' %>
+        <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
+        <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_information.phone_number.label'), size: 'm' }, hint: { text: t('application_form.contact_information.phone_number.hint_text') }, autocomplete: 'tel' %>
+        <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
       <% end %>
 
       <%= f.govuk_submit 'Update details' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,6 +249,20 @@ en:
             phone_number:
               blank: Phone number can’t be blank
               invalid: Enter a phone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
+            email_address:
+              blank: Email address cannot be blank
+            first_name:
+              blank: First name cannot be blank
+              too_long: First name must be %{count} characters or fewer
+            last_name:
+              blank: Last name cannot be blank
+              too_long: Last name must be %{count} characters or fewer
+            date_of_birth:
+              invalid: Enter a date of birth in the correct format
+              future: Enter a date of birth that is in the past, for example 31 3 1980
+              below_lower_age_limit: Enter a date of birth before %{date} – candidate must be over 16 years old to Apply for teacher training
+            audit_comment:
+              blank: You must provide an audit comment
         provider_interface/pick_response_form:
           attributes:
             decision:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -686,8 +686,8 @@ Rails.application.routes.draw do
       get '/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
       post '/comments' => 'application_forms/comments#create', as: :application_form_comments
 
-      get '/applicant_details' => 'application_forms/applicant_details#edit', as: :application_form_edit_applicant_details
-      post '/applicant_details' => 'application_forms/applicant_details#update', as: :application_form_update_applicant_details
+      get '/applicant-details' => 'application_forms/applicant_details#edit', as: :application_form_edit_applicant_details
+      post '/applicant-details' => 'application_forms/applicant_details#update', as: :application_form_update_applicant_details
     end
 
     get '/ucas-matches' => 'ucas_matches#index'

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -8,14 +8,16 @@ RSpec.feature 'Editing application details' do
     and_an_application_exists
 
     when_i_visit_the_application_page
-    and_i_click_the_change_link_next_to_the_phone_number
+    and_i_click_the_change_link_next_to_full_name
     and_i_supply_a_new_first_name
     and_i_supply_a_new_last_name
+    and_i_supply_a_new_date_of_birth
     and_i_supply_a_new_phone_number
     and_i_add_a_note_for_the_audit_log
 
     then_i_should_see_a_flash_message
     and_i_should_see_the_new_name_in_full
+    and_i_should_see_the_new_date_of_birth
     and_i_should_see_the_new_phone_number
     and_i_should_see_my_comment_in_the_audit_log
   end
@@ -32,7 +34,7 @@ RSpec.feature 'Editing application details' do
     visit support_interface_application_form_path(@form)
   end
 
-  def and_i_click_the_change_link_next_to_the_phone_number
+  def and_i_click_the_change_link_next_to_full_name
     all('.govuk-summary-list__actions')[0].click_link 'Change'
   end
 
@@ -46,6 +48,12 @@ RSpec.feature 'Editing application details' do
 
   def and_i_supply_a_new_last_name
     fill_in 'support_interface_application_forms_edit_applicant_details_form[last_name]', with: 'Seagal'
+  end
+
+  def and_i_supply_a_new_date_of_birth
+    fill_in 'Day', with: '5'
+    fill_in 'Month', with: '5'
+    fill_in 'Year', with: '1950'
   end
 
   def and_i_add_a_note_for_the_audit_log
@@ -64,6 +72,10 @@ RSpec.feature 'Editing application details' do
 
   def and_i_should_see_the_new_name_in_full
     expect(page).to have_content 'Steven Seagal'
+  end
+
+  def and_i_should_see_the_new_date_of_birth
+    expect(page).to have_content('5 May 1950')
   end
 
   def and_i_should_see_my_comment_in_the_audit_log


### PR DESCRIPTION
## Context

Adding the ability to update the Date of birth through the support UI. This should allow the support team to change this without dev intervention.

## Changes proposed in this pull request

Updated the 

## Guidance to review

Test in the review app to check functionality.

I have started with minimal validation, would be interested to know thoughts on this? Should we carry over all validation from the Candidate Interface or is this unnecessary in the Support UI? 

## Link to Trello card

https://trello.com/c/wMmxTDoE/2684-expand-the-personal-details-review-section-in-the-support-ui-date-of-birth

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
