### PR TITLE
Strip whitespace from candidate input

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,8 @@ gem 'archive-zip'
 # Geocoding
 gem 'geocoder'
 
+gem 'strip_attributes'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,6 +462,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strip_attributes (1.11.0)
+      activemodel (>= 3.0, < 7.0)
     super_diff (0.5.2)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -587,6 +589,7 @@ DEPENDENCIES
   simplecov
   simplecov-cobertura
   skylight
+  strip_attributes
   super_diff
   timecop
   tzinfo-data

--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -26,7 +26,7 @@ module CandidateInterface
   private
 
     def feedback_params
-      params.require(:candidate_interface_application_feedback_form).permit(
+      strip_whitespace params.require(:candidate_interface_application_feedback_form).permit(
         :path, :page_title, :does_not_understand_section,
         :need_more_information, :answer_does_not_fit_format,
         :other_feedback, :consent_to_be_contacted,

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -55,12 +55,11 @@ module CandidateInterface
     def current_application
       @current_application ||= current_candidate.current_application
     end
+    helper_method :current_application
 
     def render_application_feedback_component
       @render_application_feedback_component = true
     end
-
-    helper_method :current_application
 
     def render_404
       render 'errors/not_found', status: :not_found
@@ -91,6 +90,10 @@ module CandidateInterface
       when 'end_date(1i)' then 'end_date_year'
       else key
       end
+    end
+
+    def strip_whitespace(params)
+      StripWhitespace.from_hash(params)
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -24,10 +24,9 @@ module CandidateInterface
   private
 
     def contact_details_params
-      params.require(:candidate_interface_contact_details_form).permit(
+      strip_whitespace params.require(:candidate_interface_contact_details_form).permit(
         :address_line1, :address_line2, :address_line3, :address_line4, :postcode, :international_address
       )
-        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -22,7 +22,7 @@ module CandidateInterface
   private
 
     def address_type_params
-      params.require(:candidate_interface_contact_details_form).permit(
+      strip_whitespace params.require(:candidate_interface_contact_details_form).permit(
         :address_type,
         :country,
       )

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -32,8 +32,7 @@ module CandidateInterface
   private
 
     def contact_details_params
-      params.require(:candidate_interface_contact_details_form).permit(:phone_number)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:candidate_interface_contact_details_form).permit(:phone_number)
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -15,8 +15,7 @@ module CandidateInterface
   private
 
     def application_form_params
-      params.require(:application_form).permit(:contact_details_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:contact_details_completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/degrees/grade_controller.rb
+++ b/app/controllers/candidate_interface/degrees/grade_controller.rb
@@ -54,10 +54,9 @@ module CandidateInterface
       end
 
       def grade_params
-        params
+        strip_whitespace params
           .require(:candidate_interface_degree_grade_form)
           .permit(:grade, :other_grade)
-          .transform_values(&:strip)
           .merge(degree: current_degree)
       end
 

--- a/app/controllers/candidate_interface/degrees/institution_controller.rb
+++ b/app/controllers/candidate_interface/degrees/institution_controller.rb
@@ -48,7 +48,7 @@ module CandidateInterface
       end
 
       def institution_params
-        params
+        strip_whitespace params
           .require(:candidate_interface_degree_institution_form)
           .permit(:institution_name, :institution_country)
           .merge(degree: current_degree)

--- a/app/controllers/candidate_interface/degrees/naric_controller.rb
+++ b/app/controllers/candidate_interface/degrees/naric_controller.rb
@@ -34,7 +34,7 @@ module CandidateInterface
     private
 
       def naric_params
-        params
+        strip_whitespace params
           .require(:candidate_interface_degree_naric_form)
           .permit(:have_naric_reference, :naric_reference, :comparable_uk_degree)
           .merge(degree: current_degree)

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -21,8 +21,7 @@ module CandidateInterface
     private
 
       def application_form_params
-        params.require(:application_form).permit(:degrees_completed)
-          .transform_values(&:strip)
+        strip_whitespace params.require(:application_form).permit(:degrees_completed)
       end
     end
   end

--- a/app/controllers/candidate_interface/degrees/subject_controller.rb
+++ b/app/controllers/candidate_interface/degrees/subject_controller.rb
@@ -39,7 +39,7 @@ module CandidateInterface
       end
 
       def subject_params
-        params
+        strip_whitespace params
           .require(:candidate_interface_degree_subject_form)
           .permit(:subject)
           .merge(degree: current_degree)

--- a/app/controllers/candidate_interface/degrees/type_controller.rb
+++ b/app/controllers/candidate_interface/degrees/type_controller.rb
@@ -52,7 +52,7 @@ module CandidateInterface
       end
 
       def degree_type_params
-        params
+        strip_whitespace params
           .require(:candidate_interface_degree_type_form)
           .permit(:uk_degree, :type_description, :international_type_description)
       end

--- a/app/controllers/candidate_interface/degrees/year_controller.rb
+++ b/app/controllers/candidate_interface/degrees/year_controller.rb
@@ -35,11 +35,9 @@ module CandidateInterface
     private
 
       def degree_year_params
-        params
-          .require(:candidate_interface_degree_year_form)
-          .permit(:start_year, :award_year)
-          .transform_values(&:strip)
-          .merge(degree: current_degree)
+        strip_whitespace(
+          params.require(:candidate_interface_degree_year_form).permit(:start_year, :award_year),
+        ).merge(degree: current_degree)
       end
     end
   end

--- a/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/ielts_controller.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     private
 
       def ielts_params
-        params
+        strip_whitespace params
           .fetch(:candidate_interface_english_foreign_language_ielts_form, {})
           .permit(:trf_number, :band_score, :award_year)
           .merge(application_form: current_application)

--- a/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/other_efl_qualification_controller.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     private
 
       def other_params
-        params
+        strip_whitespace params
           .fetch(:candidate_interface_english_foreign_language_other_efl_qualification_form, {})
           .permit(:name, :grade, :award_year)
           .merge(application_form: current_application)

--- a/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/review_controller.rb
@@ -27,7 +27,7 @@ module CandidateInterface
       end
 
       def completion_params
-        params
+        strip_whitespace params
           .require(:application_form)
           .permit(:efl_completed)
       end

--- a/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/start_controller.rb
@@ -36,7 +36,7 @@ module CandidateInterface
     private
 
       def start_params
-        params
+        strip_whitespace params
           .fetch(:candidate_interface_english_foreign_language_start_form, {})
           .permit(:qualification_status, :no_qualification_details)
           .merge(application_form: current_application)

--- a/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/toefl_controller.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     private
 
       def toefl_params
-        params
+        strip_whitespace params
           .fetch(:candidate_interface_english_foreign_language_toefl_form, {})
           .permit(:registration_number, :total_score, :award_year)
           .merge(application_form: current_application)

--- a/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
+++ b/app/controllers/candidate_interface/english_foreign_language/type_controller.rb
@@ -21,7 +21,7 @@ module CandidateInterface
     private
 
       def type_params
-        params
+        strip_whitespace params
           .fetch(:candidate_interface_english_foreign_language_type_form, {})
           .permit(:type)
       end

--- a/app/controllers/candidate_interface/feedback_form_controller.rb
+++ b/app/controllers/candidate_interface/feedback_form_controller.rb
@@ -19,7 +19,7 @@ module CandidateInterface
   private
 
     def feedback_params
-      params.require(:candidate_interface_feedback_form).permit(
+      strip_whitespace params.require(:candidate_interface_feedback_form).permit(
         :satisfaction_level, :suggestions
       )
     end

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -20,7 +20,7 @@ module CandidateInterface
     end
 
     def details_params
-      params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year other_grade])
+      strip_whitespace params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year other_grade])
     end
 
     def details_form

--- a/app/controllers/candidate_interface/gcse/english/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/english/grade_controller.rb
@@ -28,26 +28,28 @@ module CandidateInterface
   private
 
     def english_details_params
-      params.require(:candidate_interface_english_gcse_grade_form).permit([
-        :english_single_award,
-        :grade_english_single,
-        :english_double_award,
-        :grade_english_double,
-        :english_language,
-        :grade_english_language,
-        :english_literature,
-        :grade_english_literature,
-        :english_studies_single_award,
-        :grade_english_studies_single,
-        :english_studies_double_award,
-        :grade_english_studies_double,
-        :other_english_gcse,
-        :other_english_gcse_name,
-        :grade_other_english_gcse,
-        :grade,
-        :other_grade,
-        english_gcses: [],
-      ])
+      strip_whitespace params
+        .require(:candidate_interface_english_gcse_grade_form)
+        .permit([
+          :english_single_award,
+          :grade_english_single,
+          :english_double_award,
+          :grade_english_double,
+          :english_language,
+          :grade_english_language,
+          :english_literature,
+          :grade_english_literature,
+          :english_studies_single_award,
+          :grade_english_studies_single,
+          :english_studies_double_award,
+          :grade_english_studies_double,
+          :other_english_gcse,
+          :other_english_gcse_name,
+          :grade_other_english_gcse,
+          :grade,
+          :other_grade,
+          english_gcses: [],
+        ])
     end
 
     def next_gcse_path

--- a/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
@@ -44,7 +44,7 @@ module CandidateInterface
     end
 
     def maths_params
-      params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year other_grade])
+      strip_whitespace params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year other_grade])
     end
 
     def maths_gsce_grade_form

