### PR TITLE
Show UCAS matches statistics

### DIFF
--- a/app/components/support_interface/ucas_matches_statistics_component.html.erb
+++ b/app/components/support_interface/ucas_matches_statistics_component.html.erb
@@ -1,0 +1,39 @@
+<ul class='govuk-list'>
+  <li><span class='govuk-!-font-weight-bold'><%= candidates_on_apply_count %></span> candidates on Apply with submitted application</li>
+  <li><span class='govuk-!-font-weight-bold'><%= candidates_matched_with_ucas_count %></span> candidates matched with UCAS, of which</li>
+  <li class='govuk-!-margin-left-5'>
+    <span class='govuk-!-font-weight-bold'><%= applied_for_the_same_course_on_both_services %></span> have applied for the same course on both services
+  </li>
+  <li class='govuk-!-margin-left-5'>
+    <span class='govuk-!-font-weight-bold'><%= accepted_offers_on_both_services %></span> have accepted offers on both services
+  </li>
+</ul>
+
+<div class="govuk-grid-row app-grid-row--flex govuk-!-margin-bottom-6">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: resolved_count || '0', label: 'resolved', colour: :blue) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: action_taken_count['resolved_on_ucas'] || '0', label: 'resolved on UCAS') %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: action_taken_count['resolved_on_apply'] || '0', label: 'resolved on Apply') %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: action_taken_count['manually_resolved'] || '0', label: 'resolved manually') %>
+  </div>
+</div>
+
+<p class='govuk-body'>For the matches which have not been resolved yet, we have taken the following actions</p>
+
+<div class="govuk-grid-row app-grid-row--flex govuk-!-margin-bottom-6">
+  <div class="govuk-grid-column-one-third">
+    <%= render SupportInterface::TileComponent.new(count: action_taken_count['initial_emails_sent'] || '0', label: "#{'set'.pluralize(action_taken_count['initial_emails_sent'])} of initial emails sent", size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render SupportInterface::TileComponent.new(count: action_taken_count['reminder_emails_sent'] || '0', label: "reminder #{'email'.pluralize(action_taken_count['reminder_emails_sent'])} sent", size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render SupportInterface::TileComponent.new(count: action_taken_count['ucas_withdrawal_requested'] || '0', label: "UCAS #{'withdrawal'.pluralize(action_taken_count['ucas_withdrawal_requested'])} requested", size: :reduced) %>
+  </div>
+</div>

--- a/app/components/support_interface/ucas_matches_statistics_component.html.erb
+++ b/app/components/support_interface/ucas_matches_statistics_component.html.erb
@@ -1,6 +1,6 @@
 <ul class='govuk-list'>
   <li><span class='govuk-!-font-weight-bold'><%= candidates_on_apply_count %></span> candidates on Apply with submitted application</li>
-  <li><span class='govuk-!-font-weight-bold'><%= candidates_matched_with_ucas_count %></span> candidates matched with UCAS, of which</li>
+  <li><span class='govuk-!-font-weight-bold'><%= candidates_matched_with_ucas_count_and_percentage %></span> candidates matched with UCAS, of which</li>
   <li class='govuk-!-margin-left-5'>
     <span class='govuk-!-font-weight-bold'><%= applied_for_the_same_course_on_both_services %></span> have applied for the same course on both services
   </li>
@@ -10,8 +10,14 @@
 </ul>
 
 <div class="govuk-grid-row app-grid-row--flex govuk-!-margin-bottom-6">
+  <div class="govuk-grid-column-full">
+    <%= render SupportInterface::TileComponent.new(count: candidates_with_dual_applications_or_dual_acceptance || '0', label: 'candidates with dual application or multiple acceptances', colour: :blue) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row app-grid-row--flex govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-one-quarter">
-    <%= render SupportInterface::TileComponent.new(count: resolved_count || '0', label: 'resolved', colour: :blue) %>
+    <%= render SupportInterface::TileComponent.new(count: unresolved_count || '0', label: 'unresolved', colour: :blue) %>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= render SupportInterface::TileComponent.new(count: action_taken_count['resolved_on_ucas'] || '0', label: 'resolved on UCAS') %>

--- a/app/components/support_interface/ucas_matches_statistics_component.rb
+++ b/app/components/support_interface/ucas_matches_statistics_component.rb
@@ -1,0 +1,79 @@
+module SupportInterface
+  class UCASMatchesStatisticsComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(ucas_matches)
+      @ucas_matches = ucas_matches
+    end
+
+    def candidates_on_apply_count
+      @candidates_on_apply_count ||= ApplicationChoice
+        .where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+        .includes([:application_form])
+        .where(application_forms: { recruitment_cycle_year: recruitment_cycle_years }).references(:application_forms)
+        .map(&:application_form).map(&:candidate_id).uniq.compact.size
+    end
+
+    def candidates_matched_with_ucas_count
+      count = @ucas_matches.size
+
+      "#{count} (#{formatted_percentage(count, candidates_on_apply_count)})"
+    end
+
+    def applied_for_the_same_course_on_both_services
+      "#{dual_applications_count} (#{formatted_percentage(dual_applications_count, candidates_on_apply_count)} of candidates on Apply)"
+    end
+
+    def accepted_offers_on_both_services
+      "#{multiple_acceptances_count} (#{formatted_percentage(multiple_acceptances_count, candidates_on_apply_count)} of candidates on Apply)"
+    end
+
+    def resolved_count
+      @ucas_matches.count(&:resolved?)
+    end
+
+    def action_taken_count
+      @ucas_matches.pluck(:action_taken).tally
+    end
+
+  private
+
+    def dual_applications_count
+      both_scheme_array = @ucas_matches.map do |ucas_match|
+        ucas_match.ucas_matched_applications.map(&:both_scheme?).any?
+      end
+
+      both_scheme_array.count(true)
+    end
+
+    def multiple_acceptances_count
+      # Since the statuses get updated daily, we also include matches that were
+      # in this situation but are now resolved.
+      # Matches which were marked as manually resolved are not counted twice.
+      [@ucas_matches.select(&:application_accepted_on_ucas_and_accepted_on_apply?),
+       resolved_multiple_acceptances].uniq.count
+    end
+
+    def resolved_multiple_acceptances
+      @ucas_matches.select(&:resolved?).reject do |ucas_match|
+        ucas_match.ucas_matched_applications.map(&:both_scheme?).any?
+      end
+    end
+
+    def recruitment_cycle_years
+      @ucas_matches.distinct.pluck(:recruitment_cycle_year)
+    end
+
+    def formatted_percentage(count, total)
+      percentage = count.percent_of(total)
+      precision = (percentage % 1).zero? ? 0 : 2
+      number_to_percentage(percentage, precision: precision)
+    end
+  end
+end
+
+class Numeric
+  def percent_of(number)
+    to_f / number * 100.0
+  end
+end

--- a/app/components/support_interface/ucas_matches_statistics_component.rb
+++ b/app/components/support_interface/ucas_matches_statistics_component.rb
@@ -14,7 +14,7 @@ module SupportInterface
         .map(&:application_form).map(&:candidate_id).uniq.compact.size
     end
 
-    def candidates_matched_with_ucas_count
+    def candidates_matched_with_ucas_count_and_percentage
       count = @ucas_matches.size
 
       "#{count} (#{formatted_percentage(count, candidates_on_apply_count)})"
@@ -28,8 +28,14 @@ module SupportInterface
       "#{multiple_acceptances_count} (#{formatted_percentage(multiple_acceptances_count, candidates_on_apply_count)} of candidates on Apply)"
     end
 
-    def resolved_count
-      @ucas_matches.count(&:resolved?)
+    def candidates_with_dual_applications_or_dual_acceptance
+      dual_applications_count + multiple_acceptances_count
+    end
+
+    def unresolved_count
+      [action_taken_count['initial_emails_sent'],
+       action_taken_count['reminder_emails_sent'],
+       action_taken_count['ucas_withdrawal_requested']].compact.sum
     end
 
     def action_taken_count

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -13,5 +13,7 @@ module SupportInterface
     def unavailable_choices
       @monitor = SupportInterface::ApplicationMonitor.new
     end
+
+    def ucas_matches_stats; end
   end
 end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -6,4 +6,5 @@
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
   <li><%= govuk_link_to 'Applications with unavailable choices', support_interface_unavailable_choices_path %></li>
   <li><%= govuk_link_to 'Feature metrics', support_interface_feature_metrics_dashboard_path %></li>
+  <li><%= govuk_link_to 'UCAS matches statistics', support_interface_ucas_matches_stats_path %></li>
 </ul>

--- a/app/views/support_interface/performance/ucas_matches_stats.html.erb
+++ b/app/views/support_interface/performance/ucas_matches_stats.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'UCAS matches stats' %>
+<% content_for :title, 'UCAS matches statistics' %>
 
 <% content_for :before_content do %>
   <%= render BreadcrumbComponent.new(items: [
@@ -7,7 +7,12 @@
       path: support_interface_performance_path
     },
     {
-      text: 'UCAS matches stats'
+      text: 'UCAS matches statistics'
     }
   ]) %>
 <% end %>
+<h2 class="govuk-heading-m govuk-!-margin-top-9"> Recruitment cycle <%= RecruitmentCycle::CYCLES[RecruitmentCycle.current_year.to_s] %></h2>
+<%= render SupportInterface::UCASMatchesStatisticsComponent.new(UCASMatch.where(recruitment_cycle_year: RecruitmentCycle.current_year)) %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-9"> Recruitment cycle <%= RecruitmentCycle::CYCLES[RecruitmentCycle.previous_year.to_s] %></h2>
+<%= render SupportInterface::UCASMatchesStatisticsComponent.new(UCASMatch.where(recruitment_cycle_year: RecruitmentCycle.previous_year)) %>

--- a/app/views/support_interface/performance/ucas_matches_stats.html.erb
+++ b/app/views/support_interface/performance/ucas_matches_stats.html.erb
@@ -11,8 +11,15 @@
     }
   ]) %>
 <% end %>
