### PR TITLE
Add received at columns to Application Reference Data Extract

### DIFF
--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -15,6 +15,7 @@ module SupportInterface
           output["Ref #{index} type"] = reference.referee_type
           output["Ref #{index} state"] = reference.feedback_status
           output["Ref #{index} requested at"] = reference.requested_at
+          output["Ref #{index} received at"] = received_at(reference)
         end
 
         output
@@ -23,6 +24,12 @@ module SupportInterface
       # The DataExport class creates the header row for us so we need to ensure
       # we sort by longest hash length to ensure all headers appear
       data_for_export.sort_by(&:length).reverse
+    end
+
+  private
+
+    def received_at(reference)
+      reference.audits.where("audited_changes#>>'{feedback_status, 1}' = 'feedback_provided'").last&.created_at
     end
   end
 end

--- a/spec/services/support_interface/application_references_export_spec.rb
+++ b/spec/services/support_interface/application_references_export_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
       create(:reference, feedback_status: 'feedback_requested', referee_type: 'school-based', application_form: application_form_one)
       create(:reference, feedback_status: 'feedback_requested', referee_type: 'character', application_form: application_form_one)
 
+      application_form_one.application_references[3].update!(feedback_status: 'feedback_provided')
+
       application_form_two = create(:application_form)
       create(:reference, feedback_status: 'feedback_refused', referee_type: 'academic', application_form: application_form_two)
 
@@ -24,15 +26,19 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
           'Ref 1 type' => application_form_one.application_references[0].referee_type,
           'Ref 1 state' => application_form_one.application_references[0].feedback_status,
           'Ref 1 requested at' => application_form_one.application_references[0].requested_at,
+          'Ref 1 received at' => nil,
           'Ref 2 type' => application_form_one.application_references[1].referee_type,
           'Ref 2 state' => application_form_one.application_references[1].feedback_status,
-          'Ref 2 requested at' => application_form_one.application_references[0].requested_at,
+          'Ref 2 requested at' => application_form_one.application_references[1].requested_at,
+          'Ref 2 received at' => nil,
           'Ref 3 type' => application_form_one.application_references[2].referee_type,
           'Ref 3 state' => application_form_one.application_references[2].feedback_status,
-          'Ref 3 requested at' => application_form_one.application_references[0].requested_at,
+          'Ref 3 requested at' => application_form_one.application_references[2].requested_at,
+          'Ref 3 received at' => nil,
           'Ref 4 type' => application_form_one.application_references[3].referee_type,
           'Ref 4 state' => application_form_one.application_references[3].feedback_status,
-          'Ref 4 requested at' => application_form_one.application_references[0].requested_at,
+          'Ref 4 requested at' => application_form_one.application_references[3].requested_at,
+          'Ref 4 received at' => application_form_one.application_references[3].audits.where("audited_changes#>>'{feedback_status, 1}' = 'feedback_provided'").last&.created_at,
         },
         {
           'Recruitment cycle year' => application_form_two.recruitment_cycle_year,
@@ -42,6 +48,7 @@ RSpec.describe SupportInterface::ApplicationReferencesExport do
           'Ref 1 type' => application_form_two.application_references[0].referee_type,
           'Ref 1 state' => application_form_two.application_references[0].feedback_status,
           'Ref 1 requested at' => application_form_one.application_references[0].requested_at,
+          'Ref 1 received at' => nil,
         },
       )
     end


### PR DESCRIPTION
## Context

As a requirement on the current Application Reference Data Extract, business analysts require
the capacity to view the time at which references have been completed.

## Changes proposed in this pull request

This solution builds on the
existing data extract model and adds the columns along with a method to find find the received_at
time in the audit log.

## Guidance to review

Test in the review app and review test coverage.

## Link to Trello card

https://trello.com/c/utHH62RD/2755-dev-update-application-references-data-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
