### PR TITLE
Fix link errors to only point to one radio button

### DIFF
--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -15,16 +15,16 @@
 
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
 
-        <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" } %>
 
         <% if @alternative_study_mode %>
-          <%= f.govuk_radio_button :decision, 'edit_study_mode', label: { text: "#{offer_text} but change to #{@alternative_study_mode.humanize.downcase}" }, link_errors: true %>
+          <%= f.govuk_radio_button :decision, 'edit_study_mode', label: { text: "#{offer_text} but change to #{@alternative_study_mode.humanize.downcase}" } %>
         <% end %>
 
-        <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" }, link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" } %>
 
         <% if current_provider_user.providers.size > 1 %>
-          <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" }, link_errors: true %>
+          <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" } %>
         <% end %>
 
         <%= f.govuk_radio_button :decision, 'new_reject', label: { text: reject_text } %>


### PR DESCRIPTION
## Context
Provider Application response form from DAC review
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Remove the incorrect usages of link_errors so that the form error link goes to the first radio button in the list
<!-- If there are UI changes, please include Before and After screenshots. -->


## Link to Trello card
https://trello.com/c/ubEzhRRk/3169-respond-to-application-missing-labels-dac-review
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
