### PR TITLE
Fix state-mixing bug in "Other qualifications" section

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -9,20 +9,12 @@ module CandidateInterface
 
   private
 
-    def reset_intermediate_state!
-      intermediate_data_service.clear_state!
-    end
-
     def intermediate_data_service
       @intermediate_data_service ||= IntermediateDataService.new(
         WizardStateStores::RedisStore.new(
-          key: persistence_key_for_current_user,
+          key: "candidate_user_other_qualification_flow-#{current_candidate.id}-#{params[:id] || 'new'}",
         ),
       )
-    end
-
-    def persistence_key_for_current_user
-      "candidate_user_other_qualification_flow-#{current_candidate.id}"
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -3,10 +3,6 @@ module CandidateInterface
     def show
       redirect_to candidate_interface_other_qualification_type_path and return if current_application.application_qualifications.other.blank?
 
-      # This to ensure that old state is not merged accidentally when
-      # the user goes on to edit a qualification
-      intermediate_data_service.clear_state!
-
       @application_form = current_application
     end
 
@@ -36,14 +32,6 @@ module CandidateInterface
 
     def section_marked_as_complete?
       application_form_params[:other_qualifications_completed] == 'true'
-    end
-
-    def intermediate_data_service
-      IntermediateDataService.new(
-        WizardStateStores::RedisStore.new(
-          key: persistence_key_for_current_user,
-        ),
-      )
     end
   end
 end

--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -59,7 +59,10 @@ module CandidateInterface
       @intermediate_data_service.write(intermediate_state)
     end
 
-    def save!
+    def save
+      save_intermediate!
+      return unless valid?
+
       @next_step = :check
 
       application_qualification = current_qualification ||
@@ -68,7 +71,7 @@ module CandidateInterface
         )
 
       application_qualification.assign_attributes(attributes_for_persistence)
-      application_qualification.save!
+      application_qualification.save
     end
 
     def initialize_from_last_qualification(qualifications)
@@ -104,11 +107,6 @@ module CandidateInterface
     PERSISTENT_ATTRIBUTES = %w[qualification_type other_uk_qualification_type non_uk_qualification_type subject predicted_grade grade award_year institution_country].freeze
     def persistent_attributes(application_qualification)
       application_qualification.attributes.select { |key, _| PERSISTENT_ATTRIBUTES.include?(key) }
-    end
-
-    def missing_type_validation_error?
-      valid?
-      errors.details[:qualification_type].any? { |e| e[:error] == :blank }
     end
 
     def grade_hint

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -42,9 +42,14 @@ module CandidateInterface
       super(options)
     end
 
+    def save_intermediate
+      valid? && save_intermediate!
+    end
+
     def save_intermediate!
       @intermediate_data_service.write(intermediate_state)
       @next_step = editing && !qualification_type_changed? ? :check : :details
+      true
     end
 
     def save!

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -377,27 +377,6 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     end
   end
 
