### PR TITLE
Add request specs for redirects (Candidate interface)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -500,7 +500,7 @@ Rails.application.routes.draw do
       end
     end
 
-    get '*path', to: redirect('/candidate/application')
+    get '*path', to: 'errors#not_found'
   end
 
   namespace :referee_interface, path: '/reference' do

--- a/spec/requests/candidate_interface/redirects_spec.rb
+++ b/spec/requests/candidate_interface/redirects_spec.rb
@@ -45,7 +45,15 @@ RSpec.describe 'Candidate Interface - Redirects', type: :request do
         get path
 
         expect(response.status).to eq(301)
+        expect(path_exists?(response.location)).to be true
       end
     end
+  end
+
+  def path_exists?(path)
+    controller_params = Rails.application.routes.recognize_path(path)
+    controller_params[:action] != 'not_found'
+  rescue ActionController::RoutingError
+    false
   end
 end

--- a/spec/requests/candidate_interface/redirects_spec.rb
+++ b/spec/requests/candidate_interface/redirects_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate Interface - Redirects', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  def candidate
+    @candidate ||= create :candidate
+  end
+
+  before { sign_in candidate }
+
+  describe 'Permanent redirects (301)' do
+    [
+      '/candidate/confirm_authentication',
+      '/candidate/application/personal-details',
+      '/candidate/application/personal-details/edit',
+      '/candidate/application/personal-details/nationalities',
+      '/candidate/application/personal-details/nationalities/edit',
+      '/candidate/application/personal-details/languages',
+      '/candidate/application/personal-details/languages/edit',
+      '/candidate/application/personal-details/right-to-work-or-study',
+      '/candidate/application/personal-details/right-to-work-or-study/edit',
+      '/candidate/application/personal-details/review',
+      '/candidate/application/personal-statement/becoming-a-teacher',
+      '/candidate/application/personal-statement/becoming-a-teacher/review',
+      '/candidate/application/personal-statement/subject-knowledge',
+      '/candidate/application/personal-statement/subject-knowledge/review',
+      '/candidate/application/personal-statement/interview-preferences',
+      '/candidate/application/personal-statement/interview-preferences/review',
+      '/candidate/application/training-with-a-disability',
+      '/candidate/application/training-with-a-disability/review',
+      '/candidate/application/contact-details',
+      '/candidate/application/contact-details/address_type',
+      '/candidate/application/contact-details/address',
+      '/candidate/application/contact-details/review',
+      '/candidate/application/school-experience',
+      '/candidate/application/school-experience/new',
+      '/candidate/application/school-experience/edit/any_id',
+      '/candidate/application/school-experience/review',
+      '/candidate/application/school-experience/delete/any_id',
+      '/candidate/application/degrees/any_id/completion_status',
+      '/candidate/application/degrees/any_id/completion_status/edit',
+    ].each do |path|
+      it "returns status code 301 for #{path}" do
+        get path
+
+        expect(response.status).to eq(301)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We've added some redirects to the `routes.rb` file as part of the wider work to update routes.

As we plan to now keep these new redirects around indefinitely we should add request specs to ensure redirects are working as expected.

## Changes proposed in this pull request

- Add request specs for redirects

## Guidance to review

NA

## Link to Trello card

https://trello.com/c/UiFVoJp8/2834-add-request-specs-for-redirects

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
