### PR TITLE
Allow support users to sign in as provider users

### DIFF
--- a/app/controllers/provider_interface/feedback_controller.rb
+++ b/app/controllers/provider_interface/feedback_controller.rb
@@ -22,6 +22,7 @@ module ProviderInterface
 
     def create
       SaveAndSendRejectByDefaultFeedback.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
         rejection_reason: feedback_params[:rejection_reason],
       ).call!

--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -11,7 +11,7 @@ module ProviderInterface
     end
 
     def create_data_sharing_agreement
-      if current_provider_user.impersonator && HostingEnvironment.production?
+      if current_provider_user.impersonator
         flash[:warning] = 'Cannot be signed by a support user'
         redirect_to(provider_interface_new_data_sharing_agreement_path) and return
       end

--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -11,6 +11,11 @@ module ProviderInterface
     end
 
     def create_data_sharing_agreement
+      if current_provider_user.impersonator && HostingEnvironment.production?
+        flash[:warning] = 'Cannot be signed by a support user'
+        redirect_to(provider_interface_new_data_sharing_agreement_path) and return
+      end
+
       @provider_agreement = ProviderAgreement.new(provider_agreement_params.merge(provider_user: current_provider_user))
 
       render :data_sharing_agreement and return unless @provider_agreement.save

--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -11,7 +11,7 @@ module ProviderInterface
     end
 
     def create_data_sharing_agreement
-      if current_provider_user.impersonator
+      if current_provider_user.impersonator && HostingEnvironment.production?
         flash[:warning] = 'Cannot be signed by a support user'
         redirect_to(provider_interface_new_data_sharing_agreement_path) and return
       end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -60,6 +60,12 @@ module ProviderInterface
         provider_user_admin_url: support_interface_provider_user_url(current_provider_user),
       }
 
+      if (impersonator = current_provider_user.impersonator)
+        useful_debugging_info[:dfe_sign_in_uid] = impersonator.dfe_sign_in_uid
+        useful_debugging_info[:support_user_email] = impersonator.email_address
+        useful_debugging_info[:support_user_admin_url] = support_interface_support_user_url(impersonator)
+      end
+
       RequestLocals.store[:identity] = useful_debugging_info
       Raven.user_context(useful_debugging_info)
     end

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -81,13 +81,18 @@ module SupportInterface
     def impersonate
       @provider_user = ProviderUser.find(params[:provider_user_id])
       dfe_sign_in_user.begin_impersonate! session, @provider_user
-      flash[:success] = 'Provider user impersonated'
-      redirect_to support_interface_provider_user_path(@provider_user)
+      flash[:success] = "Impersonating #{@provider_user.email_address}"
+      redirect_to provider_interface_applications_path
     end
 
     def end_impersonate
-      dfe_sign_in_user.end_impersonate! session
-      redirect_to support_interface_provider_users_path
+      if (impersonated_user = current_support_user.impersonated_provider_user)
+        dfe_sign_in_user.end_impersonate! session
+        redirect_to support_interface_provider_user_path(impersonated_user)
+      else
+        flash[:success] = "No active provider user impersonation to stop"
+        redirect_to support_interface_provider_users_path
+      end
     end
 
   private

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -80,8 +80,14 @@ module SupportInterface
 
     def impersonate
       @provider_user = ProviderUser.find(params[:provider_user_id])
+      dfe_sign_in_user.begin_impersonate! session, @provider_user
       flash[:success] = 'Provider user impersonated'
       redirect_to support_interface_provider_user_path(@provider_user)
+    end
+
+    def end_impersonate
+      dfe_sign_in_user.end_impersonate! session
+      redirect_to support_interface_provider_users_path
     end
 
   private

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -78,6 +78,12 @@ module SupportInterface
       redirect_to support_interface_provider_user_path(provider_user)
     end
 
+    def impersonate
+      @provider_user = ProviderUser.find(params[:provider_user_id])
+      flash[:success] = 'Provider user impersonated'
+      redirect_to support_interface_provider_user_path(@provider_user)
+    end
+
   private
 
     def scope_by_use_of_service

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -80,14 +80,13 @@ module SupportInterface
 
     def impersonate
       @provider_user = ProviderUser.find(params[:provider_user_id])
-      dfe_sign_in_user.begin_impersonate! session, @provider_user
-      flash[:success] = "Impersonating #{@provider_user.email_address}"
-      redirect_to provider_interface_applications_path
+      dfe_sign_in_user.begin_impersonation! session, @provider_user
+      redirect_to support_interface_provider_user_path(@provider_user)
     end
 
-    def end_impersonate
+    def end_impersonation
       if (impersonated_user = current_support_user.impersonated_provider_user)
-        dfe_sign_in_user.end_impersonate! session
+        dfe_sign_in_user.end_impersonation! session
         redirect_to support_interface_provider_user_path(impersonated_user)
       else
         flash[:success] = 'No active provider user impersonation to stop'

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -90,7 +90,7 @@ module SupportInterface
         dfe_sign_in_user.end_impersonate! session
         redirect_to support_interface_provider_user_path(impersonated_user)
       else
-        flash[:success] = "No active provider user impersonation to stop"
+        flash[:success] = 'No active provider user impersonation to stop'
         redirect_to support_interface_provider_users_path
       end
     end

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -32,9 +32,9 @@ class NavigationItems
 
     def for_support_account_nav(current_support_user)
       if current_support_user && current_support_user.impersonated_provider_user
-        impersonated_email = current_support_user.impersonated_provider_user.email_address
+        impersonated_user = current_support_user.impersonated_provider_user
         [
-          NavigationItem.new("🤿 #{impersonated_email} 🤿", provider_interface_applications_path, false),
+          NavigationItem.new("#{impersonated_user.email_address} 🤿", support_interface_provider_user_path(impersonated_user), false),
           NavigationItem.new('Stop', support_interface_end_impersonate_path, false),
         ]
       elsif current_support_user

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -31,9 +31,9 @@ class NavigationItems
     end
 
     def for_support_account_nav(current_support_user)
