### PR TITLE
Create csv data export to assess performance of notifications feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,9 @@ gem 'geocoder'
 
 gem 'strip_attributes'
 
+# Capturing metric data
+gem 'public_activity'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,11 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     psych (3.2.0)
+    public_activity (1.6.4)
+      actionpack (>= 3.0.0)
+      activerecord (>= 3.0)
+      i18n (>= 0.5.0)
+      railties (>= 3.0.0)
     public_suffix (4.0.6)
     puma (5.1.1)
       nio4r (~> 2.0)
@@ -575,6 +580,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-rails
+  public_activity
   puma (~> 5.1)
   rails (~> 6.0)
   rails-erd

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -61,6 +61,8 @@ module ProviderInterface
       )
 
       if @application_offer.save
+        notification_status = current_provider_user.send_notifications ? 'on' : 'off'
+        Metrics::Tracker.new(@application_choice, "notifications.#{notification_status}", current_provider_user).track(:decision)
         flash[:success] = 'Offer successfully made to candidate'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,
@@ -93,6 +95,8 @@ module ProviderInterface
         rejection_reason: params.dig(:reject_application, :rejection_reason),
       )
       if @reject_application.save
+        notification_status = current_provider_user.send_notifications ? 'on' : 'off'
+        Metrics::Tracker.new(@application_choice, "notifications.#{notification_status}", current_provider_user).track(:decision)
         flash[:success] = 'Application successfully rejected'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,

--- a/app/controllers/provider_interface/notes_controller.rb
+++ b/app/controllers/provider_interface/notes_controller.rb
@@ -23,6 +23,8 @@ module ProviderInterface
       @new_note_form = ProviderInterface::NewNoteForm.new(note_params)
 
       if @new_note_form.save
+        notification_status = current_provider_user.send_notifications ? 'on' : 'off'
+        Metrics::Tracker.new(@application_choice, "notifications.#{notification_status}", current_provider_user).track(:note_added)
         flash[:success] = 'Note successfully added'
         redirect_to provider_interface_application_choice_notes_path(@application_choice)
       else

--- a/app/controllers/provider_interface/notifications_controller.rb
+++ b/app/controllers/provider_interface/notifications_controller.rb
@@ -4,6 +4,7 @@ module ProviderInterface
       current_provider_user.update!(
         send_notifications: notification_params[:send_notifications],
       )
+      track_notification_status_change
 
       flash[:success] = 'Email notification settings saved'
       redirect_to provider_interface_notifications_path
@@ -13,6 +14,11 @@ module ProviderInterface
 
     def notification_params
       params.require(:provider_user).permit(:send_notifications)
+    end
+
+    def track_notification_status_change
+      notification_status = current_provider_user.send_notifications ? 'on' : 'off'
+      Metrics::Tracker.new(current_provider_user, "notifications.update.#{notification_status}", current_provider_user).track(:status_update)
     end
   end
 end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -95,6 +95,11 @@ class DataExport < ApplicationRecord
       description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
       class: SupportInterface::SitesExport,
     },
+    notifications_export: {
+      name: 'Notifications',
+      description: 'Data to enable performance assesment of Notification feature',
+      class: SupportInterface::NotificationsExport,
+    },
   }.freeze
 
   belongs_to :initiator, polymorphic: true, optional: true

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -26,6 +26,7 @@ class AcceptOffer
 
     NotificationsList.for(@application_choice).each do |provider_user|
       ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
+      Metrics::Tracker.new(@application_choice, 'notifications.on', provider_user).track(:offer_accepted)
     end
 
     CandidateMailer.offer_accepted(@application_choice).deliver_later

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -29,6 +29,10 @@ class AcceptOffer
       Metrics::Tracker.new(@application_choice, 'notifications.on', provider_user).track(:offer_accepted)
     end
 
+    NotificationsList.off_for(@application_choice).each do |provider_user|
+      Metrics::Tracker.new(@application_choice, 'notifications.off', provider_user).track(:offer_accepted)
+    end
+
     CandidateMailer.offer_accepted(@application_choice).deliver_later
 
     StateChangeNotifier.accept_offer(accepted: @application_choice, declined: declined, withdrawn: withdrawn)

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -14,6 +14,7 @@ class DeclineOffer
 
     NotificationsList.for(@application_choice).each do |provider_user|
       ProviderMailer.declined(provider_user, @application_choice).deliver_later
+      Metrics::Tracker.new(@application_choice, 'notifications.on', provider_user).track(:offer_declined)
     end
   end
 end

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -16,5 +16,9 @@ class DeclineOffer
       ProviderMailer.declined(provider_user, @application_choice).deliver_later
       Metrics::Tracker.new(@application_choice, 'notifications.on', provider_user).track(:offer_declined)
     end
+
+    NotificationsList.off_for(@application_choice).each do |provider_user|
+      Metrics::Tracker.new(@application_choice, 'notifications.off', provider_user).track(:offer_declined)
+    end
   end
 end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -19,6 +19,7 @@ class DeclineOfferByDefault
     application_choices.each do |application_choice|
       NotificationsList.for(application_choice).each do |provider_user|
         ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
+        Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:offer_declined_by_default)
       end
     end
 

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -21,6 +21,10 @@ class DeclineOfferByDefault
         ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
         Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:offer_declined_by_default)
       end
