### PR TITLE
Update UCAS matches emails content

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -303,12 +303,11 @@ class CandidateMailer < ApplicationMailer
   def ucas_match_reminder_email_duplicate_applications(application_choice, ucas_match)
     @course_name_and_code = application_choice.course_option.course.name_and_code
     @provider_name = application_choice.course_option.course.provider.name
-    @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
-    @request_ucas_withdrawal_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
+    @withdraw_by_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
 
     email_for_candidate(
       application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.ucas_match_reminder_email.duplicate_applications.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.duplicate_applications.subject', withdraw_by_date: @withdraw_by_date),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -296,7 +296,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       candidate.current_application,
-      subject: I18n.t!('candidate_mailer.ucas_match_initial_email.multiple_acceptances.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
     )
   end
 
@@ -317,7 +317,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       ucas_match.candidate.current_application,
-      subject: I18n.t!('candidate_mailer.ucas_match_reminder_email.multiple_acceptances.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -283,11 +283,11 @@ class CandidateMailer < ApplicationMailer
   def ucas_match_initial_email_duplicate_applications(application_choice)
     @course_name_and_code = application_choice.course_option.course.name_and_code
     @provider_name = application_choice.course_option.course.provider.name
-    @date_to_withdraw_application_by = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
+    @withdraw_by_date = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
 
     email_for_candidate(
       application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.ucas_match_initial_email.duplicate_applications.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.duplicate_applications.subject', withdraw_by_date: @withdraw_by_date),
     )
   end
 

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -95,11 +95,14 @@ class ProviderMailer < ApplicationMailer
 
   def ucas_match_initial_email_duplicate_applications(provider_user, application_choice)
     @application_form = application_choice.application_form
+    @course_name_and_code = application_choice.course_option.course.name_and_code
+    @provider_name = application_choice.course_option.course.provider.name
+    @withdraw_by_date = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
 
     email_for_provider(
       provider_user,
       @application_form,
-      subject: I18n.t!('provider_mailer.ucas_match.initial_email.duplicate_applications.subject', candidate_name: application_choice.application_form.full_name),
+      subject: I18n.t!('provider_mailer.ucas_match.initial_email.duplicate_applications.subject'),
     )
   end
 

--- a/app/views/candidate_mailer/ucas_match_initial_email_duplicate_applications.text.erb
+++ b/app/views/candidate_mailer/ucas_match_initial_email_duplicate_applications.text.erb
@@ -1,22 +1,21 @@
 Dear <%= @application_form.full_name %>
 
-It looks like you submitted an application for <%= @course_name_and_code %> at <%= @provider_name %> on both DfE Apply for teacher training and UCAS Teacher Training Apply.
+You applied to study <%= @course_name_and_code %> at <%= @provider_name %> through both GOV.UK and UCAS.
 
-This has been flagged to us, as well as to <%= @provider_name %>, as applying for the same course on both services is not allowed, as outlined by the terms of use.
+You can only continue with your application through one of the services.
 
-# Action required – withdraw your duplicate application
+# Withdraw one of your applications
 
-To ensure your application progresses effectively, you need to withdraw the course choice from either DfE Apply for teacher training or UCAS Teacher Training by <%= @date_to_withdraw_application_by %>.
+You need to withdraw your application from one of the services by <%= @withdraw_by_date %>.
 
-It’s up to you which system you choose to progress the choice on. If you have additional UCAS Teacher Training choices, you may want to keep the choice on UCAS Teacher Training, so all your choices are in one place.
+GOV.UK: [https://www.apply-for-teacher-training.service.gov.uk](https://www.apply-for-teacher-training.service.gov.uk)
 
-# What happens if you don’t do anything?
+UCAS: [https://teachertraining.track.ucas.com/track/Login.jsp](https://teachertraining.track.ucas.com/track/Login.jsp)
 
-If you don’t withdraw your duplicate choice by <%= @date_to_withdraw_application_by %> (in 10 working days), we will withdraw the choice from your UCAS Teacher Training application – meaning you’ll use DfE Apply for teacher training to progress this choice.
+# If you do not withdraw an application
 
-If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+We’ll withdraw your UCAS application if you do not withdraw an application by <%= @withdraw_by_date %>.
 
+You’ll then need to continue your application on GOV.UK.
 
-Sincerely,
-
-The Department for Education & UCAS
+<%= render 'get_support' %>

--- a/app/views/candidate_mailer/ucas_match_reminder_email_duplicate_applications.text.erb
+++ b/app/views/candidate_mailer/ucas_match_reminder_email_duplicate_applications.text.erb
@@ -1,19 +1,21 @@
 Dear <%= @application_form.full_name %>
 
-Further to our email on <%= @initial_email_date %>, we’ve noticed you’ve applied to study <%= @course_name_and_code %> at <%= @provider_name %> on both DfE Apply for teacher training and UCAS Teacher Training Apply – which isn’t allowed.
+You need to withdraw one of your duplicate applications for teacher training.
 
-# What you need to do
+You applied to study <%= @course_name_and_code %> at <%= @provider_name %> through both GOV.UK and UCAS. You can only continue through one of the services.
 
-You need to withdraw the choice from one of the systems to ensure you’re not applying twice.
+# Withdraw one of your applications
 
-It’s up to you which system you choose to progress the choice on. If you have additional UCAS Teacher Training choices, you may want to keep the choice on UCAS Teacher Training Track, so all your choices are in one place.
+You need to withdraw your application from one of the services by <%= @withdraw_by_date %>.
 
-# What happens if you don’t do anything?
+GOV.UK: https://www.apply-for-teacher-training.service.gov.uk
 
-If you don’t withdraw your duplicate choice by <%= @request_ucas_withdrawal_date %> (5 working days), we will withdraw the choice from your UCAS Teacher Training application – meaning you’ll use DfE Apply for teacher training to progress this choice.
+UCAS: https://teachertraining.track.ucas.com/track/Login.jsp
 
-If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+# If you do not withdraw an application
 
-Sincerely,
+We’ll withdraw your UCAS application if you do not withdraw an application by <%= @withdraw_by_date %>.
 
-The Department for Education & UCAS
+You’ll then need to continue your application on GOV.UK.
+
+<%= render 'get_support' %>

--- a/app/views/provider_mailer/_get_support_no_action.text.erb
+++ b/app/views/provider_mailer/_get_support_no_action.text.erb
@@ -1,0 +1,3 @@
+# Get support
+
+You do not need to contact us about this, but if you have any questions you can get in touch with us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/app/views/provider_mailer/_get_support_no_action.text.erb
+++ b/app/views/provider_mailer/_get_support_no_action.text.erb
@@ -1,3 +1,0 @@
-# Get support
-
-You do not need to contact us about this, but if you have any questions you can get in touch with us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/app/views/provider_mailer/ucas_match_initial_email_duplicate_applications.text.erb
+++ b/app/views/provider_mailer/ucas_match_initial_email_duplicate_applications.text.erb
@@ -15,5 +15,3 @@ We’ve told them that their UCAS application will be automatically withdrawn if
 We’ll send you an email once the duplicate application has been withdrawn. We’ll tell you which service it has been withdrawn from.
 
 You can review the candidate’s application in the meantime.
-
-<%= render 'get_support_no_action' %>

--- a/app/views/provider_mailer/ucas_match_initial_email_duplicate_applications.text.erb
+++ b/app/views/provider_mailer/ucas_match_initial_email_duplicate_applications.text.erb
@@ -1,20 +1,19 @@
 Dear <%= @provider_user_name %>
 
-<%= @application_form.full_name %> has applied to <%= @course_name_and_code %> on both DfE Apply for teacher training and UCAS Teacher Training Apply.
+<%= @application_form.full_name %> has applied to study <%= @course_name_and_code %> at <%= @provider_name %> through both DfE Apply for teacher training and UCAS Teacher Training Apply.
 
-We’re letting you know so you recognise this is a duplicate and you do not process this application twice.
+We’re letting you know so that you do not process their application twice.
 
-# Next steps
+# What we’ve done
 
-We’ve contacted the candidate and asked them to withdraw their application from one of the services within 10 working days. If they have not acted within 10 working days, their course choice will be deleted from their UCAS application.
+We’ve contacted the candidate and asked them to withdraw their application from one of the services by <%= @withdraw_by_date %>.
 
-In the meantime, you can review the candidate’s application.
+We’ve told them that their UCAS application will be automatically withdrawn if they do not withdraw from one of the services.
 
-We’ll send you an email once the duplicate application has been deleted.
+# What will happen next
 
+We’ll send you an email once the duplicate application has been withdrawn. We’ll tell you which service it has been withdrawn from.
 
-You do not have to do anything, but if you have any questions you can get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
+You can review the candidate’s application in the meantime.
 
-Sincerely,
-
-The Department for Education & UCAS
+<%= render 'get_support_no_action' %>

--- a/app/views/provider_mailer/ucas_match_resolved_on_apply_email.text.erb
+++ b/app/views/provider_mailer/ucas_match_resolved_on_apply_email.text.erb
@@ -4,8 +4,6 @@ Dear <%= @provider_user_name %>
 
 We’ve let the candidate know that they can continue their application for the course through UCAS Teacher Training.
 
-You do not have to do anything, but if you have any questions you can get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
-
 Sincerely,
 
 The Department for Education & UCAS

--- a/app/views/provider_mailer/ucas_match_resolved_on_ucas_email.text.erb
+++ b/app/views/provider_mailer/ucas_match_resolved_on_ucas_email.text.erb
@@ -4,8 +4,6 @@ Dear <%= @provider_user_name %>
 
 We’ve let the candidate know that they can continue their application for the course through Apply for teacher training.
 
-You do not have to do anything, but if you have any questions you can get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
-
 Sincerely,
 
 The Department for Education & UCAS

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -90,15 +90,11 @@ en:
         course_full: "%{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"
         location_full: "%{course_name} at %{provider_name} became full at %{location} while %{candidate_name} was awaiting references"
         study_mode_full: "%{study_mode} places for %{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"
-    ucas_match_initial_email:
-      multiple_acceptances:
-        subject: 'Action required: it looks like you’ve accepted two offers'
-    ucas_match_reminder_email:
-      multiple_acceptances:
-        subject: 'Action required: please withdraw one of your acceptances'
     ucas_match:
       duplicate_applications:
         subject: "Withdraw your duplicate application by %{withdraw_by_date}"
+      multiple_acceptances:
+        subject: "Withdraw from one of your offers by %{withdraw_by_date}"
       resolved_on_ucas:
         subject: Your application has been deleted from UTT
       resolved_on_apply:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -94,11 +94,11 @@ en:
       multiple_acceptances:
         subject: 'Action required: it looks like you’ve accepted two offers'
     ucas_match_reminder_email:
-      duplicate_applications:
-        subject: 'Action required: please withdraw one of your duplicate applications'
       multiple_acceptances:
         subject: 'Action required: please withdraw one of your acceptances'
     ucas_match:
+      duplicate_applications:
+        subject: "Withdraw your duplicate application by %{withdraw_by_date}"
       resolved_on_ucas:
         subject: Your application has been deleted from UTT
       resolved_on_apply:

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -91,8 +91,6 @@ en:
         location_full: "%{course_name} at %{provider_name} became full at %{location} while %{candidate_name} was awaiting references"
         study_mode_full: "%{study_mode} places for %{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"
     ucas_match_initial_email:
-      duplicate_applications:
-        subject: 'Action required: it looks like you submitted a duplicate application'
       multiple_acceptances:
         subject: 'Action required: it looks like you’ve accepted two offers'
     ucas_match_reminder_email:

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -21,7 +21,7 @@ en:
     ucas_match:
       initial_email:
         duplicate_applications:
-          subject: "%{candidate_name} applied for your course twice"
+          subject: "Duplicate application identified"
       resolved_on_ucas:
         subject: Duplicate applicant removed from UTT
       resolved_on_apply:

--- a/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match_initial_email.multiple_acceptances.subject'),
+      I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
       'heading' => 'Dear Jane',
       'withdrawal day' => '1 February 2021',
     )

--- a/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match_initial_email.duplicate_applications.subject'),
+      I18n.t!('candidate_mailer.ucas_match.duplicate_applications.subject', withdraw_by_date: '1 February 2021'),
       'heading' => 'Dear Jane',
       'course' => 'Physics (3PH5)',
       'provider' => 'Coventry University',
-      'withdrawal day' => '1 February 2021 (in 10 working days)',
+      'withdraw by date' => '1 February 2021',
     )
   end
 

--- a/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
@@ -21,12 +21,11 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match_reminder_email.duplicate_applications.subject'),
+      I18n.t!('candidate_mailer.ucas_match.duplicate_applications.subject', withdraw_by_date: '30 November 2020'),
       'heading' => 'Dear Jane',
       'course name and code' => 'Physics (3PH5)',
       'provider' => 'City University',
-      'initial email date' => '16 November 2020',
-      'withdrawn by date' => '30 November 2020',
+      'withdraw by date' => '30 November 2020',
     )
   end
 

--- a/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match_reminder_email.multiple_acceptances.subject'),
+      I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
       'heading' => 'Dear Jane',
       'initial email date' => '16 November 2020',
-      'withdrawn by date' => '30 November 2020',
+      'withdraw by date' => '30 November 2020',
     )
   end
 end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -158,8 +158,10 @@ RSpec.describe ProviderMailer, type: :mailer do
     let(:email) { ProviderMailer.ucas_match_initial_email_duplicate_applications(provider_user, application_choice) }
 
     it_behaves_like('a mail with subject and content',
-                    'Harry Potter applied for your course twice',
-                    'candidate name' => 'Harry Potter')
+                    'Duplicate application identified',
+                    'candidate name' => 'Harry Potter',
+                    'course name and code' => 'Computer Science (6IND)',
+                    'withdraw by date' => 'February 2021')
   end
 
   describe '.ucas_match_resolved_on_ucas_email' do

