### PR TITLE
"Open all courses" now opens ratified courses too

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -48,6 +48,14 @@ class Provider < ApplicationRecord
     Course.where(accredited_provider: self)
   end
 
+  def acts_as_accredited_body_in_current_cycle?
+    accredited_courses.current_cycle.exposed_in_find.any?
+  end
+
+  def all_courses_open_in_current_cycle?
+    accredited_courses.or(courses).current_cycle.exposed_in_find.all?(&:open_on_apply?)
+  end
+
   def application_forms
     ApplicationForm.where(id: application_choices.select(:application_form_id))
   end

--- a/app/services/open_provider_courses.rb
+++ b/app/services/open_provider_courses.rb
@@ -6,10 +6,24 @@ class OpenProviderCourses
   end
 
   def call
-    if provider.courses.current_cycle.exposed_in_find.update_all(open_on_apply: true).positive?
+    if run_courses.or(ratified_courses).update_all(open_on_apply: true).positive?
       provider.provider_users.each do |provider_user|
         ProviderMailer.courses_open_on_apply(provider_user)
       end
     end
+  end
+
+private
+
+  def run_courses
+    @provider.courses
+      .current_cycle
+      .exposed_in_find
+  end
+
+  def ratified_courses
+    @provider.accredited_courses
+      .current_cycle
+      .exposed_in_find
   end
 end

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -1,11 +1,14 @@
 <%= render 'provider_navigation', title: 'Courses' %>
 
 <% if @provider.sync_courses? %>
-  <% unless @courses[RecruitmentCycle.current_year].to_a.all?(&:open_on_apply?) %>
+  <% unless @provider.all_courses_open_in_current_cycle? %>
     <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>
       <h2 class="govuk-heading-m">Open all courses</h2>
 
       <p class="govuk-body">This will toggle every course on this provider to be available through Apply.</p>
+      <% if @provider.acts_as_accredited_body_in_current_cycle? %>
+        <p class="govuk-body"><%= govuk_link_to 'Courses this provider ratifies at other providers', support_interface_provider_ratified_courses_path(@provider) %> will also be opened.</p>
+      <% end %>
 
       <% unless @provider.all_associated_accredited_providers_onboarded? %>
         <%= render WarningTextComponent.new(

--- a/spec/services/open_provider_courses_spec.rb
+++ b/spec/services/open_provider_courses_spec.rb
@@ -23,4 +23,17 @@ RSpec.describe OpenProviderCourses do
     expect { OpenProviderCourses.new(provider: provider).call }
       .not_to(change { Course.open_on_apply.count })
   end
+
+  it 'opens the correct ratified courses' do
+    training_provider = create(:provider)
+    accredited_body = create(:provider)
+    ratified_course = create(:course, exposed_in_find: true, open_on_apply: false, provider: training_provider, accredited_provider: accredited_body)
+    other_course = create(:course, exposed_in_find: true, open_on_apply: false, provider: training_provider, accredited_provider: nil)
+
+    expect {
+      described_class.new(provider: accredited_body).call
+    }.to(change { ratified_course.reload.open_on_apply? }.from(false).to(true))
+
+    expect(other_course.reload).not_to be_open_on_apply
+  end
 end

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -46,15 +46,16 @@ RSpec.feature 'Providers and courses' do
     then_it_should_be_open_on_apply
 
     when_i_visit_the_providers_page
-    when_i_click_on_a_provider
+    and_i_click_on_an_accredited_body
     and_i_click_on_courses
-    then_i_see_the_updated_providers_courses_and_sites
-
-    when_i_visit_the_providers_page
-    when_i_click_on_a_different_provider
+    no_courses_should_be_open_on_apply
+    and_i_click_on_ratified_courses
+    no_ratified_courses_should_be_open_on_apply
     and_i_click_on_courses
     and_i_choose_to_open_all_courses
     then_all_courses_should_be_open_on_apply
+    and_when_i_click_on_ratified_courses
+    then_all_ratified_courses_should_be_open_on_apply
 
     and_when_i_click_the_other_providers_tab
     and_i_should_see_the_list_of_other_providers
@@ -76,10 +77,13 @@ RSpec.feature 'Providers and courses' do
     create(:application_choice, application_form: create(:application_form, support_reference: 'XYZ123'), course_option: course_option)
 
     create :provider, code: 'DEF', name: 'Gorse SCITT', sync_courses: true
-    create :provider, code: 'GHI', name: 'Somerset SCITT Consortium', sync_courses: true
     create :provider, code: 'DOF', name: 'An Unsynced Provider', sync_courses: false
+    somerset_scitt = create :provider, code: 'GHI', name: 'Somerset SCITT Consortium', sync_courses: true
 
     create(:course_option, course: create(:course, accredited_provider: provider))
+
+    create(:course_option, course: create(:course, exposed_in_find: true, accredited_provider: somerset_scitt))
+    create(:course_option, course: create(:course, exposed_in_find: true, provider: somerset_scitt))
   end
 
   def then_i_should_see_the_providers
@@ -263,16 +267,12 @@ RSpec.feature 'Providers and courses' do
     expect(page).to have_content 'University of Chester'
   end
 
-  def when_i_click_on_a_different_provider
-    click_link 'Gorse SCITT'
-  end
-
   def and_i_choose_to_open_all_courses
     click_button 'Open all courses for the 2021 cycle'
   end
 
   def then_all_courses_should_be_open_on_apply
-    expect(page).to have_content '1 course (1 on DfE Apply)'
+    expect(page).to have_content '2 courses (2 on DfE Apply)'
   end
 
   def and_when_i_click_the_other_providers_tab
@@ -282,5 +282,25 @@ RSpec.feature 'Providers and courses' do
 
   def and_i_should_see_the_list_of_other_providers
     expect(page).to have_content('An Unsynced Provider')
+  end
+
+  def and_i_click_on_an_accredited_body
+    click_link 'Somerset SCITT'
+  end
+
+  def and_when_i_click_on_ratified_courses
+    click_link 'Ratified courses'
+  end
+
+  def then_all_ratified_courses_should_be_open_on_apply
+    expect(page).to have_content 'ratifies 1 course (1 on DfE Apply)'
+  end
+
+  def no_courses_should_be_open_on_apply
+    expect(page).to have_content '2 courses (0 on DfE Apply)'
+  end
+
+  def no_ratified_courses_should_be_open_on_apply
+    expect(page).to have_content 'ratifies 1 course (0 on DfE Apply)'
   end
 end


### PR DESCRIPTION
This makes onboarding HEIs much more straightforward as we don't have to visit each ratified org and pick out the exact courses we need to open.

## Context

We're onboarding more HEIs and this is a painful part of the process.

## Changes proposed in this pull request

Make the "Open all courses" button open ratified courses too.

<img width="1036" alt="Screenshot 2021-01-27 at 13 08 38" src="https://user-images.githubusercontent.com/642279/105995421-ddf84000-60a0-11eb-9ef9-bb07b487d0c4.png">

## Guidance to review

Does it do the right thing?
