### PR TITLE
Slack: "withdraw applications" instead of "withdraw remaining applications"

### DIFF
--- a/config/locales/slack_notifications.yml
+++ b/config/locales/slack_notifications.yml
@@ -18,8 +18,8 @@ en:
     withdrawn:
       message:
         primary:
-          one: ":runner: %{applicant} has withdrawn their remaining application from %{providers}."
-          other: ":runner: %{applicant} has withdrawn their remaining applications from %{providers}."
+          one: ":runner: %{applicant} has withdrawn their application from %{providers}."
+          other: ":runner: %{applicant} has withdrawn their applications from %{providers}."
         other_applications: "withdrew from %{providers}"
     recruited:
       message:

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe StateChangeNotifier do
 
         StateChangeNotifier.new(:withdrawn, application_choice).application_outcome_notification
 
-        message = /:runner: #{applicant} has withdrawn their remaining applications from #{provider_name} and #{withdrawn_choice.provider.name}./
+        message = /:runner: #{applicant} has withdrawn their applications from #{provider_name} and #{withdrawn_choice.provider.name}./
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
     end


### PR DESCRIPTION
## Context

"remaining" is redundant here because we notify about all applications at once.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
