### PR TITLE
Change the way we detect users when a token is expired

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -21,7 +21,7 @@ module CandidateInterface
         raw_token: params[:token],
       )
 
-      if authentication_token && authentication_token.still_valid?
+      if authentication_token&.still_valid?
         render 'confirm_authentication'
       elsif authentication_token
         # If the token is expired, redirect the user to a page

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -23,11 +23,11 @@ module CandidateInterface
 
       if authentication_token && authentication_token.still_valid?
         render 'confirm_authentication'
-      elsif params[:u]
-        # If the token is invalid or expired, redirect the user to a page
-        # with their encrypted user id as a param where they can request
+      elsif authentication_token
+        # If the token is expired, redirect the user to a page
+        # with their token as a param where they can request
         # a new sign in email.
-        redirect_to candidate_interface_expired_sign_in_path(u: params[:u], path: params[:path])
+        redirect_to candidate_interface_expired_sign_in_path(token: params[:token], path: params[:path])
       else
         redirect_to(action: :new)
       end
@@ -48,25 +48,33 @@ module CandidateInterface
         sign_in(candidate, scope: :candidate)
         add_identity_to_log(candidate.id)
         candidate.update!(last_signed_in_at: Time.zone.now)
-        authentication_token.destroy!
+        authentication_token.update!(used_at: Time.zone.now)
 
         redirect_to candidate_interface_interstitial_path(path: params[:path])
       else
-        redirect_to candidate_interface_expired_sign_in_path(u: params[:u], path: params[:path])
+        redirect_to candidate_interface_expired_sign_in_path(token: params[:token], path: params[:path])
       end
     end
 
     def expired
-      if params[:u].blank?
+      authentication_token = AuthenticationToken.find_by_hashed_token(
+        user_type: 'Candidate',
+        raw_token: params[:token],
+      )
+
+      if authentication_token.blank?
         redirect_to candidate_interface_sign_in_path
       end
     end
 
     def create_from_expired_token
-      candidate_id = Encryptor.decrypt(params.fetch(:u))
+      authentication_token = AuthenticationToken.find_by_hashed_token(
+        user_type: 'Candidate',
+        raw_token: params[:token],
+      )
 
-      if candidate_id
-        candidate = Candidate.find(candidate_id)
+      if authentication_token
+        candidate = authentication_token.user
         CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate)
         add_identity_to_log candidate.id
         redirect_to candidate_interface_check_email_sign_in_path

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -1,6 +1,6 @@
 class AuthenticationMailer < ApplicationMailer
   def sign_up_email(candidate:, token:)
-    @magic_link = candidate_interface_authenticate_url(magic_link_params(token, candidate))
+    @magic_link = candidate_interface_authenticate_url(magic_link_params(token))
 
     notify_email(
       to: candidate.email_address,
@@ -10,7 +10,7 @@ class AuthenticationMailer < ApplicationMailer
   end
 
   def sign_in_email(candidate:, token:)
-    @magic_link = candidate_interface_authenticate_url(magic_link_params(token, candidate))
+    @magic_link = candidate_interface_authenticate_url(magic_link_params(token))
 
     notify_email(
       to: candidate.email_address,
@@ -27,10 +27,9 @@ class AuthenticationMailer < ApplicationMailer
 
 private
 
-  def magic_link_params(token, candidate)
+  def magic_link_params(token)
     {
       token: token,
-      u: Encryptor.encrypt(candidate.id),
     }
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -382,7 +382,7 @@ private
 
   def candidate_magic_link(candidate)
     raw_token = candidate.create_magic_link_token!
-    candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token)
+    candidate_interface_authenticate_url(token: raw_token)
   end
 
   helper_method :candidate_magic_link

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -4,7 +4,7 @@ class AuthenticationToken < ApplicationRecord
   belongs_to :user, polymorphic: true
 
   def still_valid?
-    created_at > (Time.zone.now - MAX_TOKEN_DURATION) && used_at.nil?
+    created_at.present? && created_at > (Time.zone.now - MAX_TOKEN_DURATION) && used_at.nil?
   end
 
   def self.find_by_hashed_token(user_type:, raw_token:)

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -4,7 +4,7 @@ class AuthenticationToken < ApplicationRecord
   belongs_to :user, polymorphic: true
 
   def still_valid?
-    created_at > (Time.zone.now - MAX_TOKEN_DURATION)
+    created_at > (Time.zone.now - MAX_TOKEN_DURATION) && used_at.nil?
   end
 
   def self.find_by_hashed_token(user_type:, raw_token:)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -31,10 +31,6 @@ class Candidate < ApplicationRecord
     application_forms.max_by(&:updated_at)
   end
 
-  def encrypted_id
-    Encryptor.encrypt(id)
-  end
-
 private
 
   def downcase_email

--- a/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
+++ b/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
@@ -10,7 +10,6 @@
         Click below to sign in
       </p>
       <%= hidden_field_tag :token, params[:token] %>
-      <%= hidden_field_tag :u, params[:u] %>
       <%= f.govuk_submit t('authentication.confirm_authentication.button_continue') %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -10,7 +10,7 @@
         Sign in links only work once and expire after one hour, so you need to request a new one. We’ll send this by email.
       </p>
 
-      <%= hidden_field_tag :u, params[:u] %>
+      <%= hidden_field_tag :token, params[:token] %>
 
       <%= f.govuk_submit t('authentication.expired_token.button') %>
     <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -850,7 +850,8 @@ FactoryBot.define do
   end
 
   factory :authentication_token do
-    user { support_user }
+    user { create(:support_user) }
+    hashed_token { '1234567890' }
   end
 
   factory :provider_user do

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it 'sends an email with a magic link and encrypted candidate id' do
       allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/sign-in/confirm?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/sign-in/confirm?token=#{token}",
       )
     end
 