--- a/spec/services/ucas_matches/send_ucas_match_emails_spec.rb
+++ b/spec/services/ucas_matches/send_ucas_match_emails_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe UCASMatches::SendUCASMatchEmails, sidekiq: true do
     it 'sends reminder emails for a UCAS match that needs action' do
       reminder_email = email_for_candidate(ucas_match_to_send_remider_emails.candidate)
       expect(reminder_email).to be_present
-      expect(reminder_email.subject).to include 'Action required: please withdraw one of your duplicate applications'
+      expect(reminder_email.subject).to include 'Withdraw your duplicate application by'
     end
 
     it 'records when the reminder emails were sent' do

--- a/spec/services/ucas_matches/send_ucas_match_emails_spec.rb
+++ b/spec/services/ucas_matches/send_ucas_match_emails_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UCASMatches::SendUCASMatchEmails, sidekiq: true do
     it 'sends initial emails for a UCAS match that needs action' do
       initial_email = email_for_candidate(ucas_match_action_needed.candidate)
       expect(initial_email).to be_present
-      expect(initial_email.subject).to include 'Action required: it looks like you submitted a duplicate application'
+      expect(initial_email.subject).to include 'Withdraw your duplicate application by'
     end
 
     it 'records when the initial emails were sent' do

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     course = create(:course, code: 'XYZ', provider: create(:provider, code: 'XX', provider_users: [@provider_user]))
     course_option = create(:course_option, course: course)
     application_choice = create(:submitted_application_choice, course_option: course_option)
