### PR TITLE
Allow users to be pointed to a specific endpoint using the AuthenticationToken

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class AfterSignInController < CandidateInterfaceController
-    before_action :redirect_to_path_if_path_params_are_present_and_valid
+    before_action :redirect_to_path_if_path_params_are_present
     before_action :redirect_to_application_form_unless_course_from_find_is_present
 
     def interstitial
@@ -23,8 +23,8 @@ module CandidateInterface
 
   private
 
-    def redirect_to_path_if_path_params_are_present_and_valid
-      redirect_to path_params if params[:path].present? || valid_paths.include?(params[:path])
+    def redirect_to_path_if_path_params_are_present
+      redirect_to params[:path] if params[:path].present?
     end
 
     def redirect_to_application_form_unless_course_from_find_is_present
@@ -41,14 +41,6 @@ module CandidateInterface
       else
         redirect_to candidate_interface_application_form_path
       end
-    end
-
-    def valid_paths
-      Rails.application.routes.named_routes.helper_names
-    end
-
-    def path_params
-      Rails.application.routes.url_helpers.send(params[:path])
     end
 
     def course_from_find

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -84,7 +84,7 @@ module CandidateInterface
         end
 
       if candidate
-        CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate, path: authentication_token.path)
+        CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate, path: authentication_token&.path)
         add_identity_to_log candidate.id
         redirect_to candidate_interface_check_email_sign_in_path
       else

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class SignInController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
-    before_action :redirect_to_application_if_signed_in, except: %i[authenticate]
+    before_action :redirect_to_application_if_signed_in, except: %i[confirm_authentication authenticate]
 
     def new
       candidate = Candidate.new
@@ -16,14 +16,14 @@ module CandidateInterface
     # some email clients preload links in emails, this is an extra step where
     # they click a button to confirm the sign in.
     def confirm_authentication
-      authentication_token = AuthenticationToken.find_by_hashed_token(
+      @authentication_token = AuthenticationToken.find_by_hashed_token(
         user_type: 'Candidate',
         raw_token: params[:token],
       )
 
-      if authentication_token&.still_valid?
+      if @authentication_token&.still_valid?
         render 'confirm_authentication'
-      elsif authentication_token
+      elsif @authentication_token
         # If the token is expired, redirect the user to a page
         # with their token as a param where they can request
         # a new sign in email.

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -84,7 +84,7 @@ module CandidateInterface
         end
 
       if candidate
-        CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate)
+        CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate, path: authentication_token.path)
         add_identity_to_log candidate.id
         redirect_to candidate_interface_check_email_sign_in_path
       else

--- a/app/models/concerns/authenticated_using_magic_links.rb
+++ b/app/models/concerns/authenticated_using_magic_links.rb
@@ -5,9 +5,9 @@ module AuthenticatedUsingMagicLinks
     has_many :authentication_tokens, as: :user, dependent: :destroy
   end
 
-  def create_magic_link_token!
+  def create_magic_link_token!(path: nil)
     magic_link_token = MagicLinkToken.new
-    authentication_tokens.create!(hashed_token: magic_link_token.encrypted)
+    authentication_tokens.create!(hashed_token: magic_link_token.encrypted, path: path)
     magic_link_token.raw
   end
 end

--- a/app/services/candidate_interface/request_magic_link.rb
+++ b/app/services/candidate_interface/request_magic_link.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class RequestMagicLink
-    def self.for_sign_in(candidate:)
-      magic_link_token = candidate.create_magic_link_token!
+    def self.for_sign_in(candidate:, path: nil)
+      magic_link_token = candidate.create_magic_link_token!(path: path)
       AuthenticationMailer.sign_in_email(candidate: candidate, token: magic_link_token).deliver_later
     end
 

