### PR TITLE
Prevent LocalJump error in config/clock.rb

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -40,9 +40,9 @@ class Clock
   end
 
   every(1.day, 'UCASIntegrationCheck', at: '11:00') do
-    return unless HostingEnvironment.production?
-
-    UCASIntegrationCheck.perform_async if Time.zone.yesterday.weekday?
+    if HostingEnvironment.production?
+      UCASIntegrationCheck.perform_async if Time.zone.yesterday.weekday?
+    end
   end
 
   every(1.hour, 'SyncAllFromTeacherTrainingPublicAPI') do


### PR DESCRIPTION
## Context

Using `return` in blocks within the clockwork config results in `LocalJump Error: unexpected return`.

## Changes proposed in this pull request

Use `if` rather than `return`.

## Guidance to review

Easy peasy.

## Link to Trello card

General maintenance

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
