### PR TITLE
Send a slack notification when a feature flag is changed in production

### DIFF
--- a/app/controllers/support_interface/settings_controller.rb
+++ b/app/controllers/support_interface/settings_controller.rb
@@ -2,13 +2,25 @@ module SupportInterface
   class SettingsController < SupportInterfaceController
     def activate_feature_flag
       FeatureFlag.activate(params[:feature_name])
-      flash[:success] = "Feature ‘#{params[:feature_name].humanize}’ activated"
+
+      SlackNotificationWorker.perform_async(
+        ":flags: Feature ‘#{feature_name}‘ was activated",
+        support_interface_feature_flags_url,
+      )
+
+      flash[:success] = "Feature ‘#{feature_name}’ activated"
       redirect_to support_interface_feature_flags_path
     end
 
     def deactivate_feature_flag
       FeatureFlag.deactivate(params[:feature_name])
-      flash[:success] = "Feature ‘#{params[:feature_name].humanize}’ deactivated"
+
+      SlackNotificationWorker.perform_async(
+        ":flags: Feature ‘#{feature_name}‘ was deactivated",
+        support_interface_feature_flags_url,
+      )
+
+      flash[:success] = "Feature ‘#{feature_name}’ deactivated"
       redirect_to support_interface_feature_flags_path
     end
 
@@ -22,6 +34,12 @@ module SupportInterface
 
       flash[:success] = 'Cycle schedule updated'
       redirect_to support_interface_cycles_path
+    end
+
+  private
+
+    def feature_name
+      params[:feature_name].humanize
     end
   end
 end

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -13,10 +13,12 @@ RSpec.feature 'Feature flags', with_audited: true do
     when_i_activate_the_feature
     then_the_feature_is_activated
     and_i_can_see_the_activation_in_the_audit_trail
+    and_a_slack_notification_about_the_activation_is_sent
 
     when_i_deactivate_the_feature
     then_the_feature_is_deactivated
     and_i_can_see_the_deactivation_in_the_audit_trail
+    and_a_slack_notification_about_the_deactivation_is_sent
   end
 
   def given_i_am_a_support_user
@@ -50,6 +52,10 @@ RSpec.feature 'Feature flags', with_audited: true do
     expect(page).to have_content('Changed to active by user@apply-support.com')
   end
 
+  def and_a_slack_notification_about_the_activation_is_sent
+    expect_slack_message_with_text(':flags: Feature ‘Pilot open‘ was activated')
+  end
+
   def when_i_deactivate_the_feature
     within(pilot_open_summary_card) { click_button 'Deactivate' }
   end
@@ -61,6 +67,10 @@ RSpec.feature 'Feature flags', with_audited: true do
 
   def and_i_can_see_the_deactivation_in_the_audit_trail
     expect(page).to have_content('Changed to inactive by user@apply-support.com')
+  end
+
+  def and_a_slack_notification_about_the_deactivation_is_sent
+    expect_slack_message_with_text(':flags: Feature ‘Pilot open‘ was deactivated')
   end
 
   def pilot_open_summary_card


### PR DESCRIPTION
## Context

The feature flags can be changed by clicking a button. We have a daily notification
if they are not consistent between environments but we should be notified earlier
to prevent accidental changes in production.

## Changes proposed in this pull request

Send a slack notification when a feature flag is changed in production

## Guidance to review

Should we be sending it out in all environments?
Other suggestions for the emoji welcome.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
