### PR TITLE
Display provider header links on Export data page

### DIFF
--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -66,7 +66,7 @@ class NavigationItems
     end
 
     def for_provider_account_nav(current_provider_user, current_controller, performing_setup = false)
-      return [] if is_active_action(current_controller, 'new') || is_active_action(current_controller, 'sign_in_by_email')
+      return [] if (is_active_action(current_controller, 'new') && !is_active(current_controller, 'application_data_export')) || is_active_action(current_controller, 'sign_in_by_email')
 
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 


### PR DESCRIPTION
## Context
<img width="1148" alt="export-data-page" src="https://user-images.githubusercontent.com/159200/104710887-878e1780-5718-11eb-958f-bef5f5b96d50.png">


## Link to Trello card

https://trello.com/c/iSUeKLt0/3238-email-address-and-sign-out-link-disappear-from-manage-header-when-looking-at-the-export-data-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
