### PR TITLE
Return prevalent nationality for HESA export

### DIFF
--- a/app/decorators/application_choice_hesa_export_decorator.rb
+++ b/app/decorators/application_choice_hesa_export_decorator.rb
@@ -1,0 +1,8 @@
+class ApplicationChoiceHesaExportDecorator < ApplicationChoiceExportDecorator
+  def nationality
+    return 'GB' if nationalities.include?('GB')
+    return (nationalities & EU_COUNTRY_CODES).first if (nationalities & EU_COUNTRY_CODES).any?
+
+    nationalities.first
+  end
+end

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -16,7 +16,7 @@ module ProviderInterface
       rows = []
 
       applications.each do |application_choice|
-        application = ApplicationChoiceExportDecorator.new(application_choice)
+        application = ApplicationChoiceHesaExportDecorator.new(application_choice)
 
         first_degree = application.application_form.application_qualifications
           .order(created_at: :asc)
@@ -28,7 +28,7 @@ module ProviderInterface
           'first_name' => application.application_form.first_name,
           'last_name' => application.application_form.last_name,
           'date_of_birth' => application.application_form.date_of_birth,
-          'nationality' => application.application_form.first_nationality,
+          'nationality' => application.nationality,
           'domicile' => application.application_form.domicile,
           'email' => application.application_form.candidate.email_address,
           'recruitment_cycle_year' => application.application_form.recruitment_cycle_year,

--- a/config/initializers/nationalities.rb
+++ b/config/initializers/nationalities.rb
@@ -228,3 +228,44 @@ NATIONALITIES = [
 
 NATIONALITIES_BY_NAME = NATIONALITIES.map(&:reverse).to_h
 NATIONALITY_DEMONYMS = NATIONALITIES.map(&:second)
+
+# Last updated on 21/12/2020. To update run the following code in irb and update the EU_COUNTRY_CODES array with the result.
+# require 'net/http' # require 'json'
+# response = Net::HTTP.get('restcountries.eu', '/rest/v2/regionalbloc/eu?fields=alpha2Code;name')
+# JSON.parse(response).inject([]) { |response, country| response << [ country['alpha2Code'], country['name'] ] }
+
+EU_COUNTRY_CODES = [
+  'AX',
+  'AT',
+  'BE',
+  'BG',
+  'HR',
+  'CY',
+  'CZ',
+  'DK',
+  'EE',
+  'FO',
+  'FI',
+  'FR',
+  'GF',
+  'DE',
+  'GI',
+  'GR',
+  'HU',
+  'IE',
+  'IM',
+  'IT',
+  'LV',
+  'LT',
+  'LU',
+  'MT',
+  'NL',
+  'PL',
+  'PT',
+  'RO',
+  'SK',
+  'SI',
+  'ES',
+  'SE',
+  'GB'
+].freeze

--- a/spec/decorators/application_choice_hesa_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_hesa_export_decorator_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationChoiceHesaExportDecorator do
+  describe 'nationality' do
+    let(:decorated_application_form) { described_class.new(application_choice) }
+    let(:application_choice) { create(:application_choice, application_form: application_form) }
+
+    context 'when dual nationality including British' do
+      let(:application_form) { create(:application_form, first_nationality: 'Cypriot', second_nationality: 'British') }
+
+      it 'returns GB' do
+        expect(decorated_application_form.nationality).to eq('GB')
+      end
+    end
+
+    context 'when dual nationality, not including British, but including non-UK EU country' do
+      let(:application_form) { create(:application_form, first_nationality: 'Cypriot', second_nationality: 'American') }
+
+      it 'returns the EU country code' do
+        expect(decorated_application_form.nationality).to eq('CY')
+      end
+    end
+
+    context 'when dual nationality and both are non-UK EU countries' do
+      let(:application_form) { create(:application_form, first_nationality: 'Greek', second_nationality: 'Hungarian') }
+
+      it 'returns the first EU country code' do
+        expect(decorated_application_form.nationality).to eq('GR')
+      end
+    end
+
+    context 'when dual nationality and both are neither is British or EU' do
+      let(:application_form) { create(:application_form, first_nationality: 'Indian', second_nationality: 'American') }
+
+      it 'returns the first occuring nationality' do
+        expect(decorated_application_form.nationality).to eq('IN')
+      end
+    end
+  end
+end

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ProviderInterface::HesaDataExport do
     let(:training_provider) { provider_relationship.training_provider }
     let(:accredited_provider) { provider_relationship.ratifying_provider }
     let(:provider_user) { create(:provider_user, :with_view_diversity_information, providers: [training_provider]) }
-
     let(:hesa_disabilities) { [53, 55, 54] }
+    let(:decorated_application) { ApplicationChoiceHesaExportDecorator.new(@application_with_offer) }
 
     subject(:export_data) { described_class.new(actor: provider_user).call }
 
@@ -21,7 +21,7 @@ RSpec.describe ProviderInterface::HesaDataExport do
         expect(row['first_name']).to eq(@application_with_offer.application_form.first_name)
         expect(row['last_name']).to eq(@application_with_offer.application_form.last_name)
         expect(row['date_of_birth']).to eq(@application_with_offer.application_form.date_of_birth.to_s)
-        expect(row['nationality']).to eq(@application_with_offer.application_form.first_nationality)
+        expect(row['nationality']).to eq(decorated_application.nationality)
         expect(row['domicile']).to eq(@application_with_offer.application_form.domicile)
         expect(row['email']).to eq(@application_with_offer.application_form.candidate.email_address)
         expect(row['recruitment_cycle_year']).to eq(@application_with_offer.application_form.recruitment_cycle_year.to_s)


### PR DESCRIPTION
## Context

Exposes #nationality field in ApplicationChoiceDecorator satisfying conditions mentioned in notes section: https://www.hesa.ac.uk/collection/c18051/a/nation

> Where a student has dual nationality including British, they should be coded as United Kingdom (GB). If a dual nationality, not including British, but including non-UK EU country then use relevant EU country code. If neither British or non-UK EU country then code as either nationality.

## Changes proposed in this pull request

Add`EU_COUNTRY_CODES` constant in nationalities initialiser and `nationality` field in `ApplicationChoice` decorator

## Link to Trello card

https://trello.com/c/428KZfgZ/3147-improve-nationality-value-calculation-in-hesa-export

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
