### PR TITLE
Further fixes for inaccurate geocoding results

### DIFF
--- a/app/services/geocode_filter.rb
+++ b/app/services/geocode_filter.rb
@@ -1,0 +1,15 @@
+class GeocodeFilter
+  SOUTHERLY_LIMIT = 49.51
+  NORTHERLY_LIMIT = 60.51
+  WESTERLY_LIMIT = -8.638
+  EASTERLY_LIMIT = 1.46
+
+  def outside_uk_or_unknown?(coordinates)
+    latitude, longitude = coordinates
+    (latitude.blank? || longitude.blank?) ||
+      latitude < SOUTHERLY_LIMIT ||
+      latitude > NORTHERLY_LIMIT ||
+      longitude < WESTERLY_LIMIT ||
+      longitude > EASTERLY_LIMIT
+  end
+end

--- a/app/services/geocode_filter.rb
+++ b/app/services/geocode_filter.rb
@@ -4,7 +4,7 @@ class GeocodeFilter
   WESTERLY_LIMIT = -8.638
   EASTERLY_LIMIT = 1.46
 
-  def outside_uk_or_unknown?(coordinates)
+  def self.outside_uk_or_unknown?(coordinates)
     latitude, longitude = coordinates
     (latitude.blank? || longitude.blank?) ||
       latitude < SOUTHERLY_LIMIT ||

--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -1,7 +1,7 @@
 class GeocodeApplicationAddressWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low_priority
+  sidekiq_options queue: :low_priority, retry: 5
 
   def perform(application_form_id)
     return unless Geocoder.config.api_key

--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -10,24 +10,8 @@ class GeocodeApplicationAddressWorker
     coordinates = application_form.geocode
     return if coordinates.nil?
 
-    application_form.latitude, application_form.longitude = outside_uk_or_unknown?(coordinates) ? [nil, nil] : coordinates
+    application_form.latitude, application_form.longitude = GeocodeFilter.outside_uk_or_unknown?(coordinates) ? [nil, nil] : coordinates
 
     application_form.save!
-  end
-
-private
-
-  SOUTHERLY_LIMIT = 49.51
-  NORTHERLY_LIMIT = 60.51
-  WESTERLY_LIMIT = -8.638
-  EASTERLY_LIMIT = 1.46
-
-  def outside_uk_or_unknown?(coordinates)
-    latitude, longitude = coordinates
-    (latitude.blank? || longitude.blank?) ||
-      latitude < SOUTHERLY_LIMIT ||
-      latitude > NORTHERLY_LIMIT ||
-      longitude < WESTERLY_LIMIT ||
-      longitude > EASTERLY_LIMIT
   end
 end

--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -8,6 +8,8 @@ class GeocodeApplicationAddressWorker
 
     application_form = ApplicationForm.find(application_form_id)
     coordinates = application_form.geocode
+    return if coordinates.nil?
+
     application_form.latitude, application_form.longitude = outside_uk_or_unknown?(coordinates) ? [nil, nil] : coordinates
 
     application_form.save!

--- a/lib/tasks/geocode.rake
+++ b/lib/tasks/geocode.rake
@@ -18,8 +18,11 @@ namespace :geocode do
           application_batch.each_slice(10) do |slice|
             threads = slice.map do |application|
               Thread.new do
-                application.latitude, application.longitude = application.geocode
-                application.save!
+                coordinates = application.geocode
+                if coordinates
+                  application.latitude, application.longitude = GeocodeFilter.outside_uk?(coordinates) ? [nil, nil] : coordinates
+                  application.save!
+                end
               end
             end
             threads.each(&:join)

--- a/spec/workers/geocode_application_address_worker_spec.rb
+++ b/spec/workers/geocode_application_address_worker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe GeocodeApplicationAddressWorker do
         expect(application.longitude).to eq(-0.124808)
       end
 
-      it 'does not use coordinates returned by the geocoder if they are outside UK bounding box' do
+      it 'sets location to nil if coordinates returned by the geocoder are outside UK' do
         application = create(:application_form)
         allow(application).to receive(:geocode).and_return([13.7244416, 100.35291])
         allow(ApplicationForm).to receive(:find).with(application.id).and_return(application)

--- a/spec/workers/geocode_application_address_worker_spec.rb
+++ b/spec/workers/geocode_application_address_worker_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe GeocodeApplicationAddressWorker do
         expect(application.latitude).to be_nil
         expect(application.longitude).to be_nil
       end
+
+      it 'does not use result if geocoder returns nil' do
+        application = create(:application_form, latitude: 51.23456, longitude: 1.23456)
+        allow(application).to receive(:geocode).and_return(nil)
+        allow(ApplicationForm).to receive(:find).with(application.id).and_return(application)
+
+        described_class.new.perform(application.id)
+
+        application.reload
+        expect(application.latitude).to eq 51.23456
+        expect(application.longitude).to eq 1.23456
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3603 to resolve issues with international addresses being geocoded.

## Changes proposed in this pull request

- Fix logic in `outside_uk?` method to handle `nil` geocode results.
- Extract `outside_uk?` to `GeocodeFilter` service class
- Use the filter in `geocode.rake`.

## Guidance to review

- Could anything else go wrong with the logic here?

## Link to Trello card

https://trello.com/c/txBLFAYG/2674-inaccurate-geocoding-results

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
