### PR TITLE
Add message when we can't add course choices to the application

### DIFF
--- a/app/components/support_interface/application_add_course_component.html.erb
+++ b/app/components/support_interface/application_add_course_component.html.erb
@@ -1,3 +1,11 @@
-<% if application_form.submitted? && !application_form.has_the_maximum_number_of_course_choices? %>
+<% if !application_form.submitted? %>
+  <p class='govuk-body'>
+    This candidate can add <%= application_form.maximum_number_of_course_choices %> course choices to this application.
+  </p>
+<% elsif application_form.has_the_maximum_number_of_course_choices? %>
+  <p class='govuk-body'>
+    This application already has the maximum number of course choices (<%= application_form.maximum_number_of_course_choices %>), so we can't add any more.
+  </p>
+<% else %>
   <%= govuk_button_link_to 'Add a course', support_interface_application_form_search_course_new_path(application_form_id: application_form.id), form_class: 'govuk-!-display-inline-block' %>
 <% end %>

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -263,10 +263,14 @@ class ApplicationForm < ApplicationRecord
   end
 
   def has_the_maximum_number_of_course_choices?
+    application_choices.count >= maximum_number_of_course_choices
+  end
+
+  def maximum_number_of_course_choices
     if apply_1?
-      application_choices.count >= MAXIMUM_PHASE_ONE_COURSE_CHOICES
+      MAXIMUM_PHASE_ONE_COURSE_CHOICES
     else
-      application_choices.count >= MAXIMUM_PHASE_TWO_COURSE_CHOICES
+      MAXIMUM_PHASE_TWO_COURSE_CHOICES
     end
   end
 


### PR DESCRIPTION
## Context

It's not clear when we can or cannot add new courses to a candidate's application in support.


## Changes proposed in this pull request

Add text when we can't add more courses or the application is not submitted yet.

![Screenshot 2021-01-11 at 17 13 34](https://user-images.githubusercontent.com/233676/104206905-67b4d600-5430-11eb-8e17-dad6e1ed48fa.png)
![Screenshot 2021-01-11 at 17 13 07](https://user-images.githubusercontent.com/233676/104206906-684d6c80-5430-11eb-8158-921588a3d57a.png)
![Screenshot 2021-01-11 at 17 12 17](https://user-images.githubusercontent.com/233676/104206907-684d6c80-5430-11eb-9e69-e250baf1cbcb.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Would perhaps have prevented https://trello.com/c/tegFtY9C/104-candidate-would-like-to-add-two-courses-on-the-application-ticket-number-11235 from being sent to the devs.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
