### PR TITLE
Refactor application state change to use symbols

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -206,7 +206,7 @@ class ApplicationForm < ApplicationRecord
 
   def ended_without_success?
     application_choices.present? &&
-      application_choices.map(&:status).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }
+      application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }
   end
 
   def can_add_reference?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -131,7 +131,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def all_provider_decisions_made?
-    application_choices.any? && (application_choices.map(&:status) & ApplicationStateChange::DECISION_PENDING_STATUSES).empty?
+    application_choices.any? && (application_choices.map(&:status).map(&:to_sym) & ApplicationStateChange::DECISION_PENDING_STATUSES).empty?
   end
 
   def all_choices_withdrawn?

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -55,7 +55,6 @@ class PerformanceStatistics
 
   def ended_without_success_sql
     sql = 'ARRAY_AGG(DISTINCT ch.status)'
-
     ApplicationStateChange::UNSUCCESSFUL_END_STATES.each do |state|
       sql = "ARRAY_REMOVE(#{sql}, '#{state}')"
     end

--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -80,13 +80,13 @@ class UCASMatchedApplication
   def application_in_progress_on_ucas?
     return false if dfe_scheme? || provider_not_on_apply?
 
-    !ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(mapped_ucas_status)
+    !ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(mapped_ucas_status.to_sym)
   end
 
   def application_in_progress_on_apply?
     return false if ucas_scheme?
 
-    !ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status)
+    !ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status.to_sym)
   end
 
   def application_accepted_on_ucas?

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -8,7 +8,7 @@ class ApplicationStateChange
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
   UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent].freeze
-  DECISION_PENDING_STATUSES = %w[awaiting_provider_decision].freeze
+  DECISION_PENDING_STATUSES = %i[awaiting_provider_decision].freeze
   TERMINAL_STATES = UNSUCCESSFUL_END_STATES + %i[recruited].freeze
 
   attr_reader :application_choice

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -7,7 +7,7 @@ class ApplicationStateChange
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze
-  UNSUCCESSFUL_END_STATES = %w[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent].freeze
+  UNSUCCESSFUL_END_STATES = %i[withdrawn cancelled rejected declined conditions_not_met offer_withdrawn application_not_sent].freeze
   DECISION_PENDING_STATUSES = %i[awaiting_provider_decision].freeze
   TERMINAL_STATES = UNSUCCESSFUL_END_STATES + %i[recruited].freeze
 

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -73,7 +73,7 @@ class ProcessState
       :pending_conditions
     elsif any_state_is?('offer_deferred')
       :offer_deferred
-    elsif (states.uniq - ApplicationStateChange::UNSUCCESSFUL_END_STATES).empty?
+    elsif (states.uniq.map(&:to_sym) - ApplicationStateChange::UNSUCCESSFUL_END_STATES).empty?
       :ended_without_success
     else
       :unknown_state

--- a/app/services/send_apply_again_call_to_action.rb
+++ b/app/services/send_apply_again_call_to_action.rb
@@ -16,7 +16,7 @@ private
       .joins("LEFT OUTER JOIN emails ON emails.application_form_id = application_forms.id AND emails.mailer = 'candidate_mailer' AND emails.mail_template = 'apply_again_call_to_action'")
       .joins('LEFT OUTER JOIN application_forms AS subsequent_application_form ON application_forms.id = subsequent_application_form.previous_application_form_id')
       .where.not(application_choices: {
-        status: ApplicationStateChange.valid_states - ApplicationStateChange::UNSUCCESSFUL_END_STATES.map(&:to_sym),
+        status: ApplicationStateChange.valid_states - ApplicationStateChange::UNSUCCESSFUL_END_STATES,
       })
       .where(emails: { id: nil })
       .where(subsequent_application_form: { id: nil })

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -135,7 +135,7 @@ module SupportInterface
     def ended_without_success
       earliest_update_audit_for(
         @application_choice,
-        status: ApplicationStateChange::UNSUCCESSFUL_END_STATES,
+        status: ApplicationStateChange::UNSUCCESSFUL_END_STATES.map(&:to_s),
       )
     end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#all_provider_decisions_made?' do
-    it 'returns false if the application choices are in awaiting providor descision state' do
+    it 'returns false if the application choices are in awaiting provider decision state' do
       application_choice = create :submitted_application_choice
       application_form = create(:completed_application_form, application_choices: [application_choice])
       expect(application_form.all_provider_decisions_made?).to eq(false)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -511,4 +511,18 @@ RSpec.describe ApplicationForm do
       expect(application_form.domicile).to eq(':)')
     end
   end
+
+  describe '#all_provider_decisions_made?' do
+    it 'returns false if the application choices are in awaiting providor descision state' do
+      application_choice = create :submitted_application_choice
+      application_form = create(:completed_application_form, application_choices: [application_choice])
+      expect(application_form.all_provider_decisions_made?).to eq(false)
+    end
+
+    it 'returns true if the application choices are not in awaiting providor descision state' do
+      application_choice = create(:application_choice, :with_offer)
+      application_form = create(:completed_application_form, application_choices: [application_choice])
+      expect(application_form.all_provider_decisions_made?).to eq(true)
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -519,7 +519,7 @@ RSpec.describe ApplicationForm do
       expect(application_form.all_provider_decisions_made?).to eq(false)
     end
 
-    it 'returns true if the application choices are not in awaiting providor descision state' do
+    it 'returns true if the application choices are not in awaiting provider decision state' do
       application_choice = create(:application_choice, :with_offer)
       application_form = create(:completed_application_form, application_choices: [application_choice])
       expect(application_form.all_provider_decisions_made?).to eq(true)

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -91,12 +91,10 @@ RSpec.describe PerformanceStatistics, type: :model do
       create_list(:application_choice, 2, application_form: rejected_form, status: 'rejected')
       create_list(:application_choice, 2, application_form: declined_form, status: 'declined')
       create_list(:application_choice, 2, application_form: conditions_not_met_form, status: 'conditions_not_met')
-
       expect(ProcessState.new(withdrawn_form).state).to be :ended_without_success
       expect(ProcessState.new(rejected_form).state).to be :ended_without_success
       expect(ProcessState.new(declined_form).state).to be :ended_without_success
       expect(ProcessState.new(conditions_not_met_form).state).to be :ended_without_success
-
       expect(count_for_process_state(:ended_without_success)).to be(4)
     end
   end


### PR DESCRIPTION
## Context

We used to use symbols and strings to store state of the application, we have moved to using only symbols for consistency.

## Changes proposed in this pull request

No frontend changes, no change in behaviour.

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/gsLTW1zC/3211-low-refactor-applicationstatechange-to-make-the-arrays-consistent


## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
