### PR TITLE
Changes to support performance dashboard

### DIFF
--- a/app/components/support_interface/anchor_link_component.html.erb
+++ b/app/components/support_interface/anchor_link_component.html.erb
@@ -1,0 +1,3 @@
+<%= link_to "##{link_to_id}", style: "text-decoration: none; color: inherit;" do %>
+  <%= render content %>
+<% end %>

--- a/app/components/support_interface/anchor_link_component.rb
+++ b/app/components/support_interface/anchor_link_component.rb
@@ -1,0 +1,10 @@
+module SupportInterface
+  class AnchorLinkComponent < ViewComponent::Base
+    attr_reader :link_to_id, :content
+
+    def initialize(link_to_id:, content:)
+      @link_to_id = link_to_id
+      @content = content
+    end
+  end
+end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -94,11 +94,15 @@ class PerformanceStatistics
   end
 
   def total_submitted_count
-    total_form_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress])
+    total_form_count(except: %i[unsubmitted_not_started_form unsubmitted_in_progress])
   end
 
   def apply_again_submitted_count
-    total_form_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress], phase: :apply_2)
+    total_form_count(except: %i[unsubmitted_not_started_form unsubmitted_in_progress], phase: :apply_2)
+  end
+
+  def still_being_processed_count
+    total_form_count(only: %i[awaiting_provider_decisions awaiting_candidate_response])
   end
 
   def ended_without_success_count

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -173,7 +173,7 @@ private
 
     query = "created_at >= '#{start_date}'"
 
-    if EndOfCycleTimetable::CYCLE_DATES.to_a.map(&:first).max != cycle_year
+    if EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1].present?
       end_date = EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_reopens]
 
       query += " AND created_at <= '#{end_date}'"

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -104,12 +104,6 @@ class PerformanceStatistics
       .to_a
   end
 
-  def application_form_status_total_counts
-    application_form_status_counts.group_by { |row| row['status'] }.map do |status, rows|
-      { 'status' => status, 'count' => rows.map { |r| r['count'] }.sum }
-    end
-  end
-
   def total_submitted_count
     total_form_count(except: %i[unsubmitted_not_started_form unsubmitted_in_progress])
   end
@@ -118,16 +112,32 @@ class PerformanceStatistics
     total_form_count(except: %i[unsubmitted_not_started_form unsubmitted_in_progress], phase: :apply_2)
   end
 
+  def unsubmitted_application_form_status_total_counts
+    application_form_status_total_counts(only: %i[unsubmitted_not_started_form unsubmitted_in_progress])
+  end
+
   def still_being_processed_count
     total_form_count(only: %i[awaiting_provider_decisions awaiting_candidate_response])
+  end
+
+  def still_being_processed_application_form_status_total_counts
+    application_form_status_total_counts(only: %i[awaiting_provider_decisions awaiting_candidate_response])
   end
 
   def ended_without_success_count
     total_form_count(only: %i[ended_without_success])
   end
 
+  def ended_without_success_application_form_status_total_counts
+    application_form_status_total_counts(only: %i[ended_without_success])
+  end
+
   def accepted_offer_count
     total_form_count(only: %i[pending_conditions recruited offer_deferred])
+  end
+
+  def accepted_offer_application_form_status_total_counts
+    application_form_status_total_counts(only: %i[pending_conditions recruited offer_deferred])
   end
 
   def apply_again_accepted_offer_count
@@ -155,6 +165,16 @@ class PerformanceStatistics
         else
           '-'
         end
+      end
+  end
+
+private
+
+  def application_form_status_total_counts(only: nil)
+    application_form_status_counts
+      .select { |row| only.nil? || row['status'].to_sym.in?(only) }
+      .group_by { |row| row['status'] }.map do |status, rows|
+        { 'status' => status, 'count' => rows.map { |r| r['count'] }.sum }
       end
   end
 end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -1,4 +1,8 @@
 class PerformanceStatistics
+  UNSUBMITTED_STATUSES = %i[unsubmitted_not_started_form unsubmitted_in_progress]
+  PROCESSING_STATUSES = %i[awaiting_provider_decisions awaiting_candidate_response]
+  ACCEPTED_STATUSES = %i[pending_conditions recruited offer_deferred]
+
   attr_reader :year
 
   def initialize(year)
@@ -99,23 +103,23 @@ class PerformanceStatistics
   end
 
   def total_submitted_count
-    total_form_count(except: %i[unsubmitted_not_started_form unsubmitted_in_progress])
+    total_form_count(except: UNSUBMITTED_STATUSES)
   end
 
   def apply_again_submitted_count
-    total_form_count(except: %i[unsubmitted_not_started_form unsubmitted_in_progress], phase: :apply_2)
+    total_form_count(except: UNSUBMITTED_STATUSES, phase: :apply_2)
   end
 
   def unsubmitted_application_form_status_total_counts
