### PR TITLE
Display rejection reasons in the support UI

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -25,6 +25,9 @@ module SupportInterface
         else
           rows << { key: 'Rejected at', value: application_choice.rejected_at.to_s(:govuk_date_and_time) }
         end
+        if rejection_reasons_text
+          rows << { key: 'Rejection reason', value: rejection_reasons_text }
+        end
       end
 
       rows << { key: 'Feedback', value: application_choice.rejection_reason } if application_choice.rejection_reason.present?
@@ -37,6 +40,24 @@ module SupportInterface
 
     def accredited_body
       application_choice.course.accredited_provider
+    end
+
+  private
+
+    def rejection_reasons_text
+      @_rejection_reasons_text ||= begin
+        if application_choice.structured_rejection_reasons.present?
+          render(
+            ReasonsForRejectionComponent.new(
+              application_choice: application_choice,
+              reasons_for_rejection: ReasonsForRejection.new(application_choice.structured_rejection_reasons),
+              editable: false,
+            ),
+          )
+        elsif application_choice.rejection_reason.present?
+          application_choice.rejection_reason
+        end
+      end
     end
   end
 end

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -18,4 +18,23 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     expect(result.text).to include('Rejected by default at')
     expect(result.text).to include('1 January 2020 at 10:00am')
   end
+
+  it 'displays reasons for rejection on rejected application with structured reasons' do
+    application_choice = create(:application_choice, :with_structured_rejection_reasons)
+
+    result = render_inline(described_class.new(application_choice))
+
+    expect(result.text).to include('Rejection reason')
+    expect(result.text).to include('Something you did')
+    expect(result.text).to include('Persistent scratching')
+  end
+
+  it 'displays reasons for rejection on rejected application without structured reasons' do
+    application_choice = create(:application_choice, :with_rejection)
+
+    result = render_inline(described_class.new(application_choice))
+
+    expect(result.text).to include('Rejection reason')
+    expect(result.text).to include(application_choice.rejection_reason)
+  end
 end


### PR DESCRIPTION

## Context
There was previously no way to view rejection reasons in the support UI
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Add a row to the application choice component that displays the structured or unstructured reason for rejection.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
The ticket only asks for *structured* reasons for rejection, but it seems sensible to fall back on the original reason format
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/AsxGSADI/3222-present-structured-reasons-for-rejection-to-support-users

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
