### PR TITLE
Handle deleted model files in 'Detect enum changes' checks

### DIFF
--- a/.github/scripts/enums_in_models.rb
+++ b/.github/scripts/enums_in_models.rb
@@ -7,16 +7,11 @@ if filename
     next unless line =~ /^<enum> /
     line.split('<enum> ')[1].split('.')[0]
   end
-  model_names.compact.uniq.map(&:constantize)
+  model_names.compact.uniq.map(&:constantize) rescue nil
 else
-  diff_tree_output = `git diff-tree -r --name-only --no-commit-id origin/master HEAD app/models`
+  diff_tree_output = `git diff-tree -r --name-only --no-commit-id --no-renames --diff-filter=d origin/master HEAD app/models`
   diff_tree_output.split(/\n/).map do |model_path|
-    puts model_path
-    begin
-      require "./#{model_path}"
-    rescue LoadError
-      puts "Could not load file #{model_path}. Has it been deleted or moved?"
-    end
+    require "./#{model_path}"
   end
 end
 

--- a/.github/scripts/enums_in_models.rb
+++ b/.github/scripts/enums_in_models.rb
@@ -11,7 +11,12 @@ if filename
 else
   diff_tree_output = `git diff-tree -r --name-only --no-commit-id origin/master HEAD app/models`
   diff_tree_output.split(/\n/).map do |model_path|
-    require "./#{model_path}"
+    puts model_path
+    begin
+      require "./#{model_path}"
+    rescue LoadError
+      puts "Could not load file #{model_path}. Has it been deleted or moved?"
+    end
   end
 end
 


### PR DESCRIPTION
## Context

I'm getting build failures because I've moved a model file from one namespace to another and the `enum_in_models.rb` is erroring because it can't `require` the deleted file from the source tree.

## Changes proposed in this pull request

- For now just handle the error

## Guidance to review

- I think this is the 'right thing to do' in cases where the model has genuinely been deleted. But what if the file has been moved? We shouldn't really ignore these cases because the file could have been moved _and_ modified.

## Link to Trello card

n/a

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
