### PR TITLE
Extend GetActivityLog to retrieve associated audits for interviews

### DIFF
--- a/app/components/provider_interface/activity_log_event_component.html.erb
+++ b/app/components/provider_interface/activity_log_event_component.html.erb
@@ -15,16 +15,13 @@
     <div class="app-timeline__log-card">
       <div class="app-timeline__log-card__note">
         <p class="app-timeline__log-card__note--title">
-          <%= course_option.course.name_and_code %>
-          at
-          <%= course_option.site.name %>
+          <%= event_note_title %>
         </p>
-        <p class="app-timeline__log-card__note--content govuk-!-margin-top-0">
-          <%= course_option.provider.name %>
-          <% if course_option.course.accredited_provider.present? %>
-            – ratified by <%= course_option.course.accredited_provider.name %>
-          <% end %>
-        </p>
+        <% if event_note_content.present? %>
+          <p class="app-timeline__log-card__note--content govuk-!-margin-top-0">
+            <%= event_note_content %>
+          </p>
+        <% end %>
         <% if link[:url].present? %>
           <p class="app-timeline__event_link"><a class="govuk-link" href="<%= link[:url] %>"><%= link[:text] %></a></p>
         <% end %>

--- a/app/components/provider_interface/activity_log_event_component.html.erb
+++ b/app/components/provider_interface/activity_log_event_component.html.erb
@@ -15,11 +15,11 @@
     <div class="app-timeline__log-card">
       <div class="app-timeline__log-card__note">
         <p class="app-timeline__log-card__note--title">
-          <%= event_note_title %>
+          <%= event_title %>
         </p>
-        <% if event_note_content.present? %>
+        <% if event_content.present? %>
           <p class="app-timeline__log-card__note--content govuk-!-margin-top-0">
-            <%= event_note_content %>
+            <%= event_content %>
           </p>
         <% end %>
         <% if link[:url].present? %>

--- a/app/components/provider_interface/activity_log_event_component.rb
+++ b/app/components/provider_interface/activity_log_event_component.rb
@@ -77,10 +77,7 @@ module ProviderInterface
         "#{course_option.course.name_and_code} at #{course_option.site.name}"
       elsif event.audit.auditable.is_a?(Interview)
         interview = event.audit.auditable
-        title = "Interviewing on #{interview.date_and_time.to_s(:govuk_date_and_time)}"
-        title << ", #{interview.location}" if interview.location.present?
-
-        title
+        "Interviewing on #{interview.date_and_time.to_s(:govuk_date_and_time)}, #{interview.location}"
       end
     end
 

--- a/app/components/provider_interface/activity_log_event_component.rb
+++ b/app/components/provider_interface/activity_log_event_component.rb
@@ -72,7 +72,7 @@ module ProviderInterface
                          end
     end
 
-    def event_note_title
+    def event_title
       if application_choice.present?
         "#{course_option.course.name_and_code} at #{course_option.site.name}"
       elsif event.audit.auditable.is_a?(Interview)
@@ -81,7 +81,7 @@ module ProviderInterface
       end
     end
 
-    def event_note_content
+    def event_content
       if application_choice.present?
         content = course_option.provider.name
 

--- a/app/components/provider_interface/activity_log_event_component.rb
+++ b/app/components/provider_interface/activity_log_event_component.rb
@@ -120,7 +120,7 @@ module ProviderInterface
           }
         elsif event.audit.auditable.is_a?(Interview)
           {
-            url: routes.provider_interface_application_choice_path(event.audit.associated),
+            url: routes.provider_interface_application_choice_interviews_path(event.audit.associated, anchor: "interview-#{event.audit.auditable.id}"),
             text: 'View interview',
           }
         else

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -88,7 +88,7 @@ module ProviderInterface
     end
 
     def interview_events
