### PR TITLE
Fix issues with validation errors and summaries

### DIFF
--- a/app/components/provider_interface/change_offer/change_course_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_course_component.html.erb
@@ -14,7 +14,7 @@
         caption: { text: application_choice.application_form.full_name, size: "xl" } do %>
 
         <% courses.each_with_index do |course, i| %>
-          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint: { text: course.description }, link_errors: i.zero?  %>
+          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint: { text: course.description }, link_errors: i.zero? %>
         <% end %>
       <% end %>
 

--- a/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
+++ b/app/components/provider_interface/edit_provider_user_permissions_component.html.erb
@@ -21,7 +21,8 @@
 
         <%= f.govuk_check_box :manage_organisations, true, multiple: false,
                               label: { text: 'Manage organisational permissions' },
-                              hint: { text: 'Change permissions between organisations' } %>
+                              hint: { text: 'Change permissions between organisations' },
+                              link_errors: true %>
 
         <%= f.govuk_check_box :manage_users, true, multiple: false,
                               label: { text: 'Manage users' },

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -7,17 +7,18 @@ module CandidateInterface
     end
 
     def edit
-      @safeguarding = SafeguardingIssuesDeclarationForm.build_from_application(current_application)
+      @safeguarding_form = SafeguardingIssuesDeclarationForm.build_from_application(current_application)
     end
 
     def update
-      @safeguarding = SafeguardingIssuesDeclarationForm.new(safeguarding_params)
+      @safeguarding_form = SafeguardingIssuesDeclarationForm.new(safeguarding_params)
 
-      if @safeguarding.save(current_application)
+      if @safeguarding_form.save(current_application)
         current_application.update!(safeguarding_issues_completed: false)
 
         redirect_to candidate_interface_review_safeguarding_path
       else
+        track_validation_error(@safeguarding_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -2,17 +2,18 @@ module CandidateInterface
   class TrainingWithADisabilityController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
 
+    def show
+      @application_form = current_application
+    end
+
     def edit
-      @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(
-        current_application,
-      )
+      @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(current_application)
     end
 
     def update
       @training_with_a_disability_form = TrainingWithADisabilityForm.new(training_with_a_disability_params)
 
       if @training_with_a_disability_form.save(current_application)
-        @application_form = current_application
         current_application.update!(training_with_a_disability_completed: false)
 
         redirect_to candidate_interface_training_with_a_disability_show_path
@@ -20,13 +21,6 @@ module CandidateInterface
         track_validation_error(@training_with_a_disability_form)
         render :edit
       end
-    end
-
-    def show
-      @application_form = current_application
-      @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(
-        current_application,
-      )
     end
 
     def complete

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -24,13 +24,14 @@
         <% if @application_choices.count >= 1 %>
           <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: nil do %>
             <%= f.hidden_field :course_choices_completed, value: false %>
-            <%= f.govuk_check_box :course_choices_completed,
+            <%= f.govuk_check_box(:course_choices_completed,
               true,
               multiple: false,
-              link_errors: true,
               label: {
                 text: t('application_form.courses.complete.completed_checkbox'),
-              } %>
+              },
+              link_errors: true,
+            ) %>
           <% end %>
 
           <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/application_feedback/new.html.erb
+++ b/app/views/candidate_interface/application_feedback/new.html.erb
@@ -15,7 +15,7 @@
       <%= f.hidden_field :original_controller %>
 
       <%= f.govuk_check_boxes_fieldset :issues, multiple: false, legend: { text: t('application_feedback.issues.label'), size: 'm' } do %>
-        <%= f.govuk_check_box :does_not_understand_section, true, multiple: false, label: { text: t('application_feedback.issues.does_not_understand_section') } %>
+        <%= f.govuk_check_box :does_not_understand_section, true, multiple: false, label: { text: t('application_feedback.issues.does_not_understand_section') }, link_errors: true %>
         <%= f.govuk_check_box :need_more_information, true, multiple: false, label: { text: t('application_feedback.issues.need_more_information') } %>
         <%= f.govuk_check_box :answer_does_not_fit_format, true, multiple: false, label: { text: t('application_feedback.issues.answer_does_not_fit_format') } %>
       <% end %>
@@ -23,7 +23,7 @@
       <%= f.govuk_text_area :other_feedback, label: { text: t('application_feedback.other_feedback.label'), size: 'm' }, rows: 5, max_words: 300 %>
 
       <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, inline: true, legend: { text: t('application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
-        <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('application_feedback.consent_to_be_contacted.yes') }  %>
+        <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('application_feedback.consent_to_be_contacted.yes') }, link_errors: true %>
         <%= f.govuk_radio_button :consent_to_be_contacted, false, label: { text:t('application_feedback.consent_to_be_contacted.no') } %>
       <% end %>
 

--- a/app/views/candidate_interface/course_choices/have_you_chosen/ask.html.erb
+++ b/app/views/candidate_interface/course_choices/have_you_chosen/ask.html.erb
@@ -7,10 +7,8 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :choice, legend: { size: 'xl', text: t('page_titles.have_you_chosen'), tag: 'h1' } do %>
-        <div class="govuk-!-margin-top-6">
-          <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, I know where I want to apply' }, link_errors: true %>
-          <%= f.govuk_radio_button :choice, :no, label: { text: 'No, I need to find a course' } %>
-        </div>
+        <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, I know where I want to apply' }, link_errors: true %>
+        <%= f.govuk_radio_button :choice, :no, label: { text: 'No, I need to find a course' } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/course_choices/site_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/site_selection/new.html.erb
@@ -11,12 +11,10 @@
         ) do |f| %>
             <%= f.govuk_error_summary %>
 
