### PR TITLE
Implement Google analytics

### DIFF
--- a/app/components/flash_message_component.html.erb
+++ b/app/components/flash_message_component.html.erb
@@ -21,6 +21,11 @@
         <h2 class="govuk-heading-m" id="success-message">
           <%= flash[:success] %>
         </h2>
+        <% if flash[:link] %>
+          <p class="govuk-link">
+            <%= link_to flash[:link]['text'], flash[:link]['url'], class: 'govuk-link' %>
+          </p>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
     before_action :protect_with_basic_auth
     before_action :authenticate_candidate!
     before_action :add_identity_to_log
+    before_action :check_cookie_preferences
     layout 'application'
     alias_method :audit_user, :current_candidate
 
@@ -14,6 +15,10 @@ module CandidateInterface
       return unless current_candidate
 
       Raven.extra_context(application_support_url: support_interface_application_form_url(current_application))
+    end
+
+    def check_cookie_preferences
+      @google_analytics_id = ENV.fetch('GOOGLE_ANALYTICS_APPLY', '') if cookies['consented-to-apply-cookies'].eql?('yes')
     end
 
     def track_validation_error(form)

--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -17,6 +17,8 @@ module CandidateInterface
       @cookie_ga_code = ENV.fetch('GOOGLE_ANALYTICS_APPLY', '').gsub(/-/, '_')
       @cookie_preferences = CookiePreferencesForm.new(consent: cookies['consented-to-apply-cookies'])
       @cookie_settings_path = candidate_interface_cookie_preferences_path
+      session[:previous_referer] = request.referer
+
       render 'content/cookies'
     end
 

--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -1,6 +1,8 @@
 module CandidateInterface
-  class ContentController < ApplicationController
+  class ContentController < CandidateInterfaceController
     include ContentHelper
+    skip_before_action :authenticate_candidate!
+    skip_before_action :add_identity_to_log
 
     def accessibility
       render_content_page :accessibility

--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -10,8 +10,12 @@ module CandidateInterface
       render_content_page :privacy_policy
     end
 
-    def cookies_candidate
-      render_content_page :cookies_candidate
+    def cookies_page
+      @application = :apply
+      @cookie_ga_code = ENV.fetch('GOOGLE_ANALYTICS_APPLY', '').gsub(/-/, '_')
+      @cookie_preferences = CookiePreferencesForm.new(consent: cookies['consented-to-apply-cookies'])
+      @cookie_settings_path = candidate_interface_cookie_preferences_path
+      render 'content/cookies'
     end
 
     def terms_candidate

--- a/app/controllers/candidate_interface/cookie_preferences_controller.rb
+++ b/app/controllers/candidate_interface/cookie_preferences_controller.rb
@@ -1,0 +1,11 @@
+class CandidateInterface::CookiePreferencesController < ApplicationController
+  include CookiePreferenceConcerns
+
+  def consent_cookie
+    'consented-to-apply-cookies'
+  end
+
+  def cookie_page_path
+    candidate_interface_cookies_path
+  end
+end

--- a/app/controllers/concerns/cookie_preference_concerns.rb
+++ b/app/controllers/concerns/cookie_preference_concerns.rb
@@ -1,0 +1,16 @@
+module CookiePreferenceConcerns
+  def create
+    @cookie_preferences = CookiePreferencesForm.new(consent: cookie_preferences_consent)
+    cookies[consent_cookie] = { value: @cookie_preferences.consent, expires: 6.months.from_now }
+    flash[:success] = 'Your cookie preferences have been updated'
+
+    redirect_back(fallback_location: cookie_page_path)
+  end
+
+private
+
+  def cookie_preferences_consent
+    cookie_preference_params = params.key?(:cookie_preferences_form) ? params[:cookie_preferences_form] : params
+    cookie_preference_params.permit(:consent)[:consent]
+  end
+end

--- a/app/controllers/concerns/cookie_preference_concerns.rb
+++ b/app/controllers/concerns/cookie_preference_concerns.rb
@@ -2,7 +2,9 @@ module CookiePreferenceConcerns
   def create
     @cookie_preferences = CookiePreferencesForm.new(consent: cookie_preferences_consent)
     cookies[consent_cookie] = { value: @cookie_preferences.consent, expires: 6.months.from_now }