-<h2 class="govuk-heading-m govuk-!-margin-top-9"> Recruitment cycle <%= RecruitmentCycle::CYCLES[RecruitmentCycle.current_year.to_s] %></h2>
-<%= render SupportInterface::UCASMatchesStatisticsComponent.new(UCASMatch.where(recruitment_cycle_year: RecruitmentCycle.current_year)) %>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-9"> Recruitment cycle <%= RecruitmentCycle::CYCLES[RecruitmentCycle.previous_year.to_s] %></h2>
-<%= render SupportInterface::UCASMatchesStatisticsComponent.new(UCASMatch.where(recruitment_cycle_year: RecruitmentCycle.previous_year)) %>
+<% year_choices = RecruitmentCycle::CYCLES.map do |year, label| %>
+  <% { name: label, url: "?year=#{year}", current: params[:year] == year } %>
+<% end %>
+
+<%= render TabNavigationComponent.new(items: [
+  { name: 'All years', url: '?', current: params[:year].nil? },
+] + year_choices ) %>
+
+<% ucas_matches = params[:year].nil? ? UCASMatch.all : UCASMatch.where(recruitment_cycle_year: params[:year])%>
+
+<%= render SupportInterface::UCASMatchesStatisticsComponent.new(ucas_matches) %>

--- a/app/views/support_interface/performance/ucas_matches_stats.html.erb
+++ b/app/views/support_interface/performance/ucas_matches_stats.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, 'UCAS matches stats' %>
+
+<% content_for :before_content do %>
+  <%= render BreadcrumbComponent.new(items: [
+    {
+      text: 'Performance',
+      path: support_interface_performance_path
+    },
+    {
+      text: 'UCAS matches stats'
+    }
+  ]) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -805,6 +805,7 @@ Rails.application.routes.draw do
       get '/course-stats', to: 'performance#course_stats', as: :course_stats
       get '/course-options', to: 'performance#course_options', as: :course_options
       get '/unavailable-choices' => 'performance#unavailable_choices', as: :unavailable_choices
