### PR TITLE
Fix Redis connection for OK Computer healtcheck

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -27,7 +27,10 @@ end
 OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
-OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
+
+# Ideally we'd use Redis.current here, but OkComputer doesn't support that
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ApplyRedisConnection.url)
+
 OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new


### PR DESCRIPTION
## Context

Missed in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3818. The healthcheck is currently taking a long time and erroring. The hypothesis is that this is making all of Apply slow. 

## Changes proposed in this pull request

Use the correct Redis URL to connect.

## Guidance to review

Ok?

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1610549863262100
