### PR TITLE
Add ability to edit candidate addresses

### DIFF
--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -109,6 +109,8 @@ module SupportInterface
       {
         key: 'Address',
         value: application_form.full_address,
+        action: 'address',
+        change_path: support_interface_application_form_edit_address_type_path(application_form),
       }
     end
 

--- a/app/controllers/support_interface/application_forms/address_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_details_controller.rb
@@ -4,13 +4,14 @@ module SupportInterface
       before_action :set_application_form
 
       def edit
-        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
+        @details_form = EditAddressDetailsForm.build_from_application_form(@application_form)
       end
 
       def update
         @application_form.assign_attributes(address_details_params)
-        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
-        if @details.save_address(@application_form)
+        @details_form = EditAddressDetailsForm.build_from_application_form(@application_form)
+
+        if @details_form.save_address(@application_form)
           flash[:success] = 'Address details updated'
           redirect_to support_interface_application_form_path(@application_form)
         else

--- a/app/controllers/support_interface/application_forms/address_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_details_controller.rb
@@ -8,8 +8,9 @@ module SupportInterface
       end
 
       def update
-        @application_form.assign_attributes(address_details_params)
-        @details_form = EditAddressDetailsForm.build_from_application_form(@application_form)
+        @details_form = EditAddressDetailsForm.new(
+          address_details_params.merge(address_type: @application_form.address_type),
+        )
 
         if @details_form.save_address(@application_form)
           flash[:success] = 'Address details updated'

--- a/app/controllers/support_interface/application_forms/address_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_details_controller.rb
@@ -1,0 +1,37 @@
+module SupportInterface
+  module ApplicationForms
+    class AddressDetailsController < SupportInterfaceController
+      def edit
+        @details = details_form
+      end
+
+      def update
+        application_form.assign_attributes(address_details_params)
+        @details = details_form
+        if @details.save_address(application_form)
+          flash[:success] = 'Address details updated'
+          redirect_to support_interface_application_form_path(application_form)
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def address_details_params
+        params.require(:support_interface_application_forms_edit_address_details_form).permit(
+          :address_line1, :address_line2, :address_line3, :address_line4, :postcode, :international_address, :audit_comment
+        )
+          .transform_values(&:strip)
+      end
+
+      def details_form
+        @details ||= EditAddressDetailsForm.build_from_application_form(application_form)
+      end
+
+      def application_form
+        @application_form ||= ApplicationForm.find(params[:application_form_id])
+      end
+    end
+  end
+end

--- a/app/controllers/support_interface/application_forms/address_details_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_details_controller.rb
@@ -1,16 +1,18 @@
 module SupportInterface
   module ApplicationForms
     class AddressDetailsController < SupportInterfaceController
+      before_action :set_application_form
+
       def edit
-        @details = details_form
+        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
       end
 
       def update
-        application_form.assign_attributes(address_details_params)
-        @details = details_form
-        if @details.save_address(application_form)
+        @application_form.assign_attributes(address_details_params)
+        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
+        if @details.save_address(@application_form)
           flash[:success] = 'Address details updated'
-          redirect_to support_interface_application_form_path(application_form)
+          redirect_to support_interface_application_form_path(@application_form)
         else
           render :edit
         end
@@ -19,18 +21,15 @@ module SupportInterface
     private
 
       def address_details_params
-        params.require(:support_interface_application_forms_edit_address_details_form).permit(
-          :address_line1, :address_line2, :address_line3, :address_line4, :postcode, :international_address, :audit_comment
-        )
-          .transform_values(&:strip)
+        StripWhitespace.from_hash params
+          .require(:support_interface_application_forms_edit_address_details_form)
+          .permit(
+            :address_line1, :address_line2, :address_line3, :address_line4, :postcode, :international_address, :audit_comment
+          )
       end
 
-      def details_form
-        @details ||= EditAddressDetailsForm.build_from_application_form(application_form)
-      end
-
-      def application_form
-        @application_form ||= ApplicationForm.find(params[:application_form_id])
+      def set_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
       end
     end
   end

