### PR TITLE
Add received_at column to references table

### DIFF
--- a/db/migrate/20210114112934_add_received_at_to_references.rb
+++ b/db/migrate/20210114112934_add_received_at_to_references.rb
@@ -1,0 +1,5 @@
+class AddReceivedAtToReferences < ActiveRecord::Migration[6.0]
+  def change
+    add_column :references, :received_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_10_112942) do
+ActiveRecord::Schema.define(version: 2021_01_14_115857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -491,6 +491,7 @@ ActiveRecord::Schema.define(version: 2021_01_10_112942) do
     t.string "referee_type"
     t.string "safeguarding_concerns_status", default: "not_answered_yet", null: false
     t.datetime "reminder_sent_at"
+    t.datetime "received_at"
     t.index ["application_form_id", "email_address"], name: "index_references_on_application_form_id_and_email_address", unique: true
     t.index ["application_form_id"], name: "index_references_on_application_form_id"
     t.index ["feedback_status"], name: "index_references_on_feedback_status"


### PR DESCRIPTION
## Context

As part of technical debt we use several database queries throughout our export files
to call the value for the time a reference moves into feedback provided status from the audit
log. Rather than do this each time it makes sense to have a separate column in the database.

## Changes proposed in this pull request

This PR adds this column and it's migration. Schema updated.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/LLEPTmu1/2854-add-receivedat-to-the-applicationreference-model

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
