### PR TITLE
Group rejected_by_default and declined_by_default applications in Slack notifications

### DIFF
--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -23,5 +23,9 @@ class DeclineOfferByDefault
     end
 
     CandidateMailer.declined_by_default(application_form).deliver_later
+
+    if application_form.ended_without_success?
+      StateChangeNotifier.new(:declined_by_default, application_choices.first).application_outcome_notification
+    end
   end
 end

--- a/app/services/reject_application_by_default.rb
+++ b/app/services/reject_application_by_default.rb
@@ -15,7 +15,7 @@ class RejectApplicationByDefault
     SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
 
     if application_choice.application_form.ended_without_success?
-      StateChangeNotifier.new(:rejected, application_choice).application_outcome_notification
+      StateChangeNotifier.new(:rejected_by_default, application_choice).application_outcome_notification
     end
 
     # We delay sending the candidate email because we want processing for all

--- a/config/locales/slack_notifications.yml
+++ b/config/locales/slack_notifications.yml
@@ -6,15 +6,37 @@ en:
     rejected:
       message:
         primary: ":broken_heart: %{applicant}'s application was rejected by %{providers}."
-        other: "was rejected by %{providers}"
+        other_applications: "was rejected by %{providers}"
+    rejected_by_default:
+      message:
+        primary:
+          one: ":broken_heart: %{applicant}'s application to %{providers} was rejected by default."
+          other: ":broken_heart: %{applicant}'s applications to %{providers} were rejected by default."
+        other_applications:
+          one: "was rejected by default from %{providers}"
+          other: "were rejected by default from %{providers}"
     withdrawn:
       message:
-        primary: ":runner: %{applicant} has withdrawn their remaining applications from %{providers}."
-        other: "withdrew from %{providers}"
+        primary:
+          one: ":runner: %{applicant} has withdrawn their remaining application from %{providers}."
+          other: ":runner: %{applicant} has withdrawn their remaining applications from %{providers}."
+        other_applications: "withdrew from %{providers}"
     recruited:
       message:
         primary: ":handshake: %{applicant} has been recruited to %{providers}."
     declined:
       message:
-        primary: ":no_good: %{applicant} has declined %{providers} offer."
-        other: "declined offers from %{providers}"
+        primary:
+          one: ":no_good: %{applicant} has declined an offer from %{providers}."
+          other: ":no_good: %{applicant} has declined offers from %{providers}."
+        other_applications:
+          one: "declined an offer from %{providers}"
+          other: "declined offers from %{providers}"
+    declined_by_default:
+      message:
+        primary:
+          one: ":no_good: %{applicant} has declined by defaults %{providers}'s offer."
+          other: ":no_good: %{applicant} has declined by default offers from %{providers}."
+        other_applications:
+          one: "declined by default an offer from %{providers}"
+          other: "declined by default offers from %{providers}"

--- a/spec/models/application_dates_spec.rb
+++ b/spec/models/application_dates_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe ApplicationDates, type: :model do
     end
   end
 
-  describe '#declined_by_default_at' do
+  describe '#decline_by_default_at' do
     let(:choices) { application_form.application_choices }
 
-    it 'returns correct declined_by_default_at' do
+    it 'returns correct decline_by_default_at' do
       choices.update_all(status: :offer, decline_by_default_at: 10.business_days.after(submitted_at))
 
       expect(application_dates.decline_by_default_at).to eq(10.business_days.after(submitted_at))

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ChangeOffer do
     expect(application_choice.offer['conditions']).to eq(['First condition', 'Second condition'])
   end
 