-    @not_previously_matched_application_form = create(:completed_application_form, candidate: @not_previously_matched, application_choices: [application_choice])
+    create(:completed_application_form, candidate: @not_previously_matched, application_choices: [application_choice])
   end
 
   def and_there_is_a_previous_match_with_dual_application_we_emailed_about
@@ -127,7 +127,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
     expect(candidate_email.subject).to include 'Withdraw your duplicate application'
 
     provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == @provider_user.email_address }
-    expect(provider_email.subject).to include "#{@not_previously_matched_application_form.full_name} applied for your course twice"
+    expect(provider_email.subject).to include 'Duplicate application identified'
   end
 
   def when_i_visit_the_ucas_matches_page_in_support

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def then_we_have_sent_emails_about_dual_application_to_the_candidate_and_the_provider
     candidate_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == @not_previously_matched.email_address }
-    expect(candidate_email.subject).to include 'Action required: it looks like you submitted a duplicate application'
+    expect(candidate_email.subject).to include 'Withdraw your duplicate application'
 
     provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == @provider_user.email_address }
     expect(provider_email.subject).to include "#{@not_previously_matched_application_form.full_name} applied for your course twice"


### PR DESCRIPTION
## Context

We're building a duplicate matching process with UCAS that advises candidates with duplicate applications to make changes to comply with the business rules:

- Candidates can only accept one offer (whether that's through Apply or UCAS) 
- Candidates can't apply for the same course and provider across both services

We need to improve the content of the emails.

## Changes proposed in this pull request

See commit messages 
[New content](https://docs.google.com/document/d/1Ngp6q3xj69KGQEpUO3zTk2nr3Ju7xndHYdOs9Of5DsU/edit#heading=h.tyjcwt)
<img width="451" alt="Screenshot 2021-01-20 at 15 31 13" src="https://user-images.githubusercontent.com/38078064/105197930-0b8b3980-5b35-11eb-9978-67f40b84d764.png">
<img width="500" alt="Screenshot 2021-01-20 at 15 32 01" src="https://user-images.githubusercontent.com/38078064/105197940-0e862a00-5b35-11eb-8981-bc470544aa75.png">
<img width="451" alt="Screenshot 2021-01-20 at 15 33 54" src="https://user-images.githubusercontent.com/38078064/105197947-10e88400-5b35-11eb-8293-1017b10948a4.png">


## Guidance to review

This is the first part of this work. Next steps need some clarification.
How to deal with the footer for provider emails?

## Link to Trello card

https://trello.com/c/j9YmgCWM/3276-update-ucas-matches-emails-content

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training#azure-hosting-devops-pipeline)
