### PR TITLE
Append document link sentence to UCAS Match action instructions

### DIFF
--- a/app/components/support_interface/ucas_match_action_component.rb
+++ b/app/components/support_interface/ucas_match_action_component.rb
@@ -66,10 +66,10 @@ module SupportInterface
     end
 
     def required_action_details
-      instructions = ACTIONS[@match.next_action][:instructions]
-      support_manual_info = "<br><br>Please refer to <a class='govuk-link' href='https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4'>Dual-running user support manual</a> for more information about the current process."
-
-      instructions.concat(support_manual_info).html_safe
+      (
+        ACTIONS[@match.next_action][:instructions] +
+        %(<br><br>Please refer to <a class="govuk-link" href="https://docs.google.com/document/d/1XvZiD8_ng_aG_7nvDGuJ9JIdPu6pFdCO2ujfKeFDOk4">Dual-running user support manual</a> for more information about the current process.)
+      ).html_safe
     end
 
     def last_action_details


### PR DESCRIPTION
## Context

Refreshing the UCAS matches details page under certain conditions would concatenate the same sentence to existing instructions meaning the same text was repeated on the page.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Appends the document link sentence to the instructions returning a new string.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

It's quite hard to find the exact setup to see the instructions and link text, but once you have a page displaying these, refreshing the page should not render repeat text. 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Ih5ADiL0/3054-instruction-text-is-added-after-each-refresh-on-ucas-match-page
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
