### PR TITLE
Add another button on review pages

### DIFF
--- a/app/components/candidate_interface/add_reference_component.html.erb
+++ b/app/components/candidate_interface/add_reference_component.html.erb
@@ -1,31 +1,15 @@
 <% unless application_form.enough_references_have_been_provided? %>
-  <div class="govuk-inset-text govuk-!-margin-top-0">
+  <div class="govuk-inset-text">
     <% if no_viable_references? %>
-
-      <h2 class="govuk-heading-m">Add a referee</h2>
-
       <p class="govuk-body">You need 2 references before you can submit your application.</p>
-
       <%= govuk_button_link_to 'Add a referee', candidate_interface_references_start_path %>
-
     <% elsif one_viable_reference? %>
-
-      <h2 class="govuk-heading-m">Add a second referee</h2>
-
       <p class="govuk-body">You need 2 references before you can submit your application.</p>
-
       <%= govuk_button_link_to 'Add a second referee', candidate_interface_references_start_path %>
-
     <% else  %>
-
-      <h2 class="govuk-heading-m">Add another referee</h2>
-
       <p class="govuk-body">You can add more referees to increase the chances of getting 2 references quickly.</p>
-
       <p class="govuk-body">We’ll cancel any remaining requests when you’ve received 2 references.</p>
-
-      <%= govuk_button_link_to 'Add another referee', candidate_interface_references_start_path %>
-
+      <%= govuk_button_link_to 'Add another referee', candidate_interface_references_start_path, class: 'govuk-button--secondary' %>
     <% end %>
   </div>
 <% end %>

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -37,6 +37,7 @@ module ViewHelper
     mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
   end
 
+  # TODO: Make `body` param optional if `block` is provided
   def govuk_button_link_to(body, url, html_options = {}, &_block)
     html_options = {
       class: prepend_css_class('govuk-button', html_options[:class]),

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -1,13 +1,24 @@
 <% content_for :title, t('page_titles.courses') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
-  <% if @application_form.candidate_can_choose_single_course? %>
-    <%= t('page_titles.course_choice') %>
-  <% else %>
-    <%= t('page_titles.course_choices') %>
-  <% end %>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <% if @application_form.candidate_can_choose_single_course? %>
+        <%= t('page_titles.course_choice') %>
+      <% else %>
+        <%= t('page_titles.course_choices') %>
+      <% end %>
+    </h1>
+
+    <% if @application_choices.present? && @application_form.can_add_more_choices? %>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">You can choose <%= pluralize(current_application.choices_left_to_make, "more course") %>.</p>
+        <%= govuk_button_link_to t('application_form.courses.another.button'), candidate_interface_course_choices_choose_path, class: 'govuk-button--secondary' %>
+      </div>
+    <% end %>
+  </div>
+</div>
 
 <%= form_with model: @application_form, url: candidate_interface_course_choices_complete_path do |f| %>
   <%= f.govuk_error_summary %>
@@ -17,10 +28,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @application_choices.present? %>
-        <% if @application_form.can_add_more_choices? %>
-          <%= govuk_button_link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button--secondary govuk-!-margin-bottom-9' %>
-        <% end %>
-
         <% if @application_choices.count >= 1 %>
           <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: nil do %>
             <%= f.hidden_field :course_choices_completed, value: false %>

--- a/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
@@ -1,4 +1,4 @@
-<% title = "You can choose #{current_application.choices_left_to_make} more #{'course'.pluralize(current_application.choices_left_to_make)}" %>
+<% title = "You can choose #{pluralize(current_application.choices_left_to_make, "more course")}" %>
 <% content_for :title, title_with_error_prefix(title, @add_another_course.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -1,16 +1,20 @@
 <% content_for :title, t('page_titles.degree') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.degree') %>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.degree') %>
+    </h1>
+
+    <%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_new_degree_path, class: 'govuk-button--secondary' %>
+  </div>
+</div>
 
 <%= render(CandidateInterface::DegreesReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_new_degree_path, class: 'govuk-button--secondary' %>
-
 <%= form_with model: @application_form, url: candidate_interface_degrees_complete_path do |f| %>
-  <div class='govuk-form-group'>
+  <div class="govuk-form-group">
     <%= f.hidden_field :degrees_completed, value: false %>
     <%= f.govuk_check_box :degrees_completed, true, multiple: false, label: { text: t('application_form.degree.review.completed_checkbox') } %>
   </div>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -6,15 +6,15 @@
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.other_qualification') %>
     </h1>
+
+    <%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_other_qualification_type_path, class: 'govuk-button--secondary' %>
   </div>
 </div>
 
 <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_other_qualification_type_path, class: 'govuk-button--secondary' %>
-
 <%= form_with model: @application_form, url: candidate_interface_complete_other_qualifications_path do |f| %>
-  <div class='govuk-form-group'>
+  <div class="govuk-form-group">
     <%= f.hidden_field :other_qualifications_completed, value: false %>
     <%= f.govuk_check_box :other_qualifications_completed, true, multiple: false, label: { text: t('application_form.other_qualification.review.completed_checkbox') } %>
   </div>

--- a/app/views/candidate_interface/references/review/show.html.erb
+++ b/app/views/candidate_interface/references/review/show.html.erb
@@ -14,11 +14,15 @@
   </div>
 <% end %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.references') %>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.references') %>
+    </h1>
 
-<%= render CandidateInterface::AddReferenceComponent.new(@application_form) %>
+    <%= render CandidateInterface::AddReferenceComponent.new(@application_form) %>
+  </div>
+</div>
 
 <% if @references_given.present? %>
   <div id="references_given">

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -2,22 +2,24 @@
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.volunteering.short') %>
     </h1>
 
-    <%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form)) %>
-
-    <%= govuk_button_link_to t('application_form.volunteering.another.button'), candidate_interface_new_volunteering_role_path, class: 'govuk-button--secondary' %>
-
-    <%= form_with model: @application_form, url: candidate_interface_complete_volunteering_path do |f| %>
-      <div class='govuk-form-group'>
-        <%= f.hidden_field :volunteering_completed, value: false %>
-        <%= f.govuk_check_box :volunteering_completed, true, multiple: false, label: { text: t('application_form.volunteering.review.completed_checkbox') } %>
-      </div>
-
-      <%= f.govuk_submit t('continue') %>
+    <%= govuk_button_link_to nil, candidate_interface_course_choices_choose_path, class: 'govuk-button--secondary' do %>
+      <%= @application_form.application_volunteering_experiences.any? ? t('application_form.volunteering.another.button') : t('application_form.volunteering.add.button') %>
     <% end %>
   </div>
 </div>
