### PR TITLE
Don't call SetDeclineByDefault inside a DB transaction

### DIFF
--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -45,8 +45,9 @@ class MakeAnOffer
           application_choice.offer = { 'conditions' => offer_conditions }
           application_choice.offered_at = Time.zone.now
           application_choice.save!
-          SetDeclineByDefault.new(application_form: application_choice.application_form).call
         end
+
+        SetDeclineByDefault.new(application_form: application_choice.application_form).call
 
         SendNewOfferEmailToCandidate.new(application_choice: @application_choice).call
       else


### PR DESCRIPTION
This service looks at the database to see if there are any offers before
proceeding. If the transaction hasn't committed yet, the offer in
progress will be missing.
