### PR TITLE
Add support for parallel tests

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,3 @@
+--require spec_helper
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/Gemfile
+++ b/Gemfile
@@ -119,4 +119,5 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'bullet'
+  gem 'parallel_tests'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,8 @@ GEM
       webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     parallel (1.19.2)
+    parallel_tests (3.4.0)
+      parallel
     parser (2.7.2.0)
       ast (~> 2.4.1)
     patience_diff (1.1.0)
@@ -572,6 +574,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   openapi3_parser (= 0.8.2)
+  parallel_tests
   pdfkit
   pg (~> 1.2.3)
   pry

--- a/app/lib/apply_redis_connection.rb
+++ b/app/lib/apply_redis_connection.rb
@@ -1,4 +1,6 @@
 class ApplyRedisConnection
+  HOST_AND_PORT = 'redis://localhost:6379'.freeze
+
   def self.url
     if ENV['REDIS_URL'].present?
       # Always use the Redis database defined by the environment, if available.
@@ -7,13 +9,14 @@ class ApplyRedisConnection
       # If we're in the test environment and tests are being run in parallel,
       # use a different database for each process. Add 1 to the environment
       # number so that we don't clobber the development database at 0.
-      "redis://localhost:6379/#{ENV['TEST_ENV_NUMBER'].to_i + 1}"
+      database_number = ENV['TEST_ENV_NUMBER'].to_i + 1
+      "#{HOST_AND_PORT}/#{database_number}"
     elsif Rails.env.test?
       # If we're in the test environment and tests are being run in a single
       # process, default to database 9 (this could be any number except 0).
-      'redis://localhost:6379/9'
+      "#{HOST_AND_PORT}/9"
     else
-      'redis://localhost:6379/0'
+      "#{HOST_AND_PORT}/0"
     end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,7 @@ development:
 
 test:
   <<: *default
-  database: 'bat_apply_test'
+  database: bat_apply_test<%= ENV['TEST_ENV_NUMBER'] %>
   variables:
     idle_in_transaction_session_timeout: 0
 

--- a/docs/parallel_tests.md
+++ b/docs/parallel_tests.md
@@ -1,0 +1,54 @@
+# Parallel Tests
+
+This document explains how to run the test suite across multiple cores in development.
+
+## Prerequisites
+
+### Check environment
+
+Ensure that REDIS_URL is not present in .env.test or .env.
+
+In order to successfully run tests in parallel, each process needs its own Redis database. We determine the Redis database id in [ApplyRedisConnection](app/lib/apply_redis_connection.rb). This class always uses REDIS_URL if present in the environment. In order for it to return the appropriate URL for test runs, we need to ensure REDIS_URL is not set in the test environment.
+
+### Prepare Postgres databases
+
+Run the following commands.
+
+Create additional databases:
+`bundle exec rake parallel:create`
+
+Copy development schema (repeat this after migrations)
+`bundle exec rake parallel:prepare`
+
+### Update Redis database count if needed
+
+By default, Redis has 16 databases available numbered 0-15. We allocate databases 1-n to each process created during parallel test runs.
+
+If you have 16 cores you'll start seeing the following error:
+
+`ERR DB index is out of range (Redis::CommandError)`
+
+You can fix this as follows:
+
+- Find your Redis configuration file (eg - /etc/redis.conf)
+- Change the value of `databases` to CPU count + 2
+  ```
+  databases 18
+  ```
+- Restart the Redis service.
+
+## Commands
+
+`bundle exec parallel_rspec [folder]`
+
+Run system specs only:
+
+`bundle exec parallel_rspec spec/system`
+
+Run non-system specs only:
+
+`bundle exec parallel_rspec --exclude-pattern=spec/system spec`
+
+## Aliases
+
+`alias prspec='bundle exec parallel_rspec'`

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,8 +71,10 @@ RSpec.configure do |config|
   config.before { ActionMailer::Base.deliveries.clear }
 
   config.before(:suite) do
-    puts "ℹ️  If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
-    puts "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
+    unless ENV['TEST_ENV_NUMBER']
+      puts "ℹ️  If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
+      puts "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
+    end
   end
 
   config.before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,9 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::CoberturaFormatter,
 ]
-SimpleCov.start 'rails'
+unless ENV['TEST_ENV_NUMBER']
+  SimpleCov.start 'rails'
+end
 
 require 'sidekiq/testing'
 require 'clockwork/test'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,10 @@
 require 'capybara/rails'
 
+# Use different Capybara ports when running tests in parallel
+if ENV['TEST_ENV_NUMBER']
+  Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
+end
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by(:rack_test)

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -3,6 +3,11 @@ ActiveJob::Base.queue_adapter = :test
 RSpec.configure do |config|
   include ActiveJob::TestHelper
 
+  # Show the Redis connections being used when running tests in parallel
+  if ENV['TEST_ENV_NUMBER'] && ENV['DEBUG_REDIS_CONNECTIONS']
+    Sidekiq.redis { |c| p c }
+  end
+
   # Turn Sidekiq on automatically in system tests. Use `sidekiq: false` in
   # tests to avoid Sidekiq running.
   config.define_derived_metadata(file_path: Regexp.new('/spec/system/')) do |metadata|


### PR DESCRIPTION
## Context
For faster test runs, we want to be able to run our test suite in parallel using multiple cores.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Add the [parallel_tests](https://github.com/grosser/parallel_tests) gem
- Update config for Postgres, Capybara, and Redis
- Document how to run the test suite in parallel locally

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Per-commit gives a good breakdown of the changes
- Does the doc make sense?
- Run it locally! Are you seeing any issues?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/ySrLogAF
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
