### PR TITLE
Fix naming on fieldsets for non UK GCSE grades

### DIFF
--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
 
       <% if @gcse_grade_form.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>

--- a/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/multiple_gcse_edit.html.erb
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-xl"><%= t('multiple_gcse_edit_grade.page_title')%></h1>
 
       <% if @gcse_grade_form.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>

--- a/app/views/candidate_interface/gcse/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade/edit.html.erb
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-xl"><%=grade_step_title(@subject, @qualification_type)%></h1>
 
       <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>

--- a/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/maths/grade/edit.html.erb
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
 
       <% if @application_qualification.qualification.qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
 
       <% if @qualification_type == 'non_uk' %>
-        <%= f.govuk_radio_buttons_fieldset :naric_details, legend: nil do %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: nil do %>
           <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>


### PR DESCRIPTION
## Context

UI designer spotted an inconsistency on the naming of radio button fieldsets on GCSE grade views.
Current name suggests that grade is linked to NARIC details but is actually independent of this.

## Changes proposed in this pull request

Have changed the fieldset name on all views to reflect this.

## Guidance to review

Is this a good renaming?

## Link to Trello card

https://trello.com/c/VBaC2onK/2765-name-inconsistency-on-fieldset-for-non-uk-gcse

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
