### PR TITLE
Remove unnecessary validation from EditApplicantDetailsForm

### DIFF
--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -18,8 +18,6 @@ module SupportInterface
 
       validates :email_address, presence: true, email_address: true, length: { maximum: 100 }
 
-      validate :candidate_email_address_has_access
-
       validates :date_of_birth, presence: true
       validate :date_of_birth_valid
       validate :date_of_birth_not_in_future
@@ -78,14 +76,6 @@ module SupportInterface
 
         age_limit = Time.zone.today - 16.years
         errors.add(:date_of_birth, :below_lower_age_limit, date: age_limit.to_s(:govuk_date)) if date_of_birth > age_limit
-      end
-
-      def candidate_email_address_has_access
-        if HostingEnvironment.dfe_signup_only? &&
-            email_address.present? &&
-            !email_address.match(/education\.gov\.uk$/)
-          errors.add(:email_address, :dfe_signup_only)
-        end
       end
 
     private


### PR DESCRIPTION
## Context

Bug spotted at product review that unnamed validation error fires when changing address. On
 investigation this is because there is a validation that was copied over from the sign up
form which prevents users from signing up to test environments. This will not be affecting
prod but should be removed regardless.

## Changes proposed in this pull request

Remove validation

## Guidance to review

Test in review app that validation does not persist. Test in qa for good measure when merged.

## Link to Trello card

https://trello.com/c/FAc067DI/2686-expand-the-personal-details-review-section-in-the-support-ui-email-address

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