--- a/app/controllers/support_interface/application_forms/address_type_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_type_controller.rb
@@ -1,14 +1,16 @@
 module SupportInterface
   module ApplicationForms
     class AddressTypeController < SupportInterfaceController
+      before_action :set_application_form
+
       def edit
-        @details = details_form
+        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
       end
 
       def update
-        application_form.assign_attributes(address_type_params)
-        @details = details_form
-        if @details.save_address_type(application_form)
+        @application_form.assign_attributes(address_type_params)
+        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
+        if @details.save_address_type(@application_form)
           redirect_to support_interface_application_form_edit_address_details_path
         else
           render :edit
@@ -24,12 +26,8 @@ module SupportInterface
         )
       end
 
-      def details_form
-        @details ||= EditAddressDetailsForm.build_from_application_form(application_form)
-      end
-
-      def application_form
-        @application_form ||= ApplicationForm.find(params[:application_form_id])
+      def set_application_form
+        @application_form = ApplicationForm.find(params[:application_form_id])
       end
     end
   end

--- a/app/controllers/support_interface/application_forms/address_type_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_type_controller.rb
@@ -8,8 +8,7 @@ module SupportInterface
       end
 
       def update
-        @application_form.assign_attributes(address_type_params)
-        @details_form = EditAddressDetailsForm.build_from_application_form(@application_form)
+        @details_form = EditAddressDetailsForm.new(address_type_params)
         if @details_form.save_address_type(@application_form)
           redirect_to support_interface_application_form_edit_address_details_path
         else

--- a/app/controllers/support_interface/application_forms/address_type_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_type_controller.rb
@@ -4,13 +4,13 @@ module SupportInterface
       before_action :set_application_form
 
       def edit
-        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
+        @details_form = EditAddressDetailsForm.build_from_application_form(@application_form)
       end
 
       def update
         @application_form.assign_attributes(address_type_params)
-        @details = EditAddressDetailsForm.build_from_application_form(@application_form)
-        if @details.save_address_type(@application_form)
+        @details_form = EditAddressDetailsForm.build_from_application_form(@application_form)
+        if @details_form.save_address_type(@application_form)
           redirect_to support_interface_application_form_edit_address_details_path
         else
           render :edit

