### PR TITLE
Only redirect to prod Apply service in production 

### DIFF
--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Use <%= govuk_link_to service_name, GOVUK_APPLY_START_PAGE_URL %> if the courses you want to do are listed on this page.</p>
+    <p class="govuk-body">Use <%= govuk_link_to service_name, candidate_interface_root_path %> if the courses you want to do are listed on this page.</p>
     <p class="govuk-body">Otherwise, apply through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %>.</p>
     <p class="govuk-body">Do not apply for the same courses on both services.<p>
     <p class="govuk-body">You can apply for up to 3 courses in total.<p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,11 @@ Rails.application.routes.draw do
   end
 
   namespace :candidate_interface, path: '/candidate' do
-    get '/', to: redirect(GOVUK_APPLY_START_PAGE_URL)
+    if HostingEnvironment.production?
+      root to: redirect(GOVUK_APPLY_START_PAGE_URL)
+    else
+      root to: redirect('/')
+    end
 
     get '/accessibility', to: 'content#accessibility'
     get '/cookies', to: 'content#cookies_candidate', as: :cookies


### PR DESCRIPTION
## Context

Resolve sandbox issue with url redirecting to production but ensuring that production apply service is only linked in production hosting environment

## Link to Trello card

https://trello.com/c/Dxtjrq4o/3243-sandbox-candidate-redirecting-to-apply-landing-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
