### PR TITLE
Specify healthCheckPath to determine if app service instance is healthy

### DIFF
--- a/azure/containers.json
+++ b/azure/containers.json
@@ -173,6 +173,9 @@
                     },
                     "appServiceAppSettings": {
                         "value": "[json(replace(string(variables('appServiceAppSettings')), 'secureValue', 'value'))]"
+                    },
+                    "healthCheckPath":{
+                        "value": "/check"
                     }
                 }
             }

--- a/azure/template.json
+++ b/azure/template.json
@@ -688,6 +688,10 @@
                                 "value": "0"
                             },
                             {
+                                "name": "WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
+                                "value": "5" //At 1 ping per minute
+                            },
+                            {
                                 "name": "RAILS_SERVE_STATIC_FILES",
                                 "value": "[parameters('railsServeStaticFiles')]"
                             },


### PR DESCRIPTION
Specify a healthCheckPath to determine if an instance
is healthy and can be included in the load balancer pool.

## Context

When running more than 1 instance of the app, 
the healthCheckPath is used to determine the health of the specific instance and if it can service traffic.
If the path returns a non 2xx status the instance is removed from the azure load balancer pool.

## Changes proposed in this pull request
Configure '/check' as healthCheckPath for each instance
Drop the instance from the pool after 5 failed pings.
## Guidance to review

To be merged after https://github.com/DFE-Digital/bat-platform-building-blocks/pull/82
Tested in [DevOps ](https://dev.azure.com/dfe-ssp/Become-A-Teacher/_build/results?buildId=137232&view=results)environment

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