-      if (impersonated_user = current_support_user&.impersonated_provider_user)
+      if current_support_user && (impersonated_user = current_support_user.impersonated_provider_user)
         [
-          NavigationItem.new("🎭 #{current_support_user.email_address}", support_interface_provider_user_path(impersonated_user), false),
+          NavigationItem.new("<span aria-hidden=\"true\">🎭</span><span class=\"govuk-visually-hidden\">Provider user impersonation: active -- Current support user:</span> #{current_support_user.email_address}".html_safe, support_interface_provider_user_path(impersonated_user), false),
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),
         ]
       elsif current_support_user

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -33,7 +33,8 @@ class NavigationItems
     def for_support_account_nav(current_support_user)
       if current_support_user && (impersonated_user = current_support_user.impersonated_provider_user)
         [
-          NavigationItem.new("<span aria-hidden=\"true\">🎭</span><span class=\"govuk-visually-hidden\">Provider user impersonation: active -- Current support user:</span> #{current_support_user.email_address}".html_safe, support_interface_provider_user_path(impersonated_user), false),
+          NavigationItem.new("<span aria-hidden=\"true\">🎭 ⚙️</span><span class=\"govuk-visually-hidden\">Currently impersonating: #{impersonated_user.email_address}</span>".html_safe, support_interface_provider_user_path(impersonated_user), false),
+          NavigationItem.new(current_support_user.email_address, nil, false),
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),
         ]
       elsif current_support_user

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -31,7 +31,13 @@ class NavigationItems
     end
 
     def for_support_account_nav(current_support_user)
-      if current_support_user
+      if current_support_user && current_support_user.impersonated_provider_user
+        impersonated_email = current_support_user.impersonated_provider_user.email_address
+        [
+          NavigationItem.new("🤿 #{impersonated_email} 🤿", provider_interface_applications_path, false),
+          NavigationItem.new('Stop', support_interface_end_impersonate_path, false),
+        ]
+      elsif current_support_user
         [
           NavigationItem.new(current_support_user.email_address, nil, false),
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -31,13 +31,7 @@ class NavigationItems
     end
 
     def for_support_account_nav(current_support_user)
-      if current_support_user && current_support_user.impersonated_provider_user
-        impersonated_user = current_support_user.impersonated_provider_user
-        [
-          NavigationItem.new("#{impersonated_user.email_address} 🤿", support_interface_provider_user_path(impersonated_user), false),
-          NavigationItem.new('Stop', support_interface_end_impersonate_path, false),
-        ]
-      elsif current_support_user
+      if current_support_user
         [
           NavigationItem.new(current_support_user.email_address, nil, false),
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),
@@ -76,7 +70,11 @@ class NavigationItems
         items << NavigationItem.new(t('page_titles.provider.account'), provider_interface_account_path, is_active(current_controller, %w[account profile provider_users organisations provider_relationship_permissions]))
       end
 
-      items << NavigationItem.new('Sign out', provider_interface_sign_out_path, false)
+      if current_provider_user.impersonator
+        items << NavigationItem.new('Return to support', support_interface_provider_user_path(current_provider_user), false)
+      else
+        items << NavigationItem.new('Sign out', provider_interface_sign_out_path, false)
+      end
     end
 
     def for_api_docs(current_controller)

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -31,7 +31,12 @@ class NavigationItems
     end
 
     def for_support_account_nav(current_support_user)
-      if current_support_user
+      if (impersonated_user = current_support_user&.impersonated_provider_user)
+        [
+          NavigationItem.new("🎭 #{current_support_user.email_address}", support_interface_provider_user_path(impersonated_user), false),
+          NavigationItem.new('Sign out', support_interface_sign_out_path, false),
+        ]
+      elsif current_support_user
         [
           NavigationItem.new(current_support_user.email_address, nil, false),
           NavigationItem.new('Sign out', support_interface_sign_out_path, false),

--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -1,8 +1,10 @@
 module AuditHelper
   def audit(actor)
-    impersonator = actor.try(:impersonator)
-
-    Audited.audit_class.as_user(impersonator || actor) do
+    if ::Audited.store[:audited_user].blank?
+      Audited.audit_class.as_user(actor.try(:impersonator) || actor) do
+        yield
+      end
+    else # preserve previously set Audited.audited_class.as_user
       yield
     end
   end

--- a/app/lib/audit_helper.rb
+++ b/app/lib/audit_helper.rb
@@ -1,0 +1,9 @@
+module AuditHelper
+  def audit(actor)
+    impersonator = actor.try(:impersonator)
+
+    Audited.audit_class.as_user(impersonator || actor) do
+      yield
+    end
+  end
+end

--- a/app/lib/impersonation_audit_helper.rb
+++ b/app/lib/impersonation_audit_helper.rb
@@ -1,4 +1,4 @@
-module AuditHelper
+module ImpersonationAuditHelper
   def audit(actor)
     if ::Audited.store[:audited_user].blank?
       Audited.audit_class.as_user(actor.try(:impersonator) || actor) do

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -340,10 +340,10 @@ class TestApplications
       fast_forward
       ConfirmOfferConditions.new(actor: actor, application_choice: choice).save
       choice.update_columns(recruited_at: time, updated_at: time)
+      # service generates two audit writes, one for status, one for timestamp
+      choice.audits.second_to_last&.update_columns(created_at: time)
+      choice.audits.last&.update_columns(created_at: time)
     end
-    # service generates two audit writes, one for status, one for timestamp
-    choice.audits.second_to_last&.update_columns(created_at: time)
-    choice.audits.last&.update_columns(created_at: time)
   end
 
   def maybe_add_note(choice)

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,16 +1,17 @@
 class DfESignInUser
-  attr_reader :email_address, :dfe_sign_in_uid
+  attr_reader :email_address, :dfe_sign_in_uid, :impersonated_provider_user
   attr_accessor :first_name, :last_name
 
   # we need to be able to redirect back to our sign-out callback path
   include Rails.application.routes.url_helpers
 
-  def initialize(email_address:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil)
+  def initialize(email_address:, dfe_sign_in_uid:, first_name:, last_name:, id_token: nil, impersonated_provider_user: nil)
     @email_address = email_address&.downcase
     @dfe_sign_in_uid = dfe_sign_in_uid
     @first_name = first_name
     @last_name = last_name
     @id_token = id_token
+    @impersonated_provider_user = impersonated_provider_user
   end
 
   def provider_interface_dsi_logout_url
@@ -54,12 +55,31 @@ class DfESignInUser
       first_name: dfe_sign_in_session['first_name'],
       last_name: dfe_sign_in_session['last_name'],
       id_token: dfe_sign_in_session['id_token'],
+      impersonated_provider_user: impersonated_provider_user_from(session),
     )
+  end
+
+  def begin_impersonate!(session, provider_user)
+    session['impersonated_provider_user'] = {
+      'provider_user_id' => provider_user.id,
+      'impersonated_at' => Time.zone.now,
+    }
+  end
+
+  def end_impersonate!(session)
+    session.delete('impersonated_provider_user')
   end
 
   def self.end_session!(session)
     session.delete('post_dfe_sign_in_path')
     session.delete('dfe_sign_in_user')
+    session.delete('impersonated_provider_user')
+  end
+
+  def self.impersonated_provider_user_from(session)
+    if session['impersonated_provider_user']
+      ProviderUser.find session['impersonated_provider_user']['provider_user_id']
+    end
   end
 
 private

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -59,14 +59,11 @@ class DfESignInUser
     )
   end
 
