### PR TITLE
Prevent excessive sidekiq retries when geocoding produces nil coordinates

### DIFF
--- a/app/workers/geocode_application_address_worker.rb
+++ b/app/workers/geocode_application_address_worker.rb
@@ -8,7 +8,7 @@ class GeocodeApplicationAddressWorker
 
     application_form = ApplicationForm.find(application_form_id)
     coordinates = application_form.geocode
-    application_form.latitude, application_form.longitude = outside_uk?(coordinates) ? [nil, nil] : coordinates
+    application_form.latitude, application_form.longitude = outside_uk_or_unknown?(coordinates) ? [nil, nil] : coordinates
 
     application_form.save!
   end
@@ -20,9 +20,10 @@ private
   WESTERLY_LIMIT = -8.638
   EASTERLY_LIMIT = 1.46
 
-  def outside_uk?(coordinates)
+  def outside_uk_or_unknown?(coordinates)
     latitude, longitude = coordinates
-    latitude < SOUTHERLY_LIMIT ||
+    (latitude.blank? || longitude.blank?) ||
+      latitude < SOUTHERLY_LIMIT ||
       latitude > NORTHERLY_LIMIT ||
       longitude < WESTERLY_LIMIT ||
       longitude > EASTERLY_LIMIT


### PR DESCRIPTION
## Context

When geocoding fails, the `outside_uk?` check throws `NoMethodError: undefined method < for nil:NilClass`, which causes sidekiq to retry over and over again and builds up a retry queue. This in turn triggers the availability alert for production.

## Changes proposed in this pull request

Handle this.

## Guidance to review

Inspect the code changes. Aim is to prevent out-of-hours alerts and confusion.

## Link to Trello card

No Trello card, general maintenance.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