-    application_form_status_total_counts(only: %i[unsubmitted_not_started_form unsubmitted_in_progress])
+    application_form_status_total_counts(only: UNSUBMITTED_STATUSES)
   end
 
   def still_being_processed_count
-    total_form_count(only: %i[awaiting_provider_decisions awaiting_candidate_response])
+    total_form_count(only: PROCESSING_STATUSES)
   end
 
   def still_being_processed_application_form_status_total_counts
-    application_form_status_total_counts(only: %i[awaiting_provider_decisions awaiting_candidate_response])
+    application_form_status_total_counts(only: PROCESSING_STATUSES)
   end
 
   def ended_without_success_count
@@ -127,11 +131,11 @@ class PerformanceStatistics
   end
 
   def accepted_offer_count
-    total_form_count(only: %i[pending_conditions recruited offer_deferred])
+    total_form_count(only: ACCEPTED_STATUSES)
   end
 
   def accepted_offer_application_form_status_total_counts
-    application_form_status_total_counts(only: %i[pending_conditions recruited offer_deferred])
+    application_form_status_total_counts(only: ACCEPTED_STATUSES)
   end
 
   def apply_again_accepted_offer_count

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -70,7 +70,7 @@ class PerformanceStatistics
       .sum
   end
 
-  def total_candidate_count(only: nil, except: [], phase: nil)
+  def total_form_count(only: nil, except: [], phase: nil)
     candidate_status_counts
       .select { |row| only.nil? || row['status'].to_sym.in?(only) }
       .select { |row| phase.nil? || row['phase']&.to_sym == phase.to_sym }
@@ -93,23 +93,23 @@ class PerformanceStatistics
   end
 
   def total_submitted_count
-    total_candidate_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress])
+    total_form_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress])
   end
 
   def apply_again_submitted_count
-    total_candidate_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress], phase: :apply_2)
+    total_form_count(except: %i[never_signed_in unsubmitted_not_started_form unsubmitted_in_progress], phase: :apply_2)
   end
 
   def ended_without_success_count
-    total_candidate_count(only: %i[ended_without_success])
+    total_form_count(only: %i[ended_without_success])
   end
 
   def accepted_offer_count
-    total_candidate_count(only: %i[pending_conditions recruited offer_deferred])
+    total_form_count(only: %i[pending_conditions recruited offer_deferred])
   end
 
   def apply_again_accepted_offer_count
-    total_candidate_count(only: %i[pending_conditions recruited offer_deferred], phase: :apply_2)
+    total_form_count(only: %i[pending_conditions recruited offer_deferred], phase: :apply_2)
   end
 
   def rejected_by_default_count

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -13,7 +13,7 @@ class PerformanceStatistics
     candidates = Candidate.all
 
     if year.present?
-      year_query = date_range_query_for_recruitment_cycle_year(year)
+      year_query = date_range_query_for_recruitment_cycle_year(year.to_i)
       candidates = candidates.where(year_query)
     end
 
@@ -173,7 +173,7 @@ private
 
     query = "created_at >= '#{start_date}'"
 
-    if EndOfCycleTimetable::CYCLE_DATES.to_a.map(&:first).max != year
+    if EndOfCycleTimetable::CYCLE_DATES.to_a.map(&:first).max != cycle_year
       end_date = EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_reopens]
 
       query += " AND created_at <= '#{end_date}'"

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -1,7 +1,7 @@
 class PerformanceStatistics
-  UNSUBMITTED_STATUSES = %i[unsubmitted_not_started_form unsubmitted_in_progress]
-  PROCESSING_STATUSES = %i[awaiting_provider_decisions awaiting_candidate_response]
-  ACCEPTED_STATUSES = %i[pending_conditions recruited offer_deferred]
+  UNSUBMITTED_STATUSES = %i[unsubmitted_not_started_form unsubmitted_in_progress].freeze
+  PROCESSING_STATUSES = %i[awaiting_provider_decisions awaiting_candidate_response].freeze
+  ACCEPTED_STATUSES = %i[pending_conditions recruited offer_deferred].freeze
 
   attr_reader :year
 
@@ -173,7 +173,7 @@ private
 
     query = "created_at >= '#{start_date}'"
 
-    if EndOfCycleTimetable::CYCLE_DATES.to_a.map(&:first).sort.last != year
+    if EndOfCycleTimetable::CYCLE_DATES.to_a.map(&:first).max != year
       end_date = EndOfCycleTimetable::CYCLE_DATES[cycle_year + 1][:apply_reopens]
 
       query += " AND created_at <= '#{end_date}'"

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -5,6 +5,23 @@ class PerformanceStatistics
     @year = year
   end
 
