### PR TITLE
Set postgres server storage size at 15GB

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -469,6 +469,7 @@
         "rubyAuthHosts": "[parameters('authorisedHosts')]",
         "defaultAvailabilityCheckHosts": "[if(variables('useCustomDomains'), createArray(concat('azcheck:', variables('appServiceName'), '.azurewebsites.net/check'), concat('check:', parameters('customDomains')[0].domainName, '/check')), createArray(concat('azcheck:', variables('appServiceName'), '.azurewebsites.net/check')))]",
         "availabilityCheckHosts": "[if(greater(length(parameters('customAvailabilityMonitors')), 0), concat(variables('defaultAvailabilityCheckHosts'), parameters('customAvailabilityMonitors')), variables('defaultAvailabilityCheckHosts'))]",
+        "dbStorageMB": "[if(equals('production', parameters('environment')), 15360 , 5120)]",
         "copy": [
             {
                 "name": "availabilityTests",
@@ -1079,6 +1080,9 @@
                     "storageAutoGrow": {
                         "value": "[parameters('databaseStorageAutoGrow')]"
                     },
+                    "dbStorageMB": {
+                        "value": "[variables('dbStorageMB')]"
+                    },
                     "backupRetentionDays": {
                         "value": "[parameters('databaseBackupRetentionDays')]"
                     }
@@ -1201,6 +1205,9 @@
                     },
                     "storageAccountName": {
                         "value": "[variables('storageAccountName')]"
+                    },
+                    "dbStorageMB": {
+                        "value": "[variables('dbStorageMB')]"
                     }
                 }
             },


### PR DESCRIPTION
## Context
DB data has grown to about 9GB,
When autogrow is set and when the free storage is below
the greater of 1GB or 10% of the provisioned storage, the db size will grow.
Since autogrow is set to true in production, the DB size has grown to 15GB.

## Changes proposed in this pull request

Specify DB size as 15GB for production.

## Guidance to review

To be merged once https://github.com/DFE-Digital/bat-platform-building-blocks/pull/81 is merged.

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