-            <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location'), tag: 'h1' } do %>
-              <div class="govuk-!-margin-top-6">
-                <% @pick_site.available_sites.each_with_index do |option, i| %>
-                  <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, link_errors: i.zero?, hint: { text: option.site.full_address } %>
-                <% end %>
-              </div>
+            <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: t('page_titles.which_location'), size: 'xl', tag: 'h1' } do %>
+              <% @pick_site.available_sites.each_with_index do |option, i| %>
+                <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, hint: { text: option.site.full_address }, link_errors: i.zero? %>
+              <% end %>
             <% end %>
 
           <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/course_choices/study_mode_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/study_mode_selection/new.html.erb
@@ -14,8 +14,8 @@
 
         <%= f.govuk_error_summary %>
 
-        <%= f.govuk_radio_buttons_fieldset :study_mode, legend: { size: 'xl', text: t('page_titles.which_study_mode'), tag: 'h1' } do %>
-          <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' } %>
+        <%= f.govuk_radio_buttons_fieldset :study_mode, legend: { text: t('page_titles.which_study_mode'), size: 'xl', tag: 'h1' } do %>
+          <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' }, link_errors: true %>
           <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
         <% end %>
 

--- a/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
+++ b/app/views/candidate_interface/decisions/withdrawal_feedback.html.erb
@@ -19,14 +19,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_radio_buttons_fieldset :withdrawal_reason, legend: { text: CandidateInterface::WithdrawalQuestionnaire::EXPLANATION_QUESTION } do %>
-        <%= f.govuk_radio_button :feedback, 'yes', link_errors: true, label: { text: t('decisions.withdrawal_feedback.feedback.yes.label') } do %>
+        <%= f.govuk_radio_button :feedback, 'yes', label: { text: t('decisions.withdrawal_feedback.feedback.yes.label') }, link_errors: true do %>
           <%= f.govuk_text_area :explanation, label: { text: t('decisions.withdrawal_feedback.explanation.label') }, hint: { text: t('decisions.withdrawal_feedback.explanation.hint') } %>
         <% end %>
         <%= f.govuk_radio_button :feedback, 'no', label: { text: t('decisions.withdrawal_feedback.feedback.no.label') } %>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :can_be_contacted, legend: { text: CandidateInterface::WithdrawalQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION }, hint: { text: t('decisions.withdrawal_feedback.can_be_contacted.hint') } do %>
-        <%= f.govuk_radio_button :consent_to_be_contacted,'yes', link_errors: true, label: { text: t('decisions.withdrawal_feedback.consent_to_be_contacted.yes.label') } do %>
+        <%= f.govuk_radio_button :consent_to_be_contacted,'yes', label: { text: t('decisions.withdrawal_feedback.consent_to_be_contacted.yes.label') }, link_errors: true do %>
           <%= f.govuk_text_area :contact_details, label: { text: t('decisions.withdrawal_feedback.contact_details.label') } %>
         <% end %>
         <%= f.govuk_radio_button :consent_to_be_contacted, 'no', label: { text: t('decisions.withdrawal_feedback.consent_to_be_contacted.no.label') } %>

--- a/app/views/candidate_interface/degrees/completion_status/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/completion_status/_form_fields.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_radio_buttons_fieldset :degree_completed, legend: { tag: 'h1', size: 'xl', text: t('page_titles.degree_completion_status') } do %>
-  <%= f.govuk_radio_button :degree_completed, 'yes', label: { text: 'Yes' } %>
+<%= f.govuk_radio_buttons_fieldset :degree_completed, legend: { text: t('page_titles.degree_completion_status'), size: 'xl', tag: 'h1' } do %>
+  <%= f.govuk_radio_button :degree_completed, 'yes', label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :degree_completed, 'no', label: { text: 'No' } %>
 <% end %>
 

--- a/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/grade/_form_fields.html.erb
@@ -3,7 +3,7 @@
   <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: @page_title, size: 'xl', tag: 'h1' } do %>
     <p class="govuk-body"><%= t('application_form.degree.grade.international.grade_examples') %></p>
 
-    <%= f.govuk_radio_button :grade, 'other', label: { text: 'Yes' } do %>
+    <%= f.govuk_radio_button :grade, 'other', label: { text: 'Yes' }, link_errors: true do %>
       <% if degree.predicted_grade? %>
         <% text_field_options = { label: nil, hint: { text: t('application_form.degree.grade.international.hint_text') } } %>
       <% else %>
@@ -12,8 +12,8 @@
       <% text_field_options.merge(width: 20) %>
       <%= f.govuk_text_field(:other_grade, text_field_options) %>
     <% end %>
-    <% @international_main_grades.each_with_index do |grade, i | %>
-      <%= f.govuk_radio_button :grade, grade, label: { text: grade }, link_errors: i.zero?  %>
+    <% @international_main_grades.each do |grade| %>
+      <%= f.govuk_radio_button :grade, grade, label: { text: grade } %>
     <% end %>
   <% end %>
 

--- a/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
 <%= f.govuk_radio_buttons_fieldset :have_naric_reference, legend: { text: t('application_form.degree.naric_statment.label'), size: 'm' } do %>