-  it 'resets declined_by_default_at for the application choice' do
+  it 'resets decline_by_default_at for the application choice' do
     expect { service.save && application_choice.reload }.to change(application_choice, :decline_by_default_at)
   end
 

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe DeclineOfferByDefault do
+  let(:application_choice) { create(:application_choice, status: :offer) }
+
+  it 'updates the application_choice and posts Slack notifications' do
+    notifier = instance_double(StateChangeNotifier, application_outcome_notification: nil)
+    allow(StateChangeNotifier).to receive(:new).and_return(notifier)
+
+    described_class.new(application_form: application_choice.application_form).call
+
+    application_choice.reload
+
+    expect(application_choice.declined_by_default).to eq(true)
+    expect(application_choice.declined_at).not_to be_nil
+
+    expect(StateChangeNotifier).to have_received(:new).with(:declined_by_default, application_choice)
+    expect(notifier).to have_received(:application_outcome_notification)
+  end
+end

--- a/spec/services/reject_application_by_default_spec.rb
+++ b/spec/services/reject_application_by_default_spec.rb
@@ -1,47 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe RejectApplicationByDefault do
-  def create_application
-    application_form = create :application_form
-    create(
-      :application_choice,
-      application_form: application_form,
-      status: 'awaiting_provider_decision',
-      reject_by_default_at: 2.business_days.ago,
-    )
+  let(:application_choice) do
+    create(:application_choice, status: 'awaiting_provider_decision', reject_by_default_at: 2.business_days.ago)
   end
 
-  around do |example|
-    Timecop.freeze do
-      example.run
-    end
-  end
+  it 'updates the application_choice and calls the SetDeclineByDefault service' do
+    notifier = instance_double(StateChangeNotifier, application_outcome_notification: nil)
+    allow(StateChangeNotifier).to receive(:new).and_return(notifier)
 
-  it 'sets the status to `rejected`' do
-    application_choice = create_application
-    described_class.new(application_choice: application_choice).call
-    expect(application_choice.reload.status).to eq 'rejected'
-  end
-
-  it 'sets `rejected_by_default` to `true`' do
-    application_choice = create_application
-    described_class.new(application_choice: application_choice).call
-    expect(application_choice.reload.rejected_by_default).to be true
-  end
-
-  it 'sets `rejected_at`' do
-    application_choice = create_application
-    described_class.new(application_choice: application_choice).call
-    expect(application_choice.reload.rejected_at).not_to be_nil
-  end
-
-  it 'calls SetDeclineByDefault service' do
     service_double = instance_double(SetDeclineByDefault)
     allow(service_double).to receive(:call)
+
     allow(SetDeclineByDefault).to receive(:new).and_return(service_double)
 
-    application_choice = create_application
     described_class.new(application_choice: application_choice).call
+
+    expect(application_choice.status).to eq 'rejected'
+    expect(application_choice.rejected_by_default).to be true
+    expect(application_choice.rejected_at).not_to be_nil
     expect(service_double).to have_received(:call)
+
+    expect(StateChangeNotifier).to have_received(:new).with(:rejected_by_default, application_choice)
+    expect(notifier).to have_received(:application_outcome_notification)
   end
 end

--- a/spec/services/reject_applications_by_default_spec.rb
+++ b/spec/services/reject_applications_by_default_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RejectApplicationsByDefault do
 
     described_class.new.call
 
-    expect(StateChangeNotifier).to have_received(:new).with(:rejected, application_choice)
+    expect(StateChangeNotifier).to have_received(:new).with(:rejected_by_default, application_choice)
     expect(notifier).to have_received(:application_outcome_notification)
   end
 end


### PR DESCRIPTION
## Context

Update Slack notifications to indicate **rejected_by_default** and **declined_by_default** applications.

- Adds missing declined_by_default field on application_choice
- Add call to notified from `DeclinedOfferByDefault` service and add service spec
- Refactor `RejectedByDefault` spec to avoid setting up `ApplicationChoice` object multiple times and to verify notification serice call
- Update `StateChangeNotified` spec - remove unecessary duplication by only checking for contructed notification message for sibling applications.
- Update locale so that message posted uses correct tense (indicating one or multiple applications) 

## Link to Trello card

https://trello.com/c/vJrXG4Ss/3249-applications-rejected-by-default-are-simply-marked-rejected-in-slack-notifications

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
