### PR TITLE
Add nationality editing to support interface

### DIFF
--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -68,6 +68,8 @@ module SupportInterface
       {
         key: 'Nationality',
         value: application_form.nationalities.to_sentence(last_word_connector: ' and '),
+        action: 'nationality',
+        change_path: support_interface_application_form_edit_nationalities_path(application_form),
       }
     end
 
@@ -84,6 +86,8 @@ module SupportInterface
       {
         key: 'Has the right to work or study in the UK?',
         value: RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.fetch(application_form.right_to_work_or_study),
+        action: 'right to work or study',
+        change_path: support_interface_application_form_edit_right_to_work_or_study_path(application_form),
       }
     end
 
@@ -93,6 +97,8 @@ module SupportInterface
       {
         key: 'Residency details',
         value: application_form.right_to_work_or_study_details,
+        action: 'residency details',
+        change_path: support_interface_application_form_edit_right_to_work_or_study_path(application_form),
       }
     end
 

--- a/app/controllers/support_interface/application_forms/nationalities_controller.rb
+++ b/app/controllers/support_interface/application_forms/nationalities_controller.rb
@@ -42,7 +42,8 @@ module SupportInterface
         StripWhitespace.from_hash params
           .require(:support_interface_application_forms_nationalities_form)
           .permit(
-            :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3, nationalities: []
+            :first_nationality, :second_nationality, :other_nationality1, :other_nationality2,
+            :other_nationality3, :audit_comment, nationalities: []
           )
       end
 

--- a/app/controllers/support_interface/application_forms/nationalities_controller.rb
+++ b/app/controllers/support_interface/application_forms/nationalities_controller.rb
@@ -11,10 +11,10 @@ module SupportInterface
         @nationalities_form = NationalitiesForm.new(prepare_nationalities_params)
 
         if @nationalities_form.save(@application_form)
-          if !british_or_irish?
-            redirect_to support_interface_application_form_edit_right_to_work_or_study_path
-          else
+          if british_or_irish?
             redirect_to support_interface_application_form_path(@application_form)
+          else
+            redirect_to support_interface_application_form_edit_right_to_work_or_study_path
           end
         else
           render :edit

