### PR TITLE
Pin docker image to alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # To use or update to a ruby version, change {BASE_RUBY_IMAGE}
-ARG BASE_RUBY_IMAGE=ruby:2.7.2-alpine
+ARG BASE_RUBY_IMAGE=ruby:2.7.2-alpine3.12
 # BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES will default to apply-for-teacher-training-gems-node-modules
 # building all layers above it if a value is not specidied during the build
 ARG BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES=apply-for-teacher-training-gems-node-modules


### PR DESCRIPTION
## Context

alpine has released version 3.13 with an updated version of node which might cause version conflicts.

## Changes proposed in this pull request

Use ruby-2.7.2:alpine:3-12

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