-    flash[:success] = 'Your cookie preferences have been updated'
+
+    link_to_previous_referer
+    flash[:success] = 'Your cookie preferences have been updated.'
 
     redirect_back(fallback_location: cookie_page_path)
   end
@@ -12,5 +14,18 @@ private
   def cookie_preferences_consent
     cookie_preference_params = params.key?(:cookie_preferences_form) ? params[:cookie_preferences_form] : params
     cookie_preference_params.permit(:consent)[:consent]
+  end
+
+  def link_to_previous_referer
+    request_uri = URI(request.referer).request_uri
+    previous_referer_uri = URI(session[:previous_referer]).request_uri if session[:previous_referer].present?
+
+    if previous_referer_uri && request_uri.eql?(cookie_page_path) && !previous_referer_uri.eql?(cookie_page_path)
+      flash[:link] = {
+        text: 'Go back to the page you were looking at',
+        url: session[:previous_referer],
+      }
+      session.delete(:previous_referer)
+    end
   end
 end

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -20,6 +20,8 @@ module ProviderInterface
       @cookie_ga_code = ENV.fetch('GOOGLE_ANALYTICS_MANAGE', '').gsub(/-/, '_')
       @cookie_preferences = CookiePreferencesForm.new(consent: cookies['consented-to-manage-cookies'])
       @cookie_settings_path = provider_interface_cookie_preferences_path
+      session[:previous_referer] = request.referer
+
       render 'content/cookies'
     end
 

--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -15,8 +15,12 @@ module ProviderInterface
       render_content_page :privacy_policy
     end
 
-    def cookies_provider
-      render_content_page :cookies_provider
+    def cookies_page
+      @application = :manage
+      @cookie_ga_code = ENV.fetch('GOOGLE_ANALYTICS_MANAGE', '').gsub(/-/, '_')
+      @cookie_preferences = CookiePreferencesForm.new(consent: cookies['consented-to-manage-cookies'])
+      @cookie_settings_path = provider_interface_cookie_preferences_path
+      render 'content/cookies'
     end
 
     def service_guidance_provider

--- a/app/controllers/provider_interface/cookie_preferences_controller.rb
+++ b/app/controllers/provider_interface/cookie_preferences_controller.rb
@@ -1,0 +1,11 @@
+class ProviderInterface::CookiePreferencesController < ApplicationController
+  include CookiePreferenceConcerns
+
+  def consent_cookie
+    'consented-to-manage-cookies'
+  end
+
+  def cookie_page_path
+    provider_interface_cookies_path
+  end
+end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -16,6 +16,7 @@ module ProviderInterface
     before_action :authenticate_provider_user!
     before_action :add_identity_to_log
     before_action :redirect_if_setup_required
+    before_action :check_cookie_preferences
 
     layout 'application'
 
@@ -29,6 +30,10 @@ module ProviderInterface
 
     def current_provider_user
       !@current_provider_user.nil? ? @current_provider_user : @current_provider_user = (ProviderUser.load_from_session(session) || false)
+    end
+
+    def check_cookie_preferences
+      @google_analytics_id = ENV.fetch('GOOGLE_ANALYTICS_MANAGE', '') if cookies['consented-to-manage-cookies'].eql?('yes')
     end
 
     alias_method :audit_user, :current_provider_user

--- a/app/forms/cookie_preferences_form.rb
+++ b/app/forms/cookie_preferences_form.rb
@@ -1,0 +1,11 @@
+class CookiePreferencesForm
+  include ActiveModel::Model
+
+  attr_accessor :consent
+
+  validates :consent, inclusion: { in: %w[yes no] }
+
+  def initialize(consent:)
+    @consent = consent
+  end
+end

