### PR TITLE
Improve Reasons for Rejection validation messaging

### DIFF
--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -3,8 +3,7 @@ class RejectApplication
 
   attr_accessor :rejection_reason, :structured_rejection_reasons
 
-  validates_presence_of :rejection_reason, if: -> { structured_rejection_reasons.blank? }
-  validates_presence_of :structured_rejection_reasons, if: -> { rejection_reason.blank? }
+  validate :at_least_one_rejection_reason_format
   validates_length_of :rejection_reason, maximum: 10240
 
   def initialize(actor:, application_choice:, rejection_reason: nil, structured_rejection_reasons: nil)
@@ -40,5 +39,13 @@ class RejectApplication
       I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
     )
     false
+  end
+
+private
+
+  def at_least_one_rejection_reason_format
+    if rejection_reason.blank? && structured_rejection_reasons.blank?
+      errors.add(:rejection_reason, :blank)
+    end
   end
 end

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RejectApplication do
 
     it 'validates rejection_reason and structured_rejection_reasons' do
       expect(invalid_service.valid?).to be false
-      expect(invalid_service.errors.keys.sort).to eq(%i[rejection_reason structured_rejection_reasons])
+      expect(invalid_service.errors.keys.sort).to eq(%i[rejection_reason])
     end
   end
 


### PR DESCRIPTION
## Context
When rejecting an application either via the API or via the UI, if the rejection reason is left blank then two error messages show.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Only display one validation error if both structured and freetext reasons for rejection are left blank
<!-- If there are UI changes, please include Before and After screenshots. -->

Over the API:
<img width="634" alt="Screenshot 2021-01-07 at 14 56 36" src="https://user-images.githubusercontent.com/30071178/103906985-8cd7da80-50f8-11eb-9bac-69fd5f8233b5.png">


In the UI:
<img width="490" alt="Screenshot 2021-01-07 at 14 54 41" src="https://user-images.githubusercontent.com/30071178/103906772-484c3f00-50f8-11eb-9433-62ac13826bc6.png">


## Guidance to review
Is there a recommended way to get a nice error message in the UI as well as over the API?
I like the look of it on manage, but the API message isn't perfect. It'd be nice to keep the code as common as possible though
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/26TUwK3C/3177-improve-reasons-for-rejection-error-handling
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
