### PR TITLE
Refactor and speed up Mailer specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,9 @@ RSpec/EmptyLineAfterSubject:
   Exclude:
     - 'spec/factories.rb'
 
+RSpec/LetSetup:
+  Enabled: false
+
 Naming/MethodParameterName:
   AllowedNames:
     - e

--- a/app/views/candidate_mailer/ucas_match_resolved_on_ucas_email.text.erb
+++ b/app/views/candidate_mailer/ucas_match_resolved_on_ucas_email.text.erb
@@ -1,8 +1,8 @@
 Dear <%= @application_form.full_name %>
 
-We’ve written to you a couple of times as we noticed you applied to study  <%= @course_name_and_code %> at <%= @provider_name %> on both Apply for teacher training and UCAS Teacher Training Apply – which isn’t allowed.
+We’ve written to you a couple of times as we noticed you applied to study <%= @course_name_and_code %> at <%= @provider_name %> on both Apply for teacher training and UCAS Teacher Training Apply – which isn’t allowed.
 
-As you didn’t withdraw the choice, as requested, we have removed it from your UCAS application meaning you should use Apply for teacher training to track the progress of your application for [course name and code].
+As you didn’t withdraw the choice, as requested, we have removed it from your UCAS application meaning you should use Apply for teacher training to track the progress of your application for <%= @course_name_and_code %>.
 
 Any other courses you applied to have not been affected.
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -557,6 +557,14 @@ FactoryBot.define do
       withdrawn_at { Time.zone.now }
     end
 
+    trait :dbd do
+      with_offer
+
+      status { :declined }
+      declined_by_default { true }
+      decline_by_default_days { 10 }
+    end
+
     trait :withdrawn_with_survey_completed do
       status { :withdrawn }
       withdrawn_at { Time.zone.now }

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -1,466 +1,252 @@
 require 'rails_helper'
 
 RSpec.describe CandidateMailer, type: :mailer do
-  include CourseOptionHelpers
   include TestHelpers::MailerSetupHelper
 
   subject(:mailer) { described_class }
 
-  shared_examples 'a mail with subject and content' do |mail, subject, content|
-    let(:email) { described_class.send(mail, @application_choice) }
+  let(:candidate) { build_stubbed(:candidate) }
+  let!(:application_form) { build_stubbed(:application_form, first_name: 'Bob', candidate: candidate, application_choices: application_choices) }
+  let(:provider) { build_stubbed(:provider, name: 'Brighthurst Technical College') }
+  let(:course) { build_stubbed(:course, name: 'Applied Science (Psychology)', code: '3TT5', provider: provider) }
+  let(:offered_course) { build_stubbed(:course, name: 'Primary', code: '33WA', provider: other_provider) }
+  let(:course_option) { build_stubbed(:course_option, course: course) }
+  let(:offered_option) { build_stubbed(:course_option, course: offered_course) }
 
-    it 'sends an email with the correct subject' do
-      expect(email.subject).to include(subject)
-    end
+  let(:other_provider) { build_stubbed(:provider, name: 'Falconholt Technical College', code: 'X100') }
+  let(:other_course) { build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: other_provider) }
+  let(:site) { build_stubbed(:site, name: 'Aquaria') }
+  let(:other_option) { build_stubbed(:course_option, course: other_course, site: site) }
 
-    content.each do |key, expectation|
-      it "sends an email containing the #{key} in the body" do
-        expectation = expectation.call if expectation.respond_to?(:call)
-        expect(email.body).to include(expectation)
-      end
-    end
-  end
+  let(:offer) { build_stubbed(:application_choice, :with_offer, course_option: course_option) }
+  let(:awaiting_decision) { build_stubbed(:application_choice, :awaiting_provider_decision, course_option: other_option, offered_course_option: other_option) }
+
+  let(:application_choices) { [] }
 
   before do
-    setup_application
-    magic_link_stubbing(@application_form.candidate)
+    magic_link_stubbing(candidate)
   end
 
   around do |example|
-    Timecop.freeze(Time.zone.local(2020, 2, 11)) do
+    Timecop.freeze(Time.zone.local(2020, 2, 18)) do
       example.run
     end
   end
 
   describe '.new_offer_single_offer' do
