### PR TITLE
Multi-line international contact addresses in candidate interface

### DIFF
--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -46,14 +46,9 @@ module CandidateInterface
 
     def full_address
       if @contact_details_form.uk?
-        [
-          @contact_details_form.address_line1,
-          @contact_details_form.address_line2,
-          @contact_details_form.address_line3,
-          @contact_details_form.address_line4,
-          @contact_details_form.postcode,
-        ]
-          .reject(&:blank?)
+        local_address.reject(&:blank?)
+      elsif FeatureFlag.active?(:international_addresses)
+        local_address.concat([COUNTRIES[@contact_details_form.country]]).reject(&:blank?)
       else
         [
           @contact_details_form.international_address,
@@ -61,6 +56,16 @@ module CandidateInterface
         ]
           .reject(&:blank?)
       end
+    end
+
+    def local_address
+      [
+        @contact_details_form.address_line1,
+        @contact_details_form.address_line2,
+        @contact_details_form.address_line3,
+        @contact_details_form.address_line4,
+        @contact_details_form.postcode,
+      ]
     end
   end
 end

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -6,7 +6,8 @@ module CandidateInterface
                   :address_line4, :postcode, :address_type, :country, :international_address
 
     validates :address_line1, :address_line3, :postcode, presence: true, on: :address, if: :uk?
-    validates :international_address, presence: true, on: :address, if: :international?
+    validates :address_line1, presence: true, on: :address, if: ->(form){ form.international? && FeatureFlag.active?(:international_addresses) }
+    validates :international_address, presence: true, on: :address, if: ->(form){ form.international? && !FeatureFlag.active?(:international_addresses) }
     validates :address_type, presence: true, on: :address_type
     validates :country, presence: true, on: :address_type, if: :international?
 
@@ -15,7 +16,7 @@ module CandidateInterface
 
     validates :phone_number, length: { maximum: 50 }, phone_number: true, on: :base
 
