### PR TITLE
Enable 'add a course' in support interface

### DIFF
--- a/app/components/support_interface/application_add_course_component.html.erb
+++ b/app/components/support_interface/application_add_course_component.html.erb
@@ -1,0 +1,3 @@
+<% if application_form.submitted? && !application_form.has_the_maximum_number_of_course_choices? %>
+  <%= govuk_button_link_to 'Add a course', support_interface_application_form_search_course_new_path(application_form_id: application_form.id), form_class: 'govuk-!-display-inline-block' %>
+<% end %>

--- a/app/components/support_interface/application_add_course_component.rb
+++ b/app/components/support_interface/application_add_course_component.rb
@@ -1,0 +1,11 @@
+module SupportInterface
+  class ApplicationAddCourseComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+  end
+end

--- a/app/controllers/support_interface/application_forms/courses_controller.rb
+++ b/app/controllers/support_interface/application_forms/courses_controller.rb
@@ -1,0 +1,72 @@
+module SupportInterface
+  module ApplicationForms
+    class CoursesController < SupportInterfaceController
+      def new_search
+        @course_search = CourseSearchForm.new(
+          application_form_id: application_form_id,
+          course_code: course_code,
+        )
+      end
+
+      def search
+        @course_search = CourseSearchForm.new(
+          application_form_id: application_form_id,
+          course_code: course_search_params[:course_code],
+        )
+
+        if @course_search.valid?
+          redirect_to support_interface_application_form_new_course_path(
+            course_code: course_search_params[:course_code],
+            application_form_id: application_form_id,
+          )
+        else
+          render :new_search
+        end
+      end
+
+      def new
+        @pick_course = PickCourseForm.new(
+          course_code: course_code,
+          application_form_id: application_form_id,
+        )
+      end
+
+      def create
+        @pick_course = PickCourseForm.new(
+          course_option_id: course_option_id,
+          course_code: course_code,
+          application_form_id: application_form_id,
+        )
+
+        if @pick_course.save
+          redirect_to support_interface_application_form_path
+        else
+          render :new
+        end
+      end
+
+    private
+
+      def application_form
+        @application_form ||= ApplicationForm.find(application_form_id)
+      end
+
+      def course_option_id
+        params.dig(:support_interface_application_forms_pick_course_form, :course_option_id)
+      end
+
+      def course_search_params
+        params.require(:support_interface_application_forms_course_search_form)
+              .permit(:course_code)
+      end
+
+      def application_form_id
+        params[:application_form_id]
+      end
+
+      def course_code
+        params[:course_code]
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/course_search_form.rb
+++ b/app/forms/support_interface/application_forms/course_search_form.rb
@@ -1,0 +1,22 @@
+module SupportInterface
+  module ApplicationForms
+    class CourseSearchForm
+      include ActiveModel::Model
+      include ValidationUtils
+
+      attr_accessor :course_code, :application_form_id
+
+      validates :course_code, presence: true
+
+      def applicant_name
+        application_form.full_name
+      end
+
+    private
+
+      def application_form
+        @application_form ||= ApplicationForm.find(application_form_id)
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/pick_course_form.rb
+++ b/app/forms/support_interface/application_forms/pick_course_form.rb
@@ -1,0 +1,73 @@
+module SupportInterface
+  module ApplicationForms
+    class PickCourseForm
+      include ActiveModel::Model
+      include ValidationUtils
+
+      attr_accessor :course_code, :application_form_id, :candidate_id, :course_option_id
+
+      validates :course_option_id, presence: true
+      validates :application_form_id, presence: true
+      validates :course_code, presence: true
+
+      RadioOption = Struct.new(:course_option_id, :course_name, :course_code, :site_name)
+
+      def course_options
+        return @course_options if @course_options
+
+        course_options = courses.map { |course|
+          course.course_options
+                .available
+                .reject { |course_option| existing_course_ids.include?(course_option.course_id) }
+                .map { |course_option| RadioOption.new(course_option.id, course.name, course.code, course_option.site.name) }
+        }.flatten
+
+        sorted_course_options = course_options.sort_by(&:course_name)
+        @course_options = sorted_course_options
+      end
+
+      def save
+        return false unless valid?
+
+        SupportInterface::AddCourseChoiceAfterSubmission.new(
+          application_form: application_form,
+          course_option: course_option,
+        ).call
+      end
+
+      def applicant_name
+        application_form.full_name
+      end
+
+    private
+
+      def application_form
+        @application_form ||= ApplicationForm
+          .includes(application_choices: [:course_option])
+          .find(application_form_id)
+      end
+
+      def course_option
+        @course_option ||= CourseOption.find(course_option_id)
+      end
+
+      def courses
+        Course
+          .current_cycle
+          .includes(course_options: [:site])
+          .where(code: sanitize(course_code))
+      end
+
+      def sanitize(course_code)
+        course_code.strip.upcase
+      end
+
+      def existing_course_ids
+        application_form
+          .application_choices
+          .map(&:course_option)
+          .pluck(:course_id)
+      end
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/courses/new.html.erb
+++ b/app/views/support_interface/application_forms/courses/new.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, title_with_error_prefix("Select a course to add to #{@pick_course.applicant_name}’s application", @pick_course.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @pick_course.course_options.present? %>
+      <%= form_with model: @pick_course, url: support_interface_application_form_create_course_path(course_code: @pick_course.course_code) do |f| %>
+        <%= f.govuk_error_summary %>
+        <%= f.govuk_radio_buttons_fieldset :course_option_id, legend:  { text: "Which course should be added to the application?", size: "m" } do %>
+          <% @pick_course.course_options.each do |co| %>
+            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.course_name} (#{co.course_code}) - #{co.site_name}" } %>
+          <% end %>
+        <% end %>
+        <%= f.govuk_submit 'Add course to application' %>
+      <% end %>
+    <% else %>
+     <p class="govuk-body">No results</p>
+      <%= govuk_link_to( 'Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code)) %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/support_interface/application_forms/courses/new_search.html.erb
+++ b/app/views/support_interface/application_forms/courses/new_search.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, title_with_error_prefix("Search for a course to add to #{@course_search.applicant_name}’s application", @course_search.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+            model: @course_search,
+            url: support_interface_application_form_search_course_path,
+        ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :course_code, label: { text: 'Course code' }, width: 5 %>
+      <%= f.govuk_submit "Search" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -25,6 +25,8 @@
   <% end %>
 <% end %>
 
+<%= render SupportInterface::ApplicationAddCourseComponent.new(application_form: @application_form) %>
+
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
 
 <% if @application_form.application_references.any? %>

--- a/config/locales/support_interface.yml
+++ b/config/locales/support_interface.yml
@@ -5,3 +5,14 @@ en:
       confirm_restore: Are you sure you want to restore support user %{email}?
       remove: Remove support user
       restore: Restore support user
+  activemodel:
+    errors:
+      models:
+        support_interface/application_forms/course_search_form:
+          attributes:
+            course_code:
+              blank: Please enter a course code
+        support_interface/application_forms/pick_course_form:
+          attributes:
+            course_option_id:
+              blank: Please select a course

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -682,6 +682,12 @@ Rails.application.routes.draw do
 
     scope path: '/applications/:application_form_id' do
       get '/' => 'application_forms#show', as: :application_form
+
+      get '/add-course/search' => 'application_forms/courses#new_search', as: :application_form_search_course_new
+      post '/add-course/search' => 'application_forms/courses#search', as: :application_form_search_course
+      get '/add-course/:course_code' => 'application_forms/courses#new', as: :application_form_new_course
+      post '/add-course/:course_code' => 'application_forms/courses#create', as: :application_form_create_course
+
       get '/audit' => 'application_forms#audit', as: :application_form_audit
       get '/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
       post '/comments' => 'application_forms/comments#create', as: :application_form_comments

--- a/spec/components/support_interface/application_add_course_component_spec.rb
+++ b/spec/components/support_interface/application_add_course_component_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationAddCourseComponent do
+  context 'application is submitted and has less than three application choices' do
+    it "renders the 'add a course' button" do
+      application_form = create(:completed_application_form)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-button').text).to include('Add a course')
+    end
+  end
+
+  context 'application is submitted and has more than three application choices' do
+    it "does not render the 'add a course' button" do
+      application_form = create(:completed_application_form)
+
+      create_list(:application_choice, 4, application_form_id: application_form.id)
+
+      application_form.reload
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-button').text).not_to include('Add a course')
+    end
+  end
+
+  context 'application is unsubmitted and has less than three application choices' do
+    it "does not render the 'add a course' button" do
+      application_form = create(:application_form)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-button').text).not_to include('Add a course')
+    end
+  end
+end

--- a/spec/forms/support_interface/application_forms/course_search_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/course_search_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::CourseSearchForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:course_code) }
+  end
+end

--- a/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model do
+  describe '#course_options' do
+    let(:first_site) { create(:site) }
+    let(:second_site) { create(:site) }
+    let(:provider) { create(:provider, sites: [first_site, second_site]) }
+    let(:course) { create(:course, code: 'ABC', provider: provider) }
+
+    it 'returns only course options that have vacancies' do
+      course_option_with_vacancies = create(:course_option, site_id: first_site.id, course_id: course.id)
+      create(:course_option, course_id: course.id, site_id: second_site.id, vacancy_status: 'no_vacancies')
+      application_form = create(:completed_application_form)
+
+      form_data = {
+        application_form_id: application_form.id,
+        course_code: course.code,
+      }
+
+      course_options = described_class.new(form_data).course_options
+
+      expect(course_options.length).to eq(1)
+      expect(course_options.first.course_option_id).to eq(course_option_with_vacancies.id)
+    end
+
+    it 'does not return course options that have already been added to an application form' do
+      course_option = create(:course_option, site_id: first_site.id, course_id: course.id)
+      application_choice = create(:application_choice, course_option_id: course_option.id)
+      application_form = create(:completed_application_form, application_choices: [application_choice])
+
+      form_data = {
+        application_form_id: application_form.id,
+        course_code: course.code,
+      }
+
+      course_options = described_class.new(form_data).course_options
+
+      expect(course_options.length).to eq(0)
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      expect(described_class.new.save).to be false
+    end
+
+    it 'updates the application form with the course choice' do
+      application_form = create(:application_form)
+      course_option = create(:course_option)
+
+      form_data = {
+        application_form_id: application_form.id,
+        course_option_id: course_option.id,
+        course_code: course_option.course.code,
+      }
+
+      expect(described_class.new(form_data).save).to be_truthy
+      expect(application_form.reload.application_choices.last.course_option_id).to eq form_data[:course_option_id]
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:course_option_id) }
+    it { is_expected.to validate_presence_of(:application_form_id) }
+  end
+end

