### PR TITLE
Speed up UCAS spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,7 @@ group :test do
   gem 'deepsort'
   gem 'ruby-jmeter'
   gem 'super_diff'
+  gem 'test-prof'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,6 +477,7 @@ GEM
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
+    test-prof (0.12.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     timecop (0.9.2)
@@ -595,6 +596,7 @@ DEPENDENCIES
   skylight
   strip_attributes
   super_diff
+  test-prof
   timecop
   tzinfo-data
   uk_postcode

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -1,25 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe UCASMatchedApplication do
-  let(:course) { create(:course, recruitment_cycle_year: 2020) }
-  let(:candidate) { create(:candidate) }
-  let(:course_option) { create(:course_option, course: course) }
-  let(:application_choice) { create(:application_choice, course_option: course_option) }
-  let(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
-  let(:apply_again_application_form) { create(:application_form, candidate_id: candidate.id) }
-  let(:recruitment_cycle_year) { 2020 }
-  let(:candidate1) { create(:candidate) }
-  let(:application_choice1) { create(:application_choice, :with_accepted_offer, course_option: course_option) }
-  let(:application_form1) { create(:completed_application_form, candidate_id: candidate1.id, application_choices: [application_choice1]) }
-  let(:candidate2) { create(:candidate) }
-  let(:application_choice2) { create(:application_choice, :with_rejection, course_option: course_option) }
-  let(:application_form2) { create(:completed_application_form, candidate_id: candidate2.id, application_choices: [application_choice2]) }
+  # Reduce database interaction by using the let_it_be/before_all methods. This
+  # creates each record once before running the examples in this group.
+  let_it_be(:course) { create(:course, recruitment_cycle_year: 2020) }
+  let_it_be(:candidate) { create(:candidate) }
+  let_it_be(:course_option) { create(:course_option, course: course) }
+  # Use the reload: true option to reload this object after we roll back any
+  # changes made in the examples below.
+  let_it_be(:application_choice, reload: true) { create(:application_choice, course_option: course_option) }
+  let_it_be(:application_form) { create(:completed_application_form, candidate_id: candidate.id, application_choices: [application_choice]) }
+  let_it_be(:apply_again_application_form) { create(:application_form, candidate_id: candidate.id) }
+  let_it_be(:recruitment_cycle_year) { 2020 }
+  let_it_be(:candidate1) { create(:candidate) }
+  let_it_be(:application_choice1) { create(:application_choice, :with_accepted_offer, course_option: course_option) }
+  let_it_be(:application_form1) { create(:completed_application_form, candidate_id: candidate1.id, application_choices: [application_choice1]) }
+  let_it_be(:candidate2) { create(:candidate) }
+  let_it_be(:application_choice2) { create(:application_choice, :with_rejection, course_option: course_option) }
+  let_it_be(:application_form2) { create(:completed_application_form, candidate_id: candidate2.id, application_choices: [application_choice2]) }
 
-  before do
-    apply_again_application_form
-    application_form
-    application_form1
-    application_form2
+  before_all do
     create(:course, code: course.code, provider: course.provider, recruitment_cycle_year: 2021)
   end
 
@@ -323,9 +323,9 @@ RSpec.describe UCASMatchedApplication do
 
   describe '#application_withdrawn_on_apply?' do
     context 'when the application_choice status is set to withdrawn' do
-      let(:application_choice) { create(:application_choice, course_option: course_option, status: 'withdrawn') }
+      before { application_choice.withdrawn! }
 
-      it 'retuns true' do
+      it 'returns true' do
         dfe_matching_data =
           { 'Course code' => course.code.to_s,
             'Provider code' => course.provider.code.to_s,
@@ -337,9 +337,9 @@ RSpec.describe UCASMatchedApplication do
     end
 
     context 'when the application_choice status is not set to withdrawn' do
-      let(:application_choice) { create(:application_choice, course_option: course_option, status: (ApplicationStateChange.valid_states - [:withdrawn]).sample) }
+      before { application_choice.update!(status: (ApplicationStateChange.valid_states - [:withdrawn]).sample) }
 
-      it 'retuns false' do
+      it 'returns false' do
         dfe_matching_data =
           { 'Course code' => course.code.to_s,
             'Provider code' => course.provider.code.to_s,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,8 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+require 'test_prof/recipes/rspec/before_all'
+require 'test_prof/recipes/rspec/let_it_be'
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.


### PR DESCRIPTION
## Context

This is one of the slower specs in the test suite. Running the [RSpecDissect](https://test-prof.evilmartians.io/#/profilers/rspec_dissect) profiler against it indicates that this is largely because of the amount of time it spends in `let` (ie - creating records in the database).

The approach recommended by the test-prof docs for dealing with this is using the `let_it_be`/`before_all` methods provided by the gem. These methods hook into RSpec's `before(:context)` to allow database records to be set up once before executing examples in the group (rather than recreating them for each example). Any modifications to these records are automatically rolled back between examples, and an option is available to automatically reload the ActiveRecord object as well.

The unfamiliar syntax and new behaviour can potentially make the spec more difficult to follow. Raising this PR for discussion to weigh up the performance improvement vs impact on clarity.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Use the `let_it_be`/`before_all` methods in ucas_matched_application_spec. This change reduces the runtime from 6.72 seconds to 0.5 seconds (tested on a machine with an AMD Ryzen 7 3700X).

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

- Is it still reasonably clear what's going on in the spec?
- We can specify an alias for `let_it_be` if we think that would help clarify things.

## Link to Trello card
https://trello.com/c/ySrLogAF
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