-      @activity_log_events.select { |e| e.audit.auditable_type == 'Interview' }.map do |event|
+      @activity_log_events.select { |e| e.audit.auditable.is_a?(Interview) }.map do |event|
         Event.new(
           interview_title_for(event.audit),
           actor_for(event),

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -137,8 +137,7 @@ module ProviderInterface
     def interview_link_params(interview)
       return [nil, nil] if interview.discarded?
 
-      # TODO : Amend to interview path
-      ['View interview', provider_interface_application_choice_path(application_choice)]
+      ['View interview', provider_interface_application_choice_interviews_path(application_choice, anchor: "interview-#{interview.id}")]
     end
 
     def provider_name(provider_user)

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -93,8 +93,7 @@ module ProviderInterface
           interview_title_for(event.audit),
           actor_for(event),
           event.created_at,
-          'View interview',
-          provider_interface_application_choice_path(application_choice),
+          *interview_link_params(event.audit.auditable),
         )
       end
     end
@@ -133,6 +132,13 @@ module ProviderInterface
 
     def offer_link_params
       ['View offer', provider_interface_application_choice_offer_path(application_choice)]
+    end
+
+    def interview_link_params(interview)
+      return [nil, nil] if interview.discarded?
+
+      # TODO : Amend to interview path
+      ['View interview', provider_interface_application_choice_path(application_choice)]
     end
 
     def provider_name(provider_user)

--- a/app/lib/activity_log_event.rb
+++ b/app/lib/activity_log_event.rb
@@ -19,7 +19,8 @@ class ActivityLogEvent
   end
 
   def candidate_full_name
-    audit.auditable.try(:application_form)&.full_name
+    audit.auditable.try(:application_form)&.full_name ||
+      audit.associated.try(:application_form)&.full_name
   end
 
   def application_status_at_event

--- a/spec/components/provider_interface/activity_log_event_component_spec.rb
+++ b/spec/components/provider_interface/activity_log_event_component_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
     end
   end
 
+  describe '#event_description for an interview audit' do
+    it 'presents interview details' do
+      audit = create(:interview_audit)
+      expected = "#{audit.user.full_name} set up an interview with #{audit.associated.application_form.full_name}"
+      expect(component_for(audit).event_description).to eq(expected)
+    end
+  end
+
   describe '#link' do
     let(:routes) { Rails.application.routes.url_helpers }
 
@@ -87,6 +95,15 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
           text: 'View offer',
         })
       end
+    end
+
+    it 'links to the interview tab for an interview audit' do
+      audit = create(:interview_audit)
+
+      expect(component_for(audit).link).to eq({
+        url: routes.provider_interface_application_choice_path(audit.associated),
+        text: 'View interview',
+      })
     end
   end
 

--- a/spec/components/provider_interface/activity_log_event_component_spec.rb
+++ b/spec/components/provider_interface/activity_log_event_component_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
       audit = create(:interview_audit)
 
       expect(component_for(audit).link).to eq({
-        url: routes.provider_interface_application_choice_path(audit.associated),
+        url: routes.provider_interface_application_choice_interviews_path(audit.associated, anchor: "interview-#{audit.auditable.id}"),
         text: 'View interview',
       })
     end

--- a/spec/components/provider_interface/activity_log_event_component_spec.rb
+++ b/spec/components/provider_interface/activity_log_event_component_spec.rb
@@ -43,7 +43,12 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
 
   describe '#event_description for an interview audit' do
     it 'presents interview details' do
-      audit = create(:interview_audit)
+      audit = build_stubbed(:interview_audit)
+      application_choice = build_stubbed(:application_choice)
+      interview = build_stubbed(:interview)
+      allow(audit).to receive(:auditable).and_return(interview)
+      allow(audit).to receive(:associated).and_return(application_choice)
+
       expected = "#{audit.user.full_name} set up an interview with #{audit.associated.application_form.full_name}"
       expect(component_for(audit).event_description).to eq(expected)
     end
