### PR TITLE
Return domicile values consistent with HESA codes, not ISO 3166-2

### DIFF
--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -26,6 +26,7 @@ module SupportInterface
         name_row,
         date_of_birth_row,
         nationality_row,
+        domicile_row,
         right_to_work_or_study_row,
         residency_details_row,
         phone_number_row,
@@ -67,6 +68,13 @@ module SupportInterface
       {
         key: 'Nationality',
         value: application_form.nationalities.to_sentence(last_word_connector: ' and '),
+      }
+    end
+
+    def domicile_row
+      {
+        key: 'Domicile',
+        value: application_form.domicile,
       }
     end
 

--- a/app/lib/domicile_resolver.rb
+++ b/app/lib/domicile_resolver.rb
@@ -1,0 +1,42 @@
+class DomicileResolver
+  def self.hesa_code_for_country(iso_country_code)
+    case iso_country_code
+    when nil then 'ZZ'
+    when 'AQ' then 'XX'
+    when 'CY' then 'XC'
+    when 'XK' then 'QO'
+    else
+      iso_country_code
+    end
+  end
+
+  def self.hesa_code_for_postcode(uk_postcode)
+    prefix = uk_postcode.scan(/^[a-zA-Z]+/).first if uk_postcode.present?
+
+    case prefix
+    when nil then 'ZZ'
+    when *POSTCODE_PREFIXES['England'] then 'XF'
+    when *POSTCODE_PREFIXES['Wales'] then 'XI'
+    when *POSTCODE_PREFIXES['Scotland'] then 'XH'
+    when *POSTCODE_PREFIXES['Northern Ireland'] then 'XG'
+    when *POSTCODE_PREFIXES['Channel Islands'] then 'XL'
+    when *POSTCODE_PREFIXES['Spanning Two Countries'] then 'XK'
+    else
+      'XK'
+    end
+  end
+
+  POSTCODE_PREFIXES = {
+    'England' => %w[
+      AL B BA BB BD BH BL BN BR BS CA CB CM CO CR CT CV CW DA DE DH DL DN DT DY
+      E EC EN EX FY GL GU HA HD HG HP HU HX IG IP KT L LA LE LN LS LU M ME MK
+      N NE NG NN NR NW OL OX PE PL PO PR RG RH RM S SE SG SK SL SM SN SO SP SR
+      SS ST SW TA TF TN TQ TR TS TW UB W WA WC WD WF WN WR WS WV YO
+    ],
+    'Wales' => %w[CF SA],
+    'Scotland' => %w[AB DD EH FK G HS IV KA KW KY ML PA PH ZE],
+    'Northern Ireland' => %w[BT],
+    'Channel Islands' => %w[GY JE],
+    'Spanning Two Countries' => %w[CH DG HR LD LL NP SY TD],
+  }.freeze
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -319,6 +319,14 @@ class ApplicationForm < ApplicationRecord
     full_address.compact.join(', ')
   end
 
+  def domicile
+    if international?
+      DomicileResolver.hesa_code_for_country country
+    else
+      DomicileResolver.hesa_code_for_postcode postcode
+    end
+  end
+
 private
 
   def geocode_address_if_required

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -27,7 +27,7 @@ module VendorAPI
             last_name: application_form.last_name,
             date_of_birth: application_form.date_of_birth,
             nationality: application_choice.nationalities,
-            domicile: application_form.country,
+            domicile: application_form.domicile,
             uk_residency_status: uk_residency_status,
             english_main_language: application_form.english_main_language,
             english_language_qualifications: application_form.english_language_details,

--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -25,7 +25,7 @@ module ProviderInterface
           'last_name' => application.application_form.last_name,
           'date_of_birth' => application.application_form.date_of_birth,
           'nationality' => application.nationalities.join(' '),
