### PR TITLE
Enforce .editorconfig in markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # https://gds-way.cloudapps.digital/manuals/programming-languages/editorconfig
 root = true
 
-[*.{css,erb,js,json,rb,scss,sh,yml}]
+[*.{css,erb,js,json,rb,scss,sh,yml,md}]
 indent_size = 2
 indent_style = space
 charset = utf-8


### PR DESCRIPTION
Make sure these files are consistent with the others, preventing noisy diffs as in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3740.