+  def candidate_count
+    candidates = Candidate.all
+
+    if year.present?
+      candidates = candidates.joins(:application_forms).where('application_forms.recruitment_cycle_year': year)
+    end
+
+    candidates.where(hide_in_reporting: false).uniq.count
+  end
+
+  def candidate_never_signed_in_count
+    ApplicationForm.joins('FULL OUTER JOIN candidates c on application_forms.candidate_id = c.id')
+                   .where('application_forms.id IS NULL')
+                   .where.not('c.hide_in_reporting')
+                   .count
+  end
+
   def application_form_query
     year_clause = year ? "AND f.recruitment_cycle_year = #{year}" : ''
 

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -73,8 +73,13 @@
   </div>
 </div>
 
-<table class="govuk-table govuk-!-margin-top-8">
-  <caption class="govuk-table__caption govuk-heading-m">Application form breakdown</caption>
+<h3 class="govuk-heading-m govuk-!-font-size-27">Application form breakdown</h3>
+
+<h4 class="govuk-heading-s">Unsubmitted applications</h4>
+<p class="govuk-body">
+  Application forms that have not been sent to providers yet.
+</p>
+<table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
@@ -84,7 +89,55 @@
   </thead>
 
   <tbody class="govuk-table__body">
-    <% @statistics.application_form_status_total_counts.each do |row| %>
+    <% @statistics.unsubmitted_application_form_status_total_counts.each do |row| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>
+        <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<h4 class="govuk-heading-s">Applications being processed</h4>
+<p class="govuk-body">
+  Application forms that have been sent to providers and require action from either the candidate or provider to progress.
+</p>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Count</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Description</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @statistics.still_being_processed_application_form_status_total_counts.each do |row| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>
+        <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<h4 class="govuk-heading-s">Unsuccessful applications</h4>
+<p class="govuk-body">
+  Applications that have ended without success. The rejected by default count is included in the ended without success count
+</p>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Count</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Description</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @statistics.ended_without_success_application_form_status_total_counts.each do |row| %>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>
@@ -96,6 +149,30 @@
       <td class="govuk-table__cell govuk-table__cell--numeric"><%= @statistics.rejected_by_default_count %></td>
       <td class="govuk-table__cell govuk-!-width-two-thirds"><%= t("performance_dashboard_other_metrics.rejected_by_default.description") %></td>
     </tr>
+  </tbody>
+</table>
+
+<h4 class="govuk-heading-s">Successful applications</h4>
+<p class="govuk-body">
+  Applications that have received an offer and the candidate has accepted.
+</p>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Count</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Description</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @statistics.accepted_offer_application_form_status_total_counts.each do |row| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>
+        <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
+      </tr>
+    <% end %>
   </tbody>
 </table>
 

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -32,10 +32,10 @@
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count(only: %i{unsubmitted_not_started_form unsubmitted_in_progress}), label: 'unsubmitted application forms') %>
+    <%= render SupportInterface::AnchorLinkComponent.new(link_to_id: 'unsubmitted', content: SupportInterface::TileComponent.new(count: @statistics.total_form_count(only: %i{unsubmitted_not_started_form unsubmitted_in_progress}), label: 'unsubmitted application forms') ) %>
   </div>
   <div class="govuk-grid-column-one-half">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.total_submitted_count, label: 'submitted application forms') %>
+    <%= render SupportInterface::AnchorLinkComponent.new(link_to_id: 'being-processed', content: SupportInterface::TileComponent.new(count: @statistics.total_submitted_count, label: 'submitted application forms') ) %>
   </div>
 </div>
 
@@ -43,10 +43,10 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <%= render SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_not_started_form], label: 'forms not started', size: :reduced) %>
+        <%= render SupportInterface::AnchorLinkComponent.new(link_to_id: 'unsubmitted', content: SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_not_started_form], label: 'forms not started', size: :reduced) ) %>
       </div>
       <div class="govuk-grid-column-one-half">
-        <%= render SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_in_progress], label: 'forms in progress', size: :reduced) %>
+        <%= render SupportInterface::AnchorLinkComponent.new(link_to_id: 'unsubmitted', content: SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_in_progress], label: 'forms in progress', size: :reduced) ) %>
       </div>
     </div>
   </div>
@@ -54,13 +54,13 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.still_being_processed_count, label: 'still being processed', size: :reduced) %>
+        <%= render SupportInterface::AnchorLinkComponent.new(link_to_id: 'being-processed', content: SupportInterface::TileComponent.new(count: @statistics.still_being_processed_count, label: 'still being processed', size: :reduced) ) %>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.ended_without_success_count, label: 'ended w/o success', size: :reduced, colour: :red) %>
+        <%= render SupportInterface::AnchorLinkComponent.new(link_to_id: 'unsuccessful', content: SupportInterface::TileComponent.new(count: @statistics.ended_without_success_count, label: 'ended w/o success', size: :reduced, colour: :red) ) %>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.accepted_offer_count, label: 'accepted an offer', size: :reduced, colour: :green) %>
+        <%= render SupportInterface::AnchorLinkComponent.new(link_to_id: 'successful', content: SupportInterface::TileComponent.new(count: @statistics.accepted_offer_count, label: 'accepted an offer', size: :reduced, colour: :green) ) %>
       </div>
     </div>
   </div>