-          'domicile' => application.application_form.country,
+          'domicile' => application.application_form.domicile,
           'uk_residency_status' => application.application_form.uk_residency_status,
           'english_main_language' => application.application_form.english_main_language,
           'english_language_qualifications' => application.application_form.english_language_details,

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -29,7 +29,7 @@ module ProviderInterface
           'last_name' => application.application_form.last_name,
           'date_of_birth' => application.application_form.date_of_birth,
           'nationality' => application.application_form.first_nationality,
-          'country' => application.application_form.country,
+          'domicile' => application.application_form.domicile,
           'email' => application.application_form.candidate.email_address,
           'recruitment_cycle_year' => application.application_form.recruitment_cycle_year,
           'provider_code' => application.provider.code,

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 16th December 2020
+
+Changes to existing attributes:
+
+- The `domicile` attribute of `Candidate` has been updated to return two-letter HESA codes instead of ISO 3166-2 country codes. For most international addresses the two types of code are identical, but HESA domicile codes do not include a `GB` value, specifying the country instead (e.g. `XF` for England, `XI` for Wales etc.)
+
 ### 15th December 2020
 
 New feature: reference data. See the [Codes and reference data section](https://www.apply-for-teacher-training.service.gov.uk/api-docs#codes-and-reference-data) of the documentation.

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -587,7 +587,7 @@ components:
           type: string
           maxLength: 2
           description: The candidate’s domicile, as extracted from their address
-          example: GB
+          example: XF
         uk_residency_status:
           type: string
           maxLength: 256

--- a/spec/components/support_interface/personal_details_component_spec.rb
+++ b/spec/components/support_interface/personal_details_component_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
     expect(result.css('.govuk-summary-list__value').text).to include('British, Irish and Spanish')
   end
 
+  it 'renders their HESA domicile code' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.domicile)
+  end
+
   it 'renders the candidate phone number' do
     expect(result.css('.govuk-summary-list__value').text).to include(application_form.phone_number)
   end
@@ -59,8 +63,8 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
       SupportInterface::PersonalDetailsComponent::RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.each do |key, value|
         application_form.right_to_work_or_study = key
         result = render_inline(SupportInterface::PersonalDetailsComponent.new(application_form: application_form))
-        row_title = result.css('.govuk-summary-list__row')[3].css('dt').text
-        row_value = result.css('.govuk-summary-list__row')[3].css('dd').text
+        row_title = result.css('.govuk-summary-list__row')[4].css('dt').text
+        row_value = result.css('.govuk-summary-list__row')[4].css('dd').text
         expect(row_title).to include 'Has the right to work or study in the UK?'
         expect(row_value).to include value
       end

--- a/spec/lib/domicile_resolver_spec.rb
+++ b/spec/lib/domicile_resolver_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe DomicileResolver do
+  def hesa_code_for_country(iso_country_code)
+    DomicileResolver.hesa_code_for_country iso_country_code
+  end
+
+  def hesa_code_for_postcode(uk_postcode)
+    DomicileResolver.hesa_code_for_postcode uk_postcode
+  end
+
+  it 'returns ZZ if it receives a nil argument' do
+    expect(hesa_code_for_country(nil)).to eq('ZZ')
+    expect(hesa_code_for_postcode(nil)).to eq('ZZ')
+  end
+
+  describe 'for international addresses' do
+    hesa_remaps = {
+      'XX' => { country_code: 'AQ', country_name: 'Antarctica' },
+      'XC' => { country_code: 'CY', country_name: 'Cyprus' },
+      'QO' => { country_code: 'XK', country_name: 'Kosovo' },
+    }
+
+    hesa_remaps.each do |expected, iso|
+      it "returns #{expected} when the country code is #{iso[:country_code]} (#{iso[:country_name]})" do
+        expect(hesa_code_for_country(iso[:country_code])).to eq(expected)
+      end
+    end
+
+    it 'returns the ISO code in all other cases' do
+      expect(hesa_code_for_country('FR')).to eq('FR')
+    end
+  end
+
+  describe 'for UK addresses' do
+    it 'returns XF for English postcodes' do
+      expect(hesa_code_for_postcode('SW1P 3BT')).to eq('XF')
+    end
+
+    it 'returns XI for Welsh postcodes' do
+      expect(hesa_code_for_postcode('SA6 7JL')).to eq('XI')
+    end
+
+    it 'returns XH for Scottish postcodes' do
+      expect(hesa_code_for_postcode('EH6 6QQ')).to eq('XH')
+    end
+
+    it 'returns XG for Northern Ireland' do
+      expect(hesa_code_for_postcode('BT48 7NN')).to eq('XG')
+    end
+
+    it 'returns XL for Channel Islands' do
+      expect(hesa_code_for_postcode('GY1 1FH')).to eq('XL')
+    end
+
+    it 'returns XK for non-geographical postcodes' do
+      expect(hesa_code_for_postcode('BF1 2AA')).to eq('XK')
+    end
+
+    it 'returns XK for postcode prefixes spanning two countries' do
+      expect(hesa_code_for_postcode('HR1 2LX')).to eq('XK')
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -493,4 +493,22 @@ RSpec.describe ApplicationForm do
       expect(application_form.full_address).to eq ['Beverley Hills 90210', 'United States']
     end
   end
