### PR TITLE
Include service guidance content on disabling notifications

### DIFF
--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -160,7 +160,9 @@ Note that you can defer an offer at any point in the cycle, and with conditions 
 
 ### Email alerts
 
-You’ll receive an email every time an application’s status changes, for example from ‘Offer’ to ‘Offer accepted’.
+You’ll receive an email every time an application’s status changes, for example from ‘Offered’ to ‘Accepted’.
+
+You can turn these emails off in the ‘Email notifications’ section of ‘Your account’.
 
 ### Notes
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Amends 2 incorrect statuses given in example
- Adds a line to provider service guidance page about disabling email notifications

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/93511/103015386-3f743e80-4538-11eb-8909-b12395afae12.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/vB4TtZmh/3172-add-content-about-managing-email-notifications-to-guidance-page-and-provider-welcome-email

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
