### PR TITLE
Fix 'confirm_authentication' redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
     get '/sign-in/expired', to: 'sign_in#expired', as: :expired_sign_in
 
     # TODO: remove redirect from Jan 15 2021
-    get '/confirm_authentication', to: redirect('/sign-in/confirm')
+    get '/confirm_authentication', to: redirect('/candidate/sign-in/confirm')
     get '/sign-in/confirm', to: 'sign_in#confirm_authentication', as: :authenticate
     post '/sign-in/confirm', to: 'sign_in#authenticate'
     get '/authenticate', to: 'sign_in#expired'


### PR DESCRIPTION
## Context

See https://trello.com/c/EmpbwjXY/2602-update-routes-paths-and-controllers-to-align-with-interface-misc for context

## Changes proposed in this pull request

Fixes redirect from `/confirm_authentication`  to `/candidate/sign-in/confirm`

## Link to Trello card

https://trello.com/c/EmpbwjXY/2602-update-routes-paths-and-controllers-to-align-with-interface-misc

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
