### PR TITLE
Show API-formatted applications in Support

### DIFF
--- a/app/components/support_interface/application_api_representation_component.html.erb
+++ b/app/components/support_interface/application_api_representation_component.html.erb
@@ -1,0 +1,8 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">See this application choice as it appears over the API</span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= json_code_sample(application_json) %>
+  </div>
+</details>

--- a/app/components/support_interface/application_api_representation_component.rb
+++ b/app/components/support_interface/application_api_representation_component.rb
@@ -1,0 +1,15 @@
+module SupportInterface
+  class ApplicationAPIRepresentationComponent < ViewComponent::Base
+    include APIDocsHelper
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+  private
+
+    def application_json
+      VendorAPI::SingleApplicationPresenter.new(@application_choice).as_json
+    end
+  end
+end

--- a/app/components/support_interface/application_api_representation_component.rb
+++ b/app/components/support_interface/application_api_representation_component.rb
@@ -9,7 +9,7 @@ module SupportInterface
   private
 
     def application_json
-      VendorAPI::SingleApplicationPresenter.new(@application_choice).as_json
+      AllowedCrossNamespaceUsage::VendorAPISingleApplicationPresenter.new(@application_choice).as_json
     end
   end
 end

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -42,7 +42,13 @@ module SupportInterface
       rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at && application_choice.awaiting_provider_decision?
       rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at && application_choice.offer?
 
-      rows.flatten
+      if ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.include?(application_choice.status.to_sym)
+        rows << { key: 'API', value: render(SupportInterface::ApplicationAPIRepresentationComponent.new(application_choice: application_choice)) }
+      else
+        rows << { key: 'API', value: 'This application hasn’t been sent to the provider yet, so it isn’t available over the API' }
+      end
+
+      rows
     end
 
   private

--- a/app/frontend/styles/_syntax-highlighting.scss
+++ b/app/frontend/styles/_syntax-highlighting.scss
@@ -40,7 +40,8 @@ $code-delete-bg: #FADDDD;
   word-wrap:break-word;
   -ms-word-break:break-all;
   word-break:break-all;
-  word-break:break-word
+  word-break:break-word;
+  white-space: break-spaces;
 
   /* Map Rouge / Pygments Tokens to work with 'Base 16' themes */
 

--- a/app/frontend/styles/support/_all.scss
+++ b/app/frontend/styles/support/_all.scss
@@ -11,3 +11,4 @@
 @import "_checkboxes-scroll";
 @import "_details";
 @import "_sort";
+@import "_syntax-highlighting";

--- a/app/lib/allowed_cross_namespace_usage.rb
+++ b/app/lib/allowed_cross_namespace_usage.rb
@@ -1,0 +1,9 @@
+# Our specs forbid parts of the application to use parts from other namespaces,
+# which is as it should be.
+#
+# In very rare circumstances we would like to share code between namespaces.
+# This module aliases namespaced code into a neutral, explicit namespace for
+# reuse.
+module AllowedCrossNamespaceUsage
+  VendorAPISingleApplicationPresenter = VendorAPI::SingleApplicationPresenter
+end

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'See application history', with_audited: true do
 
     Audited.audit_class.as_user(candidate) do
       application_form = create(
-        :application_form,
+        :completed_application_form,
         first_name: 'Alice',
         last_name: 'Wunder',
         candidate: candidate,


### PR DESCRIPTION
## Context

We want to make the API more accessible and less mysterious. This might also be handy for debugging one day.

This will support James's and my talk about the API tomorrow!

## Changes proposed in this pull request

<img width="1010" alt="Screenshot 2021-01-27 at 15 55 11" src="https://user-images.githubusercontent.com/642279/106017125-0f303a80-60b8-11eb-9c4d-a1369c484f0c.png">

## Guidance to review

Does the wording work? Is the dev-design sufficient?