### PR TITLE
Use ApplyRedisConnection directly in Sidekiq init

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,7 +9,7 @@ end
 
 # Configure Redis connection
 sidekiq_redis_config = proc { |config|
-  config.redis = { url: Redis.current.id }
+  config.redis = { url: ApplyRedisConnection.url }
 }
 Sidekiq.configure_server(&sidekiq_redis_config)
 Sidekiq.configure_client(&sidekiq_redis_config)


### PR DESCRIPTION
`Redis.current.id` doesn't return the whole URL required for connecting to Redis. As we can't pass `Redis.current` or rely on `REDIS_URL`, go directly to `ApplyRedisConnection`

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1610471654096600