### PR TITLE
Reinstate authentication links from emails that rely on the `u` (user id) param

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -70,13 +70,13 @@ module CandidateInterface
     end
 
     def create_from_expired_token
-      encrypted_user_id = params.fetch(:u)
+      encrypted_user_id = params[:u]
       authentication_token = AuthenticationToken.find_by_hashed_token(
         user_type: 'Candidate',
         raw_token: params[:token],
       )
 
-      candidate = if encrypted_user_id
+      candidate = if encrypted_user_id.present?
         Candidate.find(Encryptor.decrypt(encrypted_user_id))
       elsif authentication_token
         authentication_token.user

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -76,11 +76,12 @@ module CandidateInterface
         raw_token: params[:token],
       )
 
-      candidate = if encrypted_user_id.present?
-        Candidate.find(Encryptor.decrypt(encrypted_user_id))
-      elsif authentication_token
-        authentication_token.user
-      end
+      candidate =
+        if encrypted_user_id.present?
+          Candidate.find(Encryptor.decrypt(encrypted_user_id))
+        elsif authentication_token
+          authentication_token.user
+        end
 
       if candidate
         CandidateInterface::RequestMagicLink.for_sign_in(candidate: candidate)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -31,6 +31,10 @@ class Candidate < ApplicationRecord
     application_forms.max_by(&:updated_at)
   end
 
+  def encrypted_id
+    Encryptor.encrypt(id)
+  end
+
 private
 
   def downcase_email

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -10,6 +10,7 @@
         Sign in links only work once and expire after one hour, so you need to request a new one. We’ll send this by email.
       </p>
 
+      <%= hidden_field_tag :u, params[:u] %>
       <%= hidden_field_tag :token, params[:token] %>
 
       <%= f.govuk_submit t('authentication.expired_token.button') %>

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -65,4 +65,14 @@ RSpec.describe Candidate, type: :model do
       expect(candidate.course_from_find).to eq(nil)
     end
   end
+ 
+  describe '#encrypted_id' do
+    let(:candidate) { create(:candidate) }
+
+    it 'invokes Encryptor to encrypt id' do
+      allow(Encryptor).to receive(:encrypt).with(candidate.id).and_return 'encrypted id value'
+
+      expect(candidate.encrypted_id).to eq 'encrypted id value'
+    end
+  end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Candidate, type: :model do
       expect(candidate.course_from_find).to eq(nil)
     end
   end
- 
+
   describe '#encrypted_id' do
     let(:candidate) { create(:candidate) }
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
@@ -43,14 +43,10 @@ RSpec.feature 'Candidate account' do
   end
 
   def and_i_try_to_use_a_legacy_email_link
-    visit candidate_interface_authenticate_path(
-      token: :missing_token,
-      u: current_candidate.encrypted_id,
-    )
+    visit "/candidate/sign-in/confirm?token=missing_token&u=#{current_candidate.encrypted_id}"
   end
 
   def then_i_am_prompted_to_get_a_new_magic_link
-    save_and_open_page
     expect(page).to have_content 'The link you clicked has expired'
   end
 

--- a/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
+++ b/spec/system/candidate_interface/signup_and_signin/candidate_signs_in_using_legacy_email_link_with_u_param_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate account' do
+  include CandidateHelper
+  include SignInHelper
+
+  scenario 'Candidate tries to sign in with a legacy email link containing a missing token and `u` param' do
+    given_the_pilot_is_open
+    and_i_am_an_existing_candidate
+
+    when_i_sign_in_and_out
+    and_i_try_to_use_a_legacy_email_link
+    then_i_am_prompted_to_get_a_new_magic_link
+
+    when_i_get_a_new_magic_link
+    then_i_can_sign_in_again
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_i_am_an_existing_candidate
+    current_candidate
+  end
+
+  def when_i_sign_in_and_out
+    visit candidate_interface_sign_in_path
+    fill_in 'Enter your email address', with: current_candidate.email_address
+    click_button 'Continue'
+    open_email(current_candidate.email_address)
+    expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+
+    @magic_link = current_email.find_css('a').first
+    @magic_link.click
+    confirm_sign_in
+    within 'header' do
+      expect(page).to have_content current_candidate.email_address
+    end
+
+    click_link 'Sign out'
+    expect(page).to have_current_path(candidate_interface_create_account_or_sign_in_path)
+  end
+
+  def and_i_try_to_use_a_legacy_email_link
+    visit candidate_interface_authenticate_path(
+      token: :missing_token,
+      u: current_candidate.encrypted_id,
+    )
+  end
+
+  def then_i_am_prompted_to_get_a_new_magic_link
+    save_and_open_page
+    expect(page).to have_content 'The link you clicked has expired'
+  end
+
+  def when_i_get_a_new_magic_link
+    click_button 'Email me a new link'
+
+    open_email(current_candidate.email_address)
+    @new_magic_link = current_email.find_css('a').first
+  end
+
+  def then_i_can_sign_in_again
+    @new_magic_link.click
+    confirm_sign_in
+    within 'header' do
+      expect(page).to have_content current_candidate.email_address
+    end
+  end
+end


### PR DESCRIPTION
## Context

https://github.com/DFE-Digital/apply-for-teacher-training/pull/3717 removed the uniquely identify users via the `u` (encrypted user id) param in favour of the `token` param that is being used going forward. This broke existing links in emails that have been sent in the past. This PR reinstates the old functionality alongside the new so that links such as `/candidate/sign-in/confirm?token=<token>&u=<encrypted-user-id>` where `token` is a missing token continue to work.

## Changes proposed in this pull request

- New system spec to reproduce the issue.
- Reinstate the flow through `CandidateInterface::SignInController` that uses the `u` param to prompt the candidate to resend a new magic link without the candidate having to re-enter their email address.

## Guidance to review

- Does this completely restore the original feature?
- Does the new system spec cover the legacy use case?

## Link to Trello card

https://trello.com/c/sVFcG2EJ/2824-reinstate-authentication-links-from-emails-that-rely-on-the-u-user-id-param

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
