### PR TITLE
Support interface cleanup

### DIFF
--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -5,7 +5,10 @@ import initApiTokenProviderAutocomplete from "./autocompletes/api-token-autocomp
 import "../styles/application-support.scss";
 import filter from "./components/paginated_filter";
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
+import initCountryAutocomplete from "./autocompletes/country-autocomplete";
+
 
 govUKFrontendInitAll();
 initApiTokenProviderAutocomplete();
 filter();
+initCountryAutocomplete();

--- a/app/frontend/packs/autocompletes/country-autocomplete.js
+++ b/app/frontend/packs/autocompletes/country-autocomplete.js
@@ -11,6 +11,8 @@ const initCountryAutocomplete = () => {
       "#candidate-interface-gcse-institution-country-form-institution-country-field-error",
       "#candidate-interface-other-qualification-details-form-institution-country-field",
       "#candidate-interface-other-qualification-form-institution-country-field-error",
+      "#support-interface-application-forms-edit-address-details-form-country-field",
+      "#support-interface-application-forms-edit-address-details-form-country-field-error",
     ];
 
     inputIds.forEach(id => {

--- a/app/views/support_interface/application_forms/address_type/edit.html.erb
+++ b/app/views/support_interface/application_forms/address_type/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :browser_title, title_with_error_prefix('Edit address details', @details_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(application_form_id: params[:application_form_id]), 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,6 +271,12 @@ en:
               below_lower_age_limit: Enter a date of birth before %{date} – candidate must be over 16 years old to Apply for teacher training
             audit_comment:
               blank: You must provide an audit comment
+        support_interface/application_forms/nationalities_form:
+          attributes:
+            nationalities:
+              blank: What is the candidates nationality?
+            audit_comment:
+              blank: You must provide an audit comment
         support_interface/application_forms/edit_reference_details_form:
           attributes:
             name:


### PR DESCRIPTION
## Context

There were a few small issues with the support UI work. This PR covers the cleanup work for the int address and nationalities cards.

## Changes proposed in this pull request

1. Add autocomplete to the country dropdown on the type selection page
2. Fix backlink on the same page
3. Fix blank error messaging on the nationalities page

## Link to Trello card

https://trello.com/c/vYKaG1or/2685-expand-the-personal-details-review-section-in-the-support-ui-nationality-right-to-work

https://trello.com/c/jJsZshMb/2751-add-multi-line-international-addresses-to-support-ui

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
