### PR TITLE
Standardise email validation

### DIFF
--- a/app/forms/candidate_interface/create_account_or_sign_in_form.rb
+++ b/app/forms/candidate_interface/create_account_or_sign_in_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     attr_accessor :existing_account, :email
 
     validates :existing_account, presence: true
-    validates :email, presence: true, email_address: true, if: -> { existing_account? }
+    validates :email, presence: true, valid_for_notify: true, if: -> { existing_account? }
 
     def existing_account?
       ActiveModel::Type::Boolean.new.cast(existing_account)

--- a/app/forms/candidate_interface/find_feedback_form.rb
+++ b/app/forms/candidate_interface/find_feedback_form.rb
@@ -7,7 +7,7 @@ module CandidateInterface
 
     validates :path, :find_controller, :feedback, presence: true
     validates :hidden_feedback_field, absence: true
-    validates :email_address, email_address: true, allow_blank: true
+    validates :email_address, valid_for_notify: true, allow_blank: true
 
     def save
       return false unless valid?

--- a/app/forms/candidate_interface/reference/referee_email_address_form.rb
+++ b/app/forms/candidate_interface/reference/referee_email_address_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     attr_accessor :email_address, :reference_id
 
     validates :email_address, presence: true,
-                              email_address: true,
+                              valid_for_notify: true,
                               length: { maximum: 100 }
 
     validates :reference_id, presence: true

--- a/app/forms/provider_interface/provider_user_form.rb
+++ b/app/forms/provider_interface/provider_user_form.rb
@@ -8,7 +8,7 @@ module ProviderInterface
 
     validates :first_name, :last_name, presence: true, if: :new_provider_user?
     validates :email_address, presence: true, if: :new_provider_user?
-    validates :email_address, email_address: true, if: :new_provider_user?
+    validates :email_address, valid_for_notify: true, if: :new_provider_user?
     validates :provider_permissions, presence: true
     validate :permitted_providers
 

--- a/app/forms/provider_interface/provider_user_form.rb
+++ b/app/forms/provider_interface/provider_user_form.rb
@@ -8,7 +8,7 @@ module ProviderInterface
 
     validates :first_name, :last_name, presence: true, if: :new_provider_user?
     validates :email_address, presence: true, if: :new_provider_user?
-    validates :email_address, email: true, if: :new_provider_user?
+    validates :email_address, email_address: true, if: :new_provider_user?
     validates :provider_permissions, presence: true
     validate :permitted_providers
 

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -9,7 +9,7 @@ module ProviderInterface
 
     with_options(on: :details) do
       validates :email_address, presence: true
-      validates :email_address, email_address: true
+      validates :email_address, valid_for_notify: true
       validates :first_name, presence: true
       validates :last_name, presence: true
     end

--- a/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_applicant_details_form.rb
@@ -16,7 +16,7 @@ module SupportInterface
       validates :first_name, :last_name,
                 length: { maximum: 60 }
 
-      validates :email_address, presence: true, email_address: true, length: { maximum: 100 }
+      validates :email_address, presence: true, valid_for_notify: true, length: { maximum: 100 }
 
       validates :date_of_birth, presence: true
       validate :date_of_birth_valid

--- a/app/forms/support_interface/application_forms/edit_reference_details_form.rb
+++ b/app/forms/support_interface/application_forms/edit_reference_details_form.rb
@@ -7,7 +7,7 @@ module SupportInterface
       attr_accessor :name, :email_address, :relationship, :audit_comment
 
       validates :name, presence: true, length: { minimum: 2, maximum: 200 }
-      validates :email_address, presence: true, email_address: true, length: { maximum: 100 }
+      validates :email_address, presence: true, valid_for_notify: true, length: { maximum: 100 }
       validates :relationship, presence: true, word_count: { maximum: 50 }
       validates :audit_comment, presence: true
 

--- a/app/forms/support_interface/provider_user_form.rb
+++ b/app/forms/support_interface/provider_user_form.rb
@@ -9,7 +9,7 @@ module SupportInterface
     attr_reader :email_address
 
     validates :email_address, :first_name, :last_name, presence: true
-    validates :email_address, email_address: true
+    validates :email_address, valid_for_notify: true
     validate :email_is_unique
     validates :provider_permissions, presence: true
 

