### PR TITLE
Update provider service guidance with key dates

### DIFF
--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -182,11 +182,20 @@ For now, interview scheduling is not part of the Manage service.
 
 For clarity and fairness, while [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk/candidate) and UCAS Teacher Training run side by side (until October 2021), we’ve kept the rules governing applications closely aligned.
 
+Candidates can:
+
+ - submit a new application through either service until 7 September 2021
+ - apply again through either service until 21 September 2021
+
+Applications will be automatically rejected on 4 October 2021 if you have not responded to them.
+
 ### Reject by default and decline by default deadlines
 
 Training providers have 40 working days to respond to an application (starting from the date when references have been submitted).
 
 Candidates have 10 working days to accept or reject offer(s) (starting from the date when all their training providers have responded to their application).
+
+The period from 2 to 16 April 2021 does not count as working days.
 
 ### Changing the terms of an offer
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds key dates to _Deadlines and terms of use_ and _Reject by default and decline by default deadlines_ sections.

![image](https://user-images.githubusercontent.com/93511/102999693-6a06cd00-4521-11eb-9eb8-f9c2558c2a45.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

@johndoates can you confirm this content is right?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/249QZ4KX/3173-update-terms-of-use-page-with-key-dates
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
