### PR TITLE
Filter Vendor API Requests by request method

### DIFF
--- a/app/controllers/support_interface/vendor_api_requests_controller.rb
+++ b/app/controllers/support_interface/vendor_api_requests_controller.rb
@@ -2,25 +2,9 @@ module SupportInterface
   class VendorAPIRequestsController < SupportInterfaceController
     def index
       @filter = SupportInterface::VendorAPIRequestsFilter.new(params: params)
-      @vendor_api_requests = VendorAPIRequest.includes(:provider).order(created_at: :desc).page(params[:page] || 1).per(30)
-
-      if params[:q]
-        @vendor_api_requests = @vendor_api_requests.where("CONCAT(request_path, ' ', request_body, ' ', response_body) ILIKE ?", "%#{params[:q]}%")
-      end
-
-      if params[:status_code]
-        @vendor_api_requests = @vendor_api_requests.where('status_code IN (?)', params[:status_code])
-      end
-
-      if params[:provider_id]
-        @vendor_api_requests = @vendor_api_requests.where('provider_id IN (?)', params[:provider_id])
-      end
-
-      %w[created_at request_path].each do |column|
-        next unless params[column]
-
-        @vendor_api_requests = @vendor_api_requests.where(column => params[column])
-      end
+      @vendor_api_requests = @filter.filter_records(
+        VendorAPIRequest.includes(:provider).order(created_at: :desc).page(params[:page] || 1).per(30),
+      )
     end
   end
 end

--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -48,8 +48,9 @@ private
     {
       path: @request.path,
       params: @request.params,
+      body: @request.body.read,
       headers: request_headers,
-      method: @request.env['REQUEST_METHOD'],
+      method: @request.request_method,
     }
   end
 

--- a/app/models/support_interface/vendor_api_requests_filter.rb
+++ b/app/models/support_interface/vendor_api_requests_filter.rb
@@ -7,7 +7,33 @@ module SupportInterface
     end
 
     def filters
-      @filters ||= [free_text] + [status_code] + [provider]
+      @filters ||= [free_text] + [request_method] + [status_code] + [provider]
+    end
+
+    def filter_records(vendor_api_requests)
+      if applied_filters[:q]
+        vendor_api_requests = vendor_api_requests.where("CONCAT(request_path, ' ', request_body, ' ', response_body) ILIKE ?", "%#{applied_filters[:q]}%")
+      end
+
+      if applied_filters[:status_code]
+        vendor_api_requests = vendor_api_requests.where('status_code IN (?)', applied_filters[:status_code])
+      end
+
+      if applied_filters[:request_method]
+        vendor_api_requests = vendor_api_requests.where('request_method IN (?)', applied_filters[:request_method])
+      end
+
+      if applied_filters[:provider_id]
+        vendor_api_requests = vendor_api_requests.where('provider_id IN (?)', applied_filters[:provider_id])
+      end
+
+      %w[created_at request_path].each do |column|
+        next unless applied_filters[column]
+
+        vendor_api_requests = vendor_api_requests.where(column => applied_filters[column])
+      end
+
+      vendor_api_requests
     end
 
   private
@@ -38,12 +64,29 @@ module SupportInterface
       }
     end
 
+    def request_method
+      options = VendorAPIRequest.distinct(:request_method).pluck(:request_method).compact.map do |request_method|
+        {
+          value: request_method,
+          label: request_method,
+          checked: applied_filters[:request_method]&.include?(request_method),
+        }
+      end
+
+      {
+        type: :checkboxes,
+        heading: 'Method',
+        name: 'request_method',
+        options: options,
+      }
+    end
+
     def provider
       options = Provider.where(id: VendorAPIRequest.distinct(:provider_id).select(:provider_id)).map do |provider|
         {
-          value: provider.id,
+          value: provider.id.to_s,
           label: provider.name,
-          checked: applied_filters[:provider_id]&.include?(provider.id),
+          checked: applied_filters[:provider_id]&.include?(provider.id.to_s),
         }
       end
 

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -31,7 +31,7 @@
                 <h3 class="govuk-!-margin-top-0">Headers</h3>
                 <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_headers)) %>
                 <% if vendor_api_request.request_body.present? %>
-                  <h3>Request params</h3>
+                  <h3>Request <%= vendor_api_request.request_method == 'GET' ? 'params' : 'body' %></h3>
                   <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_body)) %>
                 <% end %>
                 <% if vendor_api_request.response_headers.present? %>

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -17,6 +17,7 @@
           <td class="govuk-table__cell govuk-!-padding-top-0">
             <%= render SummaryListComponent.new(rows: [
               { key: 'Status', value: vendor_api_request.status_code },
+              { key: 'Method', value: vendor_api_request.request_method },
               { key: 'Path', value: vendor_api_request.request_path },
               { key: 'Provider', value: vendor_api_request.provider.present? ? vendor_api_request.provider.name : 'Unknown' },
             ]) %>

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -30,10 +30,18 @@
               <div class="govuk-details__text govuk-body-xs">
                 <h3 class="govuk-!-margin-top-0">Headers</h3>
                 <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_headers)) %>