-  <%= f.govuk_radio_button :have_naric_reference, 'yes', label: { text: 'Yes' } do %>
+  <%= f.govuk_radio_button :have_naric_reference, 'yes', label: { text: 'Yes' }, link_errors: true do %>
     <%= f.govuk_text_field(
       :naric_reference,
       label: { text: t('application_form.degree.naric_reference.label'), size: 's' },

--- a/app/views/candidate_interface/degrees/type/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/type/_form_fields.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_radio_button :uk_degree, 'yes', label: { text: t('application_form.degree.uk_degree.label') } do %>
+<%= f.govuk_radio_button :uk_degree, 'yes', label: { text: t('application_form.degree.uk_degree.label') }, link_errors: true do %>
   <%= f.govuk_text_field(
     :type_description,
     label: { text: t('application_form.degree.qualification_type.label'), size: 's' },

--- a/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/start/_form_fields.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_radio_buttons_fieldset :qualification_status, caption: { text: t('page_titles.efl.start'), size: 'xl' }, legend: { text: 'Have you done an English as a foreign language assessment?', size: 'xl', tag: 'h1' } do %>
-  <%= f.govuk_radio_button :qualification_status, 'has_qualification', label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :qualification_status, 'has_qualification', label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :qualification_status, 'qualification_not_needed', label: { text: 'No, English is not a foreign language to me' } %>
   <%= f.govuk_radio_button :qualification_status, 'no_qualification', label: { text: 'No, I have not done an English as a foreign language assessment' } do %>
     <p class='govuk-hint'>If English is a foreign language to you, or if you do not have an English GCSE or equivalent, you may have to give evidence for your level of English.</p>

--- a/app/views/candidate_interface/english_foreign_language/type/new.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/type/new.html.erb
@@ -9,7 +9,7 @@
       <%= f.govuk_radio_buttons_fieldset :type,
         legend: { text: t('page_titles.efl.type'), size: 'xl', tag: 'h1' },
         caption: { text: t('page_titles.efl.start'), size: 'xl' } do %>
-        <%= f.govuk_radio_button :type, 'ielts', label: { text: 'International English Language Testing System (IELTS)' } %>
+        <%= f.govuk_radio_button :type, 'ielts', label: { text: 'International English Language Testing System (IELTS)' }, link_errors: true %>
         <%= f.govuk_radio_button :type, 'toefl', label: { text: 'Test of English as a Foreign Language (TOEFL)' } %>
         <%= f.govuk_radio_button :type, 'other', label: { text: 'Other' } %>
       <% end %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -6,9 +6,9 @@
     <%= form_with model: @disabilities, url: candidate_interface_edit_equality_and_diversity_disabilities_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_check_boxes_fieldset :disabilities, multiple: false, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.disabilities.title'), size: 'xl' } do %>
-        <% disabilities_checkboxes.each do |checkbox| %>
-          <%= f.govuk_check_box :disabilities, checkbox.name, label: { text: checkbox.name, size: 's' }, hint: { text: checkbox.hint_text } %>
+      <%= f.govuk_check_boxes_fieldset :disabilities, multiple: false, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: t('equality_and_diversity.disabilities.title'), size: 'xl', tag: 'h1' } do %>
+        <% disabilities_checkboxes.each_with_index do |checkbox, i| %>
+          <%= f.govuk_check_box :disabilities, checkbox.name, label: { text: checkbox.name, size: 's' }, hint: { text: checkbox.hint_text }, link_errors: i.zero? %>
         <% end %>
 
         <%= f.govuk_check_box :disabilities, t('equality_and_diversity.disabilities.other.label'), label: { text: t('equality_and_diversity.disabilities.other.label'), size: 's' } do %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -8,10 +8,10 @@
 
       <%= f.govuk_radio_buttons_fieldset :ethnic_background, caption: { text: t('equality_and_diversity.title'), size: 'xl' }, legend: { text: ethnic_background_title(@ethnic_group), size: 'xl' } do %>
         <% ethnic_backgrounds(@ethnic_group).each_with_index do |background, i| %>
-            <% if background.textfield_label.nil? %>
-              <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label }, link_errors: i.zero? %>
-            <% else %>
-              <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label } do %>
+          <% if background.textfield_label.nil? %>
+            <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label }, link_errors: i.zero? %>
+          <% else %>
+            <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label } do %>
               <%= f.govuk_text_field :other_background, label: { text: background.textfield_label } %>
             <% end %>
           <% end %>

--- a/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
+++ b/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
@@ -21,7 +21,7 @@
       </div>
 
       <%= f.govuk_radio_buttons_fieldset :confirm, legend: { text: t('confirm_selection.question'), size: 'm' } do %>
-        <%= f.govuk_radio_button :confirm, true, label: { text: 'Yes' } %>
+        <%= f.govuk_radio_button :confirm, true, label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :confirm, false, label: { text: 'No' } %>
       <% end %>
 

--- a/app/views/candidate_interface/gcse/english/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/english/grade/edit.html.erb
@@ -8,7 +8,7 @@
 
       <% if @qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: grade_step_title(@subject, @qualification_type), size: 'xl', tag: 'h1' } do %>
-          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
+          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }, link_errors: true  %>
           <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
             <%=  f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>

--- a/app/views/candidate_interface/gcse/naric/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric/edit.html.erb
@@ -12,10 +12,10 @@
 
       <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
       <%= f.govuk_radio_buttons_fieldset :naric_details, legend: { text: t('application_form.gcse.naric_statement.label'), size: 'm' } do %>
-        <%= f.govuk_radio_button :have_naric_reference, 'Yes', label: { text: 'Yes' } do %>
+        <%= f.govuk_radio_button :have_naric_reference, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_field :naric_reference, label: { text: 'UK NARIC reference number', size: 's' }, hint: { text: 'For example ‘4000228363’' }, width: 20, spellcheck: false %>
           <%= f.govuk_radio_buttons_fieldset :comparable_uk_qualification, legend: { text: t('application_form.gcse.comparable_uk_qualification.label'), size: 's'}, hint: { text: t('application_form.gcse.comparable_uk_qualification.hint_text') } do %>
-            <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') } %>
+            <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse') }, link_errors: true %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.gcse_aslevel') } %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.aslevel_alevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.aslevel_alevel') } %>
             <%= f.govuk_radio_button :comparable_uk_qualification, t('application_form.gcse.comparable_uk_qualification.values.alevel'), label: { text: t('application_form.gcse.comparable_uk_qualification.values.alevel') } %>

