### PR TITLE
Add edit functionality to email address attribute on Support UI

### DIFF
--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -49,6 +49,8 @@ module SupportInterface
       {
         key: 'Email address',
         value: mail_to(email_address, email_address, class: 'govuk-link'),
+        action: 'email address',
+        change_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }
     end
 

--- a/app/controllers/support_interface/application_forms/applicant_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/applicant_details_controller.rb
@@ -27,7 +27,7 @@ module SupportInterface
       def edit_application_params
         params.require(
           :support_interface_application_forms_edit_applicant_details_form,
-        ).permit(:first_name, :last_name, :"date_of_birth(3i)", :"date_of_birth(2i)",
+        ).permit(:first_name, :last_name, :email_address, :"date_of_birth(3i)", :"date_of_birth(2i)",
                  :"date_of_birth(1i)", :phone_number, :audit_comment)
           .transform_keys { |key| dob_field_to_attribute(key) }
           .transform_values(&:strip)

--- a/app/views/support_interface/application_forms/applicant_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/applicant_details/edit.html.erb
@@ -9,6 +9,7 @@
       <%= f.govuk_fieldset legend: { text: 'Edit applicant details', size: 'l' } do %>
         <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.first_name.hint_text') }, autocomplete: 'given-name' %>
         <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.last_name.hint_text') }, autocomplete: 'family-name' %>
+        <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, autocomplete: 'email', spellcheck: false %>
         <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
         <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_information.phone_number.label'), size: 'm' }, hint: { text: t('application_form.contact_information.phone_number.hint_text') }, autocomplete: 'tel' %>
         <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,6 +257,11 @@ en:
             last_name:
               blank: Last name cannot be blank
               too_long: Last name must be %{count} characters or fewer
+            email_address:
+              blank: Enter an email address
+              invalid: Enter an email address in the correct format, like name@example.com
+              taken: Email address is already in use
+              too_long: Email address must be %{count} characters or fewer
             date_of_birth:
               invalid: Enter a date of birth in the correct format
               future: Enter a date of birth that is in the past, for example 31 3 1980

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -9,16 +9,23 @@ RSpec.feature 'Editing application details' do
 
     when_i_visit_the_application_page
     and_i_click_the_change_link_next_to_full_name
-    and_i_supply_a_new_first_name
+    and_i_fill_in_all_fields_with_blank_values
+    and_i_submit_the_update_form
+    then_i_should_see_relevant_blank_error_messages
+
+    when_i_supply_a_new_first_name
     and_i_supply_a_new_last_name
     and_i_supply_a_new_date_of_birth
     and_i_supply_a_new_phone_number
+    and_i_supply_a_new_email_address
     and_i_add_a_note_for_the_audit_log
+    and_i_submit_the_update_form
 
     then_i_should_see_a_flash_message
     and_i_should_see_the_new_name_in_full
     and_i_should_see_the_new_date_of_birth
     and_i_should_see_the_new_phone_number
+    and_i_should_see_the_new_email_address
     and_i_should_see_my_comment_in_the_audit_log
   end
 
@@ -38,16 +45,40 @@ RSpec.feature 'Editing application details' do
     all('.govuk-summary-list__actions')[0].click_link 'Change'
   end
 
+  def and_i_fill_in_all_fields_with_blank_values
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[first_name]', with: ''
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[last_name]', with: ''
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[email_address]', with: ''
+    fill_in 'Day', with: ''
+    fill_in 'Month', with: ''
+    fill_in 'Year', with: ''
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[phone_number]', with: ''
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[audit_comment]', with: ''
+  end
+
+  def then_i_should_see_relevant_blank_error_messages
+    expect(page).to have_content 'First name cannot be blank'
+    expect(page).to have_content 'Last name cannot be blank'
+    expect(page).to have_content 'Enter an email address'
+    expect(page).to have_content 'Enter a date of birth in the correct format'
+    expect(page).to have_content 'Phone number can’t be blank'
+    expect(page).to have_content 'You must provide an audit comment'
+  end
+
   def and_i_supply_a_new_phone_number
     fill_in 'support_interface_application_forms_edit_applicant_details_form[phone_number]', with: '0891 50 50 50'
   end
 
-  def and_i_supply_a_new_first_name
+  def when_i_supply_a_new_first_name
     fill_in 'support_interface_application_forms_edit_applicant_details_form[first_name]', with: 'Steven'
   end
 
   def and_i_supply_a_new_last_name
     fill_in 'support_interface_application_forms_edit_applicant_details_form[last_name]', with: 'Seagal'
+  end
+
+  def and_i_supply_a_new_email_address
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[email_address]', with: 'steven.seagal@example.com'
   end
 
   def and_i_supply_a_new_date_of_birth
@@ -58,7 +89,9 @@ RSpec.feature 'Editing application details' do
 
   def and_i_add_a_note_for_the_audit_log
     fill_in 'support_interface_application_forms_edit_applicant_details_form[audit_comment]', with: 'https://becomingateacher.zendesk.com/12345'
+  end
 
+  def and_i_submit_the_update_form
     click_button 'Update'
   end
 
@@ -75,7 +108,11 @@ RSpec.feature 'Editing application details' do
   end
 
   def and_i_should_see_the_new_date_of_birth
-    expect(page).to have_content('5 May 1950')
+    expect(page).to have_content '5 May 1950'
+  end
+
+  def and_i_should_see_the_new_email_address
+    expect(page).to have_content 'steven.seagal@example.com'
   end
 
   def and_i_should_see_my_comment_in_the_audit_log


### PR DESCRIPTION
## Context

As part of a bigger feature, the support team require the ability to edit candidate applications
 without dev intervention. 

## Changes proposed in this pull request

Changes made in this PR add email address field to existing Edit Applicant Details form along with validation. Change link has been added to Support UI review page spec rewritten to encompass some form validation.

## Guidance to review

Check functionality and validations in review App

## Link to Trello card

https://trello.com/c/FAc067DI/2686-expand-the-personal-details-review-section-in-the-support-ui-email-address

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