@@ -98,10 +103,14 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
     end
 
     it 'links to the interview tab for an interview audit' do
-      audit = create(:interview_audit)
+      audit = build_stubbed(:interview_audit, audited_changes: {})
+      application_choice = build_stubbed(:application_choice)
+      interview = build_stubbed(:interview)
+      allow(audit).to receive(:auditable).and_return(interview)
+      allow(audit).to receive(:associated).and_return(application_choice)
 
       expect(component_for(audit).link).to eq({
-        url: routes.provider_interface_application_choice_interviews_path(audit.associated, anchor: "interview-#{audit.auditable.id}"),
+        url: routes.provider_interface_application_choice_interviews_path(application_choice, anchor: "interview-#{interview.id}"),
         text: 'View interview',
       })
     end

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Interview set up'
       expect(rendered.text).to include '11 February 2020 at 10:00pm'
       expect(rendered.css('a').text).to eq 'View interview'
-      expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}"
+      expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
 
     it 'renders the interview updated event' do
@@ -142,7 +142,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Interview updated'
       expect(rendered.text).to include '11 February 2020 at 10:00pm'
       expect(rendered.css('a').text).to eq 'View interview'
-      expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}"
+      expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
 
     it 'renders the interview cancelled event' do
@@ -156,7 +156,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Interview cancelled'
       expect(rendered.text).to include '11 February 2020 at 10:00pm'
       expect(rendered.css('a').text).to eq 'View interview'
-      expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}"
+      expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
   end
 

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -120,11 +120,16 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
 
   context 'for an interview event' do
     it 'renders the interview set up event' do
-      application_choice = create(:application_choice, status: 'interviewing')
-      interview = create(:interview)
-      application_choice_audit = create(:application_choice_audit, application_choice: application_choice)
-      application_choice_audit.update(audited_changes: { status: %w[awaiting_provider_decision interviewing] })
-      create(:interview_audit, interview: interview, application_choice: application_choice)
+      application_choice = build_stubbed(:application_choice, status: 'interviewing')
+      interview = build_stubbed(:interview)
+      application_choice_audit = build_stubbed(:application_choice_audit, application_choice: application_choice, audited_changes: { status: %w[awaiting_provider_decision interviewing] })
+      interview_audit = build_stubbed(:interview_audit, interview: interview, application_choice: application_choice, audited_changes: {})
+      allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
+      allow(interview_audit).to receive(:auditable).and_return(interview)
+      allow(GetActivityLogEvents).to receive(:call)
+        .with(application_choices: [application_choice])
+        .and_return([interview_audit, application_choice_audit])
+
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview set up'
       expect(rendered.text).to include '11 February 2020 at 10:00pm'
@@ -133,11 +138,16 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     end
 
     it 'renders the interview updated event' do
-      application_choice = create(:application_choice, status: 'interviewing')
-      interview = create(:interview)
-      application_choice_audit = create(:application_choice_audit, application_choice: application_choice)
-      application_choice_audit.update(audited_changes: { status: %w[awaiting_provider_decision interviewing] })
-      create(:interview_audit, action: 'update', interview: interview, application_choice: application_choice)
+      application_choice = build_stubbed(:application_choice, status: 'interviewing')
+      interview = build_stubbed(:interview)
+      application_choice_audit = build_stubbed(:application_choice_audit, application_choice: application_choice, audited_changes: { status: %w[awaiting_provider_decision interviewing] })
+      interview_audit = build_stubbed(:interview_audit, action: 'update', interview: interview, application_choice: application_choice, audited_changes: {})
+      allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
+      allow(interview_audit).to receive(:auditable).and_return(interview)
+      allow(GetActivityLogEvents).to receive(:call)
+        .with(application_choices: [application_choice])
+        .and_return([interview_audit, application_choice_audit])
+
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview updated'
       expect(rendered.text).to include '11 February 2020 at 10:00pm'
