### PR TITLE
Use the correct enum value in failing migration

### DIFF
--- a/db/migrate/20210125142659_backfill_new_application_reference_datetime_columns.rb
+++ b/db/migrate/20210125142659_backfill_new_application_reference_datetime_columns.rb
@@ -13,7 +13,7 @@ class BackfillNewApplicationReferenceDatetimeColumns < ActiveRecord::Migration[6
         feedback_provided_at: feedback_provided_at,
         feedback_refused_at: feedback_refused_at,
         cancelled_at: cancelled_at,
-        cancelled_at_the_end_of_cycle_at: cancelled_at_eoc_at,
+        cancelled_at_end_of_cycle: cancelled_at_eoc_at,
         email_bounced_at: email_bounced_at,
         audit_comment: 'Backfilled after adding new datetime columns https://github.com/DFE-Digital/apply-for-teacher-training/pull/3901',
       )
@@ -28,7 +28,7 @@ class BackfillNewApplicationReferenceDatetimeColumns < ActiveRecord::Migration[6
         feedback_provided_at: nil,
         feedback_refused_at: nil,
         cancelled_at: nil,
-        cancelled_at_the_end_of_cycle_at: nil,
+        cancelled_at_end_of_cycle: nil,
         email_bounced_at: nil,
       )
     end


### PR DESCRIPTION
## Context

Currently, the migration is failing because i input 'cancelled_at_the_end_of_cycle_at' instead of 'cancelled_at_end_of_cycle'

## Changes proposed in this pull request

- Use the correct enum value

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
