### PR TITLE
Specify withdraw by date in the subject for multiple acceptances email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -292,11 +292,11 @@ class CandidateMailer < ApplicationMailer
   end
 
   def ucas_match_initial_email_multiple_acceptances(candidate)
-    @date_to_withdraw_application_by = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
+    @withdraw_by_date = TimeLimitCalculator.new(rule: :ucas_match_candidate_withdrawal_request, effective_date: Time.zone.today).call.fetch(:time_in_future).to_s(:govuk_date)
 
     email_for_candidate(
       candidate.current_application,
-      subject: I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject', withdraw_by_date: @withdraw_by_date),
     )
   end
 

--- a/app/views/candidate_mailer/ucas_match_initial_email_multiple_acceptances.text.erb
+++ b/app/views/candidate_mailer/ucas_match_initial_email_multiple_acceptances.text.erb
@@ -6,7 +6,7 @@ This has been flagged to us, as you can only accept one offer to start a teacher
 
 # Action required – withdraw your duplicate application
 
-To ensure your application progresses effectively, you need to withdraw the choice from either Apply for teacher training or UCAS Teacher Training by <%= @date_to_withdraw_application_by %>.
+To ensure your application progresses effectively, you need to withdraw the choice from either Apply for teacher training or UCAS Teacher Training by <%= @withdraw_by_date %>.
 
 For advice on choosing the right course for you, talk to a teacher training adviser.
 

--- a/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
+      I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject', withdraw_by_date: '1 February 2021'),
       'heading' => 'Dear Jane',
       'withdrawal day' => '1 February 2021',
     )


### PR DESCRIPTION
## Context

It was missed in the last PR.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Preview path `/rails/mailers/candidate_mailer/ucas_match_initial_email_multiple_acceptances`

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
