### PR TITLE
Improve undocumented response-changing

### DIFF
--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -13,21 +13,25 @@
         caption: { text: @application_choice.application_form.full_name, size: 'xl' },
         legend: { text: t('page_titles.provider.respond'), size: 'xl', tag: 'h1' } do %>
 
-        <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
+        <% if ApplicationStateChange.new(@application_choice).can_make_offer? %>
+          <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
 
-        <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" } %>
+          <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" } %>
 
-        <% if @alternative_study_mode %>
-          <%= f.govuk_radio_button :decision, 'edit_study_mode', label: { text: "#{offer_text} but change to #{@alternative_study_mode.humanize.downcase}" } %>
+          <% if @alternative_study_mode %>
+            <%= f.govuk_radio_button :decision, 'edit_study_mode', label: { text: "#{offer_text} but change to #{@alternative_study_mode.humanize.downcase}" } %>
+          <% end %>
+
+          <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" } %>
+
+          <% if current_provider_user.providers.size > 1 %>
+            <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" } %>
+          <% end %>
         <% end %>
 
-        <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" } %>
-
-        <% if current_provider_user.providers.size > 1 %>
-          <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" } %>
+        <% if ApplicationStateChange.new(@application_choice).can_reject? %>
+          <%= f.govuk_radio_button :decision, 'new_reject', label: { text: reject_text } %>
         <% end %>
-
-        <%= f.govuk_radio_button :decision, 'new_reject', label: { text: reject_text } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/spec/system/provider_interface/provider_makes_an_offer_on_rejected_application_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_on_rejected_application_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes an offer' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  scenario 'Provider makes an offer' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_application_choices_exist_for_my_provider
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_a_rejected_application
+    and_i_visit_the_secret_respond_url
+
+    and_i_choose_to_make_an_offer
+    then_i_see_some_application_info
+
+    and_i_see_standard_reasons_are_checked
+    and_i_add_optional_further_conditions
+    and_i_click_to_continue
+    then_i_am_asked_to_confirm_the_offer
+    and_i_see_the_correct_offer_conditions
+
+    when_i_confirm_the_offer
+    then_i_am_back_to_the_application_page
+    and_i_can_see_the_application_has_an_offer_made
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_application_choices_exist_for_my_provider
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    @rejected_application = create(:application_choice, :rejected, rejected_at: Time.zone.now, course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def when_i_visit_a_rejected_application
+    visit provider_interface_application_choice_path(
+      @rejected_application.id,
+    )
+  end
+
+  def and_i_visit_the_secret_respond_url
+    visit provider_interface_application_choice_respond_path(
+      @rejected_application.id,
+    )
+  end
+
+  def and_i_choose_to_make_an_offer
+    choose 'Make an offer'
+    click_on 'Continue'
+  end
+
+  def then_i_see_some_application_info
+    expect(page).to have_content \
+      @rejected_application.application_form.first_name
+    expect(page).to have_content \
+      @rejected_application.application_form.last_name
+  end
+
+  def and_i_see_standard_reasons_are_checked
+    expect(find("input[value='Fitness to Teach check']")).to be_checked
+    expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
+  end
+
+  def and_i_add_optional_further_conditions
+    fill_in('make_an_offer[further_conditions0]', with: 'A further condition')
+  end
+
+  def and_i_click_to_continue
+    click_on 'Continue'
+  end
+
+  def then_i_am_asked_to_confirm_the_offer
+    expect(page).to have_current_path(
+      provider_interface_application_choice_confirm_offer_path(
+        @rejected_application.id,
+      ),
+    )
+    expect(page).to have_content 'Check and confirm offer'
+  end
+
+  def and_i_see_the_correct_offer_conditions
+    expect(page).to have_content 'Fitness to Teach check'
+    expect(page).to have_content 'A further condition'
+  end
+
+  def when_i_confirm_the_offer
+    click_on 'Make offer'
+  end
+
+  def then_i_am_back_to_the_application_page
+    expect(page).to have_current_path(
+      provider_interface_application_choice_path(
+        @rejected_application.id,
+      ),
+    )
+    expect(page).to have_content @rejected_application.application_form.first_name
+    expect(page).to have_content @rejected_application.application_form.last_name
+  end
+
+  def and_i_can_see_the_application_has_an_offer_made
+    expect(page).to have_content 'Offer successfully made to candidate'
+  end
+end


### PR DESCRIPTION
## Context

The `/respond` page is available to providers even if they've already made a decision. This is a kind of bug (https://trello.com/c/ahz5YKbC/1121-do-not-show-the-respond-page-if-the-application-is-not-awaiting-provider-decision-or-offered) but also a feature! Namely, it allows providers to change their response from a rejection into an offer, as is allowed in our state machine.

## Changes proposed in this pull request

This PR does 2 things:

- Adds a test that verifies that everything still works if a provider makes an offer on a rejected application
- Hides the "reject" option from the respond page if it's not possible to reject (for example, when the application is already rejected)
- Hides the "offer" option if an offer can't be made (when the offer was declined for example)

## Guidance to review

Does this make sense.

## Link to Trello card

https://trello.com/c/SwJ1jNhF/118-br8429-change-course-offer