-  def begin_impersonate!(session, provider_user)
-    session['impersonated_provider_user'] = {
-      'provider_user_id' => provider_user.id,
-      'impersonated_at' => Time.zone.now,
-    }
+  def begin_impersonation!(session, provider_user)
+    session['impersonated_provider_user'] = { 'provider_user_id' => provider_user.id }
   end
 
-  def end_impersonate!(session)
+  def end_impersonation!(session)
     session.delete('impersonated_provider_user')
   end
 

--- a/app/models/provider_impersonation.rb
+++ b/app/models/provider_impersonation.rb
@@ -1,0 +1,19 @@
+class ProviderImpersonation
+  attr_reader :support_user, :provider_user
+
+  def initialize(support_user:, provider_user:)
+    @support_user = support_user
+    @provider_user = provider_user
+  end
+
+  def self.load_from_session(session)
+    dfe_sign_in_user = DfESignInUser.load_from_session(session)
+    return unless dfe_sign_in_user
+
+    support_user = SupportUser.load_from_session(session)
+    if (impersonated_user = support_user&.impersonated_provider_user)
+      impersonated_user.impersonator = support_user
+      new(support_user: support_user, provider_user: impersonated_user)
+    end
+  end
+end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -25,11 +25,8 @@ class ProviderUser < ActiveRecord::Base
     dfe_sign_in_user = DfESignInUser.load_from_session(session)
     return unless dfe_sign_in_user
 
-    support_user = SupportUser.load_from_session(session)
-    if (impersonated_user = support_user&.impersonated_provider_user)
-      impersonated_user.impersonator = support_user
-      return impersonated_user
-    end
+    impersonation = ProviderImpersonation.load_from_session(session)
+    return impersonation.provider_user if impersonation
 
     provider_user = ProviderUser.find_by dfe_sign_in_uid: dfe_sign_in_user.dfe_sign_in_uid
     provider_user || onboard!(dfe_sign_in_user)

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -1,5 +1,6 @@
 class ChangeOffer
   include ActiveModel::Validations
+  include AuditHelper
 
   attr_reader :application_choice, :course_option
 
@@ -22,22 +23,24 @@ class ChangeOffer
 
   def save
     @auth.assert_can_make_decisions! application_choice: @application_choice, course_option_id: @course_option.id
-    if valid?
-      now = Time.zone.now
-      attributes = {
-        offered_course_option: @course_option,
-        offer_changed_at: now,
-      }
-      attributes[:offer] = { 'conditions' => @offer_conditions } if @offer_conditions
-      @application_choice.update! attributes
+    audit(@auth.actor) do
+      if valid?
+        now = Time.zone.now
+        attributes = {
+          offered_course_option: @course_option,
+          offer_changed_at: now,
+        }
+        attributes[:offer] = { 'conditions' => @offer_conditions } if @offer_conditions
+        @application_choice.update! attributes
 
-      SetDeclineByDefault.new(application_form: @application_choice.application_form).call
-      CandidateMailer.changed_offer(@application_choice).deliver_later
-      StateChangeNotifier.call(:change_an_offer, application_choice: @application_choice)
+        SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+        CandidateMailer.changed_offer(@application_choice).deliver_later
+        StateChangeNotifier.call(:change_an_offer, application_choice: @application_choice)
 
-      true
-    else
-      false
+        true
+      else
+        false
+      end
     end
   end
 

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -1,6 +1,6 @@
 class ChangeOffer
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   attr_reader :application_choice, :course_option
 

--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -1,6 +1,6 @@
 class ConditionsNotMet
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor: actor)

--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -1,5 +1,6 @@
 class ConditionsNotMet
   include ActiveModel::Validations
+  include AuditHelper
 
   def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor: actor)
@@ -9,9 +10,11 @@ class ConditionsNotMet
   def save
     @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
-    ApplicationStateChange.new(@application_choice).conditions_not_met!
-    @application_choice.update!(conditions_not_met_at: Time.zone.now)
-    CandidateMailer.conditions_not_met(@application_choice).deliver_later
+    audit(@auth.actor) do
+      ApplicationStateChange.new(@application_choice).conditions_not_met!
+      @application_choice.update!(conditions_not_met_at: Time.zone.now)
+      CandidateMailer.conditions_not_met(@application_choice).deliver_later
+    end
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -1,6 +1,6 @@
 class ConfirmOfferConditions
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor: actor)

--- a/app/services/defer_offer.rb
+++ b/app/services/defer_offer.rb
@@ -1,6 +1,6 @@
 class DeferOffer
   include ActiveModel::Model
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor: actor)

--- a/app/services/defer_offer.rb
+++ b/app/services/defer_offer.rb
@@ -1,5 +1,6 @@
 class DeferOffer
   include ActiveModel::Model