--- a/spec/system/support_interface/add_course_to_submitted_application_spec.rb
+++ b/spec/system/support_interface/add_course_to_submitted_application_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.feature 'Add course to submitted application' do
+  include DfESignInHelpers
+
+  scenario 'Support user adds course to submitted application' do
+    given_i_am_a_support_user
+    and_there_is_a_submitted_application_in_the_system_logged_by_a_candidate
+    and_i_visit_the_support_page
+
+    when_i_click_on_an_application
+    when_i_click_on_add_a_course
+
+    then_i_should_see_the_course_search_page
+    when_i_click_search
+    then_i_should_see_a_course_code_blank_validation_error
+
+    when_i_fill_in_the_course_code_for_a_course_that_does_not_exist
+    and_i_click_search
+    then_i_should_see_the_course_results_page_with_no_results
+
+    when_i_click_search_again
+    then_i_should_see_the_course_search_page_with_the_course_code_i_entered
+
+    when_i_enter_a_course_code_for_a_course_that_does_exist
+    and_i_click_search
+    then_i_should_see_the_course_results_page_with_results
+
+    when_i_click_add_course_to_application
+    then_i_should_see_an_add_course_validation_error
+
+    when_i_select_a_course
+    and_i_click_add_course_to_application
+    then_i_should_see_the_application_with_the_course_added
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_a_submitted_application_in_the_system_logged_by_a_candidate
+    candidate = create :candidate, email_address: 'alice@example.com'
+
+    @application_form = Audited.audit_class.as_user(candidate) do
+      create(
+        :completed_application_form,
+        first_name: 'Alice',
+        last_name: 'Wunder',
+        candidate: candidate,
+      )
+    end
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_an_application
+    click_on 'Alice Wunder'
+  end
+
+  def when_i_click_on_add_a_course
+    click_on 'Add a course'
+  end
+
+  def then_i_should_see_the_course_search_page
+    expect(page).to have_current_path support_interface_application_form_search_course_new_path(application_form_id: @application_form.id)
+  end
+
+  def when_i_click_search
+    click_on 'Search'
+  end
+
+  def then_i_should_see_a_course_code_blank_validation_error
+    expect(page).to have_content 'Please enter a course code'
+  end
+
+  def when_i_fill_in_the_course_code_for_a_course_that_does_not_exist
+    @non_existent_course_code = 'ABCD'
+    fill_in('Course code', with: @non_existent_course_code)
+  end
+
+  def and_i_click_search
+    when_i_click_search
+  end
+
+  def then_i_should_see_the_course_results_page_with_no_results
+    expect(page).to have_current_path support_interface_application_form_new_course_path(
+      application_form_id: @application_form.id,
+      course_code: @non_existent_course_code,
+    )
+    expect(page).to have_content 'No results'
+  end
+
+  def when_i_click_search_again
+    click_link 'Search again'
+  end
+
+  def then_i_should_see_the_course_search_page_with_the_course_code_i_entered
+    expect(page).to have_current_path support_interface_application_form_search_course_new_path(
+      application_form_id: @application_form.id,
+      course_code: @non_existent_course_code,
+    )
+  end
+
+  def when_i_enter_a_course_code_for_a_course_that_does_exist
+    @course_option = create(:course_option)
+    @course_code = @course_option.course.code
+    fill_in('Course code', with: @course_code)
+  end
+
+  def then_i_should_see_the_course_results_page_with_results
+    expect(page).to have_current_path support_interface_application_form_new_course_path(
+      application_form_id: @application_form.id,
+      course_code: @course_code,
+    )
+
+    expect(page).to have_content 'Which course should be added to the application?'
+  end
+
+  def when_i_click_add_course_to_application
+    click_on 'Add course to application'
+  end
+
+  def then_i_should_see_an_add_course_validation_error
+    expect(page).to have_content('Please select a course')
+  end
+
+  def when_i_select_a_course
+    choose "#{@course_option.course.name} (#{@course_code}) - #{@course_option.site.name}"
+  end
+
+  def and_i_click_add_course_to_application
+    when_i_click_add_course_to_application
+  end
+
+  def then_i_should_see_the_application_with_the_course_added
+    expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
+    expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
+  end
+end


### PR DESCRIPTION
## Context
We've had some support queries come through where candidates have requested adding an additional course to their application post-submission. This is something that ideally, should be able to be done through the support interface.

## Changes proposed in this pull request

Adds the ability to search for course options by course code and add to an existing application. Includes basic validation.

## Guidance to review

To test it out, log into support and select an application _that has been submitted_. Under the course choice section you should see an 'add a course' button.

Git history will be rebased once approved 👍 

![add_a_course_v2](https://user-images.githubusercontent.com/5256922/102072925-704aca00-3dfa-11eb-9d7e-84e199c455d0.gif)

## Link to Trello card

https://trello.com/c/yZ7Ahqvp/2621-dev-%F0%9F%8F%88-allow-support-users-to-add-a-course-in-support-post-submission


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
