### PR TITLE
Apply again content bugs

### DIFF
--- a/app/views/candidate_interface/application_choices/_guidance.html.erb
+++ b/app/views/candidate_interface/application_choices/_guidance.html.erb
@@ -1,3 +1,3 @@
 <p class="govuk-body">You can apply for up to 3 courses.</p>
 <p class="govuk-body">Some courses are not on <%= service_name %> yet and are only available through UCAS Teacher Training.</p>
-<p class="govuk-body"><%= govuk_link_to 'Check which courses you can apply to on ' + service_name, candidate_interface_providers_path %></p>
+<p class="govuk-body"><%= govuk_link_to 'See a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>

--- a/app/views/candidate_interface/application_choices/_guidance_apply_again.html.erb
+++ b/app/views/candidate_interface/application_choices/_guidance_apply_again.html.erb
@@ -1,3 +1,4 @@
 <p class="govuk-body">You can only apply to 1 course at a time at this stage of your application.</p>
 <p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that is not signed up to the service, you’ll be directed to UCAS to continue your application.</p>
 <p class="govuk-body">You can preview courses currently available on Apply for teacher training.</p>
+<p class="govuk-body">You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>

--- a/app/views/candidate_interface/application_choices/_guidance_apply_again.html.erb
+++ b/app/views/candidate_interface/application_choices/_guidance_apply_again.html.erb
@@ -1,4 +1,3 @@
 <p class="govuk-body">You can only apply to 1 course at a time at this stage of your application.</p>
-<p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that is not signed up to the service, you’ll be directed to UCAS to continue your application.</p>
-<p class="govuk-body">You can preview courses currently available on Apply for teacher training.</p>
-<p class="govuk-body">You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>
+<p class="govuk-body">Some courses are not on <%= service_name %> yet and are only available through UCAS Teacher Training.</p>
+<p class="govuk-body"><%= govuk_link_to 'See a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>

--- a/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
@@ -23,10 +23,7 @@
         :name,
         label: { text: t('page_titles.which_provider'), size: 'xl', tag: 'h1' },
       ) do %>
-        <p class="govuk-body">
-          You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %>
-          currently available on Apply for teacher training.
-        </p>
+        <p class="govuk-body">You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
+++ b/app/views/candidate_interface/course_choices/provider_selection/new.html.erb
@@ -23,7 +23,7 @@
         :name,
         label: { text: t('page_titles.which_provider'), size: 'xl', tag: 'h1' },
       ) do %>
-        <p class="govuk-body">You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>
+        <p class="govuk-body">You can <%= govuk_link_to 'see a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.</p>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/submitted_application_form/start_apply_again.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/start_apply_again.html.erb
@@ -10,7 +10,7 @@
     <p class="govuk-body">If you apply again we’ll:</p>
     <p class="govuk-body">
       <ul class="govuk-body">
-        <li>edit your saved application, so you do not need to start again</li>
+        <li>copy your saved application, so you do not need to start again</li>
         <li>keep your references, so you will not need to request new ones</li>
       </ul>
     </p>


### PR DESCRIPTION
## Context

Spotted a few issues when reviewing the apply again journey.

## Changes proposed in this pull request

Fixes:

* Add a link to list of providers on ‘Choose a course’ section landing page
* Use ‘copy’ not ‘edit’ in apply again guidance.

Improvements

* Use `service_name` variable
* Use consistent verb for link to list of providers. Not ‘preview’, not ‘check’, but always ‘See’
* Use same paragraph of guidance about dual running on choose a course(s) section landing page:

> Some courses are not on Apply for teacher training yet and are only available through UCAS Teacher Training.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
