### PR TITLE
Feature metric dashboard part 3 - Accessing the service

### DIFF
--- a/app/controllers/support_interface/feature_metrics_dashboard_controller.rb
+++ b/app/controllers/support_interface/feature_metrics_dashboard_controller.rb
@@ -3,6 +3,7 @@ module SupportInterface
     def dashboard
       @reference_statistics = ReferenceFeatureMetrics.new
       @work_history_statistics = WorkHistoryFeatureMetrics.new
+      @magic_link_statistics = MagicLinkFeatureMetrics.new
       @reasons_for_rejection_statistics = ReasonsForRejectionFeatureMetrics.new
     end
   end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -61,7 +61,6 @@ class TestApplications
                    with_safeguarding_issues_never_asked].sample]
       traits << :with_equality_and_diversity_data if rand < 0.55
 
-
       simulate_signin(candidate)
 
       @application_form = FactoryBot.create(

--- a/app/models/magic_link_feature_metrics.rb
+++ b/app/models/magic_link_feature_metrics.rb
@@ -7,18 +7,34 @@ class MagicLinkFeatureMetrics
     end_time = Time.zone.now.beginning_of_day
   )
     counts = ApplicationForm
-      .select('count(DISTINCT audits.id)')
+      .select(
+        'count(DISTINCT audits.id) as audit_count',
+        'count(DISTINCT authentication_tokens.id) as token_count',
+      )
       .joins(:application_choices)
       .joins('LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id')
-      .where('application_choices.offered_at BETWEEN ? AND ?', start_time, end_time)
+      .joins('LEFT OUTER JOIN authentication_tokens ON authentication_tokens.user_id = application_forms.candidate_id')
+      .where("application_choices.#{timestamp} BETWEEN ? AND ?", start_time, end_time)
       .where(
         'audits.auditable_type': 'Candidate',
         'audits.action': 'update',
       )
       .where("audits.audited_changes#>>'{magic_link_token, 1}' IS NOT NULL")
       .where("audits.created_at < application_choices.#{timestamp}")
+      .or(
+        ApplicationForm.select(
+          'count(DISTINCT audits.id) as audit_count',
+          'count(DISTINCT authentication_tokens.id) as token_count',
+        )
+        .joins(:application_choices)
+        .joins('LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id')
+        .joins('LEFT OUTER JOIN authentication_tokens ON authentication_tokens.user_id = application_forms.candidate_id')
+        .where("application_choices.#{timestamp} BETWEEN ? AND ?", start_time, end_time)
+        .where('authentication_tokens.user_type': 'Candidate')
+        .where("authentication_tokens.created_at < application_choices.#{timestamp}")
+      )
       .group('application_forms.id')
-      .map(&:count)
+      .map { |record| record.audit_count + record.token_count }
     return 'n/a' if counts.empty?
 
     number_with_precision(

--- a/app/models/magic_link_feature_metrics.rb
+++ b/app/models/magic_link_feature_metrics.rb
@@ -6,35 +6,17 @@ class MagicLinkFeatureMetrics
     start_time,
     end_time = Time.zone.now.beginning_of_day
   )
-    counts = ApplicationForm
+    records = ApplicationForm
       .select(
         'count(DISTINCT audits.id) as audit_count',
         'count(DISTINCT authentication_tokens.id) as token_count',
       )
       .joins(:application_choices)
-      .joins('LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id')
-      .joins('LEFT OUTER JOIN authentication_tokens ON authentication_tokens.user_id = application_forms.candidate_id')
+      .joins("LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id AND audits.auditable_type = 'Candidate' AND audits.action = 'update' AND audits.audited_changes#>>'{magic_link_token, 1}' IS NOT NULL AND audits.created_at <= application_choices.#{timestamp}")
+      .joins("LEFT OUTER JOIN authentication_tokens ON authentication_tokens.user_id = application_forms.candidate_id AND authentication_tokens.user_type = 'Candidate' AND authentication_tokens.created_at <= application_choices.#{timestamp}")
       .where("application_choices.#{timestamp} BETWEEN ? AND ?", start_time, end_time)