@@ -68,7 +68,7 @@
 
 <h3 class="govuk-heading-m govuk-!-font-size-27">Application form breakdown</h3>
 
-<h4 class="govuk-heading-s">Unsubmitted applications</h4>
+<h4 class="govuk-heading-s" id="unsubmitted">Unsubmitted applications</h4>
 <p class="govuk-body">
   Application forms that have not been sent to providers yet.
 </p>
@@ -92,7 +92,7 @@
   </tbody>
 </table>
 
-<h4 class="govuk-heading-s">Applications being processed</h4>
+<h4 class="govuk-heading-s" id="being-processed">Applications being processed</h4>
 <p class="govuk-body">
   Application forms that have been sent to providers and require action from either the candidate or provider to progress.
 </p>
@@ -116,7 +116,7 @@
   </tbody>
 </table>
 
-<h4 class="govuk-heading-s">Unsuccessful applications</h4>
+<h4 class="govuk-heading-s" id="unsuccessful">Unsuccessful applications</h4>
 <p class="govuk-body">
   Applications that have ended without success. The rejected by default count is included in the ended without success count
 </p>
@@ -145,7 +145,7 @@
   </tbody>
 </table>
 
-<h4 class="govuk-heading-s">Successful applications</h4>
+<h4 class="govuk-heading-s" id="successful">Successful applications</h4>
 <p class="govuk-body">
   Applications that have received an offer and the candidate has accepted.
 </p>

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -21,15 +21,15 @@
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Candidates</h3>
 
 <div id="headline-stat" class="govuk-!-margin-bottom-4">
-  <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count, label: 'sign ups (excluding test users)', colour: :blue) %>
+  <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count, label: 'sign ups (excluding test users)', colour: :blue) %>
 </div>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count(only: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'in pre-submission') %>
+    <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count(only: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'unsubmitted application forms') %>
   </div>
   <div class="govuk-grid-column-one-half">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.total_submitted_count, label: 'submitted') %>
+    <%= render SupportInterface::TileComponent.new(count: @statistics.total_submitted_count, label: 'submitted application forms') %>
   </div>
 </div>
 
@@ -51,7 +51,7 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count(except: %i{ended_without_success pending_conditions recruited never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'still being processed', size: :reduced) %>
+        <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count(except: %i{ended_without_success pending_conditions recruited never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'still being processed', size: :reduced) %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= render SupportInterface::TileComponent.new(count: @statistics.ended_without_success_count, label: 'ended w/o success', size: :reduced, colour: :red) %>

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -20,8 +20,12 @@
 
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Candidates</h3>
 
-<div id="headline-stat" class="govuk-!-margin-bottom-4">
+<div id="candidate-count" class="govuk-!-margin-bottom-4">
   <%= render SupportInterface::TileComponent.new(count: Candidate.where(hide_in_reporting: false).count, label: 'unique candidates', colour: :blue) %>
+</div>
+
+<div id="application-form-count" class="govuk-!-margin-bottom-4">
+  <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count, label: 'application forms', colour: :blue) %>
 </div>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
@@ -64,7 +68,7 @@
 </div>
 
 <table class="govuk-table govuk-!-margin-top-8">
-  <caption class="govuk-table__caption govuk-heading-m">Candidate breakdown</caption>
+  <caption class="govuk-table__caption govuk-heading-m">Application form breakdown</caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
@@ -74,7 +78,7 @@
   </thead>
 
   <tbody class="govuk-table__body">
-    <% @statistics.candidate_status_total_counts.each do |row| %>
+    <% @statistics.application_form_status_total_counts.each do |row| %>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
         <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(row['count']) %></td>

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -21,14 +21,7 @@
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Candidates</h3>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.candidate_count, label: 'unique candidates', colour: :blue) %>
-  </div>
-<% if params[:year].nil? && @statistics.candidate_never_signed_in_count.positive? %>
-  <div class="govuk-grid-column-one-third govuk-!-margin-bottom-4">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.candidate_never_signed_in_count, label: 'never signed in', colour: :red) %>
-  </div>
-<% end %>
+  <%= render SupportInterface::TileComponent.new(count: @statistics.candidate_count, label: 'unique candidates', colour: :blue) %>
 </div>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Applications</h3>

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -20,13 +20,13 @@
 
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Candidates</h3>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-4">
+<div class="govuk-!-margin-bottom-4">
   <%= render SupportInterface::TileComponent.new(count: @statistics.candidate_count, label: 'unique candidates', colour: :blue) %>
 </div>
 
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Applications</h3>
 