--- a/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
+++ b/app/views/candidate_interface/sign_in/confirm_authentication.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: candidate_interface_authenticate_path(path: params[:path]), method: :post do |f| %>
+    <%= form_with url: candidate_interface_authenticate_path(path: @authentication_token.path), method: :post do |f| %>
       <h1 class="govuk-heading-xl">
         <%= t('authentication.confirm_authentication.heading') %>
       </h1>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,26 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "01e22ed63f381bb4b86dccec3d36ccea3421257bfa1bbfaa67410f416a9a5456",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/candidate_interface/after_sign_in_controller.rb",
+      "line": 27,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(params[:path])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CandidateInterface::AfterSignInController",
+        "method": "redirect_to_path_if_path_params_are_present"
+      },
+      "user_input": "params[:path]",
+      "confidence": "High",
+      "note": ""
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "07081676ffe0bf0ef753045ae9dcc86c848df5f35a9e48a22692159d5352fbd1",
@@ -121,26 +141,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "cb6f23f5b570c8aed112a88283fabb07b15412263e43126b941534f3e99074d1",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/controllers/candidate_interface/after_sign_in_controller.rb",
-      "line": 53,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "Rails.application.routes.url_helpers.send(params[:path])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "CandidateInterface::AfterSignInController",
-        "method": "path_params"
-      },
-      "user_input": "params[:path]",
-      "confidence": "High",
-      "note": ""
-    },
-    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "d910924006fc5ba7182ea2b067b9113b5ea86616fc332f0f15291fd9f34cec66",
@@ -161,6 +161,6 @@
       "note": ""
     }
   ],
-  "updated": "2020-11-03 19:37:48 +0000",
-  "brakeman_version": "4.10.0"
+  "updated": "2021-01-07 21:49:29 +0000",
+  "brakeman_version": "4.10.1"
 }

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidates authenitcation token has the path attriute populated' do
+  include SignInHelper
+  include CandidateHelper
+
+  scenario 'Candidate is redirected to the appropriate page' do
+    given_the_pilot_is_open
+    and_i_am_a_candidate_with_an_account
+    and_i_have_received_a_token_associated_with_the_personal_statment_path
+
+    when_i_sign_in_using_the_token
+    and_i_confirm_the_sign_in
+    then_i_receive_am_redirected_to_the_personal_statement_page
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_i_am_a_candidate_with_an_account
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_received_a_token_associated_with_the_personal_statment_path
+    @magic_link_token = MagicLinkToken.new
+    create(:authentication_token, user: current_candidate, hashed_token: @magic_link_token.encrypted, path: 'candidate_interface_edit_becoming_a_teacher_path')
+  end
+
+  def when_i_sign_in_using_the_token
+    visit candidate_interface_authenticate_path(token: @magic_link_token.raw)
+  end
+
+  def and_i_confirm_the_sign_in
+    confirm_sign_in
+  end
+
+  def then_i_receive_am_redirected_to_the_personal_statement_page
+    expect(page).to have_current_path candidate_interface_edit_becoming_a_teacher_path
+  end
+end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -23,6 +23,20 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
     when_i_click_on_the_link_in_my_email
     and_i_confirm_the_sign_in
     then_i_am_redirected_to_the_personal_statement_page
+
+    given_i_have_a_reference_in_the_not_requested_yet_state
+    and_i_have_received_a_token_associated_with_the_review_unsubmitted_reference_path
+
+    when_i_sign_in_using_the_token
+    and_i_confirm_the_sign_in
+    then_i_am_redirected_to_the_review_unsubmitted_reference_page
+
+    given_i_have_received_a_token_associated_with_the_review_unsubmitted_reference_path
+    and_i_have_subsequently_deleted_the_reference
+
+    when_i_sign_in_using_the_token
+    and_i_confirm_the_sign_in
+    then_i_see_the_references_start_page
   end
 
   def given_the_pilot_is_open
@@ -82,5 +96,35 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
   def then_i_receive_an_email_inviting_me_to_sign_in
     open_email(@candidate.email_address)
     expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+  end
