### PR TITLE
Structured reasons for rejection for previous applications in candidate interface

### DIFF
--- a/app/components/candidate_interface/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons_component.html.erb
@@ -6,7 +6,7 @@
   </summary>
 
   <div class="govuk-details__text govuk-!-padding-bottom-0">
-    <% @application_form.application_choices.includes(:course, :provider, [:offered_course_option]).rejected.each do |application_choice| %>
+    <% rejected_application_choices.each do |application_choice| %>
       <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
         <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>
       <% end %>

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
     end
 
     def course_details_row_value(application_choice)
-      if EndOfCycleTimetable.find_down? || FeatureFlag.active?(:structured_reasons_for_rejection)
+      if EndOfCycleTimetable.find_down?
         tag.p(application_choice.offered_course.name_and_code, class: 'govuk-!-margin-bottom-0') + tag.p(application_choice.course.description, class: 'govuk-body')
       else
         govuk_link_to(application_choice.offered_course.name_and_code,

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -15,6 +15,10 @@ module CandidateInterface
       ].compact
     end
 
+    def render?
+      rejected_application_choices.present?
+    end
+
   private
 
     def course_details_row(application_choice)
@@ -60,6 +64,14 @@ module CandidateInterface
           key: 'Feedback',
           value: application_choice.rejection_reason,
         }
+      end
+    end
+
+    def rejected_application_choices
+      @rejected_application_choices ||= begin
+        rejected_applications = @application_form.application_choices.includes(:course, :provider, [:offered_course_option]).rejected
+        rejected_applications = rejected_applications.where('application_choices.rejection_reason IS NOT NULL OR application_choices.structured_rejection_reasons IS NOT NULL') if FeatureFlag.active?(:structured_reasons_for_rejection)
+        rejected_applications
       end
     end
   end

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -10,6 +10,7 @@ module CandidateInterface
     def application_choice_rows(application_choice)
       [
         course_details_row(application_choice),
+        status_row(application_choice),
         rejection_reasons_row(application_choice),
       ].compact
     end
@@ -24,13 +25,22 @@ module CandidateInterface
     end
 
     def course_details_row_value(application_choice)
-      if EndOfCycleTimetable.find_down?
+      if EndOfCycleTimetable.find_down? || FeatureFlag.active?(:structured_reasons_for_rejection)
         tag.p(application_choice.offered_course.name_and_code, class: 'govuk-!-margin-bottom-0') + tag.p(application_choice.course.description, class: 'govuk-body')
       else
         govuk_link_to(application_choice.offered_course.name_and_code,
                       application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') +
           tag.p(application_choice.course.description, class: 'govuk-body')
       end
+    end
+
+    def status_row(application_choice)
+      return nil unless FeatureFlag.active?(:structured_reasons_for_rejection)
+
+      {
+        key: 'Status',
+        value: render(ApplicationStatusTagComponent.new(application_choice: application_choice)),
+      }
     end
 
     def rejection_reasons_row(application_choice)

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
   context 'with `structured_reasons_for_rejection` feature flag active' do
     before { FeatureFlag.activate(:structured_reasons_for_rejection) }
 
-    it 'renders component with correct values (without the Find link)' do
+    it 'renders component with correct values (with the Find link)' do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
       expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
       expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
-      expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+      expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
     end
 
     it 'adds a status row' do

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -4,25 +4,29 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
   let(:application_form) { create(:completed_application_form) }
   let!(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
 
-  it 'renders component with correct values' do
-    result = render_inline(described_class.new(application_form: application_form))
+  context 'with `structured_reasons_for_rejection` feature flag inactive' do
+    before { FeatureFlag.deactivate(:structured_reasons_for_rejection) }
 
-    expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
-    expect(result.css('.govuk-summary-list__key').text).to include('Course')
-    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_and_code)
-    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
-    expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
-    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
-    expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
-  end
+    it 'renders component with correct values' do
+      result = render_inline(described_class.new(application_form: application_form))
 
-  context 'when Find is down' do
-    it 'removes the link to Find' do
-      Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
-        result = render_inline(described_class.new(application_form: application_form))
+      expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
+      expect(result.css('.govuk-summary-list__key').text).to include('Course')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_and_code)
+      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
+      expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
+      expect(result.css('a').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+    end
 
-        expect(result.css('.govuk-summary-list__value').to_html).to include("#{application_choice.course.name} (#{application_choice.course.code})")
-        expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+    context 'when Find is down' do
+      it 'removes the link to Find' do
+        Timecop.travel(EndOfCycleTimetable.find_closes.end_of_day + 1.hour) do
+          result = render_inline(described_class.new(application_form: application_form))
+
+          expect(result.css('.govuk-summary-list__value').to_html).to include("#{application_choice.course.name} (#{application_choice.course.code})")
+          expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
+        end
       end
     end
   end
@@ -30,10 +34,15 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
   context 'with `structured_reasons_for_rejection` feature flag active' do
     before { FeatureFlag.activate(:structured_reasons_for_rejection) }
 
-    it 'removes the link to Find' do
+    it 'renders component with correct values (without the Find link)' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__value').to_html).to include("#{application_choice.course.name} (#{application_choice.course.code})")
+      expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
+      expect(result.css('.govuk-summary-list__key').text).to include('Course')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_and_code)
+      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
+      expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
       expect(result.css('a').to_html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}")
     end
 

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
     end
 
     context 'when there are no rejected application choices with feedback' do
-      let!(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form, rejection_reason: nil) }
+      let(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form, rejection_reason: nil) }
 
       it 'does not render' do
         result = render_inline(described_class.new(application_form: application_form))

