### PR TITLE
Redirect to the offer page after deferring an offer

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -150,7 +150,7 @@ module ProviderInterface
       ).save!
 
       flash[:success] = 'Offer successfully deferred'
-      redirect_to provider_interface_application_choice_path(@application_choice)
+      redirect_to provider_interface_application_choice_offer_path(@application_choice)
     end
 
   private

--- a/spec/system/provider_interface/provider_defers_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_defers_an_offer_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Provider defers an offer' do
 
   def then_i_am_back_to_the_application_page
     expect(page).to have_current_path(
-      provider_interface_application_choice_path(
+      provider_interface_application_choice_offer_path(
         @application_offered.id,
       ),
     )


### PR DESCRIPTION
## Context

Currently, confirming the deferral takes the user to the application page, which makes it difficult for the user to see what offer they've actually deferred

## Changes proposed in this pull request

Redirect to the offer page after deferring an offer

- <kbd>![redirect](https://user-images.githubusercontent.com/38078064/103409646-9a70eb80-4b5f-11eb-8f90-e7ff4ac9efeb.gif)</kbd>

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ckrS3ru8/3175-only-export-the-current-cycles-data-for-the-hesa-export

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
