### PR TITLE
Outlaw underscores in URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -598,11 +598,16 @@ Rails.application.routes.draw do
       patch '/conditions' => 'conditions#update', as: :application_choice_update_conditions
       get '/offer/change/*step' => 'offer_changes#edit_offer', as: :application_choice_edit_offer
       patch '/offer/change' => 'offer_changes#update_offer', as: :application_choice_update_offer
-      get '/offer/new_withdraw' => 'decisions#new_withdraw_offer', as: :application_choice_new_withdraw_offer
-      post '/offer/confirm_withdraw' => 'decisions#confirm_withdraw_offer', as: :application_choice_confirm_withdraw_offer
+
+      get '/offer/new_withdraw' => redirect('/offer/withdraw')
+      post '/offer/confirm_withdraw' => redirect('/offer/confirm-withdraw')
+      get '/offer/withdraw' => 'decisions#new_withdraw_offer', as: :application_choice_new_withdraw_offer
+      post '/offer/confirm-withdraw' => 'decisions#confirm_withdraw_offer', as: :application_choice_confirm_withdraw_offer
       post '/offer/withdraw' => 'decisions#withdraw_offer', as: :application_choice_withdraw_offer
+
       get '/offer/defer' => 'decisions#new_defer_offer', as: :application_choice_new_defer_offer
       post '/offer/defer' => 'decisions#defer_offer', as: :application_choice_defer_offer
+
       get '/feedback' => 'feedback#new', as: :application_choice_new_feedback
       post '/feedback/check' => 'feedback#check', as: :application_choice_check_feedback
       post '/feedback' => 'feedback#create', as: :application_choice_feedback
@@ -749,7 +754,8 @@ Rails.application.routes.draw do
       post '/record-ucas-withdrawal-requested' => 'ucas_matches#record_ucas_withdrawal_requested', as: :record_ucas_withdrawal_requested
     end
 
-    get '/application_choices/:application_choice_id' => 'application_choices#show', as: :application_choice
+    get '/application_choices/:application_choice_id' => redirect('/application-choices/%{application_choice_id}')
+    get '/application-choices/:application_choice_id' => 'application_choices#show', as: :application_choice
 
     get '/candidates' => 'candidates#index'
 
@@ -786,7 +792,8 @@ Rails.application.routes.draw do
       post '/relationships' => 'providers#update_relationships', as: :update_provider_relationships
 
       post '' => 'providers#open_all_courses'
-      post '/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing
+      post '/enable_course_syncing' => redirect('/enable-course-syncing')
+      post '/enable-course-syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing
     end
 
     scope path: '/courses/:course_id' do

--- a/spec/config/routes_spec.rb
+++ b/spec/config/routes_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'routes.rb' do
+  it 'does not use underscores' do
+    paths = Rails.application.routes.routes.map { |r| r.path.spec.to_s if r.defaults[:controller] }.compact
+
+    paths.each do |path|
+      next if path.in?(%w[/rails/view_components(.:format) /rails/view_components/*path(.:format)])
+
+      has_underscores = path.split('/').any? { |component| !component.start_with?(':') && component.match('_') }
+
+      expect(has_underscores).to be(false), "#{path} should not have underscores"
+    end
+  end
+end

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe DetectInvariants do
             One or more application choices are still in `awaiting_references` or
             `application_complete` state, but all these states have been removed:
 
-            http://localhost:3000/support/application_choices/#{application_choice_bad.id}
-            http://localhost:3000/support/application_choices/#{application_choice_bad_too.id}
+            http://localhost:3000/support/application-choices/#{application_choice_bad.id}
+            http://localhost:3000/support/application-choices/#{application_choice_bad_too.id}
           MSG
         ),
       )


### PR DESCRIPTION
## Context

Underscores are for computers, dashes are for humans.

## Changes proposed in this pull request

Remove underscores, add a test.

## Guidance to review

Ok?

## Link to Trello card

@paulrobertlloyd 