+      get '/ucas-matches-stats' => 'performance#ucas_matches_stats', as: :ucas_matches_stats
 
       get '/validation-errors' => 'validation_errors#index', as: :validation_errors
       get '/validation-errors/search' => 'validation_errors#search', as: :validation_error_search

--- a/spec/components/support_interface/ucas_matches_statistics_component_spec.rb
+++ b/spec/components/support_interface/ucas_matches_statistics_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SupportInterface::UCASMatchesStatisticsComponent do
     expect(result.css('li')[0].text).to include('8 candidates on Apply with submitted application')
   end
 
-  it 'renders number of candidates matched with UCAS' do
+  it 'renders number and percentage of candidates matched with UCAS' do
     result = render_inline(described_class.new(ucas_matches))
 
     expect(result.css('li')[1].text).to include('7 (87.50%) candidates matched with UCAS, of which')
@@ -39,45 +39,51 @@ RSpec.describe SupportInterface::UCASMatchesStatisticsComponent do
     expect(result.css('li')[3].text).to include('2 (25% of candidates on Apply) have accepted offers on both services')
   end
 
-  it 'renders the total number of resolved matches' do
+  it 'renders number of candidates with dual application or multiple acceptances' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('.app-card--blue').text.strip).to include("3\n  resolved")
+    expect(result.css('.app-card--blue')[0].text.strip).to include("7\n  candidates with dual application or multiple acceptances")
+  end
+
+  it 'renders the total number of unresolved matches' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('.app-card--blue')[1].text.strip).to include("3\n  unresolved")
   end
 
   it 'renders the number of matches resolved on UCAS' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('.app-card')[1].text.strip).to include("1\n  resolved on UCAS")
