### PR TITLE
Email accredited bodies about changes

### DIFF
--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -24,7 +24,7 @@ class AcceptOffer
       end
     end
 
-    NotificationsList.for(@application_choice).each do |provider_user|
+    NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
     end
 

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -12,7 +12,7 @@ class DeclineOffer
       StateChangeNotifier.new(:declined, @application_choice).application_outcome_notification
     end
 
-    NotificationsList.for(@application_choice).each do |provider_user|
+    NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.declined(provider_user, @application_choice).deliver_later
     end
   end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -17,7 +17,7 @@ class DeclineOfferByDefault
     end
 
     application_choices.each do |application_choice|
-      NotificationsList.for(application_choice).each do |provider_user|
+      NotificationsList.for(application_choice, include_ratifying_provider: true).each do |provider_user|
         ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
       end
     end

--- a/app/services/notifications_list.rb
+++ b/app/services/notifications_list.rb
@@ -1,5 +1,9 @@
 class NotificationsList
-  def self.for(application_choice)
-    application_choice.provider.provider_users.where(send_notifications: true)
+  def self.for(application_choice, include_ratifying_provider: false)
+    return application_choice.provider.provider_users.where(send_notifications: true) if application_choice.accredited_provider.nil? || !include_ratifying_provider
+
+    application_choice.provider.provider_users.where(send_notifications: true).or(
+      application_choice.accredited_provider.provider_users.where(send_notifications: true),
+    )
   end
 end

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -8,7 +8,7 @@ class SendNewApplicationEmailToProvider
   def call
     return false unless application_choice.awaiting_provider_decision?
 
-    NotificationsList.for(application_choice).each do |provider_user|
+    NotificationsList.for(application_choice, include_ratifying_provider: true).each do |provider_user|
       if application_choice.application_form.has_safeguarding_issues_to_declare?
         ProviderMailer.application_submitted_with_safeguarding_issues(provider_user, application_choice).deliver_later
       else

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -9,7 +9,7 @@ class SubmitApplication
   def call
     application_form.update!(submitted_at: Time.zone.now)
 
-    application_choices.includes(%i[course_option provider]).each do |application_choice|
+    application_choices.includes(%i[course_option provider accredited_provider]).each do |application_choice|
       SendApplicationToProvider.call(application_choice)
     end
 

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -25,7 +25,7 @@ private
   attr_reader :application_choice
 
   def send_email_notification_to_provider_users(application_choice)
-    NotificationsList.for(application_choice).each do |provider_user|
+    NotificationsList.for(application_choice, include_ratifying_provider: true).each do |provider_user|
       ProviderMailer.application_withdrawn(provider_user, application_choice).deliver_later
     end
   end

--- a/spec/services/decline_offer_by_default_spec.rb
+++ b/spec/services/decline_offer_by_default_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe DeclineOfferByDefault do
+  include CourseOptionHelpers
+
   let(:application_choice) { create(:application_choice, status: :offer) }
 
   it 'updates the application_choice and posts Slack notifications' do
@@ -16,5 +18,24 @@ RSpec.describe DeclineOfferByDefault do
 
     expect(StateChangeNotifier).to have_received(:new).with(:declined_by_default, application_choice)
     expect(notifier).to have_received(:application_outcome_notification)
+  end
+
+  it 'sends emails to the training provider and ratyfing provider', sidekiq: true do
+    training_provider = create(:provider)
+    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+    ratifying_provider = create(:provider)
+    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+    course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+    application_choice = create(:application_choice, :with_offer, course_option: course_option)
+
+    described_class.new(application_form: application_choice.application_form).call
+
+    training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+    ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+    expect(training_provider_email['rails-mail-template'].value).to eq('declined_by_default')
+    expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined_by_default')
   end
 end

--- a/spec/services/decline_offer_spec.rb
+++ b/spec/services/decline_offer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe DeclineOffer do
+  include CourseOptionHelpers
+
   it 'sets the declined_at date and sends a Slack notification' do
     application_choice = create(:application_choice, status: :offer)
     notifier = instance_double(StateChangeNotifier, application_outcome_notification: nil)
@@ -14,5 +16,24 @@ RSpec.describe DeclineOffer do
       expect(StateChangeNotifier).to have_received(:new).with(:declined, application_choice)
       expect(notifier).to have_received(:application_outcome_notification)
     end
+  end
+
+  it 'sends emails to the training provider and ratyfing provider', sidekiq: true do
+    training_provider = create(:provider)
+    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+    ratifying_provider = create(:provider)
+    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+    course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+    application_choice = create(:application_choice, :with_offer, course_option: course_option)
+
+    DeclineOffer.new(application_choice: application_choice).save!
+
+    training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+    ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
+
+    expect(training_provider_email['rails-mail-template'].value).to eq('declined')
+    expect(ratifying_provider_email['rails-mail-template'].value).to eq('declined')
   end
 end

--- a/spec/services/notifications_list_spec.rb
+++ b/spec/services/notifications_list_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe NotificationsList do
   describe '.for' do
-    it 'returns provider users for the application choice' do
+    it 'returns training provider users for the application choice by default' do
       application_choice = create(:application_choice)
 
       create(:provider_user, send_notifications: false, providers: [application_choice.course.provider])
@@ -10,6 +10,18 @@ RSpec.describe NotificationsList do
       provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
 
       expect(NotificationsList.for(application_choice).to_a).to eql([provider_user])
+    end
+
+    it 'returns training and ratifying provider users for the application choice when specified' do
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+      application_choice = create(:application_choice, course_option: create(:course_option, course: create(:course, accredited_provider: ratifying_provider)))
+
+      create(:provider_user, send_notifications: false, providers: [application_choice.course.provider])
+      create(:provider_user, send_notifications: true)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [application_choice.course.provider])
+
+      expect(NotificationsList.for(application_choice, include_ratifying_provider: true).to_a).to match_array([training_provider_user, ratifying_provider_user])
     end
   end
 end

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -3,17 +3,23 @@ require 'rails_helper'
 RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
   include CourseOptionHelpers
 
-  it 'sends an email to the provider' do
-    provider = create(:provider)
-    create(:provider_user, send_notifications: true, providers: [provider])
-    option = course_option_for_provider(provider: provider)
+  it 'sends an email to the training provider and ratifying provider' do
+    training_provider = create(:provider)
+    training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+    ratifying_provider = create(:provider)
+    ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+    option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
     choice = create(:application_choice, :awaiting_provider_decision, course_option: option)
 
     SendNewApplicationEmailToProvider.new(application_choice: choice).call
 
-    email = ActionMailer::Base.deliveries.find { |e| e.header['rails_mail_template'].value == 'application_submitted' }
+    training_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == training_provider_user.email_address }
+    ratifying_provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == ratifying_provider_user.email_address }
 
-    expect(email).to be_present
+    expect(training_provider_email['rails-mail-template'].value).to eq('application_submitted')
+    expect(ratifying_provider_email['rails-mail-template'].value).to eq('application_submitted')
   end
 
   it 'sends a different email when the candidate supplied safeguarding information' do


### PR DESCRIPTION
## Context

We currently only notify the training provider when an application arrives. In keeping with the principle that providers are assumed to be interested in all applications they can see in Manage, we should also send emails to users of the accredited body.

Providers should receive emails for all applications they can view.

## Changes proposed in this pull request

- extend `NotificationsList` to conditionally return list including ratifying provider users (accredited body)
- Email ratifying providers when 
  - Application is received
  - Offer is accepted
  - Offer is declined
  - Candidate withdraws

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/AoTxywFa/3269-email-accredited-bodies-as-well-as-training-providers-about-changes-to-applications

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
