### PR TITLE
Change columns of the qualifications table

### DIFF
--- a/app/components/qualification_row_component.html.erb
+++ b/app/components/qualification_row_component.html.erb
@@ -1,10 +1,11 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell"><%= render QualificationTitleComponent.new(qualification: qualification) %></td>
-  <td class="govuk-table__cell"><%= render QualificationSubjectComponent.new(qualification: qualification) %></td>
+  <td class="govuk-table__cell">
+    <b><%= render QualificationSubjectComponent.new(qualification: qualification) %></b>
+    <%= render QualificationTitleComponent.new(qualification: qualification) %>
+  </td>
   <% if qualification.missing_qualification? %>
     <td colspan="2" class="govuk-table__cell"><%= qualification.missing_explanation %></td>
   <% else %>
-    <td class="govuk-table__cell"><%= qualification.start_year %></td>
     <td class="govuk-table__cell"><%= qualification.award_year %></td>
     <td class="govuk-table__cell"><%= render QualificationGradeComponent.new(qualification: qualification) %></td>
   <% end %>

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -41,13 +41,11 @@ private
   end
 
   def type_for_other_uk_qualification
-    I18n.t('application_form.gcse.qualification_types.other_uk')
-      .concat(': ', @qualification.other_uk_qualification_type)
+    @qualification.other_uk_qualification_type
   end
 
   def type_for_non_uk_qualification
-    I18n.t('application_form.gcse.qualification_types.non_uk')
-      .concat(': ', @qualification.non_uk_qualification_type)
+    @qualification.non_uk_qualification_type
   end
 
   def type_for_gcse

--- a/app/components/qualifications_table_component.html.erb
+++ b/app/components/qualifications_table_component.html.erb
@@ -5,8 +5,6 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-table__header">Qualification</th>
-          <th class="govuk-table__header govuk-table__header">Subject</th>
-          <th class="govuk-table__header govuk-table__header">Started</th>
           <th class="govuk-table__header govuk-table__header">Awarded</th>
           <th class="govuk-table__header govuk-table__header">Grade</th>
         </tr>

--- a/spec/components/qualification_row_component_spec.rb
+++ b/spec/components/qualification_row_component_spec.rb
@@ -14,9 +14,8 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('BSc')
-    expect(result.text).to include('Psychology')
-    expect(result.text).to include('2015')
+    expect(result.text.gsub(/\s+/, ' ')).to include('Psychology BSc')
+    expect(result.text).not_to include('2015')
     expect(result.text).to include('2018')
     expect(result.text).to include('Upper second')
   end
@@ -35,8 +34,7 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('MEng')
-    expect(result.text).to include('Engineering')
+    expect(result.text.gsub(/\s+/, ' ')).to include('Engineering MEng')
     expect(result.text).to include('2020')
     expect(result.text).to include('First (predicted)')
   end
@@ -54,8 +52,7 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('BSc')
-    expect(result.text).to include('Chemistry')
+    expect(result.text.gsub(/\s+/, ' ')).to include('Chemistry BSc')
     expect(result.text).to include('2001')
     expect(result.text).to include('I did my best')
   end
@@ -73,8 +70,7 @@ RSpec.describe QualificationRowComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('GCSE')
-    expect(result.text).to include('Maths')
+    expect(result.text.gsub(/\s+/, ' ')).to include('Maths GCSE')
     expect(result.text).to include('I am taking the exam this summer')
   end
 end

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('Other UK qualification: A Level')
+    expect(result.text.strip).to eq('A Level')
   end
 
   it 'renders the correct title for an non_uk GCSE equivalent' do
@@ -80,7 +80,7 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('Non-UK qualification: High School Diploma')
+    expect(result.text.strip).to eq('High School Diploma')
   end
 
   it 'renders the correct title for an other qualificaiton' do
@@ -93,7 +93,7 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('A Level')
+    expect(result.text.strip).to eq('A Level')
   end
 
   it 'renders the correct title for an other_uk other qualification' do
@@ -107,7 +107,7 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('Other UK qualification: Orienteering')
+    expect(result.text.strip).to eq('Orienteering')
   end
 
   it 'renders the correct title for an non_uk other qualification' do
@@ -121,6 +121,6 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('Non-UK qualification: High School Diploma')
+    expect(result.text.strip).to eq('High School Diploma')
   end
 end

--- a/spec/components/qualifications_table_component_spec.rb
+++ b/spec/components/qualifications_table_component_spec.rb
@@ -9,10 +9,19 @@ RSpec.describe QualificationsTableComponent do
 
   it 'renders a qualifications table' do
     qualifications = [
-      build_stubbed(:application_qualification),
+      build_stubbed(
+        :application_qualification,
+        level: 'degree',
+        qualification_type: 'BSc',
+        subject: 'Rocket Surgery',
+        grade: 'Third',
+        award_year: '2020',
+      ),
     ]
     result = render_inline(described_class.new(qualifications: qualifications, header: 'My header'))
 
     expect(result.css('table').first['data-qa']).to eq 'qualifications-table-my-header'
+    expect(result.css('table thead tr')[0].text.gsub(/\s+/, ' ')).to include('Qualification Awarded Grade')
+    expect(result.css('table tbody tr')[0].text.gsub(/\s+/, ' ')).to include('Rocket Surgery BSc 2020 Third')
   end
 end


### PR DESCRIPTION
## Context

This PR tidies up the other qualifications table used in the support and provider interfaces.

## Changes proposed in this pull request

- [x] Merge qualification/subject columns.
- [x] Remove the start year column.
- [x] Remove the _Other UK Qualification: _ and _Non-UK Qualification_ prefixes in the _Qualification_ column.

Before:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/450843/103322307-9183fb00-4a35-11eb-9873-8dd17bfedcf6.png">

After:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/450843/103322261-626d8980-4a35-11eb-8980-0a3d34ff710a.png">

## Guidance to review

- Does this work in both the support and provider interfaces?
- Does it work for all qualification types?

## Link to Trello card

https://trello.com/c/ev3Hvs0a/2650-update-other-qualifications-table

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
