### PR TITLE
Only show status change events for statuses visible to providers

### DIFF
--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -15,8 +15,7 @@ class GetActivityLogEvents
     ],
   }.freeze
 
-  ONLY_CHANGES_TO = %w[
-    status
+  CHANGES_TO = %w[
     reject_by_default_feedback_sent_at
     offer_changed_at
   ].freeze
@@ -24,8 +23,11 @@ class GetActivityLogEvents
   def self.call(application_choices:, since: nil)
     since ||= Time.zone.local(2018, 1, 1) # before the pilot began, i.e. all records
 
-    filter = ONLY_CHANGES_TO.map { |f| "jsonb_exists(audited_changes, '#{f}')" }
-                            .join(' OR ')
+    filter = CHANGES_TO.map { |f| "jsonb_exists(audited_changes, '#{f}')" }
+                      .join(' OR ')
+
+    statuses_visible_to_providers = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.map { |status| "'#{status}'" }.join(', ')
+    filter += " OR audited_changes::json#>>'{status, 1}' IN (#{statuses_visible_to_providers})"
 
     Audited::Audit.includes(INCLUDES)
                   .where(auditable: application_choices)

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -117,6 +117,27 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
       expect(result).not_to include(excluded)
       expect(result).to include(included)
     end
+
+    it 'includes only status change events visible to providers' do
+      choice = create_application_choice_for_course course_provider_a
+
+      excluded = create(
+        :application_choice_audit,
+        application_choice: choice,
+        changes: { 'status' => %w[awaiting_references application_complete] },
+      )
+
+      included = create(
+        :application_choice_audit,
+        application_choice: choice,
+        changes: { 'status' => %w[status_not_visible_to_providers awaiting_provider_decision] },
+      )
+
+      result = service_call
+
+      expect(result).not_to include(excluded)
+      expect(result).to include(included)
+    end
   end
 
   context 'sorts events in reverse chronological order' do


### PR DESCRIPTION
## Context

<kbd><img width="820" alt="Screenshot 2021-01-08 at 09 22 12" src="https://user-images.githubusercontent.com/38078064/103997496-0d4b1980-5193-11eb-9947-e16b00aae769.png"></kbd>

https://sentry.io/organizations/dfe-bat/issues/2132714011/events/5d13bf5b27cd4c9b9ec9760efcc9230e/?project=1765973

The `title_for(status)` was nil for statuses not visible to providers because they are not defined in the TITLES constant.  Those type of events (e.g. when status changes from "awaiting_references" to "application_complete") should not
be included in the timeline.

## Changes proposed in this pull request

Only show status change events for statuses visible to providers

## Guidance to review

Does it make sense to exclude those ones from the timeline?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