+
+      NotificationsList.off_for(application_choice).each do |provider_user|
+        Metrics::Tracker.new(application_choice, 'notifications.off', provider_user).track(:offer_declined_by_default)
+      end
     end
 
     CandidateMailer.declined_by_default(application_form).deliver_later

--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -45,4 +45,16 @@ module Metrics
       PublicActivity::Activity.where(activity_params)
     end
   end
+
+  class IntervalToSeconds
+    attr_reader :interval
+
+    def initialize(interval)
+      @interval = interval
+    end
+
+    def call
+      interval.split(':').map(&:to_i).inject(0) { |a, b| a * 60 + b }
+    end
+  end
 end

--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -1,0 +1,39 @@
+module Metrics
+  class Tracker
+    attr_reader :model, :key, :user
+
+    def initialize(model, key, user)
+      @model = model
+      @key = key
+      @user = user
+    end
+
+    def track(event)
+      create(event: event)
+    end
+
+  private
+
+    def create(changes)
+      PublicActivity::Activity.create(trackable: model,
+                                      key: key,
+                                      owner: user,
+                                      parameters: changes)
+    end
+  end
+
+  class Data
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def for(key = nil, event = nil)
+      activity_params = { owner: user }
+      activity_params.merge!(key: key) if key.present?
+      activity_params.merge!(parameters: { event: event }) if event.present?
+      PublicActivity::Activity.where(activity_params)
+    end
+  end
+end

--- a/app/services/notifications_list.rb
+++ b/app/services/notifications_list.rb
@@ -2,4 +2,8 @@ class NotificationsList
   def self.for(application_choice)
     application_choice.provider.provider_users.where(send_notifications: true)
   end
+
+  def self.off_for(application_choice)
+    application_choice.provider.provider_users.where(send_notifications: false)
+  end
 end

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -11,8 +11,10 @@ class SendNewApplicationEmailToProvider
     NotificationsList.for(application_choice).each do |provider_user|
       if application_choice.application_form.has_safeguarding_issues_to_declare?
         ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later
+        Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:application_submitted_with_safeguarding_issues)
       else
         ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
+        Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:application_submitted)
       end
     end
   end

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -10,6 +10,7 @@ class SendRejectByDefaultEmailToProvider
 
     NotificationsList.for(application_choice).each do |provider_user|
       ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_later
+      Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:application_rejected_by_default)
     end
   end
 end

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -12,5 +12,8 @@ class SendRejectByDefaultEmailToProvider
       ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_later
       Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:application_rejected_by_default)
     end
+    NotificationsList.off_for(application_choice).each do |provider_user|
+      Metrics::Tracker.new(application_choice, 'notifications.off', provider_user).track(:application_rejected_by_default)
+    end
   end
 end

--- a/app/services/support_interface/notifications_export.rb
+++ b/app/services/support_interface/notifications_export.rb
@@ -1,0 +1,56 @@
+module SupportInterface
+  class NotificationsExport
+    def data_for_export
+      active_provider_users = ProviderUser.includes(:providers)
+      active_provider_users.flat_map { |provider_user| data_for_user(provider_user) }
+    end
+
+  private
+
+    def data_for_user(provider_user)
+      {
+        text_for(:email_address) => provider_user.email_address,
+        text_for(:notification_setting) => provider_user.send_notifications? ? 'Yes' : 'No',
+        text_for(:notifications_for_setting, status: 'On') => metrics_data_for(provider_user, key: 'notifications.on'),
+        text_for(:notifications_for_setting, status: 'Off') => metrics_data_for(provider_user, key: 'notifications.off'),
+        text_for(:number_of_changes) => metrics_data_for(provider_user, event: :status_update),
+        text_for(:notifications_received) => [metrics_data_for(provider_user, key: 'notifications.off'), metrics_data_for(provider_user, key: 'notifications.on')].inject(:+),
+        notifications_received_for(:application_submitted) => metrics_data_for(provider_user, event: :application_submitted),
+        notifications_received_for(:application_submitted_with_safeguarding_issues) => metrics_data_for(provider_user, event: :application_submitted_with_safeguarding_issues),
+        notifications_received_for(:application_submitted_with_no_response) => metrics_data_for(provider_user, event: :application_with_no_response),
+        notifications_received_for(:application_rejected_by_default) => metrics_data_for(provider_user, event: :application_rejected_by_default),
+        notifications_received_for(:application_withdrawn) => metrics_data_for(provider_user, event: :application_withdrawn),
+        notifications_received_for(:offer_accepted) => metrics_data_for(provider_user, event: :offer_accepted),
+        notifications_received_for(:offer_declined) => metrics_data_for(provider_user, event: :offer_declined),
+        notifications_received_for(:offer_declined_by_default) => metrics_data_for(provider_user, event: :offer_declined_by_default),
+        notifications_received_for(:note_added) => metrics_data_for(provider_user, event: :note_added),
+        text_for(:decision_count, status: 'On') => metrics_data_for(provider_user, key: 'notifications.on', event: :decision),
+        text_for(:decision_count, status: 'Off') => metrics_data_for(provider_user, key: 'notifications.off', event: :decision),
+        text_for(:avg_decision_time) => 0,
+        text_for(:avg_decision_time_on) => 0,
+        text_for(:avg_decision_time_off) => 0,
+        text_for(:org_users_with_notifications, status: 'On') => org_users_with_notifications(provider_user, status: 'on'),
+        text_for(:org_users_with_notifications, status: 'Off') => org_users_with_notifications(provider_user, status: 'off'),
+        text_for(:automatic_rejections) => 0,
+      }
+    end
+
+    def text_for(event, params = nil)
+      I18n.t("notifications_export.#{event}", params)
+    end
+
+    def notifications_received_for(event)
+      event_string = text_for(event)
+      "Number of Notifications received for: #{event_string}"
+    end
+
+    def metrics_data_for(provider_user, key: nil, event: nil)
+      Metrics::Data.new(provider_user).for(key, event).count
+    end
+
+    def org_users_with_notifications(provider_user, status: 'on')
+      send_notifications = (status == 'on')
+      provider_user.providers.map { |provider| provider.provider_users.where(send_notifications: send_notifications) }.flatten.count
+    end
+  end
+end