-<div id="application-form-count" class="govuk-!-margin-bottom-4">
+<div class="govuk-!-margin-bottom-4">
   <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count, label: 'application forms', colour: :blue) %>
 </div>
 

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -30,7 +30,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count(only: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'unsubmitted application forms') %>
+    <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count(only: %i{unsubmitted_not_started_form unsubmitted_in_progress}), label: 'unsubmitted application forms') %>
   </div>
   <div class="govuk-grid-column-one-half">
     <%= render SupportInterface::TileComponent.new(count: @statistics.total_submitted_count, label: 'submitted application forms') %>
@@ -40,14 +40,11 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics[:never_signed_in], label: 'never signed in', size: :reduced) %>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_not_started_form], label: 'forms not started', size: :reduced) %>
       </div>
-      <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_not_started_form], label: 'not started the form', size: :reduced) %>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_in_progress], label: 'form in progress', size: :reduced) %>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(count: @statistics[:unsubmitted_in_progress], label: 'forms in progress', size: :reduced) %>
       </div>
     </div>
   </div>
@@ -55,7 +52,7 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count(except: %i{ended_without_success pending_conditions recruited never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'still being processed', size: :reduced) %>
+        <%= render SupportInterface::TileComponent.new(count: @statistics.still_being_processed_count, label: 'still being processed', size: :reduced) %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= render SupportInterface::TileComponent.new(count: @statistics.ended_without_success_count, label: 'ended w/o success', size: :reduced, colour: :red) %>

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -20,9 +20,18 @@
 
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Candidates</h3>
 
-<div id="candidate-count" class="govuk-!-margin-bottom-4">
-  <%= render SupportInterface::TileComponent.new(count: Candidate.where(hide_in_reporting: false).count, label: 'unique candidates', colour: :blue) %>
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4">
+    <%= render SupportInterface::TileComponent.new(count: @statistics.candidate_count, label: 'unique candidates', colour: :blue) %>
+  </div>
+<% if params[:year].nil? && @statistics.candidate_never_signed_in_count.positive? %>
+  <div class="govuk-grid-column-one-third govuk-!-margin-bottom-4">
+    <%= render SupportInterface::TileComponent.new(count: @statistics.candidate_never_signed_in_count, label: 'never signed in', colour: :red) %>
+  </div>
+<% end %>
 </div>
+
+<h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Applications</h3>
 
 <div id="application-form-count" class="govuk-!-margin-bottom-4">
   <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count, label: 'application forms', colour: :blue) %>

--- a/app/views/support_interface/performance_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/performance_dashboard/dashboard.html.erb
@@ -21,7 +21,7 @@
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Candidates</h3>
 
 <div id="headline-stat" class="govuk-!-margin-bottom-4">
-  <%= render SupportInterface::TileComponent.new(count: @statistics.total_form_count, label: 'sign ups (excluding test users)', colour: :blue) %>
+  <%= render SupportInterface::TileComponent.new(count: Candidate.where(hide_in_reporting: false).count, label: 'unique candidates', colour: :blue) %>
 </div>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-4">

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -102,51 +102,36 @@ RSpec.describe PerformanceStatistics, type: :model do
   end
 
   describe '#candidate_count' do
-    it 'returns the total number of candidates for a given cycle' do
-      create(:application_form, recruitment_cycle_year: 2020)
-      create(:application_form, recruitment_cycle_year: 2021)
-      create(:application_form, recruitment_cycle_year: 2021)
+    it 'returns the total number of candidates that were created during a given cycle' do
+      Timecop.freeze(2020, 1, 5) do
+        create_list(:candidate, 2)
+      end
+      Timecop.freeze(2020, 12, 25) do
+        create_list(:candidate, 3)
+      end
 
-      expect(described_class.new(2020).candidate_count).to eq(1)
-      expect(described_class.new(2021).candidate_count).to eq(2)
+      expect(described_class.new(2020).candidate_count).to eq(2)
+      expect(described_class.new(2021).candidate_count).to eq(3)
     end
 
     it 'returns the total number of candidates that exist when no cycle is given' do
-      create(:application_form, recruitment_cycle_year: 2020)
-      create(:application_form, recruitment_cycle_year: 2021)
-      create(:application_form, recruitment_cycle_year: 2021)
+      Timecop.freeze(2020, 1, 5) do
+        create_list(:candidate, 2)
+      end
+      Timecop.freeze(2020, 12, 25) do
+        create_list(:candidate, 3)
+      end
 
