### PR TITLE
Remove duplicate assignments to @application_form

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -253,9 +253,8 @@ class CandidateMailer < ApplicationMailer
 
   def course_unavailable_notification(application_choice, reason)
     @application_choice = application_choice
-    @application_form = application_choice.application_form
     email_for_candidate(
-      @application_form,
+      application_choice.application_form,
       subject: I18n.t!(
         "candidate_mailer.course_unavailable_notification.subject.#{reason}",
         course_name: application_choice.course_option.course.name_and_code,
@@ -267,13 +266,12 @@ class CandidateMailer < ApplicationMailer
   end
 
   def offer_accepted(application_choice)
-    @application_form = application_choice.application_form
     @course_name_and_code = application_choice.offered_option.course.name_and_code
     @provider_name = application_choice.offered_option.provider.name
     @start_date = application_choice.offered_option.course.start_date.to_s(:month_and_year)
 
     email_for_candidate(
-      @application_form,
+      application_choice.application_form,
       subject: I18n.t!('candidate_mailer.offer_accepted.subject', {
         course_name_and_code: @course_name_and_code,
         provider_name: @provider_name,
@@ -283,69 +281,63 @@ class CandidateMailer < ApplicationMailer
   end
 
   def ucas_match_initial_email_duplicate_applications(application_choice)
-    @application_form = application_choice.application_form
     @course_name_and_code = application_choice.course_option.course.name_and_code
     @provider_name = application_choice.course_option.course.provider.name
     @date_to_withdraw_application_by = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
 
     email_for_candidate(
-      @application_form,
+      application_choice.application_form,
       subject: I18n.t!('candidate_mailer.ucas_match_initial_email.duplicate_applications.subject'),
     )
   end
 
   def ucas_match_initial_email_multiple_acceptances(candidate)
-    @application_form = candidate.application_forms.first
     @date_to_withdraw_application_by = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
 
     email_for_candidate(
-      @application_form,
+      candidate.current_application,
       subject: I18n.t!('candidate_mailer.ucas_match_initial_email.multiple_acceptances.subject'),
     )
   end
 
   def ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match)
-    @application_form = application_choice.application_form
     @course_name_and_code = application_choice.course_option.course.name_and_code
     @provider_name = application_choice.course_option.course.provider.name
     @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
     @request_ucas_withdrawal_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
 
     email_for_candidate(
-      @application_form,
+      application_choice.application_form,
       subject: I18n.t!('candidate_mailer.ucas_match_reminder_email.duplicate_applications.subject'),
     )
   end
 
   def ucas_match_reminder_email_multiple_acceptances(ucas_match)
-    @application_form = ucas_match.candidate.current_application
     @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
     @request_ucas_withdrawal_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
 
     email_for_candidate(
-      @application_form,
+      ucas_match.candidate.current_application,
       subject: I18n.t!('candidate_mailer.ucas_match_reminder_email.multiple_acceptances.subject'),
     )
   end
 
   def ucas_match_resolved_on_ucas_email(application_choice)
-    @application_form = application_choice.application_form
     @course_name_and_code = application_choice.offered_option.course.name_and_code
     @provider_name = application_choice.offered_option.provider.name
 
     email_for_candidate(
-      @application_form,
+      application_choice.application_form,
       subject: I18n.t!('candidate_mailer.ucas_match.resolved_on_ucas.subject'),
     )
   end
 
   def ucas_match_resolved_on_apply_email(application_choice)
-    @application_form = application_choice.application_form
     @course_name_and_code = application_choice.offered_option.course.name_and_code
     @provider_name = application_choice.offered_option.provider.name
 
     email_for_candidate(
-      @application_form,
+      application_choice.application_form,
       subject: I18n.t!('candidate_mailer.ucas_match.resolved_on_apply.subject'),
     )
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
   end
 
-  describe '#offer_accepted' do
+  describe '.offer_accepted' do
     def build_stubbed_application_form
       build_stubbed(
         :application_form,


### PR DESCRIPTION
Remove assignments to @application_form as `email_for_candidate` [takes care of that](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/mailers/candidate_mailer.rb#L379).