### PR TITLE
Fix issue with referee sign in creating excess tokens

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -153,9 +153,9 @@ module SupportInterface
       if reference.feedback_requested? && HostingEnvironment.test_environment?
         {
           key: 'Sign in as referee',
-          value: govuk_link_to('Give feedback', referee_interface_reference_relationship_path(token: reference.refresh_feedback_token!)) +
+          value: govuk_link_to('Give feedback', support_interface_impersonate_referee_and_give_reference_path(reference_id: reference.id)) +
             ' or ' +
-            govuk_link_to('decline to give a reference', referee_interface_refuse_feedback_path(token: reference.refresh_feedback_token!)),
+            govuk_link_to('decline to give a reference', support_interface_impersonate_referee_and_decline_reference_path(reference_id: reference.id)),
         }
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -765,6 +765,8 @@ Rails.application.routes.draw do
       post '/cancel' => 'references#confirm_cancel'
       get '/reinstate' => 'references#reinstate', as: :reinstate_reference
       post '/reinstate' => 'references#confirm_reinstate'
+      get '/impersonate-and-give' => 'references#impersonate_and_give', as: :impersonate_referee_and_give_reference
+      get 'impersonate-and-decline' => 'references#impersonate_and_decline', as: :impersonate_referee_and_decline_reference
     end
 
     get '/tokens' => 'api_tokens#index', as: :api_tokens

--- a/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
+++ b/spec/system/support_interface/provide_or_refuse_feedback_for_a_feedback_requested_reference_spec.rb
@@ -45,10 +45,6 @@ RSpec.feature 'Support user can access the RefereeInterface' do
     click_link 'decline to give a reference'
   end
 
-  def and_click_the_sign_in_button
-    click_on 'Sign in as this candidate'
-  end
-
   def then_i_see_the_refuse_feedback_page
     expect(page).to have_content "#{@application.full_name} will be able to submit the application quicker if you give a reference"
   end


### PR DESCRIPTION
## Context

 Currently, when you visit the application show page on the support interface, a new reference token is created for each reference in the feedback requested state.

## Changes proposed in this pull request

This PR adds the `impersonate_and_give` and `impersonate_and_decline` endpoints to the reference controller. These endpoints do 2 things.

 1. Call the reference.refresh_feedback_token! method
 2. Redirect to the appropriate page of reference flow

## Guidance to review

Does this all seem reasonable?

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
