### PR TITLE
Stub geocoder requests in our specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,11 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
+  config.include GeocodeTestHelper
+  config.before do
+    stub_const('Geokit::Geocoders::GoogleGeocoder', stub_geocoder)
+  end
+
   config.before { Faker::UniqueGenerator.clear }
 
   config.before { ActionMailer::Base.deliveries.clear }

--- a/spec/support/geocode_test_helper.rb
+++ b/spec/support/geocode_test_helper.rb
@@ -1,0 +1,17 @@
+module GeocodeTestHelper
+  def stub_geocoder
+    Geocoder.configure(lookup: :test)
+
+    Geocoder::Lookup::Test.set_default_stub(
+      [
+        {
+          'coordinates' => [51.4524877, -0.1204749],
+          'address' => 'AA Teamworks W Yorks SCITT, School Street, Greetland, Halifax, West Yorkshire HX4 8JB',
+          'state' => 'England',
+          'country' => 'United Kingdom',
+          'country_code' => 'UK',
+        },
+      ],
+    )
+  end
+end


### PR DESCRIPTION
## Context

At the moment, we are not stubbing out our geocoder requests. This means that if you have a google maps api key set then the tests don't start failing due to WebMock errors.

## Changes proposed in this pull request

- Add a default geocoder stub

## Guidance to review

Checkout master, add `GOOGLE_MAPS_API_KEY=xxx` to your .env file and run your tests. You should see failures.

Checkout  2857-stub-geocoder-requests-in-specs and run your tests. They should be 🟢 

## Link to Trello card

https://trello.com/c/mk7N2FyH/2857-stub-geocoder-requests-in-our-tests

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