--- a/app/services/support_interface/notifications_export.rb
+++ b/app/services/support_interface/notifications_export.rb
@@ -59,16 +59,12 @@ module SupportInterface
     end
 
     def completion_time_total(data)
-      data.map(&:completion_time).map { |interval| convert_to_seconds(interval: interval) }.compact.inject(:+) || 0
+      data.map(&:completion_time).map { |interval| Metrics::IntervalToSeconds.new(interval).call }.compact.inject(:+) || 0
     end
 
     def org_users_with_notifications(provider_user, status: 'on')
       send_notifications = (status == 'on')
       provider_user.providers.map { |provider| provider.provider_users.where(send_notifications: send_notifications) }.flatten.count
-    end
-
-    def convert_to_seconds(interval:)
-      interval.split(':').map(&:to_i).inject(0) { |a, b| a * 60 + b }
     end
   end
 end

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -29,6 +29,10 @@ private
       ProviderMailer.application_withdrawn(provider_user, application_choice).deliver_later
       Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:application_withdrawn)
     end
+
+    NotificationsList.off_for(application_choice).each do |provider_user|
+      Metrics::Tracker.new(application_choice, 'notifications.off', provider_user).track(:application_withdrawn)
+    end
   end
 
   def resolve_ucas_match(application_choice)

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -27,6 +27,7 @@ private
   def send_email_notification_to_provider_users(application_choice)
     NotificationsList.for(application_choice).each do |provider_user|
       ProviderMailer.application_withdrawn(provider_user, application_choice).deliver_later
+      Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:application_withdrawn)
     end
   end
 

--- a/config/locales/notifications_export.yml
+++ b/config/locales/notifications_export.yml
@@ -1,0 +1,22 @@
+en:
+  notifications_export:
+    email_address: User
+    notification_setting: Notification Setting
+    notifications_for_setting: No. Notifications received whilst Notifications %{status}
+    number_of_changes: Number of changes
+    notifications_received: Total number of notifications received
+    application_submitted: Application submitted
+    application_submitted_with_safeguarding_issues: Application submitted with safeguarding issues
+    application_submitted_with_no_response: Application submitted more than 5 days ago (and no response)
+    application_rejected_by_default: Application rejected by default
+    application_withdrawn: Application withdrawn
+    offer_accepted: Offer accepted
+    offer_declined: Offer declined
+    offer_declined_by_default: Offer declined by default
+    note_added: Note added to application
+    decision_count: Number of decision made with Notifications #{status}
+    avg_decision_time: Average time from application receipt to decision (for decisions made by this user)
+    avg_decision_time_on: Average time from application receipt to decision (for decisions made by this user) - Notifications On
+    avg_decision_time_off: Average time from application receipt to decision (for decisions made by this user) - Notifications Off
+    org_users_with_notifications: No. Users in Org with Notifications %{status}
+    automatic_rejections: No. Applications rejected automatically by this organisation

--- a/db/migrate/20201224110901_create_activities.rb
+++ b/db/migrate/20201224110901_create_activities.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Migration responsible for creating a table with activities
+class CreateActivities < ActiveRecord::Migration[6.0]
+  # Create table
+  def self.up
+    create_table :activities do |t|
+      t.belongs_to :trackable, polymorphic: true
+      t.belongs_to :owner, polymorphic: true
+      t.string  :key
+      t.text    :parameters
+
+      t.timestamps
+    end
+
+    add_index :activities, %i[trackable_id trackable_type]
+    add_index :activities, %i[owner_id owner_type]
+  end
+
+  # Drop table
+  def self.down
+    drop_table :activities
+  end
+end

--- a/db/migrate/20201229171142_add_completion_time_to_activity.rb
+++ b/db/migrate/20201229171142_add_completion_time_to_activity.rb
@@ -1,0 +1,5 @@
+class AddCompletionTimeToActivity < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activities, :completion_time, :interval
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,21 @@ ActiveRecord::Schema.define(version: 2020_12_29_093456) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
+  create_table "activities", force: :cascade do |t|
+    t.string "trackable_type"
+    t.bigint "trackable_id"
+    t.string "owner_type"
+    t.bigint "owner_id"
+    t.string "key"
+    t.text "parameters"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type"
+    t.index ["owner_type", "owner_id"], name: "index_activities_on_owner_type_and_owner_id"
+    t.index ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type"
+    t.index ["trackable_type", "trackable_id"], name: "index_activities_on_trackable_type_and_trackable_id"
+  end
+
   create_table "application_choices", force: :cascade do |t|
     t.bigint "application_form_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_29_093456) do
