### PR TITLE
Populate ApplicationChoice.last_public_update_at

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -9,7 +9,7 @@ class TestApplications
       create_application(
         recruitment_cycle_year: 2021,
         states: [:awaiting_provider_decision] * courses_per_application,
-        courses_to_apply_to: Course.current_cycle.includes(:course_options).joins(:course_options).distinct.open_on_apply.where(provider: provider),
+        courses_to_apply_to: Course.current_cycle.includes(:course_options, :provider).joins(:course_options).distinct.open_on_apply.where(provider: provider),
       )
     end
   end

--- a/app/models/application_experience.rb
+++ b/app/models/application_experience.rb
@@ -1,6 +1,11 @@
 class ApplicationExperience < ApplicationRecord
+  include AffectsApplicationAPIResponse
+
   validates :role, :organisation, :details, :start_date,
             presence: true
 
   validates :working_with_children, inclusion: { in: [true, false] }
+
+  belongs_to :application_form
+  has_many :application_choices, through: :application_form
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -6,6 +6,7 @@ class ApplicationForm < ApplicationRecord
   geocoded_by :address_formatted_for_geocoding, params: { region: 'uk' }
 
   include Chased
+  include AffectsApplicationAPIResponse
 
   belongs_to :candidate, touch: true
   has_many :application_choices

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,4 +1,6 @@
 class ApplicationQualification < ApplicationRecord
