### PR TITLE
Remove the find_feedback feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -31,7 +31,6 @@ class FeatureFlag
     [:structured_reasons_for_rejection, 'Allows providers to give specific reasons for rejecting an application', 'Steve Laing'],
     [:sync_from_public_teacher_training_api, 'Pull data from the public Teacher training API as well as the old "Find" API', 'Duncan Brown'],
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
-    [:find_feedback, 'Candidate can provide feedback on the Find service', 'David Gisbey'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_arrives_from_find_to_provide_feedback_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Candidate providing feedback on Find' do
 
   scenario 'Candidate arrives from Find and provides feedback' do
     given_i_arrive_from_the_course_show_page
-    and_the_find_feedback_flag_is_active
 
     when_i_complete_and_submit_the_feedback_form_with_an_invalid_email_address
     then_i_am_asked_to_provide_a_valid_email_address
@@ -31,10 +30,6 @@ RSpec.describe 'Candidate providing feedback on Find' do
 
   def given_i_arrive_from_the_course_show_page
     visit candidate_interface_find_feedback_path(find_controller: 'courses', path: '/course/T92/X130')
-  end
-
-  def and_the_find_feedback_flag_is_active
-    FeatureFlag.activate('find_feedback')
   end
 
   def when_i_complete_and_submit_the_feedback_form_with_an_invalid_email_address


### PR DESCRIPTION
## Context

While working on the find feedback card I realised that there is no need to put this piece of work behind a flag, but forgot to take it out before merging the previous PR.

## Changes proposed in this pull request

- remove the find_feedback flag

## Guidance to review

The feedback component can't be switched off on Find, so switching if off on Apply doesn't really make sense

## Link to Trello card

https://trello.com/c/DrnKcnnW/2466-%F0%9F%93%9D-%F0%9F%8F%88-dev-add-feedback-prompt-find

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
