### PR TITLE
Remove Received At column from References table and refactor

### DIFF
--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ApplicationReferencesExport
     def data_for_export
-      application_forms = ApplicationForm.includes(:application_references, :application_choices)
+      application_forms = ApplicationForm.includes(:application_choices, application_references: :audits)
 
       data_for_export = application_forms.map do |af|
         output = {
@@ -29,7 +29,7 @@ module SupportInterface
   private
 
     def received_at(reference)
-      reference.audits.where("audited_changes#>>'{feedback_status, 1}' = 'feedback_provided'").last&.created_at
+      reference.feedback_provided_at
     end
   end
 end

--- a/app/services/support_interface/candidate_journey_tracker.rb
+++ b/app/services/support_interface/candidate_journey_tracker.rb
@@ -155,7 +155,7 @@ module SupportInterface
       @received_reference_timings ||=
         received_references.map do |reference|
           {
-            received_at: earliest_update_audit_for(reference, feedback_status: 'feedback_provided'),
+            received_at: reference.feedback_provided_at,
             requested_at: reference.requested_at,
           }
         end

--- a/db/migrate/20210118135658_remove_received_at_from_references.rb
+++ b/db/migrate/20210118135658_remove_received_at_from_references.rb
@@ -1,0 +1,5 @@
+class RemoveReceivedAtFromReferences < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :references, :received_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_14_115857) do
+ActiveRecord::Schema.define(version: 2021_01_18_135658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -491,7 +491,6 @@ ActiveRecord::Schema.define(version: 2021_01_14_115857) do
     t.string "referee_type"
     t.string "safeguarding_concerns_status", default: "not_answered_yet", null: false
     t.datetime "reminder_sent_at"
-    t.datetime "received_at"
     t.index ["application_form_id", "email_address"], name: "index_references_on_application_form_id_and_email_address", unique: true
     t.index ["application_form_id"], name: "index_references_on_application_form_id"
     t.index ["feedback_status"], name: "index_references_on_feedback_status"


### PR DESCRIPTION
## Context

After review of the code base it was found that concise methods that can
used to call this information from the audit log are present on the application
reference model. 

## Changes proposed in this pull request

This PR removes the column and refactors export files touching
feedback provided at.

## Guidance to review

Check logic is sound

## Link to Trello card

https://trello.com/c/LLEPTmu1/2854-add-receivedat-to-the-applicationreference-model

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
