### PR TITLE
Add provide and refuse feedback links in the support UI

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -9,6 +9,10 @@
         </div>
       <% elsif reference.feedback_requested? %>
         <div class='app-summary-card__actions'>
+          <% if HostingEnvironment.test_environment? %>
+            <%= govuk_link_to 'Provide feedback', referee_interface_reference_relationship_path(token: reference.refresh_feedback_token!) %>
+            <%= govuk_link_to 'Refuse feedback', referee_interface_refuse_feedback_path(token: reference.refresh_feedback_token!) %>
+          <% end %>
           <%= link_to support_interface_cancel_reference_path(reference), class: 'govuk-link' do %>
             Cancel reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>
           <% end %>

--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -9,10 +9,6 @@
         </div>
       <% elsif reference.feedback_requested? %>
         <div class='app-summary-card__actions'>
-          <% if HostingEnvironment.test_environment? %>
-            <%= govuk_link_to 'Provide feedback', referee_interface_reference_relationship_path(token: reference.refresh_feedback_token!) %>
-            <%= govuk_link_to 'Refuse feedback', referee_interface_refuse_feedback_path(token: reference.refresh_feedback_token!) %>
-          <% end %>
           <%= link_to support_interface_cancel_reference_path(reference), class: 'govuk-link' do %>
             Cancel reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>
           <% end %>

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -25,6 +25,7 @@ module SupportInterface
         relationship_row,
         feedback_row,
         consent_row,
+        sign_in_as_referee_row,
         history_row,
         possible_actions_row,
       ].flatten.compact
@@ -144,6 +145,17 @@ module SupportInterface
         {
           key: 'Given consent for research?',
           value: consent_to_be_contacted_present,
+        }
+      end
+    end
+
+    def sign_in_as_referee_row
+      if reference.feedback_requested? && HostingEnvironment.test_environment?
+        {
+          key: 'Sign in as referee',
+          value: govuk_link_to('Give feedback ', referee_interface_reference_relationship_path(token: reference.refresh_feedback_token!)) +
+            'or ' +
+            govuk_link_to('decline to give a reference', referee_interface_refuse_feedback_path(token: reference.refresh_feedback_token!)),
         }
       end
     end

--- a/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
+++ b/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Support user can access the RefereeInterface' do
   end
 
   def and_click_the_provide_feedback_link
-    click_link 'Provide feedback'
+    click_link 'Give feedback'
   end
 
   def then_i_see_the_reference_relationship_page
@@ -42,7 +42,7 @@ RSpec.feature 'Support user can access the RefereeInterface' do
   end
 
   def and_click_the_refuse_feedback_link
-    click_link 'Refuse feedback'
+    click_link 'decline to give a reference'
   end
 
   def and_click_the_sign_in_button
@@ -62,7 +62,7 @@ RSpec.feature 'Support user can access the RefereeInterface' do
   end
 
   def then_i_do_not_see_the_provide_feedback_or_refuse_feedback_link
-    expect(page).to have_no_link 'Provide feedback'
-    expect(page).to have_no_link 'Refuse feedback'
+    expect(page).to have_no_link 'Give feedback'
+    expect(page).to have_no_link 'decline to give a reference'
   end
 end

--- a/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
+++ b/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.feature 'Support user can access the RefereeInterface' do
+  include DfESignInHelpers
+
+  scenario 'Support user accesses the provide and refuse reference flow' do
+    given_i_am_a_support_user
+    and_there_is_an_application_with_a_reference_in_the_feedback_requested_state
+
+    when_i_visit_the_application_form_page
+    and_click_the_provide_feedback_link
+    then_i_see_the_reference_relationship_page
+
+    when_i_visit_the_application_form_page
+    and_click_the_refuse_feedback_link
+    then_i_see_the_refuse_feedback_page
+
+    when_the_candidates_reference_is_in_the_feedback_provided_state
+    and_i_visit_the_application_form_page
+    then_i_do_not_see_the_provide_feedback_or_refuse_feedback_link
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_with_a_reference_in_the_feedback_requested_state
+    @application = create(:application_form, first_name: 'GOB', last_name: 'Bluth')
+    create(:reference, :feedback_requested, application_form: @application)
+  end
+
+  def when_i_visit_the_application_form_page
+    visit support_interface_application_form_path(@application)
+  end
+
+  def and_click_the_provide_feedback_link
+    click_link 'Provide feedback'
+  end
+
+  def then_i_see_the_reference_relationship_page
+    expect(page).to have_content t('page_titles.referee.relationship', full_name: @application.full_name)
+  end
+
+  def and_click_the_refuse_feedback_link
+    click_link 'Refuse feedback'
+  end
+
+  def and_click_the_sign_in_button
+    click_on 'Sign in as this candidate'
+  end
+
+  def then_i_see_the_refuse_feedback_page
+    expect(page).to have_content "#{@application.full_name} will be able to submit the application quicker if you give a reference"
+  end
+
+  def when_the_candidates_reference_is_in_the_feedback_provided_state
+    @application.application_references.first.feedback_provided!
+  end
+
+  def and_i_visit_the_application_form_page
+    when_i_visit_the_application_form_page
+  end
+
+  def then_i_do_not_see_the_provide_feedback_or_refuse_feedback_link
+    expect(page).to have_no_link 'Provide feedback'
+    expect(page).to have_no_link 'Refuse feedback'
+  end
+end


### PR DESCRIPTION
## Context

As developers (and probably others!) we would like to be able easily and intuitively access the RefereeInterface. This change does this in the simplest way possible by adding `Provide feedback` and `Refuse feedback` links to the summary headers in the `ReferenceWithFeedbackComponent`. This component is rendered on the application show page.

These links only show on test environments and for references in the feedback_requested state.

## Changes proposed in this pull request

- Add links to the summary header for references in the feedback_requested state in the Support UI

|Before|After|
|-------------|-------------|
|![image](https://user-images.githubusercontent.com/42515961/102286047-5fe83b80-3f2f-11eb-82ac-afb125c4f30f.png)|![image](https://user-images.githubusercontent.com/42515961/102285700-b7d27280-3f2e-11eb-9283-69c3974e3170.png)|

## Guidance to review

Does this approach seem reasonable? My approach for this is to do the bare minimum to get it working. There might be a need later to build in a reference section/tab in the Support UI, but it seems a bit overkill for now. I can't really see the need for it tbh and we can always iterate later if needed.

Is the design okay? Should it be clearer that these only show on test envs?

Are the links only showing when they should be?
They def shouldn't be showing on prod & it seems to be they should only show for references that are awaiting feedback.

## Link to Trello card

https://trello.com/c/9XYQ3CEk/2624-dev-allow-signing-in-as-a-referee-from-support-not-in-production-though

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
