### PR TITLE
Bug fix - editing  'other' qualifications

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -3,6 +3,10 @@ module CandidateInterface
     def show
       redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank?
 
+      # This to ensure that old state is not merged accidentally when
+      # the user goes on to edit a qualification
+      intermediate_data_service.clear_state!
+
       @application_form = current_application
     end
 
@@ -33,6 +37,14 @@ module CandidateInterface
 
     def section_marked_as_complete?
       application_form_params[:other_qualifications_completed] == 'true'
+    end
+
+    def intermediate_data_service
+      IntermediateDataService.new(
+        WizardStateStores::RedisStore.new(
+          key: persistence_key_for_current_user,
+        ),
+      )
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -13,6 +13,13 @@ module CandidateInterface
     attr_reader :next_step
     attr_accessor :editing, :id, :current_step
 
+    attr_accessor :subject
+    attr_accessor :institution_country
+    attr_accessor :choice
+    attr_accessor :award_year
+    attr_accessor :predicted_grade
+    attr_accessor :grade
+
     attr_accessor :qualification_type
     attr_accessor :other_uk_qualification_type
     attr_accessor :non_uk_qualification_type
@@ -26,6 +33,12 @@ module CandidateInterface
       @current_application = current_application
       @intermediate_data_service = intermediate_data_service
       options = @intermediate_data_service.read.merge(options.select { |_, value| value.present? }) if @intermediate_data_service
+
+      if options && [A_LEVEL_TYPE, AS_LEVEL_TYPE, GCSE_TYPE].include?(options['qualification_type'])
+        options['non_uk_qualification_type'] = nil
+        options['institution_country'] = nil
+      end
+
       super(options)
     end
 
@@ -39,7 +52,7 @@ module CandidateInterface
       application_qualification.update!(attributes_for_persistence)
     end
 
-    PERSISTENT_ATTRIBUTES = %w[id current_step editing qualification_type other_uk_qualification_type non_uk_qualification_type].freeze
+    PERSISTENT_ATTRIBUTES = %w[id current_step editing qualification_type other_uk_qualification_type non_uk_qualification_type institution_country].freeze
 
   private
 

--- a/app/views/candidate_interface/other_qualifications/details/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.qualification_details'), @form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
@@ -8,4 +8,34 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:qualification_type) }
   end
+
+  describe '#initialize' do
+    let(:current_application) { create(:application_form) }
+    let(:intermediate_data_service) do
+      Class.new {
+        def read
+          {
+            'qualification_type' => 'non_uk',
+            'institution_country' => 'New Zealand',
+            'non_uk_qualification_type' => 'German diploma',
+          }
+        end
+      }.new
+    end
+
+    context 'the qualification type is being updated from a non-uk qualification to a uk qualification' do
+      it 'assigns an empty string to the non_uk attributes' do
+        form = CandidateInterface::OtherQualificationTypeForm.new(
+          current_application,
+          intermediate_data_service,
+          'qualification_type' => 'GCSE',
+          'non_uk_qualification_type' => 'German diploma',
+        )
+
+        expect(form.qualification_type).to eq('GCSE')
+        expect(form.non_uk_qualification_type).to be_nil
+        expect(form.institution_country).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

When a user has more than one 'other' qualification and goes on to edit one of them, it's possible for old state stored in Redis to be merged into that qualification. This happens when clicking the 'back' link.

_"I have added 2 qualifications, an UK one (Scottish Advanced Higher Maths), and a non-UK one (German High school diploma Maths). When I edit the non-UK qualification, I am shown the edit page for the Scottish Advanced Higher Maths qualification, not the non-uk German qualification."_

## Changes proposed in this pull request

1. Make sure that the Redis state is wiped clean before editing individual qualifications. If not then when we come to editing a
    qualification, it may have merged state from another qualification. A modified back link is now used on the qualification details form that ensures a hard refresh occurs, which then triggers clearing of the state by the controller.

2. This PR also fixes a bug that occurs when changing an 'other' qualification type from 'non_uk' to 'uk'. We now ensure that  non-relevant fields are cleared (set to `nil`) when changing a qualification type 'non-uk' to 'uk'.

## Guidance to review

- Add two or more 'other' qualifications to an application. Then go an edit the types, subjects, grades etc for each. Should now behave as expected.
- Hopefully this all makes sense? Do you think a feature spec or more documentation / comments are required in this instance? 


## Link to Trello card

https://trello.com/c/BqTT5ptc/2675-bug-edit-other-qualifications


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
