### PR TITLE
Uniqueness validation for email address in support interface

### DIFF
--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -84,7 +84,7 @@ module SupportInterface
           @application_form.candidate.email_address == email_address
 
         return unless Candidate.exists?(email_address: email_address)
-        
+
         errors.add(
           :email_address,
           I18n.t('activemodel.errors.models.support_interface/application_forms/edit_applicant_details_form.attributes.email_address.taken'),

--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -17,6 +17,7 @@ module SupportInterface
                 length: { maximum: 60 }
 
       validates :email_address, presence: true, valid_for_notify: true, length: { maximum: 100 }
+      validate :email_address_unique
 
       validates :date_of_birth, presence: true
       validate :date_of_birth_valid
@@ -76,6 +77,18 @@ module SupportInterface
 
         age_limit = Time.zone.today - 16.years
         errors.add(:date_of_birth, :below_lower_age_limit, date: age_limit.to_s(:govuk_date)) if date_of_birth > age_limit
+      end
+
+      def email_address_unique
+        return if @application_form.persisted? &&
+          @application_form.candidate.email_address == email_address
+
+        return unless Candidate.exists?(email_address: email_address)
+        
+        errors.add(
+          :email_address,
+          I18n.t('activemodel.errors.models.support_interface/application_forms/edit_applicant_details_form.attributes.email_address.taken'),
+        )
       end
 
     private

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -13,6 +13,10 @@ RSpec.feature 'Editing application details' do
     and_i_submit_the_update_form
     then_i_should_see_relevant_blank_error_messages
 
+    when_i_supply_new_applicant_details_with_used_email_address
+    and_i_submit_the_update_form
+    then_i_should_see_a_duplicate_email_error_message
+
     when_i_supply_new_applicant_details
     and_i_submit_the_update_form
     then_i_should_see_a_flash_message
@@ -135,6 +139,16 @@ RSpec.feature 'Editing application details' do
   def and_i_should_see_my_comment_in_the_audit_log
     click_on 'History'
     expect(page).to have_content 'https://becomingateacher.zendesk.com/12345'
+  end
+
+  def when_i_supply_new_applicant_details_with_used_email_address
+    when_i_supply_new_applicant_details
+    create :candidate, email_address: 'bob@example.com'
+    fill_in 'support_interface_application_forms_edit_applicant_details_form[email_address]', with: 'bob@example.com'
+  end
+
+  def then_i_should_see_a_duplicate_email_error_message
+    expect(page).to have_content 'Email address is already in use'
   end
 
   def when_i_supply_new_applicant_details


### PR DESCRIPTION
## Context

As part of investigation into the impact of modifying email addresses via support interface I found that uniqueness validation wasn't being enforced at the form level (leading to some messy errors).

## Changes proposed in this pull request

<img width="689" alt="image" src="https://user-images.githubusercontent.com/450843/103368521-a2794e80-4abf-11eb-8458-fde812ee55af.png">


## Guidance to review

- Should be possible to test via review application

## Link to Trello card

https://trello.com/c/nn4X895M/2747-spike-effects-of-changing-email-addresses-from-support-ui

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
