### PR TITLE
Defer offer confirmation screen should show next cycle name relative to application

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -28,14 +28,6 @@ module RecruitmentCycle
     [2021, 2020, 2019]
   end
 
-  def self.current_cycle_name
-    cycle_name
-  end
-
-  def self.next_cycle_name
-    cycle_name(next_year)
-  end
-
   def self.cycle_name(year = current_year)
     "#{year} to #{year + 1}"
   end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -29,10 +29,14 @@ module RecruitmentCycle
   end
 
   def self.current_cycle_name
-    "#{current_year} to #{next_year}"
+    cycle_name
   end
 
   def self.next_cycle_name
-    "#{next_year} to #{next_year + 1}"
+    cycle_name(next_year)
+  end
+
+  def self.cycle_name(year = current_year)
+    "#{year} to #{year + 1}"
   end
 end

--- a/app/views/provider_interface/decisions/new_defer_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_defer_offer.html.erb
@@ -14,7 +14,7 @@
       </h1>
 
       <p class="govuk-body">This application will be marked as deferred.</p>
-      <p class="govuk-body">You must review and confirm your offer again at the start of the next cycle (<%= RecruitmentCycle.next_cycle_name %>).</p>
+      <p class="govuk-body">You must review and confirm your offer again at the start of the next cycle (<%= RecruitmentCycle.cycle_name(@application_choice.recruitment_cycle + 1) %>).</p>
       <p class="govuk-body">We’ll email the candidate notifying them of the deferral after you confirm below.</p>
 
       <%= f.button 'Confirm offer deferral', class: 'govuk-button', data: { module: 'govuk-button' } %>

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -24,10 +24,22 @@ RSpec.describe RecruitmentCycle do
   end
 
   describe '.next_cycle_name' do
-    it 'is next year to the following year' do
+    it 'is next year to the following year by default' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
         expect(RecruitmentCycle.next_cycle_name).to eq('2021 to 2022')
       end
+    end
+  end
+
+  describe '.cycle_name' do
+    it 'defaults to current year to the following year' do
+      Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
+        expect(RecruitmentCycle.cycle_name).to eq('2020 to 2021')
+      end
+    end
+
+    it 'is the argument year to the following year' do
+      expect(RecruitmentCycle.cycle_name(2019)).to eq('2019 to 2020')
     end
   end
 end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -15,22 +15,6 @@ RSpec.describe RecruitmentCycle do
     end
   end
 
-  describe '.current_cycle_name' do
-    it 'is current year to the following year' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        expect(RecruitmentCycle.current_cycle_name).to eq('2020 to 2021')
-      end
-    end
-  end
-
-  describe '.next_cycle_name' do
-    it 'is next year to the following year by default' do
-      Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        expect(RecruitmentCycle.next_cycle_name).to eq('2021 to 2022')
-      end
-    end
-  end
-
   describe '.cycle_name' do
     it 'defaults to current year to the following year' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do


### PR DESCRIPTION
## Context

When they try to defer an offer (e.g. with pending conditions) that was made in the previous cycle (2020), the confirmation screen states that the application will be deferred to 2022-2023, which is the cycle after the one they want. This is because the rendered date is relative to the current cycle.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a common parameterised method to render cycle names.
- Uses the method with the recruitment cycle from the application in the deferral confirmation view.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/98QAgAQX/2962-defer-offer-confirmation-screen-shows-incorrect-cycle-name
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
