### PR TITLE
Add sites data export to support

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -90,6 +90,11 @@ class DataExport < ApplicationRecord
       description: 'A list of application choices with the associated postcodes for the candidate, provider and site.',
       class: SupportInterface::LocationsExport,
     },
+    sites_export: {
+      name: 'Sites',
+      description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
+      class: SupportInterface::SitesExport,
+    },
   }.freeze
 
   belongs_to :initiator, polymorphic: true, optional: true

--- a/app/services/support_interface/sites_export.rb
+++ b/app/services/support_interface/sites_export.rb
@@ -1,0 +1,24 @@
+module SupportInterface
+  class SitesExport
+    include GeocodeHelper
+
+    def sites
+      relevant_sites.map do |site|
+        {
+          'id' => site.id,
+          'code' => site.code,
+          'provider code' => site.provider.code,
+          'distance from provider' => format_distance(site, site.provider, with_units: false),
+        }
+      end
+    end
+
+    alias_method :data_for_export, :sites
+
+  private
+
+    def relevant_sites
+      Site.includes(:provider).where(providers: { sync_courses: true }).order('providers.code ASC')
+    end
+  end
+end

--- a/spec/services/support_interface/sites_export_spec.rb
+++ b/spec/services/support_interface/sites_export_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SitesExport do
+  describe '#sites' do
+    it 'returns synced sites and provider details' do
+      unsynced_provider = create(:provider, sync_courses: false, latitude: 20, longitude: 20)
+      synced_provider = create(:provider, sync_courses: true, latitude: 20, longitude: 20)
+
+      create(:site, latitude: 20, longitude: 21, provider: unsynced_provider)
+      create(:site, latitude: 20, longitude: 21, provider: synced_provider)
+
+      sites = described_class.new.sites
+      expect(sites.size).to eq(1)
+
+      expect(sites).to contain_exactly(
+        {
+          'id' => synced_provider.sites.first.id,
+          'code' => synced_provider.sites.first.code,
+          'provider code' => synced_provider.code,
+          'distance from provider' => '64.9',
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need an extract of sites data for analysis.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add a data export to support that contains site/provider codes for synced providers, and the distance between site and provider.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Code changes are fairly simple and follow the pattern of existing exports.
- Report can be accessed locally or on the review app via `/support/performance/data-exports/new`. Distance data dependent on geocodes existing for both sites and providers.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/Mqz6Y4cO
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
