### PR TITLE
Squish extra whitespace in custom date formats

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -14,7 +14,7 @@ Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
              '%e %B %Y at %l:%M%P'
            end
 
-  time.strftime(format)
+  time.strftime(format).squish
 end
 
 Time::DATE_FORMATS[:govuk_time] = lambda do |time|
@@ -26,5 +26,5 @@ Time::DATE_FORMATS[:govuk_time] = lambda do |time|
              '%l:%M%P'
            end
 
-  time.strftime(format)
+  time.strftime(format).squish
 end

--- a/spec/config/initializers/date_formats_spec.rb
+++ b/spec/config/initializers/date_formats_spec.rb
@@ -19,5 +19,11 @@ RSpec.describe 'Time::DATE_FORMATS' do
       expect(date_and_time.to_s(:govuk_date_and_time)).to eq('25 December 2020 at 12:01pm')
       expect(date_and_time.to_s(:govuk_time)).to eq('12:01pm')
     end
+
+    it 'does not pad single-digit day and hour with whitespace' do
+      date_and_time = Time.zone.local(2020, 12, 5, 6, 0, 0)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq('5 December 2020 at 6:00am')
+      expect(date_and_time.to_s(:govuk_time)).to eq('6:00am')
+    end
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -161,13 +161,13 @@ RSpec.describe ViewHelper, type: :helper do
   describe '#time_today_or_tomorrow' do
     it 'returns the time tomorrow for a time tomorrow' do
       time = Time.zone.tomorrow.midnight + 3.hours
-      expect(helper.time_today_or_tomorrow(time)).to eq ' 3:00am tomorrow'
+      expect(helper.time_today_or_tomorrow(time)).to eq '3:00am tomorrow'
     end
 
     it 'returns the bare time for a time today' do
       Timecop.freeze(Time.zone.now.midnight) do
         time = Time.zone.now + 6.hours
-        expect(helper.time_today_or_tomorrow(time)).to eq ' 6:00am'
+        expect(helper.time_today_or_tomorrow(time)).to eq '6:00am'
       end
     end
 


### PR DESCRIPTION
Update these formats so that single digit hours and days aren't padded
with an extra space.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

```
time = Time.zone.local(2020, 6, 6, 6, 30)
```
## Before
```
time.to_s(:govuk_date_and_time)
=> " 6 June 2020 at  6:30 am"
```

## After
```
time.to_s(:govuk_date_and_time)
=> "6 June 2020 at 6:30am"
```
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Any reason not to?
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
na
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