-      .where(
-        'audits.auditable_type': 'Candidate',
-        'audits.action': 'update',
-      )
-      .where("audits.audited_changes#>>'{magic_link_token, 1}' IS NOT NULL")
-      .where("audits.created_at < application_choices.#{timestamp}")
-      .or(
-        ApplicationForm.select(
-          'count(DISTINCT audits.id) as audit_count',
-          'count(DISTINCT authentication_tokens.id) as token_count',
-        )
-        .joins(:application_choices)
-        .joins('LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id')
-        .joins('LEFT OUTER JOIN authentication_tokens ON authentication_tokens.user_id = application_forms.candidate_id')
-        .where("application_choices.#{timestamp} BETWEEN ? AND ?", start_time, end_time)
-        .where('authentication_tokens.user_type': 'Candidate')
-        .where("authentication_tokens.created_at < application_choices.#{timestamp}")
-      )
       .group('application_forms.id')
-      .map { |record| record.audit_count + record.token_count }
+    counts = records.map { |record| record.audit_count + record.token_count }
     return 'n/a' if counts.empty?
 
     number_with_precision(

--- a/app/models/magic_link_feature_metrics.rb
+++ b/app/models/magic_link_feature_metrics.rb
@@ -1,0 +1,30 @@
+class MagicLinkFeatureMetrics
+  include ActionView::Helpers::NumberHelper
+
+  def average_magic_link_requests_upto(
+    timestamp,
+    start_time,
+    end_time = Time.zone.now.beginning_of_day
+  )
+    counts = ApplicationForm
+      .select('count(DISTINCT audits.id)')
+      .joins(:application_choices)
+      .joins('LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id')
+      .where('application_choices.offered_at BETWEEN ? AND ?', start_time, end_time)
+      .where(
+        'audits.auditable_type': 'Candidate',
+        'audits.action': 'update',
+      )
+      .where("audits.audited_changes#>>'{magic_link_token, 1}' IS NOT NULL")
+      .where("audits.created_at < application_choices.#{timestamp}")
+      .group('application_forms.id')
+      .map(&:count)
+    return 'n/a' if counts.empty?
+
+    number_with_precision(
+      counts.sum.to_f / counts.size,
+      precision: 1,
+      strip_insignificant_zeros: true,
+    )
+  end
+end

--- a/app/models/reasons_for_rejection_feature_metrics.rb
+++ b/app/models/reasons_for_rejection_feature_metrics.rb
@@ -1,6 +1,4 @@
 class ReasonsForRejectionFeatureMetrics
-  include ActionView::Helpers::NumberHelper
-
   def rejections_due_to(
     reason,
     start_time,

--- a/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
@@ -111,6 +111,118 @@
   </div>
 </div>
 
+<h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Accessing the service</h3>
+<div id="accessing_the_service_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-third">
+    <div id="headline-stat" class="govuk-!-margin-bottom-4">
+      <%= render SupportInterface::TileComponent.new(
+        count: @magic_link_statistics.average_magic_link_requests_upto(
+          :created_at,
+          EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        ),
+        label: 'magic links per user to unsubmitted',
+        colour: :blue,
+        size: :reduced,
+      ) %>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @magic_link_statistics.average_magic_link_requests_upto(
+            :created_at,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'this month',
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @magic_link_statistics.average_magic_link_requests_upto(
+            :created_at,
+            Time.zone.now.beginning_of_month - 1.month,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'last month',
+          size: :reduced,
+        ) %>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div id="headline-stat" class="govuk-!-margin-bottom-4">
+      <%= render SupportInterface::TileComponent.new(
+        count: @magic_link_statistics.average_magic_link_requests_upto(
+          :offered_at,
+          EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        ),
+        label: 'magic links per user to offer',
+        colour: :blue,
+        size: :reduced,
+      ) %>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @magic_link_statistics.average_magic_link_requests_upto(
+            :offered_at,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'this month',
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @magic_link_statistics.average_magic_link_requests_upto(
+            :offered_at,
+            Time.zone.now.beginning_of_month - 1.month,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'last month',
+          size: :reduced,
+        ) %>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div id="headline-stat" class="govuk-!-margin-bottom-4">
+      <%= render SupportInterface::TileComponent.new(
+        count: @magic_link_statistics.average_magic_link_requests_upto(
+          :recruited_at,
+          EndOfCycleTimetable.apply_reopens.beginning_of_day,
+        ),
+        label: 'magic links per user to recruitment',
+        colour: :blue,
+        size: :reduced,
+      ) %>
+    </div>
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @magic_link_statistics.average_magic_link_requests_upto(
+            :recruited_at,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'this month',
+          size: :reduced,
+        ) %>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <%= render SupportInterface::TileComponent.new(
+          count: @magic_link_statistics.average_magic_link_requests_upto(
+            :recruited_at,
+            Time.zone.now.beginning_of_month - 1.month,
+            Time.zone.now.beginning_of_month,
+          ),
+          label: 'last month',
+          size: :reduced,
+        ) %>
+      </div>
+    </div>
+  </div>
+</div>
+
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Reasons for rejection</h3>
 <div id="reasons_for_rejection_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">

--- a/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
@@ -120,7 +120,7 @@
           :created_at,
           EndOfCycleTimetable.apply_reopens.beginning_of_day,
         ),
-        label: 'magic links per user to unsubmitted',
+        label: 'average number of sign-ins before submitting application',
         colour: :blue,
         size: :reduced,
       ) %>
@@ -156,7 +156,7 @@
           :offered_at,
           EndOfCycleTimetable.apply_reopens.beginning_of_day,
         ),
-        label: 'magic links per user to offer',
+        label: 'average number of sign-ins before offer',
         colour: :blue,
         size: :reduced,
       ) %>