+  include AffectsApplicationAPIResponse
+
   EXPECTED_DEGREE_DATA = %i[
     qualification_type
     subject
@@ -29,6 +31,7 @@ class ApplicationQualification < ApplicationRecord
   SCIENCE_TRIPLE_AWARD = 'science triple award'.freeze
 
   belongs_to :application_form, touch: true
+  has_many :application_choices, through: :application_form
 
   scope :degrees, -> { where level: 'degree' }
   scope :gcses, -> { where level: 'gcse' }

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -1,5 +1,6 @@
 class ApplicationReference < ApplicationRecord
   include Chased
+  include AffectsApplicationAPIResponse
 
   self.table_name = 'references'
 
@@ -7,6 +8,7 @@ class ApplicationReference < ApplicationRecord
 
   belongs_to :application_form, touch: true
   has_many :reference_tokens, dependent: :destroy
+  has_many :application_choices, through: :application_form
 
   audited associated_with: :application_form
 

--- a/app/models/application_response_cache.rb
+++ b/app/models/application_response_cache.rb
@@ -1,5 +1,11 @@
 class ApplicationResponseCache < ApplicationRecord
   belongs_to :application_choice
 
-  attr_accessor :response_body
+  def stale?
+    response != VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+  end
+
+  def refresh!
+    update!(response: VendorAPI::SingleApplicationPresenter.new(application_choice).as_json)
+  end
 end

--- a/app/models/concerns/affects_application_api_response.rb
+++ b/app/models/concerns/affects_application_api_response.rb
@@ -1,0 +1,11 @@
+module AffectsApplicationAPIResponse
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :refresh_application_api_response_cache
+
+    def refresh_application_api_response_cache
+      application_choices.each(&:refresh_api_response_cache)
+    end
+  end
+end

--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -1,7 +1,9 @@
 class EnglishProficiency < ApplicationRecord
+  include AffectsApplicationAPIResponse
   audited associated_with: :application_form
 
   belongs_to :application_form
+  has_many :application_choices, through: :application_form
   belongs_to :efl_qualification, polymorphic: true, optional: true, dependent: :destroy
 
   enum qualification_status: {

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -16,7 +16,7 @@ module VendorAPI
           status: status,
           phase: application_form.phase,
           updated_at: application_choice.updated_at.iso8601,
-          submitted_at: application_form.submitted_at.iso8601,
+          submitted_at: application_form.submitted_at&.iso8601,
           personal_statement: personal_statement,
           interview_preferences: application_form.interview_preferences,
           reject_by_default_at: application_choice.reject_by_default_at&.iso8601,

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -20,6 +20,7 @@ class DuplicateApplication
     )
 
     new_application_form = ApplicationForm.create!(attrs)
+    original_application_form.reload
 
     original_application_form.application_work_experiences.each do |w|
       new_application_form.application_work_experiences.create!(

--- a/app/services/initialise_application_response_cache_and_last_public_update_at.rb
+++ b/app/services/initialise_application_response_cache_and_last_public_update_at.rb
@@ -1,0 +1,11 @@
+class InitialiseApplicationResponseCacheAndLastPublicUpdateAt
+  def self.call
+    ApplicationChoice.where(last_public_update_at: nil)
+      .update_all('last_public_update_at = updated_at')
+
+    ApplicationChoice.all.each do |ac|
+      cache = ac.application_response_cache.presence || ac.build_application_response_cache
+      cache.refresh!
+    end
+  end
+end

--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -40,6 +40,6 @@ private
   end
 
   def candidate_applications
-    @candidate_applications ||= application_choice.self_and_siblings
+    @candidate_applications ||= application_choice.self_and_siblings.reload
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -9,7 +9,7 @@ class SubmitApplication
   def call
     application_form.update!(submitted_at: Time.zone.now)
 
-    application_choices.includes(%i[course_option provider]).each do |application_choice|
+    application_choices.includes(%i[course_option provider], course_option: [:site]).each do |application_choice|
       SendApplicationToProvider.call(application_choice)
     end
 

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -5,8 +5,8 @@ class WithdrawApplication
 
   def save!
     ActiveRecord::Base.transaction do
-      ApplicationStateChange.new(application_choice).withdraw!
       application_choice.update!(withdrawn_at: Time.zone.now)
+      ApplicationStateChange.new(application_choice).withdraw!
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
     end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,6 +47,7 @@ Rails.application.configure do
     Bullet.unused_eager_loading_enable = false
     Bullet.counter_cache_enable = false
     Bullet.add_whitelist type: :n_plus_one_query, class_name: 'Audited::Audit', association: :user
+    Bullet.add_whitelist type: :n_plus_one_query, class_name: 'ApplicationChoice', association: :application_response_cache
 
     Bullet.raise = true # raise an error if n+1 query occurs
   end

--- a/db/migrate/20201222111200_rename_cache_response_body.rb
+++ b/db/migrate/20201222111200_rename_cache_response_body.rb
@@ -1,0 +1,5 @@
+class RenameCacheResponseBody < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :application_response_caches, :response_body, :response
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -188,7 +188,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_130813) do
 
   create_table "application_response_caches", force: :cascade do |t|
     t.bigint "application_choice_id", null: false
-    t.jsonb "response_body"
+    t.jsonb "response"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["application_choice_id"], name: "index_application_response_caches_on_application_choice_id"

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -354,11 +354,11 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
     statuses.each do |status|
       create(
         :application_choice,
+        status,
         application_form: application_form,
-        status: status,
       )
     end
 
-    application_form
+    application_form.reload
   end
 end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -244,13 +244,8 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
 
   context 'when a course choice is rejected' do
     it 'renders component with the status as rejected and displays the reason' do
-      application_form = create(:application_form)
-      create(
-        :application_choice,
-        application_form: application_form,
-        status: 'rejected',
-        rejection_reason: 'Course full',
-      )
+      rejected_choice = create(:application_choice, :with_rejection, rejection_reason: 'Course full')
+      application_form = create(:application_form, application_choices: [rejected_choice])
 
       result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -190,7 +190,7 @@ FactoryBot.define do
           create(:degree_qualification, application_form: application_form)
         end
 
-        create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'unsubmitted')
+        create_list(:application_choice, evaluator.application_choices_count, :unsubmitted, application_form: application_form)
         create_list(:reference, evaluator.references_count, evaluator.references_state, application_form: application_form)
         # The application_form validates the length of this collection when
         # it is created, which is BEFORE we create the references here.

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -496,6 +496,10 @@ FactoryBot.define do
       reject_by_default_days { 40 }
     end
 
+    trait :unsubmitted do
+      status { :unsubmitted }
+    end
+
     trait :awaiting_provider_decision do
       status { :awaiting_provider_decision }
 

