### PR TITLE
Make changes to provider-access-controls CSV

### DIFF
--- a/app/services/support_interface/provider_access_controls_export.rb
+++ b/app/services/support_interface/provider_access_controls_export.rb
@@ -12,6 +12,7 @@ module SupportInterface
           last_user_permissions_change_at: access_controls.user_permissions_last_changed_at,
           total_user_permissions_changes: access_controls.total_user_permissions_changes,
           user_permissions_changed_by: access_controls.user_permissions_changed_by,
+          total_user_permissions_changes_made_by_support: access_controls.total_user_permissions_changes_made_by_support,
           total_manage_users_users: access_controls.total_manage_users_users,
           total_manage_orgs_users: access_controls.total_manage_orgs_users,
           total_users: provider.provider_users.count,

--- a/app/services/support_interface/provider_access_controls_export.rb
+++ b/app/services/support_interface/provider_access_controls_export.rb
@@ -24,6 +24,7 @@ module SupportInterface
           org_permissions_changes_made_by_this_provider_affecting_another_provider_made_by: access_controls.org_permissions_changes_made_by_this_provider_affecting_another_provider_made_by,
           org_permissions_changes_affecting_this_provider_last_made_at: access_controls.date_of_last_org_permissions_change_affecting_this_provider,
           total_org_permissions_changes_affecting_this_provider: access_controls.total_org_permissions_changes_affecting_this_provider,
+          total_org_permissions_changes_made_by_support: access_controls.total_org_permissions_changes_made_by_support,
           org_permissions_changes_affecting_this_provider_made_by: access_controls.org_permissions_changes_affecting_this_provider_made_by,
           total_org_relationships_as_trainer: access_controls.total_org_relationships_as_trainer,
           total_org_relationships: access_controls.total_org_relationships,

--- a/app/services/support_interface/provider_access_controls_stats.rb
+++ b/app/services/support_interface/provider_access_controls_stats.rb
@@ -32,6 +32,10 @@ module SupportInterface
         .sort
     end
 
+    def total_user_permissions_changes_made_by_support
+      Audited::Audit.where(action: 'update', auditable: @provider.provider_permissions, user_type: 'SupportUser').count
+    end
+
     def total_manage_users_users
       @provider.provider_permissions.where(manage_users: true).count
     end

--- a/app/services/support_interface/provider_access_controls_stats.rb
+++ b/app/services/support_interface/provider_access_controls_stats.rb
@@ -52,6 +52,10 @@ module SupportInterface
       total(:org_permissions_changes_made_by_this_provider_affecting_this_provider)
     end
 
+    def total_org_permissions_changes_made_by_support
+      total(:org_permissions_changes_made_by_support)
+    end
+
     def org_permissions_changes_made_by_this_provider_affecting_this_provider_made_by
       provider_user_emails_who_made(:org_permissions_changes_made_by_this_provider_affecting_this_provider)
     end
@@ -141,8 +145,13 @@ module SupportInterface
     end
 
     def audits_for_org_permissions_changes_affecting_this_provider
-      audits_for_org_permissions_changes_made_by_this_provider_affecting_this_provider
-        .or(audits_for_org_permissions_changes_made_by_another_provider_affecting_this_provider)
+      org_training_provider_permission_audits.where('audited_changes ?| array[:keys]', keys: TRAINING_PROVIDER_PERMISSIONS_KEYS)
+        .or(org_ratifying_provider_permission_audits.where('audited_changes ?| array[:keys]', keys: RATIFYING_PROVIDER_PERMISSIONS_KEYS))
+    end
+
+    def audits_for_org_permissions_changes_made_by_support
+      audits_for_org_permissions_changes_affecting_this_training_provider_made_by('SupportUser')
+        .or(audits_for_org_permissions_changes_affecting_this_ratifying_provider_made_by('SupportUser'))
     end
 
     def date_of_last(permission_change)

--- a/spec/services/support_interface/provider_access_controls_export_spec.rb
+++ b/spec/services/support_interface/provider_access_controls_export_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: tru
         provider_user_sets_their_view_safeguarding_information_to_true(provider_user3, 2.days.ago)
 
         support_user_sets_provider_users_view_diversity_information_to_false(support_user, provider_user1, 5.days.ago)
