### PR TITLE
Add missing h1 headings

### DIFF
--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -17,7 +17,7 @@
             label: { text: 'Extra permissions' },
             hint: { text: 'For example, being able to make offers and access sensitive content' } do %>
 
-      <%= f.govuk_check_boxes_fieldset :permissions, legend: { size: 'm', text: 'Select permissions' } do %>
+      <%= f.govuk_check_boxes_fieldset :permissions, legend: { text: 'Select permissions', size: 'm' } do %>
 
         <%= f.govuk_check_box :manage_organisations, true, multiple: false,
                               label: { text: 'Manage organisational permissions' },

--- a/app/components/support_interface/ucas_match_action_component.html.erb
+++ b/app/components/support_interface/ucas_match_action_component.html.erb
@@ -9,7 +9,7 @@
       </p>
       <% if @match.action_needed? && @match.requires_manual_action? %>
         <%= form_with url: button[:path], method: :post do |f| %>
-          <%= f.submit button[:text], class: 'govuk-button' %>
+          <%= f.govuk_submit button[:text] %>
         <% end %>
       <% end %>
     </div>

--- a/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/maths/grade_controller.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     before_action :set_subject
 
     def edit
-      @application_qualification = maths_gsce_grade_form
+      @gcse_grade_form = maths_gsce_grade_form
       @qualification_type = maths_gsce_grade_form.qualification.qualification_type
     end
 
@@ -16,14 +16,14 @@ module CandidateInterface
       maths_gsce_grade_form.grade = maths_params[:grade]
       maths_gsce_grade_form.other_grade = maths_params[:other_grade]
 
-      @application_qualification = maths_gsce_grade_form.save_grade
+      @gcse_grade_form = maths_gsce_grade_form.save_grade
 
-      if @application_qualification
+      if @gcse_grade_form
         update_gcse_completed(false)
         redirect_to next_gcse_path
       else
-        @application_qualification = maths_gsce_grade_form
-        track_validation_error(@application_qualification)
+        @gcse_grade_form = maths_gsce_grade_form
+        track_validation_error(@gcse_grade_form)
 
         render :edit
       end

--- a/app/controllers/candidate_interface/gcse/science/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/science/grade_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class Gcse::Science::GradeController < CandidateInterfaceController
     include Gcse::GradeControllerConcern
+
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
 

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -30,7 +30,7 @@
         <%= f.hidden_field :provider_code, value: @course.provider.code %>
         <%= f.hidden_field :course_code, value: @course.code %>
 
-        <%= f.govuk_radio_buttons_fieldset :service, legend: { size: 'm', text: 'Do you want to apply using a new GOV.UK service?' } do %>
+        <%= f.govuk_radio_buttons_fieldset :service, legend: { text: 'Do you want to apply using a new GOV.UK service?', size: 'm' } do %>
           <%= f.govuk_radio_button :service,
             :apply,
             label: { text: 'Yes, I want to apply using the new service', size: 's' },

--- a/app/views/candidate_interface/contact_details/address_type/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_type_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('page_titles.where_do_you_live'), size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('page_titles.where_do_you_live'), size: 'xl', tag: 'h1' } do %>
         <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_information.address_type.values.uk') } %>
         <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_information.address_type.values.international') }, link_errors: true do %>
           <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_information.country.label') } %>

--- a/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
@@ -10,7 +10,7 @@
       <h1 class="govuk-heading-xl"><%= title %></h1>
       <p class="govuk-body">After you submit your application you cannot apply for more courses through this service.</p>
 
-      <%= f.govuk_radio_buttons_fieldset :add_another_course, legend: { tag: 'h2', size: 'm', text: 'Do you want to add another course?' } do %>
+      <%= f.govuk_radio_buttons_fieldset :add_another_course, legend: { text: 'Do you want to add another course?', size: 'm' } do %>
         <%= f.govuk_radio_button :add_another_course, :yes, label: { text: 'Yes, add another course' }, link_errors: true %>
         <%= f.govuk_radio_button :add_another_course, :no, label: { text: 'No, not at the moment' } %>
       <% end %>

--- a/app/views/candidate_interface/course_choices/course_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/new.html.erb
@@ -22,11 +22,11 @@
           select_course_options(@pick_course.dropdown_available_courses),
           :id,
           :name,
-          label: { text: t('page_titles.which_course'), size: 'xl' },
+          label: { text: t('page_titles.which_course'), size: 'xl', tag: 'h1' },
           options: { selected: nil },
         ) %>
       <% else %>
-        <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
+        <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course'), tag: 'h1' } do %>
           <% @pick_course.radio_available_courses.each_with_index do |course, i| %>
             <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint: { text: course.description }, link_errors: i.zero? %>
           <% end %>

--- a/app/views/candidate_interface/course_choices/have_you_chosen/ask.html.erb
+++ b/app/views/candidate_interface/course_choices/have_you_chosen/ask.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @choice_form, url: candidate_interface_course_choices_choose_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :choice, legend: { size: 'xl', text: t('page_titles.have_you_chosen') } do %>
+      <%= f.govuk_radio_buttons_fieldset :choice, legend: { size: 'xl', text: t('page_titles.have_you_chosen'), tag: 'h1' } do %>
         <div class="govuk-!-margin-top-6">
           <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, I know where I want to apply' }, link_errors: true %>
           <%= f.govuk_radio_button :choice, :no, label: { text: 'No, I need to find a course' } %>

--- a/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
@@ -21,7 +21,7 @@
         select_provider_options(@pick_provider.available_providers),
         :id,
         :name,
-        label: { text: t('page_titles.which_provider'), size: 'xl' },
+        label: { text: t('page_titles.which_provider'), size: 'xl', tag: 'h1' },
       ) do %>
         <p class="govuk-body">
           You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %>

