### PR TITLE
Remove ambiguous graphics from accessibility tree

### DIFF
--- a/app/components/state_diagram_component.html.erb
+++ b/app/components/state_diagram_component.html.erb
@@ -1,0 +1,13 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View diagram of application flow
+      <span class="govuk-visually-hidden">(accessible example presented after diagram)</span>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <div class="app-diagram">
+      <%= StateDiagram.svg(only_from_state: nil, machine: @machine) %>
+    </div>
+  </div>
+</details>

--- a/app/components/state_diagram_component.rb
+++ b/app/components/state_diagram_component.rb
@@ -1,0 +1,5 @@
+class StateDiagramComponent < ViewComponent::Base
+  def initialize(machine:)
+    @machine = machine
+  end
+end

--- a/app/components/state_event_explanation_component.html.erb
+++ b/app/components/state_event_explanation_component.html.erb
@@ -1,4 +1,5 @@
 <li class="govuk-!-margin-top-2">
+  <span aria-hidden="true"><%= StateDiagram.event_emoji(from_state, event, machine.i18n_namespace) %></span>
   <strong><%= StateDiagram.event_name(from_state, event, machine.i18n_namespace) %></strong> (by <%= by %>).
   <%= description %>
   This will transition the application to the <%= govuk_link_to "#{human_transitions_to} state", "##{transitions_to}" %>.

--- a/app/components/state_explanation_component.html.erb
+++ b/app/components/state_explanation_component.html.erb
@@ -24,8 +24,10 @@
       <% end %>
       </dl>
     </div>
-    <div class="govuk-grid-column-one-half" aria-hidden="true">
-      <%= StateDiagram.svg(only_from_state: state_name, machine: machine) %>
+    <div class="govuk-grid-column-one-half">
+      <div class="app-diagram" aria-hidden="true">
+        <%= StateDiagram.svg(only_from_state: state_name, machine: machine) %>
+      </div>
     </div>
   </div>
 </section>

--- a/app/components/state_explanation_component.html.erb
+++ b/app/components/state_explanation_component.html.erb
@@ -24,7 +24,7 @@
       <% end %>
       </dl>
     </div>
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-one-half" aria-hidden="true">
       <%= StateDiagram.svg(only_from_state: state_name, machine: machine) %>
     </div>
   </div>

--- a/app/components/when_emails_are_sent_component.html.erb
+++ b/app/components/when_emails_are_sent_component.html.erb
@@ -47,7 +47,7 @@
         <% end %>
       </div>
 
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-one-half" aria-hidden="true">
         <%= StateDiagram.svg(only_from_state: state_name, machine: ApplicationStateChange) %>
       </div>
     </div>

--- a/app/components/when_emails_are_sent_component.html.erb
+++ b/app/components/when_emails_are_sent_component.html.erb
@@ -47,8 +47,10 @@
         <% end %>
       </div>
 
-      <div class="govuk-grid-column-one-half" aria-hidden="true">
-        <%= StateDiagram.svg(only_from_state: state_name, machine: ApplicationStateChange) %>
+      <div class="govuk-grid-column-one-half">
+        <div class="app-diagram" aria-hidden="true">
+          <%= StateDiagram.svg(only_from_state: state_name, machine: ApplicationStateChange) %>
+        </div>
       </div>
     </div>
   </section>