+    let(:email) { mailer.new_offer_single_offer(application_choices.first) }
+    let(:application_choices) { [offer] }
+
+    before do
+      allow(CourseOption).to receive(:find_by).with(id: offer.offered_course_option_id).and_return(offer.offered_course_option)
+    end
+
     it_behaves_like(
-      'a mail with subject and content', :new_offer_single_offer,
+      'a mail with subject and content',
       'Make a decision: successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
       'decline by default date' => 'Make a decision by 25 February 2020',
-      'first_condition' => 'DBS check',
-      'second_condition' => 'Pass exams',
-      'Days to make an offer' => 'If you do not reply by 25 February 2020',
-      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
+      'first_condition' => 'Be cool',
+      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
     )
 
     context 'when the provider offers the candidate a different course option' do
-      before do
-        provider = build_stubbed(:provider, name: 'Falconholt Technical College')
-        new_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
-
-        @application_choice.offered_course_option_id = new_course_option.id
-
-        allow(CourseOption).to receive(:find_by).and_return new_course_option
-      end
+      let(:other_offered_course) { build_stubbed(:course, name: 'Computer Science', code: 'X0FO', provider: other_provider) }
+      let(:other_offered_option) { build_stubbed(:course_option, course: other_offered_course) }
+      let(:offer) { build_stubbed(:application_choice, :with_offer, offered_course_option_id: other_offered_option.id, course_option: course_option, offered_course_option: other_offered_option) }
 
       it_behaves_like(
-        'a mail with subject and content', :new_offer_single_offer,
+        'a mail with subject and content',
         'Make a decision: successful application for Falconholt Technical College',
         'heading' => 'Dear Bob',
+        'course and provider' => 'offer from Falconholt Technical College to study Computer Science (X0FO)',
         'decline by default date' => 'Make a decision by 25 February 2020',
-        'first_condition' => 'DBS check',
-        'second_condition' => 'Pass exams',
-        'Days to make an offer' => 'If you do not reply by 25 February 2020',
-        'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
+        'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
       )
     end
   end
 
   describe '.new_offer_multiple_offers' do
-    before do
-      provider = build_stubbed(:provider, name: 'Falconholt Technical College')
-      other_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
-      @other_application_choice = @application_form.application_choices.build(
-        application_form: @application_form,
-        course_option: other_course_option,
-        status: :offer,
-        offer: { conditions: ['Get a degree'] },
-        offered_at: Time.zone.now,
-        offered_course_option: other_course_option,
-        decline_by_default_at: 5.business_days.from_now,
-      )
-      @application_form.application_choices = [@application_choice, @other_application_choice]
-    end
+    let(:email) { mailer.new_offer_multiple_offers(application_choices.first) }
+    let(:other_offer) { build_stubbed(:application_choice, :with_offer, course_option: other_option) }
+    let(:application_choices) { [offer, other_offer] }
 
     it_behaves_like(
-      'a mail with subject and content', :new_offer_multiple_offers,
+      'a mail with subject and content',
       'Make a decision: successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
       'decline by default date' => 'Make a decision by 25 February 2020',
-      'first_condition' => 'DBS check',
-      'second_condition' => 'Pass exams',
+      'first_condition' => 'Be cool',
       'first_offer' => 'Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
       'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College',
-      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
+      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
     )
   end
 
   describe '.new_offer_decisions_pending' do
-    before do
-      provider = build_stubbed(:provider, name: 'Falconholt Technical College')
-      other_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
-      @other_application_choice = @application_form.application_choices.build(
-        application_form: @application_form,
-        course_option: other_course_option,
-        status: :awaiting_provider_decision,
-      )
-      @application_form.application_choices = [@application_choice, @other_application_choice]
-    end
+    let(:email) { mailer.new_offer_decisions_pending(application_choices.first) }
+    let(:application_choices) { [offer, awaiting_decision] }
 
     it_behaves_like(
-      'a mail with subject and content', :new_offer_decisions_pending,
+      'a mail with subject and content',
       'Successful application for Brighthurst Technical College',
       'heading' => 'Dear Bob',
-      'first_condition' => 'DBS check',
-      'second_condition' => 'Pass exams',
+      'first_condition' => 'Be cool',
       'instructions' => 'You can wait to hear back about your other application(s) before making a decision',
-      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.'
+      'deferral_guidance' => 'Some teacher training providers allow you to defer your offer.',
     )
   end
 
   describe 'rejection emails' do
