### PR TITLE
Remove ambiguous form labelling on nationality forms

### DIFF
--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -30,20 +30,21 @@ const nationalitiesComponent = () => {
   hideSection(thirdSelectEl, thirdFormLabel);
 
   function addRemoveLink(labelEl, selectEl) {
+    const parentEl = labelEl.parentElement;
+
     const removeLink = document.createElement("a");
     removeLink.innerHTML = "Remove";
     removeLink.classList.add("govuk-link", "app-nationality__remove-link");
 
     // This has to be a link and not a button as the govuk-link class requires an
-    // href to apply  it's styling
+    // href to apply it's styling
     removeLink.href = "#";
-    labelEl.appendChild(removeLink);
+    parentEl.insertBefore(removeLink, labelEl);
 
     if (labelEl == secondFormLabel) {
       addNthNationalityHiddenSpan(removeLink, 'Second');
     } else {
       addNthNationalityHiddenSpan(removeLink, 'Third');
-
     }
 
     removeLink.addEventListener("click", function () {

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -55,7 +55,7 @@ const nationalitiesComponent = () => {
   function addNthNationalityHiddenSpan(removeLink, nthNationality) {
     const nthNationalitySpan = document.createElement("span");
     nthNationalitySpan.classList.add("govuk-visually-hidden");
-    nthNationalitySpan.innerHTML = `${nthNationality} nationality`;
+    nthNationalitySpan.innerHTML = ` ${nthNationality.toLowerCase()} nationality`;
     removeLink.appendChild(nthNationalitySpan);
   }
 

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -47,7 +47,8 @@ const nationalitiesComponent = () => {
       addNthNationalityHiddenSpan(removeLink, 'Third');
     }
 
-    removeLink.addEventListener("click", function () {
+    removeLink.addEventListener("click", function (event) {
+      event.preventDefault();
       handleRemoveLinkClick(labelEl, selectEl);
     });
   }
@@ -74,7 +75,7 @@ const nationalitiesComponent = () => {
       addNationalityButton.style.display = "none";
     }
 
-    addNationalityButton.addEventListener("click", function () {
+    addNationalityButton.addEventListener("click", function (event) {
       event.preventDefault();
       handleAddNationalityClick();
     });

--- a/app/frontend/packs/nationalities-component.js
+++ b/app/frontend/packs/nationalities-component.js
@@ -37,14 +37,14 @@ const nationalitiesComponent = () => {
     removeLink.classList.add("govuk-link", "app-nationality__remove-link");
 
     // This has to be a link and not a button as the govuk-link class requires an
-    // href to apply it's styling
+    // href to apply its styling
     removeLink.href = "#";
     parentEl.insertBefore(removeLink, labelEl);
 
     if (labelEl == secondFormLabel) {
-      addNthNationalityHiddenSpan(removeLink, 'Second');
+      addNthNationalityHiddenSpan(removeLink, "Second");
     } else {
-      addNthNationalityHiddenSpan(removeLink, 'Third');
+      addNthNationalityHiddenSpan(removeLink, "Third");
     }
 
     removeLink.addEventListener("click", function (event) {

--- a/app/frontend/styles/candidate/_nationalities.scss
+++ b/app/frontend/styles/candidate/_nationalities.scss
@@ -1,3 +1,4 @@
 .app-nationality__remove-link {
+  @include govuk-font($size: 19);
   float: right;
 }

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_error_summary %>
 
-<%= f.govuk_check_boxes_fieldset :nationalities, legend: { size: 'xl', text:  t('page_titles.nationalities'), tag: 'h1' } do %>
+<%= f.govuk_check_boxes_fieldset :nationalities, legend: { text:  t('page_titles.nationalities'), size: 'xl', tag: 'h1' } do %>
   <%= f.govuk_check_box(
     :nationalities,
     'British',

--- a/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/_shared_form.html.erb
@@ -22,9 +22,27 @@
     multiple: true,
     label: { text: 'Citizen of a different country' },
   ) do %>
-    <%= f.govuk_collection_select :other_nationality1, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
-    <%= f.govuk_collection_select :other_nationality2, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
-    <%= f.govuk_collection_select :other_nationality3, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
+    <%= f.govuk_collection_select(
+      :other_nationality1,
+      select_nationality_options,
+      :id,
+      :name,
+      label: ->{ safe_join([tag.span('First ', class: 'govuk-visually-hidden'), t('application_form.personal_details.nationality.label')]) },
+    ) %>
+    <%= f.govuk_collection_select(
+      :other_nationality2,
+      select_nationality_options,
+      :id,
+      :name,
+      label: ->{ safe_join([tag.span('Second ', class: 'govuk-visually-hidden'), t('application_form.personal_details.nationality.label')]) },
+    ) %>
+    <%= f.govuk_collection_select(
+      :other_nationality3,
+      select_nationality_options,
+      :id,
+      :name,
+      label: ->{ safe_join([tag.span('Third ', class: 'govuk-visually-hidden'), t('application_form.personal_details.nationality.label')]) },
+    ) %>
   <% end %>
 <% end %>
 

--- a/app/views/support_interface/application_forms/nationalities/edit.html.erb
+++ b/app/views/support_interface/application_forms/nationalities/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @nationalities_form, url: support_interface_application_form_edit_nationalities_path, class: 'app-nationality', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_check_boxes_fieldset :nationalities, legend: { size: 'l', text: 'Edit applicant nationality' } do %>
+      <%= f.govuk_check_boxes_fieldset :nationalities, legend: { text: 'Edit applicant nationality', size: 'l', tag: 'h1' } do %>
         <%= f.govuk_check_box(
           :nationalities,
           'British',

--- a/app/views/support_interface/application_forms/nationalities/edit.html.erb
+++ b/app/views/support_interface/application_forms/nationalities/edit.html.erb
@@ -13,29 +13,48 @@
           link_errors: true,
           multiple: true,
           label: { text: 'British' },
-          hint: { text: 'including English, Scottish, Welsh or from Northern Ireland' }) %>
+          hint: { text: 'including English, Scottish, Welsh or from Northern Ireland' }
+        ) %>
         <%= f.govuk_check_box(
           :nationalities,
           'Irish',
           multiple: true,
           label: { text: 'Irish' },
-          hint: { text: 'including from Northern Ireland' }) %>
-
+          hint: { text: 'including from Northern Ireland' }
+        ) %>
         <%= f.govuk_check_box(
           :nationalities,
           'other',
           multiple: true,
-          label: { text: 'Citizen of a different country' }) do %>
-          <%= f.govuk_collection_select :other_nationality1, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
-          <%= f.govuk_collection_select :other_nationality2, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
-          <%= f.govuk_collection_select :other_nationality3, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label') } %>
+          label: { text: 'Citizen of a different country' }
+        ) do %>
+          <%= f.govuk_collection_select(
+            :other_nationality1,
+            select_nationality_options,
+            :id,
+            :name,
+            label: ->{ safe_join([tag.span('First ', class: 'govuk-visually-hidden'), t('application_form.personal_details.nationality.label')]) },
+          ) %>
+          <%= f.govuk_collection_select(
+            :other_nationality2,
+            select_nationality_options,
+            :id,
+            :name,
+            label: ->{ safe_join([tag.span('Second ', class: 'govuk-visually-hidden'), t('application_form.personal_details.nationality.label')]) },
+          ) %>
+          <%= f.govuk_collection_select(
+            :other_nationality3,
+            select_nationality_options,
+            :id,
+            :name,
+            label: ->{ safe_join([tag.span('Third ', class: 'govuk-visually-hidden'), t('application_form.personal_details.nationality.label')]) },
+          ) %>
         <% end %>
       <% end %>
 
       <%= f.govuk_text_field :audit_comment, label: { text: 'Audit log comment', size: 'm' }, hint: { text: 'This will appear in the audit log alongside this change. If the change originated in a Zendesk ticket, paste the Zendesk URL here' } %>
 
       <%= f.govuk_submit 'Save and continue' %>
-
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Context

The DAC December audit spotted a few issues with the way we enable users to add/remove additional nationalities. 

## Changes proposed in this pull request

* Places the remove link _before_ the form label, not within it
* Fixes the title of the remove link (`RemoveSecond nationality` → `Remove second nationality`)
* Makes form labels unique by adding ordinal within hidden text (‘Nationality’ → ‘[Second] Nationality`)
* Add `event.preventDefault` to remove click handler so that clicking ‘Remove’ doesn’t take user to top of the page
* Add missing `h1` to nationalities form in support 

## Guidance to review

For adding the hidden label text, I’ve used the same `safe_join()` method we’re using on the address page.

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
