### PR TITLE
Add keepalives params to postgres driver config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,6 +9,10 @@ default: &default
   host: <%= ENV['DB_HOSTNAME'] %>
   port: <%= ENV['DB_PORT'] %>
   database: <%= ENV['DB_DATABASE'] %>
+  keepalives: 1
+  keepalives_idle: 60
+  keepalives_interval: 10
+  keepalives_count: 3
 
 development:
   <<: *default


### PR DESCRIPTION
## Context

We get many postgres errors/logs about dropped connections and new connections being established. The number of such logs went up recently when we reduced the number of availability checks (!), which exercise the database. This was matched with degraded service performance / rails response times.

![image](https://user-images.githubusercontent.com/107591/104731149-317a9d80-5733-11eb-85fa-b858b6041280.png)

This makes me think idle database connections are being silently dropped by Azure after 4 mins, which seems to be a default setting on the platform. This would explain the degraded performance, as Rails is unaware the connections have been dropped, attempts to send statements to the database, errors, then has to re-establish the database connection and eventually succeeds. Having frequent availability checks that exercise the database connection means fewer of these connections are dropped / more healthy database connections are available in the pool.

## Changes proposed in this pull request

Add explicit client-side `keepalives` configuration so that Rails db connections to Postgres send keepalive probes every minute. If this dropped db connections theory is correct, the number of dropped postgres connection events and connection re-establishing events will drop close to zero.

UPDATE

@vigneshmsft has deployed this branch to the devops environment and the db connections profile seems to have changed, possibly improved. The number of closed/re-established connections is not zero but there are scheduled background processes working and availability checks are on.

New connections:

![image](https://user-images.githubusercontent.com/107591/104749671-013ef900-574b-11eb-863a-0e524d540aff.png)

Closed connections:

![image](https://user-images.githubusercontent.com/107591/104749754-19167d00-574b-11eb-8163-7dbbf4302b4a.png)

Active db connections:

![image](https://user-images.githubusercontent.com/107591/104749807-23d11200-574b-11eb-931f-89492c00aaee.png)

(red line is min active db connections, blue line is max)

Sidekiq logs:

![image](https://user-images.githubusercontent.com/107591/104751498-60057200-574d-11eb-8358-a4de1d9dc3d1.png)

## Guidance to review

I've tested this locally with `tcpdump` and I can see the additional probes.

For configuring these values, I started adding an environment variables, but decided it may not be worth it, as the keepalive settings should be harmless on all environments.

Relevant Postgresql documentation: https://www.postgresql.org/docs/9.3/libpq-connect.html#LIBPQ-CONNECT-OPTIONS

In particular,

`keepalives` Controls whether client-side TCP keepalives are used. The default value is 1, meaning on, but you can change this to 0, meaning off, if keepalives are not wanted. This parameter is ignored for connections made via a Unix-domain socket.

`keepalives_idle` Controls the number of seconds of inactivity after which TCP should send a keepalive message to the server. A value of zero uses the system default. This parameter is ignored for connections made via a Unix-domain socket, or if keepalives are disabled. It is only supported on systems where TCP_KEEPIDLE or an equivalent socket option is available, and on Windows; on other systems, it has no effect.

`keepalives_interval` Controls the number of seconds after which a TCP keepalive message that is not acknowledged by the server should be retransmitted. A value of zero uses the system default. This parameter is ignored for connections made via a Unix-domain socket, or if keepalives are disabled. It is only supported on systems where TCP_KEEPINTVL or an equivalent socket option is available, and on Windows; on other systems, it has no effect.

`keepalives_count` Controls the number of TCP keepalives that can be lost before the client's connection to the server is considered dead. A value of zero uses the system default. This parameter is ignored for connections made via a Unix-domain socket, or if keepalives are disabled. It is only supported on systems where TCP_KEEPCNT or an equivalent socket option is available; on other systems, it has no effect.

Are the numbers chosen for this PR reasonable?

## Link to Trello card

No Trello card, responding to an incident

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