@@ -52,7 +52,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it 'sends an email with a magic link and encrypted candidate id' do
       allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/sign-in/confirm?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/sign-in/confirm?token=#{token}",
       )
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_submitted.subject'),
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
-      'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token&u=encrypted_id',
+      'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token',
     )
   end
 

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe AuthenticationToken do
+  describe '#still_valid?' do
+    it 'is valid if it has not expired or been used' do
+      authentication_token = build(
+        :authentication_token,
+        created_at: AuthenticationToken::MAX_TOKEN_DURATION - 1.minute,
+      )
+      expect(authentication_token.still_valid?).to eql(true)
+    end
+
+    it 'is invalid if it has not expired but has been used' do
+      authentication_token = build(
+        :authentication_token,
+        created_at: AuthenticationToken::MAX_TOKEN_DURATION - 1.minute,
+        used_at: 1.minute.ago,
+      )
+      expect(authentication_token.still_valid?).to eql(false)
+    end
+
+    it 'is invalid if it has not been used but has expired' do
+      authentication_token = build(
+        :authentication_token,
+        created_at: AuthenticationToken::MAX_TOKEN_DURATION + 1.minute,
+      )
+      expect(authentication_token.still_valid?).to eql(false)
+    end
+  end
+end

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -3,26 +3,33 @@ require 'rails_helper'
 RSpec.describe AuthenticationToken do
   describe '#still_valid?' do
     it 'is valid if it has not expired or been used' do
-      authentication_token = build(
+      authentication_token = create(
         :authentication_token,
-        created_at: AuthenticationToken::MAX_TOKEN_DURATION - 1.minute,
+        created_at: Time.zone.now - AuthenticationToken::MAX_TOKEN_DURATION + 1.minute,
       )
       expect(authentication_token.still_valid?).to eql(true)
     end
 
-    it 'is invalid if it has not expired but has been used' do
+    it 'is invalid if it has been saved' do
       authentication_token = build(
         :authentication_token,
-        created_at: AuthenticationToken::MAX_TOKEN_DURATION - 1.minute,
+      )
+      expect(authentication_token.still_valid?).to eql(false)
+    end
+
+    it 'is invalid if it has not expired but has been used' do
+      authentication_token = create(
+        :authentication_token,
+        created_at: Time.zone.now - AuthenticationToken::MAX_TOKEN_DURATION + 1.minute,
         used_at: 1.minute.ago,
       )
       expect(authentication_token.still_valid?).to eql(false)
     end
 
     it 'is invalid if it has not been used but has expired' do
-      authentication_token = build(
+      authentication_token = create(
         :authentication_token,
-        created_at: AuthenticationToken::MAX_TOKEN_DURATION + 1.minute,
+        created_at: Time.zone.now - AuthenticationToken::MAX_TOKEN_DURATION - 1.minute,
       )
       expect(authentication_token.still_valid?).to eql(false)
     end

--- a/spec/models/authentication_token_spec.rb
+++ b/spec/models/authentication_token_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe AuthenticationToken do
         :authentication_token,
         created_at: Time.zone.now - AuthenticationToken::MAX_TOKEN_DURATION + 1.minute,
       )
-      expect(authentication_token.still_valid?).to eql(true)
+      expect(authentication_token.still_valid?).to be(true)
     end
 
     it 'is invalid if it has been saved' do
       authentication_token = build(
         :authentication_token,
       )
-      expect(authentication_token.still_valid?).to eql(false)
+      expect(authentication_token.still_valid?).to be(false)
     end
 
     it 'is invalid if it has not expired but has been used' do
@@ -23,7 +23,7 @@ RSpec.describe AuthenticationToken do
         created_at: Time.zone.now - AuthenticationToken::MAX_TOKEN_DURATION + 1.minute,
         used_at: 1.minute.ago,
       )