--- a/app/frontend/styles/_cookies-banner.scss
+++ b/app/frontend/styles/_cookies-banner.scss
@@ -1,0 +1,7 @@
+.cookies_banner__button {
+  padding: 0;
+}
+
+.cookies_banner__button .govuk-button {
+  width: 90%;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -48,3 +48,4 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 @import "_status-box";
 @import "_summary-card";
 @import "_feedback";
+@import "_cookies-banner";

--- a/app/views/content/cookies.html.erb
+++ b/app/views/content/cookies.html.erb
@@ -1,0 +1,140 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Cookies</h1>
+
+    <h2 class="govuk-heading-l" id="cookies-that-measure-website-use">Cookies that measure website use</h2>
+
+    <p class="govuk-body">
+    We use Google Analytics software to collect information about how you use ‘<%= service_name %>’. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+    </p>
+
+    <p class="govuk-body">
+      Google Analytics stores information about:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Whether you’ve visited before
+        <li>the pages you visit on ‘<%= service_name %>’</li>
+        <li>how long you spend on each page </li>
+        <li>how you got to the site </li>
+        <li>what you click on while you’re visiting the site </li>
+    </ul>
+    <p class="govuk-body">
+    We don’t allow Google to use or share our analytics data.
+    </p>
+
+    <p id="preferences" class="govuk-body">
+    <%= form_with model: @cookie_preferences, url: @cookie_settings_path, method: :post do |f| %>
+    <%= f.govuk_collection_radio_buttons :consent,
+      [['yes', 'Yes, opt-in to Google Analytics cookies'], ['no', 'No, do not track my website usage']],
+      :first,
+      :last,
+      legend: { text: 'Do you accept Google Analytics cookies?' } %>
+    <%= f.govuk_submit "Save preferences" %>
+    <% end %>
+    </p>
+
+    <h2 class="govuk-heading-l" id="how-we-use-cookies">How we use cookies</h2>
+
+    <h3 class="govuk-heading-m" id="essential-cookies">Essential cookies</h3>
+
+    <p class="govuk-body">
+    Essential ‘<%= service_name %>’ cookies include:
+    </p>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">
+            Name
+          </th>
+          <th scope="col" class="govuk-table__header">
+            Purpose
+          </th>
+          <th scope="col" class="govuk-table__header">
+            Expires
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body govuk-!-font-size-14">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            _apply_for_postgraduate_teacher_training_session
+          </td>
+          <td class="govuk-table__cell">
+            Stores encrypted session data
+          </td>
+          <td class="govuk-table__cell">
+            When you close your browser
+          </td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">
+            <%= "consented-to-#{@application}-cookies" %>
+          </td>
+          <td class="govuk-table__cell">
+            Saves your cookie consent settings
+          </td>
+          <td class="govuk-table__cell">
+            6 months
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="govuk-heading-m" id="measuring-website-usage">Measuring website usage (Google Analytics)</h3>
+
+    <p class="govuk-body">
+    Google Analytics sets the following cookies:
+    </p>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">
+            Name
+          </th>
+          <th scope="col" class="govuk-table__header">
+            Purpose
+          </th>
+          <th scope="col" class="govuk-table__header">
+            Expires
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body govuk-!-font-size-14">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            _ga
+          </td>
+          <td class="govuk-table__cell">
+            Used to distinguish anonymous users
+          </td>
+          <td class="govuk-table__cell">
+            2 years
+          </td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">
+            _gid
+          </td>
+          <td class="govuk-table__cell">
+            Used to distinguish anonymous users
+          </td>
+          <td class="govuk-table__cell">
+            24 hours
+          </td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">
+            _gat_gtag_<%= @cookie_ga_code %>
+          </td>
+          <td class="govuk-table__cell">
+            Throttle requests
+          </td>
+          <td class="govuk-table__cell">
+            10 minutes
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/content/cookies_candidate.md
+++ b/app/views/content/cookies_candidate.md
@@ -1,9 +1,0 @@
-Cookies are used to remember who you are when you have signed in so we can show you your information and information relevant to you.
-
-## How we use cookies
-
-Apply for teacher training cookies may include:
-
-| Name                                                   | Purpose                                        | Expires                       |
-| :------------------------------------------------      | :--------------------------------------------- | :---------------------------- |
-| \_apply\_for\_postgraduate\_teacher\_training\_session | Used to remember your identity when signed in  | When you close your browser   |

--- a/app/views/content/cookies_provider.md
+++ b/app/views/content/cookies_provider.md
@@ -1,9 +1,0 @@
-Cookies are used to remember who you are when you have signed in so we can show you your information and information relevant to you.
-
-## How we use cookies
-
-Manage teacher training applications cookies may include:
-
-| Name                                                   | Purpose                                        | Expires                      |
-| :------------------------------------------------      | :--------------------------------------------- | :--------------------------- |
-| \_apply\_for\_postgraduate\_teacher\_training\_session | Used to remember your identity when signed in  | When you close your browser  |

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -41,6 +41,17 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
+      <% if try(:current_namespace).eql?('candidate_interface') && cookies['consented-to-apply-cookies'].blank? %>
+        <%= render 'shared/cookies_banner',
+                   cookies_path: candidate_interface_cookies_path,
+                   cookie_preferences_path: candidate_interface_cookie_preferences_path(consent: 'yes') %>
+
+      <% elsif try(:current_namespace).eql?('provider_interface') && cookies['consented-to-manage-cookies'].blank? %>
+        <%= render 'shared/cookies_banner',
+                   cookies_path: provider_interface_cookies_path,
+                   cookie_preferences_path: provider_interface_cookie_preferences_path(consent: 'yes') %>
+      <% end %>
+
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
     <%= render 'layouts/header' %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -41,6 +41,7 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
+    <% unless current_page?(candidate_interface_cookies_path) || current_page?(provider_interface_cookies_path) %>
       <% if try(:current_namespace).eql?('candidate_interface') && cookies['consented-to-apply-cookies'].blank? %>
         <%= render 'shared/cookies_banner',
                    cookies_path: candidate_interface_cookies_path,
@@ -51,6 +52,7 @@
                    cookies_path: provider_interface_cookies_path,
                    cookie_preferences_path: provider_interface_cookie_preferences_path(consent: 'yes') %>
       <% end %>
+    <% end %>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
+    <%= render 'shared/analytics' if @google_analytics_id.present? %>
     <meta charset="utf-8">
     <title><%= try(:browser_title) %></title>
     <%= csrf_meta_tags %>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,0 +1,8 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= @google_analytics_id %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '<%= @google_analytics_id %>');
