### PR TITLE
Avoid inadvertent rejection of applications

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -53,7 +53,7 @@ class ApplicationStateChange
 
     state :offer do
       event :make_offer, transitions_to: :offer
-      event :reject, transitions_to: :offer_withdrawn
+      event :withdraw_offer, transitions_to: :offer_withdrawn
       event :accept, transitions_to: :pending_conditions
       event :decline, transitions_to: :declined
       event :decline_by_default, transitions_to: :declined

--- a/app/services/withdraw_offer.rb
+++ b/app/services/withdraw_offer.rb
@@ -20,7 +20,7 @@ class WithdrawOffer
 
     audit(@auth.actor) do
       ActiveRecord::Base.transaction do
-        ApplicationStateChange.new(@application_choice).reject!
+        ApplicationStateChange.new(@application_choice).withdraw_offer!
         @application_choice.update!(
           offer_withdrawal_reason: @offer_withdrawal_reason,
           offer_withdrawn_at: Time.zone.now,

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -312,7 +312,7 @@ en:
         - candidate_mailer-declined_by_default
         - provider_mailer-declined_by_default
 
-    offer-reject:
+    offer-withdraw_offer:
       name: Provider rescinds offer
       by: provider
       description: As long as the candidate has not accepted the offer, the provider can reject the application.


### PR DESCRIPTION
## Context

We've got [an application](https://www.apply-for-teacher-training.service.gov.uk/support/applications/8459/audit) that was [inadvertently rejected by a provider](https://becomingateacher.zendesk.com/agent/tickets/11274). I think it's some kind of back-button issue.

Normally, this wouldn't be a problem, because our state machine protects against weird transitions. However, the state transition to reject an offer and the transition to withdraw an existing offer is the same (#reject!). This means that the `RejectApplication` service was invoked, and not the `WithdrawOffer` service. Because of this we don't set the `offer_withdrawn_at` attribute, which in turn crashes the offer page.

## Changes proposed in this pull request

This changes the transition so any inadvertent invocation of the `RejectApplication` service for offered applications will result in a crash rather than an inconsistent state. Hopefully it will allow us to find the scenario where this occurred so we can fix it.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/4IVO2PzH/111-ref-an2514