-  describe '#missing_type_validation_error?' do
-    it 'returns true if `qualification_type` is missing' do
-      qualification = CandidateInterface::OtherQualificationDetailsForm.new(
-        nil,
-        nil,
-        current_step: :details,
-      )
-      expect(qualification.missing_type_validation_error?).to be true
-    end
-
-    it 'returns false if `qualification_type` is missing' do
-      qualification = CandidateInterface::OtherQualificationDetailsForm.new(
-        nil,
-        nil,
-        current_step: :details,
-        qualification_type: 'A level',
-      )
-      expect(qualification.missing_type_validation_error?).to be false
-    end
-  end
-
   describe '#grade_hint' do
     it 'returns a GCSE hint if qualification_type is GCSE_TYPE' do
       qualification = described_class.new(

--- a/spec/services/candidate_interface/intermediate_data_service_spec.rb
+++ b/spec/services/candidate_interface/intermediate_data_service_spec.rb
@@ -33,12 +33,4 @@ RSpec.describe CandidateInterface::IntermediateDataService do
       expect(service.read).to eq({ 'key1' => 'one', 'key2' => 'two', 'key3' => 'THREE', 'key4' => 'FOUR' })
     end
   end
-
-  describe '#clear_state!' do
-    it 'removes all existing data' do
-      service = create_service
-      service.clear_state!
-      expect(service.read).to eq({})
-    end
-  end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Entering their other qualifications' do
   include CandidateHelper
 
-  scenario 'Candidate submits their other qualifications with the prompt_for_additional_qualifications on' do
+  scenario 'Candidate submits their other qualifications' do
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -15,23 +15,19 @@ RSpec.feature 'Entering their other qualifications' do
     then_i_see_the_qualification_type_error
 
     when_i_select_add_a_level_qualification
-    and_i_click_continue
     then_i_see_the_other_qualifications_form
     and_the_suggested_subject_data_matches_the_as_and_a_level_subjects_data
 
-    when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
-    and_i_submit_the_other_qualification_form
+    when_i_submit_in_some_of_my_qualification_but_omit_some_required_details
     then_i_see_validation_errors_for_my_qualification
 
-    when_i_fill_in_my_qualification
-    and_select_add_another_a_level
-    and_click_save_and_continue
+    when_i_fill_in_my_qualification_details
+    and_i_choose_to_add_another_a_level_qualification
     then_i_see_the_other_qualifications_form
     and_the_year_field_is_pre_populated_with_my_previous_details
 
     when_i_fill_out_the_remainder_of_the_form
     and_i_choose_a_different_type_of_qualification
-    and_click_save_and_continue
     then_i_see_the_select_qualification_type_page
 
     when_i_choose_other
@@ -45,14 +41,9 @@ RSpec.feature 'Entering their other qualifications' do
     and_i_should_see_my_qualifications
     and_my_other_uk_qualification_has_the_correct_format
 
-    when_i_click_the_back_button
-    and_update_the_subject
-    and_click_save_and_continue
-    then_i_should_see_the_review_page_with_a_flash_warning
-
     when_i_select_add_another_qualification
     and_choose_as_level
-    and_i_click_continue
+    then_the_form_is_empty
     and_i_visit_the_other_qualification_review_page
     then_i_should_not_see_an_incomplete_as_level_qualification
 
@@ -68,12 +59,10 @@ RSpec.feature 'Entering their other qualifications' do
     and_no_changes_have_occured
 
     when_i_click_to_change_my_first_qualification
-    then_i_see_the_qualification_type_form
-
     when_i_change_the_qualification_type_to_gcse
     and_i_click_continue
     then_i_see_my_qualification_details_filled_in
-    and_the_suggested_subject_data_matches_the_gcse_subjects_data
+    and_the_suggested_subject_data_matches_the_gcse_subjects_data # move out?
 
     when_i_change_my_qualification
     and_click_save_and_continue
@@ -93,11 +82,9 @@ RSpec.feature 'Entering their other qualifications' do
 
     when_i_delete_my_incomplete_qualification
     and_i_confirm_that_i_want_to_delete_my_additional_qualification
-    then_i_can_only_see_two_updated_qualifications
 
     when_i_mark_this_section_as_completed
     and_i_click_on_continue
-    then_i_should_see_the_form
     and_that_the_section_is_completed
 
     when_i_click_on_other_qualifications
@@ -105,7 +92,6 @@ RSpec.feature 'Entering their other qualifications' do
     then_i_see_the_select_qualification_type_page
 
     when_i_click_back_to_application_form
-    then_i_should_see_the_form
     and_that_the_section_is_not_marked_as_complete_or_incomplete
   end
 
@@ -127,6 +113,7 @@ RSpec.feature 'Entering their other qualifications' do
 
   def when_i_select_add_a_level_qualification
     choose 'A level'
+    click_button t('continue')
   end
 
   def and_i_click_continue
@@ -144,11 +131,8 @@ RSpec.feature 'Entering their other qualifications' do
     expect(JSON[suggested_subjects]).to eq A_AND_AS_LEVEL_SUBJECTS
   end
 
-  def when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
+  def when_i_submit_in_some_of_my_qualification_but_omit_some_required_details
     fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
-  end
-
-  def and_i_submit_the_other_qualification_form
     click_button t('save_and_continue')
   end
 
@@ -156,14 +140,15 @@ RSpec.feature 'Entering their other qualifications' do
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/other_qualification_details_form.attributes.award_year.blank')
   end
 
-  def when_i_fill_in_my_qualification
+  def when_i_fill_in_my_qualification_details
     fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
     fill_in t('application_form.other_qualification.grade.label'), with: 'A'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
   end
 
-  def and_select_add_another_a_level
+  def and_i_choose_to_add_another_a_level_qualification
     choose 'Yes, add another A level'
+    click_button t('save_and_continue')
   end
 
   def and_click_save_and_continue
@@ -172,6 +157,9 @@ RSpec.feature 'Entering their other qualifications' do
 
   def and_the_year_field_is_pre_populated_with_my_previous_details
     expect(page.find('#candidate-interface-other-qualification-details-form-award-year-field').value).to eq('2015')
+
+    # Test that the wizard data is cleared when starting a new qualification
+    expect(page.find('#candidate-interface-other-qualification-details-form-grade-field').value).to eq(nil)
   end
 
   def when_i_fill_out_the_remainder_of_the_form
@@ -181,6 +169,7 @@ RSpec.feature 'Entering their other qualifications' do
 
   def and_i_choose_a_different_type_of_qualification
     choose 'Yes, add a different qualification'
+    click_button t('save_and_continue')
   end
 
   def when_i_choose_other
@@ -241,6 +230,13 @@ RSpec.feature 'Entering their other qualifications' do
 
   def and_choose_as_level
     choose 'AS level'
+    and_i_click_continue
+  end
+
+  def then_the_form_is_empty
+    # Fix for bug that caused data to be persisted between qualifications
+    expect(page.find('#candidate-interface-other-qualification-details-form-grade-field').value).to eq(nil)
+    expect(page.find('#candidate-interface-other-qualification-details-form-award-year-field').value).to eq(nil)
   end
 
   def and_i_visit_the_other_qualification_review_page
@@ -345,13 +341,6 @@ RSpec.feature 'Entering their other qualifications' do
     within(all('.app-summary-card')[2]) do
       click_link(t('application_form.other_qualification.delete'))
     end
-  end
-
-  def then_i_can_only_see_two_updated_qualifications
-    expect(page).not_to have_content 'A level Losing to Yugi'
-    expect(page).not_to have_content('AS level')
-    expect(page).to have_content('GCSE How to Win Against Kaiba')
-    expect(page).to have_content('Access Course History, English and Psychology')
   end
 
   def then_i_should_see_the_form


### PR DESCRIPTION
## Context

The "Other qualifications" section uses our wizardry functionality. This means that we have multiple pages with forms, and save the candidate input into an "intermediate data service" first. Once the candidate is finished with all the pages we persist the data to the database. This allows us to ask the user for less information per page but avoid invalid and inconsistent data in the database.

The initial implementation of this feature saved the data provided by the user into a singular Redis field
(`candidate_user_other_qualification_flow-#{current_candidate.id}`). This means that every time we load a qualification form page, we have to clear the state to make sure that if we visit a different form page the wrong data isn't displayed. This is very hard to do, and we currently are seeing the following bug:

- Create a application with 2 "Other Qualifications"
- Click on "Change" for the first qualification
- Use the back button in your browser
- Click on "Change" for the second qualification
- The form is erroneously populated with the data for the first qualification, not the second

![](https://trello-attachments.s3.amazonaws.com/5cb88ec4be601441218204a0/5fd0d97da89d3142b1b80101/acc464b10bbbf1a7ad8c72227cb61885/back_button_state_nightmare.gif)

Previously we fixed this issue by adding more state clearing: https://github.com/DFE-Digital/apply-for-teacher-training/pull/3613.

## Changes proposed in this pull request

This PR changes the approach, to avoid the state clearing in most cases (this is proof of the lesson is that cache invalidation is hard so best avoided). By using key per record, it's not possible to share data between the forms.

The only place where we need to explicitly clear the state is when the candidate visits the "Add other qualification" page (the one that lets you choose the type). Without the reset, the second time a candidate clicks the "Add" button they'll see the data they've entered the first time. I've considered avoiding this by generating an ID every time you visit the page, persisting this in the session, and using this as the key suffix instead of "new". I suspect that's more trouble than it's
worth though.

## Guidance to review

- What to do with the [code added to fail gracefully when clicking "back"](https://github.com/DFE-Digital/apply-for-teacher-training/commit/36980444ec15e4d51c330095fbe2e85fe08e972e)? This doesn't fail in the same way anymore, because we haven't cleared the state. The specs are now commented out. @stevehook 
- Have I missed anything in the flow that would make this not work? Does not clearing state break anything?
- Where in the spec should I test for this? The file [already has 100 lines of steps](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_spec.rb).

## Link to Trello card

https://trello.com/c/P5pagu0l

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
