### PR TITLE
Added a link to course requirements on applicants rejected due to their qualifications

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -10,7 +10,8 @@ module CandidateInterface
       show_status: false,
       show_incomplete: false,
       missing_error: false,
-      application_choice_error: false
+      application_choice_error: false,
+      render_link_to_find_when_rejected_on_qualifications: false
     )
       @application_form = application_form
       @application_choices = @application_form.application_choices.includes(:course, :site, :provider, :offered_course_option).order(id: :asc)
@@ -20,6 +21,7 @@ module CandidateInterface
       @show_incomplete = show_incomplete
       @missing_error = missing_error
       @application_choice_error = application_choice_error
+      @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
     end
 
     def course_choice_rows(application_choice)
@@ -184,6 +186,7 @@ module CandidateInterface
               application_choice: application_choice,
               reasons_for_rejection: ReasonsForRejection.new(application_choice.structured_rejection_reasons),
               editable: false,
+              render_link_to_find_when_rejected_on_qualifications: @render_link_to_find_when_rejected_on_qualifications,
             ),
           ),
         }

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -56,6 +56,7 @@ module CandidateInterface
               application_choice: application_choice,
               reasons_for_rejection: ReasonsForRejection.new(application_choice.structured_rejection_reasons),
               editable: false,
+              render_link_to_find_when_rejected_on_qualifications: true,
             ),
           ),
         }

--- a/app/components/reasons_for_rejection_component.html.erb
+++ b/app/components/reasons_for_rejection_component.html.erb
@@ -58,7 +58,9 @@
           <% end %>
         </li>
       <% end %>
-      To check the course requirements view the course <%= link_to 'here.', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry", class: "govuk-link" %>
+        <% if @render_link_to_find_when_rejected_on_qualifications %>
+          View the course requirements on <%= govuk_link_to 'Find postgraduate teacher training courses', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry" %>.
+        <% end %>
     </ul>
     <% if editable? %>
       <p class="app-rejection__actions">

--- a/app/components/reasons_for_rejection_component.html.erb
+++ b/app/components/reasons_for_rejection_component.html.erb
@@ -58,6 +58,7 @@
           <% end %>
         </li>
       <% end %>
+      To check the course requirements view the course <%= link_to 'here.', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry", class: "govuk-link" %>
     </ul>
     <% if editable? %>
       <p class="app-rejection__actions">

--- a/app/components/reasons_for_rejection_component.rb
+++ b/app/components/reasons_for_rejection_component.rb
@@ -3,10 +3,11 @@ class ReasonsForRejectionComponent < ViewComponent::Base
 
   attr_reader :application_choice, :editable, :reasons_for_rejection
 
-  def initialize(application_choice:, reasons_for_rejection:, editable: false)
+  def initialize(application_choice:, reasons_for_rejection:, editable: false, render_link_to_find_when_rejected_on_qualifications: false)
     @application_choice = application_choice
     @reasons_for_rejection = reasons_for_rejection
     @editable = editable
+    @render_link_to_find_when_rejected_on_qualifications = render_link_to_find_when_rejected_on_qualifications
   end
 
   def editable?

--- a/app/views/candidate_interface/submitted_application_form/complete.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/complete.html.erb
@@ -12,7 +12,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render(CandidateInterface::ApplicationCompleteContentComponent.new(application_form: @application_form)) %>
 
-    <%= render(CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form, editable: false, heading_level: 3, show_status: true)) %>
+    <%= render(CandidateInterface::CourseChoicesReviewComponent.new(application_form: @application_form, editable: false, heading_level: 3, show_status: true, render_link_to_find_when_rejected_on_qualifications: true)) %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -10,7 +10,7 @@
     <% end %>
 
     <% if title == 'Qualifications' %>