-    def setup_application
-      provider = build_stubbed(:provider, name: 'Falconholt Technical College', code: 'X100')
-      course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
-      @application_form = build_stubbed(:application_form, first_name: 'Tyrell', last_name: 'Wellick')
-      @application_choice = @application_form.application_choices.build(
-        application_form: @application_form,
-        course_option: course_option,
-        status: :rejected,
-        structured_rejection_reasons: {
-          quality_of_application_y_n: 'Yes',
-          quality_of_application_which_parts_needed_improvement: %w[personal_statement subject_knowledge],
-          quality_of_application_personal_statement_what_to_improve: 'Do not refer to yourself in the third person',
-          quality_of_application_subject_knowledge_what_to_improve: 'Write in the first person',
-          qualifications_y_n: 'Yes',
-          qualifications_other_details: 'Bad qualifications',
-          qualifications_which_qualifications: %w[no_english_gcse other],
-        },
-      )
-      @application_form.application_choices = [@application_choice]
-
-      magic_link_stubbing(@application_form.candidate)
+    let(:rejection_reasons) do
+      {
+        quality_of_application_y_n: 'Yes',
+        quality_of_application_which_parts_needed_improvement: %w[personal_statement subject_knowledge],
+        quality_of_application_personal_statement_what_to_improve: 'Do not refer to yourself in the third person',
+        quality_of_application_subject_knowledge_what_to_improve: 'Write in the first person',
+        qualifications_y_n: 'Yes',
+        qualifications_other_details: 'Bad qualifications',
+        qualifications_which_qualifications: %w[no_english_gcse other],
+      }
     end
 
+    let(:rejected) { build_stubbed(:application_choice, status: :rejected, course_option: other_option, offered_course_option: other_option, structured_rejection_reasons: rejection_reasons) }
+
     describe '.application_rejected_all_applications_rejected' do
+      let(:email) { mailer.application_rejected_all_applications_rejected(application_choices.first) }
+
+      let(:application_choices) { [rejected] }
+
       it_behaves_like(
-        'a mail with subject and content', :application_rejected_all_applications_rejected,
-        I18n.t!('candidate_mailer.application_rejected_all_applications_rejected.subject',
-                provider_name: 'Falconholt Technical College'),
-        'heading' => 'Dear Tyrell',
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.application_rejected_all_applications_rejected.subject', provider_name: 'Falconholt Technical College'),
+        'heading' => 'Dear Bob',
         'course name and code' => 'Forensic Science (E0FO)',
         'rejection reason heading' => 'Quality of application',
         'rejection reason content' => 'Write in the first person',
         'qualifications rejection heading' => 'Qualifications',
         'qualifications rejection content' => 'Bad qualifications',
-        'link to course on find' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/course/X100/E0FO#section-entry'
+        'link to course on find' => 'https://www.find-postgraduate-teacher-training.service.gov.uk/course/X100/E0FO#section-entry',
       )
     end
 
     describe '.application_rejected_one_offer_one_awaiting_decision' do
-      before do
-        reasons_for_rejection = {
-          candidate_behaviour_y_n: 'Yes',
-          candidate_behaviour_what_did_the_candidate_do: %w[other],
-          candidate_behaviour_other: 'Bad language',
-          candidate_behaviour_what_to_improve: 'Do not swear',
-        }
-        provider = build_stubbed(:provider, name: 'Falconholt Technical College')
-        course_option = build_stubbed(:course_option,
-                                      course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
-        course_option2 = build_stubbed(:course_option,
-                                       course: build_stubbed(:course, name: 'Computer Science', provider: provider))
-
-        @application_form = FactoryBot.build_stubbed(
-          :application_form,
-          first_name: 'Tyrell',
-          last_name: 'Wellick',
-          candidate: @application_form.candidate,
-          application_choices: [
-            FactoryBot.build_stubbed(
-              :application_choice,
-              status: :rejected,
-              application_form: @application_form,
-              course_option: course_option,
-              structured_rejection_reasons: reasons_for_rejection,
-            ),
-            FactoryBot.build_stubbed(
-              :application_choice,
-              :with_offer,
-              application_form: @application_form,
-              course_option: course_option,
-            ),
-            FactoryBot.build_stubbed(
-              :application_choice,
-              application_form: @application_form,
-              reject_by_default_at: Time.zone.local(2021, 1, 17),
-              status: :awaiting_provider_decision,
-              course_option: course_option2,
-            ),
-          ],
-        )
-        @application_choice = @application_form.application_choices.first
-      end
+      let(:email) { mailer.application_rejected_one_offer_one_awaiting_decision(application_choices.first) }
+      let(:application_choices) { [rejected, offer, awaiting_decision] }
 
       it_behaves_like(
-        'a mail with subject and content', :application_rejected_one_offer_one_awaiting_decision,
+        'a mail with subject and content',
         I18n.t!('candidate_mailer.application_rejected_one_offer_one_awaiting_decision.subject',
-                provider_name: 'Falconholt Technical College'),
-        'heading' => 'Dear Tyrell',
-        'course name and code' => 'Forensic Science (E0FO)',
-        'rejection reason heading' => 'Something you did',
-        'rejection reason content' => 'Bad language',
+                provider_name: 'Brighthurst Technical College'),
+        'heading' => 'Dear Bob',
+        'course name and code' => 'Applied Science (Psychology)',
+        'qualifications rejection heading' => 'Qualifications',
+        'qualifications rejection content' => 'Bad qualifications',
         'other application details' => 'You have an offer and are waiting for a decision about another course',
-        'application with offer' => 'You have an offer from Falconholt Technical College to study Forensic Science',
-        'application awaiting decision' => 'to make a decision about your application to study Computer Science',
-        'decision day' => 'has until 17 January 2021 to make a decision'
+        'application with offer' => 'You have an offer from Brighthurst Technical College to study Applied Science (Psychology)',
+        'application awaiting decision' => 'to make a decision about your application to study Forensic Science',
+        'decision day' => 'has until 22 June 2020 to make a decision',
       )
     end
 
     describe '.application_rejected_awaiting_decision_only' do
