### PR TITLE
Include paragraph detailing RBD date when a user cannot make decisions

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -3,60 +3,59 @@
   <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) %>
 </h1>
 
-<% if application_choice.status == 'awaiting_provider_decision' && flash.empty? && provider_can_respond -%>
+<% if show_inset_text? -%>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <div class="govuk-inset-text govuk-!-margin-top-0">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
-          Respond to application
-        </h2>
-        <p class="govuk-body">
-          <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) %>
-            You have until <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %> to respond to this application, or it will be automatically rejected.
+        <% if respond_to_application? -%>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
+            Respond to application
+          </h2>
+          <p class="govuk-body">
+            <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
+              You have until <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %> to respond to this application. Otherwise it will be automatically rejected.
+            <% else -%>
+              <%= "You have #{days_until(application_choice.reject_by_default_at.to_date)} to respond to this application." %>
+              On <%= application_choice.reject_by_default_at.to_s(:govuk_date) %> this application will be automatically rejected.
+            <% end -%>
+          </p>
+          <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice) %>
+        <% elsif provider_cannot_respond? -%>
+          <p class="govuk-body">
+            <% if time_is_today_or_tomorrow?(application_choice.reject_by_default_at) -%>
+              This application will be automatically rejected at <%= time_today_or_tomorrow(application_choice.reject_by_default_at) %>.
+            <% else -%>
+              <%= "There are #{days_until(application_choice.reject_by_default_at.to_date)} to respond." %>
+              This application will be automatically rejected on <%= application_choice.reject_by_default_at.to_s(:govuk_date) %>.
+            <% end -%>
+          </p>
+        <% elsif deferred_offer_wizard_applicable? -%>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
+            Review and confirm the deferred offer
+          </h2>
+
+          <% if deferred_offer_equivalent_course_option_available %>
+            <p class="govuk-body">
+              The course offered to the candidate in the previous cycle is available in the current cycle.
+            </p>
           <% else %>
-            <%= "You have #{days_until(application_choice.reject_by_default_at.to_date)} to respond to this application." %>
-            On <%= application_choice.reject_by_default_at.to_s(:govuk_date) %> this application will be automatically rejected.
+            <p class="govuk-body">
+              The course offered to the candidate in the previous cycle is not available in the current cycle.
+            </p>
           <% end %>
-        </p>
-        <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice) %>
-      </div>
-    </div>
-  </div>
-<% elsif deferred_offer_wizard_applicable && flash.empty? && provider_can_respond -%>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <div class="govuk-inset-text govuk-!-margin-top-0">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
-          Review and confirm the deferred offer
-        </h2>
 
-        <% if deferred_offer_equivalent_course_option_available %>
+          <%= govuk_button_link_to 'Review deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice) %>
+        <% elsif rejection_reason_required? -%>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
+            Give feedback
+          </h2>
+
           <p class="govuk-body">
-            The course offered to the candidate in the previous cycle is available in the current cycle.
+            You did not respond to the application within <%= application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
           </p>
-        <% else %>
-          <p class="govuk-body">
-            The course offered to the candidate in the previous cycle is not available in the current cycle.
-          </p>
-        <% end %>
 
-        <%= govuk_button_link_to 'Review deferred offer', provider_interface_reconfirm_deferred_offer_path(application_choice) %>
-      </div>
-    </div>
-  </div>
-<% elsif rejection_reason_required && flash.empty? && provider_can_respond -%>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
-      <div class="govuk-inset-text govuk-!-margin-top-0">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-3">
-          Give feedback
-        </h2>
-
-        <p class="govuk-body">
-          You did not respond to the application within <%= @application_choice.reject_by_default_days %> working days. Tell the candidate why their application was unsuccessful.
-        </p>
-
-        <%= govuk_button_link_to 'Give feedback', provider_interface_application_choice_new_feedback_path(@application_choice) %>
+          <%= govuk_button_link_to 'Give feedback', provider_interface_application_choice_new_feedback_path(application_choice) %>
+        <% end -%>
       </div>
     </div>
   </div>

--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -56,5 +56,28 @@ module ProviderInterface
     def offer_present?
       ApplicationStateChange::OFFERED_STATES.include?(application_choice.status.to_sym)
     end
+
+    def respond_to_application?
+      provider_can_respond && application_choice.awaiting_provider_decision?
+    end
+
+    def deferred_offer_wizard_applicable?
+      provider_can_respond && deferred_offer_wizard_applicable
+    end
+
+    def rejection_reason_required?
+      provider_can_respond && rejection_reason_required
+    end
+
+    def provider_cannot_respond?
+      !provider_can_respond && application_choice.awaiting_provider_decision?
+    end
+
+    def show_inset_text?
+      flash.empty? && (
+        respond_to_application? || deferred_offer_wizard_applicable? ||
+        rejection_reason_required? || provider_cannot_respond?
+      )
+    end
   end
 end


### PR DESCRIPTION
## Context

We would like to draw user's attention to the reject by default date even if they do not have the ability to make decisions on an application.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds content to the inset text box above the application details which explains when the application will be rejected by default.
- Refactors some of the conditional logic in the `ApplicationChoiceHeaderComponent` markup.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/101648763-103ad900-3a32-11eb-87f5-c294131b4720.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/w7zwEUju/3110-rbd-missing-from-applications-in-manage#comment-5fd0ae1460109a548d50204c
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
