### PR TITLE
Experiment: use a whitelist of attributes to mark application choices as updated

### DIFF
--- a/adr/0017-application-choice-updated-at.md
+++ b/adr/0017-application-choice-updated-at.md
@@ -44,9 +44,9 @@ See [single_application_presenter_spec.rb](../spec/presenters/vendor_api/single_
 
 This solution will require that spec to be kept up to date with a variety of applications in different states so as to cover all the code paths the application presenter has.
 
-So far, this solution only addresses changes from the ApplicationForm model that affect API responses for ApplicationChoices.
+As described so far, this solution only addresses changes from the ApplicationForm model that affect API responses for ApplicationChoices.
 There are other models (e.g. ApplicationQualification or ApplicationWorkExperience) for which changes to their attributes affect their associated applications.
-For these smaller models, we will use a simple touch relationship between them and their application form, with touches on the application form also touching the application choices.
+For these smaller models, we have added a concern PublishedInAPI which touches the application_choices whenever the model is created, updated or deleted.
 
 ## Consequences
 

--- a/adr/0017-application-choice-updated-at.md
+++ b/adr/0017-application-choice-updated-at.md
@@ -1,0 +1,54 @@
+# 17. Application Choice Updated At
+
+Date: 2021-01-14
+
+## Status
+
+Accepted
+
+## Context
+
+Consumers of the Vendor API can filter applications by updated_at value, to get a list of applications that have changed since a certain time.
+They typically use this to avoid processing applications that have already been ingested into their services.
+If the updated_at values are inaccurate, there is a potential for vendors to process applications twice or miss application changes entirely.
+For that reason, we set up touch relationships from the application form to the application choice to ensure that changes to the application form touch the application choices.
+
+This approach resulted in false positives (where the updated_at value had changed but the data in the application API response had not). This is because there are fields on the application form which do not appear in the application API response.
+
+For example, when geocoding data was added to applications. Every application was touched, but the data was not included in the response so API consumers could not see any changes.
+
+## First approach
+
+The first idea we had to address this issue was to render the API response for an application whenever we were changing a model related to it and see if the change had affected the response.
+If a change was detected, we would change the update_at on the application choice.
+This intended to only change the updated_at value when the response changed.
+
+However, this approach is sensitive to changes to the shape of the API response, as well as changes to the data. For example, adding a new field to the response would indicate an update where there had not been one.
+
+To fix this drawback, we would have to add logic to ignore certain changes to API responses, at which point this simple idea becomes complex.
+
+## Decision
+
+For changes to the application form we will specify a whitelist of attributes that, when changed, affect the application API response. There are pros and cons to this method:
+
+Pros:
+ - We keep an explicit list of significant attributes
+ - This is a simple approach using standard Rails techniques, so is easy to follow
+
+Cons:
+ - Forgetting to mark a field as significant will result in the application updated_at not being changed (false negative)
+ - Forgetting to remove a field from the list of significant ones when it no longer affects an application response will result in the application updated_at being changed (false positive)
+
+In order to mitigate the cons, we have added specs to check that the list of significant attributes contains all attributes which affect an API response, and that there are no extra attributes included.
+See [single_application_presenter_spec.rb](../spec/presenters/vendor_api/single_application_presenter_spec.rb)
+
+This solution will require that spec to be kept up to date with a variety of applications in different states so as to cover all the code paths the application presenter has.
+
+So far, this solution only addresses changes from the ApplicationForm model that affect API responses for ApplicationChoices.
+There are other models (e.g. ApplicationQualification or ApplicationWorkExperience) for which changes to their attributes affect their associated applications.
+For these smaller models, we will use a simple touch relationship between them and their application form, with touches on the application form also touching the application choices.
+
+## Consequences
+
+- The updated_at attribute for ApplicationChoices will now accurately reflect when the last update that affected it occurred
+- There are new specs that need to be maintained when the single application presenter is changed

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -87,7 +87,7 @@ class ApplicationForm < ApplicationRecord
 
   before_save do |form|
     if (form.changed & PUBLISHED_FIELDS).any?
-      application_choices.update_all(updated_at: Time.zone.now)
+      application_choices.touch_all
     end
   end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -91,6 +91,13 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
+  # We want to touch the application_choices when models that touch application_form are changed
+  # e.g. ApplicationReference, ApplicationQualification
+  # This ensures that the updated_at for the application changes when the API response for the application changes
+  after_touch do
+    application_choices.touch_all
+  end
+
   after_commit :geocode_address_if_required
 
   def submitted?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -81,7 +81,8 @@ class ApplicationForm < ApplicationRecord
     disability_disclosure further_information safeguarding_issues_status
     address_line1 address_line2 address_line3 address_line4
     international_address country postcode equality_and_diversity
-    work_history_breaks
+    work_history_breaks first_nationality second_nationality third_nationality
+    fourth_nationality fifth_nationality phone_number
   ].freeze
 
   before_save do |form|

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -91,13 +91,6 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
-  # We want to touch the application_choices when models that touch application_form are changed
-  # e.g. ApplicationReference, ApplicationQualification
-  # This ensures that the updated_at for the application changes when the API response for the application changes
-  after_touch do
-    application_choices.touch_all
-  end
-
   after_commit :geocode_address_if_required
 
   def submitted?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -72,7 +72,24 @@ class ApplicationForm < ApplicationRecord
   attribute :recruitment_cycle_year, :integer, default: -> { RecruitmentCycle.current_year }
 
   before_create -> { self.support_reference ||= GenerateSupportRef.call }