--- a/app/controllers/support_interface/application_forms/nationalities_controller.rb
+++ b/app/controllers/support_interface/application_forms/nationalities_controller.rb
@@ -1,0 +1,54 @@
+module SupportInterface
+  module ApplicationForms
+    class NationalitiesController < SupportInterfaceController
+      before_action :set_application_form
+
+      def edit
+        @nationalities_form = NationalitiesForm.build_from_application(@application_form)
+      end
+
+      def update
+        @nationalities_form = NationalitiesForm.new(prepare_nationalities_params)
+
+        if @nationalities_form.save(@application_form)
+          if !british_or_irish?
+            redirect_to support_interface_application_form_edit_right_to_work_or_study_path
+          else
+            redirect_to support_interface_application_form_path(@application_form)
+          end
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def set_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+
+      def prepare_nationalities_params
+        nationalities_params
+          .tap { |np| np.delete(:nationalities) }
+          .merge(nationalities_hash)
+      end
+
+      def nationalities_hash
+        nationalities_options = nationalities_params[:nationalities]
+        nationalities_options ? nationalities_options.reject(&:blank?).index_by(&:downcase) : {}
+      end
+
+      def nationalities_params
+        StripWhitespace.from_hash params
+          .require(:support_interface_application_forms_nationalities_form)
+          .permit(
+            :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3, nationalities: []
+          )
+      end
+
+      def british_or_irish?
+        (NationalitiesForm::UK_AND_IRISH_NATIONALITIES & @application_form.nationalities).present?
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/application_forms/right_to_work_or_study_controller.rb
+++ b/app/controllers/support_interface/application_forms/right_to_work_or_study_controller.rb
@@ -1,0 +1,33 @@
+module SupportInterface
+  module ApplicationForms
+    class RightToWorkOrStudyController < SupportInterfaceController
+      before_action :set_application_form
+
+      def edit
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.build_from_application(@application_form)
+      end
+
+      def update
+        @right_to_work_or_study_form = RightToWorkOrStudyForm.new(right_to_work_params)
+
+        if @right_to_work_or_study_form.save(@application_form)
+          redirect_to support_interface_application_form_path(@application_form)
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def set_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
+      end
+
+      def right_to_work_params
+        StripWhitespace.from_hash params.require(:support_interface_application_forms_right_to_work_or_study_form).permit(
+          :right_to_work_or_study, :right_to_work_or_study_details
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/application_forms/right_to_work_or_study_controller.rb
+++ b/app/controllers/support_interface/application_forms/right_to_work_or_study_controller.rb
@@ -25,7 +25,7 @@ module SupportInterface
 
       def right_to_work_params
         StripWhitespace.from_hash params.require(:support_interface_application_forms_right_to_work_or_study_form).permit(
-          :right_to_work_or_study, :right_to_work_or_study_details
+          :right_to_work_or_study, :right_to_work_or_study_details, :audit_comment
         )
       end
     end

--- a/app/forms/candidate_interface/right_to_work_or_study_form.rb
+++ b/app/forms/candidate_interface/right_to_work_or_study_form.rb
@@ -5,9 +5,7 @@ module CandidateInterface
     attr_accessor :right_to_work_or_study, :right_to_work_or_study_details
 
     validates :right_to_work_or_study, presence: true
-
     validates :right_to_work_or_study_details, presence: true, if: :has_right_to_work_or_study?
-
     validates :right_to_work_or_study_details, word_count: { maximum: 200 }
 
     def self.build_from_application(application_form)

--- a/app/forms/support_interface/application_forms/nationalities_form.rb
+++ b/app/forms/support_interface/application_forms/nationalities_form.rb
@@ -5,14 +5,15 @@ module SupportInterface
 
       attr_accessor(
         :first_nationality, :second_nationality, :british, :irish, :other,
-        :other_nationality1, :other_nationality2, :other_nationality3, :nationalities
+        :other_nationality1, :other_nationality2, :other_nationality3, :nationalities,
+        :audit_comment
       )
 
       validates(
         :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3,
         inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true }
       )
-
+      validates :audit_comment, presence: true
       validate :candidate_provided_nationality
 
       UK_AND_IRISH_NATIONALITIES = ['British', 'Welsh', 'Scottish', 'Northern Irish', 'Irish', 'English'].freeze
@@ -37,6 +38,7 @@ module SupportInterface
             fifth_nationality: nationalities[4],
             right_to_work_or_study: nil,
             right_to_work_or_study_details: nil,
+            audit_comment: audit_comment,
           )
         else
           application_form.update!(
@@ -45,6 +47,7 @@ module SupportInterface
             third_nationality: nationalities[2],
             fourth_nationality: nationalities[3],
             fifth_nationality: nationalities[4],
+            audit_comment: audit_comment,
           )
         end
       end

