### PR TITLE
Reinstate missing label for deprecated work breaks page

### DIFF
--- a/app/views/candidate_interface/work_history/breaks/edit.html.erb
+++ b/app/views/candidate_interface/work_history/breaks/edit.html.erb
@@ -6,11 +6,9 @@
     <%= form_with model: @work_breaks_form, url: candidate_interface_work_history_breaks_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_area :work_history_breaks, label: { text: t('application_form.work_history.breaks.label'), tag: 'h1', size: 'xl' }, max_words: 400, rows: 10 do %>
+      <%= f.govuk_text_area :work_history_breaks, label: { text: t('application_form.work_history.breaks.label'), size: 'xl', tag: 'h1' }, max_words: 400, rows: 10 do %>
         <p class="govuk-body">
-          For example, reasons for a break in employment might include parenting
-          or caring responsibilities, study, travel, unemployment, a career
-          break or health.
+          For example, reasons for a break in employment might include parenting or caring responsibilities, study, travel, unemployment, a career break or health.
         </p>
         <p class="govuk-body">
           For safeguarding reasons, you should explain any break longer than a month.

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -157,7 +157,8 @@ en:
         review_label: Explanation of why you’ve been out of the workplace
         change_action: explanation of why you’ve been out of the workplace
       breaks:
-        review_label: Tell us about any breaks in your work history
+        label: Tell us about any breaks in your work history
+        review_label: Breaks in your work history
         enter_action: Enter explanation
         change_action: Change explanation
       complete_form_button: Save and continue


### PR DESCRIPTION
## Context

In 3857e0f458e2e02ddef5ee9edd2940231b63138f I updated the localised strings for work breaks, and in doing so, inadvertently broke this deprecated – but annoyingly still present – page for explaining work breaks. I regret the error.

## Changes proposed in this pull request

* Adds the missing string
* Ordering of attributes 💅 
* Removal of line breaks in paragraphs 💅 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
