### PR TITLE
DO NOT MERGE Unique API IDs for multi-grade GCSEs

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,4 +1,11 @@
-## 17th December
+## 25th January 2021
+
+- The `id` field on `Qualification`s is now a string and may contain
+  underscores. This is to support multiple qualifications added to a single
+  record, eg an English GCSE comprising English Language and English
+  Literature qualifications.
+
+## 17th December 2020
 
 - The `Rejection` `reason` field may now return more complex 'structured' reasons for rejection. The field type remains `string`. The field contains details and advice about the rejected application as seen by the candidate, grouped under relevant headings.
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -795,9 +795,9 @@ components:
       - hesa_degenddt
       properties:
         id:
-          type: integer
-          description: The qualification ID in the Apply system. These IDs are not guaranteed to be unique, for example when a candidate has multiple English GCSEs
-          example: 123
+          type: string
+          description: The qualification ID in the Apply system, which may contain an underscore
+          example: "123_1"
         qualification_type:
           type: string
           maxLength: 256

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -525,32 +525,26 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         application_form: application_choice.application_form,
       )
 
-      english_language = presenter.as_json.dig(
+      qualifications = presenter.as_json.dig(
         :attributes,
         :qualifications,
         :gcses,
-      ).find { |q| q[:subject] == 'English language' }
+      )
 
-      expect(english_language[:id]).to eq 1
-      expect(english_language[:grade]).to eq 'E'
+      english_language = qualifications.find { |q| q[:subject] == 'Cockney rhyming slang' }
 
-      english_literature = presenter.as_json.dig(
-        :attributes,
-        :qualifications,
-        :gcses,
-      ).find { |q| q[:subject] == 'English literature' }
+      expect(english_language[:id]).to eq '1'
+      expect(english_language[:grade]).to eq 'A*'
 
-      expect(english_literature[:id]).to eq 1
+      english_literature = qualifications.find { |q| q[:subject] == 'English language' }
+
+      expect(english_literature[:id]).to eq '1_2'
       expect(english_literature[:grade]).to eq 'E'
 
-      rhyming_slang = presenter.as_json.dig(
-        :attributes,
-        :qualifications,
-        :gcses,
-      ).find { |q| q[:subject] == 'Cockney rhyming slang' }
+      rhyming_slang = qualifications.find { |q| q[:subject] == 'English literature' }
 
-      expect(rhyming_slang[:id]).to eq 1
-      expect(rhyming_slang[:grade]).to eq 'A*'
+      expect(rhyming_slang[:id]).to eq '1_3'
+      expect(rhyming_slang[:grade]).to eq 'E'
     end
   end
 


### PR DESCRIPTION
## Context

We broke SITS because the API duplicated IDs across multiple GCSEs, eg when a candidate had english language and literature qualifications.

## Changes proposed in this pull request

When constructing these qualifications in the API, sort them so they always appear in the same order and add numbered suffixes to the IDs. See comment inline.

## Link to Trello card

https://trello.com/c/54vJ4u9D/3288-gcses-in-api-response-have-duplicate-ids-causing-sits-to-discard-them

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
