### PR TITLE
Unique sub-section label for candidate accounts in support

### DIFF
--- a/app/components/support_interface/candidates_table_component.html.erb
+++ b/app/components/support_interface/candidates_table_component.html.erb
@@ -2,7 +2,7 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Candidate</th>
+        <th scope="col" class="govuk-table__header">Email address</th>
         <th scope="col" class="govuk-table__header">Status of latest application</th>
         <th scope="col" class="govuk-table__header">Last updated</th>
       </tr>

--- a/app/views/support_interface/application_forms/_application_navigation.html.erb
+++ b/app/views/support_interface/application_forms/_application_navigation.html.erb
@@ -2,7 +2,7 @@
   <%= render BreadcrumbComponent.new(items: [
     {
       text: 'Candidates',
-      path: support_interface_candidates_path
+      path: support_interface_applications_path
     },
     {
       text: @application_form.candidate.email_address,

--- a/app/views/support_interface/candidates/_candidates_navigation.html.erb
+++ b/app/views/support_interface/candidates/_candidates_navigation.html.erb
@@ -3,7 +3,7 @@
 
 <%= render TabNavigationComponent.new(items: [
   { name: 'Applications', url: support_interface_applications_path, current: local_assigns[:current] == 'Applications' },
-  { name: 'Candidates', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
+  { name: 'Candidate accounts', url: support_interface_candidates_path, current: local_assigns[:current] == 'Candidates' },
   { name: 'UCAS matches', url: support_interface_ucas_matches_path(years: RecruitmentCycle.current_year), current: local_assigns[:current] == 'UCAS matches' },
 ]) %>
 

--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -5,7 +5,7 @@
   <%= render BreadcrumbComponent.new(items: [
     {
       text: 'Candidates',
-      path: support_interface_candidates_path
+      path: support_interface_applications_path
     },
     {
       text: @candidate.email_address


### PR DESCRIPTION
## Context

The DAC December 2020 audit spotted an issue in the support UI in that within the ‘Candidates’ section, we have a ‘Candidates’ section – duplicate links which may be confusing.

## Changes proposed in this pull request

* Rename the ‘Candidates’ sub-section to ‘Candidate accounts’
* Update the breadcrumbs in this section so that the first item always returns you to the first page in this section, not the second. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
