### PR TITLE
Fix duplication and formatting issues with the support reference

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -77,7 +77,7 @@ class ApplicationForm < ApplicationRecord
 
   attribute :recruitment_cycle_year, :integer, default: -> { RecruitmentCycle.current_year }
 
-  before_create -> { self.support_reference ||= GenerateSupportRef.call }
+  before_create -> { self.support_reference ||= GenerateSupportReference.call }
 
   PUBLISHED_FIELDS = %w[
     first_name last_name support_reference phase submitted_at

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -77,7 +77,7 @@ class ApplicationForm < ApplicationRecord
 
   attribute :recruitment_cycle_year, :integer, default: -> { RecruitmentCycle.current_year }
 
-  before_create -> { self.support_reference ||= GenerateSupportReference.call }
+  before_create :add_support_reference
 
   PUBLISHED_FIELDS = %w[
     first_name last_name support_reference phase submitted_at
@@ -387,5 +387,14 @@ private
 
   def courses_not_on_apply
     application_choices.includes(%i[course]).reject { |choice| choice.course.open_on_apply }
+  end
+
+  def add_support_reference
+    return if support_reference
+
+    loop do
+      self.support_reference = GenerateSupportReference.call
+      break unless ApplicationForm.exists?(support_reference: support_reference)
+    end
   end
 end

--- a/app/services/generate_support_reference.rb
+++ b/app/services/generate_support_reference.rb
@@ -1,4 +1,4 @@
-class GenerateSupportRef
+class GenerateSupportReference
   NUMBER_OF_LETTERS = 2
   NUMBER_OF_DIGITS = 4
 

--- a/app/services/generate_support_reference.rb
+++ b/app/services/generate_support_reference.rb
@@ -3,7 +3,7 @@ class GenerateSupportReference
   NUMBER_OF_DIGITS = 4
 
   UNCLEAR_LETTERS = %w[I L O].freeze
-  UNCLEAR_DIGIT = [0, 1].freeze
+  UNCLEAR_DIGIT = %w[0 1].freeze
 
   def self.call
     letters = ('A'..'Z').to_a - UNCLEAR_LETTERS

--- a/app/services/generate_support_reference.rb
+++ b/app/services/generate_support_reference.rb
@@ -5,12 +5,12 @@ class GenerateSupportReference
   UNCLEAR_LETTERS = %w[I L O].freeze
   UNCLEAR_DIGIT = %w[0 1].freeze
 
-  def self.call
-    letters = ('A'..'Z').to_a - UNCLEAR_LETTERS
-    digits = ('1'..'9').to_a - UNCLEAR_DIGIT
+  READABLE_LETTERS = ('A'..'Z').to_a - UNCLEAR_LETTERS
+  READABLE_DIGITS = ('1'..'9').to_a - UNCLEAR_DIGIT
 
-    random_letters = (1..NUMBER_OF_LETTERS).map { letters.sample }
-    random_digits = (1..NUMBER_OF_DIGITS).map { digits.sample }
+  def self.call
+    random_letters = (1..NUMBER_OF_LETTERS).map { READABLE_LETTERS.sample }
+    random_digits = (1..NUMBER_OF_DIGITS).map { READABLE_DIGITS.sample }
 
     (random_letters + random_digits).join
   end

--- a/db/migrate/20200110071407_set_missing_support_references_on_application_forms.rb
+++ b/db/migrate/20200110071407_set_missing_support_references_on_application_forms.rb
@@ -1,7 +1,7 @@
 class SetMissingSupportReferencesOnApplicationForms < ActiveRecord::Migration[6.0]
   def up
     ApplicationForm.where(support_reference: nil).each do |form|
-      form.update(support_reference: GenerateSupportRef.call)
+      form.update(support_reference: GenerateSupportReference.call)
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
     address_type { 'uk' }
 
     factory :completed_application_form do
-      support_reference { GenerateSupportRef.call }
+      support_reference { GenerateSupportReference.call }
       first_name { Faker::Name.first_name }
       last_name { Faker::Name.last_name }
       date_of_birth { Faker::Date.birthday }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationForm do
-  it 'sets a support reference upon creation' do
-    application_form = create :application_form
-    expect(application_form.support_reference).to be_present
+  it 'sets a unique support reference upon creation' do
+    create(:application_form, support_reference: 'AB1234')
+    allow(GenerateSupportReference).to receive(:call).and_return('AB1234', 'OK1234')
+
+    application_form = create(:application_form)
+
+    expect(application_form.support_reference).to eql('OK1234')
   end
 
   describe 'before_save' do

--- a/spec/system/decline_by_default_spec.rb
+++ b/spec/system/decline_by_default_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Decline by default' do
   end
 
   def when_i_have_an_offer_waiting_for_my_decision
-    @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter', support_reference: '123A')
+    @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter')
     @application_choice = create(:application_choice, status: :offer, application_form: @application_form, sent_to_provider_at: Time.zone.now, decline_by_default_at: Time.zone.now + 10.days)
 
     @provider_user = create(:provider_user, send_notifications: true, providers: [@application_choice.provider])
@@ -71,7 +71,7 @@ RSpec.feature 'Decline by default' do
   def and_the_provider_receives_an_email
     open_email(@provider_user.email_address)
 
-    expect(current_email.subject).to include('Harry Potter’s (123A) application withdrawn automatically')
+    expect(current_email.subject).to include("Harry Potter’s (#{@application_form.support_reference}) application withdrawn automatically")
   end
 
   def and_the_candidate_receives_a_decline_by_default_without_rejection_email


### PR DESCRIPTION
## Context

The support reference shouldn't have the numbers `0` and `1` because they can be misread as O and L/I. They currently do though. We're also not preventing support reference from being the same between applications.

## Changes proposed in this pull request

Fix the bug, do some refactoring, and guarantee uniqueness.

## Guidance to review

Per commit.

## Link to Trello card

https://trello.com/c/qDpMchNO/2926-avoid-duplicate-support-references-and-fix-formatting

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
