### PR TITLE
Correctly display optional grades

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -115,7 +115,7 @@ module CandidateInterface
     end
 
     def grade_set_key(qualification)
-      if qualification.qualification_type == 'non_uk'
+      if qualification.qualification_type == 'non_uk' || (qualification.qualification_type == 'Other' && qualification.qualification_type_name != 'BTEC')
         t('application_form.other_qualification.grade.optional_label')
       else
         t('application_form.other_qualification.grade.label')

--- a/app/components/qualification_grade_component.rb
+++ b/app/components/qualification_grade_component.rb
@@ -8,7 +8,7 @@ class QualificationGradeComponent < ViewComponent::Base
     if @qualification.predicted_grade?
       "#{@qualification.grade} (predicted)"
     else
-      @qualification.grade
+      @qualification.grade || 'Not entered'
     end
   end
 

--- a/app/components/qualification_grade_component.rb
+++ b/app/components/qualification_grade_component.rb
@@ -8,7 +8,7 @@ class QualificationGradeComponent < ViewComponent::Base
     if @qualification.predicted_grade?
       "#{@qualification.grade} (predicted)"
     else
-      @qualification.grade || 'Not entered'
+      @qualification.grade.presence || 'Not entered'
     end
   end
 

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -134,7 +134,7 @@ module CandidateInterface
         subject: subject,
         institution_country: institution_country,
         predicted_grade: predicted_grade,
-        grade: grade,
+        grade: grade.presence,
         other_uk_qualification_type: other_uk_qualification_type,
         non_uk_qualification_type: non_uk_qualification_type,
         award_year: award_year,

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -21,11 +21,31 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       subject: 'Making Cat Sounds',
     )
   end
+  let(:qualification3) do
+    build_stubbed(
+      :application_qualification,
+      level: 'other',
+      qualification_type: 'Other',
+      other_uk_qualification_type: 'BTEC',
+      subject: 'Dog walking',
+      grade: 'Merit',
+    )
+  end
+  let(:qualification4) do
+    build_stubbed(
+      :application_qualification,
+      level: 'other',
+      qualification_type: 'Other',
+      other_uk_qualification_type: 'not a BTEC',
+      subject: 'Cat walking',
+      grade: nil,
+    )
+  end
 
   context 'when other qualifications are editable' do
     before do
       allow(application_form).to receive(:application_qualifications).and_return(
-        ActiveRecordRelationStub.new(ApplicationQualification, [qualification1, qualification2], scopes: [:other]),
+        ActiveRecordRelationStub.new(ApplicationQualification, [qualification1, qualification2, qualification3, qualification4], scopes: [:other]),
       )
     end
 
@@ -64,6 +84,20 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.govuk-summary-list__actions').text).to include(
         "Change #{t('application_form.other_qualification.grade.change_action')} for A-Level, Making Doggo Sounds, 2012",
       )
+    end
+
+    it 'renders component with correct grade values for BTEC qualifications' do
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.grade.label'))
+      expect(result.css('.govuk-summary-list__value').text).to include('Merit')
+    end
+
+    it 'renders component with correct values for non-BTEC other qualifications' do
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.grade.optional_label'))
+      expect(result.css('.govuk-summary-list__value').text).to include('Not entered')
     end
 
     it 'renders component with correct values for multiple qualifications' do
@@ -169,7 +203,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       end
     end
 
-    context 'when they have an incomplete qualification and are submtting their application' do
+    context 'when they have an incomplete qualification and are submitting their application' do
       it 'returns true' do
         create(:other_qualification, application_form: application_form, award_year: nil)
         expect(described_class.new(application_form: application_form, submitting_application: true).show_missing_banner?).to eq true


### PR DESCRIPTION
## Context

If a grade is shown as optional on the form, it should be shown as ‘Grade (optional)’ on the summary card, too. We should also show ‘Not entered’ if field was left blank.

## Changes proposed in this pull request

- If a grade is not entered, make sure it is saved as `nil` rather than an empty string
- Make sure the "optional" label is shown when required
- Show "not entered" for optional grades if they are not present

## Guidance to review

I have updated the candidate review page and the support UI. Is there anywhere else that might be affected? 

By saving the grade as `nil` rather than an empty string, it meant we could avoid checking for `""` and made the code much neater. But will this change of how we store the data have repercussions  elsewhere?

## Link to Trello card

https://trello.com/c/edEWlzAL/2599-%F0%9F%93%90-dev-structured-qualifications-clean-up-work

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
