### PR TITLE
Fix feature metrics crash

### DIFF
--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -55,8 +55,10 @@ private
       provided_audit = reference.audits.where("audited_changes#>>'{feedback_status, 1}' = 'feedback_provided'").last
       [reference.requested_at, provided_audit&.created_at]
     end
-    requested_at_times = times.map(&:first)
-    provided_at_times = times.map(&:second)
+    requested_at_times = times.map(&:first).compact
+    provided_at_times = times.map(&:second).compact
+    return nil if requested_at_times.blank? || provided_at_times.blank?
+
     (provided_at_times.min - requested_at_times.max).to_i / 1.day
   end
 end

--- a/app/models/work_history_feature_metrics.rb
+++ b/app/models/work_history_feature_metrics.rb
@@ -37,6 +37,7 @@ private
       application.application_work_history_breaks.pluck(:created_at) +
       application.application_volunteering_experiences.pluck(:created_at) +
       application.application_work_experiences.pluck(:created_at)).min
+    return nil if started_at.nil? || completion_audit.nil?
 
     (completion_audit.created_at - started_at).to_i / 1.day
   end

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
       it 'returns the correct value for references received over a custom interval' do
         expect(feature_metrics.average_time_to_get_references((@today - 1.month).beginning_of_day, @today - 1.week)).to eq('3 days')
       end
+
+      it 'handles missing `requested_at` timestamp' do
+        @references1.first.update!(requested_at: nil)
+        expect(feature_metrics.average_time_to_get_references((@today - 1.month).beginning_of_day, @today)).to eq('7.5 days')
+      end
     end
 
     describe '#percentage_references_within' do

--- a/spec/models/work_history_feature_metrics_spec.rb
+++ b/spec/models/work_history_feature_metrics_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe WorkHistoryFeatureMetrics, with_audited: true do
         Timecop.freeze(@today - 11.days) do
           @application_form1 = create(:application_form)
           @application_form2 = create(:application_form)
+          @application_form3 = create(:application_form)
         end
         Timecop.freeze(@today - 10.days) do
           create(:application_work_experience, application_form: @application_form1)
@@ -26,6 +27,7 @@ RSpec.describe WorkHistoryFeatureMetrics, with_audited: true do
         end
         Timecop.freeze(@today - 1.day) do
           @application_form2.update!(work_history_completed: true)
+          @application_form3.update!(work_history_completed: true)
         end
       end
 


### PR DESCRIPTION
## Context

There are a couple of bad assumptions about data in the feature metrics query logic.

## Changes proposed in this pull request

Handle the following cases:
- [x] `ApplicationReference#requested_at` can be `nil` even if the `feedback_status` is `feedback_provided`.
- [x] `ApplicationForm#work_history_completed` can be `true` with no work history items (presumably this is valid if a person has never worked).

## Guidance to review

- Per commit (just two of them)
- Does it make sense to simply discard the figures that have nil values from the calculation of averages? e.g. if there is no work history is it reasonable to ignore such applications rather than count them as having a zero time to complete?
- Anything else missing?

## Link to Trello card

https://trello.com/c/sdK6C9kB/2894-feature-metrics-crashing-on-production

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