+
+  def given_i_have_a_reference_in_the_not_requested_yet_state
+    @reference = create(:reference, :not_requested_yet, application_form: @candidate.current_application)
+  end
+
+  def and_i_have_received_a_token_associated_with_the_review_unsubmitted_reference_path
+    @magic_link_token = MagicLinkToken.new
+    create(
+      :authentication_token,
+      user: @candidate,
+      hashed_token: @magic_link_token.encrypted,
+      path: "http://localhost:3000/candidate/application/references/review-unsubmitted/#{@reference.id}",
+    )
+  end
+
+  def then_i_am_redirected_to_the_review_unsubmitted_reference_page
+    expect(page).to have_current_path candidate_interface_references_review_unsubmitted_path(@reference.id)
+  end
+
+  def and_i_have_subsequently_deleted_the_reference
+    @reference.destroy
+  end
+
+  def given_i_have_received_a_token_associated_with_the_review_unsubmitted_reference_path
+    and_i_have_received_a_token_associated_with_the_review_unsubmitted_reference_path
+  end
+
+  def then_i_see_the_references_start_page
+    expect(page).to have_current_path candidate_interface_references_start_path
   end
 end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
 
     when_i_sign_in_using_the_token
     and_i_confirm_the_sign_in
-    then_i_receive_am_redirected_to_the_personal_statement_page
+    then_i_am_redirected_to_the_personal_statement_page
 
     given_i_am_signed_out
     and_i_have_an_expired_token_associated_with_the_personal_statment_path
@@ -22,7 +22,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
 
     when_i_click_on_the_link_in_my_email
     and_i_confirm_the_sign_in
-    then_i_receive_am_redirected_to_the_personal_statement_page
+    then_i_am_redirected_to_the_personal_statement_page
   end
 
   def given_the_pilot_is_open
@@ -52,7 +52,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
     confirm_sign_in
   end
 
-  def then_i_receive_am_redirected_to_the_personal_statement_page
+  def then_i_am_redirected_to_the_personal_statement_page
     expect(page).to have_current_path candidate_interface_edit_becoming_a_teacher_path
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -12,6 +12,17 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
     when_i_sign_in_using_the_token
     and_i_confirm_the_sign_in
     then_i_receive_am_redirected_to_the_personal_statement_page
+
+    given_i_am_signed_out
+    and_i_have_an_expired_token_associated_with_the_personal_statment_path
+
+    when_i_sign_in_using_the_token
+    and_i_request_a_new_link
+    then_i_receive_an_email_inviting_me_to_sign_in
+
+    when_i_click_on_the_link_in_my_email
+    and_i_confirm_the_sign_in
+    then_i_receive_am_redirected_to_the_personal_statement_page
   end
 
   def given_the_pilot_is_open
@@ -20,11 +31,17 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
 
   def and_i_am_a_candidate_with_an_account
     create_and_sign_in_candidate
+    @candidate = current_candidate
   end
 
   def and_i_have_received_a_token_associated_with_the_personal_statment_path
     @magic_link_token = MagicLinkToken.new
-    create(:authentication_token, user: current_candidate, hashed_token: @magic_link_token.encrypted, path: 'candidate_interface_edit_becoming_a_teacher_path')
+    create(
+      :authentication_token,
+      user: @candidate,
+      hashed_token: @magic_link_token.encrypted,
+      path: 'candidate_interface_edit_becoming_a_teacher_path',
+    )
   end
 
   def when_i_sign_in_using_the_token
@@ -37,5 +54,33 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
 
   def then_i_receive_am_redirected_to_the_personal_statement_page
     expect(page).to have_current_path candidate_interface_edit_becoming_a_teacher_path