+ActiveRecord::Schema.define(version: 2020_12_29_171142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2020_12_29_093456) do
     t.text "parameters"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.interval "completion_time"
     t.index ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type"
     t.index ["owner_type", "owner_id"], name: "index_activities_on_owner_type_and_owner_id"
     t.index ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -866,6 +866,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_signed_provider_agreement do
+      after(:create) do |user, _evaluator|
+        provider = create(:provider)
+        provider.provider_users << user
+        create(:provider_agreement, provider: provider, provider_user: user)
+      end
+    end
+
     trait :with_two_providers do
       after(:create) do |user, _evaluator|
         2.times { create(:provider).provider_users << user }

--- a/spec/requests/provider_interface/audit_trail_spec.rb
+++ b/spec/requests/provider_interface/audit_trail_spec.rb
@@ -4,17 +4,11 @@ RSpec.describe 'Provider interface - audit trail', type: :request, with_audited:
   include CourseOptionHelpers
 
   it 'creates audit records attributed to the authenticated provider' do
-    provider_user = create(:provider_user, :with_provider, :with_make_decisions)
+    provider_user = create(:provider_user, :with_signed_provider_agreement, :with_make_decisions)
     course_option = course_option_for_provider(provider: provider_user.providers.first)
     application_choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
 
-    allow(ProviderUser).to receive(:load_from_session)
-      .and_return(
-        ProviderUser.new(
-          id: provider_user.id,
-          providers: provider_user.providers,
-        ),
-      )
+    allow(ProviderUser).to receive(:load_from_session).and_return(provider_user)
 
     expect {
       post provider_interface_application_choice_create_offer_path(

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -18,7 +18,11 @@ RSpec.describe AcceptOffer do
       application_choice = create(:application_choice, status: :offer)
       provider_user = create :provider_user, send_notifications: true, providers: [application_choice.provider]
 
-      expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(2)
+      expect {
+        described_class.new(application_choice: application_choice).save!
+      }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :offer_accepted)
+        .and change { ActionMailer::Base.deliveries.count }.by(2)
+
       expect(ActionMailer::Base.deliveries.first.to).to eq [provider_user.email_address]
       expect(ActionMailer::Base.deliveries.first.subject).to match(/has accepted your offer/)
     end

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe DeclineOfferByDefault do
+  around { |example| perform_enqueued_jobs(&example) }
+
+  it 'sends a notification email to the provider' do
+    application_choice = create(:application_choice, status: :offer, declined_at: nil)
+    application_form = application_choice.application_form
+    provider_user = create :provider_user, send_notifications: true, providers: [application_choice.provider]
+
+    expect {
+      described_class.new(application_form: application_form).call
+    }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :offer_declined_by_default)
+      .and change { ActionMailer::Base.deliveries.count }.by(2)
+  end
+
+  it 'sends an email to the candidate' do
+    application_choice = create(:application_choice, status: :offer)
+    application_form = application_choice.application_form
+
+    expect { described_class.new(application_form: application_form).call }
+      .to change { ActionMailer::Base.deliveries.count }.by(1)
+
+    expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.candidate.email_address]
+    expect(ActionMailer::Base.deliveries.first.subject).to match(/You did not respond to your offe/)
+  end
+end

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -3,11 +3,13 @@ require 'rails_helper'
 RSpec.describe DeclineOffer do
   it 'sets the declined_at date for the application_choice' do
     application_choice = create(:application_choice, status: :offer)
+    provider_user = create :provider_user, send_notifications: true, providers: [application_choice.provider]
 
     Timecop.freeze do
       expect {
-        DeclineOffer.new(application_choice: application_choice).save!
-      }.to change { application_choice.declined_at }.to(Time.zone.now)
+        described_class.new(application_choice: application_choice).save!
+      }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :offer_declined)
+        .and change { application_choice.declined_at }.to(Time.zone.now)
     end
   end
 end

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -1,15 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe DeclineOffer do
-  it 'sets the declined_at date for the application_choice' do
-    application_choice = create(:application_choice, status: :offer)
-    provider_user = create :provider_user, send_notifications: true, providers: [application_choice.provider]
+  let(:application_choice) { create(:application_choice, status: :offer) }
 
-    Timecop.freeze do
+  describe 'when provider_user notifications are on' do
+    let(:provider_user) { create :provider_user, send_notifications: true, providers: [application_choice.provider] }
+
+    it 'sets the declined_at date for the application_choice and tracks the notification' do
+      Timecop.freeze do
+        expect {
+          described_class.new(application_choice: application_choice).save!
+        }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :offer_declined)
+          .and change { application_choice.declined_at }.to(Time.zone.now)
+      end
+    end
+  end
+
+  describe 'when provider_user notifications are off' do
+    let(:provider_user) { create :provider_user, send_notifications: false, providers: [application_choice.provider] }
+
+    it 'tracks that a notification was sent' do
       expect {
         described_class.new(application_choice: application_choice).save!
-      }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :offer_declined)
-        .and change { application_choice.declined_at }.to(Time.zone.now)
+      }.to have_metrics_tracked(application_choice, 'notifications.off', provider_user, :offer_declined)
     end
   end
 end

--- a/spec/services/metrics_spec.rb
+++ b/spec/services/metrics_spec.rb
@@ -45,4 +45,14 @@ RSpec.describe Metrics do
       end
     end
   end
