### PR TITLE
Bugs/issues with r4r pages

### DIFF
--- a/app/components/reasons_for_rejection_component.html.erb
+++ b/app/components/reasons_for_rejection_component.html.erb
@@ -191,10 +191,15 @@
   </div>
 <% end %>
 
-<% if reasons_for_rejection.interested_in_future_applications_y_n == 'Yes' %>
+<% if %w[Yes No].include?(reasons_for_rejection.interested_in_future_applications_y_n) %>
   <div class="app-rejection">
     <%= content_tag(subheading_tag_name, 'Future applications', class: 'govuk-heading-s') %>
-    <p class="govuk-body"><%= application_choice.provider.name %> would be interested in future applications from you.</p>
+    <p class="govuk-body">
+      <%= I18n.t(
+        "reasons_for_rejection.interested_in_future_applications.reason.#{reasons_for_rejection.interested_in_future_applications_y_n.downcase}",
+        provider_name: application_choice.provider.name,
+      )%>
+    </p>
     <% if editable? %>
       <p class="app-rejection__actions">
         <%= govuk_link_to 'Change', provider_interface_reasons_for_rejection_other_reasons_path(application_choice) %>

--- a/app/controllers/provider_interface/reasons_for_rejection_controller.rb
+++ b/app/controllers/provider_interface/reasons_for_rejection_controller.rb
@@ -54,7 +54,7 @@ module ProviderInterface
         @wizard.clear_state!
 
         flash[:success] = 'Application rejected'
-        redirect_to provider_interface_applications_path
+        redirect_to provider_interface_application_choice_path(@application_choice)
       else
         @wizard.errors.merge!(service.errors)
         render :check

--- a/app/frontend/styles/provider/_rejection.scss
+++ b/app/frontend/styles/provider/_rejection.scss
@@ -1,5 +1,5 @@
 .app-rejection {
-  margin-bottom: govuk-spacing(4);
+  margin-bottom: govuk-spacing(6);
   padding-right: 70px;
   position: relative;
 

--- a/app/presenters/rejected_application_choice_presenter.rb
+++ b/app/presenters/rejected_application_choice_presenter.rb
@@ -110,11 +110,11 @@ private
   end
 
   def interested_in_future_applications
-    return {} unless reasons.interested_in_future_applications_y_n.eql?('Yes')
+    return {} unless %w[Yes No].include?(reasons.interested_in_future_applications_y_n)
 
     reason_details(
       'interested_in_future_applications',
-      [I18n.t('reasons_for_rejection.interested_in_future_applications.reason',
+      [I18n.t("reasons_for_rejection.interested_in_future_applications.reason.#{reasons.interested_in_future_applications_y_n.downcase}",
               provider_name: course_option.course.provider.name)],
     )
   end

--- a/app/views/provider_interface/reasons_for_rejection/edit_initial_questions.html.erb
+++ b/app/views/provider_interface/reasons_for_rejection/edit_initial_questions.html.erb
@@ -117,9 +117,9 @@
         <%= f.govuk_radio_button :offered_on_another_course_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:honesty_and_professionalism_y_n, legend: { text: 'Was it related to concerns about the candidate’s honesty and professionalism', size: 'm' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:honesty_and_professionalism_y_n, legend: { text: 'Was it related to concerns about the candidate’s honesty and professionalism?', size: 'm' }) do %>
         <%= f.govuk_radio_button :honesty_and_professionalism_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_check_boxes_fieldset :honesty_and_professionalism_concerns, legend: { text: "Which qualifications?", size: "s" } do %>
+          <%= f.govuk_check_boxes_fieldset :honesty_and_professionalism_concerns, legend: { text: "What concerns did you have?", size: "s" } do %>
             <%= f.govuk_check_box :honesty_and_professionalism_concerns,
               'information_false_or_inaccurate',
               label: { text: "Information given on application form false or inaccurate" },
@@ -153,7 +153,7 @@
         <%= f.govuk_radio_button :honesty_and_professionalism_y_n, 'No', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset(:safeguarding_y_n, legend: { text: 'Was it related to safeguarding', size: 'm' }) do %>
+      <%= f.govuk_radio_buttons_fieldset(:safeguarding_y_n, legend: { text: 'Was it related to safeguarding?', size: 'm' }) do %>
         <%= f.govuk_radio_button :safeguarding_y_n, 'Yes', label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_check_boxes_fieldset :safeguarding_concerns, legend: { text: "Which safeguarding issues in particular?", size: "s" } do %>
             <%= f.govuk_check_box :safeguarding_concerns,

--- a/config/locales/reasons_for_rejection.yml
+++ b/config/locales/reasons_for_rejection.yml
@@ -29,7 +29,9 @@ en:
       title: 'Additional advice'
     interested_in_future_applications:
       title: 'Future applications'
-      reason: '%{provider_name} would be interested in future applications from you'
+      reason:
+        'yes': '%{provider_name} would be interested in future applications from you.'
+        'no': '%{provider_name} would not be interested in future applications from you.'
     candidate_behaviour_what_did_the_candidate_do:
       didnt_reply_to_interview_offer: 'Didn’t reply to our interview offer'
       didnt_attend_interview: 'Didn’t attend interview'

--- a/spec/presenters/rejected_application_choice_presenter_spec.rb
+++ b/spec/presenters/rejected_application_choice_presenter_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe RejectedApplicationChoicePresenter do
         rejected_application_choice = RejectedApplicationChoicePresenter.new(application_choice)
 
         expect(rejected_application_choice.rejection_reasons).to eq(
-          { 'Future applications' => ['UoG would be interested in future applications from you'] },
+          { 'Future applications' => ['UoG would be interested in future applications from you.'] },
         )
       end
     end

--- a/spec/presenters/vendor_api/rejection_reason_presenter_spec.rb
+++ b/spec/presenters/vendor_api/rejection_reason_presenter_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe VendorAPI::RejectionReasonPresenter do
         "Honesty and professionalism:\nLies\nLies were copied\nReferees cannot be fictional characters\nA lot of problems here",
         "Safeguarding issues:\nYou seemed very angry",
         "Additional advice:\nTry again soon",
-        "Future applications:\nUoG would be interested in future applications from you",
+        "Future applications:\nUoG would be interested in future applications from you.",
       ])
     end
 

--- a/spec/system/provider_interface/reject_an_application_spec.rb
+++ b/spec/system/provider_interface/reject_an_application_spec.rb
@@ -182,8 +182,6 @@ RSpec.describe 'Reject an application' do
   def then_i_can_see_the_reasons_why_the_application_was_rejected
     expect(page).to have_content('Application rejected')
 
-    click_on @application_choice.application_form.full_name
-
     expect(page).to have_content('Rejection details')
 
     expect(page).to have_content('The following feedback was sent to the candidate.')


### PR DESCRIPTION
## Context

A handful of things caught when reviewing reasons for rejection prior to releasing this feature.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Increased spacing between summary page sections for both candidate and provider view of R4R
- Added missing question marks and full stops.
- Redirect to the rejected application on successful rejection, rather than the applications index.
- Summarise 'Future applications' when the answer is No as well as Yes

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/93511/103924574-21006c80-510e-11eb-8249-34b06c0d3a9c.png)


![image](https://user-images.githubusercontent.com/93511/103924461-f2829180-510d-11eb-86b6-d34e97607513.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/c7jsxeqE/3221-issues-with-r4r-pages

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
