### PR TITLE
Add validations to provider permissions setting forms

### DIFF
--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -16,6 +16,7 @@ module ProviderInterface
 
     validates :providers, presence: true, on: :providers
     validates :view_applications_only, presence: { message: 'Choose whether this user has extra permissions' }, on: :permissions
+    validate :at_least_one_extra_permission_is_set_if_necessary, on: :permissions
 
     class PermissionsForm
       include ActiveModel::Model
@@ -123,6 +124,15 @@ module ProviderInterface
     end
 
   private
+
+    def at_least_one_extra_permission_is_set_if_necessary
+      return if ActiveModel::Type::Boolean.new.cast(view_applications_only)
+
+      selected_permissions = provider_permissions[current_provider_id].fetch('permissions', []).reject(&:blank?)
+      if selected_permissions.count == 0
+        errors[:provider_permissions] << 'Select extra permissions'
+      end
+    end
 
     def delete_permissions_if_view_applications_only(attrs)
       attrs.fetch(:provider_permissions, {}).each_key do |k|

--- a/app/forms/provider_interface/provider_user_invitation_wizard.rb
+++ b/app/forms/provider_interface/provider_user_invitation_wizard.rb
@@ -128,8 +128,8 @@ module ProviderInterface
     def at_least_one_extra_permission_is_set_if_necessary
       return if ActiveModel::Type::Boolean.new.cast(view_applications_only)
 
-      selected_permissions = provider_permissions[current_provider_id].fetch('permissions', []).reject(&:blank?)
-      if selected_permissions.count == 0
+      selected_permissions = permissions_for(current_provider_id).fetch('permissions', []).reject(&:blank?)
+      if selected_permissions.none?
         errors[:provider_permissions] << 'Select extra permissions'
       end
     end

--- a/app/forms/provider_interface/provider_user_permissions_form.rb
+++ b/app/forms/provider_interface/provider_user_permissions_form.rb
@@ -35,9 +35,8 @@ module ProviderInterface
     end
 
     def update_from_params(hash)
-      view_applications_only = ActiveModel::Type::Boolean.new.cast(hash[:view_applications_only])
+      self.view_applications_only = ActiveModel::Type::Boolean.new.cast(hash[:view_applications_only])
 
-      self.view_applications_only = view_applications_only
       ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
         permission_value = view_applications_only ? false : hash.fetch(permission_name, false)
         send("#{permission_name}=", permission_value)
@@ -57,7 +56,7 @@ module ProviderInterface
   private
 
     def at_least_one_extra_permission_is_set_if_necessary
-      return if ActiveModel::Type::Boolean.new.cast(view_applications_only)
+      return if view_applications_only
 
       extra_permissions = [
         manage_organisations,
@@ -67,7 +66,7 @@ module ProviderInterface
         view_diversity_information,
       ]
 
-      if extra_permissions.all? { |value| value == false }
+      if extra_permissions.none?
         errors[:permissions] << 'Select extra permissions'
       end
     end

--- a/spec/forms/provider_interface/provider_user_permissions_form_spec.rb
+++ b/spec/forms/provider_interface/provider_user_permissions_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ProviderInterface::ProviderUserPermissionsForm do
 
   describe 'validations' do
     it 'is valid when model is set' do
-      expect(described_class.new(model: provider_permissions)).to be_valid
+      expect(described_class.from(provider_permissions)).to be_valid
     end
 
     it 'is invalid without a model' do

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -15,7 +15,11 @@ RSpec.feature 'Managing provider user permissions' do
     and_i_click_to_change_permissions
 
     then_i_see_user_permissions_for_this_provider
-    and_i_add_permission_to_manage_users_for_a_provider_user
+
+    when_i_select_extra_permissions_and_no_special_permissions
+    then_i_see_a_validation_error_for_extra_permissions
+
+    when_i_add_permission_to_manage_users_for_a_provider_user
     then_i_can_see_the_manage_users_permission_for_the_provider_user
     and_i_click_to_change_permissions
 
@@ -80,7 +84,17 @@ RSpec.feature 'Managing provider user permissions' do
     end
   end
 
-  def and_i_add_permission_to_manage_users_for_a_provider_user
+  def when_i_select_extra_permissions_and_no_special_permissions
+    expect(page).not_to have_checked_field 'Manage users'
+    choose 'Extra permissions'
+    click_on 'Save'
+  end
+
+  def then_i_see_a_validation_error_for_extra_permissions
+    expect(page).to have_content 'Select extra permissions'
+  end
+
+  def when_i_add_permission_to_manage_users_for_a_provider_user
     expect(page).not_to have_checked_field 'Manage users'
     choose 'Extra permissions'
     check 'Manage users'
@@ -98,6 +112,7 @@ RSpec.feature 'Managing provider user permissions' do
   def when_i_remove_manage_users_permissions_from_a_provider_user
     expect(page).to have_checked_field 'Manage users'
     uncheck 'Manage users'
+    choose 'View applications only'
     click_on 'Save'
   end
 

--- a/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_with_new_wizard_spec.rb
@@ -33,6 +33,9 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
     and_i_press_continue
     then_i_see_the_select_permissions_form_for_selected_provider
 
+    when_i_press_continue
+    then_i_see_validation_errors_for_extra_permissions
+
     when_i_select_make_decisions_permission
     and_i_press_continue
     then_i_see_the_confirm_page
@@ -138,6 +141,10 @@ RSpec.feature 'Provider invites a new provider user using wizard interface' do
   def then_i_see_the_select_permissions_form_for_selected_provider
     expect(page).to have_content('Select permissions')
     choose 'Extra permissions'
+  end
+
+  def then_i_see_validation_errors_for_extra_permissions
+    expect(page).to have_content('Select extra permissions')
   end
 
   def when_i_select_make_decisions_permission


### PR DESCRIPTION
## Context
From the DAC review, it is confusing that when you select "Extra permissions", but don't actually choose any, you do not get a validation error. This change adds those validations
<!-- Why are you making this change? What might surprise someone about it? -->
## Guidance to review
Test using the review app
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/3SsH4Fx0/3171-no-errors-on-setting-permissions-page-dac-review
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