+</script>

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-width-container govuk-!-padding-top-4">
+        <h1 class="govuk-heading-m govuk-!-margin-bottom-4">
+          Tell us whether you accept cookies
+        </h1>
+        <p class="govuk-body">
+        We use <%= govuk_link_to 'cookies to collect information', cookies_path %> about how you use ‘<%= service_name %>’. We use this information to make the website work as well as possible and improve government services.
+        </p>
+        <div class="cookies_banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+          <%= form_with model: CookiePreferencesForm.new(consent: 'yes'), url: cookie_preferences_path, method: :post do |f| %>
+            <%= f.govuk_submit 'Accept all cookies' %>
+          <% end %>
+        </div>
+        <div class="cookies_banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+          <a class="govuk-button" href=<%= cookies_path %>>Set cookie preferences</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,11 +18,13 @@ Rails.application.routes.draw do
     get '/', to: redirect(GOVUK_APPLY_START_PAGE_URL)
 
     get '/accessibility', to: 'content#accessibility'
-    get '/cookies', to: 'content#cookies_candidate', as: :cookies
+    get '/cookies', to: 'content#cookies_page', as: :cookies
     get '/make-a-complaint', to: 'content#complaints', as: :complaints
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/providers', to: 'content#providers', as: :providers
     get '/terms-of-use', to: 'content#terms_candidate', as: :terms
+
+    resources :cookie_preferences, only: 'create', path: 'cookie-preferences'
 
     get '/account', to: 'start_page#create_account_or_sign_in', as: :create_account_or_sign_in
     post '/account', to: 'start_page#create_account_or_sign_in_handler'
@@ -553,10 +555,12 @@ Rails.application.routes.draw do
 
     get '/accessibility', to: 'content#accessibility'
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
-    get '/cookies', to: 'content#cookies_provider', as: :cookies
+    get '/cookies', to: 'content#cookies_page', as: :cookies
     get '/make-a-complaint', to: 'content#complaints', as: :complaints
     get '/service-guidance', to: 'content#service_guidance_provider', as: :service_guidance
     get '/covid-19-guidance', to: redirect('/')
