### PR TITLE
Update Get Into Teaching links

### DIFF
--- a/app/components/personal_statement_component.html.erb
+++ b/app/components/personal_statement_component.html.erb
@@ -9,7 +9,7 @@
     <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
     <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
     <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
-    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <a href="https://getintoteaching.education.gov.uk/" class="govuk-body">Get into Teaching</a> for help from a teacher training adviser.</p>
+    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <a href="https://beta-getintoteaching.education.gov.uk/" class="govuk-body">Get into Teaching</a> for help from a teacher training adviser.</p>
     <p class="govuk-body govuk-!-font-weight-bold">Suggested topics to cover include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>why you want to be a teacher</li>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -17,7 +17,7 @@
     </ul>
     <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work" class="govuk-link">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
     <h4 class="govuk-heading-s">It’s against the law to discriminate</h4>
-    <p class="govuk-body">If you’re disabled, <a href="/getintoteaching/train-to-teach-with-a-disability" class="govuk-link">it’s against the law to discriminate against you</a>. Training providers must not:</p>
+    <p class="govuk-body">If you’re disabled, <a href="https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability" class="govuk-link">it’s against the law to discriminate against you</a>. Training providers must not:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
       <li>reject your application because you’re disabled</li>

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -9,7 +9,7 @@
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
       <%= t('page_titles.apply_from_find') %>
     </h1>
-    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit Get Into Teaching for <a class="govuk-link" target="_blank" href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training">guidance on applying for teacher training</a>.</p>
+    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit Get Into Teaching for <a class="govuk-link" target="_blank" href="https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5">guidance on applying for teacher training</a>.</p>
 
     <p class="govuk-body">When you apply you’ll need these codes for the Choices section of your application form:</p>
 

--- a/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
@@ -18,7 +18,9 @@
       <li>still submit your current application to other providers</li>
     </ul>
 
-    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training' %></p>
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5' %>
+    </p>
 
     <p class="govuk-body govuk-!-margin-bottom-0">
       <%= govuk_button_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %>

--- a/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
@@ -18,7 +18,7 @@
       <li>still submit your current application with other course choices</li>
     </ul>
 
-    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training' %></p>
+    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5' %></p>
 
     <h2 class=govuk-heading-m>Make a note of your choice</h2>
     <p class="govuk-body">When you apply through UCAS, you’ll need these details for the course choices section of your application:</p>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -22,7 +22,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>you can only accept one offer, across both Apply for teacher training and UCAS teacher training</li>
         <li>if you fail to respond, or you decline all your offers, you can still apply to other courses this year through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %></li>
-        <li>you can register with <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk' %> to get help from a teacher training advisor</li>
+        <li>you can register with <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk' %> to get help from a teacher training advisor</li>
       </ul>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -26,7 +26,7 @@
           <% elsif option.id == :missing %>
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
               <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
