### PR TITLE
Extract wizard to reusable module

### DIFF
--- a/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_setup_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
     def save_permissions
       @wizard = wizard_for(permissions_params.merge(current_step: 'permissions'))
 
-      if @wizard.valid?(:permissions)
+      if @wizard.valid?
         @wizard.save_state!
 
         next_step, id = @wizard.next_step

--- a/app/controllers/provider_interface/reasons_for_rejection_controller.rb
+++ b/app/controllers/provider_interface/reasons_for_rejection_controller.rb
@@ -12,7 +12,7 @@ module ProviderInterface
     def update_initial_questions
       @wizard = ReasonsForRejectionWizard.new(store, reasons_for_rejection_params.merge(current_step: 'initial_questions'))
 
-      if @wizard.valid_for_current_step?
+      if @wizard.valid?
         @wizard.save_state!
         redirect_to next_redirect(@wizard)
       else
@@ -28,7 +28,7 @@ module ProviderInterface
     def update_other_reasons
       @wizard = ReasonsForRejectionWizard.new(store, reasons_for_rejection_params.merge(current_step: 'other_reasons'))
 
-      if @wizard.valid_for_current_step?
+      if @wizard.valid?
         @wizard.save_state!
         redirect_to next_redirect(@wizard)
       else

--- a/app/forms/concerns/wizard.rb
+++ b/app/forms/concerns/wizard.rb
@@ -1,0 +1,57 @@
+module Wizard
+  extend ActiveSupport::Concern
+
+  included do
+    attr_writer :state_store
+    attr_accessor :current_step, :review_mode
+  end
+
+  def initialize(state_store, params = {})
+    @state_store = state_store
+    sanitize_attributes!(params)
+
+    super(last_saved_state.deep_merge(params))
+
+    enter_review_mode! if current_step.eql?('check')
+  end
+
+  # placeholder for multiple step wizards
+  def next_step; end
+
+  # placeholder for multiple step wizards
+  def previous_step; end
+
+  def clear_state!
+    @state_store.delete
+  end
+
+  def save_state!
+    @state_store.write(state)
+  end
+
+  def valid?
+    current_step.present? ? super(current_step.to_sym) : super
+  end
+
+private
+
+  def state
+    as_json(except: params_to_exclude_from_saved_state).to_json
+  end
+
+  def last_saved_state
+    saved_state = @state_store.read
+    saved_state ? JSON.parse(saved_state) : {}
+  end
+
+  def params_to_exclude_from_saved_state
+    %w[state_store errors validation_context current_step]
+  end
+
+  # placeholder to enable sanitizing of input parameters if required
+  def sanitize_attributes!(params); end
+
+  def enter_review_mode!
+    @review_mode = true
+  end
+end

--- a/spec/forms/concerns/wizard_spec.rb
+++ b/spec/forms/concerns/wizard_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+RSpec.describe 'Wizard' do
+  let(:test_wizard_form) do
+    Class.new do
+      include ActiveModel::Model
+      include Wizard
+
+      attr_accessor :name, :email, :phone_number
+
+      validates :name, :email, presence: true
+      validates :phone_number, presence: true, on: :new
+    end
+  end
+
+  let(:described_class) { TestWizardForm }
+  let(:store) { instance_double(WizardStateStores::RedisStore, read: nil, delete: nil) }
+  let(:wizard) { described_class.new(store, name: 'Jean', email: 'jean@dfe.com') }
+
+  before do
+    stub_const('TestWizardForm', test_wizard_form)
+  end
+
+  describe '#initialize' do
+    let(:params) { { name: 'Fiona' } }
+
+    it 'merges any attributes with ones stored in the data store' do
+      allow(store).to receive(:read).and_return({ name: 'Jane', email: 'fiona@dfe.co.uk' }.to_json)
+
+      wizard = described_class.new(store, params)
+
+      expect(wizard.name).to eq('Fiona')
+      expect(wizard.email).to eq('fiona@dfe.co.uk')
+    end
+
+    context 'when parameter sanitisation is required' do
+      let(:test_wizard_form) do
+        Class.new do
+          include ActiveModel::Model
+          include Wizard
+
+          attr_accessor :name
+
+          def sanitize_attributes!(params)
+            params.delete(:name)
+          end
+        end
+      end
+
+      it 'must be specified in the inherited class' do
+        wizard = described_class.new(store, params)
+
+        expect(wizard.name).to be_nil
+      end
+    end
+  end
+
+  describe '#next_step' do
+    it 'is a placeholder and returns nil' do
+      expect(wizard.next_step).to eq(nil)
+    end
+  end
+
+  describe '#previous_step' do
+    it 'is a placeholder and returns nil' do
+      expect(wizard.previous_step).to eq(nil)
+    end
+  end
+
+  describe '#valid?' do
+    context 'when failing validations are related to a specific step' do
+      context 'when on another step and validating' do
+        it 'returns true' do
+          wizard.current_step = :check
+
+          expect(wizard.valid?).to be(true)
+        end
+      end
+
+      context 'when on the associated step and validating' do
+        it 'returns false' do
+          wizard.current_step = :new
+
+          expect(wizard.valid?).to be(false)
+          expect(wizard.errors[:phone_number]).to include('can\'t be blank')
+        end
+      end
+    end
+
+    context 'when no current step is specified' do
+      it 'returns true' do
+        expect(wizard.valid?).to be(true)
+      end
+    end
+  end
+
+  describe '#save_state!' do
+    it 'stores the the model params in json format excluding helper params' do
+      included_params_to_json = { name: 'Jean', email: 'jean@dfe.com' }.to_json
+      allow(store).to receive(:write)
+
+      wizard.save_state!
+
+      expect(store).to have_received(:write).with(included_params_to_json)
+    end
+  end
+
+  describe '#clear_state' do
+    it 'calls the data store\'s delete method' do
+      wizard.clear_state!
+
+      expect(store).to have_received(:delete)
+    end
+  end
+end