+  include AuditHelper
 
   def initialize(actor:, application_choice:)
     @auth = ProviderAuthorisation.new(actor: actor)
@@ -9,17 +10,19 @@ class DeferOffer
   def save!
     @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
-    prior_status = @application_choice.status
+    audit(@auth.actor) do
+      prior_status = @application_choice.status
 
-    ActiveRecord::Base.transaction do
-      ApplicationStateChange.new(@application_choice).defer_offer!
-      @application_choice.update!(
-        status_before_deferral: prior_status,
-        offer_deferred_at: Time.zone.now,
-      )
+      ActiveRecord::Base.transaction do
+        ApplicationStateChange.new(@application_choice).defer_offer!
+        @application_choice.update!(
+          status_before_deferral: prior_status,
+          offer_deferred_at: Time.zone.now,
+        )
+      end
+
+      CandidateMailer.deferred_offer(@application_choice).deliver_later
+      StateChangeNotifier.call(:defer_offer, application_choice: @application_choice)
     end
-
-    CandidateMailer.deferred_offer(@application_choice).deliver_later
-    StateChangeNotifier.call(:defer_offer, application_choice: @application_choice)
   end
 end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -5,7 +5,7 @@ class MakeAnOffer
   attr_accessor :course_option
 
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   MAX_CONDITIONS_COUNT = 20
   MAX_CONDITION_LENGTH = 255

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -5,6 +5,7 @@ class MakeAnOffer
   attr_accessor :course_option
 
   include ActiveModel::Validations
+  include AuditHelper
 
   MAX_CONDITIONS_COUNT = 20
   MAX_CONDITION_LENGTH = 255
@@ -36,23 +37,25 @@ class MakeAnOffer
 
     @auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: @course_option.id)
 
-    if ApplicationStateChange.new(application_choice).can_make_offer?
-      ActiveRecord::Base.transaction do
-        application_choice.status = 'offer'
-        application_choice.offered_course_option = course_option
-        application_choice.offer = { 'conditions' => offer_conditions }
-        application_choice.offered_at = Time.zone.now
-        application_choice.save!
-        SetDeclineByDefault.new(application_form: application_choice.application_form).call
-      end
+    audit(@auth.actor) do
+      if ApplicationStateChange.new(application_choice).can_make_offer?
+        ActiveRecord::Base.transaction do
+          application_choice.status = 'offer'
+          application_choice.offered_course_option = course_option
+          application_choice.offer = { 'conditions' => offer_conditions }
+          application_choice.offered_at = Time.zone.now
+          application_choice.save!
+          SetDeclineByDefault.new(application_form: application_choice.application_form).call
+        end
 
-      SendNewOfferEmailToCandidate.new(application_choice: @application_choice).call
-    else
-      errors.add(
-        :base,
-        I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
-      )
-      false
+        SendNewOfferEmailToCandidate.new(application_choice: @application_choice).call
+      else
+        errors.add(
+          :base,
+          I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+        )
+        false
+      end
     end
   end
 

--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class SaveProviderUserService
+    include AuditHelper
+
     attr_accessor :wizard
 
     def initialize(actor:, wizard:)
@@ -8,11 +10,13 @@ module ProviderInterface
     end
 
     def call!
-      assert_permissions_for_providers!
-      if email_exists?
-        update_user
-      else
-        create_user
+      audit(@actor) do
+        assert_permissions_for_providers!
+        if email_exists?
+          update_user
+        else
+          create_user
+        end
       end
     end
 

--- a/app/services/provider_interface/save_provider_user_service.rb
+++ b/app/services/provider_interface/save_provider_user_service.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class SaveProviderUserService
-    include AuditHelper
+    include ImpersonationAuditHelper
 
     attr_accessor :wizard
 

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -1,6 +1,6 @@
 class ReinstateConditionsMet
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   attr_reader :application_choice, :course_option
 

--- a/app/services/reinstate_conditions_met.rb
+++ b/app/services/reinstate_conditions_met.rb
@@ -1,5 +1,6 @@
 class ReinstateConditionsMet
   include ActiveModel::Validations
+  include AuditHelper
 
   attr_reader :application_choice, :course_option
 
@@ -16,14 +17,16 @@ class ReinstateConditionsMet
   def save
     @auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: @course_option.id)
 
-    if valid?
-      attrs = { offered_course_option_id: @course_option.id }
-      attrs[:recruited_at] = Time.zone.now unless application_choice.status_before_deferral == 'recruited' # conditions are 'still met'
+    audit(@auth.actor) do
+      if valid?
+        attrs = { offered_course_option_id: @course_option.id }
+        attrs[:recruited_at] = Time.zone.now unless application_choice.status_before_deferral == 'recruited' # conditions are 'still met'
 
-      ActiveRecord::Base.transaction do
-        ApplicationStateChange.new(application_choice).reinstate_conditions_met!
-        application_choice.update(attrs)
-        CandidateMailer.reinstated_offer(application_choice).deliver_later
+        ActiveRecord::Base.transaction do
+          ApplicationStateChange.new(application_choice).reinstate_conditions_met!
+          application_choice.update(attrs)
+          CandidateMailer.reinstated_offer(application_choice).deliver_later
+        end
       end
     end
   rescue Workflow::NoTransitionAllowed

--- a/app/services/reinstate_pending_conditions.rb
+++ b/app/services/reinstate_pending_conditions.rb
@@ -1,6 +1,6 @@
 class ReinstatePendingConditions
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   attr_reader :application_choice, :course_option
 
@@ -16,7 +16,6 @@ class ReinstatePendingConditions
 
   def save
     @auth.assert_can_make_decisions!(application_choice: application_choice, course_option_id: course_option.id)
-
 
     audit(@auth.actor) do
       if valid?

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -1,5 +1,6 @@
 class RejectApplication
   include ActiveModel::Validations
+  include AuditHelper
 
   attr_accessor :rejection_reason, :structured_rejection_reasons
 
@@ -19,20 +20,22 @@ class RejectApplication
 
     @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
