### PR TITLE
Automate courses open provider email

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -134,6 +134,12 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def courses_open_on_apply(provider_user)
+    @current_recruitment_cycle_year = RecruitmentCycle.current_year
+
+    notify_email(to: provider_user.email_address)
+  end
+
 private
 
   def email_for_provider(provider_user, application_form, args = {})

--- a/app/services/open_provider_courses.rb
+++ b/app/services/open_provider_courses.rb
@@ -1,9 +1,15 @@
 class OpenProviderCourses
+  attr_reader :provider
+
   def initialize(provider:)
     @provider = provider
   end
 
   def call
-    @provider.courses.current_cycle.exposed_in_find.update_all(open_on_apply: true)
+    if provider.courses.current_cycle.exposed_in_find.update_all(open_on_apply: true).positive?
+      provider.provider_users.each do |provider_user|
+        ProviderMailer.courses_open_on_apply(provider_user)
+      end
+    end
   end
 end

--- a/app/views/provider_mailer/courses_open_on_apply.text.erb
+++ b/app/views/provider_mailer/courses_open_on_apply.text.erb
@@ -1,0 +1,17 @@
+# Your courses are now live on Apply and you can access Manage teacher training applications
+
+Dear colleague,
+
+Your courses have been switched on on Apply for teacher training. Candidates can now apply for your courses through the service.
+
+You also now have access to [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider). Sign in to Manage to review and respond to any applications you receive. You'll also get a notification email when you receive any applications.
+
+# Is UCAS still running?
+
+Your courses will be available to candidates on both UCAS and on Apply until October <%=@current_recruitment_cycle_year%>. After that date, candidates will only be able to submit applications through Apply.
+
+If you need any more information about either Apply or Manage,  contact us at  [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk). We’re also keen to hear about your experiences of both services, so please do send us your feedback.
+
+
+Regards,
+Becoming a Teacher team

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -26,3 +26,5 @@ en:
         subject: Duplicate applicant removed from UTT
       resolved_on_apply:
         subject: Duplicate applicant removed from DfE Apply
+    courses_open_on_apply:
+      subject: Your courses are live on Apply and you have access to Manage

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -446,6 +446,12 @@ FactoryBot.define do
         create(:provider_agreement, provider: provider)
       end
     end
+
+    trait :with_user do
+      after(:create) do |provider|
+        create(:provider_permissions, provider: provider)
+      end
+    end
   end
 
   factory :provider_agreement do

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -49,6 +49,12 @@ class ProviderMailerPreview < ActionMailer::Preview
     )
   end
 
+  def courses_open_on_apply
+    ProviderMailer.courses_open_on_apply(
+      FactoryBot.build_stubbed(:provider_user),
+    )
+  end
+
 private
 
   def provider

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe ProviderMailer, type: :mailer do
 
   shared_examples 'a provider mail with subject and content' do |mail, subject, content|
     let(:email) do
-      mail == :account_created ? ProviderMailer.send(mail, @provider_user) : ProviderMailer.send(mail, @provider_user, @application_choice)
+      if %i[account_created courses_open_on_apply].include?(mail)
+        return ProviderMailer.send(mail, @provider_user)
+      end
+
+      ProviderMailer.send(mail, @provider_user, @application_choice)
     end
 
     it 'sends an email with the correct subject' do
@@ -171,5 +175,11 @@ RSpec.describe ProviderMailer, type: :mailer do
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')
+  end
+
+  describe '.courses_open_on_apply' do
+    it_behaves_like('a provider mail with subject and content', :courses_open_on_apply,
+                    I18n.t!('provider_mailer.courses_open_on_apply.subject'),
+                    'recruitment_cycle_year' => RecruitmentCycle.current_year)
   end
 end

--- a/spec/services/open_provider_courses_spec.rb
+++ b/spec/services/open_provider_courses_spec.rb
@@ -1,12 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe OpenProviderCourses do
-  it 'opens all courses shown on Find for a given provider' do
-    provider = create(:provider)
-    create_list(:course, 2, exposed_in_find: true, provider: provider)
+  let(:provider) { create(:provider, :with_user) }
+  let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
-    expect { OpenProviderCourses.new(provider: provider).call }
-      .to(change { Course.open_on_apply.count }.from(0).to(2))
+  it 'opens all courses shown on Find for a given provider and emails all provider users' do
+    create_list(:course, 2, provider: provider, exposed_in_find: true)
+    provider_user = provider.provider_users.first
+    allow(ProviderMailer).to receive(:courses_open_on_apply).and_return(mail)
+
+    expect {
+      described_class.new(provider: provider).call
+    }.to(change { provider.courses.open_on_apply.count }.from(0).to(2))
+
+    expect(ProviderMailer).to have_received(:courses_open_on_apply).with(provider_user).once
   end
 
   it 'does not open courses that are not exposed in Find' do

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature 'Docs' do
       provider_mailer-ucas_match_resolved_on_ucas_email
       candidate_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-ucas_match_resolved_on_apply_email
+      provider_mailer-courses_open_on_apply
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION

## Context

Add email template and automating sending to provider users when provider courses are made available on apply



<img width="665" alt="open-all-courses-email" src="https://user-images.githubusercontent.com/159200/102875537-d5766f00-443b-11eb-81b8-2bc55538aa7d.png">


## Link to Trello card

https://trello.com/c/96eb0Wlv/3150-automate-the-your-courses-are-open-on-apply-email

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
