### PR TITLE
Fix underscore in degrees completion status paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,10 +259,14 @@ Rails.application.routes.draw do
         get '/:id/institution/edit' => 'degrees/institution#edit', as: :edit_degree_institution
         patch '/:id/institution/edit' => 'degrees/institution#update'
 
-        get '/:id/completion_status' => 'degrees/completion_status#new', as: :degree_completion_status
-        post '/:id/completion_status' => 'degrees/completion_status#create'
-        get '/:id/completion_status/edit' => 'degrees/completion_status#edit', as: :edit_degree_completion_status
-        patch '/:id/completion_status/edit' => 'degrees/completion_status#update'
+        # TODO: Remove temporary redirects from Jan 15 2021
+        get '/:id/completion_status', to: redirect { |params, _| "/candidate/application/degrees/#{params[:id]}/completion-status" }
+        get '/:id/completion_status/edit', to: redirect { |params, _| "/candidate/application/degrees/#{params[:id]}/completion-status/edit" }
+
+        get '/:id/completion-status' => 'degrees/completion_status#new', as: :degree_completion_status
+        post '/:id/completion-status' => 'degrees/completion_status#create'
+        get '/:id/completion-status/edit' => 'degrees/completion_status#edit', as: :edit_degree_completion_status
+        patch '/:id/completion-status/edit' => 'degrees/completion_status#update'
 
         get '/:id/naric' => 'degrees/naric#new', as: :degree_naric
         post '/:id/naric' => 'degrees/naric#create'


### PR DESCRIPTION
## Context

As part of a wider review of candidate route, some changes are required.

## Changes proposed in this pull request
- Replace `_` with `-` for degrees `completion_status` paths
- temporary redirect added

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/dvKLje3W/2664-update-routes-paths-and-controllers-to-align-with-interface-fix-underscore-in-degree-paths

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
