### PR TITLE
Adding NARIC content to degree & GCSE pages

### DIFF
--- a/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
@@ -1,3 +1,9 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.degree_naric') %>
+</h1>
+
 <p class="govuk-body">You can get a statement from the National Recognition Information Centre for the United Kingdom (UK NARIC) which shows how your qualifications compare to UK qualifications. Not all providers need this.</p>
 <%= f.govuk_radio_buttons_fieldset :have_naric_reference, legend: { text: t('application_form.degree.naric_statment.label'), size: 'm' } do %>
   <%= f.govuk_radio_button :have_naric_reference, 'yes', label: { text: 'Yes' } do %>
@@ -23,7 +29,7 @@
     <% end %>
   <% end %>
   <%= f.govuk_radio_button :have_naric_reference, 'no', label: { text: 'No' } do %>
-    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. Register with <%= govuk_link_to "Get Into Teaching", "https://register.getintoteaching.education.gov.uk/register" %> for help if you need to get one.</p>
+    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling Get Into Teaching on Freephone 0800 389 2501.</p>
   <% end %>
 <% end %>
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/naric/edit.html.erb
+++ b/app/views/candidate_interface/degrees/naric/edit.html.erb
@@ -8,12 +8,6 @@
       url: candidate_interface_edit_degree_naric_path(@degree_naric_form.degree),
       method: :patch
     ) do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.degree_naric') %>
-      </h1>
-
       <%= render 'form_fields', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/degrees/naric/new.html.erb
+++ b/app/views/candidate_interface/degrees/naric/new.html.erb
@@ -7,12 +7,6 @@
       model: @degree_naric_form,
       url: candidate_interface_degree_naric_path(@degree_naric_form.degree)
     ) do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.degree_naric') %>
-      </h1>
-
       <%= render 'form_fields', f: f %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/gcse/naric/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric/edit.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         <% end %>
         <%= f.govuk_radio_button :have_naric_reference, 'No', label: { text: 'No' } do %>
-          <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. Register with <%= govuk_link_to 'Get Into Teaching', 'https://register.getintoteaching.education.gov.uk/register' %> for help if you need to get one.</p>
+          <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling Get Into Teaching on Freephone 0800 389 2501.</p>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
## Context

International students need to know they can get a free NARIC statement in order to provide their UK equivalent qualifications.

## Changes proposed in this pull request

Content changed on the NARIC pages (when 'no' is selected) to:

Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling Get Into Teaching on Freephone 0800 389 2501.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/znVQMgsZ/2794-dev-add-naric-content-to-4-locations

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