+
+  describe '#domicile' do
+    it 'calls #hesa_code_for_country for international addresses' do
+      application_form = build_stubbed(:completed_application_form, :international_address)
+      allow(DomicileResolver).to receive(:hesa_code_for_country)
+                                 .with(application_form.country).and_return(':)')
+
+      expect(application_form.domicile).to eq(':)')
+    end
+
+    it 'calls #hesa_code_for_postcode for UK addresses' do
+      application_form = create(:completed_application_form)
+      allow(DomicileResolver).to receive(:hesa_code_for_postcode)
+                                 .with(application_form.postcode).and_return(':)')
+
+      expect(application_form.domicile).to eq(':)')
+    end
+  end
 end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -160,13 +160,13 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   end
 
   describe 'attributes.candidate.domicile' do
-    it 'returns country code from the candidate\'s address' do
+    it 'uses DomicileResolver to return a HESA code' do
       application_form = create(:completed_application_form, :with_completed_references)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
-      expect(response.dig(:attributes, :candidate, :domicile)).to eq(application_form.country)
+      expect(response.dig(:attributes, :candidate, :domicile)).to eq(application_form.domicile)
     end
   end
 

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'last_name' => application_choice.application_form.last_name,
         'date_of_birth' => application_choice.application_form.date_of_birth&.to_s,
         'nationality' => 'GB US',
-        'domicile' => application_choice.application_form.country,
+        'domicile' => application_choice.application_form.domicile,
         'uk_residency_status' => application_choice.application_form.uk_residency_status,
         'english_main_language' => application_choice.application_form.english_main_language&.to_s,
         'english_language_qualifications' => application_choice.application_form.english_language_details,

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ProviderInterface::HesaDataExport do
         expect(row['last_name']).to eq(@application_with_offer.application_form.last_name)
         expect(row['date_of_birth']).to eq(@application_with_offer.application_form.date_of_birth.to_s)
         expect(row['nationality']).to eq(@application_with_offer.application_form.first_nationality)
-        expect(row['country']).to eq(@application_with_offer.application_form.country)
+        expect(row['domicile']).to eq(@application_with_offer.application_form.domicile)
         expect(row['email']).to eq(@application_with_offer.application_form.candidate.email_address)
         expect(row['recruitment_cycle_year']).to eq(@application_with_offer.application_form.recruitment_cycle_year.to_s)
         expect(row['provider_code']).to eq(@application_with_offer.provider.code)
@@ -74,7 +74,7 @@ RSpec.describe ProviderInterface::HesaDataExport do
     it 'generates CSV headers' do
       csv = CSV.parse(export_data, headers: true)
       expect(csv.headers).to eq(%w[id status first_name last_name date_of_birth nationality
-                                   country email recruitment_cycle_year provider_code accredited_provider_name course_code site_code
+                                   domicile email recruitment_cycle_year provider_code accredited_provider_name course_code site_code
                                    study_mode SBJCA QLAIM FIRSTDEG DEGTYPE DEGSBJ DEGCLSS institution_country DEGSTDT DEGENDDT
                                    institution_details sex disabilities ethnicity])
     end

