### PR TITLE
ApplicationFeedback cleanup (part3)

### DIFF
--- a/app/controllers/candidate_interface/application_feedback_controller.rb
+++ b/app/controllers/candidate_interface/application_feedback_controller.rb
@@ -27,7 +27,7 @@ module CandidateInterface
     def feedback_params
       strip_whitespace params.require(:candidate_interface_application_feedback_form).permit(
         :path, :page_title,
-        :other_feedback, :consent_to_be_contacted,
+        :feedback, :consent_to_be_contacted,
         :original_controller
       )
     end

--- a/app/forms/candidate_interface/application_feedback_form.rb
+++ b/app/forms/candidate_interface/application_feedback_form.rb
@@ -2,10 +2,10 @@ module CandidateInterface
   class ApplicationFeedbackForm
     include ActiveModel::Model
 
-    attr_accessor :path, :page_title, :original_controller, :other_feedback,
+    attr_accessor :path, :page_title, :original_controller, :feedback,
                   :consent_to_be_contacted
 
-    validates :path, :page_title, :other_feedback, :consent_to_be_contacted, presence: true
+    validates :path, :page_title, :feedback, :consent_to_be_contacted, presence: true
 
     validate :path_is_valid, if: -> { path.present? }
 
@@ -15,7 +15,7 @@ module CandidateInterface
       application_form.application_feedback.create!(
         path: path,
         page_title: page_title,
-        other_feedback: other_feedback,
+        feedback: feedback,
         consent_to_be_contacted: consent_to_be_contacted == 'true',
       )
     end

--- a/app/services/support_interface/candidate_application_feedback_export.rb
+++ b/app/services/support_interface/candidate_application_feedback_export.rb
@@ -10,7 +10,7 @@ module SupportInterface
           'Submitted at' => feedback.created_at.iso8601,
           'Path' => feedback.path,
           'Page title' => feedback.page_title,
-          'Other feedback' => feedback.other_feedback,
+          'Feedback' => feedback.feedback,
           'Consent to be contacted' => feedback.consent_to_be_contacted,
         }
       end

--- a/app/views/candidate_interface/application_feedback/new.html.erb
+++ b/app/views/candidate_interface/application_feedback/new.html.erb
@@ -10,7 +10,7 @@
       <%= f.hidden_field :original_controller %>
 
       <span class="govuk-caption-xl"><%= t('application_feedback.caption') %></span>
-      <%= f.govuk_text_area :other_feedback, label: { text: t('page_titles.application_feedback', section: @application_feedback_form.section_name), size: 'xl', tag: 'h1' }, rows: 5, max_words: 300, threshold: 90 %>
+      <%= f.govuk_text_area :feedback, label: { text: t('page_titles.application_feedback', section: @application_feedback_form.section_name), size: 'xl', tag: 'h1' }, rows: 5, max_words: 300, threshold: 90 %>
 
       <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, inline: true, legend: { text: t('application_feedback.consent_to_be_contacted.label'), size: 'm' } do %>
         <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('application_feedback.consent_to_be_contacted.yes') }, link_errors: true %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1012,7 +1012,7 @@ en:
               invalid: Path must be a valid endpoint
             page_title:
               blank: Page title cannot be blank
-            other_feedback:
+            feedback:
               blank: Enter feedback on how we can improve this section
             consent_to_be_contacted:
               blank: Select yes if we can contact you about your feedback

--- a/db/migrate/20210110112042_backfill_feedback_column.rb
+++ b/db/migrate/20210110112042_backfill_feedback_column.rb
@@ -1,0 +1,5 @@
+class BackfillFeedbackColumn < ActiveRecord::Migration[6.0]
+  def change
+    ApplicationFeedback.all.each { |feedback| feedback.update!(feedback: feedback.other_feedback) }
+  end
+end

--- a/db/migrate/20210110112042_backfill_feedback_column.rb
+++ b/db/migrate/20210110112042_backfill_feedback_column.rb
@@ -1,5 +1,5 @@
 class BackfillFeedbackColumn < ActiveRecord::Migration[6.0]
   def change
-    ApplicationFeedback.all.each { |feedback| feedback.update!(feedback: feedback.other_feedback) }
+    ApplicationFeedback.all.each { |feedback| feedback.update_column(:feedback, feedback.other_feedback) }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_10_100235) do
+ActiveRecord::Schema.define(version: 2021_01_10_112042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1176,7 +1176,7 @@ FactoryBot.define do
 
     path { '/candidate/application/degrees' }
     page_title { Faker::Lorem.paragraph(sentence_count: 1) }
-    other_feedback { Faker::Lorem.paragraph(sentence_count: 3) }
+    feedback { Faker::Lorem.paragraph(sentence_count: 3) }
     consent_to_be_contacted { true }
   end
 end

--- a/spec/forms/candidate_interface/application_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/application_feedback_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
     described_class.new(
       path: 'candidate/application/references/type/edit/1',
       page_title: t('page_titles.references_type'),
-      other_feedback: 'This would be easier if i could read.',
+      feedback: 'This would be easier if i could read.',
       consent_to_be_contacted: 'false',
     )
   end
@@ -16,7 +16,7 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
     it { is_expected.to validate_presence_of(:path) }
     it { is_expected.to validate_presence_of(:page_title) }
     it { is_expected.to validate_presence_of(:consent_to_be_contacted) }
-    it { is_expected.to validate_presence_of(:other_feedback) }
+    it { is_expected.to validate_presence_of(:feedback) }
 
     describe '#path_is_valid' do
       it 'returns false if the path is not one of our endpoints' do
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
       expect(application_form.application_feedback.count).to eq 1
       expect(feedback.path).to eq form.path
       expect(feedback.page_title).to eq form.page_title
-      expect(feedback.other_feedback).to eq 'This would be easier if i could read.'
+      expect(feedback.feedback).to eq 'This would be easier if i could read.'
       expect(feedback.consent_to_be_contacted).to eq false
     end
   end

--- a/spec/services/support_interface/candidate_application_feedback_export_spec.rb
+++ b/spec/services/support_interface/candidate_application_feedback_export_spec.rb
@@ -28,7 +28,7 @@ private
       'Submitted at' => application_feedback.created_at.iso8601,
       'Path' => application_feedback.path,
       'Page title' => application_feedback.page_title,
-      'Other feedback' => application_feedback.other_feedback,
+      'Feedback' => application_feedback.feedback,
       'Consent to be contacted' => application_feedback.consent_to_be_contacted,
     }
   end

--- a/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Candidate provides feedback during the application process' do
     expect(@application.application_feedback.count).to eq 1
     expect(@application.application_feedback.last.path).to eq '/candidate/application/references/start'
     expect(@application.application_feedback.last.page_title).to eq t('page_titles.references_start')
-    expect(@application.application_feedback.last.other_feedback).to eq 'Me no understand.'
+    expect(@application.application_feedback.last.feedback).to eq 'Me no understand.'
     expect(@application.application_feedback.last.consent_to_be_contacted).to eq true
   end
 end


### PR DESCRIPTION
## Context

**Do not merge until #3807 has been deployed**

PR that removed the need for several bools on the ApplicationFeedback model is #3793

 #3806 - First PR that removed references to the bools
 #3807 -Second PR that drops the unused bool columns and adds a feedback column

This PR backfills the new `feedback` column and updates the code to use it
 
## Changes proposed in this pull request

- Update the code to use the new `feedback` column (previously used the `other_feedback` column).

## Link to Trello card

https://trello.com/c/UBt82tOr/2843-applicationfeedback-cleanup

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