--- a/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
+++ b/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Candidate can see their structured reasons for rejection when re
     then_i_can_see_rejection_reasons_from_the_earlier_application
     and_i_should_see_unsuccessful_status
     and_i_should_not_see_a_link_to_the_course_on_find
+    and_i_should_see_application_with_unstructured_feedback
+    and_i_should_not_see_application_without_feedback
   end
 
   def given_i_am_signed_in
@@ -26,8 +28,9 @@ RSpec.describe 'Candidate can see their structured reasons for rejection when re
 
   def and_i_have_an_apply1_application_with_2_rejections
     @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
-    @application_choice_with_reasons = create(:application_choice, :with_structured_rejection_reasons, application_form: @application_form)
-    @application_choice = create(:application_choice, :with_rejection, application_form: @application_form)
+    @application_choice_with_feedback = create(:application_choice, :with_structured_rejection_reasons, application_form: @application_form)
+    @application_choice_with_unstructured_feedback = create(:application_choice, :with_rejection, application_form: @application_form, rejection_reason: 'Disappointing')
+    @application_choice_without_feedback = create(:application_choice, :with_rejection, application_form: @application_form, rejection_reason: nil)
   end
 
   def when_i_visit_my_application_complete_page
@@ -55,8 +58,19 @@ RSpec.describe 'Candidate can see their structured reasons for rejection when re
   end
 
   def and_i_should_not_see_a_link_to_the_course_on_find
-    course_name = @application_choice_with_reasons.offered_course.name_and_code
+    course_name = @application_choice_with_feedback.offered_course.name_and_code
     expect(page).to have_content(course_name)
     expect(page).not_to have_link(course_name)
+  end
+
+  def and_i_should_see_application_with_unstructured_feedback
+    course_name = @application_choice_with_unstructured_feedback.offered_course.name_and_code
+    expect(page).to have_content(course_name)
+    expect(page).to have_content(@application_choice_with_unstructured_feedback.rejection_reason)
+  end
+
+  def and_i_should_not_see_application_without_feedback
+    course_name = @application_choice_without_feedback.offered_course.name_and_code
+    expect(page).not_to have_content(course_name)
   end
 end

--- a/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
+++ b/spec/system/candidate_interface/rejection/candidate_reviews_reasons_for_rejection_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe 'Candidate can see their structured reasons for rejection when re
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
     given_i_am_signed_in
     and_structured_rejection_reasons_feature_is_active
-    and_i_have_an_apply1_application_with_3_rejections
+    and_i_have_an_apply1_application_with_2_rejections
 
     when_i_visit_my_application_complete_page
     then_i_can_see_my_rejection_reasons
 
     when_i_apply_again
     then_i_can_see_rejection_reasons_from_the_earlier_application
+    and_i_should_see_unsuccessful_status
+    and_i_should_not_see_a_link_to_the_course_on_find
   end
 
   def given_i_am_signed_in
@@ -22,9 +24,10 @@ RSpec.describe 'Candidate can see their structured reasons for rejection when re
     FeatureFlag.activate(:structured_reasons_for_rejection)
   end
 
-  def and_i_have_an_apply1_application_with_3_rejections
+  def and_i_have_an_apply1_application_with_2_rejections
     @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
-    create_list(:application_choice, 3, :with_structured_rejection_reasons, application_form: @application_form)
+    @application_choice_with_reasons = create(:application_choice, :with_structured_rejection_reasons, application_form: @application_form)
+    @application_choice = create(:application_choice, :with_rejection, application_form: @application_form)
   end
 
   def when_i_visit_my_application_complete_page
@@ -45,5 +48,15 @@ RSpec.describe 'Candidate can see their structured reasons for rejection when re
   def then_i_can_see_rejection_reasons_from_the_earlier_application
     expect(page).to have_content('Quality of application')
     expect(page).to have_content('Use a spellchecker.')
+  end
+
+  def and_i_should_see_unsuccessful_status
+    expect(page).to have_content('Unsuccessful')
+  end
+
+  def and_i_should_not_see_a_link_to_the_course_on_find
+    course_name = @application_choice_with_reasons.offered_course.name_and_code
+    expect(page).to have_content(course_name)
+    expect(page).not_to have_link(course_name)
   end
 end


### PR DESCRIPTION
## Context

Structured reasons for rejection are now implemented in the provider interface so we need to bring the candidate interface inline with that to give the candidate more detailed feedback on unsuccessful applications. This PR displays the structured rejection reasons for previous applications on the application dashboard of the candidate's current application.

It is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3649.

## Changes proposed in this pull request

<img width="671" alt="image" src="https://user-images.githubusercontent.com/450843/102774316-a9e37e00-4382-11eb-959c-7c225c3a6b24.png">

- [x] Show structured reasons for rejection on the application dashboard for apply again applications under _See feedback from your previous application_.
- [x] Don't show _See feedback from your previous application_ when there are no rejected applications with feedback.
- [x] Only show rejected applications that have feedback (structured or legacy).
- [x] Add status to the `ReasonsForRejectionComponent` used above.
- [x] Remove the link to Find from the `ReasonsForRejectionComponent` used above.

## Guidance to review

- Can be tested on the review app by enabling the feature flag `structured_reasons_for_rejection`, as a provider rejecting an application giving structured feedback and then logging in as that candidate to apply again.

## Link to Trello card

https://trello.com/c/Omq1ZtBK/1766-dev-feedback-on-previously-unsuccessful-applications-r4r

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
