### PR TITLE
Add manually resolved action_taken to UCASMatch

### DIFF
--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -30,6 +30,9 @@ module SupportInterface
       resolved_on_apply: {
         past_tense_description: 'confirmed that the candidate was withdrawn from Apply',
       },
+      manually_resolved: {
+        past_tense_description: 'resolved the match manually',
+      },
     }.freeze
 
     def initialize(match)

--- a/app/models/ucas_match.rb
+++ b/app/models/ucas_match.rb
@@ -15,6 +15,7 @@ class UCASMatch < ApplicationRecord
     ucas_withdrawal_requested: 'ucas_withdrawal_requested',
     resolved_on_apply: 'resolved_on_apply',
     resolved_on_ucas: 'resolved_on_ucas',
+    manually_resolved: 'manually_resolved',
   }
 
   def ready_to_resolve?
@@ -22,7 +23,7 @@ class UCASMatch < ApplicationRecord
   end
 
   def resolved?
-    %w[resolved_on_apply resolved_on_ucas].include?(action_taken)
+    %w[resolved_on_apply resolved_on_ucas manually_resolved].include?(action_taken)
   end
 
   def trackable_applicant_key

--- a/spec/components/support_interface/ucas_match_action_component_spec.rb
+++ b/spec/components/support_interface/ucas_match_action_component_spec.rb
@@ -139,5 +139,21 @@ RSpec.describe SupportInterface::UCASMatchActionComponent do
         expect(result.text).to include('We confirmed that the candidate was withdrawn from Apply on the 18 October 2020')
       end
     end
+
+    it 'renders correct information after the manual resolution of a match' do
+      Timecop.freeze(Time.zone.local(2020, 10, 19, 12, 0, 0)) do
+        ucas_match = create(:ucas_match,
+                            matching_state: 'processed',
+                            scheme: 'U',
+                            action_taken: 'manually_resolved',
+                            candidate_last_contacted_at: Time.zone.now - 1.day)
+        allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+
+        result = render_inline(described_class.new(ucas_match))
+
+        expect(result.text).to include('No action required')
+        expect(result.text).to include('We resolved the match manually')
+      end
+    end
   end
 end

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe UCASMatch do
   end
 
   describe '#action_needed?' do
+    it 'returns false if ucas match has been manually resolved' do
+      ucas_match = create(:ucas_match, action_taken: 'manually_resolved')
+
+      expect(ucas_match.action_needed?).to eq(false)
+    end
+
     it 'returns false if ucas match is processed' do
       ucas_match = create(:ucas_match, matching_state: 'processed')
 


### PR DESCRIPTION
## Context

Introduced new action_taken so that previous recruitment cycle data can be migrated to it before `matching_state` is removed.

https://github.com/DFE-Digital/apply-for-teacher-training/pull/3583


After this PR is deployed to production we need to run the following code.

```ruby
UCASMatch.where(matching_state: 'processed', recruitment_cycle_year: 2020).each do |match|
   next unless match.dual_application_or_dual_acceptance?

   match.update(candidate_last_contacted_at: match.updated_at)
   match.manually_resolved!
end
```