--- a/app/forms/support_interface/application_forms/nationalities_form.rb
+++ b/app/forms/support_interface/application_forms/nationalities_form.rb
@@ -1,0 +1,68 @@
+module SupportInterface
+  module ApplicationForms
+    class NationalitiesForm
+      include ActiveModel::Model
+
+      attr_accessor(
+        :first_nationality, :second_nationality, :british, :irish, :other,
+        :other_nationality1, :other_nationality2, :other_nationality3, :nationalities
+      )
+
+      validates(
+        :first_nationality, :second_nationality, :other_nationality1, :other_nationality2, :other_nationality3,
+        inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true }
+      )
+
+      validate :candidate_provided_nationality
+
+      UK_AND_IRISH_NATIONALITIES = ['British', 'Welsh', 'Scottish', 'Northern Irish', 'Irish', 'English'].freeze
+
+      def self.build_from_application(application_form)
+        new(
+          application_form.build_nationalities_hash,
+        )
+      end
+
+      def save(application_form)
+        return false unless valid?
+
+        nationalities = candidates_nationalities
+
+        if british.present? || irish.present?
+          application_form.update!(
+            first_nationality: nationalities[0],
+            second_nationality: nationalities[1],
+            third_nationality: nationalities[2],
+            fourth_nationality: nationalities[3],
+            fifth_nationality: nationalities[4],
+            right_to_work_or_study: nil,
+            right_to_work_or_study_details: nil,
+          )
+        else
+          application_form.update!(
+            first_nationality: nationalities[0],
+            second_nationality: nationalities[1],
+            third_nationality: nationalities[2],
+            fourth_nationality: nationalities[3],
+            fifth_nationality: nationalities[4],
+          )
+        end
+      end
+
+      def candidates_nationalities
+        other.present? ? [british, irish, other_nationality1, other_nationality2, other_nationality3].select(&:present?).uniq : [british, irish].select(&:present?)
+      end
+
+    private
+
+      def candidate_provided_nationality
+        errors.add(:nationalities, :blank) if [british, irish, other].all?(&:blank?)
+        if other.present? && other_nationality1.blank?
+          # 'nationalities' needs to be set in order for govuk form builder to be able to display this error
+          self.nationalities = ['other', british, irish].compact
+          errors.add(:other_nationality1, :blank)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/right_to_work_or_study_form.rb
+++ b/app/forms/support_interface/application_forms/right_to_work_or_study_form.rb
@@ -3,11 +3,12 @@ module SupportInterface
     class RightToWorkOrStudyForm
       include ActiveModel::Model
 
-      attr_accessor :right_to_work_or_study, :right_to_work_or_study_details
+      attr_accessor :right_to_work_or_study, :right_to_work_or_study_details, :audit_comment
 
       validates :right_to_work_or_study, presence: true
       validates :right_to_work_or_study_details, presence: true, if: :has_right_to_work_or_study?
       validates :right_to_work_or_study_details, word_count: { maximum: 200 }