-              <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/get-help-and-support/' %>.</p>
+              <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %>.</p>
               <%= f.govuk_text_area :missing_explanation, label: { text: t('application_form.gcse.missing_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
               <% end %>
             <% end %>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -7,14 +7,14 @@
 
   <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
     <div class="govuk-body">
-      Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
-      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+      Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
+      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
     </div>
   <% end %>
   <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
     <div class="govuk-body">
-      Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
-      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+      Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
+      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
     </div>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/personal_statement/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/edit.html.erb
@@ -19,7 +19,7 @@
         <li>any past experience working with children or young people, and what you learnt</li>
         <li>your thoughts on welfare and education</li>
       </ul>
-      <p class="govuk-body">If you need help, <%= govuk_link_to 'register with Get Into Teaching to talk to a teacher training adviser', 'https://register.getintoteaching.education.gov.uk/Register' %>.</p>
+      <p class="govuk-body">If you need help, <%= govuk_link_to 'register with Get Into Teaching to talk to a teacher training adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %>.</p>
 
       <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -20,7 +20,7 @@
       </ul>
       <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <%= govuk_link_to 'Access to Work', 'https://www.gov.uk/access-to-work' %>. This could include a grant to help cover the costs of practical support in the workplace.</p>
       <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
-      <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>. Training providers must not:</p>
+      <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability' %>. Training providers must not:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
         <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
         <li>reject your application because you’re disabled</li>

--- a/app/views/candidate_mailer/_get_help.text.erb
+++ b/app/views/candidate_mailer/_get_help.text.erb
@@ -2,6 +2,6 @@
 
 For advice on becoming a teacher, call Get Into Teaching for free on 0800 389 2500 or chat to an adviser online:
 
-https://getintoteaching.education.gov.uk/contact
+https://beta-getintoteaching.education.gov.uk/#talk-to-us
 
 For any technical issues using Apply for teacher training, contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/apply_again_call_to_action.text.erb
+++ b/app/views/candidate_mailer/apply_again_call_to_action.text.erb
@@ -18,6 +18,6 @@ Sign in to apply again:
 
 Call Get Into Teaching for free on 0800 389 2500 or chat to an adviser online:
 
-https://getintoteaching.education.gov.uk/contact
+https://beta-getintoteaching.education.gov.uk/#talk-to-us
 
 For any technical issues using Apply for teacher training, contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/find_another_course.text.erb
+++ b/app/views/candidate_mailer/find_another_course.text.erb
@@ -20,4 +20,4 @@ As soon as your references come in, your application will be sent for considerat
 
 # Get help from a teacher training adviser
 
-You can talk to a teacher training adviser on the phone or online: https://register.getintoteaching.education.gov.uk/register
+You can talk to a teacher training adviser on the phone or online: https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher

--- a/app/views/candidate_mailer/ucas_match_reminder_email_multiple_acceptances.text.erb
+++ b/app/views/candidate_mailer/ucas_match_reminder_email_multiple_acceptances.text.erb
@@ -4,7 +4,7 @@ It looks like you accepted offers on both Apply for teacher training and UCAS Te
 
 Further to our email on <%= @initial_email_date %>, you need to withdraw the choice from one of the systems by <%= @request_ucas_withdrawal_date %>. Accepting offers on both services is not allowed, as outlined by the terms of use.
 
-For advice on choosing the right course for you, [talk to a teacher training adviser](https://register.getintoteaching.education.gov.uk/register?gclid=Cj0KCQjwoJX8BRCZARIsAEWBFMKTN_IOJaoNoGkn16TZ-4udi-dX6GTfxDPNVAafEX5ZrPh1_m3lpbQaAhDsEALw_wcB&gclsrc=aw.ds).
+For advice on choosing the right course for you, [talk to a teacher training adviser](https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher?gclid=Cj0KCQjwoJX8BRCZARIsAEWBFMKTN_IOJaoNoGkn16TZ-4udi-dX6GTfxDPNVAafEX5ZrPh1_m3lpbQaAhDsEALw_wcB&gclsrc=aw.ds).
 
 If you think we made a mistake or have any questions, If you have any questions, get in touch with us by contacting  [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 

--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -23,11 +23,11 @@ If you apply for a course or accept an offer on both, we’ll get in touch with 
 
 You can apply for another course at this stage if you do not get an offer or if you choose not to accept your offers.
 
-[Get Into Teaching](https://getintoteaching.education.gov.uk/get-help-and-support) can guide you through the process of applying for more courses. Contact them for free on 0800 389 2500, or [chat to an adviser using the online chat service](https://getintoteaching.education.gov.uk/lp/live-chat).
- 
+[Get Into Teaching](https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher) can guide you through the process of applying for more courses. Contact them for free on 0800 389 2500, or [chat to an adviser using the online chat service](https://beta-getintoteaching.education.gov.uk/#talk-to-us).
+
 ### Making changes to your application
 
-Contact us at <becomingateacher@digital.education.gov.uk> if you need to make changes. We only have 5 working days to make changes for you. 
+Contact us at <becomingateacher@digital.education.gov.uk> if you need to make changes. We only have 5 working days to make changes for you.
 
 Once we’ve processed your request, we will not be able to make any more changes.
 

--- a/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
+++ b/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
@@ -12,18 +12,18 @@
         <% end %>
         <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
           <p class="govuk-body">
-            Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+            Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
           </p>
           <p class="govuk-body">
-            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
           </p>
         <% end %>
         <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
           <p class="govuk-body">
-            Visit <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates' %> for guidance on immigration.
+            Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
           </p>
           <p class="govuk-body">
-            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://register.getintoteaching.education.gov.uk/register' %> if you need help.
+            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
           </p>
         <% end %>
       <% end %>


### PR DESCRIPTION


## Context
We need to direct candidates to the new GiT beta site.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
Replace the various GiT links in the codebase with their equivalents on
the new beta site.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Review diff, check replacements make sense
- Test a few of the new links out

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/mn60V44A
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
