### PR TITLE
Fix for logic DegreeType controller to mark section incomplete on create

### DIFF
--- a/app/controllers/candidate_interface/degrees/type_controller.rb
+++ b/app/controllers/candidate_interface/degrees/type_controller.rb
@@ -14,6 +14,7 @@ module CandidateInterface
           redirect_to candidate_interface_degree_subject_path(
             @degree_type_form.degree,
           )
+          current_application.update!(degrees_completed: false)
         else
           track_validation_error(@degree_type_form)
           conditionally_render_new_degree_type_form

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_delete_and_replace_degrees_spec.rb
@@ -23,6 +23,10 @@ RSpec.feature 'Deleting and replacing a degree' do
     when_i_click_on_delete_degree
     and_i_confirm_that_i_want_to_delete_my_additional_degree
     then_i_can_only_see_my_undergraduate_degree
+
+    when_i_add_another_degree_type_only
+    and_return_to_the_application_review_page
+    then_i_should_see_the_form_and_the_section_is_not_completed
   end
 
   def given_i_am_signed_in
@@ -186,5 +190,17 @@ RSpec.feature 'Deleting and replacing a degree' do
     @application_form = create(:application_form, candidate: @candidate)
     create(:application_qualification, level: 'degree', application_form: @application_form)
     @application_form.update!(degrees_completed: true)
+  end
+
+  def when_i_add_another_degree_type_only
+    click_link t('application_form.degree.another.button')
+    expect(page).to have_content(t('page_titles.add_another_degree'))
+    choose 'UK degree'
+    fill_in 'Type of degree', with: 'Masters'
+    and_i_click_on_save_and_continue
+  end
+
+  def and_return_to_the_application_review_page
+    visit candidate_interface_application_form_path
   end
 end


### PR DESCRIPTION
## Context

Bug was uncovered that while adding an additional degree section remained completed if flow was exited
 after degree type only was given. This could cause problems as application form submittal validates on
on section completion, so an incomplete qualification could be submitted. 

## Changes proposed in this pull request

Action added to controller so that when degree type is created section is marked as incomplete.

## Guidance to review

Please test in review app and advise RE: system spec if it is necessary.

## Link to Trello card

https://trello.com/c/lWXlNeUg/2729-buggy-ux-when-marking-degree-section-complete

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
