### PR TITLE
Add a support UI filter for provider users who have never signed in

### DIFF
--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -5,6 +5,8 @@ module SupportInterface
         .includes(providers: %i[training_provider_permissions ratifying_provider_permissions])
         .page(params[:page] || 1).per(30)
 
+      @provider_users = scope_by_use_of_service
+
       if params[:q]
         @provider_users = @provider_users.where("CONCAT(first_name, ' ', last_name, ' ', email_address) ILIKE ?", "%#{params[:q]}%")
       end
@@ -77,6 +79,16 @@ module SupportInterface
     end
 
   private
+
+    def scope_by_use_of_service
+      if params[:use_of_service] == %w[never_signed_in]
+        @provider_users.where(last_signed_in_at: nil)
+      elsif params[:use_of_service] == %w[has_signed_in]
+        @provider_users.where.not(last_signed_in_at: nil)
+      else
+        @provider_users
+      end
+    end
 
     def provider_user_params
       params.require(:support_interface_provider_user_form)

--- a/app/models/support_interface/provider_users_filter.rb
+++ b/app/models/support_interface/provider_users_filter.rb
@@ -9,6 +9,24 @@ module SupportInterface
     def filters
       [
         {
+          type: :checkboxes,
+          heading: 'Use of service',
+          name: 'use_of_service',
+          options: [
+            {
+              value: 'has_signed_in',
+              label: 'Has signed in',
+              checked: applied_filters[:use_of_service]&.include?('has_signed_in'),
+            },
+            {
+              value: 'never_signed_in',
+              label: 'Never signed in',
+              checked: applied_filters[:use_of_service]&.include?('never_signed_in'),
+            },
+
+          ],
+        },
+        {
           type: :search,
           heading: 'Name or email',
           value: applied_filters[:q],

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -152,7 +152,10 @@ RSpec.feature 'Managing provider users' do
   end
 
   def when_i_filter_the_list_of_provider_users
+    expect(page).to have_field('Has signed in')
+
     fill_in :q, with: 'harrison'
+    check 'Never signed in'
     click_on 'Apply filters'
   end
 


### PR DESCRIPTION
## Context

We'd like to be able to quickly identify provider users who have never signed in.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a filter to easily identify provider users who have / have not signed in.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/102889216-242f0380-4452-11eb-8118-d1379940f272.png)

## Guidance to review

Amended to use dual checkboxes with the condition that if both are selected, the filter has no effect.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/2UFg04ud/3130-add-a-filter-to-show-users-in-support-who-have-never-signed-into-manage

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