+
+  describe Metrics::IntervalToSeconds do
+    describe '#call' do
+      it 'converts an interval to seconds' do
+        seconds = Metrics::IntervalToSeconds.new('336:30:20').call
+
+        expect(seconds).to eq(1211420)
+      end
+    end
+  end
 end

--- a/spec/services/metrics_spec.rb
+++ b/spec/services/metrics_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Metrics do
+  let(:user) { create(:provider_user) }
+  let(:course) { create(:course) }
+
+  describe Metrics::Tracker do
+    describe '#track' do
+      it 'tracks information for the provided event' do
+        metrics = Metrics::Tracker.new(course, 'notifications.on', user)
+        metrics.track(:tracked_event)
+
+        last_metrics = PublicActivity::Activity.last
+        expect(last_metrics.owner).to eq(user)
+        expect(last_metrics.trackable).to eq(course)
+        expect(last_metrics.parameters).to eq(event: :tracked_event)
+      end
+    end
+  end
+
+  describe Metrics::Data do
+    before do
+      Metrics::Tracker.new(course, 'notifications.on', user).track(:course_updated)
+      Metrics::Tracker.new(course, 'notifications.off', user).track(:course_updated)
+      Metrics::Tracker.new(course, 'notifications.off', create(:provider_user)).track(:course_updated)
+    end
+
+    describe '#for' do
+      it 'retrieves data for a provided key' do
+        data = Metrics::Data.new(user).for('notifications.on')
+
+        expect(data.count).to eq(1)
+      end
+
+      it 'retrieves data for a provided event' do
+        data = Metrics::Data.new(user).for(nil, :course_updated)
+
+        expect(data.count).to eq(2)
+      end
+
+      it 'retrieves data for a key/event combination' do
+        data = Metrics::Data.new(user).for('notifications.off', :course_updated)
+
+        expect(data.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -1,15 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe NotificationsList do
+  let(:application_choice) { create(:application_choice) }
+  let!(:user_with_notifications) { create(:provider_user, send_notifications: true, providers: [application_choice.course.provider]) }
+  let!(:user_without_notifications) { create(:provider_user, send_notifications: false, providers: [application_choice.course.provider]) }
+
+  before do
+    create(:provider_user, send_notifications: true)
+    create(:provider_user, send_notifications: false)
+  end
+
   describe '.for' do
-    it 'returns provider users for the application choice' do
-      application_choice = create(:application_choice)
+    it 'returns the application choice provider users with notifications disabled' do
+      expect(described_class.for(application_choice).to_a).to eql([user_with_notifications])
+    end
+  end
 
-      create(:provider_user, send_notifications: false, providers: [application_choice.course.provider])
-      create(:provider_user, send_notifications: true)
-      provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
-
-      expect(NotificationsList.for(application_choice).to_a).to eql([provider_user])
+  describe '.off_for' do
+    it 'returns the application choice provider users with notifications disabled' do
+      expect(described_class.off_for(application_choice).to_a).to eql([user_without_notifications])
     end
   end
 end

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -4,29 +4,60 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
   include CourseOptionHelpers
 
   let(:provider) { create(:provider) }
-  let(:provider_user) { create(:provider_user, send_notifications: true, providers: [provider]) }
   let(:course_option) { course_option_for_provider(provider: provider) }
 
-  it 'sends an email to the provider' do
-    choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
+  describe '.application_submitted' do
+    let!(:choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option) }
 
-    expect {
-      SendNewApplicationEmailToProvider.new(application_choice: choice).call
-    }.to have_metrics_tracked(choice, 'notifications.on', provider_user, :application_submitted)
+    describe 'when provider_user notifications are on' do
+      let!(:provider_user) { create(:provider_user, send_notifications: true, providers: [provider]) }
 
-    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted' }
-    expect(email).to be_present
+      it 'sends an email to the provider' do
+        expect {
+          described_class.new(application_choice: choice).call
+        }.to have_metrics_tracked(choice, 'notifications.on', provider_user, :application_submitted)
+
+        email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted' }
+        expect(email).to be_present
+      end
+    end
+
+    describe 'when provider_user notifications are off' do
+      let!(:provider_user) { create(:provider_user, send_notifications: false, providers: [provider]) }
+
+      it 'tracks that a notification was sent' do
+        expect {
+          described_class.new(application_choice: choice).call
+        }.to have_metrics_tracked(choice, 'notifications.off', provider_user, :application_submitted)
+      end
+    end
   end
 
-  it 'sends a different email when the candidate supplied safeguarding information' do
-    form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
-    choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option, application_form: form)
+  describe '.application_submitted_with_safeguarding_issues' do
+    let(:form) { create(:completed_application_form, :with_safeguarding_issues_disclosed) }
+    let!(:choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option, application_form: form) }
 
-    expect {
-      SendNewApplicationEmailToProvider.new(application_choice: choice).call
-    }.to have_metrics_tracked(choice, 'notifications.on', provider_user, :application_submitted_with_safeguarding_issues)
+    describe 'when provider_user notifications are on' do
+      let!(:provider_user) { create(:provider_user, send_notifications: true, providers: [provider]) }
 
