### PR TITLE
When managing a user’s providers, order them by name

### DIFF
--- a/app/forms/support_interface/provider_user_form.rb
+++ b/app/forms/support_interface/provider_user_form.rb
@@ -58,7 +58,7 @@ module SupportInterface
           existing_permissions_for_user = []
         end
 
-        Provider.where(sync_courses: true).map do |provider|
+        Provider.where(sync_courses: true).order(:name).map do |provider|
           provider_permissions = existing_permissions_for_user.find { |existing_permission| existing_permission.provider_id == provider.id }
           provider_permissions || ProviderPermissions.new(provider: provider)
         end


### PR DESCRIPTION
## Context

We fall back to 'natural' (ie nonsensical) sort in the page where we set provider a user's provider relationships in support. This isn't useful.

## Changes proposed in this pull request

Sort by provider name instead.

<img width="720" alt="Screenshot 2020-12-10 at 21 31 31" src="https://user-images.githubusercontent.com/642279/101832315-182c7300-3b2f-11eb-9432-5f3880b58d09.png">
