### PR TITLE
Update routes and paths to align with interface (contact details)

### DIFF
--- a/app/components/candidate_interface/contact_details_review_component.html.erb
+++ b/app/components/candidate_interface/contact_details_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :contact_details, section_path: candidate_interface_contact_details_edit_base_path, error: @missing_error)) %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :contact_details, section_path: candidate_interface_contact_information_edit_base_path, error: @missing_error)) %>
 <% else %>
   <%= render(SummaryCardComponent.new(rows: contact_details_form_rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -29,12 +29,12 @@ module CandidateInterface
         key: t('application_form.contact_information.phone_number.label'),
         value: @contact_details_form.phone_number,
         action: t('application_form.contact_information.phone_number.change_action'),
-        change_path: Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_base_path,
+        change_path: Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_base_path,
       }
     end
 
     def address_row
-      change_path = Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_type_path
+      change_path = Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_address_type_path
 
       {
         key: t('application_form.contact_information.full_address.label'),

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
       if @contact_details_form.save_address(current_application)
         current_application.update!(contact_details_completed: false)
 
-        redirect_to candidate_interface_contact_details_review_path
+        redirect_to candidate_interface_contact_information_review_path
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/controllers/candidate_interface/contact_details/address_type_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_type_controller.rb
@@ -12,7 +12,7 @@ module CandidateInterface
       if @contact_details_form.save_address_type(current_application)
         current_application.update!(contact_details_completed: false)
 
-        redirect_to candidate_interface_contact_details_edit_address_path
+        redirect_to candidate_interface_contact_information_edit_address_path
       else
         track_validation_error(@contact_details_form)
         render :edit

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -19,9 +19,9 @@ module CandidateInterface
         if updated_contact_details_form.valid?(:address)
           current_application.update!(contact_details_completed: false)
 
-          redirect_to candidate_interface_contact_details_review_path
+          redirect_to candidate_interface_contact_information_review_path
         else
-          redirect_to candidate_interface_contact_details_edit_address_type_path
+          redirect_to candidate_interface_contact_information_edit_address_type_path
         end
       else
         track_validation_error(@contact_details_form)

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_information_edit_address_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if @contact_details_form.uk? || FeatureFlag.active?(:international_addresses) %>

--- a/app/views/candidate_interface/contact_details/address_type/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address_type/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_address_type_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_information_edit_address_type_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :address_types, legend: { text: t('page_titles.where_do_you_live'), size: 'xl', tag: 'h1' } do %>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_edit_base_path, method: :patch do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_information_edit_base_path, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -8,6 +8,6 @@
 <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form)) %>
 
 <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
-                                        path: candidate_interface_contact_details_complete_path,
+                                        path: candidate_interface_contact_information_complete_path,
                                         request_method: :patch,
                                         field_name: :contact_details_completed)) %>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -87,7 +87,7 @@
             TaskListItemComponent.new(
               text: t('page_titles.contact_information'),
               completed: @application_form_presenter.contact_details_completed?,
-              path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_details_review_path : candidate_interface_contact_details_edit_base_path
+              path: @application_form_presenter.contact_details_valid? ? candidate_interface_contact_information_review_path : candidate_interface_contact_information_edit_base_path
             )
           ) %>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,18 +124,26 @@ Rails.application.routes.draw do
         patch '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
       end
 
+      # TODO: Remove temporary redirects from Jan 15 2021
       scope '/contact-details' do
-        get '/' => 'contact_details/base#edit', as: :contact_details_edit_base
+        get '/', to: redirect('/candidate/application/contact-information')
+        get '/address_type', to: redirect('/candidate/application/contact-information/address-type')
+        get '/address', to: redirect('/candidate/application/contact-information/address')
+        get '/review', to: redirect('/candidate/application/contact-information/review')
+      end
+
+      scope '/contact-information' do
+        get '/' => 'contact_details/base#edit', as: :contact_information_edit_base
         patch '/' => 'contact_details/base#update'
 
-        get '/address_type' => 'contact_details/address_type#edit', as: :contact_details_edit_address_type
-        patch '/address_type' => 'contact_details/address_type#update'
+        get '/address-type' => 'contact_details/address_type#edit', as: :contact_information_edit_address_type
+        patch '/address-type' => 'contact_details/address_type#update'
 
-        get '/address' => 'contact_details/address#edit', as: :contact_details_edit_address
+        get '/address' => 'contact_details/address#edit', as: :contact_information_edit_address
         patch '/address' => 'contact_details/address#update'
 
-        get '/review' => 'contact_details/review#show', as: :contact_details_review
-        patch '/complete' => 'contact_details/review#complete', as: :contact_details_complete
+        get '/review' => 'contact_details/review#show', as: :contact_information_review
+        patch '/complete' => 'contact_details/review#complete', as: :contact_information_complete
       end
 
       scope '/gcse' do

--- a/spec/components/candidate_interface/contact_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/contact_details_review_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_information.phone_number.label'))
       expect(result.css('.govuk-summary-list__value').text).to include('07700 900 982')
