### PR TITLE
[Bug] Fix status code filter for Vendor API Requests

### DIFF
--- a/app/models/support_interface/vendor_api_requests_filter.rb
+++ b/app/models/support_interface/vendor_api_requests_filter.rb
@@ -22,7 +22,7 @@ module SupportInterface
     end
 
     def status_code
-      options = VendorAPIRequest.distinct(:status_code).pluck(:status_code).map do |status_code|
+      options = VendorAPIRequest.distinct(:status_code).pluck(:status_code).map(&:to_s).map do |status_code|
         {
           value: status_code,
           label: status_code,


### PR DESCRIPTION
## Context

The status code filter is not remembering existing filter values because it is [comparing a string value from the filter params with an integer value from available codes](https://github.com/DFE-Digital/apply-for-teacher-training/blob/2a39326cc54e773ad9a0f69fe566bbcd13f5cebf/app/models/support_interface/vendor_api_requests_filter.rb#L29).

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Convert status codes to strings before rendering and comparing in the filter.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/104945401-9a227e00-59b0-11eb-859b-ce860af47bd7.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
