### PR TITLE
Add international addresses to Support UI

### DIFF
--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -114,10 +114,34 @@ module SupportInterface
     def address_row
       {
         key: 'Address',
-        value: application_form.full_address,
+        value: full_address,
         action: 'address',
         change_path: support_interface_application_form_edit_address_type_path(application_form),
       }
+    end
+
+    def full_address
+      if @application_form.address_type == 'uk'
+        local_address.reject(&:blank?)
+      elsif @application_form.address_line1.present?
+        local_address.concat([COUNTRIES[@application_form.country]]).reject(&:blank?)
+      else
+        [
+          @application_form.international_address,
+          COUNTRIES[@application_form.country],
+        ]
+            .reject(&:blank?)
+      end
+    end
+
+    def local_address
+      [
+        @application_form.address_line1,
+        @application_form.address_line2,
+        @application_form.address_line3,
+        @application_form.address_line4,
+        @application_form.postcode,
+      ]
     end
 
     attr_reader :application_form

--- a/app/forms/support_interface/application_forms/edit_address_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_address_details_form.rb
@@ -42,10 +42,10 @@ module SupportInterface
           address_line3: address_line3,
           address_line4: address_line4,
           postcode: postcode&.upcase,
-          international_address: nil,
           audit_comment: audit_comment,
         }
         attrs[:country] = 'GB' if uk?
+        attrs[:international_address] = international_address if international?
         application_form.update(attrs)
       end
 

--- a/app/forms/support_interface/application_forms/edit_address_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_address_details_form.rb
@@ -3,18 +3,20 @@ module SupportInterface
     class EditAddressDetailsForm
       include ActiveModel::Model
 
-      attr_accessor :address_line1, :address_line2, :address_line3,
-                    :address_line4, :postcode, :address_type, :country, :international_address, :audit_comment
+      attr_accessor :address_line1, :address_line2, :address_line3, :address_line4,
+                    :postcode, :address_type, :country, :international_address, :audit_comment
 
       validates :address_line1, :address_line3, :postcode, presence: true, on: :address, if: :uk?
-      validates :international_address, presence: true, on: :address, if: :international?
+
+      validates :address_line1, presence: true, on: :address, if: :international?
+
       validates :address_type, presence: true, on: :address_type
       validates :country, presence: true, on: :address_type, if: :international?
 
       validates :address_line1, :address_line2, :address_line3, :address_line4,
                 length: { maximum: 50 }, on: :address
 
-      validates :postcode, postcode: true, on: :address
+      validates :postcode, postcode: true, on: :address, if: :uk?
       validates :audit_comment, presence: true, on: :address
 
       def self.build_from_application_form(application_form)
@@ -34,28 +36,17 @@ module SupportInterface
       def save_address(application_form)
         return false unless valid?(:address)
 
-        if uk?
-          application_form.update!(
-            address_line1: address_line1,
-            address_line2: address_line2,
-            address_line3: address_line3,
-            address_line4: address_line4,
-            postcode: postcode&.upcase,
-            country: 'GB',
-            international_address: nil,
-            audit_comment: audit_comment,
-          )
-        else
-          application_form.update(
-            address_line1: nil,
-            address_line2: nil,
-            address_line3: nil,
-            address_line4: nil,
-            postcode: nil,
-            international_address: international_address,
-            audit_comment: audit_comment,
-          )
-        end
+        attrs = {
+          address_line1: address_line1,
+          address_line2: address_line2,
+          address_line3: address_line3,
+          address_line4: address_line4,
+          postcode: postcode&.upcase,
+          international_address: nil,
+          audit_comment: audit_comment,
+        }
+        attrs[:country] = 'GB' if uk?
+        application_form.update(attrs)
       end
 
       def save_address_type(application_form)
@@ -63,7 +54,7 @@ module SupportInterface
 
         application_form.update(
           address_type: address_type,
-          country: country.presence || 'GB',
+          country: country.presence,
         )
       end
 
@@ -73,6 +64,10 @@ module SupportInterface
 
       def international?
         address_type == 'international'
+      end
+
+      def label_for(attr)
+        I18n.t("application_form.contact_information.#{attr}.#{address_type}.label")
       end
     end
   end

--- a/app/views/support_interface/application_forms/address_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_details/edit.html.erb
@@ -8,7 +8,7 @@
 
       <%= f.govuk_fieldset legend: {text: t('support_interface.edit_address_details_form.address_details.label'), size: 'xl', tag: 'h1'} do %>
 
