### PR TITLE
Add an api key to local dev and review app data

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -38,6 +38,9 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   puts 'Creating users for providers 1N1, 24P, 1JB, D39 with various permission combinations...'
   CreateExampleProviderUsersWithPermissions.call
 
+  puts 'Generating a Vendor API token...'
+  VendorAPIToken.create_with_random_token!(provider: admin_provider_user.providers.first)
+
   Rake::Task['generate_test_applications'].invoke
 end
 


### PR DESCRIPTION
## Context

It seems like a good idea to add at least one API key to our test data set, which is used for both local development and review apps. This should hopefully catch any buggy migrations involving api key data.

## Changes proposed in this pull request

No UI changes.

## Guidance to review

Should be an easy task.

## Link to Trello card

No Trello card.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