-      before do
-        reasons_for_rejection = {
-          candidate_behaviour_y_n: 'Yes',
-          candidate_behaviour_what_did_the_candidate_do: %w[other],
-          candidate_behaviour_other: 'Bad language',
-          candidate_behaviour_what_to_improve: 'Do not swear',
-        }
-        provider = build_stubbed(:provider, name: 'Falconholt Technical College')
-        course_option = build_stubbed(:course_option,
-                                      course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
-        course_option2 = build_stubbed(:course_option,
-                                       course: build_stubbed(:course, name: 'Computer Science', provider: provider))
-
-        @application_form = FactoryBot.build_stubbed(
-          :application_form,
-          first_name: 'Tyrell',
-          last_name: 'Wellick',
-          candidate: @application_form.candidate,
-          application_choices: [
-            FactoryBot.build_stubbed(
-              :application_choice,
-              status: :rejected,
-              application_form: @application_form,
-              course_option: course_option,
-              structured_rejection_reasons: reasons_for_rejection,
-            ),
-            FactoryBot.build_stubbed(
-              :application_choice,
-              status: :awaiting_provider_decision,
-              reject_by_default_at: Time.zone.local(2021, 1, 17),
-              application_form: @application_form,
-              course_option: course_option,
-            ),
-            FactoryBot.build_stubbed(
-              :application_choice,
-              application_form: @application_form,
-              reject_by_default_at: Time.zone.local(2021, 1, 14),
-              status: :awaiting_provider_decision,
-              course_option: course_option2,
-            ),
-          ],
-        )
-        @application_choice = @application_form.application_choices.first
-      end
+      let(:email) { mailer.application_rejected_awaiting_decision_only(application_choices.first) }
+      let(:application_choices) { [rejected, awaiting_decision, awaiting_decision] }
 
       it_behaves_like(
-        'a mail with subject and content', :application_rejected_awaiting_decision_only,
+        'a mail with subject and content',
         I18n.t!('candidate_mailer.application_rejected_awaiting_decision_only.subject'),
-        'heading' => 'Dear Tyrell',
+        'heading' => 'Dear Bob',
         'course name and code' => 'Forensic Science (E0FO)',
-        'rejection reason heading' => 'Something you did',
-        'rejection reason content' => 'Bad language',
+        'rejection reasons' => 'Bad qualifications',
         'other application details' => "You're waiting for decisions",
         'first application' => 'Falconholt Technical College to study Forensic Science',
-        'second application' => 'Falconholt Technical College to study Computer Science',
-        'decision day' => 'They should make their decisions by 17 January 2021'
+        'decision day' => 'They should make their decisions by 22 June 2020',
       )
     end
 
     describe '.application_rejected_offers_only' do
-      before do
-        reasons_for_rejection = {
-          candidate_behaviour_y_n: 'Yes',
-          candidate_behaviour_what_did_the_candidate_do: %w[other],
-          candidate_behaviour_other: 'Bad language',
-          candidate_behaviour_what_to_improve: 'Do not swear',
-        }
-        provider = build_stubbed(:provider, name: 'Falconholt Technical College')
-        course_option = build_stubbed(:course_option,
-                                      course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
-        course_option2 = build_stubbed(:course_option,
-                                       course: build_stubbed(:course, name: 'Computer Science', provider: provider))
-
-        @application_form = FactoryBot.build_stubbed(
-          :application_form,
-          first_name: 'Tyrell',
-          last_name: 'Wellick',
-          candidate: @application_form.candidate,
-          application_choices: [
-            FactoryBot.build_stubbed(
-              :application_choice,
-              status: :rejected,
-              application_form: @application_form,
-              course_option: course_option,
-              structured_rejection_reasons: reasons_for_rejection,
-            ),
-            FactoryBot.build_stubbed(
-              :application_choice,
-              :with_offer,
-              decline_by_default_at: 5.days.from_now,
-              application_form: @application_form,
-              course_option: course_option,
-            ),
-            FactoryBot.build_stubbed(
-              :application_choice,
-              :with_offer,
-              decline_by_default_at: 10.days.from_now,
-              application_form: @application_form,
-              course_option: course_option2,
-            ),
-          ],
-        )
-        @application_choice = @application_form.application_choices.first
-      end
+      let(:email) { mailer.application_rejected_offers_only(application_choices.first) }
+      let(:application_choices) { [rejected, offer, offer] }
 
       it_behaves_like(
-        'a mail with subject and content', :application_rejected_offers_only,
-        I18n.t!('candidate_mailer.application_rejected_offers_only.subject', date: '16 February 2020'),
-        'heading' => 'Dear Tyrell',
+        'a mail with subject and content',
+        I18n.t!('candidate_mailer.application_rejected_offers_only.subject', date: '25 February 2020'),
+        'heading' => 'Dear Bob',
         'course name and code' => 'Forensic Science (E0FO)',
-        'rejection reason heading' => 'Something you did',
-        'rejection reason content' => 'Bad language',
+        'rejection reasons' => 'Do not refer to yourself in the third person',
         'other application details' => 'You’re not waiting for any other decisions.',
-        'first application details' => 'Falconholt Technical College to study Forensic Science',
-        'second application details' => 'Falconholt Technical College to study Computer Science',
-        'respond by date' => 'The offers will automatically be withdrawn if you do not respond by 16 February 2020'
+        'first application details' => 'Brighthurst Technical College to study Applied Science (Psychology)',
+        'respond by date' => 'The offers will automatically be withdrawn if you do not respond by 25 February 2020',
       )
     end
   end
 
   describe 'feedback_received_for_application_rejected_by_default' do
-    before do
-      @application_form = build_stubbed(:application_form, first_name: 'Kurt')
-      provider = build_stubbed(:provider, name: 'Geffen Records')
-      @offered_course_option = build_stubbed(
-        :course_option,
-        course: build_stubbed(:course, name: 'Nevermind', code: 'NV4', provider: provider, start_date: Date.new(2020, 9, 15)),
-        site: build_stubbed(:site, name: 'Lithium', provider: provider),
-      )
-      @application_choice = build_stubbed(
-        :application_choice,
-        :with_rejection_by_default,
-        offered_course_option: @offered_course_option,
-        application_form: @application_form,
-        rejection_reason: 'I\'m so happy',
-        rejected_at: Time.zone.today,
-      )
-    end
+    let(:email) { mailer.feedback_received_for_application_rejected_by_default(application_choices.first) }
+    let(:application_choices) { [build_stubbed(:application_choice, :with_rejection_by_default_and_feedback, course_option: course_option, rejection_reason: 'I\'m so happy')] }
 
     it_behaves_like(
       'a mail with subject and content',
-      :feedback_received_for_application_rejected_by_default,
-      'Feedback on your application for Geffen Records',
-      'heading' => 'Dear Kurt',
-      'provider name' => 'Geffen Records did not respond in time',
-      'name and code for course' => 'Nevermind (NV4)',
+      'Feedback on your application for Brighthurst Technical',
+      'heading' => 'Dear Bob',
+      'provider name' => 'Brighthurst Technical College did not respond in time',
+      'name and code for course' => 'Applied Science (Psychology) (3TT5)',
       'feedback' => 'I\'m so happy',
     )
   end
 
   describe '.deferred_offer' do
+    let(:email) { mailer.deferred_offer(application_choices.first) }
+    let(:application_choices) { [offer] }
+
     before do
-      application_form = build_stubbed(:application_form, first_name: 'Harold')
-      provider = build_stubbed(:provider, name: 'Jerome Horwitz Elementary School')
-      course_option = build_stubbed(
-        :course_option,
-        course: build_stubbed(:course, name: 'Sport', code: 'SP0', provider: provider, recruitment_cycle_year: 2021),
-        site: build_stubbed(:site, provider: provider),
-      )
-
-      @application_choice = build_stubbed(
-        :application_choice,
-        :with_deferred_offer,
-        course_option: course_option,
-        offered_course_option: course_option,
-        application_form: application_form,
-        decline_by_default_at: 10.business_days.from_now,
-      )
-
       magic_link_stubbing(application_form.candidate)
     end
 
     it_behaves_like(
       'a mail with subject and content',
-      :deferred_offer,
       'Your offer has been deferred',
-      'heading' => 'Dear Harold',
-      'name and code for course' => 'Sport (SP0)',
-      'name of provider' => 'Jerome Horwitz Elementary School',
-      'year of new course' => 'until the next academic year (2022 to 2023)',
+      'heading' => 'Dear Bob',
+      'name and code for course' => 'Applied Science (Psychology) (3TT5)',
+      'name of provider' => 'Brighthurst Technical College',
+      'year of new course' => 'until the next academic year (2021 to 2022)',
     )
   end
 
   describe '.reinstated_offer' do
+    let(:email) { mailer.reinstated_offer(application_choices.first) }
+    let(:application_choices) { [application_choice] }
+    let(:application_choice) { build_stubbed(:application_choice, :with_deferred_offer, course_option: other_option, offer_deferred_at: Time.zone.local(2019, 10, 3)) }
+    let(:other_course) do
+      build_stubbed :course, name: 'Forensic Science',
+                             code: 'E0FO',
+                             provider: other_provider,
+                             start_date: Time.zone.local(2020, 6, 5)
+    end
+
     before do
-      @application_form = build_stubbed(:application_form, first_name: 'Ron')
-      provider = build_stubbed(:provider, name: 'Hogwarts')
-      @offered_course_option = build_stubbed(
-        :course_option,
-        course: build_stubbed(:course, name: 'Potions', code: 'PT5', provider: provider, start_date: Date.new(2020, 9, 15)),
-        site: build_stubbed(:site, name: 'The Dungeons', provider: provider),
-      )
+      magic_link_stubbing(application_form.candidate)
     end
 
-    describe 'without pending conditions' do
-      before do
-        @application_choice = build_stubbed(
-          :application_choice,
-          :with_recruited,
-          offered_course_option: @offered_course_option,
-          application_form: @application_form,
-          decline_by_default_at: 10.business_days.from_now,
-          offer_deferred_at: Time.zone.local(2019, 10, 14),
-        )
-
-        magic_link_stubbing(@application_form.candidate)
-      end
-
-      it_behaves_like(
-        'a mail with subject and content',
-        :reinstated_offer,
-        'You’re due to take up your deferred offer',
-        'heading' => 'Dear Ron',
-        'provider name' => 'You have an offer from Hogwarts',
-        'name and code for course' => 'Potions (PT5)',
-        'start date of new course' => 'September 2020',
-        'date offer was deferred' => 'This was deferred from last year (October 2019)',
-      )
-    end
+    it_behaves_like(
+      'a mail with subject and content',
+      'You’re due to take up your deferred offer',
+      'heading' => 'Dear Bob',
+      'provider name' => 'You have an offer from Falconholt Technical College',
+      'name and code for course' => 'Forensic Science (E0FO)',
+      'start date of new course' => 'June 2020',
+      'date offer was deferred' => 'This was deferred from last year (October 2019)',
+    )
 
     describe 'with pending conditions' do
-      before do
-        @application_choice = build_stubbed(
-          :application_choice,
-          :with_accepted_offer,
-          offered_course_option: @offered_course_option,
-          application_form: @application_form,
-          decline_by_default_at: 10.business_days.from_now,
-          offer_deferred_at: Time.zone.local(2019, 10, 14),
-        )
-
-        magic_link_stubbing(@application_form.candidate)
-      end
-
       it_behaves_like(
         'a mail with subject and content',
-        :reinstated_offer,
         'You’re due to take up your deferred offer',
-        'heading' => 'Dear Ron',
-        'provider name' => 'You have an offer from Hogwarts',
-        'name and code for course' => 'Potions (PT5)',
-        'start date of new course' => 'September 2020',
+        'heading' => 'Dear Bob',
+        'provider name' => 'You have an offer from Falconholt Technical College',
+        'name and code for course' => 'Forensic Science (E0FO)',
+        'start date of new course' => 'June 2020',
         'date offer was deferred' => 'This was deferred from last year (October 2019)',
         'conditions of offer' => 'Be cool',
       )
@@ -468,80 +254,33 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.changed_offer' do
-    before do
-      application_form = build_stubbed(:application_form, first_name: 'Tingker Bell')
-      provider = build_stubbed(:provider, name: 'Neverland University')
-      course_option = build_stubbed(
-        :course_option,
-        course: build_stubbed(:course, name: 'Flying', code: 'F1Y', provider: provider),
-        site: build_stubbed(:site, name: 'Peter School', provider: provider),
-      )
-      offered_course_option = build_stubbed(
-        :course_option,
-        course: build_stubbed(:course, name: 'Fighting', code: 'F1G', provider: provider),
-        site: build_stubbed(:site, name: 'Pan School', provider: provider),
-      )
-
-      @application_choice = build_stubbed(
-        :submitted_application_choice,
-        course_option: course_option,
-        offered_course_option: offered_course_option,
-        application_form: application_form,
-        decline_by_default_at: 10.business_days.from_now,
-      )
-
-      magic_link_stubbing(application_form.candidate)
-    end
+    let(:email) { mailer.changed_offer(application_choices.first) }
+    let(:application_choice) { build_stubbed(:submitted_application_choice, course_option: course_option, offered_course_option: other_option, decline_by_default_at: 10.business_days.from_now) }
+    let(:application_choices) { [application_choice] }
 
     it_behaves_like(
       'a mail with subject and content',
-      :changed_offer,
-      'Offer changed by Neverland University',
-      'heading' => 'Dear Tingker Bell',
-      'name and code for original course' => 'Flying (F1Y)',
-      'name and code for new course' => 'Course: Fighting (F1G)',
-      'name of new provider' => 'Provider: Neverland University',
-      'location of new offer' => 'Location: Pan School',
+      'Brighthurst Technical College',
+      'heading' => 'Dear Bob',
+      'name and code for original course' => 'Applied Science (Psychology) (3TT5)',
+      'name and code for new course' => 'Course: Forensic Science (E0FO)',
+      'name of new provider' => 'Provider: Falconholt Technical College',
+      'location of new offer' => 'Location: Aquaria',
       'study mode of new offer' => 'Full time',
     )
   end
 
   describe 'Deferred offer reminder email' do
-    before do
-      application_form = build_stubbed(:application_form, first_name: 'Jeff')
-      provider = build_stubbed(:provider, name: 'Amazon University')
-      course_option = build_stubbed(
-        :course_option,
-        course: build_stubbed(
-          :course,
-          name: 'Business',
-          code: 'BIZ',
-          provider: provider,
-          recruitment_cycle_year: RecruitmentCycle.previous_year,
-        ),
-        site: build_stubbed(:site, provider: provider),
-      )
-
-      @application_choice = build_stubbed(
-        :application_choice,
-        :with_deferred_offer,
-        course_option: course_option,
-        offered_course_option: course_option,
-        application_form: application_form,
-        decline_by_default_at: 10.business_days.from_now,
-        offer_deferred_at: Time.zone.local(2020, 4, 15, 14),
-      )
-
-      magic_link_stubbing(application_form.candidate)
-    end
+    let(:email) { mailer.deferred_offer_reminder(application_choices.first) }
+    let(:application_choice) { build_stubbed(:application_choice, :with_deferred_offer, course_option: other_option, offer_deferred_at: Time.zone.local(2020, 4, 15)) }
+    let(:application_choices) { [application_choice] }
 
     it_behaves_like(
-      'a mail with subject and content', :deferred_offer_reminder,
+      'a mail with subject and content',
       I18n.t!('candidate_mailer.deferred_offer_reminder.subject'),
-      'heading' => 'Dear Jeff',
+      'heading' => 'Dear Bob',
       'when offer deferred' => 'On 15 April 2020',
-      'provider name' => 'Amazon University',
-      'course name and code' => 'Business (BIZ)'
+      'provider and course name' => 'Falconholt Technical College deferred your offer to study Forensic Science (E0FO)',
     )
   end
 end

--- a/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CandidateMailer, type: :mailer do
-  include TestHelpers::MailerSetupHelper
-
   around do |example|
     Timecop.freeze(Date.new(2020, 11, 23)) do
       example.run
@@ -11,59 +9,38 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   subject(:mailer) { described_class }
 
-  let(:application_choice) { create(:application_choice) }
-  let(:application_form) { create(:completed_application_form, application_choices: [application_choice]) }
-  let(:ucas_match) { create(:ucas_match, :need_to_send_reminder_emails, application_form: application_form) }
+  let(:ucas_match) { build_stubbed(:ucas_match, candidate_last_contacted_at: Time.zone.local(2020, 11, 16)) }
+  let(:application_form) { build_stubbed(:application_form, first_name: 'Jane', application_choices: [application_choice]) }
+  let(:provider) { build_stubbed(:provider, name: 'City University') }
+  let(:course_option) { build_stubbed(:course_option, course: course) }
+  let(:course) { build_stubbed(:course, name: 'Physics', code: '3PH5', provider: provider) }
+  let(:application_choice) { build_stubbed(:application_choice, course_option: course_option) }
 
   describe '.ucas_match_reminder_email_duplicate_applications' do
-    let(:email) { mailer.ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match) }
+    let(:email) { mailer.ucas_match_reminder_email_duplicate_applications(application_form.application_choices.first, ucas_match) }
 
-    it 'sends an email with the correct subject' do
-      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match_reminder_email.duplicate_applications.subject'))
-    end
-
-    it 'sends an email with the correct heading' do
-      expect(email.body.encoded).to include("Dear #{application_form.full_name}")
-    end
-
-    it 'sends an email containing the course name and code in the body' do
-      course_name_and_code = application_choice.course.name_and_code
-
-      expect(email.body).to include(course_name_and_code)
-    end
-
-    it 'sends an email containing the provider name in the body' do
-      provider_name = application_choice.course.provider.name
-
-      expect(email.body).to include(provider_name)
-    end
-
-    it 'sends an email containing the date the initial email was sent' do
-      expect(email.body).to include('16 November 2020')
-    end
-
-    it 'sends an email containing the date that the application needs to be withdrawn by' do
-      expect(email.body).to include('30 November 2020')
-    end
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.ucas_match_reminder_email.duplicate_applications.subject'),
+      'heading' => 'Dear Jane',
+      'course name and code' => 'Physics (3PH5)',
+      'provider' => 'City University',
+      'initial email date' => '16 November 2020',
+      'withdrawn by date' => '30 November 2020',
+    )
   end
 
   describe '.ucas_match_reminder_email_multiple_acceptances' do
