### PR TITLE
Other qualifications: fix issue with grades when changing BTEC to GCSE

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -122,7 +122,8 @@ module CandidateInterface
     end
 
     def btec?
-      other_uk_qualification_type == 'BTEC'
+      qualification_type == OtherQualificationTypeForm::OTHER_TYPE &&
+        other_uk_qualification_type == 'BTEC'
     end
 
     def subjects

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -43,11 +43,13 @@ module CandidateInterface
     end
 
     def save_intermediate!
+      sanitize_types
       @intermediate_data_service.write(intermediate_state)
       @next_step = editing && !qualification_type_changed? ? :check : :details
     end
 
     def save!
+      sanitize_types
       application_qualification = @current_application.application_qualifications.other.find(id)
       application_qualification.update!(attributes_for_persistence)
     end
@@ -55,6 +57,11 @@ module CandidateInterface
     PERSISTENT_ATTRIBUTES = %w[id current_step editing qualification_type other_uk_qualification_type non_uk_qualification_type institution_country].freeze
 
   private
+
+    def sanitize_types
+      self.other_uk_qualification_type = nil unless qualification_type == OTHER_TYPE
+      self.non_uk_qualification_type = nil unless qualification_type == NON_UK_TYPE
+    end
 
     def attributes_for_persistence
       {

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
@@ -20,6 +20,13 @@ RSpec.feature 'Entering their other qualifications' do
     when_i_complete_the_form
     then_i_see_my_btec_on_the_review_page
     and_my_other_uk_qualification_has_the_correct_format
+
+    when_i_click_change_qualification_type
+    and_change_qualification_to_gcse
+    then_i_should_see_simple_grade_prompt
+
+    when_i_submit_gcse_details
+    then_i_see_my_gcse_on_the_review_page
   end
 
   def given_i_am_signed_in
@@ -80,5 +87,34 @@ RSpec.feature 'Entering their other qualifications' do
     expect(@application.application_qualifications.last.qualification_type).to eq 'Other'
     expect(@application.application_qualifications.last.other_uk_qualification_type).to eq 'BTEC'
     expect(@application.application_qualifications.last.subject).to eq 'Music Theory'
+  end
+
+  def when_i_click_change_qualification_type
+    within(first('.app-summary-card')) { click_change_link('qualification') }
+  end
+
+  def and_change_qualification_to_gcse
+    choose 'GCSE'
+    click_button t('continue')
+  end
+
+  def then_i_should_see_simple_grade_prompt
+    expect(page).not_to have_field('Merit')
+    expect(page).to have_field('Grade')
+  end
+
+  def when_i_submit_gcse_details
+    fill_in t('application_form.other_qualification.grade.label'), with: 'C'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2013'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_see_my_gcse_on_the_review_page
+    expect(page).to have_current_path(candidate_interface_review_other_qualifications_path)
+
+    expect(page).to have_content('GCSE')
+    expect(page).to have_content('Music Theory')
+    expect(page).to have_content('2013')
+    expect(page).to have_content('C')
   end
 end

--- a/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_other_qualification_btec_spec.rb
@@ -112,6 +112,7 @@ RSpec.feature 'Entering their other qualifications' do
   def then_i_see_my_gcse_on_the_review_page
     expect(page).to have_current_path(candidate_interface_review_other_qualifications_path)
 
+    expect(page).not_to have_content('BTEC')
     expect(page).to have_content('GCSE')
     expect(page).to have_content('Music Theory')
     expect(page).to have_content('2013')


### PR DESCRIPTION
## Context

After creating a BTEC other qualification and then changing the qualification type to GCSE the details form still shows the grade options for BTEC (radio buttons). This is a simple change to ensure that these buttons are only shown when the qualification_type is 'Other' and the other_uk_qualification_type is 'BTEC'.

## Changes proposed in this pull request

- [x] Extend existing system spec to reproduce the issue
- [x] Fix in `OtherQualificationDetailsForm` 
- [x] Reset the `other_uk_qualification` attribute so that the qualification isn't labelled as _BTEC_

Before:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/450843/106215386-bf8d6400-61c8-11eb-92a5-b4b7ac69f8d3.png">

After:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/450843/106215263-73422400-61c8-11eb-8d7c-5a320971bc37.png">

## Guidance to review

- Is there a better way to do this?
- Should we be testing for anything else?

## Link to Trello card

Found when testing (but not the same issue as):
https://trello.com/c/P5pagu0l/2688-clicking-browser-back-button-causes-other-qualifications-to-be-loaded-with-incorrect-state

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