--- a/app/controllers/candidate_interface/gcse/naric_controller.rb
+++ b/app/controllers/candidate_interface/gcse/naric_controller.rb
@@ -42,7 +42,8 @@ module CandidateInterface
     end
 
     def naric_params
-      params.require(:candidate_interface_gcse_naric_form)
+      strip_whitespace params
+        .require(:candidate_interface_gcse_naric_form)
         .permit(:have_naric_reference, :naric_reference, :comparable_uk_qualification)
     end
   end

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -23,8 +23,7 @@ module CandidateInterface
     end
 
     def application_form_params
-      params.require(:application_form).permit(@field_name)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(@field_name)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -50,8 +50,9 @@ module CandidateInterface
     end
 
     def science_details_params
-      params.require(:candidate_interface_science_gcse_grade_form)
-            .permit(%i[gcse_science grade single_award_grade double_award_grade biology_grade chemistry_grade physics_grade])
+      strip_whitespace params
+        .require(:candidate_interface_science_gcse_grade_form)
+        .permit(%i[gcse_science grade single_award_grade double_award_grade biology_grade chemistry_grade physics_grade])
     end
 
     def gcse_science_qualification

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -63,9 +63,9 @@ module CandidateInterface
     end
 
     def qualification_params
-      params.require(:candidate_interface_gcse_qualification_type_form)
+      strip_whitespace params
+        .require(:candidate_interface_gcse_qualification_type_form)
         .permit(:qualification_type, :other_uk_qualification_type, :missing_explanation, :non_uk_qualification_type)
