### PR TITLE
Optimise ucas_matched_application spec

### DIFF
--- a/app/models/ucas_matched_application.rb
+++ b/app/models/ucas_matched_application.rb
@@ -120,6 +120,6 @@ class UCASMatchedApplication
 private
 
   def provider_not_on_apply?
-    Provider.find_by(code: @matching_data['Provider code']).nil?
+    !Provider.exists?(code: @matching_data['Provider code'])
   end
 end


### PR DESCRIPTION

## Context

Refactors and optimises ucas_matched_application spec. 
This clashes with @malcolmbaig 's [speed up UCAS PR](https://github.com/DFE-Digital/apply-for-teacher-training/pull/3836) but I wanted to see if we could easily improve the specs without having to require an external library by refactoring the data setup.

I think it's a slightly slower than Malcom's PR, however the data setup is a lot clearer and focused and I was able to get away with using `build_stubbed` across the spec with only a couple of exceptions where we were testing the retrieval of application_choice and provider.

_Test run comparison_

> master
Finished in 10.96 seconds (files took 21.9 seconds to load)
26 examples, 0 failures

> 2832-speed-up-ucas-spec
Finished in 1.02 seconds (files took 22.06 seconds to load)
26 examples, 0 failures

**current PR**
>optimise-ucas_matched_application-spec 
Finished in 1.11 seconds (files took 13.38 seconds to load)
26 examples, 0 failures

### In addition to that

- fixes spec referencing wrong method (application_accepted_on_apply)
- change `find_by` to `exists?` in ucas_matched_application as object is unnecessarily retrieved from the database.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