@@ -146,12 +156,16 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
     end
 
     it 'renders the interview cancelled event' do
-      application_choice = create(:application_choice, status: 'interviewing')
-      interview = create(:interview)
-      application_choice_audit = create(:application_choice_audit, application_choice: application_choice)
-      application_choice_audit.update(audited_changes: { status: %w[awaiting_provider_decision interviewing] })
-      interview_audit = create(:interview_audit, action: 'update', interview: interview, application_choice: application_choice)
-      interview_audit.update(audited_changes: { cancelled_at: [nil, Time.zone.now] })
+      application_choice = build_stubbed(:application_choice, status: 'interviewing')
+      interview = build_stubbed(:interview)
+      application_choice_audit = build_stubbed(:application_choice_audit, application_choice: application_choice, audited_changes: { status: %w[awaiting_provider_decision interviewing] })
+      interview_audit = build_stubbed(:interview_audit, action: 'update', interview: interview, application_choice: application_choice, audited_changes: { cancelled_at: [nil, Time.zone.now] })
+      allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
+      allow(interview_audit).to receive(:auditable).and_return(interview)
+      allow(GetActivityLogEvents).to receive(:call)
+        .with(application_choices: [application_choice])
+        .and_return([interview_audit, application_choice_audit])
+
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview cancelled'
       expect(rendered.text).to include '11 February 2020 at 10:00pm'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1233,8 +1233,8 @@ FactoryBot.define do
     created_at { Time.zone.now }
 
     transient do
-      application_choice { create(:application_choice, :awaiting_provider_decision) }
-      interview { create(:interview) }
+      application_choice { build_stubbed(:application_choice, :awaiting_provider_decision) }
+      interview { build_stubbed(:interview) }
       changes { {} }
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1154,6 +1154,16 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :with_scheduled_interview do
+      application_choice { create(:application_choice, :with_scheduled_interview) }
+
+      changes do
+        {
+          'status' => %w[awaiting_provider_decision interviewing],
+        }
+      end
+    end
   end
 
   factory :feature do
@@ -1213,5 +1223,26 @@ FactoryBot.define do
     page_title { Faker::Lorem.paragraph(sentence_count: 1) }
     feedback { Faker::Lorem.paragraph(sentence_count: 3) }
     consent_to_be_contacted { true }
+  end
+
+  factory :interview_audit, class: 'Audited::Audit' do
+    action { 'create' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    created_at { Time.zone.now }
+
+    transient do
+      application_choice { create(:application_choice, :awaiting_provider_decision) }
+      interview { create(:interview) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'Interview'
+      audit.auditable_id = evaluator.interview.id
+      audit.associated = evaluator.application_choice
+      audit.audited_changes = evaluator.changes
+    end
   end
 end

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -181,4 +181,15 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
       expect(elapsed_time).to be < 0.05
     end
   end
+
+  context 'with interviews associated to applications' do
+    let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
+
+    it 'returns events associated with interviews' do
+      result = GetActivityLogEvents.call(application_choices: [application_choice])
+
+      expect(result.first.auditable).to eq(application_choice.interviews.first)
+      expect(result.first.associated).to eq(application_choice)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Activity log and application time line need to able to render interview audit events
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Updates `GetActivityLogEvents` query to also retrieve interview events associated with the given applications.

### Application timeline
Updates the application timeline to allow interview audit items to appear. The corresponding application state change won't appear in this view.
<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/93511/104626050-5a485780-568d-11eb-953b-986611df8211.png)

### Activity log
Updates the activity log to render interview audit events, no events are filtered in this view.
![image](https://user-images.githubusercontent.com/93511/104625944-34bb4e00-568d-11eb-83ba-15863d84f2c0.png)


## Guidance to review

There's an update necessary to links to the interview tab, for the moment I've linked to the application details. This will need to be updated once we have the tab route in master.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/DrOghuNb/3235-extend-getactivitylog-to-retrieve-associatedaudits
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
