### PR TITLE
Rename Submitted state to Received in the provider interface

### DIFF
--- a/app/components/provider_interface/activity_log_event_component.rb
+++ b/app/components/provider_interface/activity_log_event_component.rb
@@ -17,7 +17,7 @@ module ProviderInterface
 
       case event.application_status_at_event
       when 'awaiting_provider_decision'
-        "#{candidate} submitted an application"
+        "Application received from #{candidate}"
       when 'withdrawn'
         "#{candidate} withdrew their application"
       when 'rejected'

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -12,7 +12,7 @@ module ProviderInterface
     Event = Struct.new(:title, :actor, :date, :link_name, :link_path)
 
     TITLES = {
-      'awaiting_provider_decision' => 'Application submitted',
+      'awaiting_provider_decision' => 'Application received',
       'withdrawn' => 'Application withdrawn',
       'rejected' => 'Application rejected',
       'offer_withdrawn' => 'Offer withdrawn',

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -51,7 +51,7 @@ en:
     conditions_not_met: Conditions not met
     offer_deferred: Offer deferred
   provider_application_states:
-    awaiting_provider_decision: Submitted
+    awaiting_provider_decision: Received
     application_not_sent: Application not sent
     cancelled: Application cancelled
     declined: Declined

--- a/spec/components/provider_interface/activity_log_event_component_spec.rb
+++ b/spec/components/provider_interface/activity_log_event_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
 
   describe '#event_description' do
     examples = {
-      awaiting_provider_decision: '<candidate> submitted an application',
+      awaiting_provider_decision: 'Application received from <candidate>',
       withdrawn: '<candidate> withdrew their application',
       with_rejection: '<user> rejected <candidate>’s application',
       with_rejection_by_default: '<candidate>’s application was automatically rejected',

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     end
   end
 
-  context 'for a submitted application sent to provider' do
+  context 'for an application received by provider' do
     it 'renders submit event' do
       audit = create(
         :application_choice_audit,
@@ -49,7 +49,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
 
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Timeline'
-      expect(rendered.text).to include 'Application submitted'
+      expect(rendered.text).to include 'Application received'
       expect(rendered.text).to include 'Candidate'
       expect(rendered.text).to include '6 February 2020 at 10:00pm'
       expect(rendered.css('a').text).to eq 'View application'

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ProviderMailer, type: :mailer do
                     'sign in path' => '/provider/sign-in')
   end
 
-  describe 'Send application submitted email' do
+  describe 'Send application received email' do
     it_behaves_like('a provider mail with subject and content', :application_submitted,
                     I18n.t!('provider_mailer.application_submitted.subject',
                             course_name_and_code: 'Computer Science (6IND)'),

--- a/spec/models/provider_emails_for_application_choices_spec.rb
+++ b/spec/models/provider_emails_for_application_choices_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ProviderEmailsForApplicationChoices do
       result = ProviderEmailsForApplicationChoices.new([application_choice.id]).as_csv
 
       expect(result).to include "email address,name,affected applications\n"
-      expect(result).to include 'pamela@example.com,Pamela Provider,* Ciara Candidate (ABC123) (Submitted)'
+      expect(result).to include 'pamela@example.com,Pamela Provider,* Ciara Candidate (ABC123) (Received)'
       expect(result).to include "https://www.apply-for-teacher-training.service.gov.uk/provider/applications/#{application_choice.id}\n"
     end
   end


### PR DESCRIPTION
## Context

It makes more sense from provider's point of view.

## Changes proposed in this pull request


| Before       | After           | 
| ------------- |:-------------:| 
| <img width="662" alt="Screenshot 2021-01-11 at 10 13 17" src="https://user-images.githubusercontent.com/38078064/104177848-556f7380-5401-11eb-84b9-0d21cb3b2513.png">| <img width="661" alt="Screenshot 2021-01-11 at 10 14 39" src="https://user-images.githubusercontent.com/38078064/104177905-6d46f780-5401-11eb-9a8c-3446f2045781.png">|
| <img width="655" alt="Screenshot 2021-01-11 at 11 39 59" src="https://user-images.githubusercontent.com/38078064/104178145-c151dc00-5401-11eb-8e20-2c4fe527dfbb.png"> | <img width="666" alt="Screenshot 2021-01-11 at 10 49 02" src="https://user-images.githubusercontent.com/38078064/104177954-8354b800-5401-11eb-8ae1-8a7b7f98ff89.png">| 


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/bvmgutmr/3224-rename-submitted-state-to-received

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