+    expect(result.css('.app-card')[2].text.strip).to include("1\n  resolved on UCAS")
   end
 
   it 'renders the number of matches resolved on Apply' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('.app-card')[2].text.strip).to include("1\n  resolved on Apply")
+    expect(result.css('.app-card')[3].text.strip).to include("1\n  resolved on Apply")
   end
 
   it 'renders the number of matches resolved manually' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('.app-card')[3].text.strip).to include("1\n  resolved manually")
+    expect(result.css('.app-card')[4].text.strip).to include("1\n  resolved manually")
   end
 
   it 'renders the number matches we contacted the candidate and the provider about' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('.app-card')[4].text.strip).to include("1\n  set of initial emails sent")
+    expect(result.css('.app-card')[5].text.strip).to include("1\n  set of initial emails sent")
   end
 
   it 'renders the number matches we sent the reminder email' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('.app-card')[5].text.strip).to include("1\n  reminder email sent")
+    expect(result.css('.app-card')[6].text.strip).to include("1\n  reminder email sent")
   end
 
   it 'renders the number matches contacted UCAS to request withdrawal' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('.app-card')[6].text.strip).to include("1\n  UCAS withdrawal requested")
+    expect(result.css('.app-card')[7].text.strip).to include("1\n  UCAS withdrawal requested")
   end
 end