+  end
+
+  def given_i_am_signed_out
+    click_link 'Sign out'
+  end
+
+  def and_i_have_an_expired_token_associated_with_the_personal_statment_path
+    @magic_link_token = MagicLinkToken.new
+    create(
+      :authentication_token,
+      user: @candidate,
+      hashed_token: @magic_link_token.encrypted,
+      path: 'candidate_interface_edit_becoming_a_teacher_path',
+      created_at: 2.hours.ago,
+    )
+  end
+
+  def and_i_request_a_new_link
+    click_button 'Email me a new link'
+  end
+
+  def when_i_click_on_the_link_in_my_email
+    click_magic_link_in_email
+  end
+
+  def then_i_receive_an_email_inviting_me_to_sign_in
+    open_email(@candidate.email_address)
+    expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
   end
 end

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -1,20 +1,20 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidates authenitcation token has the path attriute populated' do
+RSpec.feature 'Candidates authentication token has the path attribute populated' do
   include SignInHelper
   include CandidateHelper
 
   scenario 'Candidate is redirected to the appropriate page' do
     given_the_pilot_is_open
     and_i_am_a_candidate_with_an_account
-    and_i_have_received_a_token_associated_with_the_personal_statment_path
+    and_i_have_received_a_token_associated_with_the_personal_statement_path
 
     when_i_sign_in_using_the_token
     and_i_confirm_the_sign_in
     then_i_am_redirected_to_the_personal_statement_page
 
     given_i_am_signed_out
-    and_i_have_an_expired_token_associated_with_the_personal_statment_path
+    and_i_have_an_expired_token_associated_with_the_personal_statement_path
 
     when_i_sign_in_using_the_token
     and_i_request_a_new_link
@@ -48,7 +48,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
     @candidate = current_candidate
   end
 
-  def and_i_have_received_a_token_associated_with_the_personal_statment_path
+  def and_i_have_received_a_token_associated_with_the_personal_statement_path
     @magic_link_token = MagicLinkToken.new
     create(
       :authentication_token,
@@ -74,7 +74,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
     click_link 'Sign out'
   end
 
-  def and_i_have_an_expired_token_associated_with_the_personal_statment_path
+  def and_i_have_an_expired_token_associated_with_the_personal_statement_path
     @magic_link_token = MagicLinkToken.new
     create(
       :authentication_token,
@@ -108,7 +108,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
       :authentication_token,
       user: @candidate,
       hashed_token: @magic_link_token.encrypted,
-      path: "http://localhost:3000/candidate/application/references/review-unsubmitted/#{@reference.id}",
+      path: "/candidate/application/references/review-unsubmitted/#{@reference.id}",
     )
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_with_an_authentication_token_with_a_path_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
       :authentication_token,
       user: @candidate,
       hashed_token: @magic_link_token.encrypted,
-      path: 'candidate_interface_edit_becoming_a_teacher_path',
+      path: '/candidate/application/personal-statement/becoming-a-teacher',
     )
   end
 
@@ -66,7 +66,7 @@ RSpec.feature 'Candidates authenitcation token has the path attriute populated' 
       :authentication_token,
       user: @candidate,
       hashed_token: @magic_link_token.encrypted,
-      path: 'candidate_interface_edit_becoming_a_teacher_path',
+      path: '/candidate/application/personal-statement/becoming-a-teacher',
       created_at: 2.hours.ago,
     )
   end


### PR DESCRIPTION
## Context

Previously we built some functionality to be able to send users to a specific page on login. This worked by using a path param in the query string when arriving at the authentication actions.

After discussion with Rachael, Dan and Mike it seems likely that we will use this functionality going forward.

This PR changes the implementation to store the endpoint on an attribute on the AuthenticationToken.

## Changes proposed in this pull request

- Use the path att on the AuthenticationToken to point candidates the desired endpoint
- Ensures that expired tokens behave correctly
 
## Guidance to review

Does this approach seem reasonable? I know this is a bit of a weird ticket as it's not actually being used for anything right now, but does the approach seem sensible. 

## Link to Trello card

https://trello.com/c/dTjHZxp0/2682-use-authenticationtoken-to-redirect-a-user-to-the-correct-endpoint

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
