### PR TITLE
Provide a list of possible GCSE/A-Level autocomplete values in the API

### DIFF
--- a/app/controllers/vendor_api/reference_data_controller.rb
+++ b/app/controllers/vendor_api/reference_data_controller.rb
@@ -3,5 +3,9 @@ module VendorAPI
     def gcse_subjects
       render json: { data: GCSE_SUBJECTS }
     end
+
+    def a_and_as_level_subjects
+      render json: { data: A_AND_AS_LEVEL_SUBJECTS }
+    end
   end
 end

--- a/app/controllers/vendor_api/reference_data_controller.rb
+++ b/app/controllers/vendor_api/reference_data_controller.rb
@@ -7,5 +7,13 @@ module VendorAPI
     def a_and_as_level_subjects
       render json: { data: A_AND_AS_LEVEL_SUBJECTS }
     end
+
+    def gcse_grades
+      render json: { data: ALL_GCSE_GRADES }
+    end
+
+    def a_and_as_level_grades
+      render json: { data: A_LEVEL_GRADES | AS_LEVEL_GRADES }
+    end
   end
 end

--- a/app/controllers/vendor_api/reference_data_controller.rb
+++ b/app/controllers/vendor_api/reference_data_controller.rb
@@ -1,0 +1,7 @@
+module VendorAPI
+  class ReferenceDataController < VendorAPIController
+    def gcse_subjects
+      render json: { data: GCSE_SUBJECTS }
+    end
+  end
+end

