### PR TITLE
Ensure pages have unique titles

### DIFF
--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.apply_from_find') %>
 <% content_for :service_link, candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code) %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
 
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
-      <%= t('apply_from_find.heading') %>
+      <%= t('page_titles.apply_from_find') %>
     </h1>
     <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit Get Into Teaching for <a class="govuk-link" target="_blank" href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training">guidance on applying for teacher training</a>.</p>
 

--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.course_not_found') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/prefill_application_form/new.html.erb
+++ b/app/views/candidate_interface/prefill_application_form/new.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.start_new_application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Start a new application
+      <%= t('page_titles.start_new_application') %>
     </h1>
 
     <%= form_with(

--- a/app/views/candidate_interface/start_page/applications_closed.html.erb
+++ b/app/views/candidate_interface/start_page/applications_closed.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.applications_closed') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.create_account_or_sign_in') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -10,7 +10,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        Create an account or sign in
+        <%= t('page_titles.create_account_or_sign_in') %>
       </h1>
 
       <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.confirm'), @application_offer.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.confirm_offer'), @application_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_offer_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
@@ -18,7 +18,7 @@
 <%= form_with model: @application_offer, url: provider_interface_application_choice_create_offer_path(@application_choice.id), method: :post do |f| %>
   <h1 class="govuk-heading-xl">
     <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-    Check and confirm offer
+    <%= t('page_titles.provider.confirm_offer') %>
   </h1>
 
   <div class="govuk-grid-row">

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -1,27 +1,28 @@
-<% content_for :browser_title, title_with_error_prefix(t('page_titles.application'), @reject_application.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.confirm_reject'), @reject_application.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_reject_path(@application_choice.id)) %>
-
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+      <%= t('page_titles.provider.confirm_reject') %>
+    </h1>
 
-    <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
-    <h1 class="govuk-heading-l">Check feedback and reject application</h1>
-      <%= form_with model: @reject_application, url: provider_interface_application_choice_create_reject_path(@application_choice.id), method: :post do |f| %>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <%= f.govuk_error_summary %>
-          </div>
+    <%= form_with model: @reject_application, url: provider_interface_application_choice_create_reject_path(@application_choice.id), method: :post do |f| %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= f.govuk_error_summary %>
         </div>
+      </div>
 
-        <%= render ProviderInterface::FeedbackPreviewComponent.new(application_choice: @application_choice, rejection_reason: @reject_application.rejection_reason) %>
+      <%= render ProviderInterface::FeedbackPreviewComponent.new(application_choice: @application_choice, rejection_reason: @reject_application.rejection_reason) %>
 
       <%= f.hidden_field :rejection_reason %>
 
       <%= f.govuk_submit 'Reject application' %>
 
       <p class="govuk-body">
-      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
       </p>
     <% end %>
   </div>

--- a/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Withdraw offer', @withdraw_offer.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.confirm_withdraw_offer'), @withdraw_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
@@ -7,7 +7,7 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    Check and confirm withdrawal
+    <%= t('page_titles.provider.confirm_withdraw_offer') %>
   </h1>
 
   <div class="govuk-grid-row">

--- a/app/views/provider_interface/decisions/new_defer_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_defer_offer.html.erb
@@ -1,3 +1,4 @@
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.new_defer_offer'), @defer_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
 
 <div class="govuk-grid-row">
@@ -5,12 +6,9 @@
     <%= form_with model: @defer_offer, url: provider_interface_application_choice_defer_offer_path(@application_choice) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-xl">
-        <%= @application_choice.application_form.full_name %>
-      </span>
-
       <h1 class="govuk-heading-xl">
-        Check and confirm offer deferral
+        <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+        <%= t('page_titles.provider.new_defer_offer') %>
       </h1>
 
       <p class="govuk-body">This application will be marked as deferred.</p>

--- a/app/views/provider_interface/decisions/new_edit_response.html.erb
+++ b/app/views/provider_interface/decisions/new_edit_response.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Change response', @edit_response.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.new_edit_response'), @edit_response.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
 <%= form_with model: @edit_response,
@@ -7,7 +7,7 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    Change response
+    <%= t('page_titles.provider.new_edit_response') %>
   </h1>
 
   <%= render SummaryListComponent.new(rows: [

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Conditions of offer', @application_offer.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.new_offer'), @application_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
@@ -7,10 +7,10 @@
   <%= f.govuk_error_summary %>
   <%= hidden_field_tag :course_option_id, @application_offer.course_option.id %>
 
-	<h1 class="govuk-heading-xl">
-		<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-		Conditions of offer
-	</h1>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    <%= t('page_titles.provider.new_offer') %>
+  </h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Reject application', @reject_application.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.new_reject'), @reject_application.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <div class="govuk-grid-row">
@@ -19,7 +19,7 @@
       <%= f.govuk_submit 'Continue' %>
 
       <p class="govuk-body">
-      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
       </p>
     <% end %>
   </div>

