### PR TITLE
Service guidance link

### DIFF
--- a/app/components/support_interface/application_card_component.html.erb
+++ b/app/components/support_interface/application_card_component.html.erb
@@ -12,7 +12,7 @@
     <% application_choices.each do |application_choice| %>
       <li class="govuk-list__item govuk-body-s">
         <%= render SupportInterface::ApplicationStatusTagComponent.new(status: application_choice.status) %>
-        <%= application_choice.course.name_and_code %> at <%= application_choice.provider.name %>
+        <%= application_choice.course_option.course.name_and_code %> at <%= application_choice.course_option.provider.name %>
       </li>
     <% end %>
   </ul>

--- a/app/components/support_interface/application_card_component.rb
+++ b/app/components/support_interface/application_card_component.rb
@@ -16,7 +16,7 @@ module SupportInterface
     end
 
     def application_choices
-      application_form.application_choices.includes(%i[course provider])
+      application_form.application_choices
     end
 
     def overall_status

--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -8,8 +8,12 @@ module SupportInterface
 
     def filter_records(application_forms)
       application_forms = application_forms
-        .joins(:candidate)
-        .includes(:candidate, :application_choices)
+        .joins(
+          :candidate,
+        )
+        .preload(
+          application_choices: { course_option: { course: :provider } },
+        )
         .order(updated_at: :desc)
         .page(applied_filters[:page] || 1).per(30)
 

--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -232,7 +232,7 @@ Candidates will also be able to use UCAS’s Apply 2 service for this part of th
 
 ### Informing candidates your courses are on Apply
 
-Your courses will automatically be uploaded to [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk) as part of our onboarding process.
+Your courses will automatically be uploaded to [Apply for teacher training](https://www.gov.uk/apply-for-teacher-training) as part of our onboarding process.
 
 When candidates use [Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) and select one of your courses, they will have the option to continue via Apply for teacher training. (They will also be able to apply via UCAS, if you’ve decided to keep your courses listed on both services.)
 


### PR DESCRIPTION
## Context

https://trello.com/c/ytjkLIA3/3292-link-to-apply-from-manage-qa-could-be-more-specific

## Changes proposed in this pull request

Change link from 2nd apply page (https://www.apply-for-teacher-training.service.gov.uk/candidate/account) to first apply page (https://www.gov.uk/apply-for-teacher-training)

## Guidance to review

None

## Link to Trello card

https://trello.com/c/ytjkLIA3/3292-link-to-apply-from-manage-qa-could-be-more-specific

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
