### PR TITLE
Scope arriving from Find to the current cycle

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -49,7 +49,7 @@ module CandidateInterface
 
     def course_id
       @provider = Provider.find_by(code: params[:providerCode])
-      @course = @provider.courses.find_by(code: params[:courseCode]) if @provider.present?
+      @course = @provider.courses.current_cycle.find_by(code: params[:courseCode]) if @provider.present?
       @course.id if @course.present?
     end
   end


### PR DESCRIPTION
## Context

At the beginning of the cycle, we forgot to scope sites to the current cycle. We didn't actually fix the underlying issue so now we've got 81 candidates with last cycles courses on their application.

## Changes proposed in this pull request

- Scope arriving form find to this cycles courses

## Guidance to review

Once this is deployed tomorrow morning I'll run a script on prod to update the course_options to the current cycles courses.

## Link to Trello card

https://trello.com/c/DMDdxOer/2704-investigate-how-a-candidate-got-a-course-choice-from-last-year-onto-their-application-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
