### PR TITLE
Move UCASMatch file download check to worker

### DIFF
--- a/app/workers/ucas_integration_check.rb
+++ b/app/workers/ucas_integration_check.rb
@@ -1,0 +1,17 @@
+class UCASIntegrationCheck
+  include Sidekiq::Worker
+
+  def perform
+    detect_ucas_match_file_upload_failure
+  end
+
+  def detect_ucas_match_file_upload_failure
+    file_download = UCASMatching::FileDownloadCheck.new
+    file_download.check
+    return if file_download.success?
+
+    Raven.capture_exception(UCASMatchingFileDownloadFailure.new(file_download.message))
+  end
+
+  class UCASMatchingFileDownloadFailure < StandardError; end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -37,6 +37,12 @@ class Clock
     end
   end
 
+  every(1.day, 'UCASIntegrationCheck', at: '10:00') do
+    return unless HostingEnvironment.productioun?
+
+    UCASIntegrationCheck.perform_async if Time.zone.yesterday.weekday?
+  end
+
   every(1.hour, 'SyncAllFromTeacherTrainingPublicAPI') do
     if FeatureFlag.active?(:sync_from_public_teacher_training_api)
       TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -34,6 +34,5 @@ OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
 OkComputer::Registry.register 'find_sync', FindSyncCheck.new
 OkComputer::Registry.register 'version', OkComputer::AppVersionCheck.new
-OkComputer::Registry.register 'ucas_matching_file_download', UCASMatching::FileDownloadCheck.new if HostingEnvironment.production?
 
 OkComputer.make_optional %w[version]

--- a/spec/workers/ucas_integration_check_spec.rb
+++ b/spec/workers/ucas_integration_check_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe UCASIntegrationCheck do
+  before { allow(Raven).to receive(:capture_exception) }
+
+  describe '#perform' do
+    context 'detect_ucas_match_upload_failure' do
+      it 'detects a ucas match file upload failure' do
+        UCASMatching::FileDownloadCheck.set_last_sync(3.days.ago)
+
+        UCASIntegrationCheck.new.perform
+
+        expect(Raven).to have_received(:capture_exception).with(
+          UCASIntegrationCheck::UCASMatchingFileDownloadFailure.new(
+            'There was no UCAS file download taking place yesterday',
+          ),
+        )
+      end
+
+      it 'does not raise an error if the file wa uploaded successfully' do
+        UCASMatching::FileDownloadCheck.set_last_sync(1.hour.ago)
+
+        UCASIntegrationCheck.new.perform
+
+        expect(Raven).not_to have_received(:capture_exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move check for ucas match file download outside of OKComputer and follow DetectInvariant pattern

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