--- a/app/views/candidate_interface/course_choices/site_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/new.html.erb
@@ -11,7 +11,7 @@
         ) do |f| %>
             <%= f.govuk_error_summary %>
 
-            <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location') } do %>
+            <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location'), tag: 'h1' } do %>
               <div class="govuk-!-margin-top-6">
                 <% @pick_site.available_sites.each_with_index do |option, i| %>
                   <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, link_errors: i.zero?, hint: { text: option.site.full_address } %>

--- a/app/views/candidate_interface/course_choices/study_mode_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/study_mode_selection/new.html.erb
@@ -14,7 +14,7 @@
 
         <%= f.govuk_error_summary %>
 
-        <%= f.govuk_radio_buttons_fieldset :study_mode, legend: { size: 'xl', text: t('page_titles.which_study_mode'), tag: 'h2' } do %>
+        <%= f.govuk_radio_buttons_fieldset :study_mode, legend: { size: 'xl', text: t('page_titles.which_study_mode'), tag: 'h1' } do %>
           <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' } %>
           <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
         <% end %>

--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -1,7 +1,8 @@
 <% if @degree_grade_form.international? %>
 
-  <p class='govuk-hint'><%= t('application_form.degree.grade.international.grade_examples') %></p>
-  <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
+  <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: @page_title, size: 'xl', tag: 'h1' } do %>
+    <p class="govuk-body"><%= t('application_form.degree.grade.international.grade_examples') %></p>
+
     <%= f.govuk_radio_button :grade, 'other', label: { text: 'Yes' } do %>
       <% if degree.predicted_grade? %>
         <% text_field_options = { label: nil, hint: { text: t('application_form.degree.grade.international.hint_text') } } %>
@@ -19,12 +20,12 @@
 <% else %>
 
   <% if degree.predicted_grade? %>
-    <div class='govuk-inset-text'>
+    <div class="govuk-inset-text">
       You must give an academic referee who can agree that you’re aiming for this grade.
     </div>
   <% end %>
 
-  <%= f.govuk_radio_buttons_fieldset :grade, legend: { tag: 'span' } do %>
+  <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: @page_title, size: 'xl', tag: 'h1' } do %>
     <% @main_grades.each_with_index do |grade, i| %>
       <%= f.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: i.zero? %>
     <% end %>

--- a/app/views/candidate_interface/degrees/grade/edit.html.erb
+++ b/app/views/candidate_interface/degrees/grade/edit.html.erb
@@ -6,10 +6,6 @@
     <%= form_with model: @degree_grade_form, url: candidate_interface_edit_degree_grade_path(@degree_grade_form.degree), method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= @page_title %>
-      </h1>
-
       <%= render 'form_fields', f: f, degree: @degree_grade_form.degree %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/grade/new.html.erb
+++ b/app/views/candidate_interface/degrees/grade/new.html.erb
@@ -6,10 +6,6 @@
     <%= form_with model: @degree_grade_form, url: candidate_interface_degree_grade_path(@degree_grade_form.degree) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= @page_title %>
-      </h1>
-
       <%= render 'form_fields', f: f, degree: @degree_grade_form.degree %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
