### PR TITLE
Add affirmative flash messages for a candidate accepting and declining an offer

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -29,6 +29,7 @@ module CandidateInterface
     def confirm_decline
       decline = DeclineOffer.new(application_choice: @application_choice.reload)
       decline.save!
+      flash[:success] = "You have declined your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
       redirect_to candidate_interface_application_complete_path
     end
 
@@ -37,6 +38,7 @@ module CandidateInterface
     def confirm_accept
       accept = AcceptOffer.new(application_choice: @application_choice.reload)
       accept.save!
+      flash[:success] = "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
       redirect_to candidate_interface_application_complete_path
     end
 

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_accepts_offer_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Candidate accepts an offer' do
     when_i_accept_one_offer
     and_i_confirm_the_acceptance
 
+    then_i_see_a_flash_message_telling_me_i_have_accepted_the_offer
     and_i_see_that_i_accepted_the_offer
     and_i_see_that_i_declined_the_other_offer
     and_i_see_that_i_withdrawn_from_the_third_choice
@@ -88,6 +89,10 @@ RSpec.feature 'Candidate accepts an offer' do
 
   def and_i_confirm_the_acceptance
     click_button 'Accept offer'
+  end
+
+  def then_i_see_a_flash_message_telling_me_i_have_accepted_the_offer
+    expect(page).to have_content "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
   end
 
   def and_i_see_that_i_accepted_the_offer

--- a/spec/system/candidate_interface/offers_and_withdrawls/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/offers_and_withdrawls/candidate_declines_offer_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature 'Candidate declines an offer' do
     and_i_decline_the_offer
     and_i_confirm_the_decline
 
+    then_i_see_a_flash_message_telling_me_i_have_declined_the_offer
     and_i_see_that_i_declined_the_offer
     and_the_provider_receives_a_notification
 
@@ -74,6 +75,10 @@ RSpec.feature 'Candidate declines an offer' do
 
   def and_i_confirm_the_decline
     click_button 'Yes I’m sure – decline this offer'
+  end
+
+  def then_i_see_a_flash_message_telling_me_i_have_declined_the_offer
+    expect(page).to have_content "You have declined your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
   end
 
   def and_i_see_that_i_declined_the_offer


### PR DESCRIPTION
## Context

Currently, when a candidate accepts and declines (need to confirm with Paul) an offer. They should receive confirmation that their action has been successful.

## Changes proposed in this pull request

- Accepting an offer 

![image](https://user-images.githubusercontent.com/42515961/103996315-8f3a4300-5191-11eb-8493-dc99dfc572a4.png)

- Declining an offer

![image](https://user-images.githubusercontent.com/42515961/103996434-be50b480-5191-11eb-9dfd-ec56526676ed.png)

## Guidance to review

The card doesn't actually mention anything about having a flash for a declined offer, but i think it probably should right?. If it shouldn't be there @paulrobertlloyd let me know and I'll take it out.

The card also mentions that it needs a content review @gregknight1 & @Tomcowan1. Thanks guys!

## Link to Trello card

https://trello.com/c/5cDegw3k/874-when-accepting-an-offer-theres-no-affirmative-state-eg-green-success-message-at-the-top-of-the-dashboard-or-a-panel

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
