### PR TITLE
Add complaints page

### DIFF
--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -18,6 +18,10 @@ module CandidateInterface
       render_content_page :terms_candidate
     end
 
+    def complaints
+      render_content_page :complaints
+    end
+
     ProviderCourses = Struct.new(:provider_name, :courses)
     RegionProviderCourses = Struct.new(:region_code, :provider_name, :courses)
 

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -26,5 +26,9 @@ module ProviderInterface
     def guidance_for_the_new_cycle
       render_content_page :guidance_for_the_new_cycle
     end
+
+    def complaints
+      render_content_page :complaints
+    end
   end
 end

--- a/app/views/content/complaints.md
+++ b/app/views/content/complaints.md
@@ -1,13 +1,13 @@
 The Department for Education is committed to providing a high level of customer service, and takes complaints seriously. Letting us know if something is wrong means we can fix it and improve the service for everyone.
 
-##Giving feedback
+## Giving feedback
 
-If you have feedback about the service, or want to give suggestions for improvement, you can email us as [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+If you have feedback about the service, or want to give suggestions for improvement, you can email us as <becomingateacher@digital.education.gov.uk>.
 
-##How to make a complaint
+## How to make a complaint
 To make a complaint about the Apply for teacher training service, please [complete our complaints form](https://docs.google.com/forms/d/e/1FAIpQLSdkaYmy03JP0s9gxfEOkBMvMwNuU7IYO_MLwFONg5GdVFBuFg/viewform).
 
-##How we’ll respond
+## How we’ll respond
 Our support team will respond to your complaint within 5-7 working days.
 
 If we need more time to complete our investigation we’ll get in touch, and keep you updated regularly.

--- a/app/views/content/complaints.md
+++ b/app/views/content/complaints.md
@@ -1,0 +1,13 @@
+The Department for Education is committed to providing a high level of customer service, and takes complaints seriously. Letting us know if something is wrong means we can fix it and improve the service for everyone.
+
+##Giving feedback
+
+If you have feedback about the service, or want to give suggestions for improvement, you can email us as [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+##How to make a complaint
+To make a complaint about the Apply for teacher training service, please [complete our complaints form](https://docs.google.com/forms/d/e/1FAIpQLSdkaYmy03JP0s9gxfEOkBMvMwNuU7IYO_MLwFONg5GdVFBuFg/viewform).
+
+##How we’ll respond
+Our support team will respond to your complaint within 5-7 working days.
+
+If we need more time to complete our investigation we’ll get in touch, and keep you updated regularly.

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -12,6 +12,9 @@
     <%= link_to t('layout.support_links.cookies'), candidate_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
+    <%= link_to t('layout.support_links.complaints'), candidate_interface_complaints_path, class: 'govuk-footer__link' %>
+  </li>
+  <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.support_links.privacy_policy'), candidate_interface_privacy_policy_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -16,6 +16,9 @@
     <%= link_to t('layout.support_links.cookies'), provider_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
+    <%= link_to t('layout.support_links.complaints'), provider_interface_complaints_path, class: 'govuk-footer__link' %>
+  </li>
+  <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.support_links.privacy_policy'), provider_interface_privacy_policy_path, class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
     guidance_for_the_new_cycle: Guidance for the new cycle (2020 to 2021)
     cookies_candidate: Cookies
     cookies_provider: Cookies
+    complaints: Make a complaint about this service
     contact_information: Contact information
     contact_details: Contact details
     where_do_you_live: Where do you live?
@@ -192,6 +193,7 @@ en:
       title: Support links
       accessibility: Accessibility
       cookies: Cookies
+      complaints: Complaints
       terms_of_use: Terms of use
       privacy_policy: Privacy policy
   activemodel:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
     get '/accessibility', to: 'content#accessibility'
     get '/cookies', to: 'content#cookies_candidate', as: :cookies
+    get '/make-a-complaint', to: 'content#complaints', as: :complaints
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/providers', to: 'content#providers', as: :providers
     get '/terms-of-use', to: 'content#terms_candidate', as: :terms
@@ -499,6 +500,7 @@ Rails.application.routes.draw do
     get '/accessibility', to: 'content#accessibility'
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/cookies', to: 'content#cookies_provider', as: :cookies
+    get '/make-a-complaint', to: 'content#complaints', as: :complaints
     get '/service-guidance', to: 'content#service_guidance_provider', as: :service_guidance
     get '/covid-19-guidance', to: redirect('/')
 

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -11,6 +11,9 @@ RSpec.feature 'Candidate content' do
     when_i_click_on_the_cookie_policy
     then_i_can_see_the_cookie_policy
 
+    when_i_click_on_complaints
+    then_i_can_see_the_complaints_page
+
     when_i_click_on_the_privacy_policy
     then_i_can_see_the_privacy_policy
 
@@ -37,6 +40,15 @@ RSpec.feature 'Candidate content' do
   def then_i_can_see_the_cookie_policy
     expect(page).to have_content(t('page_titles.cookies_candidate'))
     expect(page).to have_content('When you close your browser')
+  end
+
+  def when_i_click_on_complaints
+    within('.govuk-footer') { click_link t('layout.support_links.complaints') }
+  end
+
+  def then_i_can_see_the_complaints_page
+    expect(page).to have_content(t('page_titles.complaints'))
+    expect(page).to have_content('Make a complaint about this service')
   end
 
   def when_i_click_on_the_privacy_policy

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -9,6 +9,9 @@ RSpec.feature 'Provider content' do
     when_i_click_on_the_cookie_policy
     then_i_can_see_the_cookie_policy
 
+    when_i_click_on_complaints
+    then_i_can_see_the_complaints_page
+
     when_i_click_on_the_privacy_policy
     then_i_can_see_the_privacy_policy
 
@@ -34,6 +37,15 @@ RSpec.feature 'Provider content' do
 
   def then_i_can_see_the_cookie_policy
     expect(page).to have_content(t('page_titles.cookies_provider'))
+  end
+
+  def when_i_click_on_complaints
+    within('.govuk-footer') { click_link t('layout.support_links.complaints') }
+  end
+
+  def then_i_can_see_the_complaints_page
+    expect(page).to have_content(t('page_titles.complaints'))
+    expect(page).to have_content('Make a complaint about this service')
   end
 
   def when_i_click_on_the_privacy_policy


### PR DESCRIPTION
## Context

We need a complaints procedure. This is a bare-bones MVP which adds a new page which links to a google form.

## Changes proposed in this pull request

Add new links to the candidate and provendor footers
Add a new page with some guidance and a link to the google form

![image](https://user-images.githubusercontent.com/33458055/102205546-3f829780-3ec3-11eb-8363-aa1e03bf37b8.png)

![image](https://user-images.githubusercontent.com/33458055/102205571-47dad280-3ec3-11eb-8cba-7027a56f073e.png)


## Guidance to review

[Link to prototype](https://apply-beta-prototype.herokuapp.com/complaints)
The card says that the URL should be top level `https://www.apply-for-teacher-training.service.gov.uk/make-a-complaint` , but at the moment it is namespaced `/candidate/make-a-complaint` similar to the existing content pages.

## Link to Trello card

https://trello.com/c/rtIl0Cuo/2670-dev-complaints-page-mvp

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