-      expect(described_class.new(nil).candidate_count).to eq(3)
+      expect(described_class.new(nil).candidate_count).to eq(5)
     end
 
-    it 'does not include candidates that do not have a form when a year is given' do
-      create(:application_form, recruitment_cycle_year: 2020)
-      create(:application_form, recruitment_cycle_year: 2021)
-      create(:application_form, recruitment_cycle_year: 2021)
-      create(:candidate)
+    it 'does not take into account any application forms that a candidate may have' do
+      Timecop.freeze(2020, 1, 5) do
+        create(:application_form, recruitment_cycle_year: 2021)
+      end
 
       expect(described_class.new(2020).candidate_count).to eq(1)
-      expect(described_class.new(2021).candidate_count).to eq(2)
-    end
-
-    it 'includes candidates that do not have a form when a year is not given' do
-      create(:application_form, recruitment_cycle_year: 2020)
-      create(:application_form, recruitment_cycle_year: 2021)
-      create(:application_form, recruitment_cycle_year: 2021)
-      create(:candidate)
-
-      expect(described_class.new(nil).candidate_count).to eq(4)
-    end
-  end
-
-  describe '#candidate_never_signed_in_count' do
-    it 'returns the number of candidates that do not have an associated application form' do
-      create(:application_form, recruitment_cycle_year: 2020)
-      create(:application_form, recruitment_cycle_year: 2021)
-      create(:candidate)
-      create(:candidate)
-
-      expect(described_class.new(nil).candidate_never_signed_in_count).to eq(2)
+      expect(described_class.new(2021).candidate_count).to eq(0)
     end
   end
 

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -101,6 +101,55 @@ RSpec.describe PerformanceStatistics, type: :model do
     end
   end
 
+  describe '#candidate_count' do
+    it 'returns the total number of candidates for a given cycle' do
+      create(:application_form, recruitment_cycle_year: 2020)
+      create(:application_form, recruitment_cycle_year: 2021)
+      create(:application_form, recruitment_cycle_year: 2021)
+
+      expect(described_class.new(2020).candidate_count).to eq(1)
+      expect(described_class.new(2021).candidate_count).to eq(2)
+    end
+
+    it 'returns the total number of candidates that exist when no cycle is given' do
+      create(:application_form, recruitment_cycle_year: 2020)
+      create(:application_form, recruitment_cycle_year: 2021)
+      create(:application_form, recruitment_cycle_year: 2021)
+
+      expect(described_class.new(nil).candidate_count).to eq(3)
+    end
+
+    it 'does not include candidates that do not have a form when a year is given' do
+      create(:application_form, recruitment_cycle_year: 2020)
+      create(:application_form, recruitment_cycle_year: 2021)
+      create(:application_form, recruitment_cycle_year: 2021)
+      create(:candidate)
+
+      expect(described_class.new(2020).candidate_count).to eq(1)
+      expect(described_class.new(2021).candidate_count).to eq(2)
+    end
+
+    it 'includes candidates that do not have a form when a year is not given' do
+      create(:application_form, recruitment_cycle_year: 2020)
+      create(:application_form, recruitment_cycle_year: 2021)
+      create(:application_form, recruitment_cycle_year: 2021)
+      create(:candidate)
+
+      expect(described_class.new(nil).candidate_count).to eq(4)
+    end
+  end
+
+  describe '#candidate_never_signed_in_count' do
+    it 'returns the number of candidates that do not have an associated application form' do
+      create(:application_form, recruitment_cycle_year: 2020)
+      create(:application_form, recruitment_cycle_year: 2021)
+      create(:candidate)
+      create(:candidate)
+
+      expect(described_class.new(nil).candidate_never_signed_in_count).to eq(2)
+    end
+  end
+
   describe '#total_form_count' do
     it 'optionally filters only on certain process states and excludes certain states' do
       create(:application_choice, status: 'recruited')

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe PerformanceStatistics, type: :model do
     end
   end
 
-  describe '#total_candidate_count' do
+  describe '#total_form_count' do
     it 'optionally filters only on certain process states and excludes certain states' do
       create(:application_choice, status: 'recruited')
       create(:application_choice, status: 'recruited')
@@ -109,8 +109,8 @@ RSpec.describe PerformanceStatistics, type: :model do
 
       stats = PerformanceStatistics.new(nil)
 
-      expect(stats.total_candidate_count(only: %i[recruited])).to eq(2)
-      expect(stats.total_candidate_count(except: %i[pending_conditions])).to eq(2)
+      expect(stats.total_form_count(only: %i[recruited])).to eq(2)
+      expect(stats.total_form_count(except: %i[pending_conditions])).to eq(2)
     end
 
     it 'optionally filters by phase' do
@@ -123,11 +123,11 @@ RSpec.describe PerformanceStatistics, type: :model do
 
       stats = PerformanceStatistics.new(nil)
 