+
+<%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: @application_form)) %>
+
+<%= form_with model: @application_form, url: candidate_interface_complete_volunteering_path do |f| %>
+  <div class="govuk-form-group">
+    <%= f.hidden_field :volunteering_completed, value: false %>
+    <%= f.govuk_check_box :volunteering_completed, true, multiple: false, label: { text: t('application_form.volunteering.review.completed_checkbox') } %>
+  </div>
+
+  <%= f.govuk_submit t('continue') %>
+<% end %>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -1,17 +1,19 @@
 <% content_for :title, t('page_titles.work_history') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.work_history') %>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.work_history') %>
+    </h1>
+
+    <%= govuk_button_link_to nil, candidate_interface_new_work_history_path, class: 'govuk-button--secondary' do %>
+      <%= @application_form.application_work_experiences.any? ? t('application_form.work_history.another.button') : t('application_form.work_history.add.button') %>
+    <% end %>
+  </div>
+</div>
 
 <%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: @application_form)) %>
-
-<% if @application_form.application_work_experiences.any? %>
-  <%= govuk_button_link_to t('application_form.work_history.another.button'), candidate_interface_new_work_history_path, class: 'govuk-button--secondary' %>
-<% else %>
-  <%= govuk_button_link_to t('application_form.work_history.add.button'), candidate_interface_new_work_history_path, class: 'govuk-button--secondary' %>
-<% end %>
 
 <%= form_with model: @application_form, url: candidate_interface_work_history_complete_path do |f| %>
   <div class="govuk-form-group">

--- a/config/locales/application_form/courses.yml
+++ b/config/locales/application_form/courses.yml
@@ -4,6 +4,8 @@ en:
       intro: You can apply for up to 3 courses.
       delete: Delete choice
       confirm_delete: Yes I’m sure - delete this choice
+      another:
+        button: Add another course
       withdraw: Withdraw
       complete:
         completed_checkbox: I have completed this section

--- a/config/locales/application_form/volunteering.yml
+++ b/config/locales/application_form/volunteering.yml
@@ -38,8 +38,10 @@ en:
         action: Delete role
         confirm: Yes I’m sure - delete this role
         cancel: Cancel
-      another:
+      add:
         button: Add a role
+      another:
+        button: Add another role
       review:
         completed_checkbox: I have completed this section
 

--- a/config/locales/application_form/work_history.yml
+++ b/config/locales/application_form/work_history.yml
@@ -62,7 +62,7 @@ en:
         confirm: Yes I’m sure - delete this entry
         cancel: Cancel
       add:
-        button: Add job
+        button: Add a job
       another:
         button: Add another job
       review:

--- a/spec/components/candidate_interface/add_reference_component_spec.rb
+++ b/spec/components/candidate_interface/add_reference_component_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe CandidateInterface::AddReferenceComponent do
 
       result = render_inline(described_class.new(application_form))
 
-      expect(heading(result)).to eq 'Add a referee'
       expect(link_text(result)).to eq 'Add a referee'
       expect(href(result)).to eq '/candidate/application/references/start'
       expect(body_text(result)).to eq 'You need 2 references before you can submit your application.'
