### PR TITLE
Update name of City University

### DIFF
--- a/config/initializers/qualifications/hesa_degree_institutions.rb
+++ b/config/initializers/qualifications/hesa_degree_institutions.rb
@@ -112,7 +112,7 @@ HESA_DEGREE_INSTITUTIONS = [
   [112, "The University of Bristol"],
   [113, "Brunel University London"],
   [114, "The University of Cambridge"],
-  [115, "The City University"],
+  [115, "City, University of London"],
   [116, "University of Durham"],
   [117, "The University of East Anglia"],
   [118, "The University of Essex"],


### PR DESCRIPTION
**The City University** was renamed to **City, University of London** when it joined the University of London on 1 September 2016. [(source)](https://www.city.ac.uk/about/history)

We were notified of this by some feedback from a candidate.