### PR TITLE
Different namespaces for service feedback and application rejection styles

### DIFF
--- a/app/components/candidate_interface/application_feedback_component.html.erb
+++ b/app/components/candidate_interface/application_feedback_component.html.erb
@@ -1,6 +1,6 @@
 <% if FeatureFlag.active?(:feedback_prompts) %>
   <div class="govuk-width-container">
-    <div class="app-feedback__container">
+    <div class="app-feedback">
       <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-4">
         <%= govuk_link_to(
           t('application_feedback.feedback_link'),

--- a/app/components/reasons_for_rejection_component.html.erb
+++ b/app/components/reasons_for_rejection_component.html.erb
@@ -1,206 +1,204 @@
-<div>
-  <% if reasons_for_rejection.candidate_behaviour_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Something you did', class: 'govuk-heading-s') %>
-      <ul class="govuk-list govuk-list--spaced">
-        <% reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.each do |reason| %>
-          <li>
-            <% if reason == 'other' %>
-              <p><%= reasons_for_rejection.candidate_behaviour_other %></p>
-              <p><%= reasons_for_rejection.candidate_behaviour_what_to_improve %></p>
-            <% else %>
-              <p><%= t("reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.#{reason}") %>.</p>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+<% if reasons_for_rejection.candidate_behaviour_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Something you did', class: 'govuk-heading-s') %>
+    <ul class="govuk-list govuk-list--spaced">
+      <% reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.each do |reason| %>
+        <li>
+          <% if reason == 'other' %>
+            <p><%= reasons_for_rejection.candidate_behaviour_other %></p>
+            <p><%= reasons_for_rejection.candidate_behaviour_what_to_improve %></p>
+          <% else %>
+            <p><%= t("reasons_for_rejection.candidate_behaviour_what_did_the_candidate_do.#{reason}") %>.</p>
+          <% end %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
+    </ul>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if reasons_for_rejection.quality_of_application_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Quality of application', class: 'govuk-heading-s') %>
-      <ul class="govuk-list govuk-list--spaced">
-        <% reasons_for_rejection.quality_of_application_which_parts_needed_improvement.each do |reason| %>
-          <li>
-            <% if reason == 'other' %>
-              <p><%= reasons_for_rejection.quality_of_application_other_details %></p>
-              <p><%= reasons_for_rejection.quality_of_application_other_what_to_improve %></p>
-            <% else %>
-              <p><%= t("reasons_for_rejection.quality_of_application.#{reason}") %>.</p>
-              <p><%= reasons_for_rejection.send(:"quality_of_application_#{reason}_what_to_improve") %>.</p>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+<% if reasons_for_rejection.quality_of_application_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Quality of application', class: 'govuk-heading-s') %>
+    <ul class="govuk-list govuk-list--spaced">
+      <% reasons_for_rejection.quality_of_application_which_parts_needed_improvement.each do |reason| %>
+        <li>
+          <% if reason == 'other' %>
+            <p><%= reasons_for_rejection.quality_of_application_other_details %></p>
+            <p><%= reasons_for_rejection.quality_of_application_other_what_to_improve %></p>
+          <% else %>
+            <p><%= t("reasons_for_rejection.quality_of_application.#{reason}") %>.</p>
+            <p><%= reasons_for_rejection.send(:"quality_of_application_#{reason}_what_to_improve") %>.</p>
+          <% end %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
+    </ul>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if reasons_for_rejection.qualifications_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Qualifications', class: 'govuk-heading-s') %>
-      <ul class="govuk-list govuk-list--spaced">
-        <% reasons_for_rejection.qualifications_which_qualifications.each do |reason| %>
-          <li>
-            <% if reason == 'other' %>
-              <p><%= reasons_for_rejection.qualifications_other_details %></p>
-            <% else %>
-              <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+<% if reasons_for_rejection.qualifications_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Qualifications', class: 'govuk-heading-s') %>
+    <ul class="govuk-list govuk-list--spaced">
+      <% reasons_for_rejection.qualifications_which_qualifications.each do |reason| %>
+        <li>
+          <% if reason == 'other' %>
+            <p><%= reasons_for_rejection.qualifications_other_details %></p>
+          <% else %>
+            <p><%= t("reasons_for_rejection.qualifications_which_qualifications.#{reason}") %>.</p>
+          <% end %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
+    </ul>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if reasons_for_rejection.performance_at_interview_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Performance at interview', class: 'govuk-heading-s') %>
-      <p class="govuk-body"><%= reasons_for_rejection.performance_at_interview_what_to_improve %></p>
+<% if reasons_for_rejection.performance_at_interview_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Performance at interview', class: 'govuk-heading-s') %>
+    <p class="govuk-body"><%= reasons_for_rejection.performance_at_interview_what_to_improve %></p>
 
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
+
+<% if reasons_for_rejection.course_full_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Course full', class: 'govuk-heading-s') %>
+    <p>We're sorry to tell you the course you applied to was full</p>
+
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
+
+<% if reasons_for_rejection.offered_on_another_course_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'They offered you a place on another course', class: 'govuk-heading-s') %>
+    <p class="govuk-body"><%= reasons_for_rejection.offered_on_another_course_details %></p>
+
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
+
+<% if reasons_for_rejection.honesty_and_professionalism_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Honesty and professionalism', class: 'govuk-heading-s') %>
+    <ul class="govuk-list govuk-list--spaced">
+      <% if reasons_for_rejection.honesty_and_professionalism_concerns_information_false_or_inaccurate_details.present? %>
+        <li>
+          <%= reasons_for_rejection.honesty_and_professionalism_concerns_information_false_or_inaccurate_details %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
-
-  <% if reasons_for_rejection.course_full_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Course full', class: 'govuk-heading-s') %>
-      <p>We're sorry to tell you the course you applied to was full</p>
-
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+      <% if reasons_for_rejection.honesty_and_professionalism_concerns_plagiarism_details.present? %>
+        <li>
+          <%= reasons_for_rejection.honesty_and_professionalism_concerns_plagiarism_details %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
-
-  <% if reasons_for_rejection.offered_on_another_course_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'They offered you a place on another course', class: 'govuk-heading-s') %>
-      <p class="govuk-body"><%= reasons_for_rejection.offered_on_another_course_details %></p>
-
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+      <% if reasons_for_rejection.honesty_and_professionalism_concerns_references_details.present? %>
+        <li>
+          <%= reasons_for_rejection.honesty_and_professionalism_concerns_references_details %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
-
-  <% if reasons_for_rejection.honesty_and_professionalism_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Honesty and professionalism', class: 'govuk-heading-s') %>
-      <ul class="govuk-list govuk-list--spaced">
-        <% if reasons_for_rejection.honesty_and_professionalism_concerns_information_false_or_inaccurate_details.present? %>
-          <li>
-            <%= reasons_for_rejection.honesty_and_professionalism_concerns_information_false_or_inaccurate_details %>
-          </li>
-        <% end %>
-        <% if reasons_for_rejection.honesty_and_professionalism_concerns_plagiarism_details.present? %>
-          <li>
-            <%= reasons_for_rejection.honesty_and_professionalism_concerns_plagiarism_details %>
-          </li>
-        <% end %>
-        <% if reasons_for_rejection.honesty_and_professionalism_concerns_references_details.present? %>
-          <li>
-            <%= reasons_for_rejection.honesty_and_professionalism_concerns_references_details %>
-          </li>
-        <% end %>
-        <% if reasons_for_rejection.honesty_and_professionalism_concerns_other_details.present? %>
-          <li>
-            <%= reasons_for_rejection.honesty_and_professionalism_concerns_other_details %>
-          </li>
-        <% end %>
-      </ul>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+      <% if reasons_for_rejection.honesty_and_professionalism_concerns_other_details.present? %>
+        <li>
+          <%= reasons_for_rejection.honesty_and_professionalism_concerns_other_details %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
+    </ul>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if reasons_for_rejection.safeguarding_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Safeguarding issues', class: 'govuk-heading-s') %>
-      <ul class="govuk-list govuk-list--spaced">
-        <% if reasons_for_rejection.safeguarding_concerns_candidate_disclosed_information_details.present? %>
-          <li>
-            <%= reasons_for_rejection.safeguarding_concerns_candidate_disclosed_information_details %>
-          </li>
-        <% end %>
-        <% if reasons_for_rejection.safeguarding_concerns_vetting_disclosed_information_details.present? %>
-          <li>
-            <%= reasons_for_rejection.safeguarding_concerns_vetting_disclosed_information_details %>
-          </li>
-        <% end %>
-        <% if reasons_for_rejection.safeguarding_concerns_other_details.present? %>
-          <li>
-            <%= reasons_for_rejection.safeguarding_concerns_other_details %>
-          </li>
-        <% end %>
-      </ul>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
+<% if reasons_for_rejection.safeguarding_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Safeguarding issues', class: 'govuk-heading-s') %>
+    <ul class="govuk-list govuk-list--spaced">
+      <% if reasons_for_rejection.safeguarding_concerns_candidate_disclosed_information_details.present? %>
+        <li>
+          <%= reasons_for_rejection.safeguarding_concerns_candidate_disclosed_information_details %>
+        </li>
       <% end %>
