### PR TITLE
Remove comments instructing redirects to be removed in future

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -482,7 +482,7 @@ Rails.application.routes.draw do
       end
     end
 
-    get '*path', to: redirect('/candidate/application')
+    get '*path', to: 'errors#not_found'
   end
 
   namespace :referee_interface, path: '/reference' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,6 @@ Rails.application.routes.draw do
     get '/sign-in/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_in
     get '/sign-in/expired', to: 'sign_in#expired', as: :expired_sign_in
 
-    # TODO: remove redirect from Jan 15 2021
     get '/confirm_authentication', to: redirect('/candidate/sign-in/confirm')
     get '/sign-in/confirm', to: 'sign_in#confirm_authentication', as: :authenticate
     post '/sign-in/confirm', to: 'sign_in#authenticate'
@@ -78,7 +77,6 @@ Rails.application.routes.draw do
       get '/start-carry-over' => 'carry_over#start', as: :start_carry_over
       post '/carry-over' => 'carry_over#create', as: :carry_over
 
-      # TODO: Remove temporary redirects from Jan 15 2021
       scope '/personal-details' do
         get '/', to: redirect('/candidate/application/personal-information')
         get '/edit', to: redirect('/candidate/application/personal-information/edit')
@@ -133,7 +131,6 @@ Rails.application.routes.draw do
         patch '/interview-preferences/complete' => 'personal_statement/interview_preferences#complete', as: :interview_preferences_complete
       end
 
-      # TODO: Remove temporary redirects from Jan 15 2021
       scope '/training-with-a-disability' do
         get '/', to: redirect('/candidate/application/additional-support')
         get '/review', to: redirect('/candidate/application/additional-support/review')
@@ -146,7 +143,6 @@ Rails.application.routes.draw do
         patch '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
       end
 
-      # TODO: Remove temporary redirects from Jan 15 2021
       scope '/contact-details' do
         get '/', to: redirect('/candidate/application/contact-information')
         get '/address_type', to: redirect('/candidate/application/contact-information/address-type')
@@ -226,7 +222,6 @@ Rails.application.routes.draw do
         delete '/delete/:id' => 'work_history/destroy#destroy'
       end
 
-      # TODO: Remove temporary redirects from Jan 15 2021
       scope '/school-experience' do
         get '/', to: redirect('/candidate/application/unpaid-experience')
         get '/new', to: redirect('/candidate/application/unpaid-experience/new')
@@ -268,7 +263,6 @@ Rails.application.routes.draw do
         get '/:id/institution/edit' => 'degrees/institution#edit', as: :edit_degree_institution
         patch '/:id/institution/edit' => 'degrees/institution#update'
 
-        # TODO: Remove temporary redirects from Jan 15 2021
         get '/:id/completion_status', to: redirect { |params, _| "/candidate/application/degrees/#{params[:id]}/completion-status" }
         get '/:id/completion_status/edit', to: redirect { |params, _| "/candidate/application/degrees/#{params[:id]}/completion-status/edit" }
 


### PR DESCRIPTION
## Context

- We are implementing GovUK's internal policy of never returning a '404' status code for a url that was previously returning a '200' status code.
- As we are keeping the redirects indefinitely, any unknown urls on the '/application' path can redirect to the 404 page as before

See https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1609860512017600?thread_ts=1609840340.004400&cid=CN1MCQCHZ

## Changes proposed in this pull request
- Comments in the `routes.rb` file instructing redirects to be removed at some point in the future have been removed.
- Any unknown urls on the '/application' path are now redirecting to the 404 page (again). 

## Link to Trello card

https://trello.com/c/fG6mxqVz/2833-remove-comments-from-routes-file-instructing-to-remove-redirects

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
