### PR TITLE
Allow partial candidate reference search terms

### DIFF
--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -1,5 +1,5 @@
 class FilterApplicationChoicesForProviders
-  CANDIDATE_REFERENCE_REGEX = /^[a-zA-Z]{2}\d{4}$/.freeze
+  CANDIDATE_REFERENCE_REGEX = /^[a-zA-Z]{2}\d{1,}$/.freeze
 
   def self.call(application_choices:, filters:)
     return application_choices if filters.empty?
@@ -16,7 +16,7 @@ class FilterApplicationChoicesForProviders
       candidate_ref_match = candidates_name_or_reference.strip.match(CANDIDATE_REFERENCE_REGEX)
 
       if candidate_ref_match
-        application_choices.joins(:application_form).where('support_reference = ?', candidate_ref_match[0])
+        application_choices.joins(:application_form).where('support_reference ILIKE ?', "#{candidate_ref_match[0]}%")
       else
         application_choices.joins(:application_form).where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name_or_reference}%")
       end

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe FilterApplicationChoicesForProviders do
       expect(result).to eq([application_choices.first])
     end
 
+    it 'filters by partial candidate reference' do
+      partial_reference = application_choices.first.application_form.support_reference[0...3]
+      result = described_class.call(application_choices: application_choices, filters: { candidate_name: partial_reference })
+
+      expect(result).to eq([application_choices.first])
+    end
+
     it 'filters by candidate name' do
       result = described_class.call(application_choices: application_choices, filters: { candidate_name: application_choices.last.application_form.last_name })
 


### PR DESCRIPTION
## Context

We've recently added the ability for providers to search applications by candidate reference (this is the support reference).
It would be good to allow this to be a partial reference term.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Allow providers to search by partial candidate reference, (this needs to be the first 2 letters and at least one digit).

![image](https://user-images.githubusercontent.com/93511/104479025-dfaf0780-55ba-11eb-9b6c-537144a588a0.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/OX3wgAMM/3245-allow-partial-matching-of-candidate-reference-number-in-provider-applications-search
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
