### PR TITLE
Update candidate routes (misc)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,8 +38,11 @@ Rails.application.routes.draw do
     post '/sign-in/expired', to: 'sign_in#create_from_expired_token', as: :create_expired_sign_in
     get '/sign-in/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_in
     get '/sign-in/expired', to: 'sign_in#expired', as: :expired_sign_in
-    get '/confirm_authentication', to: 'sign_in#confirm_authentication', as: :authenticate
-    post '/confirm_authentication', to: 'sign_in#authenticate'
+
+    # TODO: remove redirect from Jan 15 2021
+    get '/confirm_authentication', to: redirect('/sign-in/confirm')
+    get '/sign-in/confirm', to: 'sign_in#confirm_authentication', as: :authenticate
+    post '/sign-in/confirm', to: 'sign_in#authenticate'
     get '/authenticate', to: 'sign_in#expired'
 
     get '/apply', to: 'apply_from_find#show', as: :apply_from_find

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -445,7 +445,7 @@ Rails.application.routes.draw do
       end
     end
 
-    get '*path', to: 'errors#not_found'
+    get '*path', to: redirect('/candidate/application')
   end
 
   namespace :referee_interface, path: '/reference' do

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it 'sends an email with a magic link and encrypted candidate id' do
       allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/confirm_authentication?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/sign-in/confirm?token=#{token}&u=secret",
       )
     end
 
@@ -52,7 +52,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it 'sends an email with a magic link and encrypted candidate id' do
       allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/confirm_authentication?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/sign-in/confirm?token=#{token}&u=secret",
       )
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       I18n.t!('candidate_mailer.application_submitted.subject'),
       'heading' => 'Application submitted',
       'support reference' => 'SUPPORT-REFERENCE',
-      'magic link to authenticate' => 'http://localhost:3000/candidate/confirm_authentication?token=raw_token&u=encrypted_id',
+      'magic link to authenticate' => 'http://localhost:3000/candidate/sign-in/confirm?token=raw_token&u=encrypted_id',
     )
   end
 

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Decline by default' do
     expected_subject = I18n.t('chase_candidate_decision_email.subject_singular')
     expect(current_email.subject).to include(expected_subject)
 
-    expect(current_email.body).to include('http://localhost:3000/candidate/confirm_authentication')
+    expect(current_email.body).to include('http://localhost:3000/candidate/sign-in/confirm')
   end
 
   def and_when_the_decline_by_default_limit_has_been_exceeded


### PR DESCRIPTION
## Context

Following a wider review of routes, some changes are required.

## Changes proposed in this pull request

- Redirect all incorrect signed-in paths starting with `/candidate/application/*` to `/candidate/application` rather than show a 404
- Add temporary redirect from `/confirm_authentication` to `/sign-in/confirm`
- Update `/confirm_authentication` routes to `/sign-in/confirm`

## Link to Trello card

https://trello.com/c/EmpbwjXY/2602-update-routes-paths-and-controllers-to-align-with-interface-misc

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