-    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted_with_safeguarding_issues' }
-    expect(email).to be_present
+      it 'sends an email to the provider' do
+        expect {
+          described_class.new(application_choice: choice).call
+        }.to have_metrics_tracked(choice, 'notifications.on', provider_user, :application_submitted_with_safeguarding_issues)
+
+        email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted_with_safeguarding_issues' }
+        expect(email).to be_present
+      end
+
+      describe 'when provider_user notifications are off' do
+        let!(:provider_user) { create(:provider_user, send_notifications: false, providers: [provider]) }
+
+        it 'tracks that a notification was sent' do
+          expect {
+            described_class.new(application_choice: choice).call
+          }.to have_metrics_tracked(choice, 'notifications.off', provider_user, :application_submitted_with_safeguarding_issues)
+        end
+      end
+    end
   end
 end

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -3,31 +3,30 @@ require 'rails_helper'
 RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
   include CourseOptionHelpers
 
-  it 'sends an email to the provider' do
-    provider = create(:provider)
-    create(:provider_user, send_notifications: true, providers: [provider])
-    option = course_option_for_provider(provider: provider)
-    choice = create(:application_choice, :awaiting_provider_decision, course_option: option)
+  let(:provider) { create(:provider) }
+  let(:provider_user) { create(:provider_user, send_notifications: true, providers: [provider]) }
+  let(:course_option) { course_option_for_provider(provider: provider) }
 
-    SendNewApplicationEmailToProvider.new(application_choice: choice).call
+  it 'sends an email to the provider' do
+    choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
+
+    expect {
+      SendNewApplicationEmailToProvider.new(application_choice: choice).call
+    }.to have_metrics_tracked(choice, 'notifications.on', provider_user, :application_submitted)
 
     email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted' }
-
     expect(email).to be_present
   end
 
   it 'sends a different email when the candidate supplied safeguarding information' do
-    provider = create(:provider)
-    create(:provider_user, send_notifications: true, providers: [provider])
-    option = course_option_for_provider(provider: provider)
-
     form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
-    choice = create(:application_choice, :awaiting_provider_decision, course_option: option, application_form: form)
+    choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option, application_form: form)
 
-    SendNewApplicationEmailToProvider.new(application_choice: choice).call
+    expect {
+      SendNewApplicationEmailToProvider.new(application_choice: choice).call
+    }.to have_metrics_tracked(choice, 'notifications.on', provider_user, :application_submitted_with_safeguarding_issues)
 
     email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted_with_safeguarding_issues' }
-
     expect(email).to be_present
   end
 end

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe SendRejectByDefaultEmailToProvider, sidekiq: true do
+  include CourseOptionHelpers
+
+  it 'sends an email to the provider users' do
+    provider = create(:provider)
+    provider_user = create(:provider_user, send_notifications: true, providers: [provider])
+    option = course_option_for_provider(provider: provider)
+    application_choice = create(:application_choice, :with_rejection, course_option: option)
+
+    expect {
+      SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
+    }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :application_rejected_by_default)
+
+    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_rejected_by_default' }
+    expect(email).to be_present
+  end
+end

--- a/spec/services/send_reject_by_default_email_to_provider_spec.rb
+++ b/spec/services/send_reject_by_default_email_to_provider_spec.rb
@@ -3,17 +3,30 @@ require 'rails_helper'
 RSpec.describe SendRejectByDefaultEmailToProvider, sidekiq: true do
   include CourseOptionHelpers
 
-  it 'sends an email to the provider users' do
-    provider = create(:provider)
-    provider_user = create(:provider_user, send_notifications: true, providers: [provider])
-    option = course_option_for_provider(provider: provider)
-    application_choice = create(:application_choice, :with_rejection, course_option: option)
+  let(:provider) { create(:provider) }
+  let(:option) { course_option_for_provider(provider: provider) }
+  let(:application_choice) { create(:application_choice, :with_rejection, course_option: option) }
 
-    expect {
-      SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
-    }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :application_rejected_by_default)
+  describe 'when a provider_user has notifications on' do
+    let(:provider_user) { create(:provider_user, send_notifications: true, providers: [provider]) }
 
-    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_rejected_by_default' }
-    expect(email).to be_present
+    it 'sends an email to the provider users and tracks a notification on metric' do
+      expect {
+        SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
+      }.to have_metrics_tracked(application_choice, 'notifications.on', provider_user, :application_rejected_by_default)
+
+      email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_rejected_by_default' }
+      expect(email).to be_present
+    end
+  end
+
+  describe 'when a provider_user has notifications off' do
+    let(:provider_user) { create(:provider_user, send_notifications: false, providers: [provider]) }
+
+    it 'tracks a notification off metric' do
+      expect {
+        SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
+      }.to have_metrics_tracked(application_choice, 'notifications.off', provider_user, :application_rejected_by_default)
+    end
   end
 end