--- a/app/forms/support_interface/provider_user_form.rb
+++ b/app/forms/support_interface/provider_user_form.rb
@@ -9,7 +9,7 @@ module SupportInterface
     attr_reader :email_address
 
     validates :email_address, :first_name, :last_name, presence: true
-    validates :email_address, email: true
+    validates :email_address, email_address: true
     validate :email_is_unique
     validates :provider_permissions, presence: true
 

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -10,7 +10,7 @@ class Candidate < ApplicationRecord
   validates :email_address, presence: true,
                             uniqueness: { case_sensitive: false },
                             length: { maximum: 100 },
-                            email_address: true
+                            valid_for_notify: true
 
   has_one :ucas_match
   has_many :application_forms

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -10,7 +10,7 @@ class EmailAddressValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     if value.blank? || !value.match?(EMAIL_REGEX)
-      record.errors[attribute] << I18n.t('activerecord.errors.models.candidate.attributes.email_address.invalid')
+      record.errors[attribute] << I18n.t('validation_errors.email_address_format')
     end
   end
 end

--- a/app/validators/valid_for_notify_validator.rb
+++ b/app/validators/valid_for_notify_validator.rb
@@ -1,4 +1,4 @@
-class EmailAddressValidator < ActiveModel::EachValidator
+class ValidForNotifyValidator < ActiveModel::EachValidator
   ALPHANUMERIC = 'a-zA-Z0-9àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ' + # Number and letters including accented characters
     '\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\uFF00-\uFFEF\u4E00-\u9FAF\u2605-\u2606\u2190-\u2195\u203B'.freeze # Chinese/Japanese/Korean characters
   EMAIL_REGEX = %r{\A[#{ALPHANUMERIC}.!\#$%&'*+\/=?^_`{|}~-] # Local part

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -982,7 +982,6 @@ en:
           attributes:
             email_address:
               blank: Enter your referee’s email address
-              invalid: Enter an email address in the correct format, like name@example.com
               duplicate: Please give a different email address for each referee
         candidate_interface/reference/referee_relationship_form:
           attributes:

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -6,7 +6,6 @@ en:
           attributes:
             email_address:
               blank: Enter your email address
-              invalid: Enter an email address in the correct format, like name@example.com
               too_long: Email address must be %{count} characters or fewer
               dfe_signup_only: Only DfE users can sign up in this test environment
             accept_ts_and_cs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  validation_errors:
+    email_address_format: Enter an email address in the correct format, like name@example.com
   service_name:
     apply: Apply for teacher training
     manage: Manage teacher training applications

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,7 +264,6 @@ en:
               too_long: Last name must be %{count} characters or fewer
             email_address:
               blank: Email address cannot be blank
-              invalid: Enter an email address in the correct format, like name@example.com
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer
             date_of_birth:
@@ -287,7 +286,6 @@ en:
               too_long: Referee’s name must be %{count} characters or fewer
             email_address:
               blank: Enter an email address
-              invalid: Enter an email address in the correct format, like name@example.com
               too_long: Email address must be %{count} characters or fewer
             relationship:
               blank: Relationship cannot be blank
@@ -449,7 +447,6 @@ en:
               blank: Enter your email address
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer
-              invalid: Enter an email address in the correct format, like name@example.com
         application_reference:
           attributes:
             feedback_status:

--- a/spec/validators/valid_for_notify_validator_spec.rb
+++ b/spec/validators/valid_for_notify_validator_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe EmailAddressValidator do
+RSpec.describe ValidForNotifyValidator do
   before do
     stub_const('Validatable', Class.new).class_eval do
       include ActiveModel::Validations
       attr_accessor :email_address
-      validates :email_address, email_address: true
+      validates :email_address, valid_for_notify: true
     end
   end
 
@@ -85,7 +85,7 @@ RSpec.describe EmailAddressValidator do
     it 'returns the correct error message' do
       model.email_address = 'foo'
       model.validate(:no_context)
-      expect(model.errors[:email_address]).to include(t('activerecord.errors.models.candidate.attributes.email_address.invalid'))
+      expect(model.errors[:email_address]).to include(t('validation_errors.email_address_format'))
     end
   end
 end


### PR DESCRIPTION
## Context
We want to ensure we have a consistent way of validating emails.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Use EmailAddressValidator for remaining email validations that weren't using it
- Make the error message a translation string with a more general-purpose namespace
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- See diff
- Can be tested via support interface by adding a new provider user
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/VRJnsI1G
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