-    let(:email) { mailer.ucas_match_reminder_email_multiple_acceptances(ucas_match) }
+    let(:email) { mailer.ucas_match_reminder_email_multiple_acceptances(candidate.ucas_match) }
+    let(:ucas_match) { build_stubbed(:ucas_match, candidate_last_contacted_at: Time.zone.local(2020, 11, 16)) }
+    let(:candidate) { build_stubbed(:candidate, ucas_match: ucas_match, application_forms: [application_form]) }
 
-    it 'sends an email with the correct subject' do
-      expect(email.subject).to include(I18n.t!('candidate_mailer.ucas_match_reminder_email.multiple_acceptances.subject'))
-    end
-
-    it 'sends an email with the correct heading' do
-      expect(email.body.encoded).to include("Dear #{application_form.full_name}")
-    end
-
-    it 'sends an email containing the date the initial email was sent' do
-      expect(email.body).to include('16 November 2020')
-    end
-
-    it 'sends an email containing the date that the application needs to be withdrawn by' do
-      expect(email.body).to include('30 November 2020')
-    end
+    it_behaves_like(
+      'a mail with subject and content',
+      I18n.t!('candidate_mailer.ucas_match_reminder_email.multiple_acceptances.subject'),
+      'heading' => 'Dear Jane',
+      'initial email date' => '16 November 2020',
+      'withdrawn by date' => '30 November 2020',
+    )
   end
 end

--- a/spec/support/shared_examples/mailers.rb
+++ b/spec/support/shared_examples/mailers.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples 'a mail with subject and content' do |email_subject, content|
+  it "sends an email with the correct subject and #{content.keys.to_sentence} in the body" do
+    expect(email.subject).to include(email_subject)
+
+    content.each do |_, expectation|
+      expectation = expectation.call if expectation.respond_to?(:call)
+      expect(email.body).to include(expectation)
+    end
+  end
+end


### PR DESCRIPTION
## Context

- Extract reusable shared_example and group checks (this significantly reduces the spec running time as it **reduces the mailer tests from 221 to 55** just by grouping the checks) 
- Refactor specs to enable usage of the shared example (and make sure we only use stubbed data)
- Disable rubocop RSpec/LetSetup to make it easier to setup data using let! (This enables using the parameter directly instead of having to for example, go through the application form to access the references `application_form.application_references.first` to ensure that the application_form object is created)
- includes a fix for the resolved_ucas_email content (remove space, display course name and code 

## Before

> Finished in 19.63 seconds (files took 11.98 seconds to load)
> 221 examples, 0 failures

## After

> Finished in 4.29 seconds (files took 11.97 seconds to load)
> 55 examples, 0 failures