--- a/spec/services/support_interface/notifications_export_spec.rb
+++ b/spec/services/support_interface/notifications_export_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::NotificationsExport do
+  describe '#data_for_export' do
+    it 'returns the correct count for user notification related events' do
+      provider = create(:provider)
+      provider_user = create(:provider_user, email_address: 'jane@doe.com', providers: [provider], send_notifications: false)
+      other_provider_user = create(:provider_user, email_address: 'janice@doe.com', providers: [provider], send_notifications: true)
+      application_choice = create(:application_choice)
+      application_choice2 = create(:application_choice)
+      application_choice3 = create(:application_choice)
+
+      Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:application_submitted)
+      Metrics::Tracker.new(application_choice2, 'notifications.off', provider_user).track(:application_submitted)
+      Metrics::Tracker.new(application_choice3, 'notifications.off', other_provider_user).track(:application_submitted)
+      Metrics::Tracker.new(application_choice, 'notifications.on', provider_user).track(:offer_accepted)
+      Metrics::Tracker.new(application_choice2, 'notifications.off', provider_user).track(:offer_declined)
+      Metrics::Tracker.new(application_choice3, 'notifications.off', other_provider_user).track(:application_withdrawn)
+
+      expect(described_class.new.data_for_export).to match_array([
+        {
+          'User' => 'jane@doe.com',
+          'Notification Setting' => 'No',
+          'No. Notifications received whilst Notifications On' => 2,
+          'No. Notifications received whilst Notifications Off' => 2,
+          'Number of changes' => 0,
+          'Total number of notifications received' => 4,
+          'Number of Notifications received for: Application submitted' => 2,
+          'Number of Notifications received for: Application submitted with safeguarding issues' => 0,
+          'Number of Notifications received for: Application submitted more than 5 days ago (and no response)' => 0,
+          'Number of Notifications received for: Application rejected by default' => 0,
+          'Number of Notifications received for: Application withdrawn' => 0,
+          'Number of Notifications received for: Offer accepted' => 1,
+          'Number of Notifications received for: Offer declined' => 1,
+          'Number of Notifications received for: Offer declined by default' => 0,
+          'Number of Notifications received for: Note added to application' => 0,
+          'Number of decision made with Notifications' => 0,
+          'Average time from application receipt to decision (for decisions made by this user)' => 0,
+          'Average time from application receipt to decision (for decisions made by this user) - Notifications On' => 0,
+          'Average time from application receipt to decision (for decisions made by this user) - Notifications Off' => 0,
+          'No. Users in Org with Notifications On' => 1,
+          'No. Users in Org with Notifications Off' => 1,
+          'No. Applications rejected automatically by this organisation' => 0,
+        },
+        {
+          'User' => 'janice@doe.com',
+          'Notification Setting' => 'Yes',
+          'No. Notifications received whilst Notifications On' => 0,
+          'No. Notifications received whilst Notifications Off' => 2,
+          'Number of changes' => 0,
+          'Total number of notifications received' => 2,
+          'Number of Notifications received for: Application submitted' => 1,
+          'Number of Notifications received for: Application submitted with safeguarding issues' => 0,
+          'Number of Notifications received for: Application submitted more than 5 days ago (and no response)' => 0,
+          'Number of Notifications received for: Application rejected by default' => 0,
+          'Number of Notifications received for: Application withdrawn' => 1,
+          'Number of Notifications received for: Offer accepted' => 0,
+          'Number of Notifications received for: Offer declined' => 0,
+          'Number of Notifications received for: Offer declined by default' => 0,
+          'Number of Notifications received for: Note added to application' => 0,
+          'Number of decision made with Notifications' => 0,
+          'Average time from application receipt to decision (for decisions made by this user)' => 0,
+          'Average time from application receipt to decision (for decisions made by this user) - Notifications On' => 0,
+          'Average time from application receipt to decision (for decisions made by this user) - Notifications Off' => 0,
+          'No. Users in Org with Notifications On' => 1,
+          'No. Users in Org with Notifications Off' => 1,
+          'No. Applications rejected automatically by this organisation' => 0,
+        },
+      ])
+    end
+  end
+end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -9,3 +9,15 @@ RSpec::Matchers.define :have_metrics_tracked do |trackable, key, user, event|
     expect(tracker).to have_received(:track).with(event)
   end
 end
+
+RSpec::Matchers.define :have_metrics_tracked_with_interval do |trackable, key, user, interval, event|
+  supports_block_expectations
+
+  match do |block|
+    tracker = instance_double(Metrics::Tracker, track: nil)
+    allow(Metrics::Tracker).to receive(:new).and_return(tracker)
+    block.call
+    expect(Metrics::Tracker).to have_received(:new).with(trackable, key, user)
+    expect(tracker).to have_received(:track).with(event, interval)
+  end
+end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,11 @@
+RSpec::Matchers.define :have_metrics_tracked do |trackable, key, user, event|
+  supports_block_expectations
+
+  match do |block|
+    tracker = instance_double(Metrics::Tracker, track: nil)
+    allow(Metrics::Tracker).to receive(:new).and_return(tracker)
+    block.call
+    expect(Metrics::Tracker).to have_received(:new).with(trackable, key, user)
+    expect(tracker).to have_received(:track).with(event)
+  end
+end

--- a/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     when_i_visit_that_application_in_the_provider_interface
     and_i_visit_the_notes_tab
     and_i_click_to_add_a_note
-    and_i_write_a_note_with_a_subject_and_some_text
+    adding_a_note_is_tracked { when_i_write_a_note_with_a_subject_and_some_text }
 
     then_i_am_still_on_the_notes_tab
     and_the_notes_tab_includes_the_new_note