-        ^ To check the course requirements view the course here <%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry"%>
+        ^ View the course requirements on [Find postgraduate teacher training courses](<%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry" %>).
     <% end %>
 
 <% end %>

--- a/app/views/candidate_mailer/_reasons_for_rejection.text.erb
+++ b/app/views/candidate_mailer/_reasons_for_rejection.text.erb
@@ -9,4 +9,8 @@
     ^
     <% end %>
 
+    <% if title == 'Qualifications' %>
+        ^ To check the course requirements view the course here <%= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-entry"%>
+    <% end %>
+
 <% end %>

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -259,30 +259,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
     end
-
-    before { FeatureFlag.activate(:structured_reasons_for_rejection) }
-    it 'displays a link to the course requirements, if due to qualifications' do
-      application_form = create(:application_form)
-      application_choice = create(
-        :application_choice,
-        application_form: application_form,
-        status: 'rejected',
-        rejection_reason: 'Qualifications',
-        structured_rejection_reasons: {
-          "qualifications_y_n"=>"Yes",
-          "qualifications_other_details"=>"All the other stuff",
-          "qualifications_which_qualifications"=>["no_english_gcse", "other"],
-        }
-      )
-
-      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
-
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Unsuccessful')
-      expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Qualifications')
-      expect(result.css('.govuk-summary-list__value').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
-    end
   end
 
   context 'when a course choice is withdrawn by provider' do

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -259,6 +259,30 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
     end
+
+    before { FeatureFlag.activate(:structured_reasons_for_rejection) }
+    it 'displays a link to the course requirements, if due to qualifications' do
+      application_form = create(:application_form)
+      application_choice = create(
+        :application_choice,
+        application_form: application_form,
+        status: 'rejected',
+        rejection_reason: 'Qualifications',
+        structured_rejection_reasons: {
+          "qualifications_y_n"=>"Yes",
+          "qualifications_other_details"=>"All the other stuff",
+          "qualifications_which_qualifications"=>["no_english_gcse", "other"],
+        }
+      )
+
+      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Unsuccessful')
+      expect(result.css('.govuk-summary-list__key').text).to include('Feedback')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Qualifications')
+      expect(result.css('.govuk-summary-list__value').to_html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
+    end
   end
 
   context 'when a course choice is withdrawn by provider' do

--- a/spec/components/reasons_for_rejection_component_spec.rb
+++ b/spec/components/reasons_for_rejection_component_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe ReasonsForRejectionComponent do
   describe 'rendered component' do
     let(:provider) { build_stubbed(:provider, name: 'The University of Metal') }
+    let(:course) { build_stubbed(:course, provider: provider) }
     let(:application_choice) { build_stubbed(:application_choice) }
     let(:reasons_for_rejection_attrs) do
       {
@@ -31,7 +32,10 @@ RSpec.describe ReasonsForRejectionComponent do
 
     let(:reasons_for_rejection) { ReasonsForRejection.new(reasons_for_rejection_attrs) }
 
-    before { allow(application_choice).to receive(:provider).and_return(provider) }
+    before do
+      allow(application_choice).to receive(:provider).and_return(provider)
+      allow(application_choice).to receive(:course).and_return(course)
+    end
 
     it 'renders rejection reason answers under headings' do
       result = render_inline(described_class.new(application_choice: application_choice, reasons_for_rejection: reasons_for_rejection))
@@ -50,6 +54,7 @@ RSpec.describe ReasonsForRejectionComponent do
       expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
       expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
       expect(html).to include('No degree')
+      expect(html).not_to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course_option.course.code}#section-entry")
 
       expect(result.css('h3.govuk-heading-s').text).to include('Performance at interview')
       expect(html).to include('There was no need to do all those pressups')
@@ -62,6 +67,17 @@ RSpec.describe ReasonsForRejectionComponent do
 
       expect(result.css('h3.govuk-heading-s').text).to include('Future applications')
       expect(html).to include('The University of Metal would be interested in future applications from you.')
+    end
+
+    it 'renders link to course requirements when rejected on qualifications is true' do
+      result = render_inline(described_class.new(application_choice: application_choice, reasons_for_rejection: reasons_for_rejection, render_link_to_find_when_rejected_on_qualifications: true))
+      html = result.to_html
+
+      expect(result.css('h3.govuk-heading-s').text).to include('Qualifications')
+      expect(html).to include('No English GCSE grade 4 (C) or above, or valid equivalent')
+      expect(html).to include('No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)')
+      expect(html).to include('No degree')
+      expect(html).to include("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{application_choice.provider.code}/#{application_choice.course.code}#section-entry")
     end
 
     it 'renders change links when editable' do

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe 'rejection emails' do
     def setup_application
-      provider = build_stubbed(:provider, name: 'Falconholt Technical College')
+      provider = build_stubbed(:provider, name: 'Falconholt Technical College', code: 'X100')
       course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
       @application_form = build_stubbed(:application_form, first_name: 'Tyrell', last_name: 'Wellick')
       @application_choice = @application_form.application_choices.build(
@@ -133,6 +133,9 @@ RSpec.describe CandidateMailer, type: :mailer do
           quality_of_application_which_parts_needed_improvement: %w[personal_statement subject_knowledge],
           quality_of_application_personal_statement_what_to_improve: 'Do not refer to yourself in the third person',
           quality_of_application_subject_knowledge_what_to_improve: 'Write in the first person',
+          qualifications_y_n: 'Yes',
+          qualifications_other_details: 'Bad qualifications',
+          qualifications_which_qualifications: %w[no_english_gcse other],
         },
       )
       @application_form.application_choices = [@application_choice]
@@ -148,7 +151,10 @@ RSpec.describe CandidateMailer, type: :mailer do
         'heading' => 'Dear Tyrell',
         'course name and code' => 'Forensic Science (E0FO)',
         'rejection reason heading' => 'Quality of application',
-        'rejection reason content' => 'Write in the first person'
+        'rejection reason content' => 'Write in the first person',
+        'qualifications rejection heading' => 'Qualifications',
+        'qualifications rejection content' => 'Bad qualifications',
+        'link to course on find' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/course/X100/E0FO#section-entry'
       )
     end
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -128,7 +128,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       application_form: application_form,
       course_option: course_option,
       status: :rejected,
-      structured_rejection_reasons: reasons_for_rejection,
+      structured_rejection_reasons: reasons_for_rejection_with_qualifications,
     )
     CandidateMailer.application_rejected_all_applications_rejected(application_choice)
   end