@@ -23,7 +22,6 @@ RSpec.describe CandidateInterface::AddReferenceComponent do
 
       result = render_inline(described_class.new(application_form))
 
-      expect(heading(result)).to eq 'Add a second referee'
       expect(link_text(result)).to eq 'Add a second referee'
       expect(href(result)).to eq '/candidate/application/references/start'
       expect(body_text(result)).to eq 'You need 2 references before you can submit your application.'
@@ -40,7 +38,6 @@ RSpec.describe CandidateInterface::AddReferenceComponent do
       expected_first_para = 'You can add more referees to increase the chances of getting 2 references quickly.'
       expected_second_para = 'We’ll cancel any remaining requests when you’ve received 2 references.'
 
-      expect(heading(result)).to eq 'Add another referee'
       expect(link_text(result)).to eq 'Add another referee'
       expect(href(result)).to eq '/candidate/application/references/start'
       expect(body_text(result)).to eq expected_first_para + expected_second_para
@@ -54,17 +51,12 @@ RSpec.describe CandidateInterface::AddReferenceComponent do
 
       result = render_inline(described_class.new(application_form))
 
-      expect(heading(result)).to be_empty
       expect(link(result)).to be_empty
       expect(body_text(result)).to be_empty
     end
   end
 
 private
-
-  def heading(result)
-    result.css('h2').text.strip
-  end
 
   def link(result)
     result.css('a')

--- a/spec/system/candidate_interface/entering_details/candidate_edits_work_history_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_work_history_after_completing_the_section_spec.rb
@@ -115,10 +115,6 @@ RSpec.feature 'Candidate deletes their work history' do
     and_i_click_on_work_history
   end
 
-  def when_i_click_on_add_job
-    click_link t('application_form.work_history.add.button')
-  end
-
   def and_i_mark_this_section_as_completed
     check t('application_form.work_history.review.completed_checkbox')
   end


### PR DESCRIPTION
## Context

* @adamsilver suggested moving buttons to add another item to the top of the review page, below the heading, making this function easier to find and more clearly differentiated from the ‘mark as complete’ checkbox.

* The recently redesigned reference flow moved the add another functionality to the top of its review page:
  
  ![references-add-another](https://user-images.githubusercontent.com/813383/104219869-96ce4600-5436-11eb-927d-884806bb4327.png)

* We have observed an issue with candidates not adding all their relevant qualifications. **Might moving the add another button up and alongside guidance, help address this?**

## Changes proposed in this pull request

### Course choices

The button is moved to the top of the page, but remains grey as you may only want to add one course. Additional guidance shows how many more choices you have left to add. Uses intended text style like that used for very similar messaging for references.

![add-another-course](https://user-images.githubusercontent.com/813383/105069215-8d1d9180-5a79-11eb-955a-59740e52730e.png)

### References

Remains largely the same as before but:

* uses grey button once 2 references have been given
* removes headings which duplicated that in button text

![add-second-referee](https://user-images.githubusercontent.com/813383/105070118-bbe83780-5a7a-11eb-8b79-c7cc84cd7930.png)

![add-another-reference](https://user-images.githubusercontent.com/813383/105070105-b5f25680-5a7a-11eb-815c-49fe42ff1faf.png)

### Degrees

The button is moved to the top of the page, but remains grey as most candidates will likely only have 1 degree.

![add-another-degree](https://user-images.githubusercontent.com/813383/105069303-a9213300-5a79-11eb-9954-13662fc30f10.png)

### Work history

The button is moved to the top of the page. When there are no jobs it says ‘Add a job’. When there are already jobs it says ‘Add another job’.

![add-another-job](https://user-images.githubusercontent.com/813383/105069405-c9e98880-5a79-11eb-8935-205d71c70a38.png)

### Volunteering

The button is moved to the top of the page. When there are no roles it says ‘Add a role’. When there are already roles it says ‘Add another role’.

![add-another-role](https://user-images.githubusercontent.com/813383/105069459-e1c10c80-5a79-11eb-8889-e5ecb443edcf.png)

### Other qualifications

The button is moved to the top of the page.

![add-another-qualification](https://user-images.githubusercontent.com/813383/105069510-f30a1900-5a79-11eb-8cc2-d0278bcae6ea.png)

## Guidance to review

* The design has been quite possibly over-reviewed 😅 We ended at this point because:
  * moving the button to the top makes it more visible, and separates it from the other controls on this page.
  * we considered adding additional guidance on more of these pages, but realised it repeated that which had already been shown or will be shown again.
  * tried alternative designs, but these are untested. This pattern is used throughout Apply and Manage applications already.

The rest of this PR tidies up some code on these review pages, ensuring their layouts are consistent.

## Link to Trello card

https://trello.com/c/ij7yjN5x

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