-<%= f.govuk_radio_buttons_fieldset :have_naric_reference, legend: { text: t('application_form.degree.naric_statment.label'), tag: 'span' } do %>
+<%= f.govuk_radio_buttons_fieldset :have_naric_reference, legend: { text: t('application_form.degree.naric_statment.label'), size: 'm' } do %>
   <%= f.govuk_radio_button :have_naric_reference, 'yes', label: { text: 'Yes' } do %>
     <%= f.govuk_text_field(
       :naric_reference,

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -1,18 +1,15 @@
-<%= f.govuk_radio_buttons_fieldset :uk_degree, legend: { tag: 'span' }, legend: nil do %>
-  <%= f.govuk_radio_button :uk_degree, 'yes', label: { text: t('application_form.degree.uk_degree.label') } do %>
-    <%= f.govuk_text_field(
-      :type_description,
-      label: { text: t('application_form.degree.qualification_type.label'), size: 's' },
-      hint: { text: t('application_form.degree.qualification_type.hint_text.undergraduate') }
-    ) %>
-    <%= tag.div(id: 'degree-type-autosuggest', data: { source: @degree_types }) %>
-  <% end %>
-  <%= f.govuk_radio_button :uk_degree, 'no', label: { text: t('application_form.degree.non_uk_degree.label') } do %>
-    <%= f.govuk_text_field(
-      :international_type_description,
-      label: { text: t('application_form.degree.international_qualification_type.label'), size: 's' },
-      hint: { text: t('application_form.degree.international_qualification_type.hint_text') }
-    ) %>
-  <% end %>
+<%= f.govuk_radio_button :uk_degree, 'yes', label: { text: t('application_form.degree.uk_degree.label') } do %>
+  <%= f.govuk_text_field(
+    :type_description,
+    label: { text: t('application_form.degree.qualification_type.label'), size: 's' },
+    hint: { text: t('application_form.degree.qualification_type.hint_text.undergraduate') }
+  ) %>
+  <%= tag.div(id: 'degree-type-autosuggest', data: { source: @degree_types }) %>
 <% end %>
-<%= f.govuk_submit t('application_form.degree.base.button') %>
+<%= f.govuk_radio_button :uk_degree, 'no', label: { text: t('application_form.degree.non_uk_degree.label') } do %>
+  <%= f.govuk_text_field(
+    :international_type_description,
+    label: { text: t('application_form.degree.international_qualification_type.label'), size: 's' },
+    hint: { text: t('application_form.degree.international_qualification_type.hint_text') }
+  ) %>
+<% end %>

--- a/app/views/candidate_interface/degrees/type/add_another.html.erb
+++ b/app/views/candidate_interface/degrees/type/add_another.html.erb
@@ -6,11 +6,11 @@
     <%= form_with model: @degree_type_form, url: candidate_interface_new_degree_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.add_another_degree') %>
-      </h1>
+      <%= f.govuk_radio_buttons_fieldset :uk_degree, legend: { text: t('page_titles.add_another_degree'), size: 'xl', tag: 'h1' } do %>
+        <%= render 'form_fields', f: f %>
+      <% end %>
 
-      <%= render 'form_fields', f: f %>
+      <%= f.govuk_submit t('application_form.degree.base.button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/degrees/type/edit.html.erb
+++ b/app/views/candidate_interface/degrees/type/edit.html.erb
@@ -10,11 +10,11 @@
     ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.edit_degree_type') %>
-      </h1>
+      <%= f.govuk_radio_buttons_fieldset :uk_degree, legend: { text: t('page_titles.edit_degree_type'), size: 'xl', tag: 'h1' } do %>
+        <%= render 'form_fields', f: f %>
+      <% end %>
 
-      <%= render 'form_fields', f: f %>
+      <%= f.govuk_submit t('application_form.degree.base.button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/degrees/type/new.html.erb
+++ b/app/views/candidate_interface/degrees/type/new.html.erb
@@ -6,20 +6,21 @@
     <%= form_with model: @degree_type_form, url: candidate_interface_new_degree_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.add_undergraduate_degree') %>
-      </h1>
+      <%= f.govuk_radio_buttons_fieldset :uk_degree, legend: { text: t('page_titles.add_undergraduate_degree'), size: 'xl', tag: 'h1' } do %>
+        <p class="govuk-body">
+          Your undergraduate degree confirms your eligibility to teach.
+          Enter the details of your degree as they appear on your certificate,
+          translating them into English if necessary.
+        </p>
 
-      <p class="govuk-body">
-        Your undergraduate degree confirms your eligibility to teach.
-        Enter the details of your degree as they appear on your certificate,
-        translating them into English if necessary.
-      </p>
-      <p class="govuk-body">
-        If you have further postgraduate degrees, you’ll be able to add them next.
-      </p>
+        <p class="govuk-body">
+          If you have further postgraduate degrees, you’ll be able to add them next.
+        </p>
 
-      <%= render 'form_fields', f: f %>
+        <%= render 'form_fields', f: f %>
+      <% end %>
+
+      <%= f.govuk_submit t('application_form.degree.base.button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_radio_buttons_fieldset :qualification_status, legend: { size: 'm', text: 'Have you done an English as a foreign language assessment?', tag: 'span' } do %>
+<%= f.govuk_radio_buttons_fieldset :qualification_status, caption: { text: t('page_titles.efl.start'), size: 'xl' }, legend: { text: 'Have you done an English as a foreign language assessment?', size: 'xl', tag: 'h1' } do %>
   <%= f.govuk_radio_button :qualification_status, 'has_qualification', label: { text: 'Yes' } %>
   <%= f.govuk_radio_button :qualification_status, 'qualification_not_needed', label: { text: 'No, English is not a foreign language to me' } %>
   <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I have not done an English as a foreign language assessment' } do %>

--- a/app/views/candidate_interface/english_foreign_language/start/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/edit.html.erb
@@ -3,10 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t('page_titles.efl.start') %></h1>
-
     <%= form_with(model: @start_form, url: candidate_interface_english_foreign_language_edit_start_path, method: :patch) do |f| %>
-      <%= render 'form_fields', { f: f } %>
+      <%= render 'form_fields', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/english_foreign_language/start/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/new.html.erb
@@ -3,10 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t('page_titles.efl.start') %></h1>
-
     <%= form_with(model: @start_form, url: candidate_interface_english_foreign_language_start_path) do |f| %>
-      <%= render 'form_fields', { f: f } %>
+      <%= render 'form_fields', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/toefl/edit.html.erb
@@ -5,12 +5,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(model: @toefl_form, url: candidate_interface_toefl_path) do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class='govuk-heading-xl'>
+      <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= t('page_titles.efl.start') %></span>
         <%= t('page_titles.efl.toefl') %>
       </h1>
-      <%= render 'form_fields', { f: f } %>
+      <%= render 'form_fields', f: f %>
     <% end %>
-
   </div>
 </div>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @ethnic_group, url: candidate_interface_edit_equality_and_diversity_ethnic_group_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :ethnic_group, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.ethnic_group.title'), size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :ethnic_group, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.ethnic_group.title'), size: 'xl', tag: 'h1' } do %>
         <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.asian.label'), label: { text: t('equality_and_diversity.ethnic_group.asian.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.asian.hint_text') }, link_errors: true %>
         <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.black.label'), label: { text: t('equality_and_diversity.ethnic_group.black.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.black.hint_text') } %>
         <%= f.govuk_radio_button :ethnic_group, t('equality_and_diversity.ethnic_group.mixed.label'), label: { text: t('equality_and_diversity.ethnic_group.mixed.label'), size: 's' }, hint: { text: t('equality_and_diversity.ethnic_group.mixed.hint_text') } %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @sex, url: candidate_interface_edit_equality_and_diversity_sex_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :sex, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.sex.title'), size: 'xl' } do %>
+      <%= f.govuk_radio_buttons_fieldset :sex, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.sex.title'), size: 'xl', tag: 'h1' } do %>
         <%= f.govuk_radio_button :sex, :female, label: { text: t('equality_and_diversity.sex.female.label') }, link_errors: true %>
         <%= f.govuk_radio_button :sex, :male, label: { text: t('equality_and_diversity.sex.male.label') } %>
         <%= f.govuk_radio_button :sex, :intersex, label: { text: t('equality_and_diversity.sex.intersex.label') } %>

--- a/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
+++ b/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
@@ -20,7 +20,7 @@
         <% end %>
       </div>
 
-      <%= f.govuk_radio_buttons_fieldset :confirm, legend: { size: 'm', text: t('confirm_selection.question') } do %>
+      <%= f.govuk_radio_buttons_fieldset :confirm, legend: { text: t('confirm_selection.question'), size: 'm' } do %>
         <%= f.govuk_radio_button :confirm, true, label: { text: 'Yes' } %>
         <%= f.govuk_radio_button :confirm, false, label: { text: 'No' } %>
       <% end %>

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_english_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <% if @gcse_grade_form.qualification.qualification_type == 'non_uk' %>
+      <% if @qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: grade_step_title(@subject, @qualification_type), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
@@ -19,7 +19,7 @@
 
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
-        <%= f.govuk_text_field :grade, label: {text: t('application_form.gcse.grade.label'), size: 'm'}, hint: {text: t('gcse_edit_grade.hint.other.gcse_single_and_double')}, width: 4 %>
+        <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm'}, hint: {text: t('gcse_edit_grade.hint.other.gcse_single_and_double') }, width: 4 %>
       <% end %>
 
       <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -6,10 +6,8 @@
     <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_english_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
-
       <% if @gcse_grade_form.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: grade_step_title(@subject, @qualification_type), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
@@ -17,6 +15,8 @@
           <% end %>
         <% end %>
       <% else %>
+        <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
+
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
         <%= f.govuk_text_field :grade, label: {text: t('application_form.gcse.grade.label'), size: 'm'}, hint: {text: t('gcse_edit_grade.hint.other.gcse_single_and_double')}, width: 4 %>

--- a/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
@@ -6,10 +6,8 @@
     <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_english_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl"><%= t('multiple_gcse_edit_grade.page_title')%></h1>
-
       <% if @gcse_grade_form.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('multiple_gcse_edit_grade.page_title'), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
@@ -17,9 +15,11 @@
           <% end %>
         <% end %>
       <% else %>
+        <h1 class="govuk-heading-xl"><%= t('multiple_gcse_edit_grade.page_title') %></h1>
+
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
-        <%= f.govuk_check_boxes_fieldset :english_gcses, legend: { text: t('multiple_gcse_edit_grade.question'), size: "m" } do %>
+        <%= f.govuk_check_boxes_fieldset :english_gcses, legend: { text: t('multiple_gcse_edit_grade.question'), size: 'm' } do %>
           <%= f.govuk_check_box :english_gcses, 'english_single_award', label: { text: t('multiple_gcse_edit_grade.answers.english_single_award') }, link_errors: true do %>
             <%= f.govuk_text_field :grade_english_single, label: { text: "Grade" }, hint: { text: t('multiple_gcse_edit_grade.hints.single_award') }, width: 2 %>
           <% end %>
@@ -45,7 +45,7 @@
         <% end %>
       <% end %>
 
-      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+      <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/gcse/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade/edit.html.erb
@@ -6,10 +6,8 @@
     <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl"><%=grade_step_title(@subject, @qualification_type)%></h1>
-
-      <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
+      <% if @qualification_type == 'non_uk' %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: grade_step_title(@subject, @qualification_type), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
@@ -17,6 +15,8 @@
           <% end %>
         <% end %>
       <% else %>
+        <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
+
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
         <% if autocomplete_grades? %>

--- a/app/views/candidate_interface/gcse/institution_country/edit.html.erb
+++ b/app/views/candidate_interface/gcse/institution_country/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @institution_country, url: candidate_interface_gcse_details_edit_institution_country_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl' } %>
+      <%= f.govuk_collection_select :institution_country, select_country_options, :id, :name, label: { text: t("gcse_edit_institution_country.page_title", subject: @subject.capitalize), size: 'xl', tag: 'h1' } %>
       <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
@@ -1,15 +1,13 @@
-<% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @application_qualification.errors.any?) %>
+<% content_for :title, title_with_error_prefix(grade_step_title(@subject, @qualification_type), @gcse_grade_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_edit_gcse_maths_grade_path, method: :patch do |f| %>
+    <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_maths_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
-
-      <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
+      <% if @qualification_type == 'non_uk' %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: grade_step_title(@subject, @qualification_type), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
@@ -17,6 +15,8 @@
           <% end %>
         <% end %>
       <% else %>
+        <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
+
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
         <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 2 %>

--- a/app/views/candidate_interface/gcse/naric/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric/edit.html.erb
@@ -11,9 +11,9 @@
       </h1>
 
       <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
-      <%= f.govuk_radio_buttons_fieldset :naric_details, legend: { text: t('application_form.gcse.naric_statement.label'), tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :naric_details, legend: { text: t('application_form.gcse.naric_statement.label'), size: 'm' } do %>
         <%= f.govuk_radio_button :have_naric_reference, 'Yes', label: { text: 'Yes' } do %>
-          <%=  f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
+          <%= f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
           <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('application_form.gcse.comparable_uk_qualification.label'), size: 's'}, hint: { text: t('application_form.gcse.comparable_uk_qualification.hint_text') } do %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') } %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel') } %>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -6,10 +6,8 @@
     <%= form_with model: @gcse_grade_form, url: candidate_interface_edit_gcse_science_grade_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
