### PR TITLE
Document international address changes in the API

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -7,6 +7,16 @@ New feature: reference data. See the [Codes and reference data section](https://
 - `reference-data/a-and-as-level-subjects` returns a list of A and AS Level subjects
 - `reference-data/a-and-as-level-grades` returns a list of A and AS Level grades
 
+### 11th December 2020
+
+Change to international addresses:
+
+- Previously, international addresses were not structured and only the
+  address_line1 field was populated. From now on, international addresses will
+  be structured and will populate address lines 1-4.
+- `address_line1` character count is reduced from 200 to 50 in line with other
+  address lines.
+
 ### 7th December 2020
 
 Documentation:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -621,9 +621,6 @@ components:
     ContactDetails:
       type: object
       additionalProperties: false
-      description: UK addresses have country code `GB` and `address_line1`, `address_line2`,
-        `address_line3`, `address_line4` and `postcode` attributes. International addresses have
-        a valid `country` value and the address itself is serialised to `address_line1`.
       required:
       - address_line1
       - country
@@ -633,7 +630,7 @@ components:
         address_line1:
           type: string
           description: The candidate’s address line 1
-          maxLength: 200
+          maxLength: 50
           example: 45 Dialstone Lane
         address_line2:
           type: string


### PR DESCRIPTION
## Context

Docs need to be updated following https://github.com/DFE-Digital/apply-for-teacher-training/pull/3628.

## Changes proposed in this pull request

Clarify that international addresses will now be split across four lines in the API.

## Guidance to review

Does this change make sense?

## Link to Trello card

https://trello.com/c/gz9VJ1wj/3093-resolve-international-non-uk-address-structures-for-api-integration

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
