### PR TITLE
Fix provider-facing application error

### DIFF
--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -51,7 +51,7 @@ module ProviderInterface
     def reference_type_row
       {
         key: 'Type of reference',
-        value: referee_type.capitalize,
+        value: referee_type ? referee_type.capitalize.dasherize : '',
       }
     end
 

--- a/spec/components/provider_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/reference_with_feedback_component_spec.rb
@@ -22,7 +22,17 @@ RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
     it 'contains a type of reference row' do
       row = component.rows.third
       expect(row[:key]).to eq('Type of reference')
-      expect(row[:value]).to include(reference.referee_type.capitalize)
+      expect(row[:value]).to include(reference.referee_type.capitalize.dasherize)
+    end
+
+    context 'referee_type is nil' do
+      let(:reference) { build(:reference, feedback: feedback, referee_type: nil) }
+
+      it 'renders without raisin an error' do
+        row = component.rows.third
+        expect(row[:key]).to eq('Type of reference')
+        expect(row[:value]).to eq('')
+      end
     end
 
     it 'contains a relationship row' do


### PR DESCRIPTION

## Context
There are some references on production with nil referee_type (not sure how that occurs though). This causes part of the provider interface code to fail


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Allow referee_type to be nil on this page
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/5ZG3LPy2/90-provider-having-issue-seeing-application

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
