### PR TITLE
SKYLIGHT_ENABLE as string parameter

### DIFF
--- a/azure/pipelines/build.yml
+++ b/azure/pipelines/build.yml
@@ -312,7 +312,7 @@ stages:
       ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
       skylightAuthToken: '$(skylightAuthToken)'
-      skylightEnable: $(skylightEnable)
+      skylightEnable: '$(skylightEnable)'
 
 
 - stage: deploy_devops
@@ -372,4 +372,4 @@ stages:
       ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
       skylightAuthToken: '$(skylightAuthToken)'
-      skylightEnable: $(skylightEnable)
+      skylightEnable: '$(skylightEnable)'

--- a/azure/pipelines/release.yml
+++ b/azure/pipelines/release.yml
@@ -100,7 +100,7 @@ stages:
       ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
       skylightAuthToken: '$(skylightAuthToken)'
-      skylightEnable: $(skylightEnable)
+      skylightEnable: '$(skylightEnable)'
 
 - stage: deploy_sandbox
   displayName: 'Deploy - Sandbox'
@@ -159,7 +159,7 @@ stages:
       ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
       skylightAuthToken: '$(skylightAuthToken)'
-      skylightEnable: $(skylightEnable)
+      skylightEnable: '$(skylightEnable)'
 
 
 - stage: deploy_production
@@ -222,4 +222,4 @@ stages:
       ucasZipPassword: '$(ucasZipPassword)'
       sandbox: '$(sandbox)'
       skylightAuthToken: '$(skylightAuthToken)'
-      skylightEnable: $(skylightEnable)
+      skylightEnable: '$(skylightEnable)'

--- a/azure/pipelines/templates/deploy.yml
+++ b/azure/pipelines/templates/deploy.yml
@@ -64,7 +64,7 @@ parameters:
   ucasPassword:
   ucasZipPassword:
   skylightAuthToken:
-  skylightEnable: false
+  skylightEnable: 'false'
   googleAnalyticsApply:
   googleAnalyticsManage:
 
@@ -264,7 +264,7 @@ jobs:
                 -alertSlackChannel "${{parameters.alertSlackChannel}}"
                 -logRetentionDays ${{parameters.logRetentionDays}}
                 -skylightAuthToken "${{parameters.skylightAuthToken}}"
-                -skylightEnable ${{parameters.skylightEnable}}
+                -skylightEnable "${{parameters.skylightEnable}}"
                 -dsiApiUrl "${{parameters.dsiApiUrl}}"
                 -dsiApiSecret "${{parameters.dsiApiSecret}}"
                 -ucasUsername "${{parameters.ucasUsername}}"

--- a/azure/template.json
+++ b/azure/template.json
@@ -280,8 +280,8 @@
             "type": "string"
         },
         "skylightEnable":{
-            "defaultValue": false,
-            "type": "bool"
+            "defaultValue": "false",
+            "type": "string"
         },
         "findBaseUrl": {
             "type": "string",


### PR DESCRIPTION
## Context

container instance is setting boolean param as `True` or `False`
and rails ENV is loading SKYLIGHT_ENABLE as string
requiring case insensitive compare in application code.

## Changes proposed in this pull request

change SKYLIGHT_ENABLE as string parameter

## Guidance to review

## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
