### PR TITLE
Setup data model for interviews

### DIFF
--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,8 @@
+class Interview < ApplicationRecord
+  belongs_to :application_choice
+  belongs_to :provider
+
+  validates :application_choice, :provider, :date_and_time, presence: true
+
+  delegate :offered_course, to: :application_choice
+end

--- a/db/migrate/20210107175105_create_interviews.rb
+++ b/db/migrate/20210107175105_create_interviews.rb
@@ -1,0 +1,13 @@
+class CreateInterviews < ActiveRecord::Migration[6.0]
+  def change
+    create_table :interviews do |t|
+      t.references :application_choice, null: false, foreign_key: { on_delete: :cascade }
+      t.references :provider, null: false, foreign_key: { on_delete: :cascade }
+      t.datetime :date_and_time
+      t.text :location
+      t.text :additional_details
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_29_093456) do
+ActiveRecord::Schema.define(version: 2021_01_07_175105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -365,6 +365,18 @@ ActiveRecord::Schema.define(version: 2020_12_29_093456) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "interviews", force: :cascade do |t|
+    t.bigint "application_choice_id", null: false
+    t.bigint "provider_id", null: false
+    t.datetime "date_and_time"
+    t.text "location"
+    t.text "additional_details"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["application_choice_id"], name: "index_interviews_on_application_choice_id"
+    t.index ["provider_id"], name: "index_interviews_on_provider_id"
+  end
+
   create_table "notes", force: :cascade do |t|
     t.string "subject"
     t.text "message"
@@ -601,6 +613,8 @@ ActiveRecord::Schema.define(version: 2020_12_29_093456) do
   add_foreign_key "course_options", "sites", on_delete: :cascade
   add_foreign_key "courses", "providers"
   add_foreign_key "emails", "application_forms", on_delete: :cascade
+  add_foreign_key "interviews", "application_choices", on_delete: :cascade
+  add_foreign_key "interviews", "providers", on_delete: :cascade
   add_foreign_key "notes", "application_choices", on_delete: :cascade
   add_foreign_key "notes", "provider_users", on_delete: :cascade
   add_foreign_key "provider_agreements", "provider_users"

--- a/spec/models/interview_spec.rb
+++ b/spec/models/interview_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Interview, type: :model do
+  subject(:interview) { Interview.new }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:application_choice) }
+    it { is_expected.to validate_presence_of(:provider) }
+    it { is_expected.to validate_presence_of(:date_and_time) }
+  end
+
+  describe '#offered_course' do
+    it 'calls the application choice offered_course' do
+      allow(interview.application_choice).to receive(:offered_course)
+
+      interview.offered_course
+      expect(interview.application_choice).to have_received(:offered_course)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Add basic data model for interviews

Delegates course to `application_choice#offered_course` for clarity
Skipping provider checks besides presence as that feels like a responsibility of the service handling the interview creation.

## Link to Trello card

https://trello.com/c/pZRoUgU2/3213-set-up-data-model-for-interviews

## Things to check

- [] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
