### PR TITLE
Structured grades refactor

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -177,28 +177,20 @@ module VendorAPI
 
     def format_gcses
       gcses = qualifications_of_level('gcse').reject(&:missing_qualification?)
-      parsed_gcses = parse_structured_gcses(gcses)
-      parsed_gcses.map { |q| qualification_to_hash(q) }
-    end
 
-    def parse_structured_gcses(gcses)
-      multiple_gcses = gcses.select { |gcse| gcse[:subject] != 'science triple award' && gcse[:structured_grades].present? }
-
-      if multiple_gcses.any?
-        multiple_gcses.each do |multiple_gcse|
-          structured_grades = JSON.parse(multiple_gcse[:structured_grades])
-
-          structured_grades.each do |k, v|
-            new_separated_gcse = multiple_gcse.dup
-            new_separated_gcse.subject = k.humanize
-            new_separated_gcse.grade = v
-            gcses << new_separated_gcse
-          end
-
-          gcses.delete_if { |gcse| gcse == multiple_gcse }
+      # This is to split structured GCSEs in to separate GCSE qualifications for the API
+      # Science triple award grades are already properly formatted and so are left out here
+      structured_gcses = gcses.select { |gcse| gcse[:subject] != 'science triple award' && gcse[:structured_grades].present? }
+      separated_gcse_hashes = []
+      if structured_gcses.any?
+        structured_gcses.each do |structured_gcse|
+          separated_gcse_hashes << structured_gcse_to_hashes(structured_gcse)
+          gcses.delete_if { |gcse| gcse == structured_gcse }
         end
       end
-      gcses
+
+      gcses_hashes = gcses.map { |q| qualification_to_hash(q) }
+      (gcses_hashes + separated_gcse_hashes).flatten
     end
 
     def qualifications_of_level(level)
@@ -208,6 +200,28 @@ module VendorAPI
       application_form.application_qualifications.select do |q|
         q.level == level
       end
+    end
+
+    def structured_gcse_to_hashes(gcse)
+      separated_gcses_hashes = []
+      structured_grades = JSON.parse(gcse[:structured_grades])
+      structured_grades.each do |k, v|
+        separated_gcse = {
+          id: gcse.id,
+          qualification_type: gcse.qualification_type,
+          non_uk_qualification_type: gcse.non_uk_qualification_type,
+          subject: k.humanize,
+          grade: v,
+          start_year: gcse.start_year,
+          award_year: gcse.award_year,
+          institution_details: institution_details(gcse),
+          awarding_body: gcse.awarding_body,
+          equivalency_details: gcse.composite_equivalency_details,
+        }.merge HesaQualificationFieldsPresenter.new(gcse).to_hash
+
+        separated_gcses_hashes << separated_gcse
+      end
+      separated_gcses_hashes
     end
 
     def qualification_to_hash(qualification)

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -200,16 +200,11 @@ module VendorAPI
     end
 
     def structured_gcse_to_hashes(gcse)
-      separated_gcses_hashes = []
       structured_grades = JSON.parse(gcse[:structured_grades])
-
-      structured_grades.each do |subject, grade|
-        separated_gcse = qualification_to_hash(gcse)
-                             .merge(subject: subject.humanize, grade: grade)
-
-        separated_gcses_hashes << separated_gcse
+      structured_grades.reduce([]) do |array, (subject, grade)|
+        array << qualification_to_hash(gcse)
+                     .merge(subject: subject.humanize, grade: grade)
       end
-      separated_gcses_hashes
     end
 
     def qualification_to_hash(qualification)

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -796,7 +796,7 @@ components:
       properties:
         id:
           type: integer
-          description: The qualification ID in the Apply system
+          description: The qualification ID in the Apply system. These ids are not unique
           example: 123
         qualification_type:
           type: string

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -796,7 +796,7 @@ components:
       properties:
         id:
           type: integer
-          description: The qualification ID in the Apply system. These ids are not unique
+          description: The qualification ID in the Apply system. These IDs are not guaranteed to be unique, for example when a candidate has multiple English GCSEs
           example: 123
         qualification_type:
           type: string
@@ -904,7 +904,7 @@ components:
       properties:
         id:
           type: integer
-          description: A unique reference id
+          description: A unique reference ID
           example: 4321
         name:
           type: string

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -516,6 +516,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     it 'parses English GCSE structured grades' do
       create(
         :gcse_qualification,
+        id: 1,
         subject: 'english',
         grade: nil,
         structured_grades: '{"english_language":"E","english_literature":"E","Cockney Rhyming Slang":"A*"}',
@@ -530,6 +531,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :gcses,
       ).find { |q| q[:subject] == 'English language' }
 
+      expect(english_language[:id]).to eq 1
       expect(english_language[:grade]).to eq 'E'
 
       english_literature = presenter.as_json.dig(
@@ -538,6 +540,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :gcses,
       ).find { |q| q[:subject] == 'English literature' }
 
+      expect(english_literature[:id]).to eq 1
       expect(english_literature[:grade]).to eq 'E'
 
       rhyming_slang = presenter.as_json.dig(
@@ -546,6 +549,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :gcses,
       ).find { |q| q[:subject] == 'Cockney rhyming slang' }
 
+      expect(rhyming_slang[:id]).to eq 1
       expect(rhyming_slang[:grade]).to eq 'A*'
     end
   end


### PR DESCRIPTION
## Context

We want to split out structured GCSEs into separate qualifications when we present them in the API. Previously, when we split the GCSEs, the newly created separated GCSEs had an id value of `null`. This PR refactors how we handle the splitting of GCSEs and uses the original ID of the structured GCSE.


## Guidance to review

Could we refactor or improve the splitting code any further? 

## Link to Trello card

https://trello.com/c/OrxCzhO2/2772-remove-the-structured-quals-feature-flags