-    ActiveRecord::Base.transaction do
-      ApplicationStateChange.new(@application_choice).reject!
-      @application_choice.update!(
-        rejection_reason: @rejection_reason,
-        structured_rejection_reasons: @structured_rejection_reasons,
-        rejected_at: Time.zone.now,
-      )
-      SetDeclineByDefault.new(application_form: @application_choice.application_form).call
-    end
+    audit(@auth.actor) do
+      ActiveRecord::Base.transaction do
+        ApplicationStateChange.new(@application_choice).reject!
+        @application_choice.update!(
+          rejection_reason: @rejection_reason,
+          structured_rejection_reasons: @structured_rejection_reasons,
+          rejected_at: Time.zone.now,
+        )
+        SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+      end
 
-    SendCandidateRejectionEmail.new(application_choice: @application_choice).call
+      SendCandidateRejectionEmail.new(application_choice: @application_choice).call
 
-    if @application_choice.application_form.ended_without_success?
-      StateChangeNotifier.new(:rejected, @application_choice).application_outcome_notification
+      if @application_choice.application_form.ended_without_success?
+        StateChangeNotifier.new(:rejected, @application_choice).application_outcome_notification
+      end
     end
   rescue Workflow::NoTransitionAllowed
     errors.add(

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -1,6 +1,6 @@
 class RejectApplication
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   attr_accessor :rejection_reason, :structured_rejection_reasons
 

--- a/app/services/remove_provider_user.rb
+++ b/app/services/remove_provider_user.rb
@@ -1,5 +1,5 @@
 class RemoveProviderUser
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   attr_reader :current_provider_user, :user_to_remove
 

--- a/app/services/remove_provider_user.rb
+++ b/app/services/remove_provider_user.rb
@@ -1,4 +1,6 @@
 class RemoveProviderUser
+  include AuditHelper
+
   attr_reader :current_provider_user, :user_to_remove
 
   def initialize(current_provider_user:, user_to_remove:)
@@ -9,13 +11,15 @@ class RemoveProviderUser
   # Removes associations to providers common to the managing user
   # and the user we're editing/removing.
   def call!
-    managed_providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for
+    audit(current_provider_user) do
+      managed_providers = current_provider_user.authorisation.providers_that_actor_can_manage_users_for
 
-    user_to_remove.provider_permissions.includes(:provider).each do |provider_permission|
-      next unless provider_permission.provider.in?(managed_providers)
+      user_to_remove.provider_permissions.includes(:provider).each do |provider_permission|
+        next unless provider_permission.provider.in?(managed_providers)
 
-      provider_permission.audit_comment = 'User was deleted'
-      provider_permission.destroy!
+        provider_permission.audit_comment = 'User was deleted'
+        provider_permission.destroy!
+      end
     end
   end
 end

--- a/app/services/save_and_send_reject_by_default_feedback.rb
+++ b/app/services/save_and_send_reject_by_default_feedback.rb
@@ -1,5 +1,5 @@
 class SaveAndSendRejectByDefaultFeedback
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   attr_reader :application_choice, :rejection_reason
 

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -1,6 +1,6 @@
 class WithdrawOffer
   include ActiveModel::Validations
-  include AuditHelper
+  include ImpersonationAuditHelper
 
   attr_accessor :offer_withdrawal_reason
 
@@ -27,12 +27,8 @@ class WithdrawOffer
         )
         SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       end
-      StateChangeNotifier.call(:withdraw_offer, application_choice: @application_choice)
+      true
     end
-<<<<<<< HEAD
-    true
-=======
->>>>>>> 90d424c52... Record impersonator details for provider user actions in audits
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -1,5 +1,6 @@
 class WithdrawOffer
   include ActiveModel::Validations
+  include AuditHelper
 
   attr_accessor :offer_withdrawal_reason
 
@@ -17,15 +18,21 @@ class WithdrawOffer
 
     @auth.assert_can_make_decisions!(application_choice: @application_choice, course_option_id: @application_choice.offered_option.id)
 
-    ActiveRecord::Base.transaction do
-      ApplicationStateChange.new(@application_choice).reject!
-      @application_choice.update!(
-        offer_withdrawal_reason: @offer_withdrawal_reason,
-        offer_withdrawn_at: Time.zone.now,
-      )
-      SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+    audit(@auth.actor) do
+      ActiveRecord::Base.transaction do
+        ApplicationStateChange.new(@application_choice).reject!
+        @application_choice.update!(
+          offer_withdrawal_reason: @offer_withdrawal_reason,
+          offer_withdrawn_at: Time.zone.now,
+        )
+        SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+      end
+      StateChangeNotifier.call(:withdraw_offer, application_choice: @application_choice)
     end
+<<<<<<< HEAD
     true
+=======
+>>>>>>> 90d424c52... Record impersonator details for provider user actions in audits
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
@@ -1,1 +1,11 @@
-<%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), disabled: current_support_user.impersonated_provider_user == provider_user, class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+<% if current_support_user.impersonated_provider_user == provider_user %>
+  <p class="govuk-body">
+    You are now signed-in as this user.
+    <%= govuk_link_to 'Visit Manage', provider_interface_applications_path, class: 'govuk-link--no-visited-state' %>
+    to see what they see. Any changes made will be linked to you.
+  </p>
+
+  <%= link_to 'Stop impersonating this user', support_interface_end_impersonation_path, class: 'govuk-button govuk-button--secondary' %>
+<% else %>
+  <%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+<% end %>

--- a/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
@@ -1,3 +1,3 @@
 <% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+  <%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), disabled: current_support_user.impersonated_provider_user == provider_user, class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
 <% end %>

--- a/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
@@ -1,3 +1,1 @@
-<% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), disabled: current_support_user.impersonated_provider_user == provider_user, class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
-<% end %>
+<%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), disabled: current_support_user.impersonated_provider_user == provider_user, class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>

--- a/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
@@ -1,0 +1,3 @@
+<% unless HostingEnvironment.production? %>
+  <%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+<% end %>

--- a/app/views/support_interface/provider_users/audits.html.erb
+++ b/app/views/support_interface/provider_users/audits.html.erb
@@ -1,4 +1,7 @@
 <% content_for :browser_title, "History - #{provider_user_name(@provider_user)}" %>
