### PR TITLE
Fix missing link errors for radio buttons

### DIFF
--- a/app/components/provider_interface/change_offer/change_course_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_course_component.html.erb
@@ -13,8 +13,8 @@
         legend: { text: page_title, size: "xl" },
         caption: { text: application_choice.application_form.full_name, size: "xl" } do %>
 
-        <% courses.each do |course| %>
-          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint: { text: course.description } %>
+        <% courses.each_with_index do |course, i| %>
+          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint: { text: course.description }, link_errors: i.zero?  %>
         <% end %>
       <% end %>
 

--- a/app/components/provider_interface/change_offer/change_location_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_location_component.html.erb
@@ -13,8 +13,8 @@
         legend: { text: page_title, size: "xl" },
         caption: { text: application_choice.application_form.full_name, size: "xl" } do %>
 
-        <% course_options.each do |course_option| %>
-          <%= f.govuk_radio_button :course_option_id, course_option.id, label: { text: course_option.site.name }, hint: { text: course_option.site.full_address } %>
+        <% course_options.each_with_index do |course_option, i| %>
+          <%= f.govuk_radio_button :course_option_id, course_option.id, label: { text: course_option.site.name }, hint: { text: course_option.site.full_address }, link_errors: i.zero? %>
         <% end %>
       <% end %>
 

--- a/app/components/provider_interface/change_offer/change_provider_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_provider_component.html.erb
@@ -14,8 +14,8 @@
         legend: { text: page_title, size: "xl" },
         caption: { text: application_choice.application_form.full_name, size: "xl" } do %>
 
-        <% providers.each do |provider| %>
-          <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code } %>
+        <% providers.each_with_index do |provider, i| %>
+          <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code }, link_errors: i.zero? %>
         <% end %>
       <% end %>
 

--- a/app/components/provider_interface/change_offer/change_study_mode_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_study_mode_component.html.erb
@@ -13,8 +13,8 @@
         legend: { text: page_title, size: "xl" },
         caption: { text: application_choice.application_form.full_name, size: "xl" } do %>
 
-        <% study_modes.each do |study_mode| %>
-          <%= f.govuk_radio_button :study_mode, study_mode, label: { text: study_mode.to_s.humanize }, hint: { text: course.name_and_code } %>
+        <% study_modes.each_with_index do |study_mode, i| %>
+          <%= f.govuk_radio_button :study_mode, study_mode, label: { text: study_mode.to_s.humanize }, hint: { text: course.name_and_code }, link_errors: i.zero? %>
         <% end %>
       <% end %>
 

--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -11,8 +11,8 @@
       <% text_field_options.merge(width: 20) %>
       <%= f.govuk_text_field(:other_grade, text_field_options) %>
     <% end %>
-    <% @international_main_grades.each do |grade| %>
-      <%= f.govuk_radio_button :grade, grade, label: { text: grade } %>
+    <% @international_main_grades.each_with_index do |grade, i | %>
+      <%= f.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: i.zero?  %>
     <% end %>
   <% end %>
 
@@ -25,8 +25,8 @@
   <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :grade, legend: { tag: 'span' } do %>
-    <% @main_grades.each do |grade| %>
-      <%= f.govuk_radio_button :grade, grade, label: { text: grade } %>
+    <% @main_grades.each_with_index do |grade, i| %>
+      <%= f.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: i.zero? %>
     <% end %>
     <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
       <%= f.govuk_text_field :other_grade, label: { text: t('application_form.degree.grade.other.conditional.label') }, width: 10 %>

--- a/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
@@ -12,11 +12,12 @@
       legend: { text: t('application_form.degree.comparable_uk_degree.label'), size: 's' },
       hint: { text: t('application_form.degree.comparable_uk_degree.hint_text') }
     ) do %>
-      <%  ApplicationQualification.comparable_uk_degrees.values.each do |value| %>
+      <%  ApplicationQualification.comparable_uk_degrees.values.each_with_index do |value, i| %>
         <%= f.govuk_radio_button(
           :comparable_uk_degree,
           value,
           label: { text: t("application_form.degree.comparable_uk_degree.values.#{value}") },
+          link_errors: i.zero?
         ) %>
       <% end %>
     <% end %>

--- a/app/views/candidate_interface/feedback_form/new.html.erb
+++ b/app/views/candidate_interface/feedback_form/new.html.erb
@@ -9,8 +9,8 @@
         <%= t('page_titles.your_feedback') %>
       </h1>
       <%= f.govuk_radio_buttons_fieldset :satisfaction_level, legend: { text: 'How satisfied are you with this service?' } do %>
-        <% ApplicationForm.feedback_satisfaction_levels.values.each do |value| %>
-          <%= f.govuk_radio_button :satisfaction_level, value, label: { text: t("satisfaction_levels.#{value}") }  %>
+        <% ApplicationForm.feedback_satisfaction_levels.values.each_with_index do |value, i| %>
+          <%= f.govuk_radio_button :satisfaction_level, value, label: { text: t("satisfaction_levels.#{value}") }, link_errors: i.zero?  %>
         <% end %>
       <% end %>
       <%= f.govuk_text_area :suggestions, label: { text: 'How could we improve this service?', size: 'm' }, rows: 8, max_words: 400 %>

--- a/app/views/support_interface/settings/cycles.html.erb
+++ b/app/views/support_interface/settings/cycles.html.erb
@@ -9,8 +9,8 @@
 
       <%= f.govuk_radio_divider %>
 
-      <% (EndOfCycleTimetable.schedules.keys.map(&:to_s) - %w[real]).each do |option| %>
-        <%= f.govuk_radio_button :cycle_schedule_name, option, label: { text: t("cycles.#{option}.name") }, hint: { text: t("cycles.#{option}.description") } %>
+      <% (EndOfCycleTimetable.schedules.keys.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
+        <%= f.govuk_radio_button :cycle_schedule_name, option, label: { text: t("cycles.#{option}.name") }, hint: { text: t("cycles.#{option}.description") }, link_errors: i.zero? %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
## Context

A few of the forms that we use that contain radio buttons have broken link errors (ie. the link in the error summary doesn't take you to the erroneous field).

I fixed a similar issue on a previous ticket. This PR is a quick sweep to apply the same fix across other instances in the codebase.

## Guidance to review

This shouldn't change any functionality or views, but I might have misunderstood or missed something.

## Link to Trello card

https://trello.com/c/DQ3anZAU/2691-fix-broken-link-errors

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