--- a/app/views/api_docs/pages/home.md
+++ b/app/views/api_docs/pages/home.md
@@ -27,6 +27,12 @@ Codes appear in three contexts:
 - Nationality is expressed as an [ISO 3166-2](https://www.iso.org/iso-3166-country-codes.html) country code
 - Demographic data required for HESA reporting uses [HESA codes for the 2019/20 Initial Teacher Training return](https://www.hesa.ac.uk/collection/c19053/e/ittschms). When the HESA codes for the next cycle are released, we will update the documentation to reflect these.
 
+Where it is not possible to structure data strictly — for example, in the case of GCSE subjects, where candidates need to be able to enter subjects our sources might not include — we encourage candidates to enter values from an [autocomplete field](https://designnotes.blog.gov.uk/2017/04/20/were-building-an-autocomplete/).
+
+To enable API clients to benefit from this consistency, we expose the following lists of possible autocomplete values:
+
+- `/reference-data/gcse-subjects`: a list of GCSE subjects based on [Ofqual’s list](https://register.ofqual.gov.uk/Download)
+
 ## How do I connect to this API?
 
 ### Authentication and authorisation

--- a/app/views/api_docs/pages/home.md
+++ b/app/views/api_docs/pages/home.md
@@ -34,6 +34,11 @@ To enable API clients to benefit from this consistency, we expose the following 
 - `/reference-data/gcse-subjects`: a list of GCSE subjects based on [Ofqual’s list](https://register.ofqual.gov.uk/Download)
 - `/reference-data/a-and-as-level-subjects`: a list of A and AS level subjects based on [Ofqual’s list](https://register.ofqual.gov.uk/Download)
 
+Grades for GCSEs and A/AS levels are strictly validated since the ITT 2021 recruitment cycle. The following lists contain all possible grades for these qualifications:
+
+- `/reference-data/gcse-grades`
+- `/reference-data/a-and-as-level-grades`
+
 ## How do I connect to this API?
 
 ### Authentication and authorisation

--- a/app/views/api_docs/pages/home.md
+++ b/app/views/api_docs/pages/home.md
@@ -32,6 +32,7 @@ Where it is not possible to structure data strictly — for example, in the case
 To enable API clients to benefit from this consistency, we expose the following lists of possible autocomplete values:
 
 - `/reference-data/gcse-subjects`: a list of GCSE subjects based on [Ofqual’s list](https://register.ofqual.gov.uk/Download)
+- `/reference-data/a-and-as-level-subjects`: a list of A and AS level subjects based on [Ofqual’s list](https://register.ofqual.gov.uk/Download)
 
 ## How do I connect to this API?
 

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,12 @@
+### 15th December 2020
+
+New feature: reference data. See the [Codes and reference data section](https://www.apply-for-teacher-training.service.gov.uk/api-docs#codes-and-reference-data) of the documentation.
+
+- `reference-data/gcse-subjects` returns a list of GCSE subjects
+- `reference-data/gcse-grades` returns a list of GCSE grades
+- `reference-data/a-and-as-level-subjects` returns a list of A and AS Level subjects
+- `reference-data/a-and-as-level-grades` returns a list of A and AS Level grades
+
 ### 7th December 2020
 
 Documentation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -488,6 +488,7 @@ Rails.application.routes.draw do
     post '/test-data/clear' => 'test_data#clear!'
 
     get '/reference-data/gcse-subjects' => 'reference_data#gcse_subjects'
+    get '/reference-data/a-and-as-level-subjects' => 'reference_data#a_and_as_level_subjects'
 
     post '/experimental/test-data/generate' => 'test_data#experimental_endpoint_moved'
     post '/experimental/test-data/clear' => 'test_data#experimental_endpoint_moved'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -487,6 +487,8 @@ Rails.application.routes.draw do
     post '/test-data/generate' => 'test_data#generate'
     post '/test-data/clear' => 'test_data#clear!'
 
+    get '/reference-data/gcse-subjects' => 'reference_data#gcse_subjects'
+
     post '/experimental/test-data/generate' => 'test_data#experimental_endpoint_moved'
     post '/experimental/test-data/clear' => 'test_data#experimental_endpoint_moved'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -488,7 +488,9 @@ Rails.application.routes.draw do
     post '/test-data/clear' => 'test_data#clear!'
 
     get '/reference-data/gcse-subjects' => 'reference_data#gcse_subjects'
+    get '/reference-data/gcse-grades' => 'reference_data#gcse_grades'
     get '/reference-data/a-and-as-level-subjects' => 'reference_data#a_and_as_level_subjects'
+    get '/reference-data/a-and-as-level-grades' => 'reference_data#a_and_as_level_grades'
 
     post '/experimental/test-data/generate' => 'test_data#experimental_endpoint_moved'
     post '/experimental/test-data/clear' => 'test_data#experimental_endpoint_moved'

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -257,6 +257,17 @@ paths:
           "$ref": "#/components/responses/NotFound"
         '422':
           "$ref": "#/components/responses/UnprocessableEntity"
+  "/reference-data/gcse-subjects":
+    get:
+      tags:
+      - Reference data
+      responses:
+        '200':
+          description: An array of possible GCSE subjects. Candidates are offered these in an autocomplete when filling in the form, but are also able to provide free-text responses.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ListResponse"
   "/test-data/regenerate":
     post:
       tags:
@@ -1248,6 +1259,15 @@ components:
               items:
                 type: string
                 maxLength: 10
+    ListResponse:
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            type: string
   parameters:
     application_id:
       name: application_id

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -268,6 +268,17 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ListResponse"
+  "/reference-data/a-and-as-level-subjects":
+    get:
+      tags:
+      - Reference data
+      responses:
+        '200':
+          description: An array of possible A and AS level subjects. Candidates are offered these in an autocomplete when filling in the form, but are also able to provide free-text responses.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ListResponse"
   "/test-data/regenerate":
     post:
       tags:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -268,6 +268,17 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ListResponse"
+  "/reference-data/gcse-grades":
+    get:
+      tags:
+      - Reference data
+      responses:
+        '200':
+          description: An array of possible GCSE grades including double-award grades.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ListResponse"
   "/reference-data/a-and-as-level-subjects":
     get:
       tags:
@@ -275,6 +286,17 @@ paths:
       responses:
         '200':
           description: An array of possible A and AS level subjects. Candidates are offered these in an autocomplete when filling in the form, but are also able to provide free-text responses.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ListResponse"
+  "/reference-data/a-and-as-level-grades":
+    get:
+      tags:
+      - Reference data
+      responses:
+        '200':
+          description: An array of possible A and AS level grades.
           content:
             application/json:
               schema:

--- a/spec/requests/vendor_api/get_reference_data_spec.rb
+++ b/spec/requests/vendor_api/get_reference_data_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe 'Vendor API - GET /api/v1/reference-data', type: :request do
       expect(parsed_response['data']).to include('English')
     end
   end
+
+  describe '/a-and-as-level-subjects' do
+    before do
+      get_api_request '/api/v1/reference-data/a-and-as-level-subjects'
+    end
+
+    it 'returns a response that is valid according to the OpenAPI schema' do
+      expect(parsed_response).to be_valid_against_openapi_schema('ListResponse')
+    end
+
+    it 'includes appropriate subjects' do
+      expect(parsed_response['data']).to include('Applied Science')
+    end
+  end
 end

--- a/spec/requests/vendor_api/get_reference_data_spec.rb
+++ b/spec/requests/vendor_api/get_reference_data_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1/reference-data', type: :request do
+  include VendorAPISpecHelpers
+
+  describe '/gcse-subjects' do
+    before do
+      get_api_request '/api/v1/reference-data/gcse-subjects'
+    end
+
+    it 'returns a response that is valid according to the OpenAPI schema' do
+      expect(parsed_response).to be_valid_against_openapi_schema('ListResponse')
+    end
+
+    it 'includes GCSE subjects' do
+      expect(parsed_response['data']).to include('English')
+    end
+  end
+end

--- a/spec/requests/vendor_api/get_reference_data_spec.rb
+++ b/spec/requests/vendor_api/get_reference_data_spec.rb
@@ -30,4 +30,32 @@ RSpec.describe 'Vendor API - GET /api/v1/reference-data', type: :request do
       expect(parsed_response['data']).to include('Applied Science')
     end
   end
+
+  describe '/gcse-grades' do
+    before do
+      get_api_request '/api/v1/reference-data/gcse-grades'
+    end
+
+    it 'returns a response that is valid according to the OpenAPI schema' do
+      expect(parsed_response).to be_valid_against_openapi_schema('ListResponse')
+    end
+
+    it 'includes appropriate grades' do
+      expect(parsed_response['data']).to include('9-8')
+    end
+  end
+
+  describe '/a-and-as-level-grades' do
+    before do
+      get_api_request '/api/v1/reference-data/a-and-as-level-grades'
+    end
+
+    it 'returns a response that is valid according to the OpenAPI schema' do
+      expect(parsed_response).to be_valid_against_openapi_schema('ListResponse')
+    end
+
+    it 'includes appropriate grades' do
+      expect(parsed_response['data']).to include('A*A*')
+    end
+  end
 end


### PR DESCRIPTION
## Context

Vendors have requested a copy of the possible values in subject autocompletes for GCSEs to help them consistently identify subjects.

## Changes proposed in this pull request

Add a `reference-data` path to the API and underneath it add

- `gcse-subjects`
- `gcse-grades`
- `a-and-as-level-subjects`
- `a-and-as-level-grades`

## Guidance to review

Does this structure make sense?

## Link to Trello card

https://trello.com/c/OHGVySUu/3119-provide-possible-gcse-autocomplete-values-over-the-api

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
