### PR TITLE
Pluralise the 'Course choice' page title

### DIFF
--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, t('page_titles.choose_courses') %>
+<% content_for :title, t('page_titles.choose_course').pluralize(@current_application.number_of_choices_candidate_can_make) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('page_titles.choose_courses') %>
+      <%= t('page_titles.choose_course').pluralize(@current_application.number_of_choices_candidate_can_make) %>
     </h1>
     <% if @current_application.candidate_can_choose_single_course? %>
       <%= render 'guidance_apply_again' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,7 +76,7 @@ en:
     add_another_degree: Add another degree
     work_history_explanation: Tell us why you’ve been out of the workplace
     destroy_degree: Are you sure you want to delete this degree?
-    choose_courses: Choose your courses
+    choose_course: Choose your course
     courses: Courses
     course_choices: Course choices
     course_choice: Course choice

--- a/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
+++ b/spec/components/candidate_interface/application_form_course_choices_component_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
     context 'choices present' do
       let(:result) do
         render_inline(
-          described_class.new(choices_are_present: true, completed: completed),
+          described_class.new(
+            choices_are_present: true,
+            completed: completed,
+          ),
         )
       end
 
@@ -23,7 +26,10 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
     context 'no choices present' do
       let(:result) do
         render_inline(
-          described_class.new(choices_are_present: true, completed: completed),
+          described_class.new(
+            choices_are_present: true,
+            completed: completed,
+          ),
         )
       end
 
@@ -40,7 +46,10 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
     context 'no choices present' do
       let(:result) do
         render_inline(
-          described_class.new(choices_are_present: false, completed: completed),
+          described_class.new(
+            choices_are_present: false,
+            completed: completed,
+          ),
         )
       end
 
@@ -56,7 +65,10 @@ RSpec.describe CandidateInterface::ApplicationFormCourseChoicesComponent do
     context 'choices present' do
       let(:result) do
         render_inline(
-          described_class.new(choices_are_present: true, completed: completed),
+          described_class.new(
+            choices_are_present: true,
+            completed: completed,
+          ),
         )
       end
 

--- a/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_cannot_add_new_course_once_the_cycle_has_closed_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
     and_it_is_the_day_before_the_apply_2_deadline
 
     when_i_visit_the_site
-    then_there_is_a_link_to_the_course_choices_section
+    then_there_is_a_link_to_the_apply_again_course_choices_section
   end
 
   def given_i_am_signed_in
@@ -54,6 +54,10 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
 
   def then_there_is_a_link_to_the_course_choices_section
     expect(page).to have_link('Choose your courses')
+  end
+
+  def then_there_is_a_link_to_the_apply_again_course_choices_section
+    expect(page).to have_link('Choose your course')
   end
 
   def given_it_is_the_day_after_the_apply1_deadline
@@ -93,6 +97,10 @@ RSpec.describe 'Candidate vists their application form after the cycle has ended
   end
 
   def given_my_application_forms_phase_is_apply_2
+    create(
+      :application_form,
+      subsequent_application_form: current_candidate.current_application,
+    )
     current_candidate.current_application.apply_2!
   end
 


### PR DESCRIPTION
## Context

This page title for the _Choosing your course(s)_ page should be pluralised based on the number of course choices available.

## Changes proposed in this pull request

- Pluralisation should be based on the number of course choices that the candidate has in this application phase.
- Some minor changes to a related system spec to ensure that it's testing a more realistic apply again application.

## Guidance to review

- It should be possible to test on the review application, there are three cases to look at: a fresh application, a carried over application and an apply again application.

## Link to Trello card

https://trello.com/c/v9auchn6/2583-use-active-title-for-choosing-your-courses

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