--- a/spec/components/support_interface/ucas_matches_statistics_component_spec.rb
+++ b/spec/components/support_interface/ucas_matches_statistics_component_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::UCASMatchesStatisticsComponent do
+  let!(:ucas_matches) { UCASMatch.all }
+
+  before do
+    yesterday = 1.business_day.before(Time.zone.now)
+    create(:completed_application_form, application_choices: [create(:submitted_application_choice)]) # not matched candidate
+    create(:ucas_match, :with_multiple_acceptances)
+    create(:ucas_match, :with_dual_application, action_taken: 'initial_emails_sent', candidate_last_contacted_at: yesterday)
+    create(:ucas_match, :with_dual_application, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: yesterday)
+    create(:ucas_match, :with_dual_application, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: yesterday)
+    create(:ucas_match, :with_dual_application, action_taken: 'resolved_on_apply', candidate_last_contacted_at: yesterday)
+    create(:ucas_match, :with_dual_application, action_taken: 'resolved_on_ucas', candidate_last_contacted_at: yesterday)
+    create(:ucas_match, :with_multiple_acceptances, action_taken: 'manually_resolved', candidate_last_contacted_at: yesterday)
+  end
+
+  it 'renders number of candidates on Apply' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[0].text).to include('8 candidates on Apply with submitted application')
+  end
+
+  it 'renders number of candidates matched with UCAS' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[1].text).to include('7 (87.50%) candidates matched with UCAS, of which')
+  end
+
+  it 'renders number of candidates that have applied for the same course on both services' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[2].text).to include('5 (62.50% of candidates on Apply) have applied for the same course on both services')
+  end
+
+  it 'renders number of candidates that have accepted offers on both services' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[3].text).to include('2 (25% of candidates on Apply) have accepted offers on both services')
+  end
+
+  it 'renders the total number of resolved matches' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[4].text).to include('3 UCAS matches have been resolved')
+  end
+
+  it 'renders the number of matches resolved on UCAS' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[5].text).to include('1 have been resolved on UCAS')
+  end
+
+  it 'renders the number of matches resolved on Apply' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[6].text).to include('1 have been resolved on Apply')
+  end
+
+  it 'renders the number of matches resolved manually' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[7].text).to include('1 have been manually resolved before the automated process was implemented')
+  end
+
+  it 'renders the number matches we contacted the candidate and the provider about' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[9].text).to include('1 sets of initial emails have been sent to the candidate and the provider to inform them about dual application or multiple acceptances')
+  end
+
+  it 'renders the number matches we sent the reminder email' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[10].text).to include('1 reminder emails have been sent')
+  end
+
+  it 'renders the number matches contacted UCAS to request withdrawal' do
+    result = render_inline(described_class.new(ucas_matches))
+
+    expect(result.css('li')[11].text).to include('1 withdrawals from UCAS have been requested')
+  end
+end

--- a/spec/components/support_interface/ucas_matches_statistics_component_spec.rb
+++ b/spec/components/support_interface/ucas_matches_statistics_component_spec.rb
@@ -42,42 +42,42 @@ RSpec.describe SupportInterface::UCASMatchesStatisticsComponent do
   it 'renders the total number of resolved matches' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('li')[4].text).to include('3 UCAS matches have been resolved')
+    expect(result.css('.app-card--blue').text.strip).to include("3\n  resolved")
   end
 
   it 'renders the number of matches resolved on UCAS' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('li')[5].text).to include('1 have been resolved on UCAS')
+    expect(result.css('.app-card')[1].text.strip).to include("1\n  resolved on UCAS")
   end
 
   it 'renders the number of matches resolved on Apply' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('li')[6].text).to include('1 have been resolved on Apply')
+    expect(result.css('.app-card')[2].text.strip).to include("1\n  resolved on Apply")
   end
 
   it 'renders the number of matches resolved manually' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('li')[7].text).to include('1 have been manually resolved before the automated process was implemented')
+    expect(result.css('.app-card')[3].text.strip).to include("1\n  resolved manually")
   end
 
   it 'renders the number matches we contacted the candidate and the provider about' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('li')[9].text).to include('1 sets of initial emails have been sent to the candidate and the provider to inform them about dual application or multiple acceptances')
+    expect(result.css('.app-card')[4].text.strip).to include("1\n  set of initial emails sent")
   end
 
   it 'renders the number matches we sent the reminder email' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('li')[10].text).to include('1 reminder emails have been sent')
+    expect(result.css('.app-card')[5].text.strip).to include("1\n  reminder email sent")
   end
 
   it 'renders the number matches contacted UCAS to request withdrawal' do
     result = render_inline(described_class.new(ucas_matches))
 
-    expect(result.css('li')[11].text).to include('1 withdrawals from UCAS have been requested')
+    expect(result.css('.app-card')[6].text.strip).to include("1\n  UCAS withdrawal requested")
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     recruitment_cycle_year { application_form.recruitment_cycle_year }
 
     transient do
