### PR TITLE
Remove checkboxes from feedback form, and make feedback mandatory

### DIFF
--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -14,7 +14,6 @@ module CandidateInterface
       if @application_feedback_form.save(current_application)
         redirect_to candidate_interface_application_feedback_thank_you_path
       else
-        @application_feedback_form.set_booleans
         track_validation_error(@references_relationship_form)
 
         render :new
@@ -27,8 +26,7 @@ module CandidateInterface
 
     def feedback_params
       strip_whitespace params.require(:candidate_interface_application_feedback_form).permit(
-        :path, :page_title, :does_not_understand_section,
-        :need_more_information, :answer_does_not_fit_format,
+        :path, :page_title,
         :other_feedback, :consent_to_be_contacted,
         :original_controller
       )

--- a/app/forms/candidate_interface/application_feedback_form.rb
+++ b/app/forms/candidate_interface/application_feedback_form.rb
@@ -6,6 +6,7 @@ module CandidateInterface
                   :need_more_information, :answer_does_not_fit_format, :other_feedback,
                   :consent_to_be_contacted
 
+    validates :other_feedback, presence: true
     validates :path, :page_title, :consent_to_be_contacted, presence: true
 
     validate :path_is_valid, if: -> { path.present? }

--- a/app/forms/candidate_interface/application_feedback_form.rb
+++ b/app/forms/candidate_interface/application_feedback_form.rb
@@ -2,35 +2,22 @@ module CandidateInterface
   class ApplicationFeedbackForm
     include ActiveModel::Model
 
-    attr_accessor :path, :page_title, :original_controller, :does_not_understand_section,
-                  :need_more_information, :answer_does_not_fit_format, :other_feedback,
+    attr_accessor :path, :page_title, :original_controller, :other_feedback,
                   :consent_to_be_contacted
 
-    validates :other_feedback, presence: true
-    validates :path, :page_title, :consent_to_be_contacted, presence: true
+    validates :path, :page_title, :consent_to_be_contacted, :other_feedback, presence: true
 
     validate :path_is_valid, if: -> { path.present? }
 
     def save(application_form)
-      set_booleans
-
       return false unless valid?
 
       application_form.application_feedback.create!(
         path: path,
         page_title: page_title,
-        does_not_understand_section: does_not_understand_section,
-        need_more_information: need_more_information,
-        answer_does_not_fit_format: answer_does_not_fit_format,
         other_feedback: other_feedback,
         consent_to_be_contacted: consent_to_be_contacted == 'true',
       )
-    end
-
-    def set_booleans
-      @does_not_understand_section = @does_not_understand_section.present?
-      @need_more_information = @need_more_information.present?
-      @answer_does_not_fit_format = @answer_does_not_fit_format.present?
     end
 
     def section_name

--- a/app/forms/candidate_interface/application_feedback_form.rb
+++ b/app/forms/candidate_interface/application_feedback_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     attr_accessor :path, :page_title, :original_controller, :other_feedback,
                   :consent_to_be_contacted
 
-    validates :path, :page_title, :consent_to_be_contacted, :other_feedback, presence: true
+    validates :path, :page_title, :other_feedback, :consent_to_be_contacted, presence: true
 
     validate :path_is_valid, if: -> { path.present? }
 

--- a/app/views/candidate_interface/application_feedback/new.html.erb
+++ b/app/views/candidate_interface/application_feedback/new.html.erb
@@ -5,22 +5,12 @@
     <%= form_with model: @application_feedback_form, url: candidate_interface_application_feedback_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl"><%= t('application_feedback.caption') %></span>
-        <%= t('page_titles.application_feedback', section: @application_feedback_form.section_name) %>
-      </h1>
-
       <%= f.hidden_field :path %>
       <%= f.hidden_field :page_title %>
       <%= f.hidden_field :original_controller %>
 