-    </div>
-  <% end %>
+      <% if reasons_for_rejection.safeguarding_concerns_vetting_disclosed_information_details.present? %>
+        <li>
+          <%= reasons_for_rejection.safeguarding_concerns_vetting_disclosed_information_details %>
+        </li>
+      <% end %>
+      <% if reasons_for_rejection.safeguarding_concerns_other_details.present? %>
+        <li>
+          <%= reasons_for_rejection.safeguarding_concerns_other_details %>
+        </li>
+      <% end %>
+    </ul>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_initial_questions_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if reasons_for_rejection.why_are_you_rejecting_this_application.present? %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Reasons why your application was unsuccessful', class: 'govuk-heading-s') %>
-      <p class="govuk-body"><%= reasons_for_rejection.why_are_you_rejecting_this_application %></p>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
-      <% end %>
-    </div>
-  <% end %>
+<% if reasons_for_rejection.why_are_you_rejecting_this_application.present? %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Reasons why your application was unsuccessful', class: 'govuk-heading-s') %>
+    <p class="govuk-body"><%= reasons_for_rejection.why_are_you_rejecting_this_application %></p>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if reasons_for_rejection.other_advice_or_feedback_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Additional advice', class: 'govuk-heading-s') %>
-      <p class="govuk-body"><%= reasons_for_rejection.other_advice_or_feedback_details %></p>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
-      <% end %>
-    </div>
-  <% end %>
+<% if reasons_for_rejection.other_advice_or_feedback_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Additional advice', class: 'govuk-heading-s') %>
+    <p class="govuk-body"><%= reasons_for_rejection.other_advice_or_feedback_details %></p>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>
 
