### PR TITLE
Feature metric dashboard - fixes reference stats

### DIFF
--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -59,6 +59,6 @@ private
     provided_at_times = times.map(&:second).compact
     return nil if requested_at_times.blank? || provided_at_times.blank?
 
-    (provided_at_times.min - requested_at_times.max).to_i / 1.day
+    (provided_at_times.max - requested_at_times.min) / 1.day
   end
 end

--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -46,19 +46,20 @@ private
           .where('created_at BETWEEN ? AND ?', start_time, end_time),
       )
       .group('application_forms.id')
-      .having('count("references".id) = 2')
-    applications.map { |application| time_to_get_for(application) }.compact
+    applications.map { |application| time_to_get_for(application, end_time) }.compact
   end
 
-  def time_to_get_for(application)
+  def time_to_get_for(application, end_time)
+    return nil unless application.enough_references_have_been_provided?
+
     times = application.application_references.feedback_provided.map do |reference|
       provided_audit = reference.audits.where("audited_changes#>>'{feedback_status, 1}' = 'feedback_provided'").last
       [reference.requested_at, provided_audit&.created_at]
     end
-    requested_at_times = times.map(&:first).compact
-    provided_at_times = times.map(&:second).compact
-    return nil if requested_at_times.blank? || provided_at_times.blank?
+    requested_at_time = times.map(&:first).compact.min
+    provided_at_time = times.map(&:second).compact.max
+    return nil if requested_at_time.nil? || provided_at_time.nil? || provided_at_time > end_time
 
-    (provided_at_times.max - requested_at_times.min) / 1.day
+    (provided_at_time - requested_at_time) / 1.day
   end
 end

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
       Timecop.freeze(@today - 9.days - 2.hours) do
         SubmitReference.new(reference: @references1.second, send_emails: false).save!
       end
-      Timecop.freeze(@today - 1.days) do
+      Timecop.freeze(@today - 1.day) do
         SubmitReference.new(reference: @references2.second, send_emails: false).save!
       end
       Timecop.freeze(@today) do

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
         @application_form2 = create(:application_form)
         @references2 = create_list(:reference, 2, application_form: @application_form2)
         @references2.each { |reference| CandidateInterface::RequestReference.new.call(reference) }
+
+        @application_form3 = create(:application_form)
+        @references3 = create_list(:reference, 2, application_form: @application_form3)
+        @references3.each { |reference| CandidateInterface::RequestReference.new.call(reference) }
       end
       Timecop.freeze(@today - 10.days) do
         SubmitReference.new(reference: @references1.first, send_emails: false).save!
@@ -35,8 +39,15 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
       Timecop.freeze(@today - 9.days - 2.hours) do
         SubmitReference.new(reference: @references1.second, send_emails: false).save!
       end
+      Timecop.freeze(@today - 1.days) do
+        SubmitReference.new(reference: @references2.second, send_emails: false).save!
+      end
       Timecop.freeze(@today) do
-        @references2.each { |reference| SubmitReference.new(reference: reference, send_emails: false).save! }
+        SubmitReference.new(reference: @references2.first, send_emails: false).save!
+        SubmitReference.new(reference: @references3.second, send_emails: false).save!
+      end
+      Timecop.freeze(@today + 1.day) do
+        SubmitReference.new(reference: @references3.first, send_emails: false).save!
       end
     end
 


### PR DESCRIPTION
## Context

When deployed to production we noticed that there were a few oddities about the reference feature metrics. The numbers were too low.

## Changes proposed in this pull request

Two issues are addressed by this PR:

- [x] There was a mistake in the logic, we compared the maximum reference requested at date with the minimum received at date for the two provided references. This should have been minimum reference requested at date and the maximum received
at date. This mistake was compounded by some rounding errors. This was a straightforward fix.
- [x] The query that finds applications with references within a given date range was only including those for which both references were received in that date range. It should be considering applications for which only the second or both references fall within the data range.

## Guidance to review

- Per commit
- I don't think the fix for the second issue listed above is good from a maintainability point of view. I couldn't see a way to write the logic for the date range in a single database query. Instead I've added some post query filtering to ensure that only the correct applications are counted. This would be much easier given an `ApplicationForm#references_provided_at` timestamp. I wasn't 100% convinced before but I think we really need this now.

## Link to Trello card

https://trello.com/c/CBmwCoda/2770-feature-metric-dashboard

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