--- a/app/frontend/styles/_diagram.scss
+++ b/app/frontend/styles/_diagram.scss
@@ -1,3 +1,7 @@
+.app-diagram {
+  text-align: center;
+}
+
 .app-diagram svg {
   height: 100%;
   max-width: 100%;

--- a/app/frontend/styles/_diagram.scss
+++ b/app/frontend/styles/_diagram.scss
@@ -1,0 +1,4 @@
+.app-diagram svg {
+  height: 100%;
+  max-width: 100%;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -41,6 +41,7 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 @import "_banner";
 @import "_card";
 @import "_contents-list";
+@import "_diagram";
 @import "_flex-grid";
 @import "_qualification";
 @import "_section";

--- a/app/frontend/styles/support/_all.scss
+++ b/app/frontend/styles/support/_all.scss
@@ -10,4 +10,3 @@
 @import "_button";
 @import "_checkboxes-scroll";
 @import "_details";
-@import "_relationship-diagram";

--- a/app/frontend/styles/support/_relationship-diagram.scss
+++ b/app/frontend/styles/support/_relationship-diagram.scss
@@ -1,3 +1,0 @@
-.app-relationship-diagram svg {
-  width: 100%;
-}

--- a/app/lib/state_diagram.rb
+++ b/app/lib/state_diagram.rb
@@ -15,7 +15,7 @@ class StateDiagram
         graph.add_edges(
           state.name.to_s,
           event.transitions_to.to_s,
-          label: event_name(state.name, event, namespace),
+          label: event_emoji(state.name, event, namespace) + ' ' + event_name(state.name, event, namespace),
           fontname: 'Arial',
           color: '#0b0c0c',
           fontcolor: '#0b0c0c',
@@ -58,15 +58,17 @@ class StateDiagram
   end
 
   def self.event_name(state, event, namespace)
+    I18n.t!("#{namespace}events.#{state}-#{event}.name")
+  end
+
+  def self.event_emoji(state, event, namespace)
     by = I18n.t!("#{namespace}events.#{state}-#{event}.by")
 
-    emoji = {
+    {
       'candidate' => '👩‍🎓',
       'referee' => '👩‍🏫',
       'provider' => '🏫',
       'system' => '🤖',
     }.fetch(by)
-
-    emoji + ' ' + I18n.t!("#{namespace}events.#{state}-#{event}.name")
   end
 end

--- a/app/views/api_docs/pages/lifecycle.html.erb
+++ b/app/views/api_docs/pages/lifecycle.html.erb
@@ -7,11 +7,7 @@
   { name: 'When emails are sent', url: api_docs_when_emails_are_sent_path },
 ]) %>
 
-<%= StateDiagram.svg(only_from_state: nil, machine: ApplicationStateChange) %>
-
-<style>
-  svg { max-width: 100%; }
-</style>
+<%= render StateDiagramComponent.new(machine: ApplicationStateChange) %>
 
 <% ApplicationStateChange.workflow_spec.states.each do |_, state| %>
   <%= render StateExplanationComponent.new(machine: ApplicationStateChange, state: state) %>

--- a/app/views/support_interface/docs/candidate_flow.html.erb
+++ b/app/views/support_interface/docs/candidate_flow.html.erb
@@ -2,20 +2,7 @@
 
 <p class="govuk-body-l">The states and transitions that make up the Apply service, from the perspective of the candidate.</p>
 
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View full diagram
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <%= StateDiagram.svg(only_from_state: nil, machine: ProcessState) %>
-  </div>
-</details>
-
-<style>
-  svg { max-width: 100%; }
-</style>
+<%= render StateDiagramComponent.new(machine: ProcessState) %>
 
 <% ProcessState.workflow_spec.states.each do |_, state| %>
   <%= render StateExplanationComponent.new(state: state, machine: ProcessState, development_details: true) %>

--- a/app/views/support_interface/docs/provider_flow.html.erb
+++ b/app/views/support_interface/docs/provider_flow.html.erb
@@ -2,20 +2,7 @@
 
 <p class="govuk-body-l">The states and transitions that make up the Apply service, from the perspective of the provider.</p>
 
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      View full diagram
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    <%= StateDiagram.svg(only_from_state: nil, machine: ApplicationStateChange) %>
-  </div>
-</details>
-
-<style>
-  svg { max-width: 100%; }
-</style>
+<%= render StateDiagramComponent.new(machine: ApplicationStateChange) %>
 
 <% ApplicationStateChange.workflow_spec.states.each do |_, state| %>
   <%= render StateExplanationComponent.new(machine: ApplicationStateChange, state: state, development_details: true) %>

--- a/app/views/support_interface/docs/when_emails_are_sent.html.erb
+++ b/app/views/support_interface/docs/when_emails_are_sent.html.erb
@@ -1,7 +1,3 @@
 <%= render 'docs_navigation', title: 'When emails are sent' %>
 
-<style>
-  svg { max-width: 100%; }
-</style>
-
 <%= render WhenEmailsAreSentComponent.new %>

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -4,6 +4,6 @@
 
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider.provider_users)) %>
 
-<div class="app-relationship-diagram">
+<div class="app-diagram" aria-hidden="true">
   <%= @relationship_diagram.svg %>
 </div>


### PR DESCRIPTION
## Context

The DAC December 2020 audit highlighted a number of issues with our SVG diagrams, which are inaccessible – but fortunately have accessible alternatives presented on the same page they appear.

It also highlighted issues with using emoji in state descriptions. 

## Changes proposed in this pull request

* Splits out `event_emoji` value from `StateDiagram`, and removes this from accessibility tree when shown in HTML text
* Removes the smaller state diagrams from the accessibility tree (their function is replicated in the text they sit besides)
* Replaces `app-relationship-diagram` with `app-diagram`. This consolidates the SVG styling that was embedded in various pages, and also fixes it so that SVG diagrams always appear with the correct aspect ratio.
* Creates a new `state_diagram` partial, that is used in support and the API docs. This consistently hides the full state diagram behind a details disclosure, which has a non-visual description to explain that an accessible version of the diagram appears below.

## Guidance to review

* ~I have saved the state_diagram partial in a new folder: `views/shared` – is this correct?~ This is now a component: `StateDiagramComponent`
* Are we happy with the new label for the details link: ‘► View diagram of application flow (accessible example presented after diagram)’

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