-        .transform_values(&:strip)
     end
 
     def new_non_uk_qualification?

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -93,23 +93,25 @@ module CandidateInterface
   private
 
     def other_qualification_params
-      params.require(:candidate_interface_other_qualification_details_form).permit(
-        :subject,
-        :grade,
-        :award_year,
-        :choice,
-        :institution_country,
-        :other_uk_qualification_type,
-        :non_uk_qualification_type,
-      ).merge!(
-        id: params[:id],
-      )
+      strip_whitespace params
+        .require(:candidate_interface_other_qualification_details_form).permit(
+          :subject,
+          :grade,
+          :award_year,
+          :choice,
+          :institution_country,
+          :other_uk_qualification_type,
+          :non_uk_qualification_type,
+        )
+        .merge!(id: params[:id])
     end
 
     def other_qualification_update_params
       other_qualification_params.merge(
-        params.require(:candidate_interface_other_qualification_details_form).permit(
-          :qualification_type,
+        strip_whitespace(
+          params
+          .require(:candidate_interface_other_qualification_details_form)
+          .permit(:qualification_type),
         ),
       )
     end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -27,8 +27,7 @@ module CandidateInterface
   private
 
     def application_form_params
-      params.require(:application_form).permit(:other_qualifications_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:other_qualifications_completed)
     end
 
     def there_are_incomplete_qualifications?

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -99,9 +99,9 @@ module CandidateInterface
     end
 
     def other_qualification_type_params
-      params.fetch(:candidate_interface_other_qualification_type_form, {}).permit(
-        :qualification_type, :other_uk_qualification_type, :non_uk_qualification_type
-      )
+      strip_whitespace params
+        .fetch(:candidate_interface_other_qualification_type_form, {})
+        .permit(:qualification_type, :other_uk_qualification_type, :non_uk_qualification_type)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_details/base_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/base_controller.rb
@@ -42,12 +42,12 @@ module CandidateInterface
     private
 
       def personal_details_params
-        params.require(:candidate_interface_personal_details_form).permit(
-          :first_name, :last_name,
-          :"date_of_birth(3i)", :"date_of_birth(2i)", :"date_of_birth(1i)"
+        strip_whitespace(
+          params.require(:candidate_interface_personal_details_form).permit(
+            :first_name, :last_name,
+            :"date_of_birth(3i)", :"date_of_birth(2i)", :"date_of_birth(1i)"
+          ).transform_keys { |key| dob_field_to_attribute(key) },
         )
-          .transform_keys { |key| dob_field_to_attribute(key) }
-          .transform_values(&:strip)
       end
 
       def dob_field_to_attribute(key)

--- a/app/controllers/candidate_interface/personal_details/languages_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/languages_controller.rb
@@ -42,9 +42,9 @@ module CandidateInterface
     private
 
       def languages_params
-        params.require(:candidate_interface_languages_form).permit(
-          :english_main_language, :english_language_details, :other_language_details
-        )
+        strip_whitespace params
+          .require(:candidate_interface_languages_form)
+          .permit(:english_main_language, :english_language_details, :other_language_details)
       end
     end
   end

--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -61,9 +61,11 @@ module CandidateInterface
       end
 
       def nationalities_params
-        params.require(:candidate_interface_nationalities_form).permit(
-          :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3, nationalities: []
-        )
+        strip_whitespace params
+          .require(:candidate_interface_nationalities_form)
+          .permit(
+            :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3, nationalities: []
+          )
       end
 
       def british_or_irish?

--- a/app/controllers/candidate_interface/personal_details/review_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/review_controller.rb
@@ -42,8 +42,7 @@ module CandidateInterface
     private
 
       def application_form_params
-        params.require(:application_form).permit(:personal_details_completed)
-          .transform_values(&:strip)
+        strip_whitespace params.require(:application_form).permit(:personal_details_completed)
       end
 
       def hiding_languages_section?

--- a/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/right_to_work_or_study_controller.rb
@@ -40,7 +40,7 @@ module CandidateInterface
     private
 
       def right_to_work_params
-        params.require(:candidate_interface_right_to_work_or_study_form).permit(
+        strip_whitespace params.require(:candidate_interface_right_to_work_or_study_form).permit(
           :right_to_work_or_study, :right_to_work_or_study_details
         )
       end

--- a/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
@@ -34,15 +34,13 @@ module CandidateInterface
   private
 
     def becoming_a_teacher_params
-      params.require(:candidate_interface_becoming_a_teacher_form).permit(
+      strip_whitespace params.require(:candidate_interface_becoming_a_teacher_form).permit(
         :becoming_a_teacher,
       )
-        .transform_values(&:strip)
     end
 
     def application_form_params
-      params.require(:application_form).permit(:becoming_a_teacher_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:becoming_a_teacher_completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -34,15 +34,13 @@ module CandidateInterface
   private
 
     def interview_preferences_params
-      params.require(:candidate_interface_interview_preferences_form).permit(
+      strip_whitespace params.require(:candidate_interface_interview_preferences_form).permit(
         :any_preferences, :interview_preferences
       )
-        .transform_values(&:strip)
     end
 
     def application_form_params
-      params.require(:application_form).permit(:interview_preferences_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:interview_preferences_completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -36,10 +36,9 @@ module CandidateInterface
   private
 
     def subject_knowledge_params
-      params.require(:candidate_interface_subject_knowledge_form).permit(
+      strip_whitespace params.require(:candidate_interface_subject_knowledge_form).permit(
         :subject_knowledge,
       )
-        .transform_values(&:strip)
     end
 
     def chosen_course_names
@@ -47,8 +46,7 @@ module CandidateInterface
     end
 
     def application_form_params
-      params.require(:application_form).permit(:subject_knowledge_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:subject_knowledge_completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/references/candidate_name_controller.rb
+++ b/app/controllers/candidate_interface/references/candidate_name_controller.rb
@@ -10,10 +10,7 @@ module CandidateInterface
       end
 
       def create
-        @reference_candidate_name_form = Reference::CandidateNameForm.new(
-          first_name: first_name_param,
-          last_name: last_name_param,
-        )
+        @reference_candidate_name_form = Reference::CandidateNameForm.new(name_params)
 
         if @reference_candidate_name_form.save(@reference)
           RequestReference.new.call(@reference)
@@ -27,12 +24,10 @@ module CandidateInterface
 
     private
 
-      def first_name_param
-        params.dig(:candidate_interface_reference_candidate_name_form, :first_name)
-      end
-
-      def last_name_param
-        params.dig(:candidate_interface_reference_candidate_name_form, :last_name)
+      def name_params
+        strip_whitespace params
+          .require(:candidate_interface_reference_candidate_name_form)
+          .permit(:first_name, :last_name)
       end
     end
   end

--- a/app/controllers/candidate_interface/references/email_address_controller.rb
+++ b/app/controllers/candidate_interface/references/email_address_controller.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     private
 
       def referee_email_address_param
-        params
+        strip_whitespace params
           .require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
           .merge!(reference_id: @reference.id)
       end

--- a/app/controllers/candidate_interface/references/name_controller.rb
+++ b/app/controllers/candidate_interface/references/name_controller.rb
@@ -40,7 +40,7 @@ module CandidateInterface
     private
 
       def referee_name_param
-        params.require(:candidate_interface_reference_referee_name_form).permit(:name)
+        strip_whitespace params.require(:candidate_interface_reference_referee_name_form).permit(:name)
       end
     end
   end

--- a/app/controllers/candidate_interface/references/relationship_controller.rb
+++ b/app/controllers/candidate_interface/references/relationship_controller.rb
@@ -40,7 +40,7 @@ module CandidateInterface
     private
 
       def references_relationship_params
-        params.require(:candidate_interface_reference_referee_relationship_form).permit(:relationship)
+        strip_whitespace params.require(:candidate_interface_reference_referee_relationship_form).permit(:relationship)
       end
     end
   end

--- a/app/controllers/candidate_interface/references/retry_request_controller.rb
+++ b/app/controllers/candidate_interface/references/retry_request_controller.rb
@@ -35,7 +35,7 @@ module CandidateInterface
       end
 
       def retry_params
-        params
+        strip_whitespace params
           .require(:candidate_interface_reference_referee_email_address_form).permit(:email_address)
           .merge!(reference_id: @reference.id)
       end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -36,8 +36,7 @@ module CandidateInterface
     end
 
     def application_form_params
-      params.require(:application_form).permit(:safeguarding_issues_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:safeguarding_issues_completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -31,7 +31,8 @@ module CandidateInterface
   private
 
     def safeguarding_params
-      params.require(:candidate_interface_safeguarding_issues_declaration_form)
+      strip_whitespace params
+        .require(:candidate_interface_safeguarding_issues_declaration_form)
         .permit(:share_safeguarding_issues, :safeguarding_issues)
     end
 

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -27,7 +27,7 @@ module CandidateInterface
   private
 
     def create_account_or_sign_in_params
-      params.require(:candidate_interface_create_account_or_sign_in_form).permit(:existing_account, :email)
+      strip_whitespace params.require(:candidate_interface_create_account_or_sign_in_form).permit(:existing_account, :email)
     end
   end
 end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -38,9 +38,9 @@ module CandidateInterface
   private
 
     def training_with_a_disability_params
-      params.require(:candidate_interface_training_with_a_disability_form).permit(
-        :disclose_disability, :disability_disclosure
-      )
+      strip_whitespace params
+        .require(:candidate_interface_training_with_a_disability_form)
+        .permit(:disclose_disability, :disability_disclosure)
     end
 
     def application_form_params

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -44,8 +44,7 @@ module CandidateInterface
     end
 
     def application_form_params
-      params.require(:application_form).permit(:training_with_a_disability_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:training_with_a_disability_completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
+++ b/app/controllers/candidate_interface/unsubmitted_application_form_controller.rb
@@ -47,11 +47,10 @@ module CandidateInterface
   private
 
     def further_information_params
-      params.require(:candidate_interface_further_information_form).permit(
+      strip_whitespace params.require(:candidate_interface_further_information_form).permit(
         :further_information,
         :further_information_details,
       )
-        .transform_values(&:strip)
     end
 
     def redirect_to_application_if_between_cycles

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -44,15 +44,16 @@ module CandidateInterface
     end
 
     def volunteering_role_params
-      params.require(:candidate_interface_volunteering_role_form)
+      strip_whitespace(
+        params.require(:candidate_interface_volunteering_role_form)
         .permit(
           :id, :role, :organisation, :details, :working_with_children,
           :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
           :"end_date(3i)", :"end_date(2i)", :"end_date(1i)"
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
-          .transform_keys { |key| end_date_field_to_attribute(key) }
-          .transform_values(&:strip)
+          .transform_keys { |key| end_date_field_to_attribute(key) },
+      )
     end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/experience_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/experience_controller.rb
@@ -26,10 +26,9 @@ module CandidateInterface
     def volunteering_experience_form_params
       return nil unless params.key?(:candidate_interface_volunteering_experience_form)
 
-      params.require(:candidate_interface_volunteering_experience_form).permit(
+      strip_whitespace params.require(:candidate_interface_volunteering_experience_form).permit(
         :experience,
       )
-        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -15,8 +15,7 @@ module CandidateInterface
   private
 
     def application_form_params
-      params.require(:application_form).permit(:volunteering_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:volunteering_completed)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/work_history/break_controller.rb
@@ -65,14 +65,15 @@ module CandidateInterface
     end
 
     def work_history_break_params
-      params.require(:candidate_interface_work_history_break_form)
+      strip_whitespace(
+        params.require(:candidate_interface_work_history_break_form)
         .permit(
           :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
           :"end_date(3i)", :"end_date(2i)", :"end_date(1i)", :reason
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
-          .transform_keys { |key| end_date_field_to_attribute(key) }
-          .transform_values(&:strip)
+          .transform_keys { |key| end_date_field_to_attribute(key) },
+      )
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/breaks_controller.rb
+++ b/app/controllers/candidate_interface/work_history/breaks_controller.rb
@@ -22,10 +22,7 @@ module CandidateInterface
   private
 
     def work_breaks_form_params
-      params.require(:candidate_interface_work_breaks_form).permit(
-        :work_history_breaks,
-      )
-        .transform_values(&:strip)
+      strip_whitespace params.require(:candidate_interface_work_breaks_form).permit(:work_history_breaks)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -65,15 +65,16 @@ module CandidateInterface
   private
 
     def work_experience_form_params
-      params.require(:candidate_interface_work_experience_form)
+      strip_whitespace(
+        params.require(:candidate_interface_work_experience_form)
         .permit(
           :role, :organisation, :details, :working_with_children, :commitment,
           :working_pattern, :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
           :"end_date(3i)", :"end_date(2i)", :"end_date(1i)", :add_another_job
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
-          .transform_keys { |key| end_date_field_to_attribute(key) }
-          .transform_values(&:strip)
+          .transform_keys { |key| end_date_field_to_attribute(key) },
+      )
     end
 
     def work_experience_params

--- a/app/controllers/candidate_interface/work_history/explanation_controller.rb
+++ b/app/controllers/candidate_interface/work_history/explanation_controller.rb
@@ -24,10 +24,9 @@ module CandidateInterface
     def work_explanation_form_params
       return nil unless params.key?(:candidate_interface_work_explanation_form)
 
-      params.require(:candidate_interface_work_explanation_form).permit(
+      strip_whitespace params.require(:candidate_interface_work_explanation_form).permit(
         :work_history_explanation,
       )
-        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/length_controller.rb
+++ b/app/controllers/candidate_interface/work_history/length_controller.rb
@@ -26,10 +26,7 @@ module CandidateInterface
     def work_history_form_params
       return nil unless params.key?(:candidate_interface_work_history_form)
 
-      params.require(:candidate_interface_work_history_form).permit(
-        :work_history,
-      )
-        .transform_values(&:strip)
+      strip_whitespace params.require(:candidate_interface_work_history_form).permit(:work_history)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -18,8 +18,7 @@ module CandidateInterface
   private
 
     def application_form_params
-      params.require(:application_form).permit(:work_history_completed)
-        .transform_values(&:strip)
+      strip_whitespace params.require(:application_form).permit(:work_history_completed)
     end
   end
 end

--- a/app/lib/strip_whitespace.rb
+++ b/app/lib/strip_whitespace.rb
@@ -1,0 +1,9 @@
+class StripWhitespace
+  def self.from_hash(hash)
+    hash.transform_values { |v| from_string(v) }
+  end
+
+  def self.from_string(string)
+    StripAttributes.strip_string(string, allow_empty: true)
+  end
+end

--- a/spec/lib/strip_whitespace_spec.rb
+++ b/spec/lib/strip_whitespace_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe StripWhitespace do
+  describe '.from_hash' do
+    it 'removes whitespace characters from hash values' do
+      hash = {
+        key1: "\u180E\u200B\u200C\u200D\u2060\uFEFF value1 \u180E\u200B\u200C\u200D\u2060\uFEFF",
+        key2: 'value2',
+        'key3 ' => 'value3',
+      }
+
+      expect(described_class.from_hash(hash)).to eq(
+        {
+          key1: 'value1',
+          key2: 'value2',
+          'key3 ' => 'value3',
+        },
+      )
+    end
+  end
+
+  describe '.from_string' do
+    it 'removes whitespace characters from the string argument' do
+      expect(
+        StripWhitespace.from_string(
+          "\u180E\u200B\u200C\u200D\u2060\uFEFF test \u180E\u200B\u200C\u200D\u2060\uFEFF",
+        ),
+      ).to eq('test')
+    end
+  end
+end


### PR DESCRIPTION
## Context

We're seeing quite a few validation errors coming from candidates leaving whitespace on certain fields. 

For example, if a candidate copy and pastes a referee's email address and leaves some whitespace, it triggers a validation.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Add the [strip_attributes](https://github.com/rmm5t/strip_attributes) gem 
- Expose its functionality in controllers via a `strip_whitespace` method
- Use this method in candidate controllers wherever it looks like we're handling text input from candidates

### Why this gem?

- It appears to be the most popular and well-maintained of the handful of gems that deal with stripping whitespace. 
- Its stripping functionality handles [several kinds](https://github.com/rmm5t/strip_attributes/blob/master/lib/strip_attributes.rb#L22) of whitespace in addition to regular spaces.
- Its stripping functionality is easy to invoke directly rather than relying on ActiveModel/ActiveRecord integration.

### Why strip whitespace in controllers?

The other alternative would have been to do this in form objects, in a `before_validation` callback. I opted for controllers as it's the simpler of the two options. Stripping in form objects would have required converting every form that needs this functionality over to the Attributes API (instead of using `attr_accessor`), which is a much more invasive change in comparison without being obviously better. We would also need to write our own macro for stripping attributes, as the gem only integrates well with ActiveRecord not plain ActiveModel objects.

With the approach outlined here, the default technique is to `strip_whitespace` on any params that we pass in to form objects. If we need to do something slightly more complex (like only strip a subset of the params), we have the option of handling that inside the form object by invoking the `StripWhitespace` helper class directly.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Per-commit highly recommended. 
- The controller updates are in two distinct commits:
  - replacing cases where we were stripping regular spaces already
  -  other controllers where it looks like we need to strip candidate input

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/FHwkTgbp
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