@@ -192,7 +192,7 @@
           :recruited_at,
           EndOfCycleTimetable.apply_reopens.beginning_of_day,
         ),
-        label: 'magic links per user to recruitment',
+        label: 'average number of sign-ins before recruitment',
         colour: :blue,
         size: :reduced,
       ) %>

--- a/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
@@ -1,5 +1,17 @@
 <% content_for :title, 'Feature metrics' %>
 
+<% content_for :before_content do %>
+  <%= render BreadcrumbComponent.new(items: [
+    {
+      text: 'Performance',
+      path: support_interface_performance_path
+    },
+    {
+      text: 'Feature metrics'
+    }
+  ]) %>
+<% end %>
+
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
 <div id="references_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-one-half">

--- a/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
+++ b/app/views/support_interface/feature_metrics_dashboard/dashboard.html.erb
@@ -113,7 +113,7 @@
 
 <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Accessing the service</h3>
 <div id="accessing_the_service_dashboard_section" class="govuk-grid-row govuk-!-margin-bottom-4">
-  <div class="govuk-grid-column-one-third">
+  <div id="accessing_the_service_to_unsubmitted_dashboard_section" class="govuk-grid-column-one-third">
     <div id="headline-stat" class="govuk-!-margin-bottom-4">
       <%= render SupportInterface::TileComponent.new(
         count: @magic_link_statistics.average_magic_link_requests_upto(
@@ -149,7 +149,7 @@
       </div>
     </div>
   </div>
-  <div class="govuk-grid-column-one-third">
+  <div id="accessing_the_service_to_offer_dashboard_section" class="govuk-grid-column-one-third">
     <div id="headline-stat" class="govuk-!-margin-bottom-4">
       <%= render SupportInterface::TileComponent.new(
         count: @magic_link_statistics.average_magic_link_requests_upto(
@@ -185,7 +185,7 @@
       </div>
     </div>
   </div>
-  <div class="govuk-grid-column-one-third">
+  <div id="accessing_the_service_to_recruitment_dashboard_section" class="govuk-grid-column-one-third">
     <div id="headline-stat" class="govuk-!-margin-bottom-4">
       <%= render SupportInterface::TileComponent.new(
         count: @magic_link_statistics.average_magic_link_requests_upto(

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -21,6 +21,26 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "05d90ef689d855e7186cca0d43681bbb15a03b2e9f556e1a1e3aa86c22e1c510",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/magic_link_feature_metrics.rb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "ApplicationForm.select(\"count(DISTINCT audits.id) as audit_count\", \"count(DISTINCT authentication_tokens.id) as token_count\").joins(:application_choices).joins(\"LEFT OUTER JOIN audits ON audits.auditable_id = application_forms.candidate_id AND audits.auditable_type = 'Candidate' AND audits.action = 'update' AND audits.audited_changes#>>'{magic_link_token, 1}' IS NOT NULL AND audits.created_at <= application_choices.#{timestamp}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MagicLinkFeatureMetrics",
+        "method": "average_magic_link_requests_upto"
+      },
+      "user_input": "timestamp",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "07081676ffe0bf0ef753045ae9dcc86c848df5f35a9e48a22692159d5352fbd1",
@@ -181,6 +201,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-01-11 22:04:46 +0000",
+  "updated": "2021-01-13 16:37:34 +0000",
   "brakeman_version": "4.10.1"
 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -869,7 +869,7 @@ FactoryBot.define do
 
   factory :authentication_token do
     user { create(:support_user) }
-    hashed_token { '1234567890' }
+    hashed_token { SecureRandom.uuid }
   end
 
   factory :provider_user do

--- a/spec/models/magic_link_feature_metrics_spec.rb
+++ b/spec/models/magic_link_feature_metrics_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe MagicLinkFeatureMetrics, with_audited: true do
           @application_form2.candidate.update!(magic_link_token: '123456')
         end
         Timecop.freeze(@today - 9.days) do
+          create(:authentication_token, user: @application_form1.candidate, hashed_token: '7654321098')
+          create(:authentication_token, user: @application_form2.candidate, hashed_token: '8765432109')
           @application_choice1 = create(
             :application_choice,
             application_form: @application_form1,
@@ -28,24 +30,27 @@ RSpec.describe MagicLinkFeatureMetrics, with_audited: true do
           )
         end
         Timecop.freeze(@today - 2.days) do
+          @application_form1.candidate.update!(magic_link_token: '345678')
+          @application_form2.candidate.update!(magic_link_token: '234567')
+          create(:authentication_token, user: @application_form2.candidate, hashed_token: '9876543210')
           @application_choice2 = create(
             :application_choice,
             application_form: @application_form2,
-              offered_at: Time.zone.now,
+            offered_at: Time.zone.now,
           )
         end
         Timecop.freeze(@today - 1.days) do
-          @application_form1.candidate.update!(magic_link_token: '345678')
-          @application_form2.candidate.update!(magic_link_token: '234567')
+          @application_form2.candidate.update!(magic_link_token: '456789')
+          create(:authentication_token, user: @application_form2.candidate, hashed_token: '0987654321')
         end
       end
 
       it 'returns the correct value for the past month' do
-        expect(feature_metrics.average_magic_link_requests_upto(:offered_at, @today - 1.month, @today)).to eq('1.5')
+        expect(feature_metrics.average_magic_link_requests_upto(:offered_at, @today - 1.month, @today)).to eq('3.5')
       end
 
       it 'returns the correct value for the past week' do
-        expect(feature_metrics.average_magic_link_requests_upto(:offered_at, @today - 1.week, @today)).to eq('1')
+        expect(feature_metrics.average_magic_link_requests_upto(:offered_at, @today - 1.week, @today)).to eq('4')
       end
     end
   end

--- a/spec/models/magic_link_feature_metrics_spec.rb
+++ b/spec/models/magic_link_feature_metrics_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe MagicLinkFeatureMetrics, with_audited: true do
+  subject(:feature_metrics) { described_class.new }
+
+  describe '#average_magic_link_requests' do
+    context 'without any data' do
+      it 'just returns n/a' do
+        expect(feature_metrics.average_magic_link_requests_upto(:offered_at, 1.month.ago)).to eq('n/a')
+      end
+    end
+
+    context 'with data' do
+      before do
+        @today = Time.zone.local(2020, 12, 31, 12)
+        Timecop.freeze(@today - 40.days) do
+          @application_form1 = create(:application_form)
+          @application_form2 = create(:application_form)
+          @application_form1.candidate.update!(magic_link_token: '123456')
+          @application_form1.candidate.update!(magic_link_token: '234567')
+          @application_form2.candidate.update!(magic_link_token: '123456')
+        end
+        Timecop.freeze(@today - 9.days) do
+          @application_choice1 = create(
+            :application_choice,
+            application_form: @application_form1,
+            offered_at: Time.zone.now,
+          )
+        end
+        Timecop.freeze(@today - 2.days) do
+          @application_choice2 = create(
+            :application_choice,
+            application_form: @application_form2,
+              offered_at: Time.zone.now,
+          )
+        end
+        Timecop.freeze(@today - 1.days) do
+          @application_form1.candidate.update!(magic_link_token: '345678')
+          @application_form2.candidate.update!(magic_link_token: '234567')
+        end
+      end
+
+      it 'returns the correct value for the past month' do
+        expect(feature_metrics.average_magic_link_requests_upto(:offered_at, @today - 1.month, @today)).to eq('1.5')
+      end
+
+      it 'returns the correct value for the past week' do
+        expect(feature_metrics.average_magic_link_requests_upto(:offered_at, @today - 1.week, @today)).to eq('1')
+      end
+    end
+  end
+end

--- a/spec/models/magic_link_feature_metrics_spec.rb
+++ b/spec/models/magic_link_feature_metrics_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe MagicLinkFeatureMetrics, with_audited: true do
             offered_at: Time.zone.now,
           )
         end
-        Timecop.freeze(@today - 1.days) do
+        Timecop.freeze(@today - 1.day) do
           @application_form2.candidate.update!(magic_link_token: '456789')
           create(:authentication_token, user: @application_form2.candidate, hashed_token: '0987654321')
         end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature 'Feature metrics dashboard' do
 
   def and_i_should_see_accessing_the_service_metrics
     within('#accessing_the_service_to_unsubmitted_dashboard_section') do
-      expect(page).to have_content('0.8 magic links per user to unsubmitted')
+      expect(page).to have_content('0.8 average number of sign-ins before submitting application')
       expect(page).to have_content('0 this month')
       expect(page).to have_content('1 last month')
     end

--- a/spec/system/support_interface/feature_metrics_dashboard_spec.rb
+++ b/spec/system/support_interface/feature_metrics_dashboard_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Feature metrics dashboard' do
 
     then_i_should_see_reference_metrics
     and_i_should_see_work_history_metrics
+    and_i_should_see_accessing_the_service_metrics
     and_i_should_see_reasons_for_rejection_metrics
   end
 
@@ -59,6 +60,9 @@ RSpec.feature 'Feature metrics dashboard' do
     Timecop.freeze(@today - 50.days) do
       @application_form1, @references1 = create_application_form_with_references
       @application_form2, @references2 = create_application_form_with_references
+      create(:authentication_token, user: @application_form1.candidate, hashed_token: '0987654321')
+      create(:authentication_token, user: @application_form1.candidate, hashed_token: '9876543210')
+      create(:authentication_token, user: @application_form2.candidate, hashed_token: '8765432109')
       start_work_history(@application_form1)
     end
     Timecop.freeze(@today - 40.days) do
@@ -109,6 +113,14 @@ RSpec.feature 'Feature metrics dashboard' do
       expect(page).to have_content('16.8 days time to complete')
       expect(page).to have_content('19 days this month')
       expect(page).to have_content('10 days last month')
+    end
+  end
+
+  def and_i_should_see_accessing_the_service_metrics
+    within('#accessing_the_service_to_unsubmitted_dashboard_section') do
+      expect(page).to have_content('0.8 magic links per user to unsubmitted')
+      expect(page).to have_content('0 this month')
+      expect(page).to have_content('1 last month')
     end
   end
 


### PR DESCRIPTION
## Context

Product Owners I need to see in real time specific metrics for key features in dashboard so that they can see the impact of changes over time. This PR is a follow up to https://github.com/DFE-Digital/apply-for-teacher-training/pull/3794 and adds metrics for accessing the service (counts of how often candidates request new magic links).

## Changes proposed in this pull request

- [x] Add `MagicLinkFeatureMetrics` model for the query needed to fetch average work history completion times.
- [x] Add 'Accessing the service' section to dashboard.
<img width="548" alt="image" src="https://user-images.githubusercontent.com/450843/104183506-f2360f00-5409-11eb-8318-3c7eac219a12.png">

- [ ] Testing
- [ ] Rebase after https://github.com/DFE-Digital/apply-for-teacher-training/pull/3794 is merged

## Guidance to review

Draft for now, but any feedback welcome
- Does the query make sense? I would like to simplify it but it has to deal with the old style and new style magic links - both those stored in the `candidates` table and the new ones in `authentication_tokens`.
- Design almost certainly needs work. For now I've simply laid out each section one above the other with columns sized to get everything in a single section into a single row.

## Link to Trello card

https://trello.com/c/CBmwCoda/2770-feature-metric-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
