### PR TITLE
Edit acronyms on safeguarding and personal statement links

### DIFF
--- a/app/views/candidate_interface/personal_statement/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/edit.html.erb
@@ -19,7 +19,7 @@
         <li>any past experience working with children or young people, and what you learnt</li>
         <li>your thoughts on welfare and education</li>
       </ul>
-      <p class="govuk-body">If you need help, <%= govuk_link_to 'register with GIT to talk to a teacher training adviser', 'https://register.getintoteaching.education.gov.uk/Register' %>.</p>
+      <p class="govuk-body">If you need help, <%= govuk_link_to 'register with Get Into Teaching to talk to a teacher training adviser', 'https://register.getintoteaching.education.gov.uk/Register' %>.</p>
 
       <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -21,7 +21,7 @@
       </p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>your criminal record in the UK (they’ll do an enhanced <%= govuk_link_to 'DBS check', 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks', target: '_blank' %>) and abroad where relevant</li>
+        <li>your criminal record in the UK (they’ll do an enhanced <%= govuk_link_to 'Disclosure and Barring Service check', 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks', target: '_blank' %>) and abroad where relevant</li>
         <li>whether you’ve been banned from teaching or working with children</li>
         <li>your professional behaviour, such as whether you’ve been removed from teacher training and what your referees say about you</li>
       </ul>


### PR DESCRIPTION
## Context

Content designer has found a two examples of front end text within links that use
acronyms as opposed to explicit phrases.

## Changes proposed in this pull request

Changes made to make acronyms explicit.
![image](https://user-images.githubusercontent.com/62567622/104351261-16bee380-54fd-11eb-93ab-954a08a1804f.png)
![image](https://user-images.githubusercontent.com/62567622/104351289-20e0e200-54fd-11eb-87fa-3a2a5aeccf40.png)


## Guidance to review

Check in the review app that mark up meets specification

## Link to Trello card

https://trello.com/c/BUUr93l8/2753-dev-update-candidate-journey-tracking-data-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
