### PR TITLE
Don't add HESA data to every API response

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -44,7 +44,6 @@ module VendorAPI
             work_history_break_explanation: work_history_breaks,
           },
           offer: offer,
-          hesa_itt_data: hesa_itt_data,
           rejection: get_rejection,
           withdrawal: withdrawal,
           further_information: application_form.further_information,
@@ -52,8 +51,10 @@ module VendorAPI
           safeguarding_issues_details_url: safeguarding_issues_details_url,
         },
       }
-      if application_choice.status == 'enrolled'
+      if application_choice.status == 'recruited'
         hash[:attributes][:hesa_itt_data] = hesa_itt_data
+      else
+        hash[:attributes][:hesa_itt_data] = nil
       end
       hash
     end


### PR DESCRIPTION
## Context

We only want to return HESA data when an application choice has a status 'recruited'

## Changes proposed in this pull request

- Remove the hard-coded hesa attribute from SingleApplicationPresenter. This was overriding the conditional logic responsible for determining whether HESA data should be returned. 😢 
- Only return HESA data if the application choice has a status 'recruited' ('enrolled' is no longer used)
- Add test coverage 

## Guidance to review

Make sense?

## Link to Trello card

https://trello.com/c/uGBOx0F8/2933-dont-add-hesa-data-to-every-api-response

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