@@ -28,8 +28,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     @provider = create(:provider, :with_signed_agreement)
-    provider_user = create(:provider_user, dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
-    provider_user.providers << @provider
+    @provider_user = create(:provider_user, send_notifications: false, dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider_user.providers << @provider
     user_exists_in_dfe_sign_in
   end
 
@@ -50,7 +50,13 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     click_on 'Add note'
   end
 
-  def and_i_write_a_note_with_a_subject_and_some_text
+  def adding_a_note_is_tracked(&block)
+    expect {
+      yield(block)
+    }.to have_metrics_tracked(@application_choice, 'notifications.off', @provider_user, :note_added)
+  end
+
+  def when_i_write_a_note_with_a_subject_and_some_text
     @note_subject = 'Documents missing'
     @note_text = 'The candidate has not forwarded the required documents yet.'
     fill_in 'Subject', with: @note_subject

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Provider makes an offer' do
     then_i_am_asked_to_confirm_the_offer
     and_i_see_the_correct_offer_conditions
 
-    when_i_confirm_the_offer
+    making_an_offer_is_tracked_as_a_decision { when_i_confirm_the_offer }
     then_i_am_back_to_the_application_page
     and_i_can_see_the_application_has_an_offer_made
   end
@@ -40,7 +40,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_am_permitted_to_see_applications_for_my_provider
-    provider_user_exists_in_apply_database
+    @provider_user = provider_user_exists_in_apply_database(send_notifications: false)
   end
 
   def and_i_am_permitted_to_make_decisions_for_my_provider
@@ -64,6 +64,12 @@ RSpec.feature 'Provider makes an offer' do
   def and_i_choose_to_make_an_offer
     choose 'Make an offer'
     click_on 'Continue'
+  end
+
+  def making_an_offer_is_tracked_as_a_decision(&block)
+    expect {
+      yield(block)
+    }.to have_metrics_tracked(@application_awaiting_provider_decision, 'notifications.off', @provider_user, :decision)
   end
 
   def then_i_see_some_application_info

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Provider makes an offer' do
   def making_an_offer_is_tracked_as_a_decision(&block)
     expect {
       yield(block)
-    }.to have_metrics_tracked(@application_awaiting_provider_decision, 'notifications.off', @provider_user, :decision)
+    }.to have_metrics_tracked_with_interval(@application_awaiting_provider_decision, 'notifications.update.off', @provider_user, anything, :decision)
   end
 
   def then_i_see_some_application_info

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -18,13 +18,13 @@ RSpec.feature 'Provider rejects application' do
     and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
 
-    when_i_respond_to_an_application
+    when_i_respond_to_a_submitted_application
     and_i_choose_to_reject_it
     and_i_add_a_rejection_reason
     and_i_click_to_continue
     then_i_am_asked_to_confirm_the_rejection
 
-    rejecting_an_application_is_tracked_as_a_decision {when_i_confirm_the_rejection }
+    rejecting_an_application_is_tracked_as_a_decision { when_i_confirm_the_rejection }
     then_i_am_back_to_the_application_page
     and_i_can_see_the_application_has_just_been_rejected
   end
@@ -41,7 +41,7 @@ RSpec.feature 'Provider rejects application' do
     permit_make_decisions!
   end
 
-  def when_i_respond_to_an_application
+  def when_i_respond_to_a_submitted_application
     visit provider_interface_application_choice_respond_path(
       application_awaiting_provider_decision.id,
     )
@@ -75,7 +75,7 @@ RSpec.feature 'Provider rejects application' do
   def rejecting_an_application_is_tracked_as_a_decision(&block)
     expect {
       yield(block)
-    }.to have_metrics_tracked(application_awaiting_provider_decision, 'notifications.on', @provider_user, :decision)
+    }.to have_metrics_tracked_with_interval(application_awaiting_provider_decision, 'notifications.update.on', @provider_user, anything, :decision)
   end
 
   def then_i_am_back_to_the_application_page

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Provider rejects application' do
     and_i_click_to_continue
     then_i_am_asked_to_confirm_the_rejection
 
-    when_i_confirm_the_rejection
+    rejecting_an_application_is_tracked_as_a_decision {when_i_confirm_the_rejection }
     then_i_am_back_to_the_application_page
     and_i_can_see_the_application_has_just_been_rejected
   end
@@ -34,7 +34,7 @@ RSpec.feature 'Provider rejects application' do
   end
 
   def and_i_am_permitted_to_see_applications_for_my_provider
-    provider_user_exists_in_apply_database
+    @provider_user = provider_user_exists_in_apply_database
   end
 
   def and_i_am_permitted_to_make_decisions_on_applications_for_my_provider
@@ -70,6 +70,12 @@ RSpec.feature 'Provider rejects application' do
 
   def when_i_confirm_the_rejection
     click_on 'Reject application'
+  end
+
+  def rejecting_an_application_is_tracked_as_a_decision(&block)
+    expect {
+      yield(block)
+    }.to have_metrics_tracked(application_awaiting_provider_decision, 'notifications.on', @provider_user, :decision)
   end
 
   def then_i_am_back_to_the_application_page


### PR DESCRIPTION
## Context

Capturing and making available metric data related to provider_user notifications via a csv export.

## TO DO
- Track :application_submitted_with_no_response when an application does not receive a response within 5 days of submission
- Identify what automatic rejections should display (as we are already displaying rejected_by_default)

## Changes proposed in this pull request

Implement a metrics module that uses the public_activity gem to capture and retrieve the different metrics information required by key, value and trackable object.

## Link to Trello card
https://trello.com/c/r1mHcAbG/3166-create-csv-data-export-to-assess-performance-of-notifications-feature

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