-                <h3>Request params</h3>
-                <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_body)) %>
-                <h3>Response body</h3>
-                <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_body)) %>
+                <% if vendor_api_request.request_body.present? %>
+                  <h3>Request params</h3>
+                  <%= tag.pre(JSON.pretty_generate(vendor_api_request.request_body)) %>
+                <% end %>
+                <% if vendor_api_request.response_headers.present? %>
+                  <h3>Response headers</h3>
+                  <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_headers)) %>
+                <% end %>
+                <% if vendor_api_request.response_body.present? %>
+                  <h3>Response body</h3>
+                  <%= tag.pre(JSON.pretty_generate(vendor_api_request.response_body)) %>
+                <% end %>
               </div>
             </details>
           </td>

--- a/app/workers/vendor_api_request_worker.rb
+++ b/app/workers/vendor_api_request_worker.rb
@@ -4,14 +4,26 @@ class VendorAPIRequestWorker
 
   sidekiq_options retry: 3, queue: :low_priority
 
-  def perform(request_data, response_body, status_code, created_at)
+  def perform(request_data, response_data, status_code, created_at)
     request_headers = request_data['headers']
     provider_id = provider_id_from_auth_token(request_headers.delete('HTTP_AUTHORIZATION'))
+
+    # FIXME: Temporary measure to ensure any existing background jobs will populate records correctly.
+    # This can be simplified once middleware is enqueuing response headers and body in the response_data param.
+    if response_data.is_a?(Hash)
+      response_headers = response_data['headers']
+      response_body = response_data['body']
+    else
+      response_headers = nil
+      response_body = response_data
+    end
 
     VendorAPIRequest.create!(
       request_path: request_data['path'],
       request_headers: request_headers,
       request_body: request_data['params'],
+      request_method: request_data['method'],
+      response_headers: response_headers,
       response_body: response_hash(response_body, status_code),
       status_code: status_code,
       provider_id: provider_id,

--- a/app/workers/vendor_api_request_worker.rb
+++ b/app/workers/vendor_api_request_worker.rb
@@ -5,7 +5,7 @@ class VendorAPIRequestWorker
   sidekiq_options retry: 3, queue: :low_priority
 
   def perform(request_data, response_data, status_code, created_at)
-    request_headers = request_data['headers']
+    request_headers = request_data.fetch('headers', {})
     provider_id = provider_id_from_auth_token(request_headers.delete('HTTP_AUTHORIZATION'))
 
     # FIXME: Temporary measure to ensure any existing background jobs will populate records correctly.
@@ -21,7 +21,7 @@ class VendorAPIRequestWorker
     VendorAPIRequest.create!(
       request_path: request_data['path'],
       request_headers: request_headers,
-      request_body: request_data['params'],
+      request_body: request_body(request_data),
       request_method: request_data['method'],
       response_headers: response_headers,
       response_body: response_hash(response_body, status_code),
@@ -48,5 +48,15 @@ private
     JSON.parse(response_body)
   rescue JSON::ParserError
     { body: "#{status} did not respond with JSON" }
+  end
+
+  def request_body(request_data)
+    if request_data['method'] == 'POST'
+      JSON.parse(request_data['body'])
+    else
+      request_data['params']
+    end
+  rescue JSON::ParserError
+    { error: 'request data did not contain valid JSON' }
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -784,6 +784,18 @@ FactoryBot.define do
     end
   end
 
+  factory :vendor_api_request do
+    provider
+    request_path { '/api/v1/applications' }
+    request_method { 'GET' }
+    status_code { 200 }
+    request_headers { {} }
+    request_body { {} }
+    response_headers { {} }
+    response_body { {} }
+    created_at { Time.zone.now }
+  end
+
   factory :reference, class: 'ApplicationReference' do
     application_form
     email_address { "#{SecureRandom.hex(5)}@example.com" }

--- a/spec/middlewares/vendor_api_request_middleware_spec.rb
+++ b/spec/middlewares/vendor_api_request_middleware_spec.rb
@@ -32,10 +32,20 @@ RSpec.describe VendorAPIRequestMiddleware, type: :request do
 
   describe '#call on an API path' do
     it 'enqueues a worker job' do
-      get '/api/v1/applications/1'
+      get '/api/v1/applications/1', params: { 'foo': 'bar' }
 
       expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
-        hash_including(path: '/api/v1/applications/1'), anything, 401, anything
+        hash_including(path: '/api/v1/applications/1', params: { 'foo' => 'bar' }, method: 'GET'), anything, 401, anything
+      )
+    end
+  end
+
+  describe '#call on an API path with POST data' do
+    it 'enqueues a worker job including post data' do
+      post '/api/v1/applications/1/offer', as: :json, params: { 'foo' => 'bar' }
+
+      expect(VendorAPIRequestWorker).to have_received(:perform_async).with(
+        hash_including(path: '/api/v1/applications/1/offer', body: '{"foo":"bar"}', method: 'POST'), anything, 401, anything
       )
     end
   end

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -18,6 +18,13 @@ RSpec.feature 'Vendor API Requests' do
     when_i_filter_by_status
     then_i_only_see_api_requests_filtered_by_status
 
+    and_i_clear_filters
+
+    when_i_filter_by_request_method
+    then_i_see_api_requests_filtered_by_request_method
+
+    and_i_clear_filters
+
     when_i_search_for_a_specific_request_path
     then_i_only_see_api_requests_filtered_by_the_search
 
@@ -36,6 +43,8 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def and_vendor_api_requests_for_applications_have_been_made
+    @post_api_request = create(:vendor_api_request, request_method: 'POST', request_path: '/api/v1/applications/9999/offer')
+
     visit vendor_api_path(@first_application_choice)
 
     provider = @last_application_choice.provider
@@ -54,6 +63,7 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_see_the_api_request
+    expect(page).to have_content('/api/v1/applications/9999/offer')
     expect(page).to have_content(vendor_api_path(@first_application_choice))
     expect(page).to have_content(vendor_api_path(@last_application_choice))
   end
@@ -70,8 +80,6 @@ RSpec.feature 'Vendor API Requests' do
   def then_i_see_the_request_and_response_info
     expect(page).to have_content('Headers')
     expect(page).to have_content('HTTP_HOST')
-    expect(page).to have_content('Request params')
-    expect(page).to have_content('Response body')
     expect(page).to have_content('Unauthorized')
   end
 
@@ -83,10 +91,25 @@ RSpec.feature 'Vendor API Requests' do
   def then_i_only_see_api_requests_filtered_by_status
     expect(page).not_to have_content(vendor_api_path(@first_application_choice))
     expect(page).to have_content(vendor_api_path(@last_application_choice))
+    expect(page).to have_content('/api/v1/applications/9999/offer')
+  end
+
+  def and_i_clear_filters
+    click_on 'Clear filters'
+  end
+
+  def when_i_filter_by_request_method
+    check 'GET'
+    click_on 'Apply filters'
+  end
+
+  def then_i_see_api_requests_filtered_by_request_method
+    expect(page).to have_content(vendor_api_path(@first_application_choice))
+    expect(page).to have_content(vendor_api_path(@last_application_choice))
+    expect(page).not_to have_content('/api/v1/applications/9999/offer')
   end
 
   def when_i_search_for_a_specific_request_path
-    uncheck '200'
     fill_in :q, with: "applications/#{@first_application_choice.id}"
     click_on 'Apply filters'
   end

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -43,7 +43,12 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def and_vendor_api_requests_for_applications_have_been_made
-    @post_api_request = create(:vendor_api_request, request_method: 'POST', request_path: '/api/v1/applications/9999/offer')
+    @post_api_request = create(
+      :vendor_api_request,
+      request_method: 'POST',
+      request_body: { data: { 'foo' => 'bar' } },
+      request_path: '/api/v1/applications/9999/offer',
+    )
 
     visit vendor_api_path(@first_application_choice)
 
@@ -78,6 +83,7 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def then_i_see_the_request_and_response_info
+    expect(page).to have_content('Request body')
     expect(page).to have_content('Headers')
     expect(page).to have_content('HTTP_HOST')
     expect(page).to have_content('Unauthorized')

--- a/spec/workers/vendor_api_request_worker_spec.rb
+++ b/spec/workers/vendor_api_request_worker_spec.rb
@@ -19,4 +19,24 @@ RSpec.describe VendorAPIRequestWorker do
       expect(VendorAPIRequest.find_by(provider_id: provider.id)).not_to be nil
     end
   end
+
+  it 'accepts headers and body in response_data' do
+    described_class.new.perform(
+      { 'headers' => {}, 'path' => '/api/v1/foo' },
+      { 'headers' => { 'this' => 'that' }, 'body' => { 'that' => 'this' }.to_json },
+      500,
+      Time.zone.now,
+    )
+
+    vendor_api_request = VendorAPIRequest.find_by(request_path: '/api/v1/foo')
+
+    expect(vendor_api_request.response_headers).to eq({ 'this' => 'that' })
+    expect(vendor_api_request.response_body).to eq({ 'that' => 'this' })
+  end
+
+  it 'saves the request method on the vendor api request' do
+    described_class.new.perform({ 'headers' => {}, 'path' => '/api/v1/bar', 'method' => 'GET' }, {}.to_json, 500, Time.zone.now)
+
+    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_method).to eq('GET')
+  end
 end


### PR DESCRIPTION
## Context

Do not merge until https://github.com/DFE-Digital/apply-for-teacher-training/pull/3874 has been deployed.

We'd like to know the origins of some redirects occuring during API calls.
We'd also like to filter requests by request method.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Saves the request method and response headers to the `VendorAPIRequest` record.
- Exposes `request_method` and (optionally) `response_headers` in the UI
- Adds a filter by `request_method`
- Fixes provider filter which wasn't retaining the applied values

![image](https://user-images.githubusercontent.com/93511/105214320-c290b080-5b47-11eb-94cc-7ed0caa9abfe.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/LBHHTB9x/3248-single-api-request-to-qa-produces-three-vendorapirequest-entries
https://trello.com/c/Qyzx7zmE/3266-filter-vendor-api-requests-by-get-and-post-requests-in-support
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
