### PR TITLE
Add unsubscribe link to footer in status change emails

### DIFF
--- a/app/views/layouts/provider_email_with_footer.text.erb
+++ b/app/views/layouts/provider_email_with_footer.text.erb
@@ -5,3 +5,5 @@
 For an overview of Manage teacher training applications, see our [Service guidance](<%= provider_interface_service_guidance_url %>).
 
 You can also contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+
+<%= yield :additional_footer_content %>

--- a/app/views/provider_mailer/_unsubscribe.text.erb
+++ b/app/views/provider_mailer/_unsubscribe.text.erb
@@ -1,0 +1,5 @@
+# Change your email notification settings
+
+You can turn off email notifications if you do not want to be told when application statuses change:
+
+<%= provider_interface_notifications_url %>

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user_name || 'colleague' %>
 
 # Application rejected by default

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user_name || 'colleague' %>
 
 # Application submitted

--- a/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
+++ b/app/views/provider_mailer/application_submitted_with_safeguarding_issues.text.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user_name || 'colleague' %>
 
 # Application submitted with safeguarding issues disclosed

--- a/app/views/provider_mailer/application_withdrawn.text.erb
+++ b/app/views/provider_mailer/application_withdrawn.text.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user.full_name || 'colleague' %>
 
 # Application withdrawn

--- a/app/views/provider_mailer/declined.text.erb
+++ b/app/views/provider_mailer/declined.text.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user.full_name || 'colleague' %>
 
 # Offer declined

--- a/app/views/provider_mailer/declined_by_default.text.erb
+++ b/app/views/provider_mailer/declined_by_default.text.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user.full_name || 'colleague' %>
 
 # Offer declined by default

--- a/app/views/provider_mailer/offer_accepted.text.erb
+++ b/app/views/provider_mailer/offer_accepted.text.erb
@@ -1,3 +1,4 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
 Dear <%= @provider_user.full_name || 'colleague' %>
 
 # Offer accepted


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a common _Unsubscribe_ footer section with link to notification management page on all status change emails.
 
<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/93511/103765195-ad2e6900-5014-11eb-9b70-7e5d1b9fffb7.png)


## Guidance to review

I've moved the unsubscribe section and link to the end of the emails as per the updates from @johndoates and @adamsilver 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5yBfI809/3174-add-unsubscribe-content-to-emails-that-use-the-notifications-check
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
