### PR TITLE
Fix formatting of RecruitmentCycle.cycle_name

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -29,6 +29,6 @@ module RecruitmentCycle
   end
 
   def self.cycle_name(year = current_year)
-    "#{year} to #{year + 1}"
+    "#{year - 1} to #{year}"
   end
 end

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe RecruitmentCycle do
   describe '.cycle_name' do
     it 'defaults to current year to the following year' do
       Timecop.travel(Time.zone.local(2020, 1, 1, 1, 0, 0)) do
-        expect(RecruitmentCycle.cycle_name).to eq('2020 to 2021')
+        expect(RecruitmentCycle.cycle_name).to eq('2019 to 2020')
       end
     end
 
     it 'is the argument year to the following year' do
-      expect(RecruitmentCycle.cycle_name(2019)).to eq('2019 to 2020')
+      expect(RecruitmentCycle.cycle_name(2021)).to eq('2020 to 2021')
     end
   end
 end


### PR DESCRIPTION
## Context

Fixes a wrong assumption in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3714

The year we pass to this method should be the end year of the cycle as this is how it's stored on Course records and surfaced via `ApplicationChoice.recruitment_cycle`

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Treat the argument we pass to `RecruitmentCycle.cycle_name` as the end year of the cycle eg _2020 to **2021**_

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

View an application from previous cycle, navigate to offer tab and defer. The confirmation screen should show the next cycle from the one on the application (not the next cycle from our current one). This is the only place in the codebase we use this method.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/98QAgAQX/2962-defer-offer-confirmation-screen-shows-incorrect-cycle-name
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
