### PR TITLE
Fix typo in migration

### DIFF
--- a/db/migrate/20201217114113_backfill_user_id_and_user_type_columns.rb
+++ b/db/migrate/20201217114113_backfill_user_id_and_user_type_columns.rb
@@ -3,7 +3,7 @@ class BackfillUserIdAndUserTypeColumns < ActiveRecord::Migration[6.0]
     AuthenticationToken.all.each do |token|
       token.update!(
         user_id: token.authenticable_id,
-        uder_type: token.authenticable_type,
+        user_type: token.authenticable_type,
       )
     end
   end


### PR DESCRIPTION
## Context

I accidentally typoed in a data migration and it's broken master

## Changes proposed in this pull request

- fix the typo

 
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
