### PR TITLE
Fix Support email log search by email address

### DIFF
--- a/app/controllers/support_interface/email_log_controller.rb
+++ b/app/controllers/support_interface/email_log_controller.rb
@@ -9,7 +9,7 @@ module SupportInterface
         .page(params[:page] || 1).per(30)
 
       if params[:q]
-        @emails = @emails.where("CONCAT('to', ' ', subject, ' ', notify_reference, ' ', body) ILIKE ?", "%#{params[:q]}%")
+        @emails = @emails.where("CONCAT(\"to\", ' ', subject, ' ', notify_reference, ' ', body) ILIKE ?", "%#{params[:q]}%")
       end
 
       if params[:delivery_status]

--- a/spec/system/support_interface/email_log_spec.rb
+++ b/spec/system/support_interface/email_log_spec.rb
@@ -16,8 +16,9 @@ RSpec.feature 'Email log' do
     when_notify_tells_us_the_emails_have_not_been_delivered
     then_the_delivery_status_is_displayed_on_the_page
 
-    when_i_search_for_an_email
-    i_see_only_the_filtered_email
+    when_emails_to_other_recipients_have_been_sent
+    and_i_search_by_email_address
+    then_i_see_only_emails_that_match_the_supplied_address
   end
 
   def given_i_am_a_support_user
@@ -95,13 +96,21 @@ RSpec.feature 'Email log' do
     end
   end
 
-  def when_i_search_for_an_email
-    fill_in :q, with: 'harry'
+  def when_emails_to_other_recipients_have_been_sent
+    AuthenticationMailer.sign_up_email(
+      candidate: create(:candidate, email_address: 'severus.snape@example.com'),
+      token: '123',
+    ).deliver_now
+  end
+
+  def and_i_search_by_email_address
+    fill_in :q, with: 'harry@example'
     click_on 'Apply filters'
   end
 
-  def i_see_only_the_filtered_email
-    expect(page).to have_content 'Application submitted (Candidate mailer)'
-    expect(page).not_to have_content 'Sign up email (Authentication mailer)'
+  def then_i_see_only_emails_that_match_the_supplied_address
+    expect(page).to have_selector('tbody tr', count: 2)
+    expect(page).to have_content 'harry@example.com'
+    expect(page).not_to have_content 'severus.snape@example.com'
   end
 end


### PR DESCRIPTION
## Context

Searching the email log in support with an email address doesn't work. It appears to be working sometimes because names are often part of email addresses, and people's names are mentioned in email bodies. 

Currently:

![image](https://user-images.githubusercontent.com/107591/105730559-69999180-5f26-11eb-9264-0153b69d6f0c.png)

but

![image](https://user-images.githubusercontent.com/107591/105730587-71f1cc80-5f26-11eb-84e1-07838f0b693c.png)

## Changes proposed in this pull request

In postgres, column names matching reserved SQL keywords can be quoted with double quotes, but we are using single quotes instead. Switching to double quotes fixes the issue.  

## Guidance to review

Search using a full/exact email address from the log.

## Link to Trello card

https://trello.com/c/qGHgFa3S/3296-some-provider-invites-do-not-appear-in-the-support-email-log

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