-
       <% if @qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: grade_step_title(@subject, @qualification_type), size: 'xl', tag: 'h1' } do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
@@ -17,7 +15,10 @@
           <% end %>
         <% end %>
       <% else %>
+        <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
+
         <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
+
         <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint: { text: hint_for_gcse_edit_grade(@subject, @qualification_type) }, width: 10 %>
       <% end %>
 

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -10,7 +10,7 @@
         <%= t("gcse_edit_type.page_titles.#{@subject}") %>
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: t('application_form.gcse.qualification_type.label'), tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: t('application_form.gcse.qualification_type.label'), size: 'm' } do %>
         <% select_gcse_qualification_type_options.each_with_index do |option, i| %>
           <%= f.govuk_radio_divider if i == select_gcse_qualification_type_options.count - 1 %>
           <% if option.id == :other_uk %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -6,7 +6,7 @@
   <% elsif @form.btec? %>
     <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>
-    <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.other_qualification.grade.label'), tag: 'span' } do %>
+    <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.other_qualification.grade.label'), size: 'm' } do %>
       <% OTHER_UK_QUALIFICATION_GRADES.each_with_index do |grade, i| %>
         <%= f.govuk_radio_button :grade, grade, link_errors: i.zero?, label: { text: grade.to_s }%>
       <% end %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -17,7 +17,7 @@
 
       <%= render partial: 'form', locals: { f: f, subjects: @subjects, grades: @grades } %>
 
