### PR TITLE
Change how we configure Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-REDIS_URL=redis://localhost:6379/1
 TEACHER_TRAINING_API_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1
 FIND_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/v3/
 GOVUK_NOTIFY_API_KEY=

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,3 @@
-REDIS_URL=redis://localhost:6379/9
 TEACHER_TRAINING_API_BASE_URL=http://teacher-training-api-test/api/v1/
 FIND_BASE_URL=http://find-test/api/v3/
 HOSTING_ENVIRONMENT_NAME=test

--- a/app/lib/apply_redis_connection.rb
+++ b/app/lib/apply_redis_connection.rb
@@ -1,0 +1,19 @@
+class ApplyRedisConnection
+  def self.url
+    if ENV['REDIS_URL'].present?
+      # Always use the Redis database defined by the environment, if available.
+      ENV['REDIS_URL']
+    elsif ENV['TEST_ENV_NUMBER']
+      # If we're in the test environment and tests are being run in parallel,
+      # use a different database for each process. Add 1 to the environment
+      # number so that we don't clobber the development database at 0.
+      "redis://localhost:6379/#{ENV['TEST_ENV_NUMBER'].to_i + 1}"
+    elsif Rails.env.test?
+      # If we're in the test environment and tests are being run in a single
+      # process, default to database 9 (this could be any number except 0).
+      'redis://localhost:6379/9'
+    else
+      'redis://localhost:6379/0'
+    end
+  end
+end

--- a/app/lib/backup_and_restore_support_users.rb
+++ b/app/lib/backup_and_restore_support_users.rb
@@ -5,14 +5,14 @@ class BackupAndRestoreSupportUsers
     existing_users = SupportUser.pluck(:email_address, :dfe_sign_in_uid)
 
     if existing_users.any?
-      Redis.new.set(REDIS_KEY, JSON.generate(existing_users))
+      Redis.current.set(REDIS_KEY, JSON.generate(existing_users))
     end
 
     existing_users.count
   end
 
   def self.restore!
-    restored_users = JSON.parse(Redis.new.get(REDIS_KEY))
+    restored_users = JSON.parse(Redis.current.get(REDIS_KEY))
 
     restored_users.each do |(email, uid)|
       SupportUser.find_or_create_by(email_address: email, dfe_sign_in_uid: uid)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,3 @@
+require './app/lib/apply_redis_connection'
+
+Redis.current = Redis.new(url: ApplyRedisConnection.url)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,10 +1,18 @@
 require 'workers/audit_trail_attribution_middleware'
+require './app/lib/apply_redis_connection'
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Workers::AuditTrailAttributionMiddleware
   end
 end
+
+# Configure Redis connection
+sidekiq_redis_config = proc { |config|
+  config.redis = { url: Redis.current.id }
+}
+Sidekiq.configure_server(&sidekiq_redis_config)
+Sidekiq.configure_client(&sidekiq_redis_config)
 
 require 'sidekiq/web'
 Sidekiq::Web.set :sessions, false

--- a/spec/lib/apply_redis_connection_spec.rb
+++ b/spec/lib/apply_redis_connection_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ApplyRedisConnection do
+  # REDIS_URL may be set in the test environment (on CI, for example), so stub
+  # its value to nil to ensure the tests below can test the right behaviour.
+  before { stub_const('ENV', { 'REDIS_URL' => nil }) }
+
+  describe '.url' do
+    context 'when REDIS_URL is present in the environment' do
+      before { stub_const('ENV', { 'REDIS_URL' => 'redis://redis_url/1' }) }
+
+      it 'returns REDIS_URL' do
+        expect(ApplyRedisConnection.url).to eq 'redis://redis_url/1'
+      end
+    end
+
+    context 'when TEST_ENV_NUMBER is present in the environment' do
+      before { stub_const('ENV', { 'TEST_ENV_NUMBER' => '1' }) }
+
+      it 'returns local Redis with a database number TEST_ENV_NUMBER + 1' do
+        expect(ApplyRedisConnection.url).to eq 'redis://localhost:6379/2'
+      end
+    end
+
+    it 'returns local Redis with database number 9 if Rails environment is test' do
+      allow(Rails.env).to receive(:test?).and_return true
+      expect(ApplyRedisConnection.url).to eq 'redis://localhost:6379/9'
+    end
+
+    it 'returns local Redis with database number 0 in all other cases' do
+      allow(Rails.env).to receive(:test?).and_return false
+      expect(ApplyRedisConnection.url).to eq 'redis://localhost:6379/0'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,7 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   end
 
-  config.before { Redis.new.flushdb }
+  config.before { Redis.current.flushdb }
 
   config.after { Clockwork::Test.clear! }
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

For faster test runs, we want to be able to run our test suite in parallel using multiple cores. This is some of the configuration change required to support that.

## Changes proposed in this pull request

The commits are a bit wordy but to summarize:

- We plan to use parallel_tests to split up our test suite and run each set of tests in a different process.
- Each process needs a unique Redis database to ensure test runs remain free of side effects.
- To support this, update Redis config so that it follows these conventions:
  - Use REDIS_URL wherever it's already set, meaning these changes should have no effect on any existing environment that sets this variable.
  - Use Redis database 0 in development (was previously 1, as defined by .env)
  - Use Redis database 9 when running tests normally (no change here)
  - Use Redis databases 1-n when running tests in multiple processes, where n is determined by how many processes are created.
- To ensure these conventions hold, access Redis via the `ApplyRedisConnection` class.



<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Per commit recommended, commit messages give a bit more detail explaining the changes.
- Do the new conventions make sense?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/ySrLogAF
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