+
+    resources :cookie_preferences, only: 'create', path: 'cookie-preferences'
 
     get '/getting-ready-for-next-cycle', to: redirect('/provider/guidance-for-the-new-cycle')
     get '/guidance-for-the-new-cycle', to: 'content#guidance_for_the_new_cycle', as: :guidance_for_the_new_cycle

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -7,9 +7,11 @@ RSpec.feature 'Candidate content' do
     given_i_am_on_the_start_page
     when_i_click_on_accessibility
     then_i_can_see_the_accessibility_statement
+    and_i_can_see_the_cookie_banner
 
     when_i_click_on_the_cookies_page
     then_i_can_see_the_cookies_page
+    and_i_can_no_longer_see_the_cookie_banner
     and_i_can_opt_in_to_tracking_website_usage
     and_i_can_go_back_to_the_page_i_was_looking_at_before
 
@@ -35,8 +37,16 @@ RSpec.feature 'Candidate content' do
     expect(page).to have_content(t('page_titles.accessibility'))
   end
 
+  def and_i_can_see_the_cookie_banner
+    expect(page).to have_content('We use cookies to collect information about how you use ‘Apply for teacher training’')
+  end
+
   def when_i_click_on_the_cookies_page
     within('.govuk-footer') { click_link t('layout.support_links.cookies') }
+  end
+
+  def and_i_can_no_longer_see_the_cookie_banner
+    expect(page).not_to have_content('We use cookies to collect information about how you use ‘Apply for teacher training’')
   end
 
   def then_i_can_see_the_cookies_page

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -8,8 +8,9 @@ RSpec.feature 'Candidate content' do
     when_i_click_on_accessibility
     then_i_can_see_the_accessibility_statement
 
-    when_i_click_on_the_cookie_policy
-    then_i_can_see_the_cookie_policy
+    when_i_click_on_the_cookies_page
+    then_i_can_see_the_cookies_page
+    and_i_can_opt_in_to_tracking_website_usage
 
     when_i_click_on_complaints
     then_i_can_see_the_complaints_page
@@ -33,13 +34,19 @@ RSpec.feature 'Candidate content' do
     expect(page).to have_content(t('page_titles.accessibility'))
   end
 
-  def when_i_click_on_the_cookie_policy
+  def when_i_click_on_the_cookies_page
     within('.govuk-footer') { click_link t('layout.support_links.cookies') }
   end
 
-  def then_i_can_see_the_cookie_policy
+  def then_i_can_see_the_cookies_page
     expect(page).to have_content(t('page_titles.cookies_candidate'))
     expect(page).to have_content('When you close your browser')
+  end
+
+  def and_i_can_opt_in_to_tracking_website_usage
+    choose 'Yes, opt-in to Google Analytics cookies'
+    click_on 'Save preferences'
+    expect(page).to have_content('Your cookie preferences have been updated')
   end
 
   def when_i_click_on_complaints

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Candidate content' do
     when_i_click_on_the_cookies_page
     then_i_can_see_the_cookies_page
     and_i_can_opt_in_to_tracking_website_usage
+    and_i_can_go_back_to_the_page_i_was_looking_at_before
 
     when_i_click_on_complaints
     then_i_can_see_the_complaints_page
@@ -47,6 +48,10 @@ RSpec.feature 'Candidate content' do
     choose 'Yes, opt-in to Google Analytics cookies'
     click_on 'Save preferences'
     expect(page).to have_content('Your cookie preferences have been updated')
