### PR TITLE
Fix add degree validation messages

### DIFF
--- a/app/forms/candidate_interface/degree_type_form.rb
+++ b/app/forms/candidate_interface/degree_type_form.rb
@@ -8,7 +8,7 @@ module CandidateInterface
     attr_accessor :application_form, :degree
 
     validates :uk_degree, presence: true
-    validates :type_description, presence: true, unless: -> { international? }
+    validates :type_description, presence: true, if: -> { uk? }
     validates :type_description, length: { maximum: 255 }
     validates :international_type_description, presence: true, if: -> { international? }
     validates :international_type_description, length: { maximum: 255 }
@@ -68,6 +68,10 @@ module CandidateInterface
 
     def international?
       uk_degree == 'no'
+    end
+
+    def uk?
+      uk_degree == 'yes'
     end
   end
 end

--- a/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degree_with_missing_information_spec.rb
+++ b/spec/system/candidate_interface/entering_details/degrees/candidate_entering_degree_with_missing_information_spec.rb
@@ -8,6 +8,9 @@ RSpec.feature 'Entering degree with missing info' do
     when_i_click_on_degree
     then_i_see_the_undergraduate_degree_form
 
+    when_i_submit_without_selecting_a_degree_type
+    then_i_see_a_validation_error
+
     when_i_submit_a_degree_type
     and_manually_skip_ahead_to_the_review_page
     then_i_cannot_mark_this_section_complete
@@ -24,6 +27,15 @@ RSpec.feature 'Entering degree with missing info' do
 
   def then_i_see_the_undergraduate_degree_form
     expect(page).to have_content 'Add undergraduate degree'
+  end
+
+  def when_i_submit_without_selecting_a_degree_type
+    click_button t('application_form.degree.base.button')
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content 'Select if this is a UK degree or not'
+    expect(page).not_to have_content 'Enter your degree type'
   end
 
   def when_i_submit_a_degree_type


### PR DESCRIPTION
## Context

Two validation errors are displayed if a candidate doesn't specify uk/international degree type. Only one is required.

## Changes proposed in this pull request

- [x] Update system spec to reproduce issue
- [x] Fix validation

<img width="689" alt="image" src="https://user-images.githubusercontent.com/450843/103363986-71475100-4ab4-11eb-9368-8baca2dc8f03.png">

## Guidance to review

- Should be possible to test on review application

## Link to Trello card

https://trello.com/c/WGy0RUZY/2768-bug-wrong-number-of-error-messages-shown-in-add-degree-error-summary

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