--- a/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
+++ b/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Export applications in HESA format' do
   def then_i_can_download_application_data_as_csv
     csv = CSV.parse(page.body, headers: true)
     expect(csv.headers).to eq(%w[id status first_name last_name date_of_birth nationality
-                                 country email recruitment_cycle_year provider_code accredited_provider_name course_code site_code
+                                 domicile email recruitment_cycle_year provider_code accredited_provider_name course_code site_code
                                  study_mode SBJCA QLAIM FIRSTDEG DEGTYPE DEGSBJ DEGCLSS institution_country DEGSTDT DEGENDDT
                                  institution_details sex disabilities ethnicity])
 

--- a/spec/system/support_interface/editing_reference_spec.rb
+++ b/spec/system/support_interface/editing_reference_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_referee_name
-    all('.govuk-summary-list__actions')[10].click_link 'Change'
+    all('.govuk-summary-list__actions')[11].click_link 'Change'
   end
 
   def then_i_should_see_a_prepopulated_details_form
@@ -90,7 +90,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_feedback
-    all('.govuk-summary-list__actions')[13].click_link 'Change'
+    all('.govuk-summary-list__actions')[14].click_link 'Change'
   end
 
   def then_i_should_see_the_feedback_form

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
           last_name: 'Calrissian',
           date_of_birth: '1937-04-06',
           nationality: %w[GB US],
-          domicile: 'GB',
+          domicile: @application.domicile,
           uk_residency_status: 'UK Citizen',
           english_main_language: true,
           other_languages: nil,


### PR DESCRIPTION
### Context

Providers need to submit information to HESA about candidate's country of domicile. 

We currently return `domicile` as the country code of the student's address as the ISO 3166-2 country code, but these codes are not valid for particular countries of domicile.

For UK addresses:

The ISO country code GB is valid for nationality, but not domicile, where there are separate codes for the individual countries: `XF`, `XG`, `XH`, `XI` 

If the individual country isn't known for UK addresses, we can return code `XK`.

### Changes proposed in this pull request

Add a `DomicileResolver` service, with a built-in table of known domicile codes.

This PR adds the following to our `COUNTRIES` list:

```
AQ Antarctica
XK Kosovo
```

The `DomicileResolver` service will pass country codes as HESA codes for all international addresses except for the following re-maps:

```
AQ (Antartica) to XX (Antartica and Oceania not otherwise specified)
CY (Cyprus) to XC (Cyprus not otherwise specified)
XK (Kosovo) to QO (Kosovo)
unresolved international addresses to ZZ (Not known)
```

For UK addresses, the challenge is specifying the the country (England, Wales...) from the address. `DomicileResolver` uses the UK postcode prefix against a lookup table to return:

```
XF England
XG Northern Ireland
XH Scotland
XI Wales
XL Channel Islands (not otherwise specified)
XK United Kingdom (not otherwise specified) [last resort]
```

`XK` is also returned when the postcode prefix spans two countries (e.g. England/Scotland).

### Guidance to review

No stored domicile field against an application for now, as the in-memory lookup is fast. AQ and XK are added to the `COUNTRIES` list because HESA re-maps them, so it's safer to add them now. Any other ISO country codes are valid HESA codes, so devs can add them to `COUNTRIES` without worrying about HESA codes.

I have changed our API responses and HESA export to return these new values instead of ISO codes for `domicile`. We don't seem to display `domicile` anywhere else. Should we also add it to application choices within the provider interface?

Finally, will specifying `domicile` in `ApplicationDataExport` break anything?

### Link to Trello card

[3117 - Correctly return country of domicile values](https://trello.com/c/LztnQHnq)

### Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