-        <% if @details_form.international? && @details_form.international_address %>
+        <% if @details_form.international? %>
           <%= f.govuk_text_area :international_address, label: {text: t('support_interface.edit_address_details_form.international_address.label')}, autocomplete: 'address' %>
         <% end %>
         <%= f.govuk_text_field(

--- a/app/views/support_interface/application_forms/address_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_details/edit.html.erb
@@ -7,20 +7,42 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_fieldset legend: {text: t('support_interface.edit_address_details_form.address_details.label'), size: 'xl', tag: 'h1'} do %>
-        <% if @details_form.uk? %>
-          <%= f.govuk_text_field :address_line1, label: -> { safe_join([t('application_form.contact_information.address_line1.uk.label'), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) }, autocomplete: 'address-line1' %>
-          <%= f.govuk_text_field :address_line2, label: {text: t('application_form.contact_information.address_line2.uk.label'), hidden: true}, autocomplete: 'address-line2' %>
-          <%= f.govuk_text_field :address_line3, label: {text: t('application_form.contact_information.address_line3.uk.label')}, width: 'two-thirds', autocomplete: 'address-level2' %>
-          <%= f.govuk_text_field :address_line4, label: {text: t('application_form.contact_information.address_line4.uk.label')}, width: 'two-thirds', autocomplete: 'address-level1' %>
-          <%= f.govuk_text_field :postcode, label: {text: t('application_form.contact_information.postcode.uk.label')}, width: 10, autocomplete: 'postal-code' %>
-        <% else %>
+
+        <% if @details_form.international? && @details_form.international_address %>
           <%= f.govuk_text_area :international_address, label: {text: t('support_interface.edit_address_details_form.international_address.label')}, autocomplete: 'address' %>
         <% end %>
+        <%= f.govuk_text_field(
+              :address_line1,
+              label: -> { safe_join([@details_form.label_for(:address_line1), ' ', tag.span(t('application_form.contact_information.address_line1.hidden'), class: 'govuk-visually-hidden')]) },
+              autocomplete: 'address-line1',
+            ) %>
+        <%= f.govuk_text_field(
+              :address_line2,
+              label: {text: @details_form.label_for(:address_line2), hidden: true},
+              autocomplete: 'address-line2',
+            ) %>
+        <%= f.govuk_text_field(
+              :address_line3,
+              label: {text: @details_form.label_for(:address_line3)},
+              width: 'two-thirds',
+              autocomplete: 'address-level2',
+            ) %>
+        <%= f.govuk_text_field(
+              :address_line4,
+              label: {text: @details_form.label_for(:address_line4)},
+              width: 'two-thirds',
+              autocomplete: 'address-level1',
+            ) %>
+        <%= f.govuk_text_field(
+              :postcode,
+              label: {text: @details_form.label_for(:postcode)},
+              width: 10,
+              autocomplete: 'postal-code',
+            ) %>
+        <%= f.govuk_text_field :audit_comment, label: {text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm'}, hint: {text: t('support_interface.edit_address_details_form.audit_comment.hint')} %>
 
+        <%= f.govuk_submit t('application_form.contact_information.address.button') %>
       <% end %>
-      <%= f.govuk_text_field :audit_comment, label: {text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm'}, hint: {text: t('support_interface.edit_address_details_form.audit_comment.hint')} %>
-
-      <%= f.govuk_submit t('application_form.contact_information.address.button') %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,8 +299,6 @@ en:
             postcode:
               blank: Enter a postcode
               invalid: Enter a real postcode (for example, BN1 1AA)
-            international_address:
-              blank: Enter your address
             audit_comment:
               blank: You must provide an audit comment
         provider_interface/pick_response_form:

--- a/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/edit_address_details_form_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         international_address: nil,
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
-      application_form = build_stubbed(:application_form, data)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
 
       expect(details_form).to have_attributes(data)
     end
@@ -37,8 +36,8 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         international_address: nil,
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
-      application_form = build(:application_form, data)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      application_form = build(:application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
       data[:postcode] = 'BN1 1AA'
       data.except!(:audit_comment)
 
@@ -49,22 +48,20 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
 
     it 'updates the provided ApplicationForm with the international address field if valid' do
       data = {
-        address_type: 'international',
-        international_address: 'Rue de Rivoli, 75001 Paris',
-        country: 'France',
+        address_line1: '123 Chandni Chowk',
+        address_line3: 'Old Delhi',
+        postcode: '110006',
         audit_comment: 'Updated as part of Zendesk ticket 12345',
       }
-      application_form = build(:application_form, data)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      application_form = build(:application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data.merge(address_type: 'international'))
       data.except!(:audit_comment)
 
       expect(details_form.save_address(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
-      expect(application_form.address_line1).to be_nil
       expect(application_form.address_line2).to be_nil
-      expect(application_form.address_line3).to be_nil
       expect(application_form.address_line4).to be_nil
-      expect(application_form.postcode).to be_nil
+      expect(application_form.international_address).to be_nil
     end
   end
 
@@ -73,8 +70,8 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
       data = {
         address_type: 'uk',
       }
-      application_form = build(:application_form, data)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      application_form = build(:application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
 
       expect(details_form.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
@@ -85,8 +82,8 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
         address_type: 'international',
         country: 'India',
       }
-      application_form = build(:application_form, data)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      application_form = build(:application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
 
       expect(details_form.save_address_type(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
@@ -96,8 +93,8 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
       data = {
         address_type: 'international',
       }
-      application_form = build(:application_form, data)
-      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.build_from_application_form(application_form)
+      application_form = build(:application_form)
+      details_form = SupportInterface::ApplicationForms::EditAddressDetailsForm.new(data)
 
       expect(details_form.save_address_type(application_form)).to eq(false)
     end
@@ -114,17 +111,17 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
       it { is_expected.to validate_presence_of(:postcode).on(:address) }
       it { is_expected.to validate_presence_of(:audit_comment).on(:address) }
       it { is_expected.not_to validate_presence_of(:international_address).on(:address) }
+      it { is_expected.not_to allow_value('MUCH WOW').for(:postcode).on(:address) }
     end
 
     context 'for an international address' do
       subject(:form) { described_class.new(address_type: 'international') }
 
-      it { is_expected.to validate_presence_of(:country).on(:address_type) }
-      it { is_expected.to validate_presence_of(:international_address).on(:address) }
-      it { is_expected.to validate_presence_of(:audit_comment).on(:address) }
-      it { is_expected.not_to validate_presence_of(:address_line1).on(:address) }
+      it { is_expected.to validate_presence_of(:address_line1).on(:address) }
+      it { is_expected.not_to validate_presence_of(:international_address).on(:address) }
       it { is_expected.not_to validate_presence_of(:address_line3).on(:address) }
       it { is_expected.not_to validate_presence_of(:postcode).on(:address) }
+      it { is_expected.to allow_value('MUCH WOW').for(:postcode).on(:address) }
     end
 
     it { is_expected.to validate_length_of(:address_line1).is_at_most(50).on(:address) }
@@ -133,6 +130,5 @@ RSpec.describe SupportInterface::ApplicationForms::EditAddressDetailsForm, type:
     it { is_expected.to validate_length_of(:address_line4).is_at_most(50).on(:address) }
 
     it { is_expected.to allow_value('SW1P 3BT').for(:postcode).on(:address) }
-    it { is_expected.not_to allow_value('MUCH WOW').for(:postcode).on(:address) }
   end
 end

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -30,12 +30,18 @@ RSpec.feature 'Editing address' do
 
     when_i_submit_the_update_form
     then_i_should_see_blank_error_messages
-
     when_i_fill_in_an_international_address
+
     and_i_submit_the_update_form
     then_i_should_see_a_flash_message
     and_i_should_see_the_new_international_address_details
     and_i_should_see_my_international_address_details_comment_in_the_audit_log
+
+    when_i_have_an_international_address_in_the_old_format_and_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_address
+    and_i_select_outside_the_uk
+    then_i_should_see_the_international_address_details_form
+    and_i_should_see_the_old_text_area
   end
 
   def given_i_am_a_support_user
@@ -43,8 +49,7 @@ RSpec.feature 'Editing address' do
   end
 
   def and_an_application_exists
-    @form = create(:completed_application_form, :with_completed_references)
-    create(:reference, :feedback_requested, name: 'Dumbledore', email_address: 'a.dumbledore@hogwarts.ac.uk', relationship: 'Headmaster', application_form: @form)
+    @form = create(:completed_application_form)
   end
 
   def when_i_visit_the_application_page
@@ -52,7 +57,6 @@ RSpec.feature 'Editing address' do
   end
 
   def and_i_click_the_change_link_next_to_address
-    print page.body
     all('.govuk-summary-list__actions')[6].click_link 'Change'
   end
 
@@ -67,7 +71,7 @@ RSpec.feature 'Editing address' do
 
   def then_i_should_see_the_uk_address_details_form
     expect(page).to have_content('What is the candidate’s address?')
-    expect(page).to have_content('Building and street')
+    expect(page).to have_content('Town or city')
   end
 
   def when_i_submit_the_update_form
@@ -103,31 +107,44 @@ RSpec.feature 'Editing address' do
 
   def and_i_select_outside_the_uk
     choose 'Outside the UK'
-    select('France', from: t('application_form.contact_information.country.label'))
+    select('India', from: t('application_form.contact_information.country.label'))
     click_button 'Save and continue'
   end
 
   def then_i_should_see_the_international_address_details_form
-    expect(page).to have_content('International address')
+    expect(page).to have_content('What is the candidate’s address?')
+    expect(page).to have_content('City, town or village')
   end
 
   def then_i_should_see_blank_error_messages
-    expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_address_details_form.attributes.international_address.blank')
     expect(page).to have_content t('activemodel.errors.models.support_interface/application_forms/edit_address_details_form.attributes.audit_comment.blank')
   end
 
   def when_i_fill_in_an_international_address
-    fill_in t('support_interface.edit_address_details_form.international_address.label'), with: 'Rue de Rivoli, 75001 Paris'
+    fill_in 'support_interface_application_forms_edit_address_details_form[address_line1]', with: '123 Chandni Chowk'
+    fill_in 'support_interface_application_forms_edit_address_details_form[address_line3]', with: 'New Delhi'
+    fill_in 'support_interface_application_forms_edit_address_details_form[postcode]', with: '110006'
     fill_in 'support_interface_application_forms_edit_address_details_form[audit_comment]', with: 'Updated as part of Zen Desk ticket #56789'
   end
 
   def and_i_should_see_the_new_international_address_details
-    expect(page).to have_content 'Rue de Rivoli, 75001 Paris'
-    expect(page).to have_content 'France'
+    expect(page).to have_content '123 Chandni Chowk'
+    expect(page).to have_content 'New Delhi'
+    expect(page).to have_content '110006'
+    expect(page).to have_content 'India'
   end
 
   def and_i_should_see_my_international_address_details_comment_in_the_audit_log
     click_on 'History'
     expect(page).to have_content 'Updated as part of Zen Desk ticket #56789'
+  end
+
+  def when_i_have_an_international_address_in_the_old_format_and_i_visit_the_application_page
+    @form_with_old_international_address = create(:completed_application_form, international_address: '123 Chandni Chowk, New Delhi, 110006')
+    visit support_interface_application_form_path(@form_with_old_international_address)
+  end
+
+  def and_i_should_see_the_old_text_area
+    expect(page).to have_content 'International address'
   end
 end

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -36,12 +36,6 @@ RSpec.feature 'Editing address' do
     then_i_should_see_a_flash_message
     and_i_should_see_the_new_international_address_details
     and_i_should_see_my_international_address_details_comment_in_the_audit_log
-
-    when_i_have_an_international_address_in_the_old_format_and_i_visit_the_application_page
-    and_i_click_the_change_link_next_to_address
-    and_i_select_outside_the_uk
-    then_i_should_see_the_international_address_details_form
-    and_i_should_see_the_old_text_area
   end
 
   def given_i_am_a_support_user
@@ -137,14 +131,5 @@ RSpec.feature 'Editing address' do
   def and_i_should_see_my_international_address_details_comment_in_the_audit_log
     click_on 'History'
     expect(page).to have_content 'Updated as part of Zen Desk ticket #56789'
-  end
-
-  def when_i_have_an_international_address_in_the_old_format_and_i_visit_the_application_page
-    @form_with_old_international_address = create(:completed_application_form, international_address: '123 Chandni Chowk, New Delhi, 110006')
-    visit support_interface_application_form_path(@form_with_old_international_address)
-  end
-
-  def and_i_should_see_the_old_text_area
-    expect(page).to have_content 'International address'
   end
 end


### PR DESCRIPTION
## Context

This ticket allows a support user to add/edit multi-line international addresses through the support UI.

As part of switching to multi-line international addresses, there is a bit of work to update existing international addresses in to the new format (https://trello.com/c/UVA1qhQJ/2754-migrate-international-addresses-in-production-to-new-multi-line-model). To aid this process the support UI will temporarily have both the old freetext input and the new multi-line input to enable support users to update these addresses. Once this work is complete the freetext input can be removed.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/33458055/102618779-4d3e5400-4133-11eb-8e95-0a9a44030d46.png)

## Guidance to review

Is the feature flag implemented correctly? Do we need this functionality before we turn on the feature flag?

## Link to Trello card

https://trello.com/c/jJsZshMb/2751-add-multi-line-international-addresses-to-support-ui

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
