### PR TITLE
Remove Course#qualifications & program_type from Find sync

### DIFF
--- a/app/services/find_sync/sync_courses_from_find.rb
+++ b/app/services/find_sync/sync_courses_from_find.rb
@@ -96,6 +96,8 @@ module FindSync
       course.exposed_in_find = find_course.findable?
       course.subject_codes = find_course.subject_codes
       course.funding_type = find_course.funding_type
+      # this field is in the API docs, but not actually in the API yet
+      course.program_type = find_course.try(:program_type)
       course.age_range = find_course.age_range_in_years&.humanize
       course.withdrawn = find_course.content_status == 'withdrawn'
     end

--- a/app/services/find_sync/sync_courses_from_find.rb
+++ b/app/services/find_sync/sync_courses_from_find.rb
@@ -96,9 +96,6 @@ module FindSync
       course.exposed_in_find = find_course.findable?
       course.subject_codes = find_course.subject_codes
       course.funding_type = find_course.funding_type
-      # these two fields are in the API docs, but not actually in the API yet
-      course.program_type = find_course.try(:program_type)
-      course.qualifications = find_course.try(:qualifications)
       course.age_range = find_course.age_range_in_years&.humanize
       course.withdrawn = find_course.content_status == 'withdrawn'
     end

--- a/spec/services/find_sync/sync_provider_from_find_spec.rb
+++ b/spec/services/find_sync/sync_provider_from_find_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe FindSync::SyncProviderFromFind, sidekiq: true do
         expect(course_option.course.qualifications).to be_nil
       end
 
-      it 'does not update program_type even when program_type is present' do
+      it 'correctly updates program_type when program_type is present' do
         stub_find_api_provider_200_with_qualifications_and_program_type(
           provider_code: 'ABC',
           course_code: '9CBA',
@@ -329,7 +329,8 @@ RSpec.describe FindSync::SyncProviderFromFind, sidekiq: true do
         described_class.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         course_option = CourseOption.last
 
-        expect(course_option.course.program_type).to be_nil
+        # the enum field converts the value from the short code to the expanded value
+        expect(course_option.course.program_type).to eq('school_direct_training_programme')
       end
     end
 

--- a/spec/services/find_sync/sync_provider_from_find_spec.rb
+++ b/spec/services/find_sync/sync_provider_from_find_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe FindSync::SyncProviderFromFind, sidekiq: true do
         expect(course_option.course.program_type).to be_nil
       end
 
-      it 'correctly updates qualifications when qualifications are present' do
+      it 'does not update qualifications even when qualifications are present' do
         stub_find_api_provider_200_with_qualifications_and_program_type(
           provider_code: 'ABC',
           course_code: '9CBA',
@@ -315,10 +315,10 @@ RSpec.describe FindSync::SyncProviderFromFind, sidekiq: true do
         described_class.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         course_option = CourseOption.last
 
-        expect(course_option.course.qualifications).to eq(%w[PG PF])
+        expect(course_option.course.qualifications).to be_nil
       end
 
-      it 'correctly updates program_type when program_type is present' do
+      it 'does not update program_type even when program_type is present' do
         stub_find_api_provider_200_with_qualifications_and_program_type(
           provider_code: 'ABC',
           course_code: '9CBA',
@@ -329,8 +329,7 @@ RSpec.describe FindSync::SyncProviderFromFind, sidekiq: true do
         described_class.call(provider_name: 'ABC College', provider_code: 'ABC', provider_recruitment_cycle_year: stubbed_recruitment_cycle_year)
         course_option = CourseOption.last
 
-        # the enum field converts the value from the short code to the expanded value
-        expect(course_option.course.program_type).to eq('school_direct_training_programme')
+        expect(course_option.course.program_type).to be_nil
       end
     end
 


### PR DESCRIPTION
## Context

The Find sync was overwriting the values of `Course#qualifications` & `program_type` that are synched from the TTAPI with `nil`. This sets up a perpetual cycle that toggles the values from one to the other twice an hour. As a result the audit trail for `Course`s is badly bloated. 

## Changes proposed in this pull request

- [x] Just remove these attributes from the find sync.

## Guidance to review

- Is there anything else that could cause audit bloat?
- If necessary we can log another card to clean up some of the redundant entries in the audit trail.

## Link to Trello card

https://trello.com/c/qfdMyoFJ/2850-investigate-audit-trail-bloat

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