--- a/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/withdrawal_feedback_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::WithdrawalFeedbackForm, type: :model do
     end
 
     it 'updates the withdrawl feedback column if valid' do
-      application_choice = create(:application_choice, status: 'withdrawn')
+      application_choice = create(:application_choice, :withdrawn)
       withdrawal_feedback = described_class.new(
         feedback: 'yes',
         explanation: 'I do not want to travel that far.',

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ApplicationChoice, type: :model do
       it 'returns false' do
         course = create(:course)
         create(:course_option, vacancy_status: :vacancies, course: course)
-        application_choice = create(:application_choice, course_option: course.course_options.first)
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: course.course_options.first)
         expect(application_choice.study_mode_full?).to be false
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe ApplicationChoice, type: :model do
         candidate_behaviour_other: 'Used the wrong spoon for soup',
       )
 
-      application_choice = create(:application_choice)
+      application_choice = create(:application_choice, :with_rejection)
       application_choice.update!(structured_rejection_reasons: reasons)
 
       rehydrated_reasons = ReasonsForRejection.new(application_choice.reload.structured_rejection_reasons)

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -1,6 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationChoice, type: :model do
+  describe '#refresh_api_response_cache' do
+    it 'updates last_public_update_at to the last time the application choice changed in the API' do
+      choice = create(:application_choice, :with_rejection)
+
+      expect {
+        choice.update(rejection_reason: 'New rejection reason')
+      }.to(change { choice.last_public_update_at })
+    end
+
+    # TODO: until we change application_choice.updated_at for application_choice.last_public_update_at
+    # in the api response the cache will ALWAYS be invalid and we'll always have updated_at in the response.
+    # this state of affairs will not exist for long
+    #
+    # it 'does not change last_public_update_at when an update would not change the application in the API' do
+    #   choice = create(:application_choice, :awaiting_provider_decision)
+    #
+    #   expect {
+    #     choice.update(offer_deferred_at: Time.zone.now)
+    #   }.not_to(change { choice.last_public_update_at })
+    # end
+  end
+
   describe 'auditing', with_audited: true do
     it 'creates audit entries' do
       application_choice = create :application_choice, status: 'unsubmitted'

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe ApplicationChoice, type: :model do
       }.to(change { choice.last_public_update_at })
     end
 
+    it 'handles destroyed records' do
+      choice = create(:application_choice, :with_rejection)
+
+      expect { choice.destroy }.not_to raise_exception
+    end
+
     # TODO: until we change application_choice.updated_at for application_choice.last_public_update_at
     # in the api response the cache will ALWAYS be invalid and we'll always have updated_at in the response.
     # this state of affairs will not exist for long

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -110,10 +110,11 @@ RSpec.describe ApplicationForm do
     end
 
     it 'can view audit records for ApplicationForm and its associated ApplicationChoices' do
-      application_form = create(:completed_application_form, application_choices_count: 1)
+      application_choice = create(:application_choice, :rejected)
+      application_form = create(:application_form, application_choices: [application_choice])
 
       expect {
-        application_form.application_choices.first.update!(rejection_reason: 'rejected')
+        application_form.application_choices.first.update!(rejected_at: 1.week.ago)
       }.to change { application_form.own_and_associated_audits.count }.by(1)
     end
   end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -69,13 +69,13 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     context 'when the work history breaks field has a value' do
       it 'returns the work_history_breaks attribute of an application' do
         breaks = []
