### PR TITLE
Skylight tweaks: add sidekiq, track git SHA

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,6 +1,9 @@
 ---
 #The authentication token for the application
 authentication: <%= ENV.fetch('SKYLIGHT_AUTH_TOKEN') %>
+enable_sidekiq: true
+deploy:
+  git_sha: <%= ENV['SHA'] %>
 ignored_endpoints:
   - HealthcheckController#show
 agent:


### PR DESCRIPTION
## Context

It'd be useful to see sidekiq performance data in Skylight, too (these will be shown separately to the web stats, as performance of the 'worker' process). Giving Skylight a git SHA will annotate graphs with deploy events, too.

## Changes proposed in this pull request

Add sidekiq instrumentation, add the git SHA from `ENV['SHA']`.

## Guidance to review

Nothing special.

## Link to Trello card

No Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
