### PR TITLE
ApplicationFeedback cleanup (part1)

### DIFF
--- a/app/services/support_interface/candidate_application_feedback_export.rb
+++ b/app/services/support_interface/candidate_application_feedback_export.rb
@@ -10,9 +10,6 @@ module SupportInterface
           'Submitted at' => feedback.created_at.iso8601,
           'Path' => feedback.path,
           'Page title' => feedback.page_title,
-          'Understood the section' => !feedback.does_not_understand_section,
-          'Needed more information' => feedback.need_more_information,
-          'Answer does not fit the format' => feedback.answer_does_not_fit_format,
           'Other feedback' => feedback.other_feedback,
           'Consent to be contacted' => feedback.consent_to_be_contacted,
         }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1176,9 +1176,6 @@ FactoryBot.define do
 
     path { '/candidate/application/degrees' }
     page_title { Faker::Lorem.paragraph(sentence_count: 1) }
-    does_not_understand_section { [true, false].sample }
-    need_more_information { [true, false].sample }
-    answer_does_not_fit_format { [true, false].sample }
     other_feedback { Faker::Lorem.paragraph(sentence_count: 3) }
     consent_to_be_contacted { true }
   end

--- a/spec/services/support_interface/candidate_application_feedback_export_spec.rb
+++ b/spec/services/support_interface/candidate_application_feedback_export_spec.rb
@@ -28,9 +28,6 @@ private
       'Submitted at' => application_feedback.created_at.iso8601,
       'Path' => application_feedback.path,
       'Page title' => application_feedback.page_title,
-      'Understood the section' => !application_feedback.does_not_understand_section,
-      'Needed more information' => application_feedback.need_more_information,
-      'Answer does not fit the format' => application_feedback.answer_does_not_fit_format,
       'Other feedback' => application_feedback.other_feedback,
       'Consent to be contacted' => application_feedback.consent_to_be_contacted,
     }


### PR DESCRIPTION
## Context

Changes were made to the feedback page in this PR #3793 

We no longer use the following bools:
- `does_not_understand_section`
- `need_more_information`
- `answer_does_not_fit_format`

We should also change the column name from `other_feedback` to `feedback`

There are going to be a few PRs that will follow this pattern:

1. Remove any code related to the above bools
2. Drop the above bool columns from the db and add a `feedback` column
3. Update the code to use the new `feedback` column
4. Backfill the `feedback` column with the data in the `other_feedback` column
5. drop the `other_feedback` column 

## Changes proposed in this pull request

Remove code related to the following booleans:

- `does_not_understand_section`
- `need_more_information`
- `answer_does_not_fit_format`

## Guidance to review

Does all the above sound sensible?

## Link to Trello card

https://trello.com/c/UBt82tOr/2843-remove-unneeded-booleans-from-the-applicationfeedback-class

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