-      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_base_path)
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_base_path)
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_information.phone_number.change_action')}")
     end
 
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_information.full_address.label'))
         expect(result.css('.govuk-summary-list__value').to_html).to include('42<br>Much Wow Street<br>London<br>England<br>SW1P 3BT')
-        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_type_path)
+        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_address_type_path)
         expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_information.full_address.change_action')}")
       end
 
@@ -48,7 +48,7 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_information.full_address.label'))
         expect(result.css('.govuk-summary-list__value').to_html).to include('321 MG Road, Mumbai<br>India')
-        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_type_path)
+        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_address_type_path)
         expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_information.full_address.change_action')}")
       end
 
@@ -67,7 +67,7 @@ RSpec.describe CandidateInterface::ContactDetailsReviewComponent do
 
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_information.full_address.label'))
         expect(result.css('.govuk-summary-list__value').to_html).to include('321 MG Road<br>Mumbai<br>India')
-        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_type_path)
+        expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_information_edit_address_type_path)
         expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_information.full_address.change_action')}")
       end
     end

--- a/spec/requests/candidate_interface/validation_error_tracking_spec.rb
+++ b/spec/requests/candidate_interface/validation_error_tracking_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe 'Candidate interface - validation error tracking', type: :request
 
   it 'does NOT create validation error when request is valid' do
     expect {
-      patch candidate_interface_contact_details_edit_base_url(valid_attributes)
+      patch candidate_interface_contact_information_edit_base_url(valid_attributes)
     }.not_to(change { ValidationError.count })
   end
 
   it 'creates validation error when request is invalid' do
     expect {
-      patch candidate_interface_contact_details_edit_base_url(invalid_attributes)
+      patch candidate_interface_contact_information_edit_base_url(invalid_attributes)
     }.to(change { ValidationError.count }.by(1))
   end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -36,7 +36,7 @@ module CandidateHelper
     candidate_fills_in_personal_details
 
     click_link t('page_titles.contact_information')
-    visit candidate_interface_contact_details_edit_base_path
+    visit candidate_interface_contact_information_edit_base_path
     candidate_fills_in_contact_details
 
     click_link t('page_titles.work_history')

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Entering their contact information' do
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('phone_number')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_contact_details_edit_base_path)
+    expect(validation_error.request_path).to eq(candidate_interface_contact_information_edit_base_path)
   end
 
   def when_i_fill_in_my_phone_number
@@ -122,7 +122,7 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def when_i_click_to_change_my_phone_number
-    find_link('Change', href: candidate_interface_contact_details_edit_base_path).click
+    find_link('Change', href: candidate_interface_contact_information_edit_base_path).click
   end
 
   def then_i_can_see_my_phone_number
@@ -139,7 +139,7 @@ RSpec.feature 'Entering their contact information' do
   end
 
   def when_i_click_to_change_my_address_type
-    find_link('Change', href: candidate_interface_contact_details_edit_address_type_path).click
+    find_link('Change', href: candidate_interface_contact_information_edit_address_type_path).click
   end
 
   def then_i_can_see_my_address_type

--- a/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_without_international_addresses_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_contact_details_without_international_addresses_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Entering their contact information without international_addresse
     expect(validation_error).to be_present
     expect(validation_error.details).to have_key('phone_number')
     expect(validation_error.user).to eq(current_candidate)
-    expect(validation_error.request_path).to eq(candidate_interface_contact_details_edit_base_path)
+    expect(validation_error.request_path).to eq(candidate_interface_contact_information_edit_base_path)
   end
 
   def when_i_fill_in_my_phone_number
@@ -119,7 +119,7 @@ RSpec.feature 'Entering their contact information without international_addresse
   end
 
   def when_i_click_to_change_my_phone_number
-    find_link('Change', href: candidate_interface_contact_details_edit_base_path).click
+    find_link('Change', href: candidate_interface_contact_information_edit_base_path).click
   end
 
   def then_i_can_see_my_phone_number
@@ -136,7 +136,7 @@ RSpec.feature 'Entering their contact information without international_addresse
   end
 
   def when_i_click_to_change_my_address_type
-    find_link('Change', href: candidate_interface_contact_details_edit_address_type_path).click
+    find_link('Change', href: candidate_interface_contact_information_edit_address_type_path).click
   end
 
   def then_i_can_see_my_address

--- a/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'International candidate submits the application' do
     click_button 'Continue'
 
     click_link t('page_titles.contact_information')
-    visit candidate_interface_contact_details_edit_base_path
+    visit candidate_interface_contact_information_edit_base_path
     candidate_fills_in_international_contact_details
 
     click_link t('page_titles.work_history')


### PR DESCRIPTION
## Context

Following a wider review of candidate routes, some changes are required

## Changes proposed in this pull request

- `/contact-details/*` routes have been renamed to `/contact-information/*`
- temporary redirects added
- route helper methods updated

## Link to Trello card

https://trello.com/c/BULSCWRV/2661-update-routes-paths-and-controllers-to-align-with-interface-rename-contact-details

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