-    validates :postcode, postcode: true, on: :address
+    validates :postcode, postcode: true, on: :address, if: :uk?
 
     def self.build_from_application(application_form)
       new(

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -6,8 +6,8 @@ module CandidateInterface
                   :address_line4, :postcode, :address_type, :country, :international_address
 
     validates :address_line1, :address_line3, :postcode, presence: true, on: :address, if: :uk?
-    validates :address_line1, presence: true, on: :address, if: ->(form){ form.international? && FeatureFlag.active?(:international_addresses) }
-    validates :international_address, presence: true, on: :address, if: ->(form){ form.international? && !FeatureFlag.active?(:international_addresses) }
+    validates :address_line1, presence: true, on: :address, if: ->(form) { form.international? && FeatureFlag.active?(:international_addresses) }
+    validates :international_address, presence: true, on: :address, if: ->(form) { form.international? && !FeatureFlag.active?(:international_addresses) }
     validates :address_type, presence: true, on: :address_type
     validates :country, presence: true, on: :address_type, if: :international?
 

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -41,16 +41,17 @@ module CandidateInterface
     def save_address(application_form)
       return false unless valid?(:address)
 
-      if uk?
-        application_form.update(
+      if uk? || FeatureFlag.active?(:international_addresses)
+        attrs = {
           address_line1: address_line1,
           address_line2: address_line2,
           address_line3: address_line3,
           address_line4: address_line4,
           postcode: postcode&.upcase,
-          country: 'GB',
           international_address: nil,
-        )
+        }
+        attrs[:country] = 'GB' if uk?
+        application_form.update(attrs)
       else
         application_form.update(
           address_line1: nil,

--- a/app/forms/candidate_interface/contact_details_form.rb
+++ b/app/forms/candidate_interface/contact_details_form.rb
@@ -78,5 +78,9 @@ module CandidateInterface
     def international?
       address_type == 'international'
     end
+
+    def label_for(attr)
+      I18n.t("application_form.contact_information.#{attr}.#{address_type}.label")
+    end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -31,6 +31,7 @@ class FeatureFlag
     [:sync_from_public_teacher_training_api, 'Pull data from the public Teacher training API as well as the old "Find" API', 'Duncan Brown'],
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
     [:export_application_data, 'Providers can export a customised selection of application data', 'Ben Swannack'],
+    [:international_addresses, 'Replace the single free text field for international addresses with fields per line', 'Steve Hook'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -6,13 +6,36 @@
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <% if @contact_details_form.uk? %>
+      <% if @contact_details_form.uk? || FeatureFlag.active?(:international_addresses) %>
         <%= f.govuk_fieldset legend: { text: t('page_titles.address'), size: 'xl', tag: 'h1' } do %>
-          <%= f.govuk_text_field :address_line1, label: ->{ safe_join([t('application_form.contact_information.address_line1.label'), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
-          <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_information.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
-          <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_information.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
-          <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_information.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
-          <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_information.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
+          <%= f.govuk_text_field(
+            :address_line1,
+            label: ->{ safe_join([@contact_details_form.label_for(:address_line1), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) },
+            autocomplete: 'address-line1',
+          ) %>
+          <%= f.govuk_text_field(
+            :address_line2,
+            label: { text: @contact_details_form.label_for(:address_line2) },
+            autocomplete: 'address-line2',
+          ) %>
+          <%= f.govuk_text_field(
+            :address_line3,
+            label: { text: @contact_details_form.label_for(:address_line3) },
+            width: 'two-thirds',
+            autocomplete: 'address-level2',
+          ) %>
+          <%= f.govuk_text_field(
+            :address_line4,
+            label: { text: @contact_details_form.label_for(:address_line4) },
+            width: 'two-thirds',
+            autocomplete: 'address-level1',
+          ) %>
+          <%= f.govuk_text_field(
+            :postcode,
+            label: { text: @contact_details_form.label_for(:postcode) },
+            width: 10,
+            autocomplete: 'postal-code',
+          ) %>
         <% end %>
       <% else %>
         <%= f.govuk_text_area :international_address, label: { text: t('page_titles.address'), size: 'xl' }, autocomplete: 'address' %>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -15,7 +15,7 @@
           ) %>
           <%= f.govuk_text_field(
             :address_line2,
-            label: { text: @contact_details_form.label_for(:address_line2) },
+            label: { text: @contact_details_form.label_for(:address_line2), hidden: true },
             autocomplete: 'address-line2',
           ) %>
           <%= f.govuk_text_field(

--- a/app/views/support_interface/application_forms/address_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_details/edit.html.erb
@@ -8,11 +8,11 @@
 
       <%= f.govuk_fieldset legend: {text: t('support_interface.edit_address_details_form.address_details.label'), size: 'xl', tag: 'h1'} do %>
         <% if @details_form.uk? %>
-          <%= f.govuk_text_field :address_line1, label: -> { safe_join([t('application_form.contact_information.address_line1.label'), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
-          <%= f.govuk_text_field :address_line2, label: {text: t('application_form.contact_information.address_line2.label'), hidden: true}, autocomplete: 'address-line2' %>
-          <%= f.govuk_text_field :address_line3, label: {text: t('application_form.contact_information.address_line3.label')}, width: 'two-thirds', autocomplete: 'address-level2' %>
-          <%= f.govuk_text_field :address_line4, label: {text: t('application_form.contact_information.address_line4.label')}, width: 'two-thirds', autocomplete: 'address-level1' %>
-          <%= f.govuk_text_field :postcode, label: {text: t('application_form.contact_information.postcode.label')}, width: 10, autocomplete: 'postal-code' %>
+          <%= f.govuk_text_field :address_line1, label: -> { safe_join([t('application_form.contact_information.address_line1.uk.label'), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
+          <%= f.govuk_text_field :address_line2, label: {text: t('application_form.contact_information.address_line2.uk.label'), hidden: true}, autocomplete: 'address-line2' %>
+          <%= f.govuk_text_field :address_line3, label: {text: t('application_form.contact_information.address_line3.uk.label')}, width: 'two-thirds', autocomplete: 'address-level2' %>
+          <%= f.govuk_text_field :address_line4, label: {text: t('application_form.contact_information.address_line4.uk.label')}, width: 'two-thirds', autocomplete: 'address-level1' %>
+          <%= f.govuk_text_field :postcode, label: {text: t('application_form.contact_information.postcode.uk.label')}, width: 10, autocomplete: 'postal-code' %>
         <% else %>
           <%= f.govuk_text_area :international_address, label: {text: t('support_interface.edit_address_details_form.international_address.label')}, autocomplete: 'address' %>
         <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -62,16 +62,31 @@ en:
         label: Address
         change_action: address
       address_line1:
-        label: Building and street
+        uk:
+          label: Building and street
+        international:
+          label: Building and street
         hidden: line 1 of 2
       address_line2:
-        label: Building and street line 2 of 2
+        uk:
+          label: Building and street line 2 of 2
+        international:
+          label: Building and street line 2 of 2
       address_line3:
-        label: Town or city
+        uk:
+          label: Town or city
+        international:
+          label: City, town or village
       address_line4:
-        label: County
+        uk:
+          label: County
+        international:
+          label: Region, state or province
       postcode:
-        label: Postcode
+        uk:
+          label: Postcode
+        international:
+          label: ZIP or postal code
       complete_form_button: Save and continue
       base:
         button: Save and continue

--- a/spec/components/candidate_interface/contact_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/contact_details_review_component_spec.rb
@@ -33,7 +33,10 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
         expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_information.full_address.change_action')}")
       end
 
-      it 'renders component with correct values for an international address' do
+      # TODO: Remove this example when removing `international_addresses` feature flag
+      it 'renders component with correct values for an international address without `international_addresses` feature flag' do
+        FeatureFlag.deactivate(:international_addresses)
+
         application_form = build_stubbed(
           :application_form,
           phone_number: '+91 1234567890',
@@ -45,6 +48,25 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_information.full_address.label'))
         expect(result.css('.govuk-summary-list__value').to_html).to include('321 MG Road, Mumbai<br>India')
+        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_type_path)
+        expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_information.full_address.change_action')}")
+      end
+
+      it 'renders component with correct values for an international address' do
+        FeatureFlag.activate(:international_addresses)
+
+        application_form = build_stubbed(
+          :application_form,
+          phone_number: '+91 1234567890',
+          address_type: 'international',
+          address_line1: '321 MG Road',
+          address_line3: 'Mumbai',
+          country: 'IN',
+        )
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_information.full_address.label'))
+        expect(result.css('.govuk-summary-list__value').to_html).to include('321 MG Road<br>Mumbai<br>India')
         expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_type_path)
         expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_information.full_address.change_action')}")
       end

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -61,20 +61,46 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
       expect(application_form.international_address).to be_nil
     end
 
-    it 'updates the provided ApplicationForm with the international address field if valid' do
-      form_data = {
-        international_address: '123 Chandni Chowk, Old Delhi',
-      }
-      application_form = build(:application_form)
-      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+    # TODO: remove this context when removing `international_addresses` feature flag
+    context 'without international_addresses feature flag' do
+      before { FeatureFlag.deactivate(:international_addresses) }
 
-      expect(contact_details.save_address(application_form)).to eq(true)
-      expect(application_form).to have_attributes(form_data)
-      expect(application_form.address_line1).to be_nil
-      expect(application_form.address_line2).to be_nil
-      expect(application_form.address_line3).to be_nil
-      expect(application_form.address_line4).to be_nil
-      expect(application_form.postcode).to be_nil
+      it 'updates the provided ApplicationForm with the international address field if valid' do
+        form_data = {
+          international_address: '123 Chandni Chowk, Old Delhi',
+        }
+        application_form = build(:application_form)
+        contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+
+        expect(contact_details.save_address(application_form)).to eq(true)
+        expect(application_form).to have_attributes(form_data)
+        expect(application_form.address_line1).to be_nil
+        expect(application_form.address_line2).to be_nil
+        expect(application_form.address_line3).to be_nil
+        expect(application_form.address_line4).to be_nil
+        expect(application_form.postcode).to be_nil
+      end
+    end
+
+    context 'with international_addresses feature flag' do
+      before { FeatureFlag.activate(:international_addresses) }
+
+      it 'updates the provided ApplicationForm with the international address field if valid' do
+        form_data = {
+          address_line1: '123 Chandni Chowk',
+          address_line3: 'Old Delhi',
+          postcode: '110006',
+        }
+        application_form = build(:application_form)
+        contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+
+        expect(contact_details.save_address(application_form)).to eq(true)
+        expect(application_form).to have_attributes(form_data)
+        expect(application_form.address_line2).to be_nil
+        expect(application_form.address_line4).to be_nil
+        expect(application_form.postcode).to eq '110006'
+        expect(application_form.international_address).to be_nil
+      end
     end
   end
 

--- a/spec/forms/candidate_interface/contact_details_form_spec.rb
+++ b/spec/forms/candidate_interface/contact_details_form_spec.rb
@@ -123,15 +123,31 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
       it { is_expected.to validate_presence_of(:address_line3).on(:address) }
       it { is_expected.to validate_presence_of(:postcode).on(:address) }
       it { is_expected.not_to validate_presence_of(:international_address).on(:address) }
+      it { is_expected.not_to allow_value('MUCH WOW').for(:postcode).on(:address) }
     end
 
-    context 'for an international address' do
+    context 'for an international address without `international_addresses` feature flag active' do
+      before { FeatureFlag.deactivate(:international_addresses) }
+
       subject(:form) { described_class.new(address_type: 'international') }
 
       it { is_expected.to validate_presence_of(:international_address).on(:address) }
       it { is_expected.not_to validate_presence_of(:address_line1).on(:address) }
       it { is_expected.not_to validate_presence_of(:address_line3).on(:address) }
       it { is_expected.not_to validate_presence_of(:postcode).on(:address) }
+      it { is_expected.to allow_value('MUCH WOW').for(:postcode).on(:address) }
+    end
+
+    context 'for an international address' do
+      before { FeatureFlag.activate(:international_addresses) }
+
+      subject(:form) { described_class.new(address_type: 'international') }
+
+      it { is_expected.not_to validate_presence_of(:international_address).on(:address) }
+      it { is_expected.to validate_presence_of(:address_line1).on(:address) }
+      it { is_expected.not_to validate_presence_of(:address_line3).on(:address) }
+      it { is_expected.not_to validate_presence_of(:postcode).on(:address) }
+      it { is_expected.to allow_value('MUCH WOW').for(:postcode).on(:address) }
     end
 
     it { is_expected.to validate_length_of(:address_line1).is_at_most(50).on(:address) }
@@ -140,7 +156,6 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
     it { is_expected.to validate_length_of(:address_line4).is_at_most(50).on(:address) }
 
     it { is_expected.to allow_value('SW1P 3BT').for(:postcode).on(:address) }
-    it { is_expected.not_to allow_value('MUCH WOW').for(:postcode).on(:address) }
 
     it { is_expected.to allow_value('07700 900 982').for(:phone_number).on(:base) }
     it { is_expected.not_to allow_value('07700 WUT WUT').for(:phone_number).on(:base) }

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -173,8 +173,8 @@ module CandidateHelper
     choose 'In the UK'
     click_button t('application_form.contact_information.base.button')
     find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
-    fill_in t('application_form.contact_information.address_line3.label'), with: 'London'
-    fill_in t('application_form.contact_information.postcode.label'), with: 'SW1P 3BT'
+    fill_in t('application_form.contact_information.address_line3.uk.label'), with: 'London'
+    fill_in t('application_form.contact_information.postcode.uk.label'), with: 'SW1P 3BT'
     click_button t('application_form.contact_information.address.button')
 
     check t('application_form.completed_checkbox')

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -188,7 +188,14 @@ module CandidateHelper
     choose 'Outside the UK'
     select('India', from: t('application_form.contact_information.country.label'))
     click_button t('application_form.contact_information.base.button')
-    find(:css, "[autocomplete='address']").fill_in with: 'Vishnu Garden\nNew Delhi\nDelhi\n110018'
+    if FeatureFlag.active?(:international_addresses)
+      fill_in 'candidate_interface_contact_details_form[address_line1]', with: 'Vishnu Gardens'
+      fill_in 'candidate_interface_contact_details_form[address_line3]', with: 'New Delhi'
+      fill_in 'candidate_interface_contact_details_form[address_line4]', with: 'Delhi'
+      fill_in 'candidate_interface_contact_details_form[postcode]', with: '110018'
+    else
+      find(:css, "[autocomplete='address']").fill_in with: 'Vishnu Garden\nNew Delhi\nDelhi\n110018'
+    end
     click_button t('application_form.contact_information.address.button')
 
     check t('application_form.completed_checkbox')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -152,11 +152,11 @@ RSpec.feature 'Entering their contact information' do
     select('India', from: t('application_form.contact_information.country.label'))
     click_button t('application_form.contact_information.base.button')
   end
-  
+
   def and_i_incorrectly_fill_in_my_international_address
-    fill_in t('application_form.contact_information.address_line2.international.label'), with: '123 Chandni Chowk'
-    fill_in t('application_form.contact_information.address_line3.international.label'), with: 'Delhi'
-    fill_in t('application_form.contact_information.postcode.international.label'), with: '110006'
+    fill_in 'candidate_interface_contact_details_form[address_line1]', with: ''
+    fill_in 'candidate_interface_contact_details_form[address_line2]', with: 'New Delhi'
+    fill_in 'candidate_interface_contact_details_form[postcode]', with: '110006'
   end
 
   def then_i_should_see_validation_errors_for_address_line1
@@ -164,15 +164,14 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def when_i_fill_in_an_international_address
-    fill_in t('application_form.contact_information.address_line1.international.label'), with: '123 Chandni Chowk'
-    fill_in t('application_form.contact_information.address_line3.international.label'), with: 'Delhi'
-    fill_in t('application_form.contact_information.postcode.international.label'), with: '110006'
+    fill_in 'candidate_interface_contact_details_form[address_line1]', with: '123 Chandni Chowk'
+    fill_in 'candidate_interface_contact_details_form[address_line3]', with: 'New Delhi'
+    fill_in 'candidate_interface_contact_details_form[postcode]', with: '110006'
   end
 
   def then_i_can_check_my_revised_address
-    expect(page).not_to have_content t('application_form.contact_information.full_address.label')
     expect(page).to have_content '123 Chandni Chowk'
-    expect(page).to have_content 'Delhi'
+    expect(page).to have_content 'New Delhi'
     expect(page).to have_content 'India'
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -97,8 +97,8 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def and_i_incorrectly_fill_in_my_address
-    fill_in t('application_form.contact_information.address_line3.label'), with: 'London'
-    fill_in t('application_form.contact_information.postcode.label'), with: 'MUCH W0W'
+    fill_in t('application_form.contact_information.address_line3.uk.label'), with: 'London'
+    fill_in t('application_form.contact_information.postcode.uk.label'), with: 'MUCH W0W'
   end
 
   def then_i_should_see_validation_errors_for_my_address
@@ -108,8 +108,8 @@ RSpec.feature 'Entering their contact information' do
 
   def when_i_fill_in_my_address
     find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
-    fill_in t('application_form.contact_information.address_line3.label'), with: 'London'
-    fill_in t('application_form.contact_information.postcode.label'), with: 'SW1P 3BT'
+    fill_in t('application_form.contact_information.address_line3.uk.label'), with: 'London'
+    fill_in t('application_form.contact_information.postcode.uk.label'), with: 'SW1P 3BT'
   end
 
   def and_i_submit_my_address
@@ -154,9 +154,9 @@ RSpec.feature 'Entering their contact information' do
   end
   
   def and_i_incorrectly_fill_in_my_international_address
-    fill_in t('page_titles.address_line2'), with: '123 Chandni Chowk'
-    fill_in t('page_titles.address_line3'), with: 'Delhi'
-    fill_in t('page_titles.postcode'), with: '110006'
+    fill_in t('application_form.contact_information.address_line2.international.label'), with: '123 Chandni Chowk'
+    fill_in t('application_form.contact_information.address_line3.international.label'), with: 'Delhi'
+    fill_in t('application_form.contact_information.postcode.international.label'), with: '110006'
   end
 
   def then_i_should_see_validation_errors_for_address_line1
@@ -164,13 +164,13 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def when_i_fill_in_an_international_address
-    fill_in t('page_titles.address_line1'), with: '123 Chandni Chowk'
-    fill_in t('page_titles.address_line3'), with: 'Delhi'
-    fill_in t('page_titles.postcode'), with: '110006'
+    fill_in t('application_form.contact_information.address_line1.international.label'), with: '123 Chandni Chowk'
+    fill_in t('application_form.contact_information.address_line3.international.label'), with: 'Delhi'
+    fill_in t('application_form.contact_information.postcode.international.label'), with: '110006'
   end
 
   def then_i_can_check_my_revised_address
-    expect(page).to have_content t('application_form.contact_information.full_address.label')
+    expect(page).not_to have_content t('application_form.contact_information.full_address.label')
     expect(page).to have_content '123 Chandni Chowk'
     expect(page).to have_content 'Delhi'
     expect(page).to have_content 'India'

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -172,6 +172,7 @@ RSpec.feature 'Entering their contact information' do
   def then_i_can_check_my_revised_address
     expect(page).to have_content '123 Chandni Chowk'
     expect(page).to have_content 'New Delhi'
+    expect(page).to have_content '110006'
     expect(page).to have_content 'India'
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_without_international_addresses_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_without_international_addresses_spec.rb
@@ -94,8 +94,8 @@ RSpec.feature 'Entering their contact information without international_addresse
   end
 
   def and_i_incorrectly_fill_in_my_address
-    fill_in t('application_form.contact_information.address_line3.label'), with: 'London'
-    fill_in t('application_form.contact_information.postcode.label'), with: 'MUCH W0W'
+    fill_in t('application_form.contact_information.address_line3.uk.label'), with: 'London'
+    fill_in t('application_form.contact_information.postcode.uk.label'), with: 'MUCH W0W'
   end
 
   def then_i_should_see_validation_errors_for_my_address
@@ -105,8 +105,8 @@ RSpec.feature 'Entering their contact information without international_addresse
 
   def when_i_fill_in_my_address
     find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
-    fill_in t('application_form.contact_information.address_line3.label'), with: 'London'
-    fill_in t('application_form.contact_information.postcode.label'), with: 'SW1P 3BT'
+    fill_in t('application_form.contact_information.address_line3.uk.label'), with: 'London'
+    fill_in t('application_form.contact_information.postcode.uk.label'), with: 'SW1P 3BT'
   end
 
   def and_i_submit_my_address

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_without_international_addresses_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_without_international_addresses_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'Entering their contact information' do
+# TODO: Delete this spec when the `international_addresses` feature flag is removed
+RSpec.feature 'Entering their contact information without international_addresses' do
   include CandidateHelper
 
-  before { FeatureFlag.activate(:international_addresses) }
+  before { FeatureFlag.deactivate(:international_addresses) }
 
   scenario 'Candidate submits their contact information' do
     given_i_am_signed_in
@@ -37,11 +38,7 @@ RSpec.feature 'Entering their contact information' do
     then_i_can_see_my_address_type
 
     when_i_select_outside_the_uk
-    and_i_incorrectly_fill_in_my_international_address
-    and_i_submit_my_address
-    then_i_should_see_validation_errors_for_address_line1
-
-    when_i_fill_in_an_international_address
+    and_fill_in_an_international_address
     and_i_submit_my_address
     then_i_can_check_my_revised_address
 
@@ -142,6 +139,12 @@ RSpec.feature 'Entering their contact information' do
     find_link('Change', href: candidate_interface_contact_details_edit_address_type_path).click
   end
 
+  def then_i_can_see_my_address
+    expect(page).to have_selector("input[value='42 Much Wow Street']")
+    expect(page).to have_selector("input[value='London']")
+    expect(page).to have_selector("input[value='SW1P 3BT']")
+  end
+
   def then_i_can_see_my_address_type
     expect(page).to have_selector("input[value='uk']")
   end
@@ -152,27 +155,14 @@ RSpec.feature 'Entering their contact information' do
     select('India', from: t('application_form.contact_information.country.label'))
     click_button t('application_form.contact_information.base.button')
   end
-  
-  def and_i_incorrectly_fill_in_my_international_address
-    fill_in t('page_titles.address_line2'), with: '123 Chandni Chowk'
-    fill_in t('page_titles.address_line3'), with: 'Delhi'
-    fill_in t('page_titles.postcode'), with: '110006'
-  end
 
-  def then_i_should_see_validation_errors_for_address_line1
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.address_line1.blank')
-  end
-
-  def when_i_fill_in_an_international_address
-    fill_in t('page_titles.address_line1'), with: '123 Chandni Chowk'
-    fill_in t('page_titles.address_line3'), with: 'Delhi'
-    fill_in t('page_titles.postcode'), with: '110006'
+  def and_fill_in_an_international_address
+    fill_in t('page_titles.address'), with: '123 Chandni Chowk, Old Delhi'
   end
 
   def then_i_can_check_my_revised_address
     expect(page).to have_content t('application_form.contact_information.full_address.label')
-    expect(page).to have_content '123 Chandni Chowk'
-    expect(page).to have_content 'Delhi'
+    expect(page).to have_content '123 Chandni Chowk, Old Delhi'
     expect(page).to have_content 'India'
   end
 

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -81,8 +81,8 @@ RSpec.feature 'Editing address' do
 
   def when_i_complete_the_details_form
     find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
-    fill_in t('application_form.contact_information.address_line3.label'), with: 'London'
-    fill_in t('application_form.contact_information.postcode.label'), with: 'SW1P 3BT'
+    fill_in t('application_form.contact_information.address_line3.uk.label'), with: 'London'
+    fill_in t('application_form.contact_information.postcode.uk.label'), with: 'SW1P 3BT'
     fill_in 'support_interface_application_forms_edit_address_details_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12345'
   end
 


### PR DESCRIPTION
## Context

Some student record systems can’t accept the free text we currently allow candidates to enter if they have an international address. We want to update this so that they enter an address over 4 lines.

## Changes proposed in this pull request

- [x] Add `international_addresses` feature flag.
- [x] Updated the international address page to use the same fields as UK addresses with (some) different labels as specified if `international_addresses` feature flag is active.
<img width="691" alt="image" src="https://user-images.githubusercontent.com/450843/102469930-40463580-404b-11eb-952a-152cd76bee1d.png">
- [x] Update the review page to use the same address pattern as UK addresses but with the addition of _Country_ if `international_addresses` feature flag is active.
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/450843/102470424-de3a0000-404b-11eb-9caf-489065c6bed3.png">

## Guidance to review

- Per commit recommended
- It should be possible to test this manually on the review app by toggling the `international_addresses` feature flag.
- Is the feature flag enforced correctly?

## Link to Trello card

https://trello.com/c/4kYVYB6J/2676-🌐-dev-split-international-contact-address-into-multiple-lines

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
