### PR TITLE
Remove UCASMatch emails from Notifications check

### DIFF
--- a/app/services/ucas_matches/send_resolved_on_apply_emails.rb
+++ b/app/services/ucas_matches/send_resolved_on_apply_emails.rb
@@ -13,7 +13,7 @@ module UCASMatches
 
       CandidateMailer.ucas_match_resolved_on_apply_email(application_choice).deliver_later
 
-      NotificationsList.for(application_choice).each do |provider_user|
+      application_choice.provider.provider_users.each do |provider_user|
         ProviderMailer.ucas_match_resolved_on_apply_email(provider_user, application_choice).deliver_later
       end
     end

--- a/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
+++ b/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
@@ -13,7 +13,7 @@ module UCASMatches
 
       CandidateMailer.ucas_match_resolved_on_ucas_email(application_choice).deliver_later
 
-      NotificationsList.for(application_choice).each do |provider_user|
+      application_choice.provider.provider_users.each do |provider_user|
         ProviderMailer.ucas_match_resolved_on_ucas_email(provider_user, application_choice).deliver_later
       end
     end

--- a/app/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications.rb
+++ b/app/services/ucas_matches/send_ucas_match_initial_emails_duplicate_applications.rb
@@ -13,7 +13,7 @@ module UCASMatches
 
       CandidateMailer.ucas_match_initial_email_duplicate_applications(application_choice).deliver_later
 
-      NotificationsList.for(application_choice).each do |provider_user|
+      application_choice.provider.provider_users.each do |provider_user|
         ProviderMailer.ucas_match_initial_email_duplicate_applications(provider_user, application_choice).deliver_later
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -764,6 +764,7 @@ FactoryBot.define do
     email_address { "#{Faker::Name.first_name.downcase}-#{SecureRandom.hex}@example.com" }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
+    send_notifications { Faker::Boolean.boolean(true_ratio: 0.5) }
 
     trait :with_provider do
       after(:create) do |user, _evaluator|

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AcceptOffer do
 
     it 'sends a notification email to the provider' do
       application_choice = create(:application_choice, status: :offer)
-      provider_user = create :provider_user, providers: [application_choice.provider]
+      provider_user = create :provider_user, send_notifications: true, providers: [application_choice.provider]
 
       expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
       expect(ActionMailer::Base.deliveries.first.to).to eq [provider_user.email_address]

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SendApplicationToProvider do
   end
 
   it 'emails the provider’s provider users', sidekiq: true do
-    user = create(:provider_user)
+    user = create(:provider_user, send_notifications: true)
     application_choice.provider.provider_users = [user]
 
     expect {

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
 
   it 'sends an email to the provider' do
     provider = create(:provider)
-    create(:provider_user, providers: [provider])
+    create(:provider_user, send_notifications: true, providers: [provider])
     option = course_option_for_provider(provider: provider)
     choice = create(:application_choice, :awaiting_provider_decision, course_option: option)
 
@@ -18,7 +18,7 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
 
   it 'sends a different email when the candidate supplied safeguarding information' do
     provider = create(:provider)
-    create(:provider_user, providers: [provider])
+    create(:provider_user, send_notifications: true, providers: [provider])
     option = course_option_for_provider(provider: provider)
 
     form = create(:completed_application_form, :with_safeguarding_issues_disclosed)

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -30,13 +30,14 @@ module DfESignInHelpers
     support_user_signs_in_using_dfe_sign_in
   end
 
-  def provider_user_exists_in_apply_database(email_address: 'email@provider.ac.uk')
+  def provider_user_exists_in_apply_database(email_address: 'email@provider.ac.uk', send_notifications: true)
     provider_one = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Example Provider')
     provider_two = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Another Provider')
     create(:provider_user,
            providers: [provider_one, provider_two],
            dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
-           email_address: email_address)
+           email_address: email_address,
+           send_notifications: send_notifications)
   end
 
   def provider_user_exists_in_apply_database_with_multiple_providers

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_accepts_offer_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Candidate accepts an offer' do
     @course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'DEF')
 
-    @provider_user = create(:provider_user, providers: [@course_option.course.provider])
+    @provider_user = create(:provider_user, send_notifications: true, providers: [@course_option.course.provider])
 
     @application_choice = create(
       :application_choice,

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_declines_offer_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Candidate declines an offer' do
       application_form: @application_form,
     )
 
-    @provider_user = create(:provider_user, providers: [@application_choice.provider])
+    @provider_user = create(:provider_user, send_notifications: true, providers: [@application_choice.provider])
   end
 
   def when_i_visit_the_application_dashboard

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_withdraws_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'A candidate withdraws her application' do
     form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
     @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: form)
     @application_choice2 = create(:application_choice, :awaiting_provider_decision, application_form: form)
-    @provider_user = create(:provider_user)
+    @provider_user = create(:provider_user, send_notifications: true)
     create(:provider_permissions, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
   end
 

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature 'Decline by default' do
     @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter', support_reference: '123A')
     @application_choice = create(:application_choice, status: :offer, application_form: @application_form, sent_to_provider_at: Time.zone.now, decline_by_default_at: Time.zone.now + 10.days)
 
-    @provider_user = create(:provider_user, providers: [@application_choice.provider])
+    @provider_user = create(:provider_user, send_notifications: true, providers: [@application_choice.provider])
   end
 
   def and_the_time_limit_before_decline_by_default_date_has_been_exceeded

--- a/spec/system/provider_interface/sandbox_emails_spec.rb
+++ b/spec/system/provider_interface/sandbox_emails_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Emails are suppressed in Sandbox' do
 
   scenario 'when a candidate triggers a notification', sidekiq: true, sandbox: true do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_see_applications_and_receive_notifications_for_my_provider
     and_an_application_choice_with_an_offer_exists_for_the_provider
 
     when_a_user_accepts_the_offer
@@ -21,7 +21,7 @@ RSpec.feature 'Emails are suppressed in Sandbox' do
     provider_exists_in_dfe_sign_in
   end
 
-  def and_i_am_permitted_to_see_applications_for_my_provider
+  def and_i_am_permitted_to_see_applications_and_receive_notifications_for_my_provider
     provider_user_exists_in_apply_database
   end
 

--- a/spec/system/reject_by_default_spec.rb
+++ b/spec/system/reject_by_default_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature 'Reject by default' do
   include CourseOptionHelpers
 
   scenario 'An application is rejected by default', with_audited: true do
-    given_there_is_a_provider_user_with_a_provider
+    given_there_is_a_provider_user_for_the_provider_course
+    and_the_provider_user_has_send_notifications_enabled
     and_there_is_a_candidate
     and_an_application_is_ready_to_reject_by_default
 
@@ -16,9 +17,13 @@ RSpec.feature 'Reject by default' do
     and_the_candidate_should_receive_an_email
   end
 
-  def given_there_is_a_provider_user_with_a_provider
+  def given_there_is_a_provider_user_for_the_provider_course
     @course_option = course_option_for_provider_code(provider_code: 'ABC')
     @provider_user = Provider.find_by(code: 'ABC').provider_users.first
+  end
+
+  def and_the_provider_user_has_send_notifications_enabled
+    @provider_user.update(send_notifications: true)
   end
 
   def and_there_is_a_candidate


### PR DESCRIPTION
## Context

Related to #3673 as we don't want to give provider users the ability to opt out of these emails.

## Link to Trello card
https://trello.com/c/h252hN4f/3145-remove-ucasmatch-emails-from-notifications-check

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
