### PR TITLE
Let providers search by candidate reference number

### DIFF
--- a/app/components/filter_component.html.erb
+++ b/app/components/filter_component.html.erb
@@ -1,74 +1,104 @@
-<div class="moj-filter-layout__filter app-filter">
-  <div class="moj-filter">
-    <div class="moj-filter__header">
-      <div class="moj-filter__header-title">
-        <h2 class="govuk-heading-m">Filter</h2>
-      </div>
-      <div class="moj-filter__header-action">
-      </div>
-    </div>
-
-    <div class="moj-filter__content">
-      <% if active_filters.any? %>
-        <div class="moj-filter__selected">
-          <div class="moj-filter__selected-heading">
-            <div class="moj-filter__heading-title">
-              <h3 class="govuk-heading-m govuk-!-margin-bottom-1">Selected filters</h3>
-              <p class="govuk-body">
-                <%= govuk_link_to 'Clear filters', '?remove=true', class: 'govuk-link--no-visited-state' %>
-              </p>
-            </div>
-          </div>
-
-          <% active_filters.each do |active_filter| %>
-            <h4 class="govuk-heading-s govuk-!-margin-bottom-0"><%= active_filter[:heading] %></h4>
-            <ul class="moj-filter-tags">
-              <% tags_for_active_filter(active_filter).each do |tag| %>
-                <li>
-                  <%= link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", id: "tag-#{tag[:title].parameterize}") %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-
+<div class='moj-filter-layout'>
+  <div class="moj-filter-layout__filter app-filter">
+    <div class="moj-filter">
+      <div class="moj-filter__header">
+        <div class="moj-filter__header-title">
+          <h2 class="govuk-heading-m">Filter</h2>
         </div>
-      <% end %>
+        <div class="moj-filter__header-action">
+        </div>
+      </div>
 
-      <!-- Div made focusable to 'catch' focus from checkboxes. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
-       -->
-      <div class="moj-filter__options" tabindex="-1">
-        <form method="get">
-          <%= submit_tag "Apply filters", class: "govuk-button" %>
+      <div class="moj-filter__content">
+        <% if active_filters.any? %>
+          <div class="moj-filter__selected">
+            <div class="moj-filter__selected-heading">
+              <div class="moj-filter__heading-title">
+                <h3 class="govuk-heading-m govuk-!-margin-bottom-1">Selected filters</h3>
+                <p class="govuk-body">
+                  <%= govuk_link_to 'Clear filters', clear_filters_link, class: 'govuk-link--no-visited-state' %>
+                </p>
+              </div>
+            </div>
 
-          <% filters.each do |filter, idx| %>
+            <% active_filters.each do |active_filter| %>
+              <h4 class="govuk-heading-s govuk-!-margin-bottom-0"><%= active_filter[:heading] %></h4>
+              <ul class="moj-filter-tags">
+                <% tags_for_active_filter(active_filter).each do |tag| %>
+                  <li>
+                    <%= link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", id: "tag-#{tag[:title].parameterize}") %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+        <% end %>
 
-            <div class="govuk-form-group">
-              <fieldset class="govuk-fieldset">
-                <legend id="filter-legend-<%= filter[:name] %>" class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                  <%= filter[:heading] %>
-                </legend>
-                <% if filter[:type] == :search %>
-                  <input class="govuk-input <%= filter[:css_classes] %>" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" aria-labelledby="filter-legend-<%= filter[:name] %>" >
+        <!-- Div made focusable to 'catch' focus from checkboxes. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
+         -->
+        <div class="moj-filter__options" tabindex="-1">
+          <form method="get">
+            <%= submit_tag "Apply filters", class: "govuk-button" %>
 
