### PR TITLE
Feature metric dashboard part 2 - Work history/Rejections

### DIFF
--- a/app/controllers/support_interface/feature_metrics_dashboard_controller.rb
+++ b/app/controllers/support_interface/feature_metrics_dashboard_controller.rb
@@ -3,6 +3,7 @@ module SupportInterface
     def dashboard
       @reference_statistics = ReferenceFeatureMetrics.new
       @work_history_statistics = WorkHistoryFeatureMetrics.new
+      @reasons_for_rejection_statistics = ReasonsForRejectionFeatureMetrics.new
     end
   end
 end

--- a/app/controllers/support_interface/feature_metrics_dashboard_controller.rb
+++ b/app/controllers/support_interface/feature_metrics_dashboard_controller.rb
@@ -1,7 +1,8 @@
 module SupportInterface
   class FeatureMetricsDashboardController < SupportInterfaceController
     def dashboard
-      @statistics = FeatureMetrics.new
+      @reference_statistics = ReferenceFeatureMetrics.new
+      @work_history_statistics = WorkHistoryFeatureMetrics.new
     end
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -77,6 +77,7 @@ class TestApplications
         updated_at: time,
         recruitment_cycle_year: recruitment_cycle_year,
         phase: apply_again ? 'apply_2' : 'apply_1',
+        work_history_completed: false,
       )
 
       # One reference that will never be requested
@@ -128,6 +129,9 @@ class TestApplications
       if states.include?(:unsubmitted)
         return application_choices
       end
+
+      @application_form.update!(work_history_completed: true)
+      fast_forward
 
       # The first reference is declined by the referee
       @application_form.application_references.feedback_requested.first.update!(feedback_status: 'feedback_refused')

--- a/app/models/reasons_for_rejection_feature_metrics.rb
+++ b/app/models/reasons_for_rejection_feature_metrics.rb
@@ -6,6 +6,8 @@ class ReasonsForRejectionFeatureMetrics
     start_time,
     end_time = Time.zone.now.beginning_of_day
   )
+    raise ArgumentError unless ProviderInterface::ReasonsForRejectionWizard::INITIAL_TOP_LEVEL_QUESTIONS.include?(reason)
+
     ApplicationChoice
       .rejected
       .where("structured_rejection_reasons->>'#{reason}' = 'Yes'")

--- a/app/models/reasons_for_rejection_feature_metrics.rb
+++ b/app/models/reasons_for_rejection_feature_metrics.rb
@@ -1,0 +1,15 @@
+class ReasonsForRejectionFeatureMetrics
+  include ActionView::Helpers::NumberHelper
+
+  def rejections_due_to(
+    reason,
+    start_time,
+    end_time = Time.zone.now.beginning_of_day
+  )
+    application_choices = ApplicationChoice
+      .rejected
+      .where("structured_rejection_reasons->>'#{reason}' = 'Yes'")
+      .where('rejected_at BETWEEN ? AND ?', start_time, end_time)
+      .count
+  end
+end

--- a/app/models/reasons_for_rejection_feature_metrics.rb
+++ b/app/models/reasons_for_rejection_feature_metrics.rb
@@ -6,7 +6,7 @@ class ReasonsForRejectionFeatureMetrics
     start_time,
     end_time = Time.zone.now.beginning_of_day
   )
-    application_choices = ApplicationChoice
+    ApplicationChoice
       .rejected
       .where("structured_rejection_reasons->>'#{reason}' = 'Yes'")
       .where('rejected_at BETWEEN ? AND ?', start_time, end_time)