-      expect(stats.total_candidate_count(only: %i[recruited])).to eq(2)
-      expect(stats.total_candidate_count(only: %i[recruited], phase: :apply_1)).to eq(1)
-      expect(stats.total_candidate_count(only: %i[recruited], phase: :apply_2)).to eq(1)
-      expect(stats.total_candidate_count(phase: :apply_2)).to eq(1)
-      expect(stats.total_candidate_count(except: %i[pending_conditions])).to eq(3)
+      expect(stats.total_form_count(only: %i[recruited])).to eq(2)
+      expect(stats.total_form_count(only: %i[recruited], phase: :apply_1)).to eq(1)
+      expect(stats.total_form_count(only: %i[recruited], phase: :apply_2)).to eq(1)
+      expect(stats.total_form_count(phase: :apply_2)).to eq(1)
+      expect(stats.total_form_count(except: %i[pending_conditions])).to eq(3)
     end
   end
 
@@ -138,7 +138,7 @@ RSpec.describe PerformanceStatistics, type: :model do
 
       stats = PerformanceStatistics.new(2021)
 
-      expect(stats.total_candidate_count).to eq(1)
+      expect(stats.total_form_count).to eq(1)
     end
   end
 
@@ -194,6 +194,6 @@ RSpec.describe PerformanceStatistics, type: :model do
 
     stats = PerformanceStatistics.new(nil)
 
-    expect(stats.total_candidate_count).to eq(1)
+    expect(stats.total_form_count).to eq(1)
   end
 end

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe PerformanceStatistics, type: :model do
   describe '#[]' do
-    it 'counts candidates without application forms' do
+    it 'does not count candidates without application forms' do
       create(:candidate)
 
       expect(ProcessState.new(nil).state).to be :never_signed_in
 
-      expect(count_for_process_state(:never_signed_in)).to be(1)
+      expect(count_for_process_state(:never_signed_in)).to be(0)
     end
 
     it 'counts unsubmitted, unstarted applications' do
@@ -127,7 +127,7 @@ RSpec.describe PerformanceStatistics, type: :model do
       expect(stats.total_form_count(only: %i[recruited], phase: :apply_1)).to eq(1)
       expect(stats.total_form_count(only: %i[recruited], phase: :apply_2)).to eq(1)
       expect(stats.total_form_count(phase: :apply_2)).to eq(1)
-      expect(stats.total_form_count(except: %i[pending_conditions])).to eq(3)
+      expect(stats.total_form_count(except: %i[pending_conditions])).to eq(2)
     end
   end
 

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -15,11 +15,11 @@ RSpec.feature 'Service performance' do
     when_there_are_candidates_that_have_never_signed_in
     and_i_visit_the_performance_dashboard_in_support
 
-    then_i_see_the_total_number_of_candidates_that_have_not_signed_in
+    then_i_see_the_total_number_of_candidates_in_the_system
 
     when_i_go_a_report_for_a_specific_year
 
-    then_i_only_see_candidates_that_have_signed_in
+    then_i_only_see_candidates_that_signed_up_that_year
   end
 
   def given_i_am_a_support_user
@@ -31,7 +31,12 @@ RSpec.feature 'Service performance' do
   end
 
   def when_there_are_candidates_that_have_never_signed_in
-    create_list(:candidate, 2)
+    Timecop.freeze(2019, 12, 25) do
+      create(:candidate)
+    end
+    Timecop.freeze(2021, 1, 5) do
+      create_list(:candidate, 2)
+    end
   end
 
   def when_i_visit_the_performance_dashboard_in_support
@@ -43,7 +48,6 @@ RSpec.feature 'Service performance' do
 
   def then_i_should_see_the_total_count_of_candidates
     expect(page).to have_content '3 unique candidates'
-    expect(page).not_to have_content 'never signed in'
   end
 
   def and_i_should_see_the_total_count_of_application_forms
@@ -52,17 +56,15 @@ RSpec.feature 'Service performance' do
     end
   end
 
-  def then_i_see_the_total_number_of_candidates_that_have_not_signed_in
-    expect(page).to have_content '5 unique candidates'
-    expect(page).to have_content '2 never signed in'
+  def then_i_see_the_total_number_of_candidates_in_the_system
+    expect(page).to have_content '6 unique candidates'
   end
 
   def when_i_go_a_report_for_a_specific_year
     click_on RecruitmentCycle.cycle_name
   end
 
-  def then_i_only_see_candidates_that_have_signed_in
-    expect(page).to have_content '3 unique candidates'
-    expect(page).not_to have_content 'never signed in'
+  def then_i_only_see_candidates_that_signed_up_that_year
+    expect(page).to have_content '5 unique candidates'
   end
 end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -7,11 +7,19 @@ RSpec.feature 'Service performance' do
     given_i_am_a_support_user
     and_there_are_candidates_and_application_forms_in_the_system
 
