### PR TITLE
Update the R4R percentage tile 

### DIFF
--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -1,9 +1,9 @@
 <h3 class="govuk-heading-m govuk-!-font-size-27"><%=@heading%></h3>
-<div class="govuk-grid-row govuk-!-margin-bottom-8">
+<div id="<%= set_div_id_from_heading %>"class="govuk-grid-row govuk-!-margin-bottom-8">
   <div class="govuk-grid-column-one-half">
     <%= render SupportInterface::TileComponent.new(
       count: @percentage_rejected,
-      label: 'of all structured rejections',
+      label: number_of_rejections_out_of_total_rejections,
       colour: :blue,
       size: :reduced,
     ) %>

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
@@ -1,10 +1,21 @@
 module SupportInterface
   class ReasonForRejectionDashboardSectionComponent < ViewComponent::Base
-    def initialize(heading:, total_count:, this_month:, percentage_rejected:)
+    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_structured_rejection_reasons_count:)
       @heading = heading
       @total_count = total_count
       @this_month = this_month
       @percentage_rejected = percentage_rejected
+      @total_structured_rejection_reasons_count = total_structured_rejection_reasons_count
+    end
+
+  private
+
+    def set_div_id_from_heading
+      @heading.parameterize.underscore
+    end
+
+    def number_of_rejections_out_of_total_rejections
+      "#{@total_count} of #{@total_structured_rejection_reasons_count} application choices"
     end
   end
 end

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -3,6 +3,7 @@
   total_count:  total_rejection_count("course_full_y_n"),
   this_month: current_month_rejection_count("course_full_y_n"),
   percentage_rejected: percentage_rejected_for_reason("course_full_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -11,6 +12,7 @@
   total_count:  total_rejection_count("candidate_behaviour_y_n"),
   this_month: current_month_rejection_count("candidate_behaviour_y_n"),
   percentage_rejected: percentage_rejected_for_reason("candidate_behaviour_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -19,6 +21,7 @@
   total_count:  total_rejection_count("honesty_and_professionalism_y_n"),
   this_month: current_month_rejection_count("honesty_and_professionalism_y_n"),
   percentage_rejected: percentage_rejected_for_reason("honesty_and_professionalism_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -27,6 +30,7 @@
   total_count:  total_rejection_count("offered_on_another_course_y_n"),
   this_month: current_month_rejection_count("offered_on_another_course_y_n"),
   percentage_rejected: percentage_rejected_for_reason("offered_on_another_course_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -35,6 +39,7 @@
   total_count:  total_rejection_count("performance_at_interview_y_n"),
   this_month: current_month_rejection_count("performance_at_interview_y_n"),
   percentage_rejected: percentage_rejected_for_reason("performance_at_interview_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -43,6 +48,7 @@
   total_count:  total_rejection_count("qualifications_y_n"),
   this_month: current_month_rejection_count("qualifications_y_n"),
   percentage_rejected: percentage_rejected_for_reason("qualifications_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -51,6 +57,7 @@
   total_count:  total_rejection_count("quality_of_application_y_n"),
   this_month: current_month_rejection_count("quality_of_application_y_n"),
   percentage_rejected: percentage_rejected_for_reason("quality_of_application_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -59,6 +66,7 @@
   total_count:  total_rejection_count("safeguarding_y_n"),
   this_month: current_month_rejection_count("safeguarding_y_n"),
   percentage_rejected: percentage_rejected_for_reason("safeguarding_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -67,6 +75,7 @@
   total_count:  total_rejection_count("interested_in_future_applications_y_n"),
   this_month: current_month_rejection_count("interested_in_future_applications_y_n"),
   percentage_rejected: percentage_rejected_for_reason("interested_in_future_applications_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>
 
@@ -75,5 +84,6 @@
   total_count:  total_rejection_count("other_advice_or_feedback_y_n"),
   this_month: current_month_rejection_count("other_advice_or_feedback_y_n"),
   percentage_rejected: percentage_rejected_for_reason("other_advice_or_feedback_y_n"),
+  total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
 )
 %>

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
@@ -19,12 +19,11 @@ module SupportInterface
     end
 
     def percentage_rejected_for_reason(reason)
-      count = current_month_rejection_count(reason) + previous_rejection_count(reason)
-      formatted_percentage(count, total_structured_rejection_reasons_count)
+      formatted_percentage(total_rejection_count(reason), total_structured_rejection_reasons_count)
     end
 
     def total_structured_rejection_reasons_count
-      ApplicationChoice.where.not(structured_rejection_reasons: nil).count
+      @total_structured_rejection_reasons_count ||= ApplicationChoice.where.not(structured_rejection_reasons: nil).count
     end
 
     def previous_rejection_count(reason)

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.rb
@@ -5,6 +5,8 @@ module SupportInterface
       @rejection_reasons = rejection_reasons
     end
 
+  private
+
     def current_month_rejection_count(reason)
       values = @rejection_reasons.find { |h| h['key'] == reason && h['time_period'] == 'this_month' }
       return 0 if values.nil?
@@ -18,11 +20,12 @@ module SupportInterface
 
     def percentage_rejected_for_reason(reason)
       count = current_month_rejection_count(reason) + previous_rejection_count(reason)
-      total = @rejection_reasons.inject(0) { |sum, hash| sum + hash['count'] }
-      formatted_percentage(count, total)
+      formatted_percentage(count, total_structured_rejection_reasons_count)
     end
 
-  private
+    def total_structured_rejection_reasons_count
+      ApplicationChoice.where.not(structured_rejection_reasons: nil).count
+    end
 
     def previous_rejection_count(reason)
       values = @rejection_reasons.find { |h| h['key'] == reason && h['time_period'] == 'before_this_month' }

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -29,14 +29,20 @@ RSpec.feature 'Reasons for rejection dashboard' do
     application_choice1 = create(:application_choice, :awaiting_provider_decision)
     application_choice2 = create(:application_choice, :awaiting_provider_decision)
     application_choice3 = create(:application_choice, :awaiting_provider_decision)
+    application_choice4 = create(:application_choice, :awaiting_provider_decision)
+    application_choice5 = create(:application_choice, :awaiting_provider_decision)
+    application_choice6 = create(:application_choice, :awaiting_provider_decision)
 
     Timecop.freeze(@today - 40.days) do
-      reject_application_with_structured_reasons(application_choice1)
+      reject_application_for_candidate_behaviour_qualifications_and_safeguarding(application_choice1)
+      reject_application_for_candidate_behaviour_and_qualifications(application_choice2)
+      reject_application_for_candidate_behaviour(application_choice3)
     end
 
     Timecop.freeze(@today) do
-      reject_application_with_structured_reasons(application_choice2)
-      reject_application_without_structured_reasons(application_choice3)
+      reject_application_for_candidate_behaviour_qualifications_and_safeguarding(application_choice4)
+      reject_application_for_candidate_behaviour(application_choice5)
+      reject_application_without_structured_reasons(application_choice6)
     end
   end
 
@@ -54,7 +60,7 @@ RSpec.feature 'Reasons for rejection dashboard' do
     and_i_should_see_reasons_for_rejection_honesty_and_professionalism
     and_i_should_see_reasons_for_rejection_interested_in_future_applications
     and_i_should_see_reasons_for_rejection_offered_on_another_course
-    and_i_should_see_reasons_for_rejection_other_advice_or_feeback
+    and_i_should_see_reasons_for_rejection_other_advice_or_feedback
     and_i_should_see_reasons_for_rejection_performance_at_interview
     and_i_should_see_reasons_for_rejection_qualifications
     and_i_should_see_reasons_for_rejection_quality_of_application
@@ -63,20 +69,58 @@ RSpec.feature 'Reasons for rejection dashboard' do
 
 private
 
-  def reject_application_with_structured_reasons(application_choice)
+  def reject_application_for_candidate_behaviour_qualifications_and_safeguarding(application_choice)
     application_choice.update!(
       status: :rejected,
       structured_rejection_reasons: {
-        course_full_y_n: 'Yes',
+        course_full_y_n: 'No',
         candidate_behaviour_y_n: 'Yes',
-        honesty_and_professionalism_y_n: 'Yes',
-        performance_at_interview_y_n: 'Yes',
+        honesty_and_professionalism_y_n: 'No',
+        performance_at_interview_y_n: 'No',
         qualifications_y_n: 'Yes',
-        quality_of_application_y_n: 'Yes',
+        quality_of_application_y_n: 'No',
         safeguarding_y_n: 'Yes',
-        offered_on_another_course_y_n: 'Yes',
-        interested_in_future_applications_y_n: 'Yes',
-        other_advice_or_feedback_y_n: 'Yes',
+        offered_on_another_course_y_n: 'No',
+        interested_in_future_applications_y_n: 'No',
+        other_advice_or_feedback_y_n: 'No',
+      },
+      rejected_at: Time.zone.now,
+    )
+  end
+
+  def reject_application_for_candidate_behaviour_and_qualifications(application_choice)
+    application_choice.update!(
+      status: :rejected,
+      structured_rejection_reasons: {
+        course_full_y_n: 'No',
+        candidate_behaviour_y_n: 'Yes',
+        honesty_and_professionalism_y_n: 'No',
+        performance_at_interview_y_n: 'No',
+        qualifications_y_n: 'Yes',
+        quality_of_application_y_n: 'No',
+        safeguarding_y_n: 'No',
+        offered_on_another_course_y_n: 'No',
+        interested_in_future_applications_y_n: 'No',
+        other_advice_or_feedback_y_n: 'No',
+      },
+      rejected_at: Time.zone.now,
+    )
+  end
+
+  def reject_application_for_candidate_behaviour(application_choice)
+    application_choice.update!(
+      status: :rejected,
+      structured_rejection_reasons: {
+        course_full_y_n: 'No',
+        candidate_behaviour_y_n: 'Yes',
+        honesty_and_professionalism_y_n: 'No',
+        performance_at_interview_y_n: 'No',
+        qualifications_y_n: 'No',
+        quality_of_application_y_n: 'No',
+        safeguarding_y_n: 'No',
+        offered_on_another_course_y_n: 'No',
+        interested_in_future_applications_y_n: 'No',
+        other_advice_or_feedback_y_n: 'No',
       },
       rejected_at: Time.zone.now,
     )
@@ -90,72 +134,82 @@ private
   end
 
   def then_i_should_see_reasons_for_rejection_course_full
-    expect(all('.govuk-heading-m')[0]).to have_content('Course full')
-    expect(all('.govuk-grid-row')[0]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[0]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[0]).to have_content('1 this month')
+    within '#course_full' do
+      expect(page).to have_content('0 of 5 application choices')
+      expect(page).to have_content('0 total')
+      expect(page).to have_content('0 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_candidate_behaviour
-    expect(all('.govuk-heading-m')[1]).to have_content('Candidate behaviour')
-    expect(all('.govuk-grid-row')[1]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[1]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[1]).to have_content('1 this month')
+    within '#candidate_behaviour' do
+      expect(page).to have_content('5 of 5 application choices')
+      expect(page).to have_content('5 total')
+      expect(page).to have_content('2 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_honesty_and_professionalism
-    expect(all('.govuk-heading-m')[2]).to have_content('Honesty and professionalism')
-    expect(all('.govuk-grid-row')[2]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[2]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[2]).to have_content('1 this month')
+    within '#honesty_and_professionalism' do
+      expect(page).to have_content('0 of 5 application choices')
+      expect(page).to have_content('0 total')
+      expect(page).to have_content('0 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_offered_on_another_course
-    expect(all('.govuk-heading-m')[3]).to have_content('Offered on another course')
-    expect(all('.govuk-grid-row')[3]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[3]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[3]).to have_content('1 this month')
+    within '#offered_on_another_course' do
+      expect(page).to have_content('0 of 5 application choices')
+      expect(page).to have_content('0 total')
+      expect(page).to have_content('0 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_performance_at_interview
-    expect(all('.govuk-heading-m')[4]).to have_content('Performance at interview')
-    expect(all('.govuk-grid-row')[4]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[4]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[4]).to have_content('1 this month')
+    within '#performance_at_interview' do
+      expect(page).to have_content('0 of 5 application choices')
+      expect(page).to have_content('0 total')
+      expect(page).to have_content('0 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_qualifications
-    expect(all('.govuk-heading-m')[5]).to have_content('Qualifications')
-    expect(all('.govuk-grid-row')[5]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[5]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[5]).to have_content('1 this month')
+    within '#qualifications' do
+      expect(page).to have_content('3 of 5 application choices')
+      expect(page).to have_content('3 total')
+      expect(page).to have_content('1 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_quality_of_application
-    expect(all('.govuk-heading-m')[6]).to have_content('Quality of application')
-    expect(all('.govuk-grid-row')[6]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[6]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[6]).to have_content('1 this month')
+    within '#quality_of_application' do
+      expect(page).to have_content('0 of 5 application choices')
+      expect(page).to have_content('0 total')
+      expect(page).to have_content('0 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_safeguarding_concerns
-    expect(all('.govuk-heading-m')[7]).to have_content('Safeguarding concerns')
-    expect(all('.govuk-grid-row')[7]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[7]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[7]).to have_content('1 this month')
+    within '#safeguarding_concerns' do
+      expect(page).to have_content('2 of 5 application choices')
+      expect(page).to have_content('2 total')
+      expect(page).to have_content('1 this month')
+    end
   end
 
   def and_i_should_see_reasons_for_rejection_interested_in_future_applications
-    expect(all('.govuk-heading-m')[8]).to have_content('Interested in future applications')
-    expect(all('.govuk-grid-row')[8]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[8]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[8]).to have_content('1 this month')
+    within '#interested_in_future_applications' do
+      expect(page).to have_content('0 of 5 application choices')
+      expect(page).to have_content('0 total')
+      expect(page).to have_content('0 this month')
+    end
   end
 
-  def and_i_should_see_reasons_for_rejection_other_advice_or_feeback
-    expect(all('.govuk-heading-m')[9]).to have_content('Other advice or feedback')
-    expect(all('.govuk-grid-row')[9]).to have_content('10% of all structured rejections')
-    expect(all('.govuk-grid-row')[9]).to have_content('2 total')
-    expect(all('.govuk-grid-row')[9]).to have_content('1 this month')
+  def and_i_should_see_reasons_for_rejection_other_advice_or_feedback
+    within '#other_advice_or_feedback' do
+      expect(page).to have_content('0 of 5 application choices')
+      expect(page).to have_content('0 total')
+      expect(page).to have_content('0 this month')
+    end
   end
 end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -135,6 +135,7 @@ private
 
   def then_i_should_see_reasons_for_rejection_course_full
     within '#course_full' do
+      expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 application choices')
       expect(page).to have_content('0 total')
       expect(page).to have_content('0 this month')
@@ -143,6 +144,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_candidate_behaviour
     within '#candidate_behaviour' do
+      expect(page).to have_content('100%')
       expect(page).to have_content('5 of 5 application choices')
       expect(page).to have_content('5 total')
       expect(page).to have_content('2 this month')
@@ -151,6 +153,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_honesty_and_professionalism
     within '#honesty_and_professionalism' do
+      expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 application choices')
       expect(page).to have_content('0 total')
       expect(page).to have_content('0 this month')
@@ -159,6 +162,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_offered_on_another_course
     within '#offered_on_another_course' do
+      expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 application choices')
       expect(page).to have_content('0 total')
       expect(page).to have_content('0 this month')
@@ -167,6 +171,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_performance_at_interview
     within '#performance_at_interview' do
+      expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 application choices')
       expect(page).to have_content('0 total')
       expect(page).to have_content('0 this month')
@@ -175,6 +180,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_qualifications
     within '#qualifications' do
+      expect(page).to have_content('60%')
       expect(page).to have_content('3 of 5 application choices')
       expect(page).to have_content('3 total')
       expect(page).to have_content('1 this month')
@@ -183,6 +189,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_quality_of_application
     within '#quality_of_application' do
+      expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 application choices')
       expect(page).to have_content('0 total')
       expect(page).to have_content('0 this month')
@@ -191,6 +198,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_safeguarding_concerns
     within '#safeguarding_concerns' do
+      expect(page).to have_content('40%')
       expect(page).to have_content('2 of 5 application choices')
       expect(page).to have_content('2 total')
       expect(page).to have_content('1 this month')
@@ -199,6 +207,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_interested_in_future_applications
     within '#interested_in_future_applications' do
+      expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 application choices')
       expect(page).to have_content('0 total')
       expect(page).to have_content('0 this month')
@@ -207,6 +216,7 @@ private
 
   def and_i_should_see_reasons_for_rejection_other_advice_or_feedback
     within '#other_advice_or_feedback' do
+      expect(page).to have_content('0%')
       expect(page).to have_content('0 of 5 application choices')
       expect(page).to have_content('0 total')
       expect(page).to have_content('0 this month')


### PR DESCRIPTION
## Context
 
The previous implementation worked as follows:

If there are 5 application choices with the following rejection reasons:
- 5 of 5 were rejected for candidates_behaviour
- 3 of 5 were rejected on quals,
- 2 of 5 were rejected on safeguarding
- 0 of 5were rejected for all other reasons

It would show the following %s
- candidates behaviour: 50% (5 of the 10 rejection reasons)
- quals: 30%  (3 of the 10 rejection reasons)
- safeguarding: 20%  (2 of the 10 rejection reasons)
- all_others: 0%

The cumulative total of all the rejection reasons will always add up to 100%.

After some discussion with James, Steve and Rachael, using a different approach which treats each rejection reason as distinct and doing the `total_rejections_for_x  /total_number_of_choices_with_structured_rejection_reasons * 100` seems to be the way to go. 

Firstly, while is indicates rejection reasons are more common, this can be ascertained by just looking at the total number of rejection for each section.

Secondly, most of the tiles on the dashboard are for rejection reasons. However, the `Interested in future applications `and` Other advice or feedback `sections are not. Due to this the actual %s of the reasons the providers gave for rejecting applicants will be distorted.

For example, there were 5 total, rejections all of which were for qualifications, but for each rejection, the provider said they would be interested in the applicant applying again and gave feedback telling the candidate to reapply, you would get the following %s on the dashboard:

33.3% rejected for quals
33.3% for Interested in future applications
33.3% Other advice or feedback

## Changes proposed in this pull request

Update the components to:

1. Calculate the percentage by taking the amount_rejected_for_reason / application_choices_with_restructured_rejection_reasons* 100
2. Be a bit more explicit what is g
Before 

![image](https://user-images.githubusercontent.com/42515961/106064716-33107200-60f2-11eb-8ee8-25739b6db8c3.png)

After

![image](https://user-images.githubusercontent.com/42515961/106066291-7bc92a80-60f4-11eb-8c89-0530414bcfb2.png)


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
