### PR TITLE
Generate applications in Interviewing state

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -198,6 +198,8 @@ class TestApplications
     return if state == :awaiting_provider_decision
 
     case state
+    when :interviewing
+      schedule_interview(choice)
     when :offer
       make_offer(choice)
     when :offer_changed
@@ -234,6 +236,22 @@ class TestApplications
     end
 
     choice.update_columns(updated_at: time)
+  end
+
+  def schedule_interview(choice)
+    as_provider_user(choice) do
+      fast_forward
+      CreateInterview.new(
+        actor: actor,
+        application_choice: choice,
+        provider: choice.course_option.provider,
+        date_and_time: 7.business_days.from_now,
+        location: Faker::Address.full_address,
+        additional_details: [nil, nil, 'Use staff entrance', 'Ask for John at the reception'].sample,
+      ).save!
+      choice.update_columns(updated_at: time)
+    end
+    choice.audits.last&.update_columns(created_at: time)
   end
 
   def accept_offer(choice)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -543,6 +543,15 @@ FactoryBot.define do
       reject_by_default_at { 40.business_days.from_now }
     end
 
+    trait :with_scheduled_interview do
+      awaiting_provider_decision
+
+      after(:build) do |choice, _evaluator|
+        choice.status = :interviewing
+        choice.interviews = [create(:interview)]
+      end
+    end
+
     trait :withdrawn do
       status { :withdrawn }
       withdrawn_at { Time.zone.now }
@@ -728,6 +737,15 @@ FactoryBot.define do
     trait :previous_year_but_still_available do
       course_option { create(:course_option, :previous_year_but_still_available) }
     end
+  end
+
+  factory :interview do
+    provider
+    application_choice
+
+    date_and_time { 7.business_days.from_now }
+    location { Faker::Address.full_address }
+    additional_details { [nil, 'Use staff entrance', 'Ask for John at the reception'].sample }
   end
 
   factory :vendor_api_user, class: 'VendorApiUser' do

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -141,4 +141,14 @@ RSpec.describe TestApplications do
       expect(references.map(&:feedback_status)).to match_array(%w[not_requested_yet feedback_requested feedback_requested feedback_requested feedback_requested])
     end
   end
+
+  describe 'scheduled interview' do
+    it 'generates an interview for application choices in the interviewing state' do
+      courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+      application_choice = TestApplications.new.create_application(recruitment_cycle_year: 2021, states: %i[interviewing], courses_to_apply_to: courses_we_want).first
+
+      expect(application_choice.interviews.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Context

We are adding a new state.

## Changes proposed in this pull request

Create an Interview for an application choice in an `interviewing` state when generating test data.

## Guidance to review

Dependent on #3815 being merged first.

## Link to Trello card

https://trello.com/c/GapoDi9e/3214-implement-set-up-an-interview-flow

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
