### PR TITLE
Redirect away from reasons for rejection flow if the application is already rejected.

### DIFF
--- a/app/controllers/provider_interface/reasons_for_rejection_controller.rb
+++ b/app/controllers/provider_interface/reasons_for_rejection_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   class ReasonsForRejectionController < ProviderInterfaceController
     before_action :ensure_structured_reasons_for_rejection_feature_is_active
     before_action :set_application_choice
+    before_action :redirect_if_application_rejected, except: :commit
 
     def edit_initial_questions
       @wizard = ReasonsForRejectionWizard.new(store, current_step: 'initial_questions')
@@ -103,6 +104,14 @@ module ProviderInterface
     def store
       key = "reasons_for_rejection_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
       WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def redirect_if_application_rejected
+      if @application_choice&.rejected?
+        flash[:warning] = 'This application has already been rejected.'
+
+        redirect_to provider_interface_application_choice_path(@application_choice)
+      end
     end
 
     def ensure_structured_reasons_for_rejection_feature_is_active

--- a/spec/system/provider_interface/reject_a_rejected_application_spec.rb
+++ b/spec/system/provider_interface/reject_a_rejected_application_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe 'Reject a rejected application' do
     and_the_same_application_is_rejected_elsewhere
     and_i_submit_the_reasons_for_rejection
     then_i_can_see_an_error_message
+
+    when_i_attempt_to_reject_the_application_again
+    then_i_can_see_that_the_application_has_already_been_rejected
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -92,5 +95,13 @@ RSpec.describe 'Reject a rejected application' do
     expect(page).to have_current_path(provider_interface_reasons_for_rejection_commit_path(@application_choice))
     expect(page).to have_content('There is a problem')
     expect(page).to have_content('The application is not ready for that action')
+  end
+
+  def when_i_attempt_to_reject_the_application_again
+    visit provider_interface_reasons_for_rejection_initial_questions_path(@application_choice)
+  end
+
+  def then_i_can_see_that_the_application_has_already_been_rejected
+    expect(page).to have_content('This application has already been rejected.')
   end
 end


### PR DESCRIPTION
## Context

It's possible to bookmark or craft a URL to reject a previously rejected application, for this scenario we should redirect the user back to the application with an explanatory message.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a redirect back to the application details from the reasons for rejection wizard flow if the application has already been rejected.

![image](https://user-images.githubusercontent.com/93511/104453467-5f79a980-559c-11eb-801b-10e59e59444c.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

To test this in Heroku:
 
 - Go to applications list and filter by `status: Rejected`
 - Click on a rejected application
 - Append `/reject` to the URL, this would previously allow you to enter the R4R wizard flow.

@johndoates Is the content _This application has already been rejected._ suitable for this case?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