-      application_form { create(:completed_application_form, application_choices_count: 1) }
+      application_form { create(:completed_application_form, submitted_application_choices_count: 1) }
       ucas_status { nil }
       scheme { rand(1..3).times.map { %w[U D B].sample } }
     end
@@ -148,6 +148,7 @@ FactoryBot.define do
 
       transient do
         application_choices_count { 0 }
+        submitted_application_choices_count { 0 }
         work_experiences_count { 0 }
         volunteering_experiences_count { 0 }
         references_count { 0 }
@@ -229,6 +230,7 @@ FactoryBot.define do
         end
 
         create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'unsubmitted')
+        create_list(:submitted_application_choice, evaluator.submitted_application_choices_count, application_form: application_form)
         create_list(:reference, evaluator.references_count, evaluator.references_state, application_form: application_form)
         # The application_form validates the length of this collection when
         # it is created, which is BEFORE we create the references here.

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Service performance' do
   scenario 'View service statistics' do
     given_i_am_a_support_user
     and_there_are_candidates_and_application_forms_in_the_system
+    and_there_are_applications_matched_with_ucas
 
     when_i_visit_the_performance_dashboard_in_support
 
@@ -20,6 +21,9 @@ RSpec.feature 'Service performance' do
     when_i_go_a_report_for_a_specific_year
 
     then_i_only_see_candidates_that_signed_up_that_year
+
+    when_i_visit_ucas_matches_stats_in_support
+    then_i_should_see_the_total_number_of_ucas_matches
   end
 
   def given_i_am_a_support_user
@@ -39,6 +43,10 @@ RSpec.feature 'Service performance' do
     end
   end
 
+  def and_there_are_applications_matched_with_ucas
+    create_list(:ucas_match, 2)
+  end
+
   def when_i_visit_the_performance_dashboard_in_support
     visit support_interface_performance_path
     click_on 'Service performance'
@@ -47,15 +55,15 @@ RSpec.feature 'Service performance' do
   alias_method :and_i_visit_the_performance_dashboard_in_support, :when_i_visit_the_performance_dashboard_in_support
 
   def then_i_should_see_the_total_count_of_candidates
-    expect(page).to have_content '3 unique candidates'
+    expect(page).to have_content '5 unique candidates'
   end
 
   def and_i_should_see_the_total_count_of_application_forms
-    expect(page).to have_content '3 application forms'
+    expect(page).to have_content '5 application forms'
   end
 
   def then_i_see_the_total_number_of_candidates_in_the_system
-    expect(page).to have_content '6 unique candidates'
+    expect(page).to have_content '8 unique candidates'
   end
 
   def when_i_go_a_report_for_a_specific_year
@@ -63,6 +71,16 @@ RSpec.feature 'Service performance' do
   end
 
   def then_i_only_see_candidates_that_signed_up_that_year
-    expect(page).to have_content '5 unique candidates'
+    expect(page).to have_content '7 unique candidates'
+  end
+
+  def when_i_visit_ucas_matches_stats_in_support
+    visit support_interface_performance_path
+    click_on 'UCAS matches statistics'
+  end
+
+  def then_i_should_see_the_total_number_of_ucas_matches
+    expect(page).to have_content '2 candidates on Apply with submitted application'
+    expect(page).to have_content '2 (100%) candidates matched with UCAS'
   end
 end


### PR DESCRIPTION
## Context
```
As an engagement manager,
I need to be able to see the statistics on processing UCAS matches,
so I can report them to the stakeholders.
```
## Changes proposed in this pull request

<img width="497" alt="Screenshot 2020-12-22 at 08 55 56" src="https://user-images.githubusercontent.com/38078064/102871256-1c616600-4436-11eb-9265-73d2c4c72862.png">

<kbd><img width="745" alt="Screenshot 2021-01-07 at 09 25 05" src="https://user-images.githubusercontent.com/38078064/103875399-48354a80-50ca-11eb-9226-15d3ea89aa54.png"></kbd>

## Guidance to review

- visit http://localhost:3000/support/performance
- click on UCAS matches statistics

## Link to Trello card

https://trello.com/c/SG6uXjic/3019-add-ucas-matches-statistics

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