+  end
+
+  def and_i_can_go_back_to_the_page_i_was_looking_at_before
+    expect(page).to have_link('Go back to the page you were looking at', href: /#{candidate_interface_accessibility_path}/)
   end
 
   def when_i_click_on_complaints

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -8,8 +8,10 @@ RSpec.feature 'Provider content' do
 
     when_i_click_on_complaints
     then_i_can_see_the_complaints_page
+    and_i_can_see_the_cookie_banner
 
     when_i_click_on_the_cookies_page
+    and_i_can_no_longer_see_the_cookie_banner
     then_i_can_see_the_cookies_page
     and_i_can_opt_in_to_tracking_website_usage
     and_i_can_go_back_to_the_page_i_was_looking_at_before
@@ -33,8 +35,16 @@ RSpec.feature 'Provider content' do
     expect(page).to have_content(t('page_titles.accessibility'))
   end
 
+  def and_i_can_see_the_cookie_banner
+    expect(page).to have_content('We use cookies to collect information about how you use ‘Manage teacher training applications’')
+  end
+
   def when_i_click_on_the_cookies_page
     within('.govuk-footer') { click_link t('layout.support_links.cookies') }
+  end
+
+  def and_i_can_no_longer_see_the_cookie_banner
+    expect(page).not_to have_content('We use cookies to collect information about how you use ‘Manage teacher training applications’')
   end
 
   def then_i_can_see_the_cookies_page

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -6,8 +6,9 @@ RSpec.feature 'Provider content' do
     when_i_click_on_accessibility
     then_i_can_see_the_accessibility_statement
 
-    when_i_click_on_the_cookie_policy
-    then_i_can_see_the_cookie_policy
+    when_i_click_on_the_cookies_page
+    then_i_can_see_the_cookies_page
+    and_i_can_opt_in_to_tracking_website_usage
 
     when_i_click_on_complaints
     then_i_can_see_the_complaints_page
@@ -31,12 +32,18 @@ RSpec.feature 'Provider content' do
     expect(page).to have_content(t('page_titles.accessibility'))
   end
 
-  def when_i_click_on_the_cookie_policy
+  def when_i_click_on_the_cookies_page
     within('.govuk-footer') { click_link t('layout.support_links.cookies') }
   end
 
-  def then_i_can_see_the_cookie_policy
+  def then_i_can_see_the_cookies_page
     expect(page).to have_content(t('page_titles.cookies_provider'))
+  end
+
+  def and_i_can_opt_in_to_tracking_website_usage
+    choose 'Yes, opt-in to Google Analytics cookies'
+    click_on 'Save preferences'
+    expect(page).to have_content('Your cookie preferences have been updated')
   end
 
   def when_i_click_on_complaints

--- a/spec/system/provider_interface/provider_content_spec.rb
+++ b/spec/system/provider_interface/provider_content_spec.rb
@@ -6,12 +6,13 @@ RSpec.feature 'Provider content' do
     when_i_click_on_accessibility
     then_i_can_see_the_accessibility_statement
 
+    when_i_click_on_complaints
+    then_i_can_see_the_complaints_page
+
     when_i_click_on_the_cookies_page
     then_i_can_see_the_cookies_page
     and_i_can_opt_in_to_tracking_website_usage
-
-    when_i_click_on_complaints
-    then_i_can_see_the_complaints_page
+    and_i_can_go_back_to_the_page_i_was_looking_at_before
 
     when_i_click_on_the_privacy_policy
     then_i_can_see_the_privacy_policy
@@ -44,6 +45,10 @@ RSpec.feature 'Provider content' do
     choose 'Yes, opt-in to Google Analytics cookies'
     click_on 'Save preferences'
     expect(page).to have_content('Your cookie preferences have been updated')
+  end
+
+  def and_i_can_go_back_to_the_page_i_was_looking_at_before
+    expect(page).to have_link('Go back to the page you were looking at', href: /#{provider_interface_complaints_path}/)
   end
 
   def when_i_click_on_complaints


### PR DESCRIPTION
## Context

Update apply and manage cookie pages. Implement GA for both services , ensuring retention period is set to 26months for Analytics and add Cookie banner.

## Apply
<img width="668" alt="apply-cookies" src="https://user-images.githubusercontent.com/159200/103900447-b7716580-50ef-11eb-9a8b-7401ec3813f6.png">

## Manage
<img width="717" alt="manage-cookies" src="https://user-images.githubusercontent.com/159200/103900455-ba6c5600-50ef-11eb-984e-328b26d0da6d.png">

## Cookie banner
<img width="724" alt="cookie-banner" src="https://user-images.githubusercontent.com/159200/103900530-cd7f2600-50ef-11eb-81e9-1ed0ea12d918.png">

## Link to Trello card

https://trello.com/c/BqQN1YZx/3163-implement-google-analytics-on-manage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