--- a/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_setup_wizard_spec.rb
@@ -61,92 +61,25 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsSetupWizard do
     end
   end
 
-  describe 'initializer' do
-    it 'deserializes state' do
-      state_store = state_store_for({
-        provider_relationships: [123],
-        provider_relationship_permissions: { 123 => { make_decisions: %w[ratifying training], view_safeguarding_information: %w[training] } },
-      })
-
-      wizard = described_class.new(state_store, current_step: 'permissions')
-
-      expect(wizard.provider_relationships).to eq([123])
-      expect(wizard.provider_relationship_permissions['123']).to eq({
-        'make_decisions' => %w[ratifying training],
-        'view_safeguarding_information' => %w[training],
-      })
-    end
-
-    it 'merges permissions attributes' do
-      state_store = state_store_for({
-        provider_relationships: [123, 456],
-        provider_relationship_permissions: { '123' => { 'make_decisions' => %w[ratifying training], 'view_safeguarding_information' => %w[training] } },
-      })
-
-      wizard = described_class.new(state_store, current_step: 'permissions')
-      wizard.save_state!
-
-      attrs = {
-        'current_step' => 'permissions',
-        'provider_relationship_permissions' => {
-          '456' => {
-            'make_decisions' => %w[training], 'view_safeguarding_information' => %w[training ratifying]
-          },
-        },
-      }
-
-      wizard = described_class.new(state_store, attrs)
-
-      expect(wizard.provider_relationship_permissions['123']).to eq({ 'make_decisions' => %w[ratifying training], 'view_safeguarding_information' => %w[training] })
-      expect(wizard.provider_relationship_permissions['456']).to eq({ 'make_decisions' => %w[training], 'view_safeguarding_information' => %w[training ratifying] })
-    end
-  end
-
   describe 'validations' do
     context 'when no providers are selected for a permission' do
       it 'is invalid' do
         wizard = described_class.new(
           state_store_for({}),
+          current_step: 'permissions',
           'current_provider_relationship_id' => '123',
-          'provider_relationship_permissions' => { '123' => { 'make_decisions' => [''], 'view_safeguarding_information' => %w[training], 'view_diversity_information' => %w[training] } },
+          'provider_relationship_permissions' => {
+            '123' => {
+              'make_decisions' => [''],
+              'view_safeguarding_information' => %w[training],
+              'view_diversity_information' => %w[training],
+            },
+          },
         )
 
-        expect(wizard.valid?(:permissions)).to be false
+        expect(wizard.valid?).to be(false)
         expect(wizard.errors.keys).to eq([:'provider_relationship_permissions[123][make_decisions]'])
       end
