### PR TITLE
Bugfix: display inline validation error for submitting reference request

### DIFF
--- a/app/views/candidate_interface/references/review/unsubmitted.html.erb
+++ b/app/views/candidate_interface/references/review/unsubmitted.html.erb
@@ -15,7 +15,7 @@
 
       <%= render CandidateInterface::UnsubmittedReferenceReviewComponent.new(reference: @reference) %>
 
-      <%= f.govuk_radio_buttons_fieldset :submit_reference, legend: { text: t('application_form.references.unsubmitted.label', reference_name: @reference.name), size: 'm' } do %>
+      <%= f.govuk_radio_buttons_fieldset :submit, legend: { text: t('application_form.references.unsubmitted.label', reference_name: @reference.name), size: 'm' } do %>
         <%= f.govuk_radio_button :submit, 'yes', label: { text: t('application_form.references.unsubmitted.yes.label') }, link_errors: true %>
         <%= f.govuk_radio_button :submit, 'no', label: { text: t('application_form.references.unsubmitted.no.label') } %>
       <% end %>


### PR DESCRIPTION
This fixes a bug that was preventing the inline validation error for choosing whether to submit a reference request now or later to be displayed.

### Before

<img width="544" alt="Screenshot 2021-01-06 at 14 39 14" src="https://user-images.githubusercontent.com/30665/103780717-436e8900-502d-11eb-9ed3-4d7e5d31f626.png">

### After

<img width="549" alt="Screenshot 2021-01-06 at 14 39 37" src="https://user-images.githubusercontent.com/30665/103780729-49fd0080-502d-11eb-98e3-295d4fa9a101.png">

## Link to Trello card

https://trello.com/c/Lnqro7u3/2807-dac-when-to-send-ref-request-error-message