### PR TITLE
Unique labels for feature flag buttons

### DIFF
--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -29,9 +29,13 @@
   ) do %>
     <%= render SummaryCardHeaderComponent.new(title: feature_name.humanize, heading_level: 3) do %>
       <% if FeatureFlag.active?(feature_name) %>
-        <%= button_to 'Deactivate', support_interface_deactivate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' %>
+        <%= button_to support_interface_deactivate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' do %>
+          Deactivate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
+        <% end %>
       <% else %>
-        <%= button_to 'Activate', support_interface_activate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' %>
+        <%= button_to support_interface_activate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' do %>
+          Activate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Context

DAC December 2020 audit spotted an issue with repeated labels for these buttons.

## Changes proposed in this pull request

Adds visually hidden text describing the feature that can be activated/deactivated.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
