### PR TITLE
Show rejected_at and rejected_by_default_at in Support

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -19,6 +19,14 @@ module SupportInterface
         { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)) },
       ]
 
+      if application_choice.rejected?
+        if application_choice.rejected_by_default
+          rows << { key: 'Rejected by default at', value: application_choice.rejected_at.to_s(:govuk_date_and_time) }
+        else
+          rows << { key: 'Rejected at', value: application_choice.rejected_at.to_s(:govuk_date_and_time) }
+        end
+      end
+
       rows << { key: 'Feedback', value: application_choice.rejection_reason } if application_choice.rejection_reason.present?
       rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at
       rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationChoiceComponent do
+  it 'displays the date an application was rejected' do
+    application_choice = create(:application_choice, :with_rejection, rejected_at: Time.zone.local(2020, 1, 1, 10, 0, 0))
+
+    result = render_inline(described_class.new(application_choice))
+
+    expect(result.text).to include('Rejected at')
+    expect(result.text).to include('1 January 2020 at 10:00am')
+  end
+
+  it 'displays the date an application was rejected by default' do
+    application_choice = create(:application_choice, :with_rejection_by_default, rejected_at: Time.zone.local(2020, 1, 1, 10, 0, 0))
+
+    result = render_inline(described_class.new(application_choice))
+
+    expect(result.text).to include('Rejected by default at')
+    expect(result.text).to include('1 January 2020 at 10:00am')
+  end
+end


### PR DESCRIPTION
Now that we link from Slack to applications once all rejections are in, include rejection dates in Support so we know when things happened