+      validates :audit_comment, presence: true
 
       def self.build_from_application(application_form)
         new(
@@ -22,6 +23,7 @@ module SupportInterface
         application_form.update(
           right_to_work_or_study: right_to_work_or_study,
           right_to_work_or_study_details: set_right_to_work_or_study_details,
+          audit_comment: audit_comment,
         )
       end
 

--- a/app/forms/support_interface/application_forms/right_to_work_or_study_form.rb
+++ b/app/forms/support_interface/application_forms/right_to_work_or_study_form.rb
@@ -1,0 +1,39 @@
+module SupportInterface
+  module ApplicationForms
+    class RightToWorkOrStudyForm
+      include ActiveModel::Model
+
+      attr_accessor :right_to_work_or_study, :right_to_work_or_study_details
+
+      validates :right_to_work_or_study, presence: true
+      validates :right_to_work_or_study_details, presence: true, if: :has_right_to_work_or_study?
+      validates :right_to_work_or_study_details, word_count: { maximum: 200 }
+
+      def self.build_from_application(application_form)
+        new(
+          right_to_work_or_study: application_form.right_to_work_or_study,
+          right_to_work_or_study_details: application_form.right_to_work_or_study_details,
+        )
+      end
+
+      def save(application_form)
+        return false unless valid?
+
+        application_form.update(
+          right_to_work_or_study: right_to_work_or_study,
+          right_to_work_or_study_details: set_right_to_work_or_study_details,
+        )
+      end
+
+    private
+
+      def has_right_to_work_or_study?
+        right_to_work_or_study == 'yes'
+      end
+
+      def set_right_to_work_or_study_details
+        has_right_to_work_or_study? ? right_to_work_or_study_details : nil
+      end
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/nationalities/edit.html.erb
+++ b/app/views/support_interface/application_forms/nationalities/edit.html.erb
@@ -32,6 +32,8 @@
         <% end %>
       <% end %>
 
+      <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
+
       <%= f.govuk_submit 'Save and continue' %>
 
     <% end %>

--- a/app/views/support_interface/application_forms/nationalities/edit.html.erb
+++ b/app/views/support_interface/application_forms/nationalities/edit.html.erb
@@ -1,0 +1,39 @@
+<% content_for :browser_title, title_with_error_prefix('Edit applicant nationality', @nationalities_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @nationalities_form, url: support_interface_application_form_edit_nationalities_path, class: 'app-nationality', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_check_boxes_fieldset :nationalities, legend: { size: 'l', text: 'Edit applicant nationality' } do %>
+        <%= f.govuk_check_box(
+          :nationalities,
+          'British',
+          link_errors: true,
+          multiple: true,
+          label: { text: 'British' },
+          hint: { text: 'including English, Scottish, Welsh or from Northern Ireland' }) %>
+        <%= f.govuk_check_box(
+          :nationalities,
+          'Irish',
+          multiple: true,
+          label: { text: 'Irish' },
+          hint: { text: 'including from Northern Ireland' }) %>
+
+        <%= f.govuk_check_box(
+          :nationalities,
+          'other',
+          multiple: true,
+          label: { text: 'Citizen of a different country' }) do %>
+          <%= f.govuk_collection_select :other_nationality1, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
+          <%= f.govuk_collection_select :other_nationality2, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
+          <%= f.govuk_collection_select :other_nationality3, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Save and continue' %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
+++ b/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
@@ -24,6 +24,12 @@
         <% end %>
       <% end %>
 
+      <%= f.govuk_text_field(
+        :audit_comment,
+        label: { text: 'Audit log comment', size: 'm' },
+        hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' }
+      ) %>
+
       <%= f.govuk_submit 'Save and continue' %>
     <% end %>
   </div>

--- a/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
+++ b/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :browser_title, title_with_error_prefix('Edit applicant right to work or study', @right_to_work_or_study_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @right_to_work_or_study_form, url: support_interface_application_form_edit_right_to_work_or_study_path, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'l', text: 'Edit applicant right to work or study', tag: 'h2' } do %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' } do %>
+          <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint: { text: 'For example, you have settled status or a permanent residence card' } %>
+        <% end %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
+          <div class="govuk-body">
+            Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+          </div>
+        <% end %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
+          <div class="govuk-body">
+            Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Save and continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -676,9 +676,13 @@ Rails.application.routes.draw do
 
       get '/applicant-address-type' => 'application_forms/address_type#edit', as: :application_form_edit_address_type
       post '/applicant-address-type' => 'application_forms/address_type#update', as: :application_form_update_address_type
-
       get '/applicant-address-details' => 'application_forms/address_details#edit', as: :application_form_edit_address_details
       post '/applicant-address-details' => 'application_forms/address_details#update', as: :application_form_update_address_details
+
+      get '/nationalities' => 'application_forms/nationalities#edit', as: :application_form_edit_nationalities
+      patch '/nationalities' => 'application_forms/nationalities#update'
+      get '/right-to-work-or-study' => 'application_forms/right_to_work_or_study#edit', as: :application_form_edit_right_to_work_or_study
+      patch '/right-to-work-or-study' => 'application_forms/right_to_work_or_study#update'
     end
 
     get '/ucas-matches' => 'ucas_matches#index'

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -17,6 +17,28 @@ RSpec.feature 'Editing application details' do
     and_i_submit_the_update_form
     then_i_should_see_a_flash_message
     and_i_should_see_the_new_applicant_details
+
+    when_i_update_the_applicant_nationality
+    then_i_see_the_updated_nationality
+  end
+
+  def when_i_update_the_applicant_nationality
+    click_on 'Details'
+    click_link 'Change nationality'
+    uncheck 'British'
+    check 'Citizen of a different country'
+    select 'Armenian', from: 'support-interface-application-forms-nationalities-form-other-nationality1-field'
+    click_button 'Save and continue'
+    choose 'Not yet – I will need to apply for permission to work or study in the UK'
+    click_button 'Save and continue'
+  end
+
+  def then_i_see_the_updated_nationality
+    within('[data-qa="personal-details"]') do
+      expect(page).to have_content 'Armenian'
+      expect(page).to have_content 'Has the right to work or study in the UK?'
+      expect(page).to have_content 'Not yet'
+    end
   end
 
   def given_i_am_a_support_user

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -28,8 +28,10 @@ RSpec.feature 'Editing application details' do
     uncheck 'British'
     check 'Citizen of a different country'
     select 'Armenian', from: 'support-interface-application-forms-nationalities-form-other-nationality1-field'
+    fill_in 'Audit log comment', with: 'Changed nationality details - zendesk ticket 1234'
     click_button 'Save and continue'
     choose 'Not yet – I will need to apply for permission to work or study in the UK'
+    fill_in 'Audit log comment', with: 'Changed nationality details - zendesk ticket 1234'
     click_button 'Save and continue'
   end
 
@@ -39,6 +41,9 @@ RSpec.feature 'Editing application details' do
       expect(page).to have_content 'Has the right to work or study in the UK?'
       expect(page).to have_content 'Not yet'
     end
+
+    click_on 'History'
+    expect(page).to have_content 'Changed nationality details - zendesk ticket 1234'
   end
 
   def given_i_am_a_support_user

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -13,20 +13,10 @@ RSpec.feature 'Editing application details' do
     and_i_submit_the_update_form
     then_i_should_see_relevant_blank_error_messages
 
-    when_i_supply_a_new_first_name
-    and_i_supply_a_new_last_name
-    and_i_supply_a_new_date_of_birth
-    and_i_supply_a_new_phone_number
-    and_i_supply_a_new_email_address
-    and_i_add_a_note_for_the_audit_log
+    when_i_supply_new_applicant_details
     and_i_submit_the_update_form
-
     then_i_should_see_a_flash_message
-    and_i_should_see_the_new_name_in_full
-    and_i_should_see_the_new_date_of_birth
-    and_i_should_see_the_new_phone_number
-    and_i_should_see_the_new_email_address
-    and_i_should_see_my_comment_in_the_audit_log
+    and_i_should_see_the_new_applicant_details
   end
 
   def given_i_am_a_support_user
@@ -118,5 +108,22 @@ RSpec.feature 'Editing application details' do
   def and_i_should_see_my_comment_in_the_audit_log
     click_on 'History'
     expect(page).to have_content 'https://becomingateacher.zendesk.com/12345'
+  end
+
+  def when_i_supply_new_applicant_details
+    when_i_supply_a_new_first_name
+    and_i_supply_a_new_last_name
+    and_i_supply_a_new_date_of_birth
+    and_i_supply_a_new_phone_number
+    and_i_supply_a_new_email_address
+    and_i_add_a_note_for_the_audit_log
+  end
+
+  def and_i_should_see_the_new_applicant_details
+    and_i_should_see_the_new_name_in_full
+    and_i_should_see_the_new_date_of_birth
+    and_i_should_see_the_new_phone_number
+    and_i_should_see_the_new_email_address
+    and_i_should_see_my_comment_in_the_audit_log
   end
 end


### PR DESCRIPTION
## Context
We would like to make more areas of an application form editable in the support interface

Some work has already been completed to allow certain characteristics to be updated. This should be expanded to encompass all Personal Details, to assist with support queries.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Add the nationality editing from the candidate interface to the support interface, including the right to work section.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Should be easy to test in the review app, just need to navigate to an application form in support
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/vYKaG1or
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
