### PR TITLE
Provider users can configure their notifications

### DIFF
--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -1,0 +1,18 @@
+module ProviderInterface
+  class NotificationsController < ProviderInterfaceController
+    def update
+      current_provider_user.update!(
+        send_notifications: notification_params[:send_notifications],
+      )
+
+      flash[:success] = 'Email notification settings saved'
+      redirect_to provider_interface_notifications_path
+    end
+
+  private
+
+    def notification_params
+      params.require(:provider_user).permit(:send_notifications)
+    end
+  end
+end

--- a/app/views/provider_interface/account/show.html.erb
+++ b/app/views/provider_interface/account/show.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l"><%= t('page_titles.provider.account') %></h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-one-half">
 
     <h2 class="govuk-heading-m">
       <%= govuk_link_to t('page_titles.provider.profile'), provider_interface_profile_path %>
@@ -15,6 +15,16 @@
       <li>change your password</li>
       <li>check your permissions</li>
     </ul>
+
+    <h2 class="govuk-heading-m">
+      <%= govuk_link_to t('page_titles.provider.notifications'), provider_interface_notifications_path %>
+    </h2>
+
+    <p class="govuk-body">Use this section to choose whether to receive notifications about applications.</p>
+
+  </div>
+
+  <div class="govuk-grid-column-one-half">
 
     <% if current_provider_user.authorisation.can_manage_users_for_at_least_one_provider? %>
       <h2 class="govuk-heading-m">

--- a/app/views/provider_interface/notifications/show.html.erb
+++ b/app/views/provider_interface/notifications/show.html.erb
@@ -1,0 +1,35 @@
+<%= content_for :browser_title, t('page_titles.provider.notifications') %>
+
+<% content_for :before_content do %>
+  <%= render BreadcrumbComponent.new(items: [
+    {
+      text: t('page_titles.provider.account'),
+      path: provider_interface_account_path
+    },
+    {
+      text: t('page_titles.provider.notifications')
+    }
+  ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+      <%= t('page_titles.provider.notifications') %>
+      <span class="govuk-caption-m govuk-!-margin-top-1">These are sent when an application is submitted, withdrawn, automatically rejected, accepted or declined.</span>
+    </h1>
+
+    <%= form_with model: current_provider_user, url: provider_interface_notifications_path, method: :put do |f| %>
+      <div class='govuk-form-group'>
+
+        <%= f.govuk_radio_buttons_fieldset :send_notifications, inline: true, legend: -> { nil} do %>
+          <%= f.govuk_radio_button :send_notifications, 'true', label: { text: 'On' } %>
+          <%= f.govuk_radio_button :send_notifications, 'false', label: { text: 'Off' } %>
+        <% end %>
+
+      </div>
+      <%= f.govuk_submit 'Save settings' %>
+    <% end %>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,7 @@ en:
       users: Users
       export_hesa_data: Export data for Higher Education Statistics Agency (HESA)
       export_application_data: Export data
+      notifications: Email notifications
     start_apply_again: Do you want to apply again?
     start_carry_over: Do you want to continue applying?
     start_carry_over_between_cycles: You can apply again

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -602,6 +602,7 @@ Rails.application.routes.draw do
       end
 
       resources :organisations, only: %i[index show], path: 'organisational-permissions'
+      resource :notifications, only: %i[show update], path: 'notification-settings'
     end
 
     scope path: '/provider-relationship-permissions' do

--- a/spec/system/provider_interface/account_page_spec.rb
+++ b/spec/system/provider_interface/account_page_spec.rb
@@ -5,8 +5,14 @@ RSpec.feature 'Viewing the provider user account page' do
 
   scenario 'Provider user visits their account page with various permissions' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_i_can_manage_organisations_but_not_users
+    given_i_cannot_manage_users_or_organisations
+
     and_i_sign_in_to_the_provider_interface
+
+    when_i_go_to_my_account
+    then_i_can_only_see_the_manage_notifications_link
+
+    given_i_can_manage_organisations_but_not_users
 
     when_i_go_to_my_account
     then_i_can_see_the_organisational_permissions_link_and_not_the_users_one
@@ -22,8 +28,21 @@ RSpec.feature 'Viewing the provider user account page' do
     provider_user_exists_in_apply_database
   end
 
-  def and_i_can_manage_organisations_but_not_users
+  def given_i_cannot_manage_users_or_organisations
     @provider_user = ProviderUser.last
+    @provider_user.provider_permissions.update_all(
+      manage_organisations: false,
+      manage_users: false,
+    )
+  end
+
+  def then_i_can_only_see_the_manage_notifications_link
+    expect(page).to have_content(t('page_titles.provider.notifications'))
+    expect(page).not_to have_content(t('page_titles.provider.users'))
+    expect(page).not_to have_content(t('page_titles.provider.org_permissions'))
+  end
+
+  def given_i_can_manage_organisations_but_not_users
     training_provider = Provider.find_by(code: 'ABC')
     ratifying_provider = Provider.find_by(code: 'DEF')
 

--- a/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_notifications_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing notifications' do
+  include DfESignInHelpers
+
+  scenario 'Provider can enable and disable email notifications' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_go_to_my_account
+    and_i_click_on_the_notification_settings_link
+
+    when_i_choose_to_receive_notifications
+    then_i_update_my_notification_preferences
+
+    when_i_choose_not_to_receive_notifications
+    then_i_update_my_notification_preferences
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def when_i_go_to_my_account
+    click_on t('page_titles.provider.account')
+  end
+
+  def and_i_click_on_the_notification_settings_link
+    click_on(t('page_titles.provider.notifications'))
+  end
+
+  def when_i_choose_to_receive_notifications
+    choose 'On'
+    click_on 'Save settings'
+  end
+
+  def then_i_update_my_notification_preferences
+    expect(page).to have_content 'Email notification settings saved'
+  end
+
+  def when_i_choose_not_to_receive_notifications
+    choose 'Off'
+    click_on 'Save settings'
+  end
+end


### PR DESCRIPTION
## Context
Enable provider users to control their email notifications

## Changes proposed in this pull request

Add a new notification settings page where provider users can check/uncheck a component to opt in or our of receiving email notifications.

<img width="1057" alt="account-page" src="https://user-images.githubusercontent.com/159200/102673178-fb291d00-418a-11eb-8dad-8b21b6d3c7dd.png">

<img width="1126" alt="notifications-page" src="https://user-images.githubusercontent.com/159200/102675044-e8651700-418f-11eb-82f1-4a23939e3c99.png">


## Link to Trello card

https://trello.com/c/hgYZ0Cqi/3026-provider-users-can-choose-whether-or-not-they-receive-emails-from-apply

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
