### PR TITLE
Support: improve how we display the course when a different course is offered

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -10,14 +10,17 @@ module SupportInterface
 
     def rows
       rows = [
-        { key: 'Recruitment cycle', value: application_choice.offered_option.course.recruitment_cycle_year },
-        { key: 'Provider', value: govuk_link_to(application_choice.offered_course.provider.name_and_code, support_interface_provider_path(application_choice.offered_course.provider)) },
-        { key: 'Accredited body', value: accredited_body.present? ? govuk_link_to(accredited_body.name_and_code, support_interface_provider_path(accredited_body)) : nil },
-        { key: 'Course', value: render(SupportInterface::CourseNameAndStatusComponent.new(application_choice: application_choice)) },
-        { key: 'Location', value: render(SupportInterface::LocationStatusComponent.new(application_choice: application_choice)) },
-        { key: 'Study mode', value: application_choice.offered_option.study_mode.humanize },
         { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)) },
       ]
+
+      if application_choice.different_offer?
+        rows << [
+          { key: 'Course candidate applied for', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option)) },
+          { key: 'Course offered by provider', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.offered_course_option)) },
+        ]
+      else
+        rows << { key: 'Course', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option)) }
+      end
 
       if application_choice.rejected?
         if application_choice.rejected_by_default
@@ -32,14 +35,10 @@ module SupportInterface
 
       rows << { key: 'Feedback', value: application_choice.rejection_reason } if application_choice.rejection_reason.present?
       rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at
-      rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at
-      rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at
+      rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at && application_choice.awaiting_provider_decision?
+      rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at && application_choice.offer?
 
-      rows
-    end
-
-    def accredited_body
-      application_choice.course.accredited_provider
+      rows.flatten
     end
 
   private

--- a/app/components/support_interface/course_name_and_status_component.html.erb
+++ b/app/components/support_interface/course_name_and_status_component.html.erb
@@ -1,16 +1,16 @@
 <%= govuk_link_to(
-  application_choice.offered_course.year_name_and_code,
-  support_interface_course_path(application_choice.offered_course)
+  course_option.course.year_name_and_code,
+  support_interface_course_path(course_option.course)
 ) %>
 
-<% if application_choice.course_not_available? %>
+<% if course_option.course_not_available? %>
   <%= render TagComponent.new(text: 'Course removed from Find', type: 'yellow') %>
 <% end %>
 
-<% if application_choice.course_closed_on_apply? %>
+<% if course_option.course_closed_on_apply? %>
   <%= render TagComponent.new(text: 'Course closed on Apply', type: 'yellow') %>
 <% end %>
 
-<% if application_choice.course_full? %>
+<% if course_option.course_full? %>
   <%= render TagComponent.new(text: 'Course is full', type: 'yellow') %>
 <% end %>

--- a/app/components/support_interface/course_name_and_status_component.rb
+++ b/app/components/support_interface/course_name_and_status_component.rb
@@ -2,10 +2,10 @@ module SupportInterface
   class CourseNameAndStatusComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :application_choice
+    attr_reader :course_option
 
-    def initialize(application_choice:)
-      @application_choice = application_choice
+    def initialize(course_option:)
+      @course_option = course_option
     end
   end
 end

--- a/app/components/support_interface/course_option_details_component.html.erb
+++ b/app/components/support_interface/course_option_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/support_interface/course_option_details_component.rb
+++ b/app/components/support_interface/course_option_details_component.rb
@@ -1,0 +1,28 @@
+module SupportInterface
+  class CourseOptionDetailsComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :course_option
+
+    def initialize(course_option:)
+      @course_option = course_option
+    end
+
+    def rows
+      [
+        { key: 'Recruitment cycle', value: course_option.course.recruitment_cycle_year },
+        { key: 'Provider', value: govuk_link_to(course_option.course.provider.name_and_code, support_interface_provider_path(course_option.course.provider)) },
+        { key: 'Accredited body', value: accredited_body.present? ? govuk_link_to(accredited_body.name_and_code, support_interface_provider_path(accredited_body)) : nil },
+        { key: 'Course', value: render(SupportInterface::CourseNameAndStatusComponent.new(course_option: course_option)) },
+        { key: 'Location', value: course_option.site.name_and_code },
+        { key: 'Chosen study mode', value: course_option.study_mode.humanize },
+      ]
+    end
+
+  private
+
+    def accredited_body
+      course_option.course.accredited_provider
+    end
+  end
+end

--- a/app/components/support_interface/location_status_component.html.erb
+++ b/app/components/support_interface/location_status_component.html.erb
@@ -1,5 +1,0 @@
-<%= application_choice.offered_option.site.name_and_code %>
-
-<% if application_choice.site_full? %>
-  <%= render TagComponent.new(text: 'No vacancies at location', type: 'yellow') %>
-<% end %>

--- a/app/components/support_interface/location_status_component.rb
+++ b/app/components/support_interface/location_status_component.rb
@@ -1,9 +1,0 @@
-module SupportInterface
-  class LocationStatusComponent < ViewComponent::Base
-    attr_reader :application_choice
-
-    def initialize(application_choice:)
-      @application_choice = application_choice
-    end
-  end
-end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -39,6 +39,10 @@ class ApplicationChoice < ApplicationRecord
     offer_deferred: 'offer_deferred',
   }
 
+  def different_offer?
+    offered_course_option_id && offered_course_option_id != course_option_id
+  end
+
   def offered_option
     offered_course_option || course_option
   end


### PR DESCRIPTION
## Context

Providers can offer a different course than the one the candidate applied to. It's not super clear in the support UI that this has happened, and what the changes are. Making it clearer in support might make it easier to debug issues like this one https://becomingateacher.zendesk.com/agent/tickets/11268, in which a provider is confused about which course was offered.

## Changes proposed in this pull request

Before, when the offered course is not different (or no offer):

![Screenshot 2021-01-13 at 14 38 40](https://user-images.githubusercontent.com/233676/104460160-0286ef00-55ae-11eb-810a-50432fcadd15.png)

After:

![Screenshot 2021-01-13 at 14 38 06](https://user-images.githubusercontent.com/233676/104460163-031f8580-55ae-11eb-9ee3-a33e996da4b6.png)

Before, when the offered course is different from the applied course:

![Screenshot 2021-01-13 at 14 43 16](https://user-images.githubusercontent.com/233676/104460154-ff8bfe80-55ad-11eb-8531-7867f639cd14.png)

After:

![Screenshot 2021-01-13 at 14 42 46](https://user-images.githubusercontent.com/233676/104460159-0155c200-55ae-11eb-8142-93febdfc5e59.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/nkRuL1iT/109-provider-has-changed-the-course-they-are-offering-a-candidate-however-they-are-not-seeing-this-mirrored-on-the-system-ticket-num