-                <% elsif filter[:type] == :checkboxes %>
+            <%= hidden_field_tag primary_filter[:name], primary_filter[:value] if primary_filter && primary_filter[:value].present? %>
+            <% secondary_filters.each do |filter, idx| %>
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  <legend id="filter-legend-<%= filter[:name] %>" class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                    <%= filter[:heading] %>
+                  </legend>
+                  <% if filter[:type] == :search %>
+                    <input class="govuk-input <%= filter[:css_classes] %>" id="<%= filter[:name] %>" name="<%= filter[:name] %>" type="text" value="<%= filter[:value] %>" aria-labelledby="filter-legend-<%= filter[:name] %>" >
+                  <% elsif filter[:type] == :checkboxes %>
                     <% filter[:options].each do |option| %>
                       <div class="govuk-checkboxes govuk-checkboxes--small">
-
                         <div class="govuk-checkboxes__item">
                           <input class="govuk-checkboxes__input" id="<%= filter[:name] %>-<%= option[:value] %>" name="<%= filter[:name] %>[]" type="checkbox" <%= "checked" if option[:checked] %> value="<%= option[:value] %>">
                           <label class="govuk-label govuk-checkboxes__label" for="<%= filter[:name] %>-<%= option[:value] %>">
                             <%= option[:label] %>
                           </label>
-
                         </div>
                       </div>
                     <% end %>
                   <% end %>
-              </fieldset>
-            </div>
-          <% end %>
-        </form>
+                </fieldset>
+              </div>
+            <% end %>
+          </form>
+        </div>
       </div>
     </div>
+  </div>
+
+  <div class='moj-filter-layout__content'>
+    <% if primary_filter %>
+      <div class="app-search<% if primary_filter[:value].blank? %> govuk-!-margin-bottom-7<% end %>">
+				<form method="get">
+          <% filters_to_params(secondary_filters).each do |name, value| %>
+            <% if value.is_a?(Array) %>
+              <% value.each do |v| %><%= hidden_field_tag("#{name}[]", v) %><% end %>
+            <% else %>
+              <%= hidden_field_tag name, value %>
+            <% end %>
+          <% end %>
+					<div class="govuk-form-group">
+            <label class="govuk-label app-search__label govuk-label--m" for="<%= primary_filter[:name] %>">
+							Search by candidate name or reference
+						</label>
+
+						<input class="govuk-input <%= primary_filter[:css_classes] %>" id="<%= primary_filter[:name] %>" name="<%= primary_filter[:name] %>" type="text" value="<%= primary_filter[:value] %>" aria-labelledby="filter-legend-<%= primary_filter[:name] %>" >
+					</div>
+					<button class="govuk-button app-search__button" data-module="govuk-button">
+						Search
+					</button>
+				</form>
+      </div>
+      <% if primary_filter[:value].present? %>
+        <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-7">
+          <%= link_to('Clear search', remove_search_tag_link(primary_filter[:name]), class: 'govuk-link govuk-link--no-visited-state') %>
+        </p>
+      <% end %>
+    <% end %>
+    <%= content %>
   </div>
 </div>

--- a/app/components/filter_component.rb
+++ b/app/components/filter_component.rb
@@ -39,10 +39,24 @@ class FilterComponent < ViewComponent::Base
     filters.select { |f| filter_active?(f) }
   end
 
+  def primary_filter
+    @primary_filter ||= filters.find { |f| f[:primary] }
+  end
+
+  def secondary_filters
+    @secondary_filters ||= filters - [primary_filter]
+  end
+
+  def clear_filters_link
+    link_params = { remove: true }
+    link_params.merge!(filters_to_params([primary_filter])) if primary_filter.present?
+    '?' + link_params.to_query
+  end
+
   def filter_active?(filter)
     case filter[:type]
     when :search
-      filter[:value].present?
+      filter[:primary] != true && filter[:value].present?
     when :checkboxes
       filter[:options].any? { |o| o[:checked] }
     end

--- a/app/components/paginated_filter_component.html.erb
+++ b/app/components/paginated_filter_component.html.erb
@@ -1,9 +1,8 @@
 <div class='moj-filter-layout'>
-  <%= render FilterComponent.new(filter: filter) %>
+  <%= render FilterComponent.new(filter: filter) do |component| %>
 
-  <div class='moj-filter-layout__content'>
     <%= content %>
 
     <%= render(PaginatorComponent.new(scope: collection)) %>