-    when_i_visit_the_performance_page_in_support
-    and_i_click_on_the_performance_dashboard_link
+    when_i_visit_the_performance_dashboard_in_support
 
     then_i_should_see_the_total_count_of_candidates
     and_i_should_see_the_total_count_of_application_forms
+
+    when_there_are_candidates_that_have_never_signed_in
+    and_i_visit_the_performance_dashboard_in_support
+
+    then_i_see_the_total_number_of_candidates_that_have_not_signed_in
+
+    when_i_go_a_report_for_a_specific_year
+
+    then_i_only_see_candidates_that_have_signed_in
   end
 
   def given_i_am_a_support_user
@@ -20,26 +28,41 @@ RSpec.feature 'Service performance' do
 
   def and_there_are_candidates_and_application_forms_in_the_system
     create_list(:application_form, 3)
-    create(:candidate)
   end
 
-  def when_i_visit_the_performance_page_in_support
+  def when_there_are_candidates_that_have_never_signed_in
+    create_list(:candidate, 2)
+  end
+
+  def when_i_visit_the_performance_dashboard_in_support
     visit support_interface_performance_path
-  end
-
-  def and_i_click_on_the_performance_dashboard_link
     click_on 'Service performance'
   end
 
+  alias_method :and_i_visit_the_performance_dashboard_in_support, :when_i_visit_the_performance_dashboard_in_support
+
   def then_i_should_see_the_total_count_of_candidates
-    within '#candidate-count' do
-      expect(page).to have_content '4'
-    end
+    expect(page).to have_content '3 unique candidates'
+    expect(page).not_to have_content 'never signed in'
   end
 
   def and_i_should_see_the_total_count_of_application_forms
     within '#application-form-count' do
       expect(page).to have_content '3'
     end
+  end
+
+  def then_i_see_the_total_number_of_candidates_that_have_not_signed_in
+    expect(page).to have_content '5 unique candidates'
+    expect(page).to have_content '2 never signed in'
+  end
+
+  def when_i_go_a_report_for_a_specific_year
+    click_on RecruitmentCycle.cycle_name
+  end
+
+  def then_i_only_see_candidates_that_have_signed_in
+    expect(page).to have_content '3 unique candidates'
+    expect(page).not_to have_content 'never signed in'
   end
 end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -51,9 +51,7 @@ RSpec.feature 'Service performance' do
   end
 
   def and_i_should_see_the_total_count_of_application_forms
-    within '#application-form-count' do
-      expect(page).to have_content '3'
-    end
+    expect(page).to have_content '3 application forms'
   end
 
   def then_i_see_the_total_number_of_candidates_in_the_system

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Service performance' do
     and_i_click_on_the_performance_dashboard_link
 
     then_i_should_see_the_total_count_of_candidates
+    and_i_should_see_the_total_count_of_application_forms
   end
 
   def given_i_am_a_support_user
@@ -19,6 +20,7 @@ RSpec.feature 'Service performance' do
 
   def and_there_are_candidates_and_application_forms_in_the_system
     create_list(:application_form, 3)
+    create(:candidate)
   end
 
   def when_i_visit_the_performance_page_in_support
@@ -30,7 +32,13 @@ RSpec.feature 'Service performance' do
   end
 
   def then_i_should_see_the_total_count_of_candidates
-    within '#headline-stat' do
+    within '#candidate-count' do
+      expect(page).to have_content '4'
+    end
+  end
+
+  def and_i_should_see_the_total_count_of_application_forms
+    within '#application-form-count' do
       expect(page).to have_content '3'
     end
   end


### PR DESCRIPTION
## Context
The application performance dashboard is unclear and a few issues have cropped up with it

## Changes proposed in this pull request
1. Rework the stats and names of things to make it clear that the dashboard is referring to application forms, not candidates
2. Add a separate candidate counter to the dashboard that matches the numbers displayed in the slack messages. Also move the never signed in counter to the candidate section
3. Rework the stats explainers so that they are grouped up with similar statuses

All years view:
<img width="768" alt="Screenshot 2021-01-05 at 13 41 17" src="https://user-images.githubusercontent.com/30071178/103652944-bc051500-4f5b-11eb-98dd-9da1aa6aeca0.png">

Explaining tables:
<img width="748" alt="Screenshot 2020-12-31 at 16 17 48" src="https://user-images.githubusercontent.com/30071178/103417725-c1d9af80-4b83-11eb-9751-e341b8e1653d.png">


## Guidance to review
Visit the dashboard in the review app

## Link to Trello card
https://trello.com/c/rzWhfLeT/3162-changes-to-support-performance-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
