### PR TITLE
Add sorting to validation error summary page

### DIFF
--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -14,7 +14,9 @@ module SupportInterface
     end
 
     def summary
-      @validation_error_summary = ::ValidationErrorSummaryQuery.new.call
+      sort_param = params.permit(:sortby)[:sortby]
+
+      @validation_error_summary = ::ValidationErrorSummaryQuery.new(sort_param).call
     end
 
     class ValidationErrorSearch

--- a/app/frontend/styles/support/_all.scss
+++ b/app/frontend/styles/support/_all.scss
@@ -10,3 +10,4 @@
 @import "_button";
 @import "_checkboxes-scroll";
 @import "_details";
+@import "_sort";

--- a/app/frontend/styles/support/_sort.scss
+++ b/app/frontend/styles/support/_sort.scss
@@ -1,0 +1,61 @@
+.validation-results-header {
+  padding-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: desktop) {
+    padding-top: govuk-spacing(2);
+  }
+
+  &__cta {
+    margin: govuk-spacing(1) 0;
+    display: none;
+
+    .js-enabled & {
+      display: block;
+    }
+  }
+
+  .govuk-form {
+    @include mq($from: desktop) {
+      text-align: right;
+    }
+  }
+
+  .govuk-form-group {
+    clear: both;
+    display: inline-block;
+    margin-bottom: 0;
+    margin-top: govuk-spacing(2);
+
+    @include mq($from: desktop) {
+      margin: 0;
+    }
+  }
+
+  .govuk-button {
+    float: right;
+    margin: govuk-spacing(2) 0 0 0;
+
+    @include mq($from: desktop) {
+      margin: 0 0 0 govuk-spacing(2);
+    }
+
+    .js-enabled & {
+      display: none;
+    }
+  }
+
+  select {
+    width: 100%;
+
+    @include mq($from: desktop) {
+      width: 220px;
+    }
+  }
+
+  .sortedby-label {
+    @include mq($from: desktop) {
+      display: inline;
+      margin-right: 0.5em;
+    }
+  }
+}

--- a/app/helpers/select_options_helper.rb
+++ b/app/helpers/select_options_helper.rb
@@ -23,6 +23,15 @@ module SelectOptionsHelper
     ] + providers.map { |provider| OpenStruct.new(id: provider.id, name: "#{provider.name} (#{provider.code})") }
   end
 
+  def select_sort_options
+    sort_options = [
+      [ValidationErrorSummaryQuery::ALL_TIME, 'All time'],
+      [ValidationErrorSummaryQuery::LAST_WEEK, 'Last week'],
+      [ValidationErrorSummaryQuery::LAST_MONTH, 'Last month'],
+    ]
+    sort_options.map { |sort_option| OpenStruct.new(value: sort_option.first, text: sort_option.last) }
+  end
+
 private
 
   def nationality_options(include_british_and_irish:)

--- a/app/views/support_interface/validation_errors/summary.html.erb
+++ b/app/views/support_interface/validation_errors/summary.html.erb
@@ -16,6 +16,37 @@
   ]) %>
 <% end %>
 
+<div class="validation-results-header">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= form_with(url: support_interface_validation_error_summary_path, method: "get", class: "govuk-form") do |f| %>
+        <div class="govuk-form-group">
+          <%= f.govuk_collection_select(
+                :sortby,
+                select_sort_options,
+                :value,
+                :text,
+                label: {
+                  text: "Sorted by",
+                  class: "govuk-label govuk-label--inline sortedby-label"
+                },
+                options: {
+                  selected: params["sortby"] || 'all_time',
+                },
+                html_options: {
+                  class: 'sortedby-label',
+                  selected: 2,
+                  onchange: "this.form.submit()",
+                  role: "listbox",
+                }
+              )%>
+        </div>
+        <%= f.submit("Update", name: nil, class: "govuk-button")%>
+      <% end %>
+    </div>
+  </div>
+</div>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/spec/queries/validation_error_summary_query_spec.rb
+++ b/spec/queries/validation_error_summary_query_spec.rb
@@ -26,4 +26,104 @@ RSpec.describe ValidationErrorSummaryQuery do
       ])
     end
   end
