### PR TITLE
Update routes and paths to align with interface (personal details)

### DIFF
--- a/app/components/candidate_interface/personal_details_review_component.html.erb
+++ b/app/components/candidate_interface/personal_details_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :personal_details, section_path: candidate_interface_edit_personal_details_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :personal_details, section_path: candidate_interface_edit_personal_information_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: rows, editable: @editable)) %>
 <% end %>

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -36,7 +36,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.name.label'),
         value: @personal_details_form.name,
         action: ('name' if @editable),
-        change_path: candidate_interface_edit_personal_details_path,
+        change_path: candidate_interface_edit_personal_information_path,
       }
     end
 
@@ -45,7 +45,7 @@ module CandidateInterface
         key: I18n.t('application_form.personal_details.date_of_birth.label'),
         value: @personal_details_form.date_of_birth.to_s(:govuk_date),
         action: ('date of birth' if @editable),
-        change_path: candidate_interface_edit_personal_details_path,
+        change_path: candidate_interface_edit_personal_information_path,
       }
     end
 

--- a/app/views/candidate_interface/personal_details/base/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_form, url: candidate_interface_edit_personal_details_path, method: :patch do |f| %>
+    <%= form_with model: @personal_details_form, url: candidate_interface_edit_personal_information_path, method: :patch do |f| %>
     <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/base/new.html.erb
+++ b/app/views/candidate_interface/personal_details/base/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_path, method: :patch do |f| %>
+    <%= form_with model: @personal_details_form, url: candidate_interface_personal_information_path, method: :patch do |f| %>
     <%= render partial: 'shared_form', locals: { f: f }  %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_details/nationalities/new.html.erb
+++ b/app/views/candidate_interface/personal_details/nationalities/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.nationalities'), @nationalities_form.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_details_path, 'Back') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_personal_information_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -78,7 +78,7 @@
             TaskListItemComponent.new(
               text: t('page_titles.personal_information'),
               completed: @application_form_presenter.personal_details_completed?,
-              path: all_sections_completed ? candidate_interface_personal_details_show_path : candidate_interface_personal_details_path
+              path: all_sections_completed ? candidate_interface_personal_details_show_path : candidate_interface_personal_information_path
             )
           ) %>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,16 +75,29 @@ Rails.application.routes.draw do
       get '/start-carry-over' => 'carry_over#start', as: :start_carry_over
       post '/carry-over' => 'carry_over#create', as: :carry_over
 
+      # TODO: Remove temporary redirects from Jan 15 2021
       scope '/personal-details' do
-        get '/' => 'personal_details/base#new', as: :personal_details
+        get '/', to: redirect('/candidate/application/personal-information')
+        get '/edit', to: redirect('/candidate/application/personal-information/edit')
+        get '/nationalities', to: redirect('/candidate/application/personal-information/nationality'), as: :personal_details_nationalities
+        get '/nationalities/edit', to: redirect('/candidate/application/personal-information/nationality/edit'), as: :personal_details_edit_nationalities
+        get '/languages', to: redirect('/candidate/application/personal-information/languages'), as: :personal_details_languages
+        get '/languages/edit', to: redirect('/candidate/application/personal-information/languages/edit'), as: :personal_details_edit_languages
+        get '/right-to-work-or-study', to: redirect('/candidate/application/personal-information/right-to-work-or-study'), as: :personal_details_right_to_work_or_study
+        get '/right-to-work-or-study/edit', to: redirect('/candidate/application/personal-information/right-to-work-or-study/edit'), as: :personal_details_edit_right_to_work_or_study
+        get 'review', to: redirect('/candidate/application/personal-information/review')
+      end
+
+      scope '/personal-information' do
+        get '/' => 'personal_details/base#new', as: :personal_information
         patch '/' => 'personal_details/base#create'
-        get '/edit' => 'personal_details/base#edit', as: :edit_personal_details
+        get '/edit' => 'personal_details/base#edit', as: :edit_personal_information
         patch '/edit' => 'personal_details/base#update'
 
-        get '/nationalities' => 'personal_details/nationalities#new', as: :nationalities
-        patch '/nationalities' => 'personal_details/nationalities#create'
-        get '/nationalities/edit' => 'personal_details/nationalities#edit', as: :edit_nationalities
-        patch '/nationalities/edit' => 'personal_details/nationalities#update'
+        get '/nationality' => 'personal_details/nationalities#new', as: :nationalities
+        patch '/nationality' => 'personal_details/nationalities#create'
+        get '/nationality/edit' => 'personal_details/nationalities#edit', as: :edit_nationalities
+        patch '/nationality/edit' => 'personal_details/nationalities#update'
 
         get '/languages' => 'personal_details/languages#new', as: :languages
         patch '/languages' => 'personal_details/languages#create'

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
       )
 
       expect(rows(personal_details_form: personal_details_form)).to include(
-        row_for(:name, 'Max Caulfield', candidate_interface_edit_personal_details_path),
-        row_for(:date_of_birth, '21 September 1995', candidate_interface_edit_personal_details_path),
+        row_for(:name, 'Max Caulfield', candidate_interface_edit_personal_information_path),
+        row_for(:date_of_birth, '21 September 1995', candidate_interface_edit_personal_information_path),
       )
     end
   end

--- a/spec/requests/candidate_interface/audit_trail_spec.rb
+++ b/spec/requests/candidate_interface/audit_trail_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Candidate interface - audit trail', type: :request, with_audited
     sign_in candidate
 
     expect {
-      patch candidate_interface_personal_details_url(
+      patch candidate_interface_personal_information_url(
         candidate_interface_personal_details_form: valid_attributes,
       )
     }.to(change { candidate.current_application.audits.count })


### PR DESCRIPTION
## Context
Following a wider review of candidate routes, some changes are required

## Changes in this PR

- `/personal-details/*` routes have been renamed to `/personal-information/*`
- temporary redirects added
- route helper methods updated

## Link to Trello card

https://trello.com/c/deDdvTnv/2660-update-routes-paths-and-controllers-to-align-with-interface-rename-personal-details

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
