### PR TITLE
Change append operator to assignment, fixes duplication of "ratified by message" in Activity Log

### DIFF
--- a/app/components/provider_interface/activity_log_event_component.rb
+++ b/app/components/provider_interface/activity_log_event_component.rb
@@ -86,7 +86,7 @@ module ProviderInterface
         content = course_option.provider.name
 
         if course_option.course.accredited_provider.present?
-          content << " – ratified by #{course_option.course.accredited_provider.name}"
+          content += " – ratified by #{course_option.course.accredited_provider.name}"
         end
       end
 

--- a/spec/components/provider_interface/activity_log_event_component_spec.rb
+++ b/spec/components/provider_interface/activity_log_event_component_spec.rb
@@ -182,4 +182,17 @@ RSpec.describe ProviderInterface::ActivityLogEventComponent do
       expect(render_inline(component_for(audit)).to_html).to be_present
     end
   end
+
+  describe '#event_content' do
+    it 'renders the correct message when event_content is called multiple times' do
+      accredited_provider = create(:provider)
+      course = create(:course, accredited_provider: accredited_provider)
+      course_option = create(:course_option, course: course)
+      application_choice = create(:application_choice, course_option: course_option)
+      audit = create(:application_choice_audit, application_choice: application_choice)
+      component_for(audit).event_content
+
+      expect(component_for(audit).event_content).to eq("#{course_option.provider.name} – ratified by #{accredited_provider.name}")
+    end
+  end
 end


### PR DESCRIPTION
## Context

Ratified by [provider name] is duplicated in the case of a course being conducted by an accredited provider.

## Changes proposed in this pull request

Change append operator (<<) to assignment (+=) so the "content" object doesnt keep getting longer. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/DV0HsZyw/3295-unexplained-number-of-ratified-by
## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