-      <%= f.govuk_check_boxes_fieldset :issues, multiple: false, legend: { text: t('application_feedback.issues.label'), size: 'm' } do %>
-        <%= f.govuk_check_box :does_not_understand_section, true, multiple: false, label: { text: t('application_feedback.issues.does_not_understand_section') }, link_errors: true %>
-        <%= f.govuk_check_box :need_more_information, true, multiple: false, label: { text: t('application_feedback.issues.need_more_information') } %>
-        <%= f.govuk_check_box :answer_does_not_fit_format, true, multiple: false, label: { text: t('application_feedback.issues.answer_does_not_fit_format') } %>
-      <% end %>
-
-      <%= f.govuk_text_area :other_feedback, label: { text: t('application_feedback.other_feedback.label'), size: 'm' }, rows: 5, max_words: 300 %>
+      <span class="govuk-caption-xl"><%= t('application_feedback.caption') %></span>
+      <%= f.govuk_text_area :other_feedback, label: { text: t('page_titles.application_feedback', section: @application_feedback_form.section_name), size: 'xl', tag: 'h1' }, rows: 5, max_words: 300, threshold: 90 %>
 
       <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, inline: true, legend: { text: t('application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
         <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('application_feedback.consent_to_be_contacted.yes') }, link_errors: true %>

--- a/config/locales/application_feedback.yml
+++ b/config/locales/application_feedback.yml
@@ -2,13 +2,6 @@ en:
   application_feedback:
     caption: Help us improve this service
     feedback_link: How can we improve this section? (Opens in a new tab)
-    issues:
-      label: What issues are there in this section?
-      does_not_understand_section: I do not understand the questions
-      need_more_information: I do not have the information needed at the moment
-      answer_does_not_fit_format: My answers do not fit the format
-    other_feedback:
-      label: Do you have any other feedback about this section?
     consent_to_be_contacted:
       label: Can we contact you about your feedback?
       'yes': 'Yes'

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1013,9 +1013,9 @@ en:
             page_title:
               blank: Page title cannot be blank
             other_feedback:
-              blank: Enter some feedback on how we can improve this section
+              blank: Enter feedback on how we can improve this section
             consent_to_be_contacted:
-              blank: Say yes if we can contact you about your feedback
+              blank: Select yes if we can contact you about your feedback
         candidate_interface/find_feedback_form:
           attributes:
             path:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1012,10 +1012,10 @@ en:
               invalid: Path must be a valid endpoint
             page_title:
               blank: Page title cannot be blank
-            issues:
-              blank: Issues cannot blank
+            other_feedback:
+              blank: Enter some feedback on how we can improve this section
             consent_to_be_contacted:
-              blank: Can we contact you about your feedback?
+              blank: Say yes if we can contact you about your feedback
         candidate_interface/find_feedback_form:
           attributes:
             path:

--- a/spec/forms/candidate_interface/application_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/application_feedback_form_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
     described_class.new(
       path: 'candidate/application/references/type/edit/1',
       page_title: t('page_titles.references_type'),
-      need_more_information: 'true',
-      answer_does_not_fit_format: 'true',
       other_feedback: 'This would be easier if i could read.',
       consent_to_be_contacted: 'false',
     )
@@ -18,6 +16,7 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
     it { is_expected.to validate_presence_of(:path) }
     it { is_expected.to validate_presence_of(:page_title) }
     it { is_expected.to validate_presence_of(:consent_to_be_contacted) }
+    it { is_expected.to validate_presence_of(:other_feedback) }
 
     describe '#path_is_valid' do
       it 'returns false if the path is not one of our endpoints' do
@@ -46,9 +45,6 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
       expect(application_form.application_feedback.count).to eq 1
       expect(feedback.path).to eq form.path
       expect(feedback.page_title).to eq form.page_title
-      expect(feedback.does_not_understand_section).to eq false
-      expect(feedback.need_more_information).to eq true
-      expect(feedback.answer_does_not_fit_format).to eq true
       expect(feedback.other_feedback).to eq 'This would be easier if i could read.'
       expect(feedback.consent_to_be_contacted).to eq false
     end

--- a/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
@@ -44,9 +44,7 @@ RSpec.feature 'Candidate provides feedback during the application process' do
   end
 
   def when_i_fill_in_my_feedback
-    check t('application_feedback.issues.does_not_understand_section')
-    check t('application_feedback.issues.answer_does_not_fit_format')
-    fill_in t('application_feedback.other_feedback.label'), with: 'Me no understand.'
+    fill_in t('page_titles.application_feedback', section: 'the references'), with: 'Me no understand.'
     choose t('application_feedback.consent_to_be_contacted.yes')
 
     click_button t('application_feedback.submit')
@@ -60,9 +58,6 @@ RSpec.feature 'Candidate provides feedback during the application process' do
     expect(@application.application_feedback.count).to eq 1
     expect(@application.application_feedback.last.path).to eq '/candidate/application/references/start'
     expect(@application.application_feedback.last.page_title).to eq t('page_titles.references_start')
-    expect(@application.application_feedback.last.does_not_understand_section).to eq true
-    expect(@application.application_feedback.last.need_more_information).to eq false
-    expect(@application.application_feedback.last.answer_does_not_fit_format).to eq true
     expect(@application.application_feedback.last.other_feedback).to eq 'Me no understand.'
     expect(@application.application_feedback.last.consent_to_be_contacted).to eq true
   end


### PR DESCRIPTION
## Context

The accessibility audit highlighted that the checkboxes and the textarea on the feedback form did not indicate that they were both optional.

## Changes proposed in this pull request

Whilst we could fix the narrow accessibility issue by adding the word "(optional)" to the legend/label, this would be a bit odd, and really it doesn't make sense that that the form can be submitted with no feedback or checkboxes ticked at all.

We did consider adding a forth catch-all checkbox, and making ticking at least one of them mandatory, but on further thought it seemed like having just a checkbox ticked with no other feedback given is unlikely to be that helpful (especially at low volumes), so a simpler approach would be to remove the checkboxes altogether, and just have a single mandatory feedback textarea.

In addition, the error message for the "Can we contact you about your feedback?" has been improved.

### Before

![localhost_3000_candidate_application_application-feedback_original_controller=candidate_interface%2Freferences%2Freview page_title=References path=%2Fcandidate%2Fapplication%2Freferences%2Freview](https://user-images.githubusercontent.com/30665/103999273-97e04880-5194-11eb-813b-2c0db81bb494.png)

![localhost_3000_candidate_application_application-feedback](https://user-images.githubusercontent.com/30665/103999330-a7f82800-5194-11eb-95fd-d4dfdf20064b.png)

### After

![localhost_3000_candidate_application_application-feedback_original_controller=candidate_interface%2Freferences%2Freview page_title=References path=%2Fcandidate%2Fapplication%2Freferences%2Freview (1)](https://user-images.githubusercontent.com/30665/103999349-adee0900-5194-11eb-8c22-e9d36b43011c.png)

![localhost_3000_candidate_application_application-feedback (1)](https://user-images.githubusercontent.com/30665/103999365-b2b2bd00-5194-11eb-9642-fd1e2109ef91.png)

## Guidance to review

Whilst this changes the form, the export is currently unaffected, and will still export the 3 boolean fields, even though for future feedback these will all be false. A follow-up Pull Request should remove these fields from the database and remove them from the export.

The feedback field is currently still named `other_feedback` in the database and the code. We should probably rename this to just `feedback` within a separate database migration.

## Link to Trello card

https://trello.com/c/eIt8mxNH/2805-dac-feedback-form-whats-optional

## Things to check

- [x] This code does not rely on migrations in the same Pull Request