+
+<%= render 'provider_user_impersonation', provider_user: @provider_user %>
+
 <%= render 'provider_user_navigation', title: 'History', provider_user: @provider_user %>
 
 <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider_user) %>

--- a/app/views/support_interface/provider_users/show.html.erb
+++ b/app/views/support_interface/provider_users/show.html.erb
@@ -1,5 +1,7 @@
 <% content_for :browser_title, "Provider user #{provider_user_name(@provider_user)}" %>
 
+<%= render 'provider_user_impersonation', provider_user: @provider_user %>
+
 <%= render 'provider_user_navigation', title: 'Details', provider_user: @provider_user %>
 
 <%= render SummaryListComponent.new(rows: [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -862,6 +862,7 @@ Rails.application.routes.draw do
       resources :provider_users, only: %i[show index new create edit update], path: :provider do
         get '/audits' => 'provider_users#audits'
         patch '/toggle-notifications' => 'provider_users#toggle_notifications', as: :toggle_notifications
+        post '/impersonate' => 'provider_users#impersonate', as: :impersonate
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -852,6 +852,8 @@ Rails.application.routes.draw do
     scope '/users' do
       get '/' => 'users#index', as: :users
 
+      get '/provider/end_impersonate' => 'provider_users#end_impersonate', as: :end_impersonate
+
       get '/delete/:id' => 'support_users#confirm_destroy', as: :confirm_destroy_support_user
       delete '/delete/:id' => 'support_users#destroy', as: :destroy_support_user
       get '/restore/:id' => 'support_users#confirm_restore', as: :confirm_restore_support_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -859,7 +859,7 @@ Rails.application.routes.draw do
 
       resources :support_users, only: %i[index new create show], path: :support
 
-      get '/provider/end_impersonation' => 'provider_users#end_impersonate', as: :end_impersonate
+      get '/provider/end-impersonation' => 'provider_users#end_impersonation', as: :end_impersonation
 
       resources :provider_users, only: %i[show index new create edit update], path: :provider do
         get '/audits' => 'provider_users#audits'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -852,14 +852,14 @@ Rails.application.routes.draw do
     scope '/users' do
       get '/' => 'users#index', as: :users
 
-      get '/provider/end_impersonate' => 'provider_users#end_impersonate', as: :end_impersonate
-
       get '/delete/:id' => 'support_users#confirm_destroy', as: :confirm_destroy_support_user
       delete '/delete/:id' => 'support_users#destroy', as: :destroy_support_user
       get '/restore/:id' => 'support_users#confirm_restore', as: :confirm_restore_support_user
       delete '/restore/:id' => 'support_users#restore', as: :restore_support_user
 
       resources :support_users, only: %i[index new create show], path: :support
+
+      get '/provider/end_impersonation' => 'provider_users#end_impersonate', as: :end_impersonate
 
       resources :provider_users, only: %i[show index new create edit update], path: :provider do
         get '/audits' => 'provider_users#audits'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -842,6 +842,22 @@ FactoryBot.define do
     hashed_token { '1234567890' }
   end
 
+  factory :dfe_sign_in_user do
+    dfe_sign_in_uid { SecureRandom.uuid }
+    email_address { "#{Faker::Name.first_name.downcase}@example.com" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+
+    initialize_with do
+      new(
+        dfe_sign_in_uid: dfe_sign_in_uid,
+        email_address: email_address,
+        first_name: first_name,
+        last_name: last_name,
+      )
+    end
+  end
+
   factory :support_user do
     dfe_sign_in_uid { SecureRandom.uuid }
     email_address { "#{Faker::Name.first_name.downcase}@example.com" }

--- a/spec/lib/audit_helper_spec.rb
+++ b/spec/lib/audit_helper_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe AuditHelper do
+  let(:service) do
+    Class.new do
+      include AuditHelper
+    end
+  end
+
+  let(:provider_user) { create(:provider_user) }
+  let(:support_user) { create(:support_user) }
+
+  before { allow(Audited.audit_class).to receive(:as_user) }
+
+  describe '#audit' do
+    it 'sets :audited_user if not already set' do
+      audited_store = {}
+      allow(Audited).to receive(:store).and_return audited_store
+
+      service.new.audit(provider_user) { 1 }
+
+      expect(Audited.audit_class).to have_received(:as_user).with(provider_user)
+    end
+
+    it 'does not set :audited_user if previously set' do
+      audited_store = { audited_user: create(:provider_user) }
+      allow(Audited).to receive(:store).and_return audited_store
+
+      service.new.audit(provider_user) { 1 }
+
+      expect(Audited.audit_class).not_to have_received(:as_user)
+    end
+
+    it 'uses support user if provider user is impersonated' do
+      audited_store = {}
+      allow(Audited).to receive(:store).and_return audited_store
+      provider_user.impersonator = support_user
+
+      service.new.audit(provider_user) { 1 }
+
+      expect(Audited.audit_class).to have_received(:as_user).with(support_user)
+    end
+  end
+end

--- a/spec/lib/impersonation_audit_helper_spec.rb
+++ b/spec/lib/impersonation_audit_helper_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe AuditHelper do
+RSpec.describe ImpersonationAuditHelper do
   let(:service) do
     Class.new do
-      include AuditHelper
+      include ImpersonationAuditHelper
     end
   end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe TestApplications do
     application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2020, states: %i[recruited], courses_to_apply_to: courses_we_want).first
     provider_user = application_choice.provider.provider_users.first
 
-    offer_audit = application_choice.reload.audits.where("audited_changes @> '{\"status\": [\"recruited\"]}'").first
-    expect(offer_audit).not_to be_nil
-    expect(offer_audit.user).to eq provider_user
+    recruited_audit = application_choice.reload.audits.where("audited_changes @> '{\"status\": [\"recruited\"]}'").first
+    expect(recruited_audit).not_to be_nil
+    expect(recruited_audit.user).to eq provider_user
   end
 
   it 'generates an application for the specified candidate' do

--- a/spec/models/df_e_sign_in_user_spec.rb
+++ b/spec/models/df_e_sign_in_user_spec.rb
@@ -33,5 +33,51 @@ RSpec.describe DfESignInUser, type: :model do
 
       expect(user).to be_nil
     end
+
+    it 'may return a DfE User with an associated impersonated_provider_user' do
+      provider_user = create(:provider_user)
+
+      session = {
+        'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now },
+        'impersonated_provider_user' => { 'provider_user_id' => provider_user.id },
+      }
+      user = DfESignInUser.load_from_session(session)
+      expect(user.impersonated_provider_user).to eq(provider_user)
+
+      session = { 'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now } }
+      user = DfESignInUser.load_from_session(session)
+      expect(user.impersonated_provider_user).to be_nil
+    end
+  end
+
+  describe '#begin_impersonate!' do
+    let(:provider_user) { create(:provider_user) }
+    let(:dsi_user) do
+      DfESignInUser.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
+    end
+
+    it 'adds an impersonated_provider_user section to the session' do
+      session = {}
+      dsi_user.begin_impersonate! session, provider_user
+      expect(session).to have_key('impersonated_provider_user')
+    end
+
+    it 'stores the impersonated provider user id' do
+      session = {}
+      dsi_user.begin_impersonate! session, provider_user
+      expect(session['impersonated_provider_user']['provider_user_id']).to eq(provider_user.id)
+    end
+  end
+
+  describe '#end_impersonate!' do
+    let(:dsi_user) do
+      DfESignInUser.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
+    end
+
+    it 'deletes the impersonated_provider_user section' do
+      session = { 'impersonated_provider_user' => {} }
+      dsi_user.end_impersonate! session
+      expect(session).not_to have_key('impersonated_provider_user')
+    end
   end
 end

--- a/spec/models/df_e_sign_in_user_spec.rb
+++ b/spec/models/df_e_sign_in_user_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DfESignInUser, type: :model do
     end
   end
 
-  describe '#begin_impersonate!' do
+  describe '#begin_impersonation!' do
     let(:provider_user) { create(:provider_user) }
     let(:dsi_user) do
       DfESignInUser.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
@@ -58,25 +58,25 @@ RSpec.describe DfESignInUser, type: :model do
 
     it 'adds an impersonated_provider_user section to the session' do
       session = {}
-      dsi_user.begin_impersonate! session, provider_user
+      dsi_user.begin_impersonation! session, provider_user
       expect(session).to have_key('impersonated_provider_user')
     end
 
     it 'stores the impersonated provider user id' do
       session = {}
-      dsi_user.begin_impersonate! session, provider_user
+      dsi_user.begin_impersonation! session, provider_user
       expect(session['impersonated_provider_user']['provider_user_id']).to eq(provider_user.id)
     end
   end
 
-  describe '#end_impersonate!' do
+  describe '#end_impersonation!' do
     let(:dsi_user) do
       DfESignInUser.new(email_address: nil, dfe_sign_in_uid: nil, first_name: nil, last_name: nil)
     end
 
     it 'deletes the impersonated_provider_user section' do
       session = { 'impersonated_provider_user' => {} }
-      dsi_user.end_impersonate! session
+      dsi_user.end_impersonation! session
       expect(session).not_to have_key('impersonated_provider_user')
     end
   end

--- a/spec/models/support_user_spec.rb
+++ b/spec/models/support_user_spec.rb
@@ -16,4 +16,32 @@ RSpec.describe SupportUser, type: :model do
       expect(support_user.audits.count).to eq 2
     end
   end
+
+  describe '#load_from_session' do
+    let(:dsi_user) { build(:dfe_sign_in_user) }
+
+    it 'obtains impersonated_provider_user information from DfESignInUser' do
+      provider_user = create(:provider_user)
+      allow(dsi_user).to receive(:impersonated_provider_user).and_return(provider_user)
+      allow(DfESignInUser).to receive(:load_from_session).and_return(dsi_user)
+
+      create(
+        :support_user,
+        dfe_sign_in_uid: dsi_user.dfe_sign_in_uid,
+        email_address: dsi_user.email_address,
+        first_name: dsi_user.first_name,
+        last_name: dsi_user.last_name,
+      )
+
+      support_user = SupportUser.load_from_session({})
+      expect(support_user.dfe_sign_in_uid).to eq(dsi_user.dfe_sign_in_uid)
+      expect(support_user.impersonated_provider_user).to eq(provider_user)
+    end
+
+    it 'returns nil if there is no associated SupportUser' do
+      allow(DfESignInUser).to receive(:load_from_session).and_return(dsi_user)
+      support_user = SupportUser.load_from_session({})
+      expect(support_user).to be_nil
+    end
+  end
 end

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RejectApplication do
   describe '#save' do
     let(:provider_user) { create(:provider_user) }
     let(:application_choice) { create(:submitted_application_choice) }
-    let(:auth) { instance_double(ProviderAuthorisation, assert_can_make_decisions!: true) }
+    let(:auth) { instance_double(ProviderAuthorisation, assert_can_make_decisions!: true, actor: provider_user) }
 
     subject(:service) { described_class.new(actor: provider_user, application_choice: application_choice, rejection_reason: 'wrong') }
 

--- a/spec/services/save_and_send_reject_by_default_feedback_spec.rb
+++ b/spec/services/save_and_send_reject_by_default_feedback_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.describe SaveAndSendRejectByDefaultFeedback, sidekiq: true do
   let(:application_choice) { create(:application_choice, :with_rejection_by_default) }
   let(:rejection_reason) { 'The course became full' }
+  let(:actor) { create(:provider_user) }
 
   def service
     SaveAndSendRejectByDefaultFeedback.new(
+      actor: actor,
       application_choice: application_choice,
       rejection_reason: rejection_reason,
     )

--- a/spec/system/support_interface/sign_in_as_provider_user_spec.rb
+++ b/spec/system/support_interface/sign_in_as_provider_user_spec.rb
@@ -48,8 +48,11 @@ RSpec.feature 'Sign in as provider user' do
 
   def when_i_try_to_sign_the_data_sharing_agreement
     provider_name = @provider_user.providers.first.name
-    check "#{provider_name} agrees to comply with the data sharing practices outlined in this agreement"
-    click_on 'Continue'
+
+    ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+      check "#{provider_name} agrees to comply with the data sharing practices outlined in this agreement"
+      click_on 'Continue'
+    end
   end
 
   def then_i_am_told_i_am_a_support_user

--- a/spec/system/support_interface/sign_in_as_provider_user_spec.rb
+++ b/spec/system/support_interface/sign_in_as_provider_user_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.feature 'Sign in as provider user' do
+  include DfESignInHelpers
+
+  scenario 'Support user signs in as a provider user' do
+    given_i_am_a_support_user
+    and_i_am_looking_at_provider_user_details
+    when_i_click_the_sign_in_button
+    then_i_am_logged_in_as_the_provider_user
+    and_i_can_tell_this_is_an_impersonation_from_the_sign_out_link
+
+    when_i_try_to_sign_the_data_sharing_agreement
+    then_i_am_told_i_am_a_support_user
+
+    when_i_click_on_return_to_support
+    and_i_click_on_stop_impersonating_this_user
+    and_i_visit_the_provider_interface
+    then_i_am_asked_to_sign_in
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_i_am_looking_at_provider_user_details
+    @provider_user = create(:provider_user, :with_provider)
+    visit support_interface_provider_user_path(@provider_user)
+  end
+
+  def when_i_visit_the_application_form_page
+    visit support_interface_application_form_path(@application)
+  end
+
+  def when_i_click_the_sign_in_button
+    click_on 'Sign in as this provider user'
+  end
+
+  def then_i_am_logged_in_as_the_provider_user
+    click_on 'Visit Manage'
+    expect(page).to have_content 'Data sharing agreement'
+  end
+
+  def and_i_can_tell_this_is_an_impersonation_from_the_sign_out_link
+    expect(page).not_to have_content('Sign out')
+    expect(page).to have_content('Return to support')
+  end
+
+  def when_i_try_to_sign_the_data_sharing_agreement
+    provider_name = @provider_user.providers.first.name
+    check "#{provider_name} agrees to comply with the data sharing practices outlined in this agreement"
+    click_on 'Continue'
+  end
+
+  def then_i_am_told_i_am_a_support_user
+    expect(page).to have_content 'Cannot be signed by a support user'
+  end
+
+  def when_i_click_on_return_to_support
+    click_on 'Return to support'
+  end
+
+  def and_i_click_on_stop_impersonating_this_user
+    click_on 'Stop impersonating this user'
+  end
+
+  def and_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def then_i_am_asked_to_sign_in
+    expect(page).to have_content 'You must sign in to your account to manage teacher training applications.'
+  end
+end


### PR DESCRIPTION
### Context

We already support signing in as the candidate from the support console, which enables support agents to investigate issues from the perspective of a candidate. We would like to do the same for provider users, as part of general support and troubleshooting.

For security & auditability, when this feature is used, the support user must be logged as extra variable in Sentry & Logit.

### Changes proposed in this pull request

Add 'Sign in as this user' button to `SupportInterface::ProviderUsersController#show` and `#audits`. 

Add impersonation methods to `DfeSignInUser`, adding the relevant `provider_user_id` to the session object for the current support user.

Change support_interface header to highlight an active provider user impersonation and provide a link to stop it.

Make `ProviderUser#load_from_session` and `SupportUser#load_from_session` impersonation-aware. Add impersonation information to logs and Sentry errors for all `ProviderInterface` actions.

Ensure any actions taken by support users impersonating provider users are attributed to the support users in the audit log. This means the timeline and the activity log will also show these as performed by 'System' (timeline) or the relevant support user (activity log).

Preserve top-level `Audited.audited_class.as_user` value if set in new `AuditHelper.audit`.

Fix `VendorApiUser` details (e.g. email_address) updating bug in `VendorAPI::DecisionsController`.

New variables logged (logstash + sentry):

```
Real provider user with id 6:

"provider_user_admin_url":"http://localhost:3000/support/users/provider/6"
"dfe_sign_in_uid":"dev-1JB-admin-2"

Impersonated provider user with id 6:

"provider_user_admin_url":"http://localhost:3000/support/users/provider/6"
"dfe_sign_in_uid":"dev-support"
"support_user_email":"support@example.com"
"support_user_admin_url":"http://localhost:3000/support/users/support/1
```

Screenshots:

![image](https://user-images.githubusercontent.com/107591/103344880-cc168380-4a87-11eb-9f4a-b7ca6ad0635d.png)

---

![image](https://user-images.githubusercontent.com/107591/103344890-d2a4fb00-4a87-11eb-8ad7-9ac714b719e3.png)

---

![image](https://user-images.githubusercontent.com/107591/103344894-d6388200-4a87-11eb-8b85-d7b7eaf6c8de.png)

### Guidance to review

Impersonating a provider user is different to impersonating a candidate, because candidate interface and support interface use different authentication techniques, which allows a single user to maintain two different authenticated sessions at once. Provider interface uses the same authentication method as  support interface, namely DfE Sign-In, so it's not possible to just create two sessions in parallel. Instead, this PR requires a current support user and annotates their session with impersonation details. `ProviderUser` has been changed to respect these impersonation instructions, if present, returning the desired `current_provider_user` with extra `.impersonator` information.

Because this is all based on the `SupportUser` session, the same session timeouts apply and impersonating a provider user does not modify their `last_signed_in_at`. `current_provider_user` returns the desired provider user, so the provider interface behaves in exactly the same way it would for the real user, which is a good thing for end-to-end testing and troubleshooting. This includes authorisation calls.

However, I've modified all services that correspond to provider user actions with an `audit` block to ensure any changes made to applications in production are attributed to the support user, not the impersonated provider user, for audit trail purposes (both in support and provider interface, e.g. timeline/activity log). Have I missed any services?

The code preserving the original audited `.as_user` setting for these services is required for two reasons: a. test data generation (which passes a support user to bypass authorisation but sets the audited user to a provider user) and b. rails console use for support reasons sets its own `.as_user` information.

Finally, I've restricted data sharing agreements on production to disallow signing by impersonated users.

### Link to Trello card

[2902 - Implement "Sign in as provider user" in prod support](https://trello.com/c/pHP2dGVp)

### Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
