### PR TITLE
Only export the current cycles data for the HESA export

### DIFF
--- a/app/queries/get_application_choices_for_providers.rb
+++ b/app/queries/get_application_choices_for_providers.rb
@@ -9,7 +9,9 @@ class GetApplicationChoicesForProviders
     course_option: [{ course: %i[provider] }, :site],
   ].freeze
 
-  def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES)
+  DEFAULT_RECRUITMENT_CYCLE_YEAR = RecruitmentCycle.years_visible_to_providers
+
+  def self.call(providers:, vendor_api: false, includes: DEFAULT_INCLUDES, recruitment_cycle_year: DEFAULT_RECRUITMENT_CYCLE_YEAR)
     providers = Array.wrap(providers).select(&:present?)
 
     raise MissingProvider if providers.none?
@@ -25,21 +27,21 @@ class GetApplicationChoicesForProviders
     applications =
       with_course_joins.where(
         'original_course.provider_id' => providers,
-        'original_course.recruitment_cycle_year' => RecruitmentCycle.years_visible_to_providers,
+        'original_course.recruitment_cycle_year' => recruitment_cycle_year,
       ).or(
         with_course_joins.where(
           'original_course.accredited_provider_id' => providers,
-          'original_course.recruitment_cycle_year' => RecruitmentCycle.years_visible_to_providers,
+          'original_course.recruitment_cycle_year' => recruitment_cycle_year,
         ),
       ).or(
         with_course_joins.where(
           'current_course.provider_id' => providers,
-          'current_course.recruitment_cycle_year' => RecruitmentCycle.years_visible_to_providers,
+          'current_course.recruitment_cycle_year' => recruitment_cycle_year,
         ),
       ).or(
         with_course_joins.where(
           'current_course.accredited_provider_id' => providers,
-          'current_course.recruitment_cycle_year' => RecruitmentCycle.years_visible_to_providers,
+          'current_course.recruitment_cycle_year' => recruitment_cycle_year,
         ),
       )
       .where('status IN (?)', statuses)

--- a/app/services/provider_interface/hesa_data_export.rb
+++ b/app/services/provider_interface/hesa_data_export.rb
@@ -7,7 +7,7 @@ module ProviderInterface
     end
 
     def call
-      applications = GetApplicationChoicesForProviders.call(providers: @actor.providers)
+      applications = GetApplicationChoicesForProviders.call(providers: @actor.providers, recruitment_cycle_year: RecruitmentCycle.current_year)
                        .where(
                          'candidates.hide_in_reporting' => false,
                          'status' => ApplicationStateChange::ACCEPTED_STATES,

--- a/app/views/provider_interface/hesa_export/new.html.erb
+++ b/app/views/provider_interface/hesa_export/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, t('page_titles.provider.export_hesa_data') %>
+<%= content_for :title, t('page_titles.provider.export_hesa_data', timeframe: '') %>
 <% if FeatureFlag.active?(:export_application_data) %>
   <% content_for :before_content do %>
     <%= render BreadcrumbComponent.new(items: [
@@ -7,7 +7,7 @@
         path: provider_interface_new_application_data_export_path
       },
       {
-        text: t('page_titles.provider.export_hesa_data')
+        text: t('page_titles.provider.export_hesa_data', timeframe: '')
       }
     ]) %>
   <% end %>
@@ -17,7 +17,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= t('page_titles.provider.export_hesa_data') %>
+      <%= t('page_titles.provider.export_hesa_data', timeframe: "since #{EndOfCycleTimetable.apply_reopens.to_s(:govuk_date)}") %>
     </h1>
     <p class="govuk-body">
       The data will include all candidates who have accepted an offer from any of your organisations.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,7 +165,7 @@ en:
       profile: Profile
       org_permissions: Organisational permissions
       users: Users
