### PR TITLE
Fix two styling issues with the API docs

### DIFF
--- a/app/frontend/styles/api_docs/_syntax-highlighting.scss
+++ b/app/frontend/styles/api_docs/_syntax-highlighting.scss
@@ -1,7 +1,7 @@
 // A Base16 palette
 // https://github.com/chriskempson/base16
 
-$code-00: scale-color(govuk-colour("light-grey"), $lightness:50%); /* Default Background */
+$code-00: govuk-colour("light-grey"); /* Default Background */
 $code-01: #f5f5f5; /* Lighter Background (Unused) */
 $code-02: #bfc1c3; /* Selection Background */
 $code-03: darken( $govuk-secondary-text-colour, 2%);; /* Comments, Invisibles, Line Highlighting */

--- a/app/views/api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/reference/reference.html.erb
@@ -80,9 +80,9 @@
 </p>
 
 <p class="govuk-body">
-  <pre><code>
+  <code>
     Authorization: Bearer {token}
-  </code></pre>
+  </code>
 </p>
 
 <p class="govuk-body">


### PR DESCRIPTION
- make the background colour of syntax-highlighted blocks of code match
the background we use for inline styling on `<code>` elements. This
prevents an ugly effect where the text bg is slightly darker than the
box bg
- remove some `<pre>` tags that smeared `<code>` background onto lines above
and below a code sample

| Before | After |
:-------------------------:|:-------------------------:
| <img width="367" alt=" before1" src="https://user-images.githubusercontent.com/642279/103787202-348bd480-5035-11eb-9877-b5eceaefcae6.png"> |  <img width="377" alt="after1" src="https://user-images.githubusercontent.com/642279/103787221-39508880-5035-11eb-8c20-0941cc215486.png"> |
| <img width="647" alt="before2" src="https://user-images.githubusercontent.com/642279/103787259-453c4a80-5035-11eb-836f-d169d0d0bb65.png"> | <img width="670" alt="after2" src="https://user-images.githubusercontent.com/642279/103787279-4b322b80-5035-11eb-8f13-a19077d40008.png"> |