-      <%= f.govuk_radio_buttons_fieldset :add_another_qualification, legend: { text: 'Do you want to add another qualification?', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :add_another_qualification, legend: { text: 'Do you want to add another qualification?', size: 'm' } do %>
         <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another #{@form.qualification_type_name}" } %>
         <%= f.govuk_radio_button :choice, 'different_type', label: { text: 'Yes, add a different qualification' } %>
         <%= f.govuk_radio_button :choice, 'no', label: { text: 'No, not at the moment' } %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -6,7 +6,7 @@
 
 <%= render 'candidate_interface/other_qualifications/shared/instructions' %>
 
-<%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', tag: 'span' } do %>
+<%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', size: 'm' } do %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' } %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::A_LEVEL_TYPE, label: { text: 'A level' } %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::AS_LEVEL_TYPE, label: { text: 'AS level' } %>

--- a/app/views/candidate_interface/personal_details/base/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/base/_shared_form.html.erb
@@ -8,6 +8,6 @@
 
   <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.last_name.hint_text') }, autocomplete: 'family-name' %>
 
-  <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
+  <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), size: 'm' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
 
   <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/personal_details/languages/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/languages/_shared_form.html.erb
@@ -2,11 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= f.govuk_error_summary %>
 
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.languages') %>
-    </h1>
-
-    <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label'), tag: 'span' } do %>
+    <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { text: t('application_form.personal_details.english_main_language.label'), size: 'xl', tag: 'h1' } do %>
       <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' }, link_errors: true do %>
         <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
       <% end %>

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_check_boxes_fieldset :nationalities, legend: { size: 'xl', text:  t('page_titles.nationalities') } do %>
+<%= f.govuk_check_boxes_fieldset :nationalities, legend: { size: 'xl', text:  t('page_titles.nationalities'), tag: 'h1' } do %>
   <%= f.govuk_check_box(
     :nationalities,
     'British',

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'xl', text: t('page_titles.right_to_work'), tag: 'h2' } do %>
+<%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'xl', text: t('page_titles.right_to_work'), tag: 'h1' } do %>
   <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' } do %>
     <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint: { text: 'For example, you have settled status or a permanent residence card' } %>
   <% end %>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -36,7 +36,7 @@
         Contact your provider if you’re concerned about the interview process.
       </p>
 
-      <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { text: t('application_form.personal_statement.interview_preferences.label'), size: 'm' } do %>
         <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label'), size: 's' }, rows: 8, max_words: 200 %>
         <% end %>

--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -34,7 +34,7 @@
 
       <p class="govuk-body">It will not necessarily stop you becoming a teacher.</p>
 
-      <%= f.govuk_radio_buttons_fieldset :share_safeguarding_issues, legend: { size: 'm', text: 'Do you want to share any safeguarding issues?' } do %>
+      <%= f.govuk_radio_buttons_fieldset :share_safeguarding_issues, legend: { text: 'Do you want to share any safeguarding issues?', size: 'm' } do %>
         <%= f.govuk_radio_button :share_safeguarding_issues, 'Yes', label: { text: 'Yes, I want to share something' }, hint: { text: 'After you have submitted your application, your provider may be in touch to discuss the information you shared. If you prefer, you can contact your provider directly.' } do %>
           <%= f.govuk_text_area :safeguarding_issues, rows: 8, label: { text: 'Give any relevant information', size: 's' }, max_words: 400 %>
         <% end %>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -26,7 +26,7 @@
         <li>reject your application because you’re disabled</li>
       </ul>
 
-      <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { size: 'm', text: t('application_form.training_with_a_disability.disclose_disability.label') } do %>
+      <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { text: t('application_form.training_with_a_disability.disclose_disability.label'), size: 'm' } do %>
         <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') } do %>
           <%= f.govuk_text_area :disability_disclosure, rows: 8, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label'), size: 's' }, max_words: 400 %>
         <% end %>

--- a/app/views/candidate_interface/unsubmitted_application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/submit_show.html.erb
@@ -33,7 +33,7 @@
         </p>
       </div>
 
-      <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
+      <%= f.govuk_radio_buttons_fieldset :further_information, legend: { text: t('application_form.further_information.further_information.label'), size: 'm' } do %>
         <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_area :further_information_details, label: { text: t('application_form.further_information.further_information_details.label') }, max_words: 300 %>
         <% end %>

--- a/app/views/candidate_interface/volunteering/base/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/base/_form.html.erb
@@ -4,19 +4,17 @@
 
 <%= f.govuk_text_field :organisation, label: { text: t('application_form.volunteering.organisation.label'), size: 'm' } %>
 
-<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), tag: 'span' }, inline: true do %>
+<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), size: 'm' }, inline: true do %>
   <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
 <% end %>
 