--- a/app/views/candidate_interface/gcse/science/grade/awards_edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/awards_edit.html.erb
@@ -9,17 +9,17 @@
       <h1 class="govuk-heading-xl"><%= grade_step_title(@subject, @qualification_type) %></h1>
 
       <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
-      <%= f.govuk_radio_buttons_fieldset :gcse_science, legend: {text: "Select the GCSEs you did and include your grade"} do %>
-        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_SINGLE_AWARD, label: {text: "Single award"}, hint: {text: t('gcse_edit_grade.hint.science.one_grade')}, link_errors: true) do %>
-          <%= f.govuk_text_field :single_award_grade, label: {text: "Grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
+      <%= f.govuk_radio_buttons_fieldset :gcse_science, legend: { text: "Select the GCSEs you did and include your grade" } do %>
+        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_SINGLE_AWARD, label: { text: "Single award" }, hint: { text: t('gcse_edit_grade.hint.science.one_grade') }, link_errors: true) do %>
+          <%= f.govuk_text_field :single_award_grade, label: { text: 'Grade' }, hint: { text: t('gcse_edit_grade.hint.other.gcse') }, width: 2 %>
         <% end %>
-        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_DOUBLE_AWARD, label: {text: "Double award"}, hint: {text: t('gcse_edit_grade.hint.science.combined_grade')}) do %>
-          <%= f.govuk_text_field :double_award_grade, label: {text: "Grade"}, hint: {text: t('gcse_edit_grade.hint.science.gcse_double_award')}, width: 4 %>
+        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_DOUBLE_AWARD, label: {text: "Double award" }, hint: { text: t('gcse_edit_grade.hint.science.combined_grade') }) do %>
+          <%= f.govuk_text_field :double_award_grade, label: { text: 'Grade' }, hint: { text: t('gcse_edit_grade.hint.science.gcse_double_award') }, width: 4 %>
         <% end %>
-        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_TRIPLE_AWARD, label: {text: "Triple award"}, hint: {text: t('gcse_edit_grade.hint.science.subject_per_grade')}) do %>
-          <%= f.govuk_text_field :biology_grade, label: {text: "Biology grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
-          <%= f.govuk_text_field :chemistry_grade, label: {text: "Chemistry grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
-          <%= f.govuk_text_field :physics_grade, label: {text: "Physics grade"}, hint: {text: t('gcse_edit_grade.hint.other.gcse')}, width: 2 %>
+        <%= f.govuk_radio_button(:gcse_science, ApplicationQualification::SCIENCE_TRIPLE_AWARD, label: {text: "Triple award" }, hint: { text: t('gcse_edit_grade.hint.science.subject_per_grade') }) do %>
+          <%= f.govuk_text_field :biology_grade, label: { text: 'Biology grade' }, hint: { text: t('gcse_edit_grade.hint.other.gcse') }, width: 2 %>
+          <%= f.govuk_text_field :chemistry_grade, label: { text: 'Chemistry grade' }, hint: { text: t('gcse_edit_grade.hint.other.gcse') }, width: 2 %>
+          <%= f.govuk_text_field :physics_grade, label: { text: 'Physics grade' }, hint: { text: t('gcse_edit_grade.hint.other.gcse') }, width: 2 %>
         <% end %>
       <% end %>
       <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>

--- a/app/views/candidate_interface/gcse/science/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/science/grade/edit.html.erb
@@ -8,8 +8,8 @@
 
       <% if @qualification_type == 'non_uk' %>
         <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: grade_step_title(@subject, @qualification_type), size: 'xl', tag: 'h1' } do %>
-          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }  %>
-          <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' }  %>
+          <%= f.govuk_radio_button :grade, 'not_applicable', label: { text: 'Not applicable' }, link_errors: true %>
+          <%= f.govuk_radio_button :grade, 'unknown', label: { text: 'Unknown' } %>
           <%= f.govuk_radio_button :grade, 'other', label: { text: 'Other' } do %>
             <%=  f.govuk_text_field :other_grade, label: { text: 'Grade' }, hint: { text: 'For example, ‘A’, ‘4.5’, ‘94%’' }, width: 10 %>
           <% end %>

--- a/app/views/candidate_interface/other_qualifications/details/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/_form.html.erb
@@ -8,7 +8,7 @@
     <%= tag.div(id: 'subject-autosuggest-data', data: { source: subjects }) if subjects %>
     <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.other_qualification.grade.label'), size: 'm' } do %>
       <% OTHER_UK_QUALIFICATION_GRADES.each_with_index do |grade, i| %>
-        <%= f.govuk_radio_button :grade, grade, link_errors: i.zero?, label: { text: grade.to_s }%>
+        <%= f.govuk_radio_button :grade, grade, label: { text: grade.to_s }, link_errors: i.zero? %>
       <% end %>
     <% end %>
     <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint: { text: t('application_form.other_qualification.award_year.hint_text') }, width: 4 %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -18,7 +18,7 @@
       <%= render partial: 'form', locals: { f: f, subjects: @subjects, grades: @grades } %>
 
       <%= f.govuk_radio_buttons_fieldset :add_another_qualification, legend: { text: 'Do you want to add another qualification?', size: 'm' } do %>
-        <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another #{@form.qualification_type_name}" } %>
+        <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another #{@form.qualification_type_name}" }, link_errors: true %>
         <%= f.govuk_radio_button :choice, 'different_type', label: { text: 'Yes, add a different qualification' } %>
         <%= f.govuk_radio_button :choice, 'no', label: { text: 'No, not at the moment' } %>
       <% end %>

