### PR TITLE
Fix reference to renamed method following rebase

### DIFF
--- a/lib/tasks/geocode.rake
+++ b/lib/tasks/geocode.rake
@@ -20,7 +20,7 @@ namespace :geocode do
               Thread.new do
                 coordinates = application.geocode
                 if coordinates
-                  application.latitude, application.longitude = GeocodeFilter.outside_uk?(coordinates) ? [nil, nil] : coordinates
+                  application.latitude, application.longitude = GeocodeFilter.outside_uk_or_unknown?(coordinates) ? [nil, nil] : coordinates
                   application.save!
                 end
               end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3610 to fix rebase over renamed method.

## Changes proposed in this pull request

Fix to rake task following rebase over renamed method.

## Guidance to review

- Does the rake task run?

## Link to Trello card

https://trello.com/c/txBLFAYG/2674-inaccurate-geocoding-results

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
