### PR TITLE
Show offered_at and DBD dates in support

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -13,6 +13,11 @@ module SupportInterface
         { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status)) },
       ]
 
+      if application_choice.offer?
+        rows << { key: 'Offer made at', value: application_choice.offered_at.to_s(:govuk_date_and_time) }
+        rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) }
+      end
+
       if application_choice.different_offer?
         rows << [
           { key: 'Course candidate applied for', value: render(CourseOptionDetailsComponent.new(course_option: application_choice.course_option)) },

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -33,7 +33,6 @@ module SupportInterface
         end
       end
 
-      rows << { key: 'Feedback', value: application_choice.rejection_reason } if application_choice.rejection_reason.present?
       rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at
       rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at && application_choice.awaiting_provider_decision?
       rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at && application_choice.offer?

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -37,4 +37,21 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     expect(result.text).to include('Rejection reason')
     expect(result.text).to include(application_choice.rejection_reason)
   end
+
+  it 'displays offer date and DBD date for offered applications' do
+    application_choice = create(
+      :application_choice,
+      :with_offer,
+      offered_at: Time.zone.local(2020, 1, 1, 10),
+      decline_by_default_at: Time.zone.local(2020, 1, 10, 10),
+    )
+
+    result = render_inline(described_class.new(application_choice))
+
+    expect(result.text).to include('Offer made at')
+    expect(result.text).to include('1 January 2020 at 10:00am')
+
+    expect(result.text).to include('Decline by default at')
+    expect(result.text).to include('10 January 2020 at 10:00am')
+  end
 end

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'See application history', with_audited: true do
   include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+  include CourseOptionHelpers
 
   around do |example|
     Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
@@ -27,6 +29,7 @@ RSpec.feature 'See application history', with_audited: true do
 
   def and_there_is_an_application_in_the_system_logged_by_a_candidate
     candidate = create :candidate, email_address: 'alice@example.com'
+    @provider = create(:provider)
 
     Audited.audit_class.as_user(candidate) do
       application_form = create(
@@ -38,8 +41,9 @@ RSpec.feature 'See application history', with_audited: true do
       Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 1)) do
         @application_choice = create(
           :application_choice,
+          :awaiting_provider_decision,
           application_form: application_form,
-          status: 'awaiting_provider_decision',
+          course_option: course_option_for_provider(provider: @provider),
         )
       end
     end
@@ -47,20 +51,22 @@ RSpec.feature 'See application history', with_audited: true do
 
   def and_a_vendor_updates_the_application_status
     vendor_api_user = create :vendor_api_user, email_address: 'bob@example.com'
+    vendor_api_user.vendor_api_token.update(provider_id: @provider.id)
 
     Timecop.freeze(Time.zone.local(2019, 10, 2, 12, 0, 0)) do
       Audited.audit_class.as_user(vendor_api_user) do
-        @application_choice.update(status: 'rejected')
+        RejectApplication.new(actor: vendor_api_user, application_choice: @application_choice, rejection_reason: 'BAD BAD BAD!').save
       end
     end
   end
 
   def and_a_provider_updates_the_application_status
-    provider_user = create :provider_user, email_address: 'derek@example.com'
+    provider_user = create :provider_user, email_address: 'derek@example.com', dfe_sign_in_uid: '123', providers: [@provider]
+    permit_make_decisions!(dfe_sign_in_uid: '123')
 
     Timecop.freeze(Time.zone.local(2019, 10, 3, 9, 0, 0)) do
       Audited.audit_class.as_user(provider_user) do
-        @application_choice.update(status: 'offer')
+        MakeAnOffer.new(actor: provider_user, application_choice: @application_choice, course_option: @application_choice.course_option).save
       end
     end
   end
@@ -78,28 +84,28 @@ RSpec.feature 'See application history', with_audited: true do
   end
 
   def then_i_should_be_able_to_see_history_events
-    within('tbody tr:eq(1)') do
+    within('tbody tr:eq(2)') do
       expect(page).to have_content '3 October 2019'
       expect(page).to have_content '09:00'
       expect(page).to have_content 'Update Application Choice'
       expect(page).to have_content 'derek@example.com (Provider user)'
       expect(page).to have_content 'status rejected → offer'
     end
-    within('tbody tr:eq(2)') do
+    within('tbody tr:eq(4)') do
       expect(page).to have_content '2 October 2019'
       expect(page).to have_content '12:00'
       expect(page).to have_content 'Update Application Choice'
       expect(page).to have_content 'bob@example.com (Vendor API)'
       expect(page).to have_content 'status awaiting_provider_decision → rejected'
     end
-    within('tbody tr:eq(3)') do
+    within('tbody tr:eq(5)') do
       expect(page).to have_content '1 October 2019'
       expect(page).to have_content '12:00'
       expect(page).to have_content 'Create Application Choice'
       expect(page).to have_content 'alice@example.com (Candidate)'
       expect(page).to have_content 'status awaiting_provider_decision'
     end
-    within('tbody tr:eq(4)') do
+    within('tbody tr:eq(6)') do
       expect(page).to have_content '1 October 2019'
       expect(page).to have_content '12:00'
       expect(page).to have_content 'Create Application Form'


### PR DESCRIPTION
## Context

These dates are useful but missing in support.

## Changes proposed in this pull request

<img width="1000" alt="Screenshot 2021-01-19 at 20 58 38" src="https://user-images.githubusercontent.com/642279/105092444-27d99880-5a99-11eb-9f4e-1a0c5034b431.png">

Also fix a bug where we rendered unstructured reasons for rejection twice.

## Guidance to review

Should be straightforward 🤞 