### PR TITLE
Add guidance to the 'add a course' flow in the support interface

### DIFF
--- a/app/views/support_interface/application_forms/courses/new_search.html.erb
+++ b/app/views/support_interface/application_forms/courses/new_search.html.erb
@@ -1,15 +1,26 @@
-<% content_for :title, title_with_error_prefix("Search for a course to add to #{@course_search.applicant_name}’s application", @course_search.errors.any?) %>
+<% content_for :title, title_with_error_prefix("Search for a course code", @course_search.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">A candidate can only add up to 3 courses. They cannot add the same course twice.</p>
+    <p class="govuk-body">You can find the course code by searching on
+      <%= govuk_link_to(
+            'Find postgraduate teacher training',
+            'https://www.find-postgraduate-teacher-training.service.gov.uk/',
+            target: "_blank",
+            rel:    "nofollow"
+          ) %>.
+    </p>
+    <p class="govuk-body">The code you need is in the title of the course.</p>
+    <p class="govuk-body">For example, the course code for York St John University Primary (Q859), is Q859.</p>
     <%= form_with(
-            model: @course_search,
-            url: support_interface_application_form_search_course_path,
+          model: @course_search,
+          url:   support_interface_application_form_search_course_path,
         ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :course_code, label: { text: 'Course code' }, width: 5 %>
+      <%= f.govuk_text_field :course_code, label: { text: 'Course code', size: 'm' }, width: 5 %>
       <%= f.govuk_submit "Search" %>
     <% end %>
   </div>


### PR DESCRIPTION
## Context

Recently, we made it possible for support users to add a course to a candidate's application. This PR add some guidance to the flow.

## Changes proposed in this pull request

- Add copy to the course code search page as per https://docs.google.com/document/d/1rpKuUtA171RyStQsAuTf4tPiwdCmPB3ok6bPI0sWqsE/edit

<img width="987" alt="add_a_course_copy" src="https://user-images.githubusercontent.com/5256922/102763714-f83c5100-4371-11eb-87e6-4ffe23c0f4a6.png">

## Link to Trello card

https://trello.com/c/yZ7Ahqvp/2621-dev-%F0%9F%8F%88-allow-support-users-to-add-a-course-in-support-post-submission

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