@@ -603,6 +603,14 @@ private
       quality_of_application_y_n: 'Yes',
       quality_of_application_which_parts_needed_improvement: %w[personal_statement subject_knowledge],
       quality_of_application_personal_statement_what_to_improve: 'Do not refer to yourself in the third person',
+    }
+  end
+
+  def reasons_for_rejection_with_qualifications
+    {
+      qualifications_y_n: 'Yes',
+      qualifications_other_details: 'Bad qualifications',
+      qualifications_which_qualifications: %w[no_english_gcse other],
     }
   end
 end


### PR DESCRIPTION
## Context

When candidates are rejected by providers due to their qualifications it provides a link to the requirements section on the relevant course, on Find.

## Changes proposed in this pull request

If 'Qualifications' is selected as a reason, the links will appear as below:

**Dashboard preview with the link:**
|Before|After|
|------------|------------|
|![Before Dashboard](https://user-images.githubusercontent.com/47917431/104594176-b1880100-5668-11eb-8345-78b7fce12223.png)|![After Dashboard](https://user-images.githubusercontent.com/47917431/104730034-3fc7ba00-5731-11eb-8ed1-decda7a14ba9.png)

**Email preview with the link:**
|Before|After|
|------------|------------|
|![Before Email](https://user-images.githubusercontent.com/47917431/104594280-da0ffb00-5668-11eb-81c0-5d24bcb70e8e.png)|![After Email](https://user-images.githubusercontent.com/47917431/104729980-2e7ead80-5731-11eb-9f90-ac89bad44fbd.png)

## Guidance to review

It would be helpful to agree on the actual wording that will be displayed along with the link.

## Link to Trello card

https://trello.com/c/JOgsnfc6/2799-dev-link-r4r-dashb-email-to-find-coursedets

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
