### PR TITLE
Prevent users from submitting gcses as completed with an empty award year

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.html.erb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.html.erb
@@ -1,5 +1,7 @@
 <% if show_missing_banner? %>
   <%= render(CandidateInterface::IncompleteSectionComponent.new(section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), error: @missing_error)) %>
+<% elsif show_values_missing_banner? %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: "#{subject}_gcse", section_path: candidate_interface_gcse_review_path(subject: subject.to_sym), text: t("review_application.#{subject}_gcse.missing"), link_text: t("review_application.#{subject}_gcse.enter_missing"), error: @missing_error)) %>
 <% elsif @application_qualification %>
   <%= render(SummaryCardComponent.new(rows: gcse_qualification_rows, editable: @editable)) do %>
     <% title = if @application_qualification.missing_qualification?

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -33,6 +33,13 @@ module CandidateInterface
       end
     end
 
+    def show_values_missing_banner?
+      if @submitting_application && @application_qualification.grade.nil? || @submitting_application && @application_qualification.award_year.nil?
+        gcse_completed = "#{@subject}_gcse_completed"
+        @application_form.send(gcse_completed) && @editable
+      end
+    end
+
   private
 
     attr_reader :application_qualification, :subject

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -34,15 +34,19 @@ module CandidateInterface
     end
 
     def show_values_missing_banner?
-      if @submitting_application && @application_qualification.grade.nil? || @submitting_application && @application_qualification.award_year.nil?
-        gcse_completed = "#{@subject}_gcse_completed"
-        @application_form.send(gcse_completed) && @editable
+      if @submitting_application
+        section_or_gcse_incomplete? && @editable
       end
     end
 
   private
 
     attr_reader :application_qualification, :subject
+
+    def section_or_gcse_incomplete?
+      gcse_completed = "#{@subject}_gcse_completed"
+      (!@application_form.send(gcse_completed) || @application_form.send("#{@subject}_gcse").incomplete_gcse_information?) && !@application_qualification.missing_qualification?
+    end
 
     def qualification_row
       {

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -11,9 +11,17 @@ module CandidateInterface
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @application_form = current_application
+      @application_qualification = current_application.qualification_in_subject(:gcse, subject_param)
 
-      redirect_to candidate_interface_application_form_path
+      if @application_qualification.incomplete_gcse_information? && !@application_qualification.missing_qualification?
+        flash[:warning] = 'You cannot mark this section complete with incomplete GCSE information.'
+        render :show
+      else
+        current_application.update!(application_form_params)
+
+        redirect_to candidate_interface_application_form_path
+      end
     end
 
   private

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -8,6 +8,12 @@ class ApplicationQualification < ApplicationRecord
     award_year
   ].freeze
 
