### PR TITLE
Ensure incomplete a levels are excluded from the qualifications export

### DIFF
--- a/app/services/support_interface/qualifications_export.rb
+++ b/app/services/support_interface/qualifications_export.rb
@@ -117,7 +117,7 @@ module SupportInterface
     end
 
     def a_levels(qualifications)
-      qualifications.where(qualification_type: 'A level').or(qualifications.where(qualification_type: 'AS level')).take(5)
+      qualifications.where(qualification_type: 'A level').or(qualifications.where(qualification_type: 'AS level')).reject(&:incomplete_other_qualification?).take(5)
     end
 
     def degrees(qualifications)

--- a/spec/services/support_interface/qualifications_export_spec.rb
+++ b/spec/services/support_interface/qualifications_export_spec.rb
@@ -17,17 +17,15 @@ RSpec.describe SupportInterface::QualificationsExport do
                                                            course_option: course_option_one, application_form: application_form_one)
       create(:application_choice, status: 'offer', course_option: course_option_two, application_form: application_form_one)
 
-      create(:application_qualification,
+      create(:gcse_qualification,
              application_form: application_form_one,
-             level: 'gcse',
              subject: 'maths',
              grade: 'A')
-      create(:application_qualification,
+      create(:gcse_qualification,
              application_form: application_form_one,
-             level: 'gcse',
              subject: 'science',
              grade: 'A*BB')
-      create(:application_qualification,
+      create(:gcse_qualification,
              application_form: application_form_one,
              level: 'gcse',
              subject: 'english',
@@ -46,12 +44,16 @@ RSpec.describe SupportInterface::QualificationsExport do
              grade: 'A')
       create(:application_qualification,
              application_form: application_form_one,
-             level: 'degree',
+             qualification_type: 'AS level',
+             subject: nil,
+             level: 'other',
+             grade: 'A')
+      create(:degree_qualification,
+             application_form: application_form_one,
              qualification_type: 'BA Memes',
              grade: 'First class honours')
-      create(:application_qualification,
+      create(:degree_qualification,
              application_form: application_form_one,
-             level: 'degree',
              subject: nil,
              qualification_type: 'BA',
              grade: '2:1')
@@ -61,17 +63,17 @@ RSpec.describe SupportInterface::QualificationsExport do
       application_form_two = create(:completed_application_form, candidate: candidate_two)
       create(:application_choice, status: 'rejected', rejection_reason: 'Cut of jib', course_option: course_option_three, application_form: application_form_two)
 
-      create(:application_qualification,
+      create(:gcse_qualification,
              application_form: application_form_two,
              level: 'gcse',
              subject: 'maths',
              grade: 'A')
-      create(:application_qualification,
+      create(:gcse_qualification,
              application_form: application_form_two,
              level: 'gcse',
              subject: 'science double award',
              grade: 'A*A*')
-      create(:application_qualification,
+      create(:gcse_qualification,
              application_form: application_form_two,
              level: 'gcse',
              subject: 'english',
@@ -82,13 +84,13 @@ RSpec.describe SupportInterface::QualificationsExport do
              subject: 'Philosophy',
              level: 'other',
              grade: 'D')
-      create(:application_qualification,
+      create(:degree_qualification,
              application_form: application_form_two,
              qualification_type: 'AS level',
              subject: 'Trout Fishing',
              level: 'other',
              grade: 'A')
-      create(:application_qualification,
+      create(:degree_qualification,
              application_form: application_form_two,
              level: 'degree',
              qualification_type: 'BA Welding',
@@ -130,7 +132,7 @@ RSpec.describe SupportInterface::QualificationsExport do
           'Degree 1 grade' => 'First class honours',
           'Degree 2 type' => nil,
           'Degree 2 grade' => nil,
-          'Number of other qualifications provided' => 2,
+          'Number of other qualifications provided' => 3,
         },
         {
           'Candidate id' => application_form_one.candidate_id,
@@ -167,7 +169,7 @@ RSpec.describe SupportInterface::QualificationsExport do
           'Degree 1 grade' => 'First class honours',
           'Degree 2 type' => nil,
           'Degree 2 grade' => nil,
-          'Number of other qualifications provided' => 2,
+          'Number of other qualifications provided' => 3,
         },
         {
           'Candidate id' => application_form_two.candidate_id,


### PR DESCRIPTION
## Context

In the qualifications export we order A levels base on subject name. At the moment we have some A levels in incomplete states causing the export to crash.

## Changes proposed in this pull request

- Exclude incomplete a levels from the export 

## Guidance to review

These incomplete quals were added prior to use adding the wizard.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