--- a/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Withdraw offer', @withdraw_offer.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.new_withdraw_offer'), @withdraw_offer.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
@@ -9,7 +9,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        Withdraw offer
+        <%= t('page_titles.provider.new_withdraw_offer') %>
       </h1>
 
       <%= render SummaryListComponent.new(rows: [

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -10,8 +10,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :decision,
-        legend: { text: 'Respond to application' , size: "xl" },
-        caption: { text: @application_choice.application_form.full_name, size: "xl" } do %>
+        caption: { text: @application_choice.application_form.full_name, size: 'xl' },
+        legend: { text: t('page_titles.provider.respond'), size: 'xl', tag: 'h1' } do %>
 
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
 

--- a/app/views/provider_interface/email_address_not_recognised.html.erb
+++ b/app/views/provider_interface/email_address_not_recognised.html.erb
@@ -1,9 +1,9 @@
-<% content_for :browser_title, t('page_titles.application') %>
+<% content_for :browser_title, t('page_titles.email_address_not_recognised') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Your email address is not recognised
+      <%= t('page_titles.email_address_not_recognised') %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -1,5 +1,4 @@
 <%= content_for :body_class, "app-start-page" %>
-<% content_for :browser_title, t('page_titles.application') %>
 
 <div class="app-masthead">
   <div class="govuk-width-container">

--- a/app/views/support_interface/unauthorized.html.erb
+++ b/app/views/support_interface/unauthorized.html.erb
@@ -1,10 +1,11 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.unauthorized') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Your account is not authorized
+      <%= t('page_titles.unauthorized') %>
     </h1>
+
     <p class="govuk-body">
       You’re seeing this page because you’ve signed in
       to the <%= t('service_name.apply') %> service but your account

--- a/config/locales/apply_from_find.yml
+++ b/config/locales/apply_from_find.yml
@@ -1,6 +1,5 @@
 en:
   apply_from_find:
-    heading: Apply for this course
     ucas_apply_button: Apply through UCAS
     find_button: Find postgraduate teacher training
     heading_not_found: We could not find the course you’re looking for

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,8 +254,6 @@ en:
             phone_number:
               blank: Phone number can’t be blank
               invalid: Enter a phone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
-            email_address:
-              blank: Email address cannot be blank
             first_name:
               blank: First name cannot be blank
               too_long: First name must be %{count} characters or fewer
@@ -263,7 +261,7 @@ en:
               blank: Last name cannot be blank
               too_long: Last name must be %{count} characters or fewer
             email_address:
-              blank: Enter an email address
+              blank: Email address cannot be blank
               invalid: Enter an email address in the correct format, like name@example.com
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,6 @@ en:
     support: Support for Apply
     api: Apply for teacher training API
   page_titles:
-    application: ""
     application_form: Your application
     application_dashboard: Application dashboard
     efl:
@@ -17,13 +16,20 @@ en:
       type: What English language assessment did you do?
     error_prefix: "Error: "
     success_prefix: "Success: "
+    course_not_found: Course not found
+    apply_from_find: Apply for this course
     apply_to_course_on_ucas: You need to apply to this course on UCAS
     apply_to_provider_on_ucas: You need to apply to this provider on UCAS
     submitted_application: Your submitted application
+    create_account_or_sign_in: Create an account or sign in
     sign_up: Create an account
     sign_in: Sign in
+    applications_closed: Create an Apply for teacher training account
+    email_address_not_recognised: Your email address is not recognised
     external_sign_up_forbidden: Only DfE users can sign into this website
+    unauthorized: Your account is not authorized
     sandbox: Use our sandbox to test Apply for teacher training
+    start_new_application: Start a new application
     check_your_email: Check your email
     not_found: Page not found
     forbidden: Access denied
@@ -146,8 +152,15 @@ en:
       lifecycle: Lifecycle
       alpha_release_notes: Alpha release notes
     provider:
+      confirm_offer: Check and confirm offer
+      confirm_reject: Check feedback and reject application
+      confirm_withdraw_offer: Check and confirm withdrawal
+      new_defer_offer: Check and confirm offer deferral
+      new_edit_response: Change response
+      new_offer: Conditions of offer
+      new_reject: Reject application
+      new_withdraw_offer: Withdraw offer
       respond: Respond to application
-      confirm: Confirm offer
       account: Your account
       profile: Profile
       org_permissions: Organisational permissions
@@ -165,7 +178,6 @@ en:
     remove_course_choice: Remove your course choice
     withdraw_application: Are you sure you want to withdraw your application?
     guidance: User guidance
-    applications_closed: Create an Apply for teacher training account
     your_feedback: Your feedback
   section_groups:
     course: Course

--- a/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def then_i_should_see_the_landing_page
-    expect(page).to have_content t('apply_from_find.heading')
+    expect(page).to have_content t('page_titles.apply_from_find')
     expect(page).to have_link href: candidate_interface_apply_from_find_path(providerCode: 'ABC', courseCode: 'XYZ1')
   end
 

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature 'Editing application details' do
   def then_i_should_see_relevant_blank_error_messages
     expect(page).to have_content 'First name cannot be blank'
     expect(page).to have_content 'Last name cannot be blank'
-    expect(page).to have_content 'Enter an email address'
+    expect(page).to have_content 'Email address cannot be blank'
     expect(page).to have_content 'Enter a date of birth in the correct format'
     expect(page).to have_content 'Phone number can’t be blank'
     expect(page).to have_content 'You must provide an audit comment'


### PR DESCRIPTION
## Context

DAC’s December 2020 audit found an example of a page without a unique title, i.e. it didn’t have a prefix before `Apply for teacher training - GOV.UK`. I found several more!

## Changes proposed in this pull request

This PR addresses the cases where the unique portion of the page title was missing because we were using an empty page string in the localisation file… not sure why. I have removed that string and replaced with alternatives.

I also started to look at page titles in one part of the provider interface (some titles were localised, others where not)… and then stopped before I started fixing numerous other big bears and issues spotted!

## Guidance to review

I suspect there are quite a few more pages that don’t have unique titles; how can we check and fix this, and how can we then ensure pages always have a unique title? @duncanjbrown @davidgisbey 

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