-<h2 class="govuk-heading-m">How long have you been in this role and what does it involve?</h2>
-
 <div class="app-work-experience__start-date" data-qa="start-date">
-  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date.label'), size: 's', tag: 'span' }, hint: { text: t('application_form.volunteering.start_date.hint_text') } %>
+  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date.label'), size: 'm' }, hint: { text: t('application_form.volunteering.start_date.hint_text') } %>
 </div>
 
 <div class="app-work-experience__end-date" data-qa="end-date">
-  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date.label'), size: 's', tag: 'span' }, hint: { text: t('application_form.volunteering.end_date.hint_text') } %>
+  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date.label'), size: 'm' }, hint: { text: t('application_form.volunteering.end_date.hint_text') } %>
 </div>
 
 <%= f.govuk_text_area :details, label: { text: t('application_form.volunteering.details.label'), size: 'm' }, hint: { text: t('application_form.volunteering.details.hint_text') }, max_words: 150 %>

--- a/app/views/candidate_interface/volunteering/experience/show.html.erb
+++ b/app/views/candidate_interface/volunteering/experience/show.html.erb
@@ -25,7 +25,7 @@
       </p>
 
       <div class="govuk-!-margin-top-6">
-        <%= f.govuk_radio_buttons_fieldset :experience, legend: { size: 'm', text: t('application_form.volunteering.experience.label'), tag: 'span' } do %>
+        <%= f.govuk_radio_buttons_fieldset :experience, legend: { text: t('application_form.volunteering.experience.label'), size: 'm' } do %>
           <%= f.govuk_radio_button :experience, 'true', label: { text: 'Yes' }, link_errors: true %>
           <%= f.govuk_radio_button :experience, 'false', label: { text: 'No' } %>
         <% end %>

--- a/app/views/candidate_interface/work_history/break/_form.html.erb
+++ b/app/views/candidate_interface/work_history/break/_form.html.erb
@@ -6,11 +6,11 @@
 </h1>
 
 <div class="app-work-experience__start-date" data-qa="start-date">
-  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: 'Start of break', size: 'm', tag: 'span' } %>
+  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: 'Start of break', size: 'm' } %>
 </div>
 
 <div class="app-work-experience__end-date" data-qa="end-date">
-  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: 'End of break', size: 'm', tag: 'span' } %>
+  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: 'End of break', size: 'm' } %>
 </div>
 
 <%= f.govuk_text_area :reason, label: { text: 'Enter reasons for break in work history', size: 'm' }, hint: { text: 'For example, parenting or caring responsibilities, unemployment, travel, health, study or other personal reasons' }, max_words: 400, threshold: 90 %>

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -5,7 +5,7 @@
 
 <%= f.govuk_text_field :organisation, label: { text: t('application_form.work_history.organisation.label'), size: 'm' }, hint: { text: t('application_form.work_history.organisation.hint_text') } %>
 
-<%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: t('application_form.work_history.commitment.label'), tag: 'span' } do %>
+<%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: t('application_form.work_history.commitment.label'), size: 'm' } do %>
   <%= f.govuk_radio_button :commitment, 'full_time', label: { text: t('application_form.work_history.commitment.full_time.label') }, link_errors: true %>
   <%= f.govuk_radio_button :commitment, 'part_time', label: { text: t('application_form.work_history.commitment.part_time.label') } do %>
     <%= f.govuk_text_area :working_pattern, label: { text: t('application_form.work_history.working_pattern.label'), size: 's' }, hint: { text: t('application_form.work_history.working_pattern.hint_text') }, rows: 3 %>
@@ -13,16 +13,16 @@
 <% end %>
 
 <div class="app-work-experience__start-date" data-qa="start-date">
-  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.work_history.start_date.label'), size: 'm', tag: 'span' }, hint: { text: t('application_form.work_history.start_date.hint_text') } %>
+  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.work_history.start_date.label'), size: 'm' }, hint: { text: t('application_form.work_history.start_date.hint_text') } %>
 </div>
 
 <div class="app-work-experience__end-date" data-qa="end-date">
-  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.work_history.end_date.label'), size: 'm', tag: 'span' }, hint: { text: t('application_form.work_history.end_date.hint_text') } %>
+  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.work_history.end_date.label'), size: 'm' }, hint: { text: t('application_form.work_history.end_date.hint_text') } %>
 </div>
 
 <%= f.govuk_text_area :details, label: { text: t('application_form.work_history.details.label'), size: 'm' }, hint: { text: t('application_form.work_history.details.hint_text') }, max_words: 150 %>
 
-<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.work_history.working_with_children.label'), tag: 'span' } do %>
+<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.work_history.working_with_children.label'), size: 'm' }, inline: true do %>
   <%= f.govuk_radio_button :working_with_children, true, label: { text: t('application_form.work_history.working_with_children.yes.label') }, link_errors: true %>
   <%= f.govuk_radio_button :working_with_children, false, label: { text: t('application_form.work_history.working_with_children.no.label') } %>
 <% end %>

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -17,7 +17,7 @@
 
       <%= render 'form', f: f %>
 
-      <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', size: 'm' } do %>
         <%= f.govuk_radio_button :add_another_job, 'yes',  label: { text: 'Yes, I want to add another job' } %>
         <%= f.govuk_radio_button :add_another_job, 'no', label: { text: 'No, not at the moment' } %>
       <% end %>

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -24,7 +24,7 @@
       </p>
 
       <div class="govuk-!-margin-top-6">
-        <%= f.govuk_radio_buttons_fieldset :work_history, legend: { size: 'm', text: 'Do you have any work history to add?', tag: 'h2' } do %>
+        <%= f.govuk_radio_buttons_fieldset :work_history, legend: { text: 'Do you have any work history to add?', size: 'm' } do %>
           <%= f.govuk_radio_button :work_history, :complete, label: { text: t('application_form.work_history.complete.label'), size: 's' }, hint: { text: t('application_form.work_history.complete.hint_text') }, link_errors: true %>
           <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing.label'), size: 's' } %>
         <% end %>