-      expect(authentication_token.still_valid?).to eql(false)
+      expect(authentication_token.still_valid?).to be(false)
     end
 
     it 'is invalid if it has not been used but has expired' do
@@ -31,7 +31,7 @@ RSpec.describe AuthenticationToken do
         :authentication_token,
         created_at: Time.zone.now - AuthenticationToken::MAX_TOKEN_DURATION - 1.minute,
       )
-      expect(authentication_token.still_valid?).to eql(false)
+      expect(authentication_token.still_valid?).to be(false)
     end
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -65,14 +65,4 @@ RSpec.describe Candidate, type: :model do
       expect(candidate.course_from_find).to eq(nil)
     end
   end
-
-  describe '#encrypted_id' do
-    let(:candidate) { create(:candidate) }
-
-    it 'invokes Encryptor to encrypt id' do
-      allow(Encryptor).to receive(:encrypt).with(candidate.id).and_return 'encrypted id value'
-
-      expect(candidate.encrypted_id).to eq 'encrypted id value'
-    end
-  end
 end

--- a/spec/support/test_helpers/mailer_setup_helper.rb
+++ b/spec/support/test_helpers/mailer_setup_helper.rb
@@ -50,7 +50,6 @@ module TestHelpers
 
     def magic_link_stubbing(candidate)
       allow(candidate).to receive(:create_magic_link_token!).and_return('raw_token')
-      allow(candidate).to receive(:encrypted_id).and_return('encrypted_id')
     end
   end
 end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
 
-    when_the_magic_link_token_is_overwritten
+    when_the_magic_link_token_is_expired
     and_i_click_on_the_link_in_my_email
     then_i_am_taken_to_the_expired_link_page
 
@@ -52,8 +52,9 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
   end
 
-  def when_the_magic_link_token_is_overwritten
-    Candidate.find_by(email_address: @email).authentication_tokens.delete_all
+  def when_the_magic_link_token_is_expired
+    Timecop.travel (AuthenticationToken::MAX_TOKEN_DURATION + 1.minute).from_now
+    # Candidate.find_by(email_address: @email).authentication_tokens.delete_all
   end
 
   def and_i_click_on_the_link_in_my_email


### PR DESCRIPTION
## Context

Following on from https://github.com/DFE-Digital/apply-for-teacher-training/pull/3611 we can now drop the `u` (encrypted user id) in URLs for regenerating expired or used tokens.

This PR should not be merged until https://github.com/DFE-Digital/apply-for-teacher-training/pull/3707 is deployed because it depends on a migration in that PR.

## Changes proposed in this pull request

- Remove `u` param from `CandidateInterface::SigninController#confirm_authentication`, `authenticate` and `expired` actions. The `token` param is now sufficient to identify users.
- Rather than delete `AuthenticationToken`s after a successful login we now just set the `used_at` timestamp. This enables us to find any token in the DB for id purposes regardless of whether it's been used or not.
- Ensure that `AuthenticationToken#still_valid?` takes account of `used_at` (return false if it's set).

## Guidance to review

- Being a change to authentication this PR requires very thorough review and testing.

## Link to Trello card

https://trello.com/c/zEo4y16R/2626-dev-change-the-way-we-detect-users-when-a-token-is-expired-and-make-the-url-nice

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
