### PR TITLE
Ensure RejectApplication service returns true

### DIFF
--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -36,6 +36,8 @@ class RejectApplication
         StateChangeNotifier.new(:rejected, @application_choice).application_outcome_notification
       end
     end
+
+    true
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/spec/services/reject_application_spec.rb
+++ b/spec/services/reject_application_spec.rb
@@ -77,5 +77,15 @@ RSpec.describe RejectApplication do
       expect(StateChangeNotifier).to have_received(:new).with(:rejected, application_choice)
       expect(notifier).to have_received(:application_outcome_notification)
     end
+
+    it 'returns true if the call was successful' do
+      expect(service.save).to be true
+    end
+
+    it 'returns false if the call was unsuccessful' do
+      allow(application_choice).to receive(:update!).and_raise(Workflow::NoTransitionAllowed)
+
+      expect(service.save).to be false
+    end
   end
 end


### PR DESCRIPTION

## Context

This return value from `RejectApplication#save` is used to decide which response to serve, it seems like recent commits altered the return value to nil despite a successful service call.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Return `true` at the end of the `save` method and back this with tests for the return value.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/WlCYDSLz/3233-structured-r4r-when-confirming-reasons-for-rejection-you-are-not-redirected
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
