### PR TITLE
Change 'Fitness to Teach' to 'Fitness to train to teach'

### DIFF
--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -9,7 +9,7 @@ class MakeAnOffer
 
   MAX_CONDITIONS_COUNT = 20
   MAX_CONDITION_LENGTH = 255
-  STANDARD_CONDITIONS = ['Fitness to Teach check', 'Disclosure and Barring Service (DBS) check'].freeze
+  STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
 
   validates :course_option, presence: true
   validate :validate_course_option_is_open_on_apply

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -205,7 +205,7 @@ en:
 
         All offers must include the following non-academic conditions:
         candidates must pass a DBS & childen’s barred list check, and
-        candidates must pass a fitness to work health check.
+        candidates must pass a fitness to train to teach health check.
 
         An email is sent to the candidate, the content of which depends on the state of the other application choices, whether there are other offers and whether there are pending decisions from providers.
       emails:
@@ -250,7 +250,7 @@ en:
 
         All offers must include the following non-academic conditions:
         candidates must pass a DBS & childen’s barred list check, and
-        candidates must pass a fitness to work health check.
+        candidates must pass a fitness to train to teach health check.
 
         An email is sent to the candidate, the content of which depends on the state of the other application choices, whether there are other offers and whether there are pending decisions from providers.
       emails:

--- a/spec/components/candidate_interface/offer_review_component_spec.rb
+++ b/spec/components/candidate_interface/offer_review_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
     create(
       :application_choice,
       status: 'offer',
-      offer: { 'conditions' => ['Fitness to Teach check', 'Be cool'] },
+      offer: { 'conditions' => ['Fitness to train to teach check', 'Be cool'] },
       course_option: course_option,
       application_form: application_form,
     )
@@ -41,7 +41,7 @@ RSpec.describe CandidateInterface::OfferReviewComponent do
     result = render_inline(described_class.new(course_choice: application_choice))
 
     expect(result.css('.govuk-summary-list__key').text).to include('Conditions')
-    expect(result.css('.govuk-summary-list__value').text).to include('Fitness to Teach')
+    expect(result.css('.govuk-summary-list__value').text).to include('Fitness to train to teach')
     expect(result.css('.govuk-summary-list__value').text).to include('Be cool')
   end
 end

--- a/spec/system/provider_interface/provider_makes_an_offer_on_rejected_application_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_on_rejected_application_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_see_standard_reasons_are_checked
-    expect(find("input[value='Fitness to Teach check']")).to be_checked
+    expect(find("input[value='Fitness to train to teach check']")).to be_checked
     expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
   end
 
@@ -93,7 +93,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_see_the_correct_offer_conditions
-    expect(page).to have_content 'Fitness to Teach check'
+    expect(page).to have_content 'Fitness to train to teach check'
     expect(page).to have_content 'A further condition'
   end
 

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_see_standard_reasons_are_checked
-    expect(find("input[value='Fitness to Teach check']")).to be_checked
+    expect(find("input[value='Fitness to train to teach check']")).to be_checked
     expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
   end
 
@@ -96,7 +96,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_see_the_correct_offer_conditions
-    expect(page).to have_content 'Fitness to Teach check'
+    expect(page).to have_content 'Fitness to train to teach check'
     expect(page).to have_content 'A further condition'
   end
 


### PR DESCRIPTION
- Fitness to Teach is required for job applicants, not trainees
- Trainees require Fitness _to train_ to teach

## Context

Policy colleagues at DfE and a few HEIs have pointed out that this is wrong in Manage.

## Changes proposed in this pull request

<img width="523" alt="Screenshot 2021-01-21 at 10 03 41" src="https://user-images.githubusercontent.com/642279/105335461-f9120e00-5bcf-11eb-8c8d-1157dbb5c2bc.png">

Change the wording. Existing applications will still carry the old "Fitness to Teach" requirement.

I haven't capitalised "Fitness to train to teach" because as far as I can find on Google there's no DfE guidance that refers to "Fitness to Train to Teach".