--- a/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/_shared_form.html.erb
@@ -7,7 +7,7 @@
 <%= render 'candidate_interface/other_qualifications/shared/instructions' %>
 
 <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', size: 'm' } do %>
-  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' } %>
+  <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::GCSE_TYPE, label: { text: 'GCSE' }, link_errors: true %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::A_LEVEL_TYPE, label: { text: 'A level' } %>
   <%= f.govuk_radio_button :qualification_type, CandidateInterface::OtherQualificationTypeForm::AS_LEVEL_TYPE, label: { text: 'AS level' } %>
 

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -4,10 +4,10 @@
   <%= f.govuk_check_box(
     :nationalities,
     'British',
-    link_errors: true,
     multiple: true,
     label: { text: 'British' },
     hint: { text: 'including English, Scottish, Welsh or from Northern Ireland' },
+    link_errors: true,
   ) %>
   <%= f.govuk_check_box(
     :nationalities,

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'xl', text: t('page_titles.right_to_work'), tag: 'h1' } do %>
-  <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' } do %>
+  <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' }, link_errors: true do %>
     <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint: { text: 'For example, you have settled status or a permanent residence card' } %>
   <% end %>
 

--- a/app/views/candidate_interface/references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/references/review/unsubmitted.html.erb
@@ -16,8 +16,8 @@
       <%= render CandidateInterface::UnsubmittedReferenceReviewComponent.new(reference: @reference) %>
 
       <%= f.govuk_radio_buttons_fieldset :submit_reference, legend: { text: t('application_form.references.unsubmitted.label', reference_name: @reference.name), size: 'm' } do %>
-        <%= f.govuk_radio_button :submit, 'yes', label: { text: t('application_form.references.unsubmitted.yes.label'), link_errors: true } %>
-        <%= f.govuk_radio_button :submit, 'no', label: { text: t('application_form.references.unsubmitted.no.label'), link_errors: true } %>
+        <%= f.govuk_radio_button :submit, 'yes', label: { text: t('application_form.references.unsubmitted.yes.label') }, link_errors: true %>
+        <%= f.govuk_radio_button :submit, 'no', label: { text: t('application_form.references.unsubmitted.no.label') } %>
       <% end %>
 
       <%= f.govuk_submit 'Save and continue' %>

--- a/app/views/candidate_interface/references/type/_shared_form.html.erb
+++ b/app/views/candidate_interface/references/type/_shared_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.govuk_error_summary %>
 
 <%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: t('page_titles.references_type'), size: 'xl', tag: 'h1' } do %>
-  <%= f.govuk_radio_button :referee_type, 'academic', link_errors: true, label: { text: t('application_form.references.referee_type.academic.label') }, hint: { text: t('application_form.references.referee_type.academic.hint_text') } %>
+  <%= f.govuk_radio_button :referee_type, 'academic', label: { text: t('application_form.references.referee_type.academic.label') }, hint: { text: t('application_form.references.referee_type.academic.hint_text') }, link_errors: true %>
   <%= f.govuk_radio_button :referee_type, 'professional', label: { text: t('application_form.references.referee_type.professional.label') }, hint: { text: t('application_form.references.referee_type.professional.hint_text') } %>
   <%= f.govuk_radio_button :referee_type, 'school-based', label: { text: t('application_form.references.referee_type.school_based.label') }, hint: { text: t('application_form.references.referee_type.school_based.hint_text') } %>
   <%= f.govuk_radio_divider %>

--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -35,7 +35,7 @@
       <p class="govuk-body">It will not necessarily stop you becoming a teacher.</p>
 
       <%= f.govuk_radio_buttons_fieldset :share_safeguarding_issues, legend: { text: 'Do you want to share any safeguarding issues?', size: 'm' } do %>
-        <%= f.govuk_radio_button :share_safeguarding_issues, 'Yes', label: { text: 'Yes, I want to share something' }, hint: { text: 'After you have submitted your application, your provider may be in touch to discuss the information you shared. If you prefer, you can contact your provider directly.' } do %>
+        <%= f.govuk_radio_button :share_safeguarding_issues, 'Yes', label: { text: 'Yes, I want to share something' }, hint: { text: 'After you have submitted your application, your provider may be in touch to discuss the information you shared. If you prefer, you can contact your provider directly.' }, link_errors: true do %>
           <%= f.govuk_text_area :safeguarding_issues, rows: 8, label: { text: 'Give any relevant information', size: 's' }, max_words: 400 %>
         <% end %>
 

--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children'), @safeguarding.errors.any?)%>
+<% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children'), @safeguarding_form.errors.any?)%>
 <% content_for :before_content, govuk_back_link_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @safeguarding, url: candidate_interface_edit_safeguarding_path, method: :post do |f| %>
+    <%= form_with model: @safeguarding_form, url: candidate_interface_edit_safeguarding_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -29,7 +29,7 @@
           <li>checking you’re safe to work with children</li>
         </ul>
 
-        <%= f.govuk_check_box :accept_ts_and_cs, 'true', multiple: false, link_errors: true, label: { text: t('authentication.sign_up.accept_terms_checkbox') } %>
+        <%= f.govuk_check_box :accept_ts_and_cs, 'true', multiple: false, label: { text: t('authentication.sign_up.accept_terms_checkbox') }, link_errors: true %>
       <% end %>
       <%= f.govuk_submit t('authentication.sign_up.button_continue') %>
     <% end %>

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -14,7 +14,7 @@
       </h1>
 
       <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>
-        <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' } do %>
+        <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' }, link_errors: true do %>
           <%= f.govuk_email_field :email, label: { text: 'Email address', size: 's' }, hint: { text: 'Enter the email address you used to register, and we will send you a link to sign in.' }, width: 'two-thirds', autocomplete: 'email', spellcheck: false %>
         <% end %>
         <%= f.govuk_radio_button :existing_account, false, label: { text: 'No, I need to create an account' } %>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -27,7 +27,7 @@
       </ul>
 
       <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { text: t('application_form.training_with_a_disability.disclose_disability.label'), size: 'm' } do %>
-        <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') } do %>
+        <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') }, link_errors: true do %>
           <%= f.govuk_text_area :disability_disclosure, rows: 8, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label'), size: 's' }, max_words: 400 %>
         <% end %>
 

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -18,7 +18,7 @@
       <%= render 'form', f: f %>
 
       <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', size: 'm' } do %>
-        <%= f.govuk_radio_button :add_another_job, 'yes',  label: { text: 'Yes, I want to add another job' } %>
+        <%= f.govuk_radio_button :add_another_job, 'yes',  label: { text: 'Yes, I want to add another job' }, link_errors: true %>
         <%= f.govuk_radio_button :add_another_job, 'no', label: { text: 'No, not at the moment' } %>
       <% end %>
 

--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -21,7 +21,7 @@
 
       <%= f.govuk_check_boxes_fieldset :recruitment_cycle_years, legend: { text: 'Select year', size: 'm' } do %>
         <% RecruitmentCycle.years_visible_to_providers.each do |year| %>
-          <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle::CYCLES[year.to_s] } %>
+          <%= f.govuk_check_box :recruitment_cycle_years, year.to_s, label: { text: RecruitmentCycle::CYCLES[year.to_s] }, link_errors: true %>
         <% end %>
       <% end %>
 

--- a/app/views/provider_interface/application_data_export/new.html.erb
+++ b/app/views/provider_interface/application_data_export/new.html.erb
@@ -26,11 +26,11 @@
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :application_status_choice, legend: { text: 'Select applications', size: 'm' } do %>
-        <%= f.govuk_radio_button :application_status_choice, 'all', label: { text: 'All applications' } %>
+        <%= f.govuk_radio_button :application_status_choice, 'all', label: { text: 'All applications' }, link_errors: true %>
         <%= f.govuk_radio_button :application_status_choice, 'custom', label: { text: 'Applications with a specific status' } do %>
           <%= f.govuk_check_boxes_fieldset :statuses, legend: { size: 's', text: 'Select statuses' } do %>
-            <% ApplicationStateChange.states_visible_to_provider.each do |state_name| %>
-              <%= f.govuk_check_box :statuses, state_name.to_s, label: { text: t("provider_application_states.#{state_name}") } %>
+            <% ApplicationStateChange.states_visible_to_provider.each_with_index do |state_name, i| %>
+              <%= f.govuk_check_box :statuses, state_name.to_s, label: { text: t("provider_application_states.#{state_name}") }, link_errors: i.zero? %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/provider_interface/notifications/show.html.erb
+++ b/app/views/provider_interface/notifications/show.html.erb
@@ -22,8 +22,8 @@
     <%= form_with model: current_provider_user, url: provider_interface_notifications_path, method: :put do |f| %>
       <div class='govuk-form-group'>
 
-        <%= f.govuk_radio_buttons_fieldset :send_notifications, inline: true, legend: -> { nil} do %>
-          <%= f.govuk_radio_button :send_notifications, 'true', label: { text: 'On' } %>
+        <%= f.govuk_radio_buttons_fieldset :send_notifications, inline: true, legend: -> { nil } do %>
+          <%= f.govuk_radio_button :send_notifications, 'true', label: { text: 'On' }, link_errors: true %>
           <%= f.govuk_radio_button :send_notifications, 'false', label: { text: 'Off' } %>
         <% end %>
 

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -350,7 +350,7 @@
     <% declaration = "#{@provider_agreement.provider.name} agrees to comply with the data sharing practices outlined in this agreement" %>
 
     <%= f.govuk_check_boxes_fieldset :accept_agreement, legend: nil do %>
-      <%= f.govuk_check_box :accept_agreement, true, multiple: false, link_errors: true, label: { text: declaration } %>
+      <%= f.govuk_check_box :accept_agreement, true, multiple: false, label: { text: declaration }, link_errors: true %>
     <% end %>
 
     <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
@@ -45,8 +45,9 @@
         <div class="govuk-form-group <%= permission_name.to_s.dasherize %>">
           <%= f.govuk_check_boxes_fieldset permission_name, legend: { text: "Which organisations can #{permission_name.to_s.humanize.downcase}?" } do %>
             <%= hidden_field_tag "#{f.object_name}[#{permission_name}][]", '' %>
-            <%= f.govuk_check_box permission_name, 'training', link_errors: true,
-                                  label: { text: @form.training_provider.name } %>
+            <%= f.govuk_check_box permission_name, 'training',
+                                  label: { text: @form.training_provider.name },
+                                  link_errors: true %>
 
             <%= f.govuk_check_box permission_name, 'ratifying',
                                   label: { text: @form.ratifying_provider.name } %>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -27,8 +27,9 @@
             <%= pf.govuk_check_boxes_fieldset permission_name, legend: { text: "Who can #{permission_name.to_s.humanize.downcase}?" } do %>
               <div id="makedecisions-hint" class="govuk-hint"><%= t("provider_relationship_permissions.#{permission_name}") %></div>
               <%= hidden_field_tag "#{pf.object_name}[#{permission_name}][]", '' %>
-              <%= pf.govuk_check_box permission_name, 'training', link_errors: true,
-                                     label: { text: @permissions_model.training_provider.name } %>
+              <%= pf.govuk_check_box permission_name, 'training',
+                                     label: { text: @permissions_model.training_provider.name },
+                                     link_errors: true %>
 
               <%= pf.govuk_check_box permission_name, 'ratifying',
                                      label: { text: @permissions_model.ratifying_provider.name } %>

