### PR TITLE
Configure Redis for parallel tests

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
+REDIS_URL=redis://localhost:6379/0
 FIND_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/v3/
 TEACHER_TRAINING_API_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1
 HOSTING_ENVIRONMENT_NAME=development

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-REDIS_URL=redis://localhost:6379/1
+REDIS_URL=redis://localhost:6379/0
 TEACHER_TRAINING_API_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1
 FIND_BASE_URL=https://api.publish-teacher-training-courses.service.gov.uk/api/v3/
 GOVUK_NOTIFY_API_KEY=

--- a/docs/parallel_tests.md
+++ b/docs/parallel_tests.md
@@ -4,11 +4,17 @@ This document explains how to run the test suite across multiple cores in develo
 
 ## Prerequisites
 
-### Check environment
+### Check development Redis config
 
-Ensure that REDIS_URL is not present in .env.test or .env.
+In order to successfully run tests in parallel, each process needs its own Redis database. Configuration in [spec/spec_helper.rb](spec/spec_helper.rb) ensures that a unique database is used per test process. These are allocated from database 1 onwards.
 
-In order to successfully run tests in parallel, each process needs its own Redis database. We determine the Redis database id in [ApplyRedisConnection](app/lib/apply_redis_connection.rb). This class always uses REDIS_URL if present in the environment. In order for it to return the appropriate URL for test runs, we need to ensure REDIS_URL is not set in the test environment.
+To ensure that your development Redis isn't affected by parallel test runs, make sure that the REDIS_URL set in development is using database 0.
+
+eg -
+
+`REDIS_URL=redis://localhost:6379/0`
+
+This should be handled by .env.development, but will be superseded by any local overrides.
 
 ### Prepare Postgres databases
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,17 @@ RSpec.configure do |config|
 
   config.before { Redis.new.flushdb }
 
+  # If running tests in parallel, use a unique Redis database per test process.
+  # This allocates databases from 1 onwards, as it's assumed that 0 is the
+  # development database.
+  if ENV['TEST_ENV_NUMBER']
+    config.around do |example|
+      ClimateControl.modify(REDIS_URL: "redis://localhost:6379/#{ENV['TEST_ENV_NUMBER'].to_i + 1}") do
+        example.run
+      end
+    end
+  end
+
   config.after { Clockwork::Test.clear! }
 
   # Print the 10 slowest examples and example groups at the


### PR DESCRIPTION
## Context

A prior commit dealing with this was reverted as part of an investigation into performance issues in production. Although seemingly unrelated to the issue, it did prompt a review of how Redis was being configured. This PR takes a simpler approach with a smaller footprint - the changes only affect parallel test runs, and no other form of Redis usage should be impacted.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR once again adds support for each parallel process to use a
different Redis database.

- Rather than configuring connections directly, we continue to rely on
  the REDIS_URL set in a given environment.
- Use ClimateControl to stub the value of REDIS_URL when running tests
  in parallel, ensuring we have uniqueness without affecting the
  configuration of anything else in the codebase.

In addition, this PR updates .env.example and .env.development to
encourage the convention of using Redis database 0 in development,
leaving databases 1 through n available for the test environment.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Run parallel tests locally, should work without issue if you've run them before (see the doc if trying for the first time).
- Is the config update clear enough?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