+  EXPECTED_GCSE_DATA = %i[
+    qualification_type
+    subject
+    award_year
+  ].freeze
+
   EXPECTED_OTHER_QUALIFICATION_DATA = %i[
     qualification_type
     subject
@@ -59,6 +65,16 @@ class ApplicationQualification < ApplicationRecord
     return true if predicted_grade.nil?
 
     return true if EXPECTED_DEGREE_DATA.any? do |field_name|
+      send(field_name).blank?
+    end
+
+    false
+  end
+
+  def incomplete_gcse_information?
+    return true if grade.nil? && structured_grades.nil?
+
+    return true if EXPECTED_GCSE_DATA.any? do |field_name|
       send(field_name).blank?
     end
 

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -30,12 +30,18 @@ en:
     maths_gcse:
       incomplete: Maths GCSE or equivalent not entered
       complete_section: Enter your Maths GCSE or equivalent
+      missing: Maths GCSE not complete
+      enter_missing: Enter all values for Maths GCSE or equivalent
     english_gcse:
       incomplete: English GCSE or equivalent not entered
       complete_section: Enter your English GCSE or equivalent
+      missing: English GCSE not complete
+      enter_missing: Enter all values for English GCSE or equivalent
     science_gcse:
       incomplete: Science GCSE or equivalent not entered
       complete_section: Enter your Science GCSE or equivalent
+      missing: Science GCSE not complete
+      enter_missing: Enter all values for Science GCSE or equivalent
     other_qualifications:
       incomplete: The academic and other relevant qualifications section has an incomplete qualification
       complete_section: Complete your academic and other relevant qualifications

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -137,22 +137,22 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
   describe '#show_values_missing_banner?' do
     context 'when they have an incomplete qualification and are submitting their application' do
       it 'returns true' do
-        application_form = build :application_form
+        application_form = create(:application_form, maths_gcse_completed: true)
 
-        application_qualification = build(
-        :application_qualification,
-        application_form: application_form,
-        qualification_type: 'gcse',
-        level: 'gcse',
-        grade: nil,
-        award_year: nil,
-        subject: 'english',
-      )
+        application_qualification = create(
+          :application_qualification,
+          application_form: application_form,
+          qualification_type: 'gcse',
+          level: 'gcse',
+          grade: nil,
+          award_year: nil,
+          subject: 'maths',
+        )
         result = described_class.new(
           application_form: application_form,
           application_qualification: application_qualification,
-          subject: 'english',
-          submitting_application: true
+          subject: 'maths',
+          submitting_application: true,
         )
 
         expect(result.show_values_missing_banner?).to eq true

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -133,4 +133,30 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       expect(result.css('.govuk-summary-list__value')[1].text).to include('E (English)D (English Literature)A* (Cockney Rhyming Slang)')
     end
   end
+
+  describe '#show_values_missing_banner?' do
+    context 'when they have an incomplete qualification and are submitting their application' do
+      it 'returns true' do
+        application_form = build :application_form
+
+        application_qualification = build(
+        :application_qualification,
+        application_form: application_form,
+        qualification_type: 'gcse',
+        level: 'gcse',
+        grade: nil,
+        award_year: nil,
+        subject: 'english',
+      )
+        result = described_class.new(
+          application_form: application_form,
+          application_qualification: application_qualification,
+          subject: 'english',
+          submitting_application: true
+        )
+
+        expect(result.show_values_missing_banner?).to eq true
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_gcse_spec.rb
@@ -28,8 +28,14 @@ RSpec.feature 'Candidate entering GCSE details' do
 
     when_i_fill_in_the_grade
     and_i_click_save_and_continue
-    then_i_see_add_year_page
+    and_i_visit_the_candidate_application_page
+    and_i_click_on_the_maths_gcse_link
+    and_i_mark_the_section_as_completed
+    and_click_continue
+    then_i_see_the_incompletion_error
 
+    when_i_click_to_change_year
+    then_i_see_add_year_page
     when_i_fill_in_the_year
     and_i_click_save_and_continue
     then_i_see_the_review_page_with_correct_details
@@ -91,6 +97,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   def when_i_visit_the_candidate_application_page
     visit '/candidate/application'
   end
+  alias_method :and_i_visit_the_candidate_application_page, :when_i_visit_the_candidate_application_page
 
   def then_the_maths_gcse_should_be_incomplete
     expect(page).to have_content 'Maths GCSE or equivalent Incomplete'
@@ -144,6 +151,10 @@ RSpec.feature 'Candidate entering GCSE details' do
     expect(page).to have_content 'Enter the type of qualification'
   end
 
+  def then_i_see_the_incompletion_error
+    expect(page).to have_content 'You cannot mark this section complete with incomplete GCSE information.'
+  end
+
   def then_i_see_the_gcse_option_selected
     expect(find_field('GCSE')).to be_checked
   end
@@ -183,6 +194,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   def when_i_mark_the_section_as_completed
     check t('application_form.completed_checkbox')
   end
+  alias_method :and_i_mark_the_section_as_completed, :when_i_mark_the_section_as_completed
 
   def then_i_see_the_maths_gcse_is_completed
     expect(page).to have_css('#maths-gcse-or-equivalent-badge-id', text: 'Completed')


### PR DESCRIPTION
## Context

Users are able to add a qualification in the 'GCSE or equivalent' section and mark it as completed without entering a value in the 'Year awarded' or 'Grade' section.

## Changes proposed in this pull request

For consistency with the incomplete degree logic, a flash message will now appear on the qualification review page, and prevent the session being redirected back to the application page, if they try to mark the qualification as complete and press continue:

|Before|After|
|------------|------------|
|![Before](https://user-images.githubusercontent.com/47917431/105333206-5c4e7100-5bcd-11eb-862b-5da9da89e4e0.png)|![After](https://user-images.githubusercontent.com/47917431/105333373-8ef86980-5bcd-11eb-8265-aef8868a1f58.png)|

It will also present a message on the application review page informing them it is incomplete, with a link back to the qualification review page:
|Before|After|
|------------|------------|
|![Before](https://user-images.githubusercontent.com/47917431/105335268-c2d48e80-5bcf-11eb-948f-af22e09d3785.png) |![After](https://user-images.githubusercontent.com/47917431/105335005-6f624080-5bcf-11eb-81b0-7483b2e87f6e.png) |

## Guidance to review

Considering this is an edge case, is it acceptable for these messages to be generic rather than specifying which fields are incomplete?

## Link to Trello card

https://trello.com/c/iJKKl9KS

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
