### PR TITLE
Show filetype on download buttons

### DIFF
--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -40,7 +40,7 @@
         <%= f.govuk_collection_check_boxes :provider_ids, @application_data_export_form.providers_that_actor_belongs_to, ->(p) { p.id.to_s }, :name, legend: { text: 'Select applications for certain organisations', size: 'm' } %>
       <% end %>
 
-      <%= f.govuk_submit 'Export data' %>
+      <%= f.govuk_submit 'Export data (CSV)' %>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/hesa_export/new.html.erb
+++ b/app/views/provider_interface/hesa_export/new.html.erb
@@ -30,7 +30,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: provider_interface_hesa_export_path(format: :csv), method: :get do %>
       <button class="govuk-button" data-module="govuk-button">
-        Export data for HESA
+        Export data for HESA (CSV)
       </button>
     <% end %>
   </div>

--- a/app/views/support_interface/data_exports/show.html.erb
+++ b/app/views/support_interface/data_exports/show.html.erb
@@ -26,7 +26,7 @@
     Export generation completed in <%= @data_export.generation_time %> <%= 'second'.pluralize(@data_export.generation_time) %>.
   </p>
 
-  <%= govuk_button_link_to 'Download export', download_support_interface_data_export_path(@data_export) %>
+  <%= govuk_button_link_to 'Download export (CSV)', download_support_interface_data_export_path(@data_export), { type: 'text/csv' } %>
 <% else %>
   <p class="govuk-body">
     This export is being generated. Refresh the page to see if it completed.


### PR DESCRIPTION
## Context

Our DAC December 2020 audit noted that we don’t state the file type for our downloads:

> The download button provided did not state the file type that will be downloaded, this may cause difficulty for users as they may not have the appropriate software installed to access the downloaded file.

## Changes proposed in this pull request

* Adds ~`(.csv)`~ `(CSV)` to data exports in the support UI, and 2 export functions in the provider UI.
* Where this is implemented as a link, also added `type` attribute for a lil‘ bit of HTML 💅 

## Guidance to review

Happy with the wording/design?

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