-  <% if reasons_for_rejection.interested_in_future_applications_y_n == 'Yes' %>
-    <div class="app-feedback">
-      <%= content_tag(subheading_tag_name, 'Future applications', class: 'govuk-heading-s') %>
-      <p class="govuk-body"><%= application_choice.provider.name %> would be interested in future applications from you.</p>
-      <% if editable? %>
-        <p class="app-rejection-change-link">
-          <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice), class: 'app-rejection-change-link' %>
-        </p>
-      <% end %>
-    </div>
-  <% end %>
-</div>
+<% if reasons_for_rejection.interested_in_future_applications_y_n == 'Yes' %>
+  <div class="app-rejection">
+    <%= content_tag(subheading_tag_name, 'Future applications', class: 'govuk-heading-s') %>
+    <p class="govuk-body"><%= application_choice.provider.name %> would be interested in future applications from you.</p>
+    <% if editable? %>
+      <p class="app-rejection__actions">
+        <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/frontend/styles/_feedback.scss
+++ b/app/frontend/styles/_feedback.scss
@@ -1,4 +1,4 @@
-.app-feedback__container {
+.app-feedback {
   @include govuk-clearfix;
   align-items: center;
   background-color: govuk-colour("light-grey");

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -10,6 +10,6 @@
 @import "_count";
 @import "_masthead";
 @import "_notes";
-@import "_timeline";
 @import "_offer";
-@import "_reject";
+@import "_rejection";
+@import "_timeline";

--- a/app/frontend/styles/provider/_rejection.scss
+++ b/app/frontend/styles/provider/_rejection.scss
@@ -1,9 +1,10 @@
-.app-feedback {
-  margin-bottom: 20px;
+.app-rejection {
+  margin-bottom: govuk-spacing(4);
   padding-right: 70px;
   position: relative;
 
-  .app-rejection-change-link {
+  .app-rejection__actions {
+    margin: 0;
     position: absolute;
     right: 0;
     top: 0;

--- a/spec/components/provider_interface/reasons_for_rejection_component_spec.rb
+++ b/spec/components/provider_interface/reasons_for_rejection_component_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ReasonsForRejectionComponent do
     it 'renders change links when editable' do
       result = render_inline(described_class.new(application_choice: application_choice, reasons_for_rejection: reasons_for_rejection, editable: true))
 
-      expect(result.css('.app-rejection-change-link').text).to include('Change')
+      expect(result.css('.app-rejection__actions').text).to include('Change')
     end
 
     it 'renders subheadings as h2s when editable' do

--- a/spec/components/reasons_for_rejection_component_spec.rb
+++ b/spec/components/reasons_for_rejection_component_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ReasonsForRejectionComponent do
     it 'renders change links when editable' do
       result = render_inline(described_class.new(application_choice: application_choice, reasons_for_rejection: reasons_for_rejection, editable: true))
 
-      expect(result.css('.app-rejection-change-link').text).to include('Change')
+      expect(result.css('.app-rejection__actions').text).to include('Change')
     end
 
     it 'renders subheadings as h2s when editable' do


### PR DESCRIPTION
## Context

I noticed a potential area of conflict in our CSS styles, only avoided due to these (currently) living in separate interfaces. We have `app-feedback__container` for the module requesting service feedback that appears above the footer in the candidate interface, and `app-feedback` for the rejection reasons in the provider interface.

## Changes proposed in this pull request

### Rejection component
* Given the original SCSS file was called `reject.scss` and the markup appears in the `reasons_for_rejection_component.html.erb` file, updated the namespace for this component to `app-rejection` (and updated the CSS file name to match)
* Updated the class name for the change link:
  * Use BEM `__*` notation for a child class
  * Use `actions` suffix to match pattern used in design system components: `app-rejection__actions`
  * Only apply the class to the containing paragraph, not the link as well
* Removed an unnecessary containing `div`
* Fixing the positioning of the change link so that it appears in the top right of the parent container by removing the margin on the paragraph
* Used `govuk-spacing` helper for margin value

### Feedback component
* Renamed `app-feedback__container` to `app-feedback` since we no longer need the distinction between parent `div` and inner container element given the redesign of this component

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
