### PR TITLE
Reasons for reject email tweaks

### DIFF
--- a/app/views/candidate_mailer/_get_support.text.erb
+++ b/app/views/candidate_mailer/_get_support.text.erb
@@ -1,7 +1,3 @@
 # Get support
 
-If you need help getting a place on a course, contact Get Into Teaching (8:30am to 5pm Monday to Friday). Call for free on 0800 389 2500 or chat to an adviser online:
-
-https://getintoteaching.education.gov.uk/lp/live-chat
-
 Contact [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) if you have problems applying online or want to give feedback.

--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -1,5 +1,4 @@
-<%= @course.provider.name %> has decided not to make you an offer to study <%= @course.name_and_code %>.
-They've given feedback to explain this decision.
+<%= @course.provider.name %> has decided not to make you an offer to study <%= @course.name_and_code %>. They've given feedback to explain this decision.
 
 <% @application_choice.rejection_reasons.each_pair do |title, reasons| %>
 

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -24,4 +24,4 @@ Your last application has been saved. You can make changes before you submit you
 
 <%= @candidate_magic_link %>
 
-<%= render 'get_support' %>
+<%= render 'get_help' %>

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -23,4 +23,6 @@ Contact <%= @course.provider.name %> directly if you have any questions about th
 
 Your last application has been saved. You can make changes before you submit your new application.
 
+<%= @candidate_magic_link %>
+
 <%= render 'get_support' %>

--- a/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
+++ b/app/views/candidate_mailer/application_rejected_all_applications_rejected.text.erb
@@ -14,7 +14,6 @@ Dear <%= @application_form.first_name %>,
 
 Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
 
-
 # You can apply again
 
 <% if @multiple_applications %>

--- a/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_awaiting_decision_only.text.erb
@@ -12,9 +12,7 @@ Dear <%= @application_form.first_name %>,
 
 <% end %>
 
-
 Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
-
 
 <% if @awaiting_decision.length == 1 %>
 
@@ -32,7 +30,7 @@ You're waiting for decisions about your applications to:
   - <%= awaiting_decision.course_option.course.provider.name %> to study <%= awaiting_decision.course_option.course.name %>
 <% end %>
 
-They should make their decisions by <%= @awaiting_decisions_by %>
+They should make their decisions by <%= @awaiting_decisions_by %>.
 
 <% end %>
 

--- a/app/views/candidate_mailer/application_rejected_offers_only.text.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_only.text.erb
@@ -14,7 +14,6 @@ Dear <%= @application_form.first_name %>,
 
 Contact <%= @course.provider.name %> directly if you have any questions about their feedback.
 
-
 # Respond to your <%= 'offer'.pluralize(@offers.length) %> by <%= @respond_by_date %>
 
 <% if @offers.length == 1 %>


### PR DESCRIPTION
## Context
While reviewing the reasons for rejection emails, a few mistakes were spotted
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Ensure "Get Support" footer section consistent with Design History

Include sign in link enabling candidates to apply again in emails for: When all applications have been rejected

Remove line breaks between first/ second sentences in all emails

Correct fullstops

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/AQahBckd/3220-issues-with-reasons-for-rejection-emails-text-links

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