--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -19,13 +19,13 @@
           ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { size: 'm', text: 'Select year' } do %>
+      <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { text: 'Select year', size: 'm' } do %>
         <% RecruitmentCycle.years_visible_to_providers.each do |year| %>
           <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle::CYCLES[year.to_s] } %>
         <% end %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset :application_status_choice, legend: { size: 'm', text: 'Select applications' } do %>
+      <%= f.govuk_radio_buttons_fieldset :application_status_choice, legend: { text: 'Select applications', size: 'm' } do %>
         <%= f.govuk_radio_button :application_status_choice, 'all', label: { text: 'All applications' } %>
         <%= f.govuk_radio_button :application_status_choice, 'custom', label: { text: 'Applications with a specific status' } do %>
           <%= f.govuk_check_boxes_fieldset :statuses, legend: { size: 's', text: 'Select statuses' } do %>
@@ -37,7 +37,7 @@
       <% end %>
 
       <% if @application_data_export_form.actor_has_more_than_one_provider? %>
-        <%= f.govuk_collection_check_boxes :provider_ids, @application_data_export_form.providers_that_actor_belongs_to, ->(p) { p.id.to_s }, :name, legend: { size: 'm', text: 'Select applications for certain organisations' } %>
+        <%= f.govuk_collection_check_boxes :provider_ids, @application_data_export_form.providers_that_actor_belongs_to, ->(p) { p.id.to_s }, :name, legend: { text: 'Select applications for certain organisations', size: 'm' } %>
       <% end %>
 
       <%= f.govuk_submit 'Export data' %>

--- a/app/views/provider_interface/conditions/edit.html.erb
+++ b/app/views/provider_interface/conditions/edit.html.erb
@@ -26,7 +26,7 @@
 
       <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice, show_header: false) %>
 
-      <%= f.govuk_radio_buttons_fieldset :conditions_met, legend: { size: 'm', text: 'Has the candidate met all of the conditions?', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :conditions_met, legend: { text: 'Has the candidate met all of the conditions?', size: 'm' } do %>
         <%= f.govuk_radio_button :conditions_met, 'yes', label: { text: 'Yes, they’ve met all of the conditions' }, link_errors: true %>
         <%= f.govuk_radio_button :conditions_met, 'no', label: { text: 'No' } %>
       <% end %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -15,11 +15,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_collection_check_boxes(
-            :standard_conditions,
-            standard_conditions_checkboxes,
-            :id,
-            :name,
-            legend: { text: 'Standard conditions', size: 'm', tag: 'h2' },
+        :standard_conditions,
+        standard_conditions_checkboxes,
+        :id,
+        :name,
+        legend: { text: 'Standard conditions', size: 'm' },
       ) %>
 
       <%= f.govuk_fieldset legend: { text: 'Further conditions (optional)', size: 'm' } do %>

--- a/app/views/provider_interface/reasons_for_rejection/edit_initial_questions.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/edit_initial_questions.html.erb
@@ -11,7 +11,7 @@
 
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:candidate_behaviour_y_n, legend: { size: 'm', text: 'Was it related to candidate behaviour?' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:candidate_behaviour_y_n, legend: { text: 'Was it related to candidate behaviour?', size: 'm' }) do %>
         <%= f.govuk_radio_button :candidate_behaviour_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_check_boxes_fieldset :candidate_behaviour_what_did_the_candidate_do, legend: { text: "What did the candidate do?", size: "s" } do %>
             <%= f.govuk_check_box :candidate_behaviour_what_did_the_candidate_do,
@@ -35,7 +35,7 @@
         <%= f.govuk_radio_button :candidate_behaviour_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:quality_of_application_y_n, legend: { size: 'm', text: 'Was it related to the quality of their application?' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:quality_of_application_y_n, legend: { text: 'Was it related to the quality of their application?', size: 'm' }) do %>
         <%= f.govuk_radio_button :quality_of_application_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_check_boxes_fieldset :quality_of_application_which_parts_needed_improvement, legend: { text: "What did the candidate do?", size: "s" } do %>
             <%= f.govuk_check_box :quality_of_application_which_parts_needed_improvement,
@@ -65,7 +65,7 @@
         <%= f.govuk_radio_button :quality_of_application_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:qualifications_y_n, legend: { size: 'm', text: 'Was it related to their qualifications?' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:qualifications_y_n, legend: { text: 'Was it related to their qualifications?', size: 'm' }) do %>
         <%= f.govuk_radio_button :qualifications_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_check_boxes_fieldset :qualifications_which_qualifications, legend: { text: "Which qualifications?", size: "s" } do %>
             <%= f.govuk_check_box :qualifications_which_qualifications,
@@ -96,7 +96,7 @@
             <%= f.govuk_radio_button :qualifications_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:performance_at_interview_y_n, legend: { size: 'm', text: 'Was it related to their performance at interview?' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:performance_at_interview_y_n, legend: { text: 'Was it related to their performance at interview?', size: 'm' }) do %>
         <%= f.govuk_radio_button :performance_at_interview_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_area :performance_at_interview_what_to_improve,
             label: { text: 'What could they do to improve?' }, max_words: 100 %>
@@ -104,12 +104,12 @@
         <%= f.govuk_radio_button :performance_at_interview_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:course_full_y_n, legend: { size: 'm', text: 'Was it because this course is full?' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:course_full_y_n, legend: { text: 'Was it because this course is full?', size: 'm' }) do %>
         <%= f.govuk_radio_button :course_full_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :course_full_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:offered_on_another_course_y_n, legend: { size: 'm', text: 'Was it because you offered them a place on another course?' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:offered_on_another_course_y_n, legend: { text: 'Was it because you offered them a place on another course?', size: 'm' }) do %>
         <%= f.govuk_radio_button :offered_on_another_course_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_area :offered_on_another_course_details,
             label: { text: 'Give details about the course you offered' }, max_words: 100 %>
@@ -117,7 +117,7 @@
         <%= f.govuk_radio_button :offered_on_another_course_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:honesty_and_professionalism_y_n, legend: { size: 'm', text: 'Was it related to concerns about the candidate’s honesty and professionalism' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:honesty_and_professionalism_y_n, legend: { text: 'Was it related to concerns about the candidate’s honesty and professionalism', size: 'm' }) do %>
         <%= f.govuk_radio_button :honesty_and_professionalism_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_check_boxes_fieldset :honesty_and_professionalism_concerns, legend: { text: "Which qualifications?", size: "s" } do %>
             <%= f.govuk_check_box :honesty_and_professionalism_concerns,
@@ -152,7 +152,7 @@
         <%= f.govuk_radio_button :honesty_and_professionalism_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:safeguarding_y_n, legend: { size: 'm', text: 'Was it related to safeguarding' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:safeguarding_y_n, legend: { text: 'Was it related to safeguarding', size: 'm' }) do %>
         <%= f.govuk_radio_button :safeguarding_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_check_boxes_fieldset :safeguarding_concerns, legend: { text: "Which safeguarding issues in particular?", size: "s" } do %>
             <%= f.govuk_check_box :safeguarding_concerns,

--- a/app/views/provider_interface/reasons_for_rejection/edit_other_reasons.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/edit_other_reasons.html.erb
@@ -15,14 +15,14 @@
         <%= f.govuk_text_area :why_are_you_rejecting_this_application, label: { text: 'Why are you rejecting this application?', size: 'm' }, max_words: 200 %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:other_advice_or_feedback_y_n, legend: { size: 'm', text: "Is there any other advice or feedback you’d like to give #{@application_choice.application_form.full_name}?" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:other_advice_or_feedback_y_n, legend: { text: "Is there any other advice or feedback you’d like to give #{@application_choice.application_form.full_name}?", size: 'm' }) do %>
         <%= f.govuk_radio_button :other_advice_or_feedback_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_area :other_advice_or_feedback_details, label: { text: 'Please give details' }, max_words: 100 %>
         <% end %>
         <%= f.govuk_radio_button :other_advice_or_feedback_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:interested_in_future_applications_y_n, legend: { size: 'm', text: "Would you be interested in future applications from #{@application_choice.application_form.full_name}" }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:interested_in_future_applications_y_n, legend: { text: "Would you be interested in future applications from #{@application_choice.application_form.full_name}", size: 'm' }) do %>
         <%= f.govuk_radio_button :interested_in_future_applications_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :interested_in_future_applications_y_n, 'No', label: { text: 'No' } %>
       <% end %>

