### PR TITLE
Bugfix: re-render course location form if there is a validation error

### DIFF
--- a/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/site_selection_controller.rb
@@ -29,6 +29,16 @@ module CandidateInterface
         course_id = params.fetch(:course_id)
         course_option_id = params.dig(:candidate_interface_pick_site_form, :course_option_id)
 
+        @pick_site = PickSiteForm.new(
+          application_form: current_application,
+          provider_id: params.fetch(:provider_id),
+          course_id: course_id,
+          study_mode: params.fetch(:study_mode),
+          course_option_id: course_option_id,
+        )
+
+        render :new and return unless @pick_site.valid?
+
         candidate_is_updating_a_choice = params[:course_choice_id]
         if candidate_is_updating_a_choice
           PickReplacementCourseOption.new(


### PR DESCRIPTION
This fixes a bug where if you don't select a location, you get redirected to the application dashboard where the error is shown in a flash message, rather than being shown the form again, allowing you to correct the error.

https://trello.com/c/25BPHarm/2806-dac-which-location-page-error-states