+
+  describe 'sorting' do
+    it "returns results sorted by 'All time'" do
+      create :validation_error, form_object: 'Foo', created_at: 2.days.ago
+      create :validation_error, form_object: 'Bar', created_at: 6.days.ago
+      create :validation_error, form_object: 'Baz', created_at: 50.days.ago
+      create :validation_error, form_object: 'Baz', created_at: 60.days.ago
+
+      expect(described_class.new(described_class::ALL_TIME).call).to eq([
+        {
+          'form_object' => 'Baz',
+          'attribute' => 'feedback',
+          'incidents_last_week' => 0,
+          'unique_users_last_week' => 0,
+          'incidents_last_month' => 0,
+          'unique_users_last_month' => 0,
+          'incidents_all_time' => 2,
+          'unique_users_all_time' => 2,
+        },
+        {
+          'form_object' => 'Bar',
+          'attribute' => 'feedback',
+          'incidents_last_week' => 1,
+          'unique_users_last_week' => 1,
+          'incidents_last_month' => 1,
+          'unique_users_last_month' => 1,
+          'incidents_all_time' => 1,
+          'unique_users_all_time' => 1,
+        },
+        {
+          'form_object' => 'Foo',
+          'attribute' => 'feedback',
+          'incidents_last_week' => 1,
+          'unique_users_last_week' => 1,
+          'incidents_last_month' => 1,
+          'unique_users_last_month' => 1,
+          'incidents_all_time' => 1,
+          'unique_users_all_time' => 1,
+        },
+      ])
+    end
+
+    it "returns results sorted by 'Last week'" do
+      create :validation_error, form_object: 'Foo', created_at: 2.days.ago
+      create :validation_error, form_object: 'Bar', created_at: 6.days.ago
+      create :validation_error, form_object: 'Foo', created_at: 10.days.ago
+
+      expect(described_class.new(described_class::LAST_WEEK).call).to eq([
+        {
+          'form_object' => 'Bar',
+          'attribute' => 'feedback',
+          'incidents_last_week' => 1,
+          'unique_users_last_week' => 1,
+          'incidents_last_month' => 1,
+          'unique_users_last_month' => 1,
+          'incidents_all_time' => 1,
+          'unique_users_all_time' => 1,
+        },
+        {
+          'form_object' => 'Foo',
+          'attribute' => 'feedback',
+          'incidents_last_week' => 1,
+          'unique_users_last_week' => 1,
+          'incidents_last_month' => 2,
+          'unique_users_last_month' => 2,
+          'incidents_all_time' => 2,
+          'unique_users_all_time' => 2,
+        },
+      ])
+    end
+
+    it "returns resulted sorted by 'Last month'" do
+      create :validation_error, form_object: 'Foo', created_at: 2.days.ago
+      create :validation_error, form_object: 'Bar', created_at: 6.days.ago
+      create :validation_error, form_object: 'Foo', created_at: 10.days.ago
+
+      expect(described_class.new(described_class::LAST_MONTH).call).to eq([
+        {
+          'form_object' => 'Foo',
+          'attribute' => 'feedback',
+          'incidents_last_week' => 1,
+          'unique_users_last_week' => 1,
+          'incidents_last_month' => 2,
+          'unique_users_last_month' => 2,
+          'incidents_all_time' => 2,
+          'unique_users_all_time' => 2,
+        },
+        {
+          'form_object' => 'Bar',
+          'attribute' => 'feedback',
+          'incidents_last_week' => 1,
+          'unique_users_last_week' => 1,
+          'incidents_last_month' => 1,
+          'unique_users_last_month' => 1,
+          'incidents_all_time' => 1,
+          'unique_users_all_time' => 1,
+        },
+      ])
+    end
+  end
 end


### PR DESCRIPTION
## Context

```
As a... an analyst
I need to... order validation errors
So that... I can see what the most common errors in past month/week are
```

## Changes proposed in this pull request

- Add a sorting dropdown to the page
- Update SQL query on back end to change sorting as required by the front end

## Guidance to review

- Pagination will be separate ticket
- The sorting is unit tested. Do we need to feature test this as well or is that overkill?
- Might need some design input on this - I [borrowed from Find](https://www.find-postgraduate-teacher-training.service.gov.uk/results?l=2&subjects%5B%5D=31&sortby=0) as inspiration.

![sorting](https://user-images.githubusercontent.com/5256922/103295686-66c18480-49ec-11eb-9d4d-e504810bcf20.gif)

## Link to Trello card

https://trello.com/c/0U8yaXyp/2725-add-ordering-pagination-to-validation-error-summary

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