-  </div>
+  <% end %>
 </div>

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -2,6 +2,7 @@
   <header class="app-application-card__header">
     <h3 class="govuk-heading-s">
       <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice), class: 'govuk-link--no-visited-state' %>
+      <span class="app-application-card__caption"><%= application_choice.application_form.support_reference %></span>
     </h3>
     <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
   </header>

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -31,6 +31,11 @@
     }
   }
 
+  &__caption {
+    @include govuk-font($size: 16, $weight: "regular");
+    color: govuk-colour("dark-grey");
+  }
+
   &__header {
     align-items: baseline;
     display: flex;

--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -89,3 +89,27 @@
 .moj-pagination__item--next .moj-pagination__link:after {
   margin-left: 1px;
 }
+
+.app-search {
+  form {
+    align-items: flex-end;
+    display: flex;
+  }
+
+	.govuk-form-group {
+		flex: 1;
+		margin-bottom: 0;
+		vertical-align: top;
+  }
+
+  .app-search__button {
+    display: inline-block;
+    margin-bottom: 0;
+    margin-top: 0;
+    margin-left: 10px;
+    position: relative;
+    top: -2px;
+    vertical-align: bottom;
+    width: auto;
+  }
+}

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -42,9 +42,10 @@ module ProviderInterface
     def search_filter
       {
         type: :search,
-        heading: 'Candidate’s name',
+        heading: 'Candidate name or reference',
         value: applied_filters[:candidate_name],
         name: 'candidate_name',
+        primary: true,
       }
     end
 

--- a/app/models/provider_interface/provider_applications_filter.rb
+++ b/app/models/provider_interface/provider_applications_filter.rb
@@ -25,6 +25,19 @@ module ProviderInterface
       applied_filters.values.any?
     end
 
+    def no_results_message
+      filtering_keys = applied_filters.except(:remove).keys
+      filter_count = applied_filters.except(:candidate_name, :remove).keys.size
+
+      if filtering_keys == %w[candidate_name]
+        "There are no results for '#{applied_filters['candidate_name']}'."
+      elsif filtering_keys.include?('candidate_name')
+        "There are no results for '#{applied_filters['candidate_name']}' and the selected #{'filter'.pluralize(filter_count)}."
+      else
+        "There are no results for the selected #{'filter'.pluralize(filter_count)}."
+      end
+    end
+
   private
 
     def parse_params(params)

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -1,4 +1,6 @@
 class FilterApplicationChoicesForProviders
+  CANDIDATE_REFERENCE_REGEX = /^[a-zA-Z]{2}\d{4}$/.freeze
+
   def self.call(application_choices:, filters:)
     return application_choices if filters.empty?
 
@@ -8,10 +10,16 @@ class FilterApplicationChoicesForProviders
   class << self
   private
 
-    def search(application_choices, candidates_name)
-      return application_choices if candidates_name.blank?
+    def search(application_choices, candidates_name_or_reference)
+      return application_choices if candidates_name_or_reference.blank?
 
-      application_choices.joins(:application_form).where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name}%")
+      candidate_ref_match = candidates_name_or_reference.strip.match(CANDIDATE_REFERENCE_REGEX)
+
+      if candidate_ref_match
+        application_choices.joins(:application_form).where('support_reference = ?', candidate_ref_match[0])
+      else
+        application_choices.joins(:application_form).where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name_or_reference}%")
+      end
     end
 
     def recruitment_cycle_year(application_choices, years)

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -35,7 +35,7 @@
       <% end %>
     </div>
   <% elsif @filter.filtered? %>
-    <p class='govuk-body'>No applications for the selected filters.</p>
+    <p class='govuk-body'><%= @filter.no_results_message %></p>
   <% else %>
     <p class='govuk-body'>You have not received any applications from <%= t('service_name.apply') %>.</p>
   <% end %>

--- a/spec/models/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/models/provider_interface/provider_applications_filter_spec.rb
@@ -140,4 +140,36 @@ RSpec.describe ProviderInterface::ProviderApplicationsFilter do
     # Providing new params replaces the saved state
     expect(state_three.applied_filters).to eq({ 'candidate_name' => 'Another Tom' })
   end