--- a/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
+++ b/app/views/provider_interface/provider_users_invitations/edit_permissions.html.erb
@@ -21,7 +21,8 @@
             <%= pf.govuk_check_boxes_fieldset(:permissions, legend: { text: 'Select permissions', size: "m" }) do %>
               <%= pf.govuk_check_box :permissions, 'manage_organisations',
                                     label: { text: 'Manage organisational permissions' },
-                                    hint: { text: 'Change permissions between organisations' } %>
+                                    hint: { text: 'Change permissions between organisations' },
+                                    link_errors: true %>
 
               <%= pf.govuk_check_box :permissions, 'manage_users',
                                     label: { text: 'Manage users' },

--- a/app/views/provider_interface/reasons_for_rejection/edit_initial_questions.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/edit_initial_questions.html.erb
@@ -122,7 +122,8 @@
           <%= f.govuk_check_boxes_fieldset :honesty_and_professionalism_concerns, legend: { text: "Which qualifications?", size: "s" } do %>
             <%= f.govuk_check_box :honesty_and_professionalism_concerns,
               'information_false_or_inaccurate',
-              label: { text: "Information given on application form false or inaccurate" } do %>
+              label: { text: "Information given on application form false or inaccurate" },
+              link_errors: true do %>
               <%= f.govuk_text_area :honesty_and_professionalism_concerns_information_false_or_inaccurate_details,
                 label: { text: 'Please give details' }, max_words: 100 %>
             <% end %>
@@ -157,7 +158,8 @@
           <%= f.govuk_check_boxes_fieldset :safeguarding_concerns, legend: { text: "Which safeguarding issues in particular?", size: "s" } do %>
             <%= f.govuk_check_box :safeguarding_concerns,
               'candidate_disclosed_information',
-              label: { text: "Information disclosed by candidate makes them unsuitable to work with children" } do %>
+              label: { text: "Information disclosed by candidate makes them unsuitable to work with children" },
+              link_errors: true do %>
               <%= f.govuk_text_area :safeguarding_concerns_candidate_disclosed_information_details,
                 label: { text: 'Please give details' }, max_words: 100 %>
             <% end %>

--- a/app/views/provider_interface/reconfirm_deferred_offers/conditions.html.erb
+++ b/app/views/provider_interface/reconfirm_deferred_offers/conditions.html.erb
@@ -21,7 +21,7 @@
         legend: { text: "Has the candidate #{met} all of the conditions?" , size: "m" } do %>
         <%= f.govuk_radio_button :conditions_status, 'met', label: { text: "Yes, all conditions are #{met}" }, link_errors: true %>
 
-        <%= f.govuk_radio_button :conditions_status, 'not met', label: { text: 'No, one or more conditions are pending' }, link_errors: true %>
+        <%= f.govuk_radio_button :conditions_status, 'not met', label: { text: 'No, one or more conditions are pending' } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/referee_interface/reference/confirmation.html.erb
+++ b/app/views/referee_interface/reference/confirmation.html.erb
@@ -32,7 +32,7 @@
         <p class="govuk-body">Your feedback will help us to improve our service.</p>
 
         <%= f.govuk_radio_buttons_fieldset :experience, legend: { text: RefereeQuestionnaire::EXPERIENCE_QUESTION } do %>
-          <%= f.govuk_radio_button :experience_rating, 'very_poor', label: { text: t('referee.questionnaire.experience.very_poor.label') } do %>
+          <%= f.govuk_radio_button :experience_rating, 'very_poor', label: { text: t('referee.questionnaire.experience.very_poor.label') }, link_errors: true do %>
             <%= f.govuk_text_area :experience_explanation_very_poor, label: { text: t('referee.questionnaire.experience.explanation.label') } %>
           <% end %>
 
@@ -54,7 +54,7 @@
         <% end %>
 
         <%= f.govuk_radio_buttons_fieldset :guidance, legend: { text: RefereeQuestionnaire::GUIDANCE_QUESTION } do %>
-          <%= f.govuk_radio_button :guidance_rating, 'very_poor', label: { text: t('referee.questionnaire.experience.very_poor.label') } do %>
+          <%= f.govuk_radio_button :guidance_rating, 'very_poor', label: { text: t('referee.questionnaire.experience.very_poor.label') }, link_errors: true do %>
             <%= f.govuk_text_area :guidance_explanation_very_poor, label: { text: t('referee.questionnaire.experience.explanation.label') } %>
           <% end %>
 
@@ -76,7 +76,7 @@
         <% end %>
 
         <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, legend: { text: RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION }, hint: { text: t('referee.questionnaire.consent_to_be_contacted.hint') } do %>
-          <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('referee.questionnaire.consent_to_be_contacted.yes.label') } do %>
+          <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('referee.questionnaire.consent_to_be_contacted.yes.label') }, link_errors: true do %>
             <%= f.govuk_text_area :consent_to_be_contacted_details, label: { text: t('referee.questionnaire.consent_to_be_contacted_details.label') } %>
           <% end %>
 

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -17,9 +17,9 @@
 
       <p class="govuk-body"><%= @application.full_name %> will be able to submit the application quicker if you give a reference.</p>
 
-      <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name)  } do %>
-        <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }  %>
-        <%= f.govuk_radio_button :choice, 'no', label: { text: t('referee.refuse_feedback.choice.cancel') }  %>
+      <%= f.govuk_radio_buttons_fieldset :choices, legend: { text: t('referee.refuse_feedback.choice.label', full_name: @application.full_name) } do %>
+        <%= f.govuk_radio_button :choice, 'yes', label: { text: t('referee.refuse_feedback.choice.confirm') }, link_errors: true %>
+        <%= f.govuk_radio_button :choice, 'no', label: { text: t('referee.refuse_feedback.choice.cancel') } %>
       <% end %>
 
       <%= f.govuk_submit t('referee.refuse_feedback.continue') %>

