### PR TITLE
Retain the correct input nationalities if validation error occurs

### DIFF
--- a/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
+++ b/app/controllers/candidate_interface/personal_details/nationalities_controller.rb
@@ -51,7 +51,6 @@ module CandidateInterface
 
       def prepare_nationalities_params
         nationalities_params
-          .tap { |np| np.delete(:nationalities) }
           .merge(nationalities_hash)
       end
 

--- a/app/controllers/support_interface/application_forms/nationalities_controller.rb
+++ b/app/controllers/support_interface/application_forms/nationalities_controller.rb
@@ -29,7 +29,6 @@ module SupportInterface
 
       def prepare_nationalities_params
         nationalities_params
-          .tap { |np| np.delete(:nationalities) }
           .merge(nationalities_hash)
       end
 


### PR DESCRIPTION
## Context

At the moment the nationalities pages on the support and candidate facing of the application are not behaving correctly. 

Steps to reproduce bug:
1. Go to the update nationalities section
2. select British and irish
3. provide another nationality, then uncheck the other nationality checkbox
4. submit
5. You lose all the input values

## Changes proposed in this pull request

- Reconstruct the nationalities array and merge it into the form object if validations occur

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