--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -1,4 +1,4 @@
-class FeatureMetrics
+class ReferenceFeatureMetrics
   include ActionView::Helpers::NumberHelper
 
   def average_time_to_get_references(

--- a/app/models/work_history_feature_metrics.rb
+++ b/app/models/work_history_feature_metrics.rb
@@ -1,0 +1,42 @@
+class WorkHistoryFeatureMetrics
+  include ActionView::Helpers::NumberHelper
+
+  def average_time_to_complete(
+    start_time,
+    end_time = Time.zone.now.beginning_of_day
+  )
+    times_to_get = time_to_complete(start_time, end_time)
+    return 'n/a' if times_to_get.blank?
+
+    number_with_precision(
+      times_to_get.sum.to_f / times_to_get.size,
+      precision: 1,
+      strip_insignificant_zeros: true,
+    )
+  end
+
+private
+
+  def time_to_complete(start_time, end_time = Time.zone.now)
+    applications = ApplicationForm
+      .where(
+        'application_forms.id IN (:application_form_ids)',
+        application_form_ids: Audited::Audit
+          .select(:auditable_id)
+          .where(auditable_type: 'ApplicationForm')
+          .where("audited_changes#>>'{work_history_completed, 1}' = 'true'")
+          .where('created_at BETWEEN ? AND ?', start_time, end_time),
+      )
+    applications.map { |application| time_to_complete_for(application) }.compact
+  end
+
+  def time_to_complete_for(application)
+    completion_audit = application.audits.where("audited_changes#>>'{work_history_completed, 1}' = 'true'").last
+    started_at = (
+      application.application_work_history_breaks.pluck(:created_at) +
+      application.application_volunteering_experiences.pluck(:created_at) +
+      application.application_work_experiences.pluck(:created_at)).min
+
+    (completion_audit.created_at - started_at).to_i / 1.day
+  end
+end

--- a/app/models/work_history_feature_metrics.rb
+++ b/app/models/work_history_feature_metrics.rb
@@ -8,11 +8,12 @@ class WorkHistoryFeatureMetrics
     times_to_get = time_to_complete(start_time, end_time)
     return 'n/a' if times_to_get.blank?
 
-    number_with_precision(
+    average_days = number_with_precision(
       times_to_get.sum.to_f / times_to_get.size,
       precision: 1,
       strip_insignificant_zeros: true,
     )
+    "#{average_days} #{'day'.pluralize(average_days)}"
   end
 
 private

--- a/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, 'Feature metrics' %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
-<div class="govuk-grid-row govuk-!-margin-bottom-4">
+<div id="references_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">
     <div id="headline-stat" class="govuk-!-margin-bottom-4">
       <%= render SupportInterface::TileComponent.new(
-        count: @statistics.average_time_to_get_references(
+        count: @reference_statistics.average_time_to_get_references(
           EndOfCycleTimetable.apply_reopens.beginning_of_day,
         ),
         label: 'average time to get reference back',
@@ -16,7 +16,7 @@
     <div class="govuk-grid-row govuk-!-margin-bottom-4">
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
-          count: @statistics.average_time_to_get_references(
+          count: @reference_statistics.average_time_to_get_references(
             Time.zone.now.beginning_of_month,
           ),
           label: 'this month',
@@ -25,7 +25,7 @@
       </div>
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
-          count: @statistics.average_time_to_get_references(
+          count: @reference_statistics.average_time_to_get_references(
             Time.zone.now.beginning_of_month - 1.month,
             Time.zone.now.beginning_of_month,
           ),
@@ -39,7 +39,7 @@
   <div class="govuk-grid-column-one-half">
     <div id="headline-stat" class="govuk-!-margin-bottom-4">
       <%= render SupportInterface::TileComponent.new(
-        count: @statistics.percentage_references_within(
+        count: @reference_statistics.percentage_references_within(
           30,
           EndOfCycleTimetable.apply_reopens.beginning_of_day,
         ),
@@ -51,7 +51,7 @@
     <div class="govuk-grid-row govuk-!-margin-bottom-4">
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
-          count: @statistics.percentage_references_within(
+          count: @reference_statistics.percentage_references_within(
             30,
             Time.zone.now.beginning_of_month,
           ),
@@ -61,10 +61,44 @@
       </div>
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
-          count: @statistics.percentage_references_within(
+          count: @reference_statistics.percentage_references_within(
             30,
             Time.zone.now.beginning_of_month - 1.month,
             Time.zone.now.beginning_of_month,
+          ),
+          label: 'last month',
+          size: :reduced,
+        ) %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Work history</h3>
+<div id="work_history_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <div id="headline-stat" class="govuk-!-margin-bottom-4">
+      <%= render SupportInterface::TileComponent.new(
+        count: nil,
+        label: 'time to complete (days)',
+        colour: :blue,
+        size: :reduced,
+      ) %>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @work_history_statistics.average_time_to_complete(
+            EndOfCycleTimetable.apply_reopens.beginning_of_day,
+          ),
+          label: 'this cycle',
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @work_history_statistics.average_time_to_complete(
+            1.month.ago.beginning_of_day,
           ),
           label: 'last month',
           size: :reduced,

--- a/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
@@ -79,8 +79,10 @@
   <div class="govuk-grid-column-one-half">
     <div id="headline-stat" class="govuk-!-margin-bottom-4">
       <%= render SupportInterface::TileComponent.new(
-        count: nil,
-        label: 'time to complete (days)',
+        count: @work_history_statistics.average_time_to_complete(
+          EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        ),
+        label: 'time to complete',
         colour: :blue,
         size: :reduced,
       ) %>
@@ -89,16 +91,57 @@
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
           count: @work_history_statistics.average_time_to_complete(
-            EndOfCycleTimetable.apply_reopens.beginning_of_day,
+            Time.zone.now.beginning_of_month,
           ),
-          label: 'this cycle',
+          label: 'this month',
           size: :reduced,
         ) %>
       </div>
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
           count: @work_history_statistics.average_time_to_complete(
-            1.month.ago.beginning_of_day,
+            Time.zone.now.beginning_of_month - 1.month,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'last month',
+          size: :reduced,
+        ) %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Reasons for rejection</h3>
+<div id="reasons_for_rejection_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <div id="headline-stat" class="govuk-!-margin-bottom-4">
+      <%= render SupportInterface::TileComponent.new(
+        count: @reasons_for_rejection_statistics.rejections_due_to(
+          :qualifications_y_n,
+          EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        ),
+        label: 'rejections due to qualifications',
+        colour: :blue,
+        size: :reduced,
+      ) %>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @reasons_for_rejection_statistics.rejections_due_to(
+            :qualifications_y_n,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'this month',
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @reasons_for_rejection_statistics.rejections_due_to(
+            :qualifications_y_n,
+            Time.zone.now.beginning_of_month - 1.month,
+            Time.zone.now.beginning_of_month,
           ),
           label: 'last month',
           size: :reduced,

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -41,6 +41,26 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "4a0e88c74e34b17ceb1396c341da9b9d45c4f3f12b28e8b871e7dbb57ddf8b5e",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/reasons_for_rejection_feature_metrics.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationChoice.rejected.where(\"structured_rejection_reasons->>'#{reason}' = 'Yes'\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ReasonsForRejectionFeatureMetrics",
+        "method": "rejections_due_to"
+      },
+      "user_input": "reason",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "4c106936481ffa09c60383aed2a7b8e931b1672602d3f5a69ccaf9bd688cbf62",
@@ -161,6 +181,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-01-07 21:49:29 +0000",
+  "updated": "2021-01-11 22:04:46 +0000",
   "brakeman_version": "4.10.1"
 }

--- a/spec/models/reasons_for_rejection_feature_metrics_spec.rb
+++ b/spec/models/reasons_for_rejection_feature_metrics_spec.rb
@@ -29,41 +29,47 @@ RSpec.describe ReasonsForRejectionFeatureMetrics do
         Timecop.freeze(@today - 9.days) do
           reject_application(
             @application_choice1,
-            { qualifications_y_n: 'Yes' }
+            { qualifications_y_n: 'Yes' },
           )
           reject_application(
             @application_choice2,
-            { qualifications_y_n: 'No' }
+            { qualifications_y_n: 'No' },
           )
         end
         Timecop.freeze(@today - 1.day) do
           reject_application(
             @application_choice3,
-            { qualifications_y_n: 'Yes' }
+            { qualifications_y_n: 'Yes' },
           )
         end
       end
 
       it 'returns the correct value for number of rejections due to qualifications in the last week' do
-        expect(feature_metrics.rejections_due_to(
-          :qualifications_y_n,
-          (@today - 1.week).beginning_of_day,
-          @today,
-        )).to eq(1)
+        expect(
+          feature_metrics.rejections_due_to(
+            :qualifications_y_n,
+            (@today - 1.week).beginning_of_day,
+            @today,
+          ),
+        ).to eq(1)
       end
 
       it 'returns the correct value for number of rejections due to qualifications in the last month' do
-        expect(feature_metrics.rejections_due_to(
-          :qualifications_y_n,
-          (@today - 1.month).beginning_of_day,
-        )).to eq(2)
+        expect(
+          feature_metrics.rejections_due_to(
+            :qualifications_y_n,
+            (@today - 1.month).beginning_of_day,
+          ),
+        ).to eq(2)
       end
 
       it 'returns the correct value for number of rejections due to quality of application in the last month' do
-        expect(feature_metrics.rejections_due_to(
-          :quality_of_application_y_n,
-          (@today - 1.month).beginning_of_day,
-        )).to eq(0)
+        expect(
+          feature_metrics.rejections_due_to(
+            :quality_of_application_y_n,
+            (@today - 1.month).beginning_of_day,
+          ),
+        ).to eq(0)
       end
     end
   end

--- a/spec/models/reasons_for_rejection_feature_metrics_spec.rb
+++ b/spec/models/reasons_for_rejection_feature_metrics_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe ReasonsForRejectionFeatureMetrics do
+  subject(:feature_metrics) { described_class.new }
+
+  describe '#rejections_due_to' do
+    context 'without any data' do
+      it 'just returns 0' do
+        expect(feature_metrics.rejections_due_to(:qualifications_y_n, 1.month.ago)).to eq(0)
+      end
+    end
+
+    def reject_application(application_choice, reasons)
+      ApplicationStateChange.new(application_choice).reject!
+      application_choice.update!(
+        structured_rejection_reasons: reasons,
+        rejected_at: Time.zone.now,
+      )
+    end
+
+    context 'with rejection data' do
+      before do
+        @today = Time.zone.local(2020, 12, 31, 12)
+        Timecop.freeze(@today - 12.days) do
+          @application_choice1 = create(:application_choice, :awaiting_provider_decision)
+          @application_choice2 = create(:application_choice, :awaiting_provider_decision)
+          @application_choice3 = create(:application_choice, :awaiting_provider_decision)
+        end
+        Timecop.freeze(@today - 9.days) do
+          reject_application(
+            @application_choice1,
+            { qualifications_y_n: 'Yes' }
+          )
+          reject_application(
+            @application_choice2,
+            { qualifications_y_n: 'No' }
+          )
+        end
+        Timecop.freeze(@today - 1.day) do
+          reject_application(
+            @application_choice3,
+            { qualifications_y_n: 'Yes' }
+          )
+        end
+      end
+
+      it 'returns the correct value for number of rejections due to qualifications in the last week' do
+        expect(feature_metrics.rejections_due_to(
+          :qualifications_y_n,
+          (@today - 1.week).beginning_of_day,
+          @today,
+        )).to eq(1)
+      end
+
+      it 'returns the correct value for number of rejections due to qualifications in the last month' do
+        expect(feature_metrics.rejections_due_to(
+          :qualifications_y_n,
+          (@today - 1.month).beginning_of_day,
+        )).to eq(2)
+      end
+
+      it 'returns the correct value for number of rejections due to quality of application in the last month' do
+        expect(feature_metrics.rejections_due_to(
+          :quality_of_application_y_n,
+          (@today - 1.month).beginning_of_day,
+        )).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe FeatureMetrics, with_audited: true do
+RSpec.describe ReferenceFeatureMetrics, with_audited: true do
   subject(:feature_metrics) { described_class.new }
 
   context 'without any data' do

--- a/spec/models/work_history_feature_metrics_spec.rb
+++ b/spec/models/work_history_feature_metrics_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe WorkHistoryFeatureMetrics, with_audited: true do
+  subject(:feature_metrics) { described_class.new }
+
+  describe '#average_time_to_complete' do
+    context 'without any data' do
+      it 'just returns n/a' do
+        expect(feature_metrics.average_time_to_complete(1.month.ago)).to eq('n/a')
+      end
+    end
+
+    context 'with reference data' do
+      before do
+        @today = Time.zone.local(2020, 12, 31, 12)
+        Timecop.freeze(@today - 11.days) do
+          @application_form1 = create(:application_form)
+          @application_form2 = create(:application_form)
+        end
+        Timecop.freeze(@today - 10.days) do
+          create(:application_work_experience, application_form: @application_form1)
+          create(:application_work_experience, application_form: @application_form2)
+        end
+        Timecop.freeze(@today - 8.days) do
+          @application_form1.update!(work_history_completed: true)
+        end
+        Timecop.freeze(@today - 1.day) do
+          @application_form2.update!(work_history_completed: true)
+        end
+      end
+
+      it 'returns the correct value for references received in the past week' do
+        expect(feature_metrics.average_time_to_complete((@today - 1.week), @today)).to eq('9')
+      end
+
+      it 'returns the correct value for references received in the past month' do
+        expect(feature_metrics.average_time_to_complete((@today - 1.month).beginning_of_day, @today)).to eq('5.5')
+      end
+    end
+  end
+end

--- a/spec/models/work_history_feature_metrics_spec.rb
+++ b/spec/models/work_history_feature_metrics_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe WorkHistoryFeatureMetrics, with_audited: true do
       end
 
       it 'returns the correct value for references received in the past week' do
-        expect(feature_metrics.average_time_to_complete((@today - 1.week), @today)).to eq('9')
+        expect(feature_metrics.average_time_to_complete((@today - 1.week), @today)).to eq('9 days')
       end
 
       it 'returns the correct value for references received in the past month' do
-        expect(feature_metrics.average_time_to_complete((@today - 1.month).beginning_of_day, @today)).to eq('5.5')
+        expect(feature_metrics.average_time_to_complete((@today - 1.month).beginning_of_day, @today)).to eq('5.5 days')
       end
     end
   end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -94,8 +94,9 @@ RSpec.feature 'Feature metrics dashboard' do
 
   def and_i_should_see_work_history_metrics
     within('#work_history_dashboard_section') do
-      expect(page).to have_content('16.8 this cycle')
-      expect(page).to have_content('19 last month')
+      expect(page).to have_content('16.8 days time to complete')
+      expect(page).to have_content('19 days this month')
+      expect(page).to have_content('10 days last month')
     end
   end
 end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Feature metrics dashboard' do
     and_i_click_on_the_feature_metrics_link
 
     then_i_should_see_reference_metrics
+    and_i_should_see_work_history_metrics
   end
 
   def given_i_am_a_support_user
@@ -28,30 +29,46 @@ RSpec.feature 'Feature metrics dashboard' do
     application_form = create(:application_form)
     references = create_list(:reference, 2, application_form: application_form)
     references.each { |reference| CandidateInterface::RequestReference.new.call(reference) }
-    references
+    [application_form, references]
   end
 
   def provide_references(references)
     references.each { |reference| SubmitReference.new(reference: reference, send_emails: false).save! }
   end
 
+  def start_work_history(application_form)
+    create(:application_work_experience, application_form: application_form)
+  end
+
+  def complete_work_history(application_form)
+    application_form.update!(work_history_completed: true)
+  end
+
   def and_there_are_candidates_and_application_forms_in_the_system
     allow(EndOfCycleTimetable).to receive(:apply_reopens).and_return(60.days.ago)
     Timecop.freeze(@today - 50.days) do
-      @references1 = create_application_form_with_references
-      @references2 = create_application_form_with_references
+      @application_form1, @references1 = create_application_form_with_references
+      @application_form2, @references2 = create_application_form_with_references
+      start_work_history(@application_form1)
     end
     Timecop.freeze(@today - 40.days) do
-      @references3 = create_application_form_with_references
+      @application_form3, @references3 = create_application_form_with_references
       provide_references(@references1)
+      start_work_history(@application_form2)
+      complete_work_history(@application_form1)
     end
     Timecop.freeze(@today - 21.days) do
-      @references4 = create_application_form_with_references
+      @application_form4, @references4 = create_application_form_with_references
       provide_references(@references2)
+      complete_work_history(@application_form2)
+      start_work_history(@application_form3)
+      start_work_history(@application_form4)
     end
     Timecop.freeze(@today - 2.days) do
       provide_references(@references3)
       provide_references(@references4)
+      complete_work_history(@application_form3)
+      complete_work_history(@application_form4)
     end
   end
 
@@ -65,11 +82,20 @@ RSpec.feature 'Feature metrics dashboard' do
 
   def then_i_should_see_reference_metrics
     expect(page).to have_content('Feature metrics')
-    expect(page).to have_content('24 days average time to get reference back')
-    expect(page).to have_content('10 days last month')
-    expect(page).to have_content('28.7 days this month')
-    expect(page).to have_content('75% completed within 30 days')
-    expect(page).to have_content('100% last month')
-    expect(page).to have_content('66.7% this month')
+    within('#references_dashboard_section') do
+      expect(page).to have_content('24 days average time to get reference back')
+      expect(page).to have_content('10 days last month')
+      expect(page).to have_content('28.7 days this month')
+      expect(page).to have_content('75% completed within 30 days')
+      expect(page).to have_content('100% last month')
+      expect(page).to have_content('66.7% this month')
+    end
+  end
+
+  def and_i_should_see_work_history_metrics
+    within('#work_history_dashboard_section') do
+      expect(page).to have_content('16.8 this cycle')
+      expect(page).to have_content('19 last month')
+    end
   end
 end


### PR DESCRIPTION
## Context

Product Owners I need to see in real time specific metrics for key features in dashboard so that they can see the impact of changes over time. This PR is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3779 and adds metrics for work history and reasons for rejection.

## Changes proposed in this pull request

- [x] Add `WorkHistoryFeatureMetrics` model for the query needed to fetch average work history completion times.
- [x] Add `ReasonsForRejectionFeatureMetrics` model for the query needed to fetch the number of application choices rejected for a particular reason (depends on structured reasons for rejection). 
- [x] Add these metrics to the dashboard

<img width="550" alt="image" src="https://user-images.githubusercontent.com/450843/103957417-97b75d00-5142-11eb-94fd-ca2d0ddf7d2b.png">

- [x] Rebase after https://github.com/DFE-Digital/apply-for-teacher-training/pull/3779 is merged

## Guidance to review

- Per commit recommended

## Link to Trello card

https://trello.com/c/CBmwCoda/2770-feature-metric-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
