### PR TITLE
Add phase and candidate_id to the ApplicationsExport

### DIFF
--- a/app/services/support_interface/applications_export.rb
+++ b/app/services/support_interface/applications_export.rb
@@ -17,8 +17,10 @@ module SupportInterface
         associated_audits = application_form.associated_audits.sort_by(&:created_at).reverse
 
         output = {
+          candidate_id: application_form.candidate.id,
           support_reference: application_form.support_reference,
           recruitment_cycle_year: application_form.recruitment_cycle_year,
+          phase: application_form.phase,
           process_state: ProcessState.new(application_form).state,
           signed_up_at: application_form.candidate.created_at,
           first_signed_in_at: application_form.created_at,

--- a/spec/services/support_interface/applications_export_spec.rb
+++ b/spec/services/support_interface/applications_export_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe SupportInterface::ApplicationsExport, with_audited: true do
 
       row = data.first
 
+      expect(row[:candidate_id]).to eql(candidate.id)
+      expect(row[:phase]).to eql('apply_1')
       expect(row[:signed_up_at].to_s).to start_with('2020-01-01')
       expect(row[:first_signed_in_at].to_s).to start_with('2020-01-02')
       expect(row[:submitted_form_at].to_s).to start_with('2020-01-03')


### PR DESCRIPTION
## Context

Mike would like the candidate_id and phase for each application added to the ApplicationsExport.

## Changes proposed in this pull request

- Add phase and candidate_id to the applications export 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
