### PR TITLE
Hide Sign in link in header when on Sign in page

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -60,6 +60,8 @@ class NavigationItems
     end
 
     def for_provider_account_nav(current_provider_user, current_controller, performing_setup = false)
+      return [] if is_active_action(current_controller, 'new') || is_active_action(current_controller, 'sign_in_by_email')
+
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
       items = []


### PR DESCRIPTION
## Context

Clicking sign-in on the sign-in page redirects to the same page - it's not needed

## Changes proposed in this pull request

<img width="496" alt="Screenshot 2020-12-22 at 13 35 55" src="https://user-images.githubusercontent.com/38078064/102894278-c3f08f80-445a-11eb-8ea9-de0764d211e1.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/6aXsPEii/3151-hide-sign-in-link-in-header-when-on-sign-in-page

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
