### PR TITLE
Add additional context to links with duplicate labels

### DIFF
--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -23,7 +23,9 @@
             </ul>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_link_to('Update permissions', edit_support_interface_provider_user_path(row[:provider_user])) %>
+            <%= govuk_link_to(nil, edit_support_interface_provider_user_path(row[:provider_user])) do %>
+              Update permissions<span class="govuk-visually-hidden"> for <%= provider_user_name(row[:provider_user]) %></span>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -153,8 +153,8 @@ module SupportInterface
       if reference.feedback_requested? && HostingEnvironment.test_environment?
         {
           key: 'Sign in as referee',
-          value: govuk_link_to('Give feedback ', referee_interface_reference_relationship_path(token: reference.refresh_feedback_token!)) +
-            'or ' +
+          value: govuk_link_to('Give feedback', referee_interface_reference_relationship_path(token: reference.refresh_feedback_token!)) +
+            ' or ' +
             govuk_link_to('decline to give a reference', referee_interface_refuse_feedback_path(token: reference.refresh_feedback_token!)),
         }
       end
@@ -165,11 +165,14 @@ module SupportInterface
 
       {
         key: 'Email history',
-        value: govuk_link_to('View history', support_interface_email_log_path(
-                                               application_form_id: reference.application_form.id,
-                                               mailer: 'referee_mailer',
-                                               to: reference.email_address,
-                                             )),
+        value: govuk_link_to(
+          "View email history for #{title}",
+          support_interface_email_log_path(
+            application_form_id: reference.application_form.id,
+            mailer: 'referee_mailer',
+            to: reference.email_address,
+          ),
+        ),
       }
     end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,4 +1,5 @@
 module ViewHelper
+  # TODO: Make `body` param optional if `block` is provided
   def govuk_link_to(body, url, html_options = {}, &_block)
     html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
 

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -34,4 +34,4 @@
   </tbody>
 </table>
 
-<%= govuk_link_to 'Restore a removed user', support_interface_support_users_path(removed: true) unless params[:removed] == 'true' %>
+<p class="govuk-body"><%= govuk_link_to 'Restore a removed user', support_interface_support_users_path(removed: true) unless params[:removed] == 'true' %></p>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -2,25 +2,25 @@
 
 <%= govuk_button_link_to 'Add support user', new_support_interface_support_user_path %>
 
-<table class='govuk-table'>
-  <thead class='govuk-table__head'>
-    <tr class='govuk-table__row'>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Email</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>DfE Sign-in UID</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Actions</th>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Email</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">DfE Sign-in UID</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Actions</th>
     </tr>
   </thead>
 
-  <tbody class='govuk-table__body'>
+  <tbody class="govuk-table__body">
     <% @support_users.each do |support_user| %>
-      <tr class='govuk-table__row'>
-        <td class='govuk-table__cell'>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
           <%= govuk_link_to support_user.display_name, support_interface_support_user_path(support_user) %>
         </td>
-        <td class='govuk-table__cell'>
+        <td class="govuk-table__cell">
           <%= support_user.dfe_sign_in_uid %>
         </td>
-        <td class='govuk-table__cell'>
+        <td class="govuk-table__cell">
           <%
             link_action = support_user.discarded? ? 'Restore' : 'Remove'
             link_path = support_user_account_management_path(support_user)

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -22,11 +22,11 @@
         </td>
         <td class='govuk-table__cell'>
           <%
-              link_action = support_user.discarded? ? 'Restore' : 'Remove'
-              link_path = support_user_account_management_path(support_user)
-          -%>
+            link_action = support_user.discarded? ? 'Restore' : 'Remove'
+            link_path = support_user_account_management_path(support_user)
+          %>
           <%= govuk_link_to(nil, link_path) do %>
-            <%= link_action %> user<span class='govuk-visually-hidden'> <%= support_user.email_address %></span>
+            <%= link_action %> user<span class="govuk-visually-hidden"> <%= support_user.display_name %></span>
           <% end %>
         </td>
       </tr>

--- a/spec/system/support_interface/remove_and_restore_a_support_user_spec.rb
+++ b/spec/system/support_interface/remove_and_restore_a_support_user_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature 'Remove and restore support user' do
     @support_users = create_list(:support_user, 2)
     @removed_user = @support_users.last
     @removed_user_email = @removed_user.email_address
+    @removed_user_name = @removed_user.display_name
   end
 
   def when_i_visit_the_support_users_page
@@ -36,7 +37,7 @@ RSpec.feature 'Remove and restore support user' do
 
   def and_i_remove_a_support_user
     within('.govuk-table__body') do
-      click_on("Remove user #{@removed_user_email}")
+      click_on("Remove user #{@removed_user_name}")
     end
   end
 
@@ -54,7 +55,7 @@ RSpec.feature 'Remove and restore support user' do
   end
 
   def and_the_support_user_is_not_listed
-    expect(page.text).not_to include(@removed_user_email)
+    expect(page.text).not_to include(@removed_user_name)
   end
 
   def when_i_visit_the_removed_support_users_page
@@ -63,7 +64,7 @@ RSpec.feature 'Remove and restore support user' do
 
   def and_i_restore_a_support_user
     within('.govuk-table__body') do
-      click_on("Restore user #{@removed_user_email}")
+      click_on("Restore user #{@removed_user_name}")
     end
   end
 
@@ -77,6 +78,6 @@ RSpec.feature 'Remove and restore support user' do
   end
 
   def and_the_support_user_is_listed
-    expect(page.text).to include(@removed_user_email)
+    expect(page.text).to include(@removed_user_name)
   end
 end


### PR DESCRIPTION
## Context

The DAC December audit discovered a few cases where we use duplicate link texts without any context.

## Changes proposed in this pull request

* Update link title for viewing a reference’s email history
* Add name of provider whose permissions can be changed
* Tweak markup on support users page

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
