### PR TITLE
Be explicit about Skylight env in skylight.yml

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -2,6 +2,8 @@
 #The authentication token for the application
 authentication: <%= ENV.fetch('SKYLIGHT_AUTH_TOKEN') %>
 enable_sidekiq: true
+production:
+  env: <%= ENV['SKYLIGHT_ENV'] %>
 deploy:
   git_sha: <%= ENV['SHA'] %>
 ignored_endpoints:


### PR DESCRIPTION
## Context

`production` doesn't appear to be a valid skylight environment for `worker` stats, even though these stats are available for qa. This may fix it, or not!
