### PR TITLE
Prevent candidates from entering an invalid year for o levels

### DIFF
--- a/app/forms/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/forms/candidate_interface/gcse_qualification_details_form.rb
@@ -57,13 +57,21 @@ module CandidateInterface
       errors.add(:award_year, :in_future, date: date_limit) if award_year.to_i >= date_limit
     end
 
+    def gce_award_year_is_not_after_1988
+      errors.add(:award_year, :gce_o_level_in_future, date: 1989) if award_year.to_i > 1988
+    end
+
     def award_year_is_invalid
       errors.add(:award_year, :invalid)
     end
 
     def award_year_is_a_valid_date
       if valid_year?(award_year)
-        award_year_is_not_in_the_future
+        if qualification.present? && qualification.qualification_type == 'gce_o_level'
+          gce_award_year_is_not_after_1988
+        else
+          award_year_is_not_in_the_future
+        end
       else
         award_year_is_invalid
       end

--- a/app/views/candidate_interface/gcse/year/edit.html.erb
+++ b/app/views/candidate_interface/gcse/year/edit.html.erb
@@ -8,7 +8,11 @@
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= year_step_title(@subject, @qualification_type) %></h1>
 
-      <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, width: 4 %>
+      <%if @qualification_type == 'gce_o_level'%>
+        <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.gce_o_level_hint_text') }, width: 4 %>
+      <% else %>
+        <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint: { text: t('application_form.gcse.award_year.hint_text') }, width: 4 %>
+      <%end%>
 
       <%= f.govuk_submit t('application_form.gcse.complete_form_button') %>
   <% end %>

--- a/config/locales/application_form/gcse.yml
+++ b/config/locales/application_form/gcse.yml
@@ -7,7 +7,7 @@ en:
         label: Type of qualification
       qualification_types:
         gcse: GCSE
-        gce_o_level: O Level
+        gce_o_level: O level
         scottish_national_5: Scottish National 5
         other_uk: Other UK qualification
         non_uk: Non-UK qualification
@@ -24,6 +24,7 @@ en:
       award_year:
         label: Enter year
         hint_text: For example, 1996
+        gce_o_level_hint_text: For example, 1978
       naric_statement:
         label: Do you have a statement of comparability from the National Recognition Information Centre?
         review_label: Do you have a UK NARIC statement of comparability?
@@ -58,6 +59,7 @@ en:
               blank: Enter the year you gained your qualification
               invalid: Enter a real year
               in_future: Enter a year before %{date}
+              gce_o_level_in_future: Enter a year before %{date} - GSCEs replaced O levels in 1988
             other_grade:
               blank: Enter your grade
         candidate_interface/science_gcse_grade_form:

--- a/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -118,6 +118,24 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
           expect(form.errors[:grade]).to include('Enter a real grade')
         end
       end
+
+      it 'returns validation error if award year is after 1988' do
+        form.award_year = '2012'
+        form.validate(:award_year)
+
+        expect(form.errors[:award_year]).to include('Enter a year before 1989 - GSCEs replaced O levels in 1988')
+      end
+
+      it 'returns no error if award year is valid' do
+        valid_years = (1951..1988)
+
+        valid_years.each do |year|
+          form.award_year = year
+          form.validate(:award_year)
+
+          expect(form.errors[:award_year]).to be_empty
+        end
+      end
     end
 
     context 'when qualification type is Scottish National 5' do


### PR DESCRIPTION
## Context

Users are selecting the wrong type of GCSE qualification. They're able to add an O level with an invalid award year.

## Changes proposed in this pull request

If candidate enters a GCE O level, validate if awarded date is any year after 1988.
![Screenshot](https://user-images.githubusercontent.com/47917431/104738305-41977a80-573d-11eb-8b15-389502f3ff5b.png)


## Guidance to review

Was 1988 the last year that O levels could be awarded _or_ the first year they couldn't be?

I've implemented it via a nested if statement in the `award_year_is_a_valid_date` method - open to suggestions on this as I'm sure there must be a better way.

## Link to Trello card

https://trello.com/c/0lka2ppD/1113-prevent-users-from-selecting-gce-o-levels-for-years-when-they-werent-available

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