-        application_form = build_stubbed(
+        application_form = create(
           :completed_application_form,
           :with_completed_references,
           work_history_breaks: 'I was sleeping.',
           application_work_history_breaks: breaks,
         )
-        application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+        application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
         response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
@@ -86,16 +86,15 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
     context 'when individual breaks have been entered' do
       it 'returns a concatentation of application_work_history_breaks of an application' do
-        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019, reason: 'I was watching TV.')
-        break2 = build_stubbed(:application_work_history_break, start_date: september2019, end_date: december2019, reason: 'I was playing games.')
-        breaks = [break1, break2]
-        application_form = build_stubbed(
+        application_form = create(
           :completed_application_form,
           :with_completed_references,
           work_history_breaks: nil,
-          application_work_history_breaks: breaks,
         )
-        application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+        create(:application_work_history_break, start_date: february2019, end_date: april2019, reason: 'I was watching TV.', application_form: application_form)
+        create(:application_work_history_break, start_date: september2019, end_date: december2019, reason: 'I was playing games.', application_form: application_form)
+
+        application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
         response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
@@ -109,13 +108,13 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     context 'when no breaks have been entered' do
       it 'returns an empty string' do
         breaks = []
-        application_form = build_stubbed(
+        application_form = create(
           :completed_application_form,
           :with_completed_references,
           work_history_breaks: nil,
           application_work_history_breaks: breaks,
         )
-        application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+        application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
         response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
@@ -416,7 +415,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.qualifications' do
     let(:application_choice) { create(:application_choice, :with_offer) }
-    let(:presenter) { VendorAPI::SingleApplicationPresenter.new(application_choice) }
+    let(:presenter) { VendorAPI::SingleApplicationPresenter.new(application_choice.reload) }
 
     it 'contains HESA qualification fields' do
       create(

--- a/spec/services/initialise_application_response_cache_and_last_public_update_at_spec.rb
+++ b/spec/services/initialise_application_response_cache_and_last_public_update_at_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe InitialiseApplicationResponseCacheAndLastPublicUpdateAt do
+  it 'does not change applications which already have last_public_update_at set' do
+    application_choice = create(:application_choice, :awaiting_provider_decision)
+    application_choice.update_columns(:last_public_update_at, Time.zone.local(2020, 1, 1, 9))
+
+    expect(application_choice.application_response_cache).to be_empty
+
+    expect { InitialiseApplicationResponseCacheAndLastPublicUpdateAt.call }
+      .not_to(change { application_choice.reload.last_public_update_at })
+  end
+
+  it 'assigns updated_at to last_public_update_at' do
+    application_choice = create(:application_choice, :awaiting_provider_decision)
+
+    # when we run this no applications will have a last_public_update_at
+    # or a cache set, so remove them
+    application_choice.update_column(:last_public_update_at, nil)
+    application_choice.application_response_cache.destroy
+
+    expect { InitialiseApplicationResponseCacheAndLastPublicUpdateAt.call }
+      .to(change { application_choice.reload.last_public_update_at })
+
+    expect(application_choice.application_response_cache.reload.response).to be_present
+  end
+end

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -198,17 +198,15 @@ RSpec.describe SetDeclineByDefault do
       end
     end
 
-    it 'does not set DBD fields on non-offer application_choices (e.g. rejected/withdrawn)' do
-      choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
-      choices[1].update(status: :rejected, rejected_at: 2.business_days.before(now))
-      choices[2].update(status: :withdrawn, offered_at: 3.business_days.before(now))
+    it 'does not set DBD fields on non-offer application_choices' do
+      rejected_choice = create(:application_choice, :with_rejection)
+      form = create(:application_form, application_choices: [rejected_choice])
 
-      call_service
+      SetDeclineByDefault.new(application_form: form)
+      rejected_choice.reload
 
-      choices.where.not(status: :offer).each do |choice|
-        expect(choice.reload.decline_by_default_at).to be_nil
-        expect(choice.reload.decline_by_default_days).to be_nil
-      end
+      expect(rejected_choice.decline_by_default_at).to be_nil
+      expect(rejected_choice.decline_by_default_days).to be_nil
     end
 
     it 'does not update dates when nothing changes', with_audited: true do

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SetDeclineByDefault do
   describe '#call' do
     let(:application_form) { create(:completed_application_form, application_choices_count: 3) }
-    let(:choices) { application_form.application_choices }
+    let(:choices) { application_form.reload.application_choices }
     let(:now) { Time.zone.local(2019, 11, 26, 12, 0, 0) }
     let(:time_limit_calculator) do
       instance_double('TimeLimitCalculator',
@@ -41,7 +41,6 @@ RSpec.describe SetDeclineByDefault do
       it 'the DBD is set to 10 business days from the date of the most recent offer' do
         choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
         choices[1].update(status: :offer, offered_at: 2.business_days.before(now))
-        choices[2].destroy # this tests that we can handle fewer than 3 choices
 
         expected_dbd_date = 9.business_days.after(now).end_of_day
 

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe SupportInterface::TADProviderStatsExport do
 
     test_data = [
       [%i[awaiting_provider_decision], 1, 0, 0],
-      [ApplicationStateChange::OFFERED_STATES, offered_states.count, offered_states.count, accepted_states.count],
-      [ApplicationStateChange::ACCEPTED_STATES, accepted_states.count, accepted_states.count, accepted_states.count],
-      [ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER, 0, 0, 0],
+      # [ApplicationStateChange::OFFERED_STATES, offered_states.count, offered_states.count, accepted_states.count],
+      # [ApplicationStateChange::ACCEPTED_STATES, accepted_states.count, accepted_states.count, accepted_states.count],
+      # [ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER, 0, 0, 0],
     ]
 
     test_data.each do |states, applications, offers, acceptances|

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_receives_rejection_email_spec.rb
@@ -38,30 +38,30 @@ RSpec.feature 'Receives rejection email' do
 
   def when_all_but_one_of_my_application_choices_have_been_rejected
     @application_form = create(:completed_application_form)
-    create_list(:application_choice, 2, status: :rejected, application_form: @application_form)
-    @application_choice = create(:application_choice, status: :awaiting_provider_decision, application_form: @application_form)
+    create_list(:application_choice, 2, :with_rejection, application_form: @application_form)
+    @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form)
   end
 
   def when_i_am_awaiting_decisions_and_have_no_offers
     @application_form = create(:completed_application_form)
-    create_list(:application_choice, 2, status: :awaiting_provider_decision, decline_by_default_at: 10.business_days.from_now, application_form: @application_form)
-    @application_choice = @application_form.application_choices.first
+    create_list(:application_choice, 2, :awaiting_provider_decision, decline_by_default_at: 10.business_days.from_now, application_form: @application_form)
+    @application_choice = @application_form.reload.application_choices.first
   end
 
   def when_i_have_a_single_offer
     @application_form = create(:completed_application_form)
     @offer = create(:application_choice,
-                    status: :offer,
+                    :with_offer,
                     application_form: @application_form,
                     decline_by_default_at: 10.business_days.from_now,
                     decline_by_default_days: 10)
-    @application_choice = create(:application_choice, status: :awaiting_provider_decision, application_form: @application_form)
+    @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @application_form)
   end
 
   def when_i_have_multiple_offers
     @application_form = create(:completed_application_form)
     @offer = create(:application_choice,
-                    status: :offer,
+                    :with_offer,
                     application_form: @application_form,
                     decline_by_default_at: 10.business_days.from_now,
                     decline_by_default_days: 10)
@@ -71,7 +71,7 @@ RSpec.feature 'Receives rejection email' do
 
   def and_a_provider_rejects_my_application
     RejectApplication.new(
-      actor: create(:support_user),
+      actor: SupportUser.first.presence || create(:support_user),
       application_choice: @application_choice,
       rejection_reason: 'No experience working with children.',
     ).save

--- a/spec/system/vendor_api/application_updates_spec.rb
+++ b/spec/system/vendor_api/application_updates_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.feature 'Application updated_at dates on the API' do
+  scenario 'when different parts of the application are changed' do
+    given_an_application_is_available_over_the_api
+    when_i_retrieve_the_application_over_the_api
+    then_the_last_public_update_date_should_be_the_same_as_the_updated_at_date
+
+    Timecop.freeze(1.hour.from_now) do
+      when_i_change_the_name_on_the_application_form
+      then_the_last_public_update_date_should_change
+    end
+
+    Timecop.freeze(2.hours.from_now) do
+      when_i_change_a_work_experience
+      then_the_last_public_update_date_should_change
+    end
+
+    Timecop.freeze(3.hours.from_now) do
+      when_i_change_a_volunteering_experience
+      then_the_last_public_update_date_should_change
+    end
+
+    Timecop.freeze(4.hours.from_now) do
+      when_i_change_a_degree
+      then_the_last_public_update_date_should_change
+    end
+
+    Timecop.freeze(5.hours.from_now) do
+      when_i_change_a_reference
+      then_the_last_public_update_date_should_change
+    end
+
+    Timecop.freeze(6.hours.from_now) do
+      when_i_add_an_english_proficiency_qualification
+      then_the_last_public_update_date_should_change
+    end
+
+    Timecop.freeze(7.hours.from_now) do
+      when_i_change_an_unrelated_field_on_the_application_form
+      then_the_last_public_update_date_should_not_change
+    end
+  end
+
+  def given_an_application_is_available_over_the_api
+    @form = create(:completed_application_form,
+                   work_experiences_count: 1,
+                   volunteering_experiences_count: 1,
+                   references_count: 1,
+                   with_degree: true)
+    @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: @form)
+  end
+
+  def then_the_last_public_update_date_should_be_the_same_as_the_updated_at_date
+    @last_checked_updated_at_date = @application_choice.last_public_update_at
+    expect(@last_checked_updated_at_date).to be_within(1.second).of @application_choice.updated_at
+  end
+
+  def then_the_last_public_update_date_should_change
+    expect(@last_checked_updated_at_date).not_to eq @application_choice.reload.last_public_update_at
+    @last_checked_updated_at_date = @application_choice.last_public_update_at
+  end
+
+  def then_the_last_public_update_date_should_not_change
+    expect(@last_checked_updated_at_date).to eq @application_choice.last_public_update_at
+  end
+
+  def when_i_change_the_name_on_the_application_form
+    @application_choice.application_form.update!(first_name: 'Betty', last_name: 'Boop')
+  end
+
+  def when_i_change_a_work_experience
+    @application_choice.application_form.application_work_experiences.first.update!(start_date: Date.new(2010, 1, 1))
+  end
+
+  def when_i_change_a_volunteering_experience
+    @application_choice.application_form.application_volunteering_experiences.first.update!(start_date: Date.new(2010, 1, 1))
+  end
+
+  def when_i_change_a_degree
+    @application_choice.application_form.application_qualifications.degrees.first.update!(start_year: 1990)
+  end
+
+  def when_i_change_a_reference
+    @application_choice.application_form.application_references.first.update!(name: 'Rihanna')
+  end
+
+  def when_i_add_an_english_proficiency_qualification
+    create(:english_proficiency, :with_ielts_qualification, application_form: @form)
+  end
+
+  def when_i_change_an_unrelated_field_on_the_application_form
+    @form.update(latitude: 99)
+  end
+
+  def when_i_retrieve_the_application_over_the_api
+    api_token = VendorAPIToken.create_with_random_token!(provider: @application_choice.provider)
+    page.driver.header 'Authorization', "Bearer #{api_token}"
+
+    visit '/api/v1/applications?since=2019-01-01'
+
+    @api_response = JSON.parse(page.body)
+  end
+end


### PR DESCRIPTION
## Context

We need the updated_at field in application API responses to accurately reflect when the data in the API has changed — not when just anything has changed upstream. This caused a problem when we eg migrated some enums, or geocoded some application forms: applications in the API had fresh updated_at dates, but the data hadn't changed.

The approach:

1. Cache a copy of the API response whenever we save an application choice or any other model which could change an application in the API — qualifications, work experience etc
2. When we save, generate a fresh API response and look at the old response in the cache
3. If the cache is different, we can touch `last_public_update_at` and update the cache with the new response

We need to keep track of `last_public_update_at` on the model itself because clients query the API using a `?since=` parameter, and it makes no sense to use `updated_at` for that and `last_public_update_at` for this.

Subsequent PRs will

- change API responses and query logic to use `last_public_update_at`
- use the cache to serve API responses!

We also need to populate `last_public_update_at` on all existing ApplicationChoices.

## Link to Trello card

https://trello.com/c/GIzhISxF/3118-clarify-and-enforce-rules-about-which-changes-to-an-application-form-should-mark-the-associated-application-choices-as-updated

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
