### PR TITLE
Update some of the pages in /docs

### DIFF
--- a/docs/azure-infrastructure.md
+++ b/docs/azure-infrastructure.md
@@ -1,4 +1,4 @@
-# Apply for Teacher Training - Azure Infrastructure 
+# Azure Infrastructure 
 
 ## Purpose
 

--- a/docs/brakeman.md
+++ b/docs/brakeman.md
@@ -1,4 +1,4 @@
-# Brakeman
+# Security scanning with Brakeman
 
 [Brakeman](https://github.com/presidentbeef/brakeman) is a static analysis tool which checks for security vulnerabilities.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,14 +1,14 @@
-# Rails components
+# View components
 
-We use [ActionView::Component](https://github.com/github/actionview-component) for reusable view components.
+We use [ViewComponent](https://github.com/github/view_component) for reusable view components.
 
 ## Why use components?
 
-The [guide section in the actionview-component README has detailed explanations](https://github.com/github/actionview-component#guide), but in a nutshell these are some pros:
+The [guide section in the ViewComponent README has detailed explanations](https://github.com/github/view_component#guide), but in a nutshell these are some pros:
 
 - They are easy to unit test
 - They are easy to make and reuse
-- They can be used to wrap things like GOVUK Design System components
+- They can be used to wrap things like GOV.UK Design System components
 - They allow you to couple Ruby logic with a Rails partial without having to write the logic inside `erb`
 - They are 5x faster to render than partials
 - They can be previewed on their own and are easy to "Design Systemify"

--- a/docs/connecting-to-databases.md
+++ b/docs/connecting-to-databases.md
@@ -1,4 +1,4 @@
-# Connect to a production database
+# How to: connect to a production database
 
 ## Purpose
 

--- a/docs/database-restore.md
+++ b/docs/database-restore.md
@@ -1,4 +1,4 @@
-# Restore a database
+# How to: restore a database
 
 ## Purpose
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,4 +1,4 @@
-# Deploying Apply - Step by step
+# How to: deploy Apply
 
 The apply build and release process is split into two separate Azure DevOps pipelines.
 
@@ -20,7 +20,7 @@ If none of the above conditions are met the pipeline will simply load the new im
 
 ## 1. Check what you're deploying
 
-Go to [the Apply Ops Dashboard](https://apply-ops-dashboard.azurewebsites.net) and find the commit you want to deploy 
+Go to [the Apply Ops Dashboard](https://apply-ops-dashboard.azurewebsites.net) and find the commit you want to deploy
 and check the diff on GitHub to see if there's anything risky.
 
 You also have to make sure that you're deploying only work that is safe to deploy. It should be either behind a feature flag or product reviewed.

--- a/docs/deployment_checklist.md
+++ b/docs/deployment_checklist.md
@@ -1,5 +1,0 @@
-# Deploying Apply - Post-deployment checks
-
-[Check the full the full deployment guide.](deployment.md)
-
-This file left for posterity and preserving old links.

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -1,8 +1,8 @@
-# Apply for Teacher Training - Developer On-boarding
+# Developer On-boarding
 
 ## Purpose
 
-This document describes the on-boardng steps that need to be undertaken for new Developers when they join the team. 
+This document describes the on-boardng steps that need to be undertaken for new Developers when they join the team.
 
 ## Azure/DevOps steps
 

--- a/docs/docker-for-devops.md
+++ b/docs/docker-for-devops.md
@@ -1,4 +1,4 @@
-# Apply for Teacher Training - Docker for DevOps
+# Docker for DevOps
 
 ## Purpose
 
@@ -91,7 +91,7 @@ Under normal circumstances you will seldom need to run a build using these instr
 1. Take a backup of the [docker-compose.override.yml](../docker-compose.override.yml) file by renaming it to something else of your choosing.
 1. Take a copy of the [docker-compose.azure.yml](../docker-compose.azure.yml) and name it `docker-compose.override.yml` to replace the file you backed up in the previous step.
 1. Open the new `docker-compose.override.yml` file and make the following changes to it:
-   - Delete the line that starts `image:` 
+   - Delete the line that starts `image:`
    - Remove `=${railsSecretKeyBase}` from the end of the line `- SECRET_KEY_BASE=${railsSecretKeyBase}`
 1. Run the `make build` command. This will take approximately five minutes to complete.
 1. Run the `make setup` command to initialise the database.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -45,7 +45,7 @@ These steps describe the process for making environment variables available to t
         }
       }
       ```
-   2. Around [line 500](../azure/template.json#L505) duplicate this block of code in the *appEnvironmentVariables* parameter of the `app-service-and-containers` resource and configure it to match your new environment varaible. 
+   2. Around [line 500](../azure/template.json#L505) duplicate this block of code in the *appEnvironmentVariables* parameter of the `app-service-and-containers` resource and configure it to match your new environment varaible.
    If the environment variable in question is a secret, change `value` to `secureValue`.
       ```json
       {

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,4 +1,6 @@
-# Debugging
+# Frontend
+
+## Debugging
 
 We do not use the Rails asset pipeline. We use the Rails webpack wrapper
 [Webpacker](https://github.com/rails/webpacker) to compile our CSS, images, fonts

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -1,4 +1,4 @@
-# Apply for Postgraduate Teacher Training - Hotfix Deployment
+# How to: do a hotfix deployment
 
 ## Purpose
 

--- a/docs/load_testing.md
+++ b/docs/load_testing.md
@@ -1,4 +1,4 @@
-# Load testing
+# How to: perform load testing on Apply
 
 [Apache JMeter](https://jmeter.apache.org/) allows us to test our service with realistic loads.
 

--- a/docs/manual-deployment.md
+++ b/docs/manual-deployment.md
@@ -1,10 +1,8 @@
-# Apply for Postgraduate Teacher Training - Manual Deployment
-
-## Purpose
+# How to: manually deploy Apply
 
 This document describes the process of manually deploying a new Docker image into the Azure app service.
 
-### When should this process be used?
+## When should this process be used?
 
 In the event that code changes are made to the app but the Azure pipelines fail to complete the deployment stages this process should be followed to deploy the Docker image to the Azure App Service manually. It is anticipated that this process would only be following in response to bug fixes when the deployment pipeline is failing.
 

--- a/docs/new-environment.md
+++ b/docs/new-environment.md
@@ -1,4 +1,4 @@
-# Creating and Deploying to a new environment in Azure
+# How to: create and deploy a new environment in Azure
 
 All the steps required to create and deploy to an Azure environment are written in the [Pipelines deploy template file](../azure/pipelines/templates/deploy.yml). This template is referenced inside the main Azure Pipelines configuration file and reused with appropriate parameters for the required environment.
 
@@ -43,7 +43,7 @@ dNN | Dev & QA |
 tNN | Staging |
 pNN | Production |
 
-`NN` is a number with 2 digit places. 
+`NN` is a number with 2 digit places.
 
 The first step defined in the deploy template is a script which determines if a full ARM deployment is required.
 A full ARM deployment will be run when the pipeline is triggered for the first time after a new stage is configured.
@@ -64,7 +64,7 @@ in question.
 2. Issue the following query, which writes your email address (EMAIL) and DfE Sign-in uid (UID) into the support_users table.
 
 ```SQL
-INSERT INTO support_users (email_address, dfe_sign_in_uid, created_at, updated_at) 
+INSERT INTO support_users (email_address, dfe_sign_in_uid, created_at, updated_at)
 VALUES ('EMAIL', 'UID', current_timestamp, current_timestamp);
 ```
 

--- a/docs/performance-monitoring.md
+++ b/docs/performance-monitoring.md
@@ -1,4 +1,4 @@
-# Performance Monitoring
+# Performance monitoring
 
 ## External Integrations
 

--- a/docs/pim-guide.md
+++ b/docs/pim-guide.md
@@ -1,6 +1,4 @@
-# Apply for Postgraduate Teacher Training - PIM Rights 
-
-## Purpose
+# PIM rights for production access
 
 This document describes the process of elevating your permissions using PIM (Privileged Identity Management) in Azure to administer resources in the test and production subscriptions.
 

--- a/docs/pipeline-variables.md
+++ b/docs/pipeline-variables.md
@@ -1,6 +1,6 @@
-# Pipeline Variables
+# Pipeline variables
 
-The pipeline varianbles can be found in [Azure DevOps](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_library?itemType=VariableGroups)
+The pipeline variables can be found in [Azure DevOps](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_library?itemType=VariableGroups)
 
 Each environment has three tiers of pipelines variables, listed below and starting with the least specific first.
 1. `Docker Shared Variables` - This group is common to all environments in Apply and also Find. It contains the login credentials from Dockerhub used during the build and deployment processes.

--- a/docs/swap-slots-pipeline.md
+++ b/docs/swap-slots-pipeline.md
@@ -1,6 +1,6 @@
-# Swapping Azure App Service Slots
+# How to: swap Azure App Service slots
 
-In some cases where a particular deployment has to be rolledback,
+In some cases where a particular deployment has to be rolled back,
 we have to might be required to manually swap back the staging and production slot of the App service by logging on to the Azure Portal. This however requires an elevated permission and has to go through the PIM request approval workflow before being able to perform this task.
 
 We can now perform this task on any environment by running the `apply-for-teacher-training-swap-slots` pipeline in Azure DevOps.


### PR DESCRIPTION
## Context

These docs are now part of https://bat-tech-guide.london.cloudapps.digital, so remove redundant things from page titles and make them somewhat consistent.

## Changes proposed in this pull request

Fixes to titles, and some typo fixes.

## Guidance to review

Are the titles consistent now? (This might be better viewed on the live site).