+
+  describe '#no_results_message' do
+    it 'returns a message specific to text searches' do
+      filter = described_class.new(
+        params: ActionController::Parameters.new({ 'candidate_name' => 'Tom' }),
+        provider_user: provider_user,
+        state_store: {},
+      )
+
+      expect(filter.no_results_message).to eq("There are no results for 'Tom'.")
+    end
+
+    it 'returns a message specific to filtering' do
+      filter = described_class.new(
+        params: ActionController::Parameters.new({ 'status' => %w[rejected] }),
+        provider_user: provider_user,
+        state_store: {},
+      )
+
+      expect(filter.no_results_message).to eq('There are no results for the selected filter.')
+    end
+
+    it 'returns a message specific to searching combined with filtering' do
+      filter = described_class.new(
+        params: ActionController::Parameters.new({ 'candidate_name' => 'Tom', 'status' => %w[rejected] }),
+        provider_user: provider_user,
+        state_store: {},
+      )
+
+      expect(filter.no_results_message).to eq("There are no results for 'Tom' and the selected filter.")
+    end
+  end
 end

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe FilterApplicationChoicesForProviders do
+  describe '.call' do
+    let(:application_choices) do
+      create_list(:application_choice, 2)
+      ApplicationChoice.all
+    end
+
+    it 'filters by candidate reference' do
+      result = described_class.call(application_choices: application_choices, filters: { candidate_name: " #{application_choices.first.application_form.support_reference}" })
+
+      expect(result).to eq([application_choices.first])
+    end
+
+    it 'filters by candidate name' do
+      result = described_class.call(application_choices: application_choices, filters: { candidate_name: application_choices.last.application_form.last_name })
+
+      expect(result).to eq([application_choices.last])
+    end
+
+    it 'filters by recruitment cycle year' do
+      course_option = create(:course_option, course: create(:course, recruitment_cycle_year: 1999))
+      application_choices.last.update(course_option: course_option)
+
+      result = described_class.call(application_choices: application_choices.joins(:course), filters: { recruitment_cycle_year: '1999' })
+
+      expect(result).to eq([application_choices.last])
+    end
+
+    it 'filters by status' do
+      application_choices.first.update(status: 'rejected', rejected_at: Time.zone.now)
+      application_choices.last.update(status: 'withdrawn', withdrawn_at: Time.zone.now)
+      result = described_class.call(application_choices: application_choices, filters: { status: 'rejected' })
+
+      expect(result).to eq([application_choices.first])
+    end
+
+    it 'filters by provider' do
+      provider = create(:provider)
+      course = create(:course, provider: provider)
+      site = create(:site, provider: provider)
+      course_option = create(:course_option, course: course, site: site)
+      application_choices.first.update(course_option: course_option)
+      result = described_class.call(application_choices: application_choices.joins(:course), filters: { provider: provider.id })
+
+      expect(result).to eq([application_choices.first])
+    end
+
+    it 'filters by accredited provider' do
+      course_option = create(:course_option, course: create(:course, accredited_provider_id: 2121))
+      application_choices.first.update(course_option: course_option)
+      result = described_class.call(application_choices: application_choices.joins(:course), filters: { accredited_provider: '2121' })
+
+      expect(result).to eq([application_choices.first])
+    end
+
+    it 'filters by provider location' do
+      provider = create(:provider)
+      course = create(:course, provider: provider)
+      site = create(:site, provider: provider)
+      course_option = create(:course_option, course: course, site: site)
+      application_choices.last.update(course_option: course_option)
+      result = described_class.call(application_choices: application_choices.joins(:course, :site), filters: { provider_location: site.id })
+
+      expect(result).to eq([application_choices.last])
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -264,7 +264,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_should_see_the_no_filter_results_error_message
-    expect(page).to have_content('No applications for the selected filters.')
+    expect(page).to have_content('There are no results for the selected filter.')
   end
 
   def when_i_filter_for_rejected_and_offered_applications

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -210,7 +210,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_should_see_the_no_filter_results_error_message
-    expect(page).to have_content('No applications for the selected filters.')
+    expect(page).to have_content("There are no results for 'Simon Says' and the selected filter.")
   end
 
   def when_i_filter_by_provider

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -56,8 +56,8 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_search_for_part_of_a_candidate_name
-    find(:css, '#candidate_name').set('ame')
-    click_button('Apply filters')
+    fill_in 'Search by candidate name or reference', with: 'ame'
+    click_button('Search')
   end
 
   def and_the_part_of_the_name_should_appear_in_search_field
