### PR TITLE
Make user_id & user_not not nullable and add index to AuthenticationToken table

### DIFF
--- a/db/migrate/20201222123211_remove_unused_sign_in_related_columns.rb
+++ b/db/migrate/20201222123211_remove_unused_sign_in_related_columns.rb
@@ -1,0 +1,6 @@
+class RemoveUnusedSignInRelatedColumns < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :authentication_tokens, :authenticable_id, :bigint
+    remove_column :authentication_tokens, :authenticable_type, :string
+  end
+end

--- a/db/migrate/20201222134529_make_user_id_and_user_type_not_nullable_and_add_index.rb
+++ b/db/migrate/20201222134529_make_user_id_and_user_type_not_nullable_and_add_index.rb
@@ -1,0 +1,7 @@
+class MakeUserIdAndUserTypeNotNullableAndAddIndex < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :authentication_tokens, :user_id, false
+    change_column_null :authentication_tokens, :user_type, false
+    add_index :authentication_tokens, %i[user_id user_type], name: 'index_authentication_tokens_on_id_and_type'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_130813) do
+ActiveRecord::Schema.define(version: 2020_12_22_134529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -227,16 +227,14 @@ ActiveRecord::Schema.define(version: 2020_12_22_130813) do
   end
 
   create_table "authentication_tokens", force: :cascade do |t|
-    t.bigint "authenticable_id"
-    t.string "authenticable_type"
     t.string "hashed_token", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id"
-    t.string "user_type"
     t.datetime "used_at"
-    t.index ["authenticable_id", "authenticable_type"], name: "index_authentication_tokens_on_id_and_type"
+    t.bigint "user_id", null: false
+    t.string "user_type", null: false
     t.index ["hashed_token"], name: "index_authentication_tokens_on_hashed_token", unique: true
+    t.index ["user_id", "user_type"], name: "index_authentication_tokens_on_id_and_type"
   end
 
   create_table "candidates", force: :cascade do |t|


### PR DESCRIPTION
## Context

This PR covers a bit of clean up work from the magic link refactor.

It removes a couple of unused columns, makes user_type & user_id not nullable and creates an index.

## Changes proposed in this pull request

- Migration to remove authenticable_id and authenticable_type
- Migration to make user_id and user_type not nullable & adds an index to auth tokens table  

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