-    end
-  end
-
-  describe '#save_state!' do
-    it 'serializes state to state store' do
-      state_store = state_store_for({
-        provider_relationships: [123],
-        provider_relationship_permissions: { 123 => { make_decisions: %w[ratifying training], view_safeguarding_information: %w[training] } },
-      })
-      wizard = described_class.new(state_store)
-
-      wizard.save_state!
-
-      expect(JSON.parse(state_store.read).symbolize_keys).to eq({
-        provider_relationships: [123],
-        provider_relationship_permissions: {
-          '123' => {
-            'make_decisions' => %w[ratifying training],
-            'view_safeguarding_information' => %w[training],
-          },
-        },
-      })
-    end
-  end
-
-  describe '#clear_state!' do
-    it 'purges all state' do
-      state_store = state_store_for({})
-      wizard = described_class.new(state_store, current_step: 'info')
-
-      wizard.clear_state!
-
-      expect(state_store.read).to be_nil
     end
   end
 

--- a/spec/forms/provider_interface/reasons_for_rejection_wizard_spec.rb
+++ b/spec/forms/provider_interface/reasons_for_rejection_wizard_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
     subject(:wizard) { described_class.new(store, wizard_params) }
 
     it 'validates top level questions' do
-      wizard.valid_for_current_step?
+      wizard.valid?
 
       expect(wizard.errors.keys.sort).to eq(
         %i[
@@ -44,7 +44,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
       end
 
       it 'validates second level options' do
-        wizard.valid_for_current_step?
+        wizard.valid?
 
         expect(wizard.errors.keys.sort).to eq(
           %i[
@@ -83,7 +83,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
       let(:long_text) { Faker::Lorem.sentence(word_count: 101) }
 
       it 'validates details and advice fields' do
-        wizard.valid_for_current_step?
+        wizard.valid?
 
         expect(wizard.errors.keys.sort).to eq(
           %i[
@@ -121,7 +121,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
         wizard_params[:safeguarding_concerns_vetting_disclosed_information_details] = long_text
         wizard_params[:safeguarding_concerns_other_details] = long_text
 
-        wizard.valid_for_current_step?
+        wizard.valid?
 
         expect(wizard.errors.keys.sort).to eq(
           %i[
@@ -162,7 +162,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
       end
 
       it 'skips validation on other fields' do
-        wizard.valid_for_current_step?
+        wizard.valid?
 
         expect(wizard.errors.keys.sort).to be_empty
       end
@@ -185,7 +185,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
       end
 
       it 'validates the selected reasons' do
-        wizard.valid_for_current_step?
+        wizard.valid?
 
         expect(wizard.errors.keys).to eq(%i[honesty_and_professionalism_concerns_information_false_or_inaccurate_details])
       end
@@ -195,7 +195,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
       let(:current_step) { 'other_reasons' }
 
       it 'validates top level questions' do
-        wizard.valid_for_current_step?
+        wizard.valid?
 
         expect(wizard.errors.keys.sort).to eq(%i[interested_in_future_applications_y_n other_advice_or_feedback_y_n])
       end
@@ -211,7 +211,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
       end
 
       it 'validates second level reasons fields' do
-        wizard.valid_for_current_step?
+        wizard.valid?
 
         expect(wizard.errors.keys).to eq(%i[other_advice_or_feedback_details])
       end

--- a/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/reconfirm_deferred_offer_wizard_spec.rb
@@ -204,38 +204,4 @@ RSpec.describe ProviderInterface::ReconfirmDeferredOfferWizard do
       expect(wizard.previous_step).to eq(:conditions)
     end
   end
-
-  describe 'initializer' do
-    it 'deserializes state' do
-      state_store = state_store_for(application_choice_id: application_choice.id)
-      wizard = described_class.new(state_store, current_step: 'start')
-      expect(wizard.application_choice_id).to eq application_choice.id
-    end
-  end
-
-  describe '#save_state!' do
-    it 'serializes state to state store' do
-      state_store = state_store_for(application_choice_id: application_choice.id)
-      wizard = described_class.new(state_store)
-      wizard.course_option_id = 99
-
-      wizard.save_state!
-
-      expect(JSON.parse(state_store.read).symbolize_keys).to eq({
-        application_choice_id: application_choice.id,
-        course_option_id: 99,
-      })
-    end
-  end
-
-  describe '#clear_state!' do
-    it 'purges all state' do
-      state_store = state_store_for(application_choice_id: application_choice.id)
-      wizard = described_class.new(state_store)
-
-      wizard.clear_state!
-
-      expect(state_store.read).to be_nil
-    end
-  end
 end


### PR DESCRIPTION
## Context

Extracts reusable wizard functionality to module

## Link to Trello card

https://trello.com/c/HfJPOWEM/3299-extract-wizard-to-reusable-module

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