--- a/app/controllers/support_interface/application_forms/address_type_controller.rb
+++ b/app/controllers/support_interface/application_forms/address_type_controller.rb
@@ -1,0 +1,36 @@
+module SupportInterface
+  module ApplicationForms
+    class AddressTypeController < SupportInterfaceController
+      def edit
+        @details = details_form
+      end
+
+      def update
+        application_form.assign_attributes(address_type_params)
+        @details = details_form
+        if @details.save_address_type(application_form)
+          redirect_to support_interface_application_form_edit_address_details_path
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def address_type_params
+        params.require(:support_interface_application_forms_edit_address_details_form).permit(
+          :address_type,
+          :country,
+        )
+      end
+
+      def details_form
+        @details ||= EditAddressDetailsForm.build_from_application_form(application_form)
+      end
+
+      def application_form
+        @application_form ||= ApplicationForm.find(params[:application_form_id])
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_address_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_address_details_form.rb
@@ -1,0 +1,79 @@
+module SupportInterface
+  module ApplicationForms
+    class EditAddressDetailsForm
+      include ActiveModel::Model
+
+      attr_accessor :address_line1, :address_line2, :address_line3,
+                    :address_line4, :postcode, :address_type, :country, :international_address, :audit_comment
+
+      validates :address_line1, :address_line3, :postcode, presence: true, on: :address, if: :uk?
+      validates :international_address, presence: true, on: :address, if: :international?
+      validates :address_type, presence: true, on: :address_type
+      validates :country, presence: true, on: :address_type, if: :international?
+
+      validates :address_line1, :address_line2, :address_line3, :address_line4,
+                length: { maximum: 50 }, on: :address
+
+      validates :postcode, postcode: true, on: :address
+      validates :audit_comment, presence: true, on: :address
+
+      def self.build_from_application_form(application_form)
+        new(
+          address_line1: application_form.address_line1,
+          address_line2: application_form.address_line2,
+          address_line3: application_form.address_line3,
+          address_line4: application_form.address_line4,
+          postcode: application_form.postcode,
+          address_type: application_form.address_type || 'GB',
+          country: application_form.country,
+          international_address: application_form.international_address,
+          audit_comment: application_form.audit_comment,
+        )
+      end
+
+      def save_address(application_form)
+        return false unless valid?(:address)
+
+        if uk?
+          application_form.update!(
+            address_line1: address_line1,
+            address_line2: address_line2,
+            address_line3: address_line3,
+            address_line4: address_line4,
+            postcode: postcode&.upcase,
+            country: 'GB',
+            international_address: nil,
+            audit_comment: audit_comment,
+          )
+        else
+          application_form.update(
+            address_line1: nil,
+            address_line2: nil,
+            address_line3: nil,
+            address_line4: nil,
+            postcode: nil,
+            international_address: international_address,
+            audit_comment: audit_comment,
+          )
+        end
+      end
+
+      def save_address_type(application_form)
+        return false unless valid?(:address_type)
+
+        application_form.update(
+          address_type: address_type,
+          country: country.presence || 'GB',
+        )
+      end
+
+      def uk?
+        address_type == 'uk'
+      end
+
+      def international?
+        address_type == 'international'
+      end
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/address_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_details/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :browser_title, title_with_error_prefix('Edit address details', @details.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @details, url: support_interface_application_form_update_address_details_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_fieldset legend: {text: t('support_interface.edit_address_details_form.address_details.label'), size: 'xl', tag: 'h1'} do %>
+        <% if @details.uk? %>
+          <%= f.govuk_text_field :address_line1, label: -> { safe_join([t('application_form.contact_information.address_line1.label'), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
+          <%= f.govuk_text_field :address_line2, label: {text: t('application_form.contact_information.address_line2.label'), hidden: true}, autocomplete: 'address-line2' %>
+          <%= f.govuk_text_field :address_line3, label: {text: t('application_form.contact_information.address_line3.label')}, width: 'two-thirds', autocomplete: 'address-level2' %>
+          <%= f.govuk_text_field :address_line4, label: {text: t('application_form.contact_information.address_line4.label')}, width: 'two-thirds', autocomplete: 'address-level1' %>
+          <%= f.govuk_text_field :postcode, label: {text: t('application_form.contact_information.postcode.label')}, width: 10, autocomplete: 'postal-code' %>
+        <% else %>
+          <%= f.govuk_text_area :international_address, label: {text: t('support_interface.edit_address_details_form.international_address.label')}, autocomplete: 'address' %>
+        <% end %>
+
+      <% end %>
+      <%= f.govuk_text_field :audit_comment, label: {text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm'}, hint: {text: t('support_interface.edit_address_details_form.audit_comment.hint')} %>
+
+      <%= f.govuk_submit t('application_form.contact_information.address.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/address_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_details/edit.html.erb
@@ -1,13 +1,13 @@
-<% content_for :browser_title, title_with_error_prefix('Edit address details', @details.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Edit address details', @details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @details, url: support_interface_application_form_update_address_details_path do |f| %>
+    <%= form_with model: @details_form, url: support_interface_application_form_update_address_details_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: {text: t('support_interface.edit_address_details_form.address_details.label'), size: 'xl', tag: 'h1'} do %>
-        <% if @details.uk? %>
+        <% if @details_form.uk? %>
           <%= f.govuk_text_field :address_line1, label: -> { safe_join([t('application_form.contact_information.address_line1.label'), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
           <%= f.govuk_text_field :address_line2, label: {text: t('application_form.contact_information.address_line2.label'), hidden: true}, autocomplete: 'address-line2' %>
           <%= f.govuk_text_field :address_line3, label: {text: t('application_form.contact_information.address_line3.label')}, width: 'two-thirds', autocomplete: 'address-level2' %>

--- a/app/views/support_interface/application_forms/address_type/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_type/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :browser_title, title_with_error_prefix('Edit address details', @details.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @details, url: support_interface_application_form_update_address_type_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('support_interface.edit_address_details_form.address_types.label'), size: 'xl' } do %>
+        <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_information.address_type.values.uk') } %>
+        <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_information.address_type.values.international') }, link_errors: true do %>
+          <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_information.country.label') } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit t('application_form.contact_information.address_type.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/address_type/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_type/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :browser_title, title_with_error_prefix('Edit address details', @details.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Edit address details', @details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @details, url: support_interface_application_form_update_address_type_path do |f| %>
+    <%= form_with model: @details_form, url: support_interface_application_form_update_address_type_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('support_interface.edit_address_details_form.address_types.label'), size: 'xl' } do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,6 +284,25 @@ en:
               blank: You must provide an audit comment
             send_emails:
               blank: You must select an email option
+        support_interface/application_forms/edit_address_details_form:
+          attributes:
+            address_line1:
+              blank: Enter your building and street
+              too_long: Building and street must be %{count} characters or fewer
+            address_line2:
+              too_long: Building and street must be %{count} characters or fewer
+            address_line3:
+              blank: Enter your town or city
+              too_long: Town or city must be %{count} characters or fewer
+            address_line4:
+              too_long: County must be %{count} characters or fewer
+            postcode:
+              blank: Enter a postcode
+              invalid: Enter a real postcode (for example, BN1 1AA)
+            international_address:
+              blank: Enter your address
+            audit_comment:
+              blank: You must provide an audit comment
         provider_interface/pick_response_form:
           attributes:
             decision:

--- a/config/locales/support_interface.yml
+++ b/config/locales/support_interface.yml
@@ -20,6 +20,16 @@ en:
         hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
       send_emails:
         label: Send notification emails to candidate and referee?
+    edit_address_details_form:
+      address_types:
+        label: Where does the candidate live?
+      address_details:
+        label: What is the candidate’s address?
+      international_address:
+        label: International address
+      audit_comment:
+        label: Audit log comment
+        hint: This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here
   activemodel:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -673,6 +673,12 @@ Rails.application.routes.draw do
 
       get '/references/:reference_id/feedback' => 'application_forms/references#edit_reference_feedback', as: :application_form_edit_reference_feedback
       post '/references/:reference_id/feedback' => 'application_forms/references#update_reference_feedback', as: :application_form_update_reference_feedback
+
+      get '/applicant-address-type' => 'application_forms/address_type#edit', as: :application_form_edit_address_type
+      post '/applicant-address-type' => 'application_forms/address_type#update', as: :application_form_update_address_type
+
+      get '/applicant-address-details' => 'application_forms/address_details#edit', as: :application_form_edit_address_details
+      post '/applicant-address-details' => 'application_forms/address_details#update', as: :application_form_update_address_details
     end
 
     get '/ucas-matches' => 'ucas_matches#index'

--- a/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
       application_form = build_stubbed(:application_form, data)
-      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
 
-      expect(details).to have_attributes(data)
+      expect(details_form).to have_attributes(data)
     end
   end
 
   describe '#save_address' do
     it 'returns false if not valid' do
-      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.new
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new
 
-      expect(details.save_address(ApplicationForm.new)).to eq(false)
+      expect(details_form.save_address(ApplicationForm.new)).to eq(false)
     end
 
     it 'updates the provided ApplicationForm with the address fields if valid' do
@@ -38,11 +38,11 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
       application_form = build(:application_form, data)
-      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
       data[:postcode] = 'BN1 1AA'
       data.except!(:audit_comment)
 
-      expect(details.save_address(application_form)).to eq(true)
+      expect(details_form.save_address(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
       expect(application_form.international_address).to be_nil
     end
@@ -55,10 +55,10 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
       application_form = build(:application_form, data)
-      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
       data.except!(:audit_comment)
 
-      expect(details.save_address(application_form)).to eq(true)
+      expect(details_form.save_address(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
       expect(application_form.address_line1).to be_nil
       expect(application_form.address_line2).to be_nil
@@ -74,9 +74,9 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         address_type: 'uk',
       }
       application_form = build(:application_form, data)
-      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
 
-      expect(details.save_address_type(application_form)).to eq(true)
+      expect(details_form.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
     end
 
@@ -86,9 +86,9 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         country: 'India',
       }
       application_form = build(:application_form, data)
-      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
 
-      expect(details.save_address_type(application_form)).to eq(true)
+      expect(details_form.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
     end
 
@@ -97,9 +97,9 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         address_type: 'international',
       }
       application_form = build(:application_form, data)
-      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
 
-      expect(details.save_address_type(application_form)).to eq(false)
+      expect(details_form.save_address_type(application_form)).to eq(false)
     end
   end
 

--- a/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type: :model do
+  describe '.build_from_application_form' do
+    it 'creates an object based on the provided ApplicationForm' do
+      data = {
+        address_line1: Faker::Address.street_name,
+        address_line2: Faker::Address.street_address,
+        address_line3: Faker::Address.city,
+        address_line4: 'United Kingdom',
+        postcode: Faker::Address.postcode,
+        international_address: nil,
+        audit_comment: 'Updated as part of Zendesk ticket 12345',
+      }
+      application_form = build_stubbed(:application_form, data)
+      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+
+      expect(details).to have_attributes(data)
+    end
+  end
+
+  describe '#save_address' do
+    it 'returns false if not valid' do
+      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.new
+
+      expect(details.save_address(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm with the address fields if valid' do
+      data = {
+        address_line1: Faker::Address.street_name,
+        address_line2: Faker::Address.street_address,
+        address_line3: Faker::Address.city,
+        address_line4: 'United Kingdom',
+        postcode: 'bn1 1aa',
+        address_type: 'uk',
+        international_address: nil,
+        audit_comment: 'Updated as part of Zendesk ticket 12345',
+      }
+      application_form = build(:application_form, data)
+      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      data[:postcode] = 'BN1 1AA'
+      data.except!(:audit_comment)
+
+      expect(details.save_address(application_form)).to eq(true)
+      expect(application_form).to have_attributes(data)
+      expect(application_form.international_address).to be_nil
+    end
+
+    it 'updates the provided ApplicationForm with the international address field if valid' do
+      data = {
+        address_type: 'international',
+        international_address: 'Rue de Rivoli, 75001 Paris',
+        country: 'France',
+        audit_comment: 'Updated as part of Zendesk ticket 12345',
+      }
+      application_form = build(:application_form, data)
+      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      data.except!(:audit_comment)
+
+      expect(details.save_address(application_form)).to eq(true)
+      expect(application_form).to have_attributes(data)
+      expect(application_form.address_line1).to be_nil
+      expect(application_form.address_line2).to be_nil
+      expect(application_form.address_line3).to be_nil
+      expect(application_form.address_line4).to be_nil
+      expect(application_form.postcode).to be_nil
+    end
+  end
+
+  describe '#save_address_type' do
+    it 'updates the provided ApplicationForm with the address type fields for a valid UK address' do
+      data = {
+        address_type: 'uk',
+      }
+      application_form = build(:application_form, data)
+      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+
+      expect(details.save_address_type(application_form)).to eq(true)
+      expect(application_form).to have_attributes(data)
+    end
+
+    it 'updates the provided ApplicationForm with the address type fields for a valid international address' do
+      data = {
+        address_type: 'international',
+        country: 'India',
+      }
+      application_form = build(:application_form, data)
+      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+
+      expect(details.save_address_type(application_form)).to eq(true)
+      expect(application_form).to have_attributes(data)
+    end
+
+    it 'returns validation errors for an invalid international address' do
+      data = {
+        address_type: 'international',
+      }
+      application_form = build(:application_form, data)
+      details = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+
+      expect(details.save_address_type(application_form)).to eq(false)
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:address_type).on(:address_type) }
+
+    context 'for a UK address' do
+      subject(:form) { described_class.new(address_type: 'uk') }
+
+      it { is_expected.to validate_presence_of(:address_line1).on(:address) }
+      it { is_expected.to validate_presence_of(:address_line3).on(:address) }
+      it { is_expected.to validate_presence_of(:postcode).on(:address) }
+      it { is_expected.to validate_presence_of(:audit_comment).on(:address) }
+      it { is_expected.not_to validate_presence_of(:international_address).on(:address) }
+    end
+
+    context 'for an international address' do
+      subject(:form) { described_class.new(address_type: 'international') }
+
+      it { is_expected.to validate_presence_of(:country).on(:address_type) }
+      it { is_expected.to validate_presence_of(:international_address).on(:address) }
+      it { is_expected.to validate_presence_of(:audit_comment).on(:address) }
+      it { is_expected.not_to validate_presence_of(:address_line1).on(:address) }
+      it { is_expected.not_to validate_presence_of(:address_line3).on(:address) }
+      it { is_expected.not_to validate_presence_of(:postcode).on(:address) }
+    end
+
+    it { is_expected.to validate_length_of(:address_line1).is_at_most(50).on(:address) }
+    it { is_expected.to validate_length_of(:address_line2).is_at_most(50).on(:address) }
+    it { is_expected.to validate_length_of(:address_line3).is_at_most(50).on(:address) }
+    it { is_expected.to validate_length_of(:address_line4).is_at_most(50).on(:address) }
+
+    it { is_expected.to allow_value('SW1P 3BT').for(:postcode).on(:address) }
+    it { is_expected.not_to allow_value('MUCH WOW').for(:postcode).on(:address) }
+  end
+end

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature 'Editing reference' do
+RSpec.feature 'Editing address' do
   include DfESignInHelpers
 
-  scenario 'Support user edits reference', with_audited: true do
+  scenario 'Support user edits address', with_audited: true do
     given_i_am_a_support_user
     and_an_application_exists
 

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing reference' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits reference', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_address
+    then_i_should_see_the_address_type_page
+
+    when_i_select_uk
+    then_i_should_see_the_uk_address_details_form
+
+    when_i_submit_the_update_form
+    then_i_should_see_blank_audit_comment_error_message
+
+    when_i_complete_the_details_form
+    and_i_submit_the_update_form
+    then_i_should_see_a_flash_message
+    and_i_should_see_the_new_details
+    and_i_should_see_my_details_comment_in_the_audit_log
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_address
+    and_i_select_outside_the_uk
+    then_i_should_see_the_international_address_details_form
+
+    when_i_submit_the_update_form
+    then_i_should_see_blank_error_messages
+
+    when_i_fill_in_an_international_address
+    and_i_submit_the_update_form
+    then_i_should_see_a_flash_message
+    and_i_should_see_the_new_international_address_details
+    and_i_should_see_my_international_address_details_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form, :with_completed_references)
+    create(:reference, :feedback_requested, name: 'Dumbledore', email_address: 'a.dumbledore@hogwarts.ac.uk', relationship: 'Headmaster', application_form: @form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_next_to_address
+    all('.govuk-summary-list__actions')[5].click_link 'Change'
+  end
+
+  def then_i_should_see_the_address_type_page
+    expect(page).to have_content('Where does the candidate live?')
+  end
+
+  def when_i_select_uk
+    choose 'In the UK'
+    click_button 'Save and continue'
+  end
+
+  def then_i_should_see_the_uk_address_details_form
+    expect(page).to have_content('What is the candidate’s address?')
+    expect(page).to have_content('Building and street')
+  end
+
+  def when_i_submit_the_update_form
+    click_button 'Save and continue'
+  end
+  alias_method :and_i_submit_the_update_form, :when_i_submit_the_update_form
+
+  def then_i_should_see_blank_audit_comment_error_message
+    expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_address_details_form.attributes.audit_comment.blank')
+  end
+
+  def when_i_complete_the_details_form
+    find(:css, "[autocomplete='address-line1']").fill_in with: '42 Much Wow Street'
+    fill_in t('application_form.contact_information.address_line3.label'), with: 'London'
+    fill_in t('application_form.contact_information.postcode.label'), with: 'SW1P 3BT'
+    fill_in 'support_interface_application_forms_edit_address_details_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #12345'
+  end
+
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'Address details updated'
+  end
+
+  def and_i_should_see_the_new_details
+    expect(page).to have_content '42 Much Wow Street'
+    expect(page).to have_content 'London'
+    expect(page).to have_content 'SW1P 3BT'
+  end
+
+  def and_i_should_see_my_details_comment_in_the_audit_log
+    click_on 'History'
+    expect(page).to have_content 'Updated as part of Zen Desk ticket #12345'
+  end
+
+  def and_i_select_outside_the_uk
+    choose 'Outside the UK'
+    select('France', from: t('application_form.contact_information.country.label'))
+    click_button 'Save and continue'
+  end
+
+  def then_i_should_see_the_international_address_details_form
+    expect(page).to have_content('International address')
+  end
+
+  def then_i_should_see_blank_error_messages
+    expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_address_details_form.attributes.international_address.blank')
+    expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_address_details_form.attributes.audit_comment.blank')
+  end
+
+  def when_i_fill_in_an_international_address
+    fill_in t('support_interface.edit_address_details_form.international_address.label'), with: 'Rue de Rivoli, 75001 Paris'
+    fill_in 'support_interface_application_forms_edit_address_details_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #56789'
+  end
+
+  def and_i_should_see_the_new_international_address_details
+    expect(page).to have_content 'Rue de Rivoli, 75001 Paris'
+    expect(page).to have_content 'France'
+  end
+
+  def and_i_should_see_my_international_address_details_comment_in_the_audit_log
+    click_on 'History'
+    expect(page).to have_content 'Updated as part of Zen Desk ticket #56789'
+  end
+end

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -52,7 +52,8 @@ RSpec.feature 'Editing address' do
   end
 
   def and_i_click_the_change_link_next_to_address
-    all('.govuk-summary-list__actions')[5].click_link 'Change'
+    print page.body
+    all('.govuk-summary-list__actions')[6].click_link 'Change'
   end
 
   def then_i_should_see_the_address_type_page


### PR DESCRIPTION
## Context

We are increasing the support UI to enable support users to make changes more easily. This PR looks add editing address details.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/33458055/102476023-7f2bb980-4052-11eb-9472-3c7bb6b655fe.png)

![image](https://user-images.githubusercontent.com/33458055/102476044-8783f480-4052-11eb-9e4d-c94695722ed5.png)

![image](https://user-images.githubusercontent.com/33458055/102476074-95397a00-4052-11eb-86cb-a9cf58cc99a4.png)

![image](https://user-images.githubusercontent.com/33458055/102476114-a08ca580-4052-11eb-8b10-c31aa8b93ee2.png)

![image](https://user-images.githubusercontent.com/33458055/102476183-b4d0a280-4052-11eb-929c-ee56e683e8fb.png)

![image](https://user-images.githubusercontent.com/33458055/102476219-c0bc6480-4052-11eb-82da-cfd696e83bf1.png)


## Guidance to review

@stevehook is currently working on refactoring international addresses. We will build on his work to offer both new and old forms on the international address details page to help support users migrate old addresses to the new format.

I've borrowed a lot from the existing flow in the candidate interface. It might be worth peeking at the `contact_details_form` and the associated system and form specs.

## Link to Trello card

https://trello.com/c/LrAuSaZs/2687-expand-the-personal-details-review-section-in-the-support-ui-address-incl-international

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
