### PR TITLE
Fix flaky spec

### DIFF
--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -49,7 +49,7 @@ module SupportInterface
           'Number of unexplained breaks in last 5 years' => unexplained_breaks_in_last_five_years,
           'Number of unexplained breaks that coincide with studying for a degree' => unexplained_breaks_that_coincide_with_degrees,
           'Work history completed' => application_form.work_history_completed,
-          'Course choice statuses' => application_form.application_choices.map(&:status),
+          'Course choice statuses' => application_form.application_choices.map(&:status).sort,
         }
         output
       end


### PR DESCRIPTION
https://github.com/DFE-Digital/apply-for-teacher-training/pull/3693/checks?check_run_id=1594247710

Failure occurs in course choice statuses order

```
Actual: 
…"Work history completed" => false, "Course choice statuses" => ["recruited", "cancelled"] }]

Expected: 
…"Work history completed" => false, "Course choice statuses" => ["cancelled", "recruited"] }
```