### PR TITLE
Candidate feedback sus survey fix

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,7 +1,6 @@
 class CandidateMailer < ApplicationMailer
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
-    @candidate_survey_magic_link_with_token = candidate_survey_magic_link_with_token(application_form.candidate)
 
     email_for_candidate(
       application_form,
@@ -406,10 +405,5 @@ private
     candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token)
   end
 
-  def candidate_survey_magic_link_with_token(candidate)
-    raw_token = candidate.refresh_magic_link_token!
-    candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token, path: 'candidate_interface_feedback_form_path')
-  end
-
-  helper_method :candidate_magic_link, :candidate_survey_magic_link_with_token
+  helper_method :candidate_magic_link
 end

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -22,10 +22,12 @@
     <p class="govuk-body">You can track or withdraw your application from your application dashboard.</p>
     <p class="govuk-body"><%= govuk_link_to 'To view your application, return to your application dashboard', candidate_interface_application_complete_path %>.</p>
 
+    <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
+    <p class="govuk-body">Your feedback will help us improve.</p>
     <% if FeatureFlag.active?('feedback_form') %>
-      <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
-      <p class="govuk-body">Your feedback will help us improve.</p>
       <%= govuk_button_link_to 'Give feedback', candidate_interface_feedback_form_path %>
+      <%else %>
+      <%= govuk_button_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/submit_success.html.erb
@@ -22,10 +22,10 @@
     <p class="govuk-body">You can track or withdraw your application from your application dashboard.</p>
     <p class="govuk-body"><%= govuk_link_to 'To view your application, return to your application dashboard', candidate_interface_application_complete_path %>.</p>
 
-    <% unless FeatureFlag.active?('feedback_form') %>
+    <% if FeatureFlag.active?('feedback_form') %>
       <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
       <p class="govuk-body">Your feedback will help us improve.</p>
-      <%= govuk_button_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path %>
+      <%= govuk_button_link_to 'Give feedback', candidate_interface_feedback_form_path %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -18,16 +18,6 @@ Sign in to your account anytime to check the progress of your application:
 
 If your training provider decides to progress your application, they’ll contact you to organise an interview.
 
-<% if FeatureFlag.active?(:feedback_form) %>
-
-# Tell us what you think
-
-Your feedback will help us improve the Apply for teacher training service:
-
-<%= @candidate_survey_magic_link_with_token %>
-
-<% end %>
-
 # Get support
 
 Email [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe CandidateMailer, type: :mailer do
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
       'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id',
-      'magic link to to authenticate with path params' => 'http://localhost:3000/candidate/confirm_authentication?path=candidate_interface_feedback_form_path&token=raw_token&u=encrypted_id',
     )
   end
 

--- a/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe 'Candidate feedback form' do
   end
 
   scenario 'Candidate completes the feedback form' do
-    given_the_candidate_completes_and_submits_their_application
-    then_i_should_receive_the_application_submitted_email
-    and_i_should_not_be_asked_to_give_feedback_on_the_submit_success_page
+    given_i_complete_and_submit_my_application
+    then_i_should_be_asked_to_give_feedback
+    and_i_should_receive_the_application_submitted_email
 
     when_i_click_give_feedback
-    and_i_confirm_my_sign_in
-    then_they_should_see_the_feedback_form
+    then_i_should_see_the_feedback_form
 
     when_i_click_send_feedback
     then_i_should_see_a_validation_error
@@ -26,29 +25,25 @@ RSpec.describe 'Candidate feedback form' do
     and_my_feedback_should_reflect_my_inputs
   end
 
-  def given_the_candidate_completes_and_submits_their_application
+  def given_i_complete_and_submit_my_application
     candidate_completes_application_form
     candidate_submits_application
   end
 
-  def then_i_should_receive_the_application_submitted_email
+  def then_i_should_be_asked_to_give_feedback
+    expect(page).to have_content('Your feedback will help us improve.')
+  end
+
+  def and_i_should_receive_the_application_submitted_email
     open_email(current_candidate.email_address)
     expect(current_email.subject).to have_content t('candidate_mailer.application_submitted.subject')
   end
 
-  def and_i_should_not_be_asked_to_give_feedback_on_the_submit_success_page
-    expect(page).not_to have_content('Your feedback will help us improve.')
-  end
-
   def when_i_click_give_feedback
-    current_email.find_css('a')[1].click
+    click_link 'Give feedback'
   end
 
-  def and_i_confirm_my_sign_in
-    click_button 'Continue'
-  end
-
-  def then_they_should_see_the_feedback_form
+  def then_i_should_see_the_feedback_form
     expect(page).to have_content(t('page_titles.your_feedback'))
   end
 


### PR DESCRIPTION
## Context

We want to move the satisfaction survey back out of emails and in to the service. 

The previous work to move it from the service and in to emails was done as part of https://github.com/DFE-Digital/apply-for-teacher-training/pull/3321.

## Changes proposed in this pull request

- Add the link to the feedback form back in to the service
- Remove the link from the email
- Update tests and tidy up

## Guidance to review

There seem to be two forms `candidate_interface_feedback_form_path` and `candidate_interface_satisfaction_survey_recommendation_path`. From the current code it looks like the first one is the one we want, but I thought it worth checking here.

Should this be behind the `feedback_form` flag? Is that flag still useful?

The previous PR set up the ability to `redirect_to_path_if_path_params_are_present_and_valid`. That functionality seems more general and potentially useful and so I have left it in. Do you agree?

## Link to Trello card

https://trello.com/c/jrsGBC9X/2681-candidate-feedback-sus-survey-fix

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
