### PR TITLE
Fix N+1 query in the support interface

### DIFF
--- a/app/components/support_interface/application_card_component.html.erb
+++ b/app/components/support_interface/application_card_component.html.erb
@@ -12,7 +12,7 @@
     <% application_choices.each do |application_choice| %>
       <li class="govuk-list__item govuk-body-s">
         <%= render SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status) %>
-        <%= application_choice.course.name_and_code %> at <%= application_choice.provider.name %>
+        <%= application_choice.course_option.course.name_and_code %> at <%= application_choice.course_option.provider.name %>
       </li>
     <% end %>
   </ul>

--- a/app/components/support_interface/application_card_component.rb
+++ b/app/components/support_interface/application_card_component.rb
@@ -15,9 +15,7 @@ module SupportInterface
       application_form.full_name.presence || application_form.candidate.email_address
     end
 
-    def application_choices
-      application_form.application_choices.includes(%i[course provider])
-    end
+    delegate :application_choices, to: :application_form
 
     def overall_status
       process_state = ProcessState.new(application_form).state

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -8,8 +8,13 @@ module SupportInterface
 
     def filter_records(application_forms)
       application_forms = application_forms
-        .joins(:candidate)
-        .includes(:candidate, :application_choices)
+        .joins(
+          :candidate,
+        )
+        .preload(
+          :candidate,
+          application_choices: { course_option: { course: :provider } },
+        )
         .order(updated_at: :desc)
         .page(applied_filters[:page] || 1).per(30)
 


### PR DESCRIPTION
## Context

Somehow the `includes` causes a N+1 error it's supposed to prevent (https://github.com/DFE-Digital/apply-for-teacher-training/commit/75c8148a4957342a6b79683d6d0bb3a826c986c7). Also the has_many through association triggers an N+1.

## Changes proposed in this pull request

Fix the N+1.

Before:

![Screenshot 2021-01-25 at 13 49 15](https://user-images.githubusercontent.com/233676/105708083-33531680-5f14-11eb-9c99-525e1ae9eea9.png)

After:

![Screenshot 2021-01-25 at 13 48 50](https://user-images.githubusercontent.com/233676/105708092-364e0700-5f14-11eb-9211-5214208576c8.png)