+        support_user_changes_org_can_view_diversity_information(support_user, training_provider, 2.days.ago)
 
         expect(described_class.new.data_for_export).to match_array([
           {
@@ -73,8 +74,9 @@ RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: tru
             total_org_permissions_changes_made_by_this_provider_affecting_another_provider: 1,
             org_permissions_changes_made_by_this_provider_affecting_another_provider_made_by: [provider_user1.email_address],
             org_permissions_changes_affecting_this_provider_last_made_at: 2.days.ago,
-            total_org_permissions_changes_affecting_this_provider: 1,
-            org_permissions_changes_affecting_this_provider_made_by: [provider_user1.email_address],
+            total_org_permissions_changes_affecting_this_provider: 2,
+            total_org_permissions_changes_made_by_support: 1,
+            org_permissions_changes_affecting_this_provider_made_by: [provider_user1.email_address, support_user.email_address].sort,
             total_org_relationships_as_trainer: 1,
             total_org_relationships: 1,
           },
@@ -96,8 +98,9 @@ RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: tru
             total_org_permissions_changes_made_by_this_provider_affecting_another_provider: 0,
             org_permissions_changes_made_by_this_provider_affecting_another_provider_made_by: [],
             org_permissions_changes_affecting_this_provider_last_made_at: 2.days.ago,
-            total_org_permissions_changes_affecting_this_provider: 1,
-            org_permissions_changes_affecting_this_provider_made_by: [provider_user1.email_address],
+            total_org_permissions_changes_affecting_this_provider: 2,
+            total_org_permissions_changes_made_by_support: 1,
+            org_permissions_changes_affecting_this_provider_made_by: [provider_user1.email_address, support_user.email_address].sort,
             total_org_relationships_as_trainer: 0,
             total_org_relationships: 1,
           },
@@ -149,6 +152,17 @@ RSpec.describe SupportInterface::ProviderAccessControlsExport, with_audited: tru
     Audited.audit_class.as_user(support_user) do
       Timecop.freeze(time) do
         provider_user.provider_permissions.last.update!(view_diversity_information: false)
+      end
+    end
+  end
+
+  def support_user_changes_org_can_view_diversity_information(support_user, provider, time)
+    Audited.audit_class.as_user(support_user) do
+      Timecop.freeze(time) do
+        provider.training_provider_permissions.last.update!(
+          training_provider_can_view_diversity_information: true,
+          ratifying_provider_can_view_diversity_information: false,
+        )
       end
     end
   end

--- a/spec/services/support_interface/provider_access_controls_stats_spec.rb
+++ b/spec/services/support_interface/provider_access_controls_stats_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ProviderAccessControlsStats, with_audited: true do
+  let(:support_user) { create(:support_user) }
+
   describe '#dsa_signer_email' do
     it 'returns the email of the user who most recently accepted the dsa' do
       provider = create(:provider)
@@ -80,6 +82,48 @@ RSpec.describe SupportInterface::ProviderAccessControlsStats, with_audited: true
       access_controls = described_class.new(provider)
 
       expect(access_controls.total_user_permissions_changes).to eq 0
+    end
+
+    it 'ignores changes that were made by support users' do
+      provider = create(:provider)
+      provider_user = create(:provider_user, providers: [provider])
+
+      Audited.audit_class.as_user(support_user) do
+        provider_user.provider_permissions.last.update!(view_diversity_information: true)
+      end
+
+      access_controls = described_class.new(provider)
+
+      expect(access_controls.total_user_permissions_changes).to eq 0
+    end
+  end
+
+  describe '#total_user_permissions_changes_made_by_support' do
+    it 'returns the number of times the user permissions have been updated for the provider by support users' do
+      provider = create(:provider)
+      provider_user = create(:provider_user, providers: [provider])
+
+      Audited.audit_class.as_user(support_user) do
+        provider_user.provider_permissions.last.update!(view_diversity_information: true)
+        provider_user.provider_permissions.last.update!(view_safeguarding_information: true)
+      end
+
+      access_controls = described_class.new(provider)
+
+      expect(access_controls.total_user_permissions_changes_made_by_support).to eq 2
+    end
+
+    it 'ignores changes that were made by other users' do
+      provider = create(:provider)
+      provider_user = create(:provider_user, providers: [provider])
+
+      Audited.audit_class.as_user('Not a support user') do
+        provider_user.provider_permissions.last.update!(view_diversity_information: true)
+      end
+
+      access_controls = described_class.new(provider)
+
+      expect(access_controls.total_user_permissions_changes_made_by_support).to eq 0
     end
   end
 


### PR DESCRIPTION
## Context

To help with permissions analysis we need to add numbers on changes made by support.

## Changes proposed in this pull request

Changes to csv download for provider-access-controls:

- add column for User permissions changes made by support
- add column for Org permissions changes made by support
- amend the query for the column "total_org_permissions_changes_affecting_this_provider" to include changes made via support.

## Guidance to review

Thoughts on the refactor welcome. 

## Link to Trello card

https://trello.com/c/Wr76j9ci/3165-make-changes-to-provider-access-controls-csv

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