-  after_save -> { application_choices.update_all(updated_at: Time.zone.now) }
+
+  PUBLISHED_FIELDS = %w[
+    first_name last_name support_reference phase submitted_at
+    becoming_a_teacher subject_knowledge interview_preferences
+    date_of_birth domicile right_to_work_or_study_details
+    english_main_language english_language_details other_language_details
+    disability_disclosure further_information safeguarding_issues_status
+    address_line1 address_line2 address_line3 address_line4
+    international_address country postcode equality_and_diversity
+    work_history_breaks
+  ].freeze
+
+  before_save do |form|
+    if (form.changed & PUBLISHED_FIELDS).any?
+      application_choices.update_all(updated_at: Time.zone.now)
+    end
+  end
+
   after_commit :geocode_address_if_required
 
   def submitted?

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,4 +1,6 @@
 class ApplicationQualification < ApplicationRecord
+  include PublishedInAPI
+
   EXPECTED_DEGREE_DATA = %i[
     qualification_type
     subject

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -1,5 +1,6 @@
 class ApplicationReference < ApplicationRecord
   include Chased
+  include PublishedInAPI
 
   self.table_name = 'references'
 

--- a/app/models/application_volunteering_experience.rb
+++ b/app/models/application_volunteering_experience.rb
@@ -1,4 +1,6 @@
 class ApplicationVolunteeringExperience < ApplicationExperience
+  include PublishedInAPI
+
   belongs_to :application_form, touch: true
 
   audited associated_with: :application_form

--- a/app/models/application_work_experience.rb
+++ b/app/models/application_work_experience.rb
@@ -1,4 +1,6 @@
 class ApplicationWorkExperience < ApplicationExperience
+  include PublishedInAPI
+
   belongs_to :application_form, touch: true
 
   validates :commitment, presence: true

--- a/app/models/application_work_history_break.rb
+++ b/app/models/application_work_history_break.rb
@@ -1,4 +1,6 @@
 class ApplicationWorkHistoryBreak < ApplicationRecord
+  include PublishedInAPI
+
   belongs_to :application_form, touch: true
 
   audited associated_with: :application_form

--- a/app/models/concerns/published_in_api.rb
+++ b/app/models/concerns/published_in_api.rb
@@ -1,0 +1,9 @@
+module PublishedInAPI
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit do
+      application_form.application_choices.touch_all
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe ApplicationForm do
     expect(application_form.support_reference).to be_present
   end
 
+  describe 'before_save' do
+    it 'touches the application choice when a field affecting the application choice is changed' do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+
+      expect { application_form.update(first_name: 'a new name') }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+
+    it 'does not touch the application choice when a field not affecting the application choice is changed' do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+
+      expect { application_form.update(latitude: '0.12343') }
+        .not_to(change { application_form.application_choices.first.updated_at })
+    end
+  end
+
   describe 'after_commit' do
     describe '#geocode_address_if_required' do
       it 'invokes geocoding of UK addresses on create' do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe 'after_touch' do
+    it 'touches the application choice when touched by a related model' do
+      application_form = create(:completed_application_form, with_gcses: true, application_choices_count: 1)
+
+      expect { application_form.maths_gcse.update!(grade: 'D') }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+  end
+
   describe 'after_commit' do
     describe '#geocode_address_if_required' do
       it 'invokes geocoding of UK addresses on create' do

--- a/spec/models/last_updated_at_spec.rb
+++ b/spec/models/last_updated_at_spec.rb
@@ -17,6 +17,39 @@ RSpec.describe '#update' do
     expect(application_choices.map(&:updated_at)).not_to include(original_time)
   end
 
+  %w[reference application_volunteering_experience application_work_experience application_qualification application_work_history_break].each do |form_attribute|
+    it "updates the application_choices when a #{form_attribute} is added" do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+
+      expect { create(form_attribute, application_form: application_form) }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+
+    it "updates the application_choices when a #{form_attribute} is updated" do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+      model = create(form_attribute, application_form: application_form)
+
+      expect { model.update(updated_at: Time.zone.now) }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+
+    it "updates the application_choices when a #{form_attribute} is deleted" do
+      application_form = create(:completed_application_form, application_choices_count: 1)
+      model = create(form_attribute, application_form: application_form)
+
+      expect { model.destroy! }
+        .to(change { application_form.application_choices.first.updated_at })
+    end
+  end
+
+  it 'does not update application_choices when unrelated models that touch the form are updated' do
+    application_form = create(:completed_application_form, application_choices_count: 1)
+    feedback = create(:application_feedback, application_form: application_form)
+
+    expect { feedback.update(feedback: 'It was easy to do really') }
+      .not_to(change { application_form.application_choices.first.updated_at })
+  end
+
   %w[application_choice reference application_volunteering_experience application_work_experience application_qualification].each do |form_attribute|
     it "updates the form when a #{form_attribute} is added" do
       original_time = Time.zone.now - 1.day


### PR DESCRIPTION
## Context

It would be nice to have correct updated_at dates in the API and on application choices generally.

We tried to do this in #3697 but ran into a problem with that approach, which was that if the structure of the JSON changed then the cache would be invalidated.

This PR pilots a simpler approach: list the fields that can affect an API response and only touch the application choices when those fields change. This would need to happen for other models (work experience etc) which affected the choice.

**Pros**

1. explicit list of significant attributes
2. no complicated cache

**Cons**

1. if we forget to mark a field as significant the choice's updated_at date will not update
2. if we accidentally leave a field as significant when it's no longer significant the choice's updated_at date _will_ update

**Mitigations for cons**

re: point 2, it would be nice to somehow be able to assert in a test that all the fields we care about are actually looked at when we build the choice. this addresses point 2 above. or we could use the caching strategy _in tests_ to assert that eg a choice renders in a certain way, then when any whitelisted property on the form changes, then that actually changes the JSON.

Potentially both these things are tricky because depending on the state of the form, we look at different fields. But in practice I think it's just international addresses which are handled differently, and those are going away soon anyway.

Not sure how we could address point 1 — any ideas?