-      export_hesa_data: Export data for Higher Education Statistics Agency (HESA)
+      export_hesa_data: Export data %{timeframe} for Higher Education Statistics Agency (HESA)
       export_application_data: Export data
       notifications: Email notifications
     start_apply_again: Do you want to apply again?

--- a/spec/queries/get_application_choices_for_providers_spec.rb
+++ b/spec/queries/get_application_choices_for_providers_spec.rb
@@ -169,18 +169,13 @@ RSpec.describe GetApplicationChoicesForProviders do
     provider_we_ratify = create(:provider)
 
     course_option_for_this_cycle = course_option_for_provider(provider: current_provider)
-    course_option_for_past_cycle = course_option_for_provider(provider: current_provider).tap do |option|
-      option.course.update!(recruitment_cycle_year: 2016)
-      option.reload
-    end
+    course_option_for_past_cycle = course_option_for_provider(provider: current_provider, recruitment_cycle_year: 2016)
 
     ratified_course_option_for_past_cycle = course_option_for_accredited_provider(
       provider: provider_we_ratify,
       accredited_provider: current_provider,
-    ).tap do |option|
-      option.course.update!(recruitment_cycle_year: 2016)
-      option.reload
-    end
+      recruitment_cycle_year: 2016,
+    )
 
     choice_for_this_cycle = create(
       :application_choice,

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -108,5 +108,16 @@ RSpec.describe ProviderInterface::HesaDataExport do
 
       it_behaves_like 'a full HESA export'
     end
+
+    context 'when provider has courses in multiple recruitment cycles' do
+      it 'only exports current recruitment cycle data' do
+        previous_cycle_course = create(:course, recruitment_cycle_year: RecruitmentCycle.previous_year, provider: training_provider, accredited_provider: accredited_provider)
+        course_option = create(:course_option, course: previous_cycle_course)
+        create(:application_choice, :with_accepted_offer, course_option: course_option)
+
+        exported_data = CSV.parse(export_data, headers: true)
+        expect(exported_data.count).to eq 1
+      end
+    end
   end
 end

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -1,6 +1,6 @@
 module CourseOptionHelpers
-  def course_option_for_provider(provider:, course: nil, site: nil, study_mode: 'full_time')
-    course ||= create(:course, :open_on_apply, provider: provider)
+  def course_option_for_provider(provider:, course: nil, site: nil, study_mode: 'full_time', recruitment_cycle_year: RecruitmentCycle.current_year)
+    course ||= create(:course, :open_on_apply, provider: provider, recruitment_cycle_year: recruitment_cycle_year)
     site ||= create(:site, provider: provider)
     create(:course_option, course: course, site: site, study_mode: study_mode)
   end
@@ -12,8 +12,8 @@ module CourseOptionHelpers
     create(:course_option, course: course, site: site)
   end
 
-  def course_option_for_accredited_provider(provider:, accredited_provider:)
-    course = create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider)
+  def course_option_for_accredited_provider(provider:, accredited_provider:, recruitment_cycle_year: RecruitmentCycle.current_year)
+    course = create(:course, :open_on_apply, provider: provider, accredited_provider: accredited_provider, recruitment_cycle_year: recruitment_cycle_year)
     site = create(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end


### PR DESCRIPTION
## Context
```
As a provider
I need to download all successful applications where conditions have been met together with any diversity information
So that I can prepare my submission for the current cycle's census (HESA or DTTP)
```

## Changes proposed in this pull request

Make HESA application export only include data from the current cycle and update H1 on the page.

<img width="322" alt="Screenshot 2020-12-30 at 16 55 50" src="https://user-images.githubusercontent.com/38078064/103368616-ec623480-4abf-11eb-8e5e-46a88d14f48f.png">


## Guidance to review

- activate the feature flag
- visit http://localhost:3000/provider/applications/hesa-export/new

## Link to Trello card

https://trello.com/c/ckrS3ru8/3175-only-export-the-current-cycles-data-for-the-hesa-export

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