--- a/app/views/support_interface/application_forms/address_type/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_type/edit.html.erb
@@ -6,9 +6,9 @@
     <%= form_with model: @details_form, url: support_interface_application_form_update_address_type_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('support_interface.edit_address_details_form.address_types.label'), size: 'xl' } do %>
-        <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_information.address_type.values.uk') } %>
-        <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_information.address_type.values.international') }, link_errors: true do %>
+      <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('support_interface.edit_address_details_form.address_types.label'), size: 'l', tag: 'h1' } do %>
+        <%= f.govuk_radio_button :address_type, 'uk', label: { text: t('application_form.contact_information.address_type.values.uk') }, link_errors: true %>
+        <%= f.govuk_radio_button :address_type, 'international', label: { text: t('application_form.contact_information.address_type.values.international') } do %>
           <%= f.govuk_collection_select :country, select_country_options, :id, :name, label: { text: t('application_form.contact_information.country.label') } %>
         <% end %>
       <% end %>

--- a/app/views/support_interface/application_forms/courses/new.html.erb
+++ b/app/views/support_interface/application_forms/courses/new.html.erb
@@ -6,16 +6,16 @@
     <% if @pick_course.course_options.present? %>
       <%= form_with model: @pick_course, url: support_interface_application_form_create_course_path(course_code: @pick_course.course_code) do |f| %>
         <%= f.govuk_error_summary %>
-        <%= f.govuk_radio_buttons_fieldset :course_option_id, legend:  { text: "Which course should be added to the application?", size: "m" } do %>
-          <% @pick_course.course_options.each do |co| %>
-            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.course_name} (#{co.course_code}) - #{co.site_name}" } %>
+        <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { text: 'Which course should be added to the application?', size: 'm' } do %>
+          <% @pick_course.course_options.each_with_index do |co, i| %>
+            <%= f.govuk_radio_button :course_option_id, co.course_option_id, label: { text: "#{co.course_name} (#{co.course_code}) - #{co.site_name}" }, link_errors: i.zero? %>
           <% end %>
         <% end %>
         <%= f.govuk_submit 'Add course to application' %>
       <% end %>
     <% else %>
-     <p class="govuk-body">No results</p>
-      <%= govuk_link_to( 'Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code)) %>
+      <p class="govuk-body">No results</p>
+      <%= govuk_link_to('Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/support_interface/application_forms/nationalities/edit.html.erb
+++ b/app/views/support_interface/application_forms/nationalities/edit.html.erb
@@ -10,10 +10,10 @@
         <%= f.govuk_check_box(
           :nationalities,
           'British',
-          link_errors: true,
           multiple: true,
           label: { text: 'British' },
-          hint: { text: 'including English, Scottish, Welsh or from Northern Ireland' }
+          hint: { text: 'including English, Scottish, Welsh or from Northern Ireland' },
+          link_errors: true
         ) %>
         <%= f.govuk_check_box(
           :nationalities,

--- a/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
+++ b/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
@@ -6,21 +6,25 @@
     <%= form_with model: @right_to_work_or_study_form, url: support_interface_application_form_edit_right_to_work_or_study_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { size: 'l', text: 'Edit applicant right to work or study', tag: 'h1' } do %>
-        <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' } do %>
+      <%= f.govuk_radio_buttons_fieldset :right_to_work_or_study, legend: { text: 'Edit applicant right to work or study', size: 'l', tag: 'h1' } do %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' }, link_errors: true do %>
           <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint: { text: 'For example, you have settled status or a permanent residence card' } %>
         <% end %>
         <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
-          <div class="govuk-body">
+          <p class="govuk-body">
             Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+          </p>
+          <p class="govuk-body">
             You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
-          </div>
+          </p>
         <% end %>
         <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
-          <div class="govuk-body">
+          <p class="govuk-body">
             Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+          </p>
+          <p class="govuk-body">
             You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
-          </div>
+          </p>
         <% end %>
       <% end %>
 

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -3,11 +3,12 @@
     <%= cache [permission_form.provider, permission_form.provider_permission] do %>
       <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
         <%= pf.govuk_check_box :active, true, multiple: false,
-                                label: { text: permission_form.provider.name_and_code } do %>
+                                label: { text: permission_form.provider.name_and_code },
+                                link_errors: true do %>
           <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
             <%= ppf.hidden_field :provider_id %>
             <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-              <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+              <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' }, link_errors: true %>
               <%= ppf.govuk_check_box :manage_organisations, true, multiple: false,
                                       label: { text: 'Manage organisational permissions' } %>
               <%= ppf.govuk_check_box :make_decisions, true, multiple: false,

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -963,6 +963,10 @@ en:
           attributes:
             ethnic_group:
               blank: Choose your ethnic group
+        candidate_interface/training_with_a_disability_form:
+          attributes:
+            disclose_disability:
+              inclusion: Choose if you want to ask for help to become a teacher
         candidate_interface/safeguarding_issues_declaration_form:
           attributes:
             share_safeguarding_issues:


### PR DESCRIPTION
## Context

The DAC December 2020 report spotted a number of issues with our validation errors.

## Changes proposed in this pull request

* Adds a missing validation error for training with a disability page
* Consistent controllers for training with a disability and safeguarding questions
* Ensure error summaries link to the fieldset when it is causing an error on the page.

  Thanks to @peteryates for alerting me to needing to use `link_errors: true` on the first radio/checkbox in a fieldset. In quite a few cases this was missed off, in other cases it was added to the every option, and in a few cases not added to the first option. This is something we’ll need to keep an eye on when reviewing.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