@@ -79,13 +79,13 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def and_the_relevant_tags_should_be_visible
-    expect(page).to have_css('.moj-filter-tags', text: 'Jim James')
-    then_i_expect_the_relevant_provider_tags_to_be_visible
+    tags = find(:css, '.moj-filter-tags:nth-of-type(2)')
+    expect(tags).to have_text('Hoth Teacher Training')
+    expect(tags).to have_text('Caladan University')
   end
 
   def then_the_relevant_tag_headings_should_be_visible
     selected_filters = find(:css, '.moj-filter__selected')
-    expect(selected_filters).to have_text('Candidate’s name')
     expect(selected_filters).to have_text('Courses run by')
   end
 
@@ -114,13 +114,13 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_search_for_candidate_name
-    find(:css, '#candidate_name').set('Jim James')
-    click_button('Apply filters')
+    fill_in 'Search by candidate name or reference', with: 'Jim James'
+    click_button('Search')
   end
 
   def when_i_search_for_a_candidate_that_does_not_exist
-    find(:css, '#candidate_name').set('Simon Says')
-    click_button('Apply filters')
+    fill_in 'Search by candidate name or reference', with: 'Simon Says'
+    click_button('Search')
   end
 
   def then_i_search_for_candidate_name
@@ -134,8 +134,8 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_search_for_candidate_name_with_odd_casing
-    find(:css, '#candidate_name').set('jiM JAmeS')
-    click_button('Apply filters')
+    fill_in 'Search by candidate name or reference', with: 'jiM JAmeS'
+    click_button('Search')
   end
 
   def then_only_applications_of_that_name_and_status_should_be_visible
@@ -150,7 +150,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_expect_to_see_the_search_input
-    expect(page).to have_content('Candidate’s name')
+    expect(page).to have_content('Search by candidate name or reference')
   end
 
   def when_i_visit_the_provider_page
@@ -166,11 +166,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_clear_the_filters
-    click_link('Clear filters')
-  end
-
-  def then_i_do_not_expect_to_see_the_filter_dialogue
-    expect(page).not_to have_button('Apply filters')
+    click_link('Clear search')
   end
 
   def and_i_am_permitted_to_see_applications_from_multiple_providers
@@ -221,11 +217,5 @@ RSpec.feature 'Providers should be able to filter applications' do
     find(:css, "#provider-#{current_provider.id}").set(true)
     find(:css, "#provider-#{second_provider.id}").set(true)
     click_button('Apply filters')
-  end
-
-  def then_i_expect_the_relevant_provider_tags_to_be_visible
-    tags = find(:css, '.moj-filter-tags:nth-of-type(2)')
-    expect(tags).to have_text('Hoth Teacher Training')
-    expect(tags).to have_text('Caladan University')
   end
 end


### PR DESCRIPTION
## Context

Providers have requested the ability to search by 'candidate reference' (ie. support reference)

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Updates provider application filter to search by candidate name or support reference depending on input
- Adds ability to configure the filter component so that the search field can be treated as 'primary' and sit above results. (See screenshot)
- Adds support reference to application card caption

![image](https://user-images.githubusercontent.com/93511/103807299-1ed6d900-504e-11eb-9b7f-6067c8b5b0a5.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
There are effectively 2 filtering forms now which have to maintain filtering params from one another, so combining filtering and searching should give expected results.
The support UI uses the same filtering mechanism, worth checking no support UI was harmed in the making of this PR.

## Link to Trello card

https://trello.com/c/XSZRMDg2/3138-implement-letting-providers-search-by-candidate-reference-number
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
