### PR TITLE
Remove the withdraw link from states with accepted offers

### DIFF
--- a/app/components/provider_interface/status_box_components/offer_deferred_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_deferred_component.html.erb
@@ -1,12 +1,6 @@
 <div class="app-offer-panel">
   <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Offer</h2>
 
-  <% if provider_can_respond %>
-  <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-display-none-print">
-    <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(application_choice.id) %>
-  </p>
-  <% end %>
-
   <h3 class="govuk-heading-m">Course details</h3>
   <%= render SummaryListComponent.new(rows: rows) %>
 

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -3,9 +3,7 @@
 
   <% if provider_can_respond %>
   <p class="govuk-body govuk-!-margin-bottom-4 govuk-!-display-none-print">
-    <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(application_choice.id) %>
-    or
-    <%= govuk_link_to 'defer offer', provider_interface_application_choice_new_defer_offer_path(application_choice.id) %>
+    <%= govuk_link_to 'Defer offer', provider_interface_application_choice_new_defer_offer_path(application_choice.id) %>
   </p>
   <% end %>
 

--- a/spec/system/provider_interface/provider_defers_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_defers_an_offer_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature 'Provider defers an offer' do
   end
 
   def and_i_click_on_defer_offer
-    click_on 'defer offer'
+    click_on 'Defer offer'
   end
 
   def then_i_am_asked_to_confirm_deferral_of_the_offer


### PR DESCRIPTION
## Context

At the moment, a provider is presented with the option to withdraw offers for application choices in the deferred and pending conditions states. When they try and confirm the withdrawal they are presented the following error:

`The application is not ready for that action` 

This is because we do not allow a provider to reject applicants once they have accepted an offer 

![image](https://user-images.githubusercontent.com/42515961/101797942-755dff80-3b02-11eb-9509-c5025485db51.png)

☝️ FYI:  `withdraw! `is when a candidate withdraws their application and `reject! ` is for providers rejecting an application.
## Changes proposed in this pull request

Pending conditions

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/101800138-d8e92c80-3b04-11eb-86fc-f6f6324c7294.png)|![image](https://user-images.githubusercontent.com/42515961/101800395-249bd600-3b05-11eb-8ebc-722e08197d02.png)|

Deferred 

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/101800644-67f64480-3b05-11eb-839a-4125a73c6bfd.png)|![image](https://user-images.githubusercontent.com/42515961/101802788-be648280-3b07-11eb-8207-6c3477db16e3.png)| 


Confirm withdrawal error

![image](https://user-images.githubusercontent.com/42515961/101799168-bf93b080-3b03-11eb-9645-9e3241f55e23.png)

## Guidance to review

I've looked into this as a result of a Zendesk ticket where a provider was getting the above error. 


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
