### PR TITLE
Present international addresses as separate fields in the API

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -286,9 +286,14 @@ module VendorAPI
 
     def contact_details
       if application_form.international?
+        address_line1 = application_form.address_line1 || application_form.international_address
+
         {
           phone_number: application_form.phone_number,
-          address_line1: application_form.international_address,
+          address_line1: address_line1,
+          address_line2: application_form.address_line2,
+          address_line3: application_form.address_line3,
+          address_line4: application_form.address_line4,
           country: application_form.country,
           email: application_form.candidate.email_address,
         }

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -253,6 +253,10 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       application_form_attributes = {
         phone_number: '07700 900 982',
         address_type: 'international',
+        address_line1: '456 Marine Drive',
+        address_line2: 'Mumbai',
+        address_line3: nil,
+        address_line4: nil,
         international_address: '456 Marine Drive, Mumbai',
         country: 'IN',
       }
@@ -272,7 +276,46 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response.dig(:attributes, :contact_details)).to eq({
         phone_number: '07700 900 982',
+        address_line1: '456 Marine Drive',
+        address_line2: 'Mumbai',
+        address_line3: nil,
+        address_line4: nil,
+        country: 'IN',
+        email: application_form.candidate.email_address,
+      })
+    end
+
+    it 'presents the international_address field if no address lines are populated' do
+      application_form_attributes = {
+        phone_number: '07700 900 982',
+        address_type: 'international',
+        international_address: '456 Marine Drive, Mumbai',
+        address_line1: nil,
+        address_line2: nil,
+        address_line3: nil,
+        address_line4: nil,
+        country: 'IN',
+      }
+      application_form = create(
+        :completed_application_form,
+        :with_completed_references,
+        application_form_attributes,
+      )
+      application_choice = create(
+        :application_choice,
+        status: 'awaiting_provider_decision',
+        application_form: application_form,
+      )
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.to_json).to be_valid_against_openapi_schema('Application')
+      expect(response.dig(:attributes, :contact_details)).to eq({
+        phone_number: '07700 900 982',
         address_line1: '456 Marine Drive, Mumbai',
+        address_line2: nil,
+        address_line3: nil,
+        address_line4: nil,
         country: 'IN',
         email: application_form.candidate.email_address,
       })


### PR DESCRIPTION
## Context

We've recently parsed and updated the single international address line into separate address lines. (See https://github.com/DFE-Digital/apply-for-teacher-training/pull/3597 for how)

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Present multiple address fields containing international address for a single application in the API.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I've included a fall-back to using `ApplicationForm#international_address` when there's an international address with no address individual fields, this is possible as we don't automatically parse the single line into multiple fields.
Once we start validating field length on multiple international addresses we can remove this fallback.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/gz9VJ1wj/3093-resolve-international-non-uk-address-structures-for-api-integration
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