--- a/app/views/support_interface/application_forms/applicant_details/edit.html.erb
+++ b/app/views/support_interface/application_forms/applicant_details/edit.html.erb
@@ -10,7 +10,7 @@
         <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.first_name.hint_text') }, autocomplete: 'given-name' %>
         <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint: { text: t('application_form.personal_details.last_name.hint_text') }, autocomplete: 'family-name' %>
         <%= f.govuk_email_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint: { text: t('authentication.sign_up.email_address.hint_label') }, autocomplete: 'email', spellcheck: false %>
-        <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
+        <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), size: 'm' }, hint: { text: t('application_form.personal_details.date_of_birth.hint_text') } %>
         <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_information.phone_number.label'), size: 'm' }, hint: { text: t('application_form.contact_information.phone_number.hint_text') }, autocomplete: 'tel' %>
         <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
       <% end %>

--- a/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
+++ b/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @right_to_work_or_study_form, url: support_interface_application_form_edit_right_to_work_or_study_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'l', text: 'Edit applicant right to work or study', tag: 'h2' } do %>
+      <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'l', text: 'Edit applicant right to work or study', tag: 'h1' } do %>
         <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' } do %>
           <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint: { text: 'For example, you have settled status or a permanent residence card' } %>
         <% end %>

--- a/app/views/support_interface/course/show.html.erb
+++ b/app/views/support_interface/course/show.html.erb
@@ -7,7 +7,7 @@
 <%= form_with model: @course, url: support_interface_course_path(@course), method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset :open_on_apply, legend: { size: 'm', text: 'Where can candidates apply for this course?', tag: 'span' } do %>
+  <%= f.govuk_radio_buttons_fieldset :open_on_apply, legend: { text: 'Where can candidates apply for this course?', size: 'm' } do %>
     <%= f.govuk_radio_button :open_on_apply, true, label: { text: 'Apply and UCAS' }, link_errors: true %>
     <%= f.govuk_radio_button :open_on_apply, false, label: { text: 'UCAS only' } %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
     personal_details: Personal details
     personal_information: Personal information
     nationalities: What is your nationality?
-    languages: Languages
+    languages: Is English your main language?
     right_to_work: Do you have the right to work or study in the UK?
     review_application: Review your application
     data_sharing_agreement: Data sharing agreement


### PR DESCRIPTION
This change adds `<h1>` elements to many form pages which currently only have a fieldset legend.

The `<h1>` heading is useful for users of assistive technologies, as it provides extra information about the page structure, and can be combined with the fieldset legend.

It looks like this is a regression caused by the removal of the `<h1>` being a default in [version 2.1.0 of the govuk_design_system_formbuilder implementation](https://github.com/DFE-Digital/govuk_design_system_formbuilder/releases/tag/v2.1.0).