### PR TITLE
Update UCAS matches dual application resolved on UCAS emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -327,7 +327,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.ucas_match.resolved_on_ucas.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.resolved.subject'),
     )
   end
 
@@ -337,7 +337,7 @@ class CandidateMailer < ApplicationMailer
 
     email_for_candidate(
       application_choice.application_form,
-      subject: I18n.t!('candidate_mailer.ucas_match.resolved_on_apply.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.resolved.subject'),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -313,11 +313,11 @@ class CandidateMailer < ApplicationMailer
 
   def ucas_match_reminder_email_multiple_acceptances(ucas_match)
     @initial_email_date = ucas_match.candidate_last_contacted_at.to_s(:govuk_date)
-    @request_ucas_withdrawal_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
+    @withdraw_by_date = ucas_match.calculate_action_date(:ucas_match_ucas_withdrawal_request, Time.zone.today).to_s(:govuk_date)
 
     email_for_candidate(
       ucas_match.candidate.current_application,
-      subject: I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
+      subject: I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject', withdraw_by_date: @withdraw_by_date),
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -331,6 +331,16 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def ucas_match_resolved_on_ucas_at_our_request_email(application_choice)
+    @course_name_and_code = application_choice.offered_option.course.name_and_code
+    @provider_name = application_choice.offered_option.provider.name
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.ucas_match.resolved_on_ucas_at_our_request.subject'),
+    )
+  end
+
   def ucas_match_resolved_on_apply_email(application_choice)
     @course_name_and_code = application_choice.offered_option.course.name_and_code
     @provider_name = application_choice.offered_option.provider.name

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -122,7 +122,7 @@ class ProviderMailer < ApplicationMailer
     email_for_provider(
       provider_user,
       @application_form,
-      subject: I18n.t!('provider_mailer.ucas_match.resolved_on_ucas.subject'),
+      subject: I18n.t!('provider_mailer.ucas_match.resolved.subject'),
     )
   end
 
@@ -133,7 +133,7 @@ class ProviderMailer < ApplicationMailer
     email_for_provider(
       provider_user,
       @application_form,
-      subject: I18n.t!('provider_mailer.ucas_match.resolved_on_apply.subject'),
+      subject: I18n.t!('provider_mailer.ucas_match.resolved.subject'),
     )
   end
 

--- a/app/services/ucas_matches/resolve_on_ucas.rb
+++ b/app/services/ucas_matches/resolve_on_ucas.rb
@@ -8,7 +8,10 @@ module UCASMatches
 
     def call
       UCASMatches::RecordActionTaken.new(ucas_match, :resolved_on_ucas).call
-      UCASMatches::SendResolvedOnUCASEmails.new(ucas_match).call
+      UCASMatches::SendResolvedOnUCASEmails.new(
+        ucas_match,
+        at_our_request: ucas_match.action_taken_before_last_save == 'ucas_withdrawal_requested',
+      ).call
     end
   end
 end

--- a/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
+++ b/app/services/ucas_matches/send_resolved_on_ucas_emails.rb
@@ -1,9 +1,10 @@
 module UCASMatches
   class SendResolvedOnUCASEmails
-    attr_reader :ucas_match
+    attr_reader :ucas_match, :at_our_request
 
-    def initialize(ucas_match)
+    def initialize(ucas_match, at_our_request:)
       @ucas_match = ucas_match
+      @at_our_request = at_our_request
     end
 
     def call
@@ -11,7 +12,11 @@ module UCASMatches
 
       application_choice = ucas_match.application_choices_for_same_course_on_both_services.first
 
-      CandidateMailer.ucas_match_resolved_on_ucas_email(application_choice).deliver_later
+      if at_our_request
+        CandidateMailer.ucas_match_resolved_on_ucas_at_our_request_email(application_choice).deliver_later
+      else
+        CandidateMailer.ucas_match_resolved_on_ucas_email(application_choice).deliver_later
+      end
 
       application_choice.provider.provider_users.each do |provider_user|
         ProviderMailer.ucas_match_resolved_on_ucas_email(provider_user, application_choice).deliver_later

--- a/app/views/candidate_mailer/ucas_match_reminder_email_multiple_acceptances.text.erb
+++ b/app/views/candidate_mailer/ucas_match_reminder_email_multiple_acceptances.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application_form.full_name %>
 
 It looks like you accepted offers on both Apply for teacher training and UCAS Teacher Training.
 
-Further to our email on <%= @initial_email_date %>, you need to withdraw the choice from one of the systems by <%= @request_ucas_withdrawal_date %>. Accepting offers on both services is not allowed, as outlined by the terms of use.
+Further to our email on <%= @initial_email_date %>, you need to withdraw the choice from one of the systems by <%= @withdraw_by_date %>. Accepting offers on both services is not allowed, as outlined by the terms of use.
 
 For advice on choosing the right course for you, [talk to a teacher training adviser](https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher?gclid=Cj0KCQjwoJX8BRCZARIsAEWBFMKTN_IOJaoNoGkn16TZ-4udi-dX6GTfxDPNVAafEX5ZrPh1_m3lpbQaAhDsEALw_wcB&gclsrc=aw.ds).
 

--- a/app/views/candidate_mailer/ucas_match_resolved_on_ucas_at_our_request_email.text.erb
+++ b/app/views/candidate_mailer/ucas_match_resolved_on_ucas_at_our_request_email.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @application_form.full_name %>
+
+You applied to study <%= @course_name_and_code %> at <%= @provider_name %> through both GOV.UK and UCAS.
+
+You can only continue through one of the services, so we’ve withdrawn your application through UCAS.
+
+We’ve told <%= @provider_name %> that you’re applying through GOV.UK.
+
+# Track your application
+
+You can track your application through GOV.UK:
+
+[https://www.apply-for-teacher-training.service.gov.uk](https://www.apply-for-teacher-training.service.gov.uk)

--- a/app/views/candidate_mailer/ucas_match_resolved_on_ucas_email.text.erb
+++ b/app/views/candidate_mailer/ucas_match_resolved_on_ucas_email.text.erb
@@ -1,15 +1,11 @@
 Dear <%= @application_form.full_name %>
 
-We’ve written to you a couple of times as we noticed you applied to study <%= @course_name_and_code %> at <%= @provider_name %> on both Apply for teacher training and UCAS Teacher Training Apply – which isn’t allowed.
+You’ve withdrawn your application through UCAS to study <%= @course_name_and_code %> with <%= @provider_name %>.
 
-As you didn’t withdraw the choice, as requested, we have removed it from your UCAS application meaning you should use Apply for teacher training to track the progress of your application for <%= @course_name_and_code %>.
+We’ve told them that your application will continue through GOV.UK.
 
-Any other courses you applied to have not been affected.
+# Track your application
 
-We informed <%= @provider_name %> that the course choice was removed from your UCAS application.
+You can track your application through GOV.UK:
 
-If you have any questions, get in touch with us by contacting [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
-
-Sincerely,
-
-The Department for Education & UCAS
+[https://www.apply-for-teacher-training.service.gov.uk](https://www.apply-for-teacher-training.service.gov.uk)

--- a/app/views/provider_mailer/ucas_match_resolved_on_ucas_email.text.erb
+++ b/app/views/provider_mailer/ucas_match_resolved_on_ucas_email.text.erb
@@ -1,9 +1,4 @@
 Dear <%= @provider_user_name %>
+<%= @application_form.full_name %>’s duplicate application for <%= @course_name_and_code %> has been withdrawn from UCAS Teacher Training Apply.
 
-<%= @application_form.full_name %>’s duplicate application for <%= @course_name_and_code %> has been removed from their UCAS application.
-
-We’ve let the candidate know that they can continue their application for the course through Apply for teacher training.
-
-Sincerely,
-
-The Department for Education & UCAS
+Their application for the course will continue through DfE Apply for teacher training.

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -95,7 +95,5 @@ en:
         subject: "Withdraw your duplicate application by %{withdraw_by_date}"
       multiple_acceptances:
         subject: "Withdraw from one of your offers by %{withdraw_by_date}"
-      resolved_on_ucas:
-        subject: Your application has been deleted from UTT
-      resolved_on_apply:
-        subject: Your application has been deleted from DfE Apply
+      resolved:
+        subject: Duplicate application withdrawn

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -95,5 +95,7 @@ en:
         subject: "Withdraw your duplicate application by %{withdraw_by_date}"
       multiple_acceptances:
         subject: "Withdraw from one of your offers by %{withdraw_by_date}"
+      resolved_on_ucas_at_our_request:
+        subject: Duplicate application automatically withdrawn
       resolved:
         subject: Duplicate application withdrawn

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -22,9 +22,7 @@ en:
       initial_email:
         duplicate_applications:
           subject: "Duplicate application identified"
-      resolved_on_ucas:
-        subject: Duplicate applicant removed from UTT
-      resolved_on_apply:
-        subject: Duplicate applicant removed from DfE Apply
+      resolved:
+        subject: Duplicate application withdrawn
     courses_open_on_apply:
       subject: Your courses are live on Apply and you have access to Manage

--- a/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe CandidateMailer, type: :mailer do
     )
   end
 
+  describe '.ucas_match_resolved_on_ucas_at_our_request_email' do
+    let(:email) { mailer.ucas_match_resolved_on_ucas_at_our_request_email(application_form.application_choices.first) }
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'Duplicate application automatically withdrawn',
+      'heading' => 'Dear Ada Lovelace',
+      'course_code_and_option' => 'to study Primary (33WA) at Wonderland University',
+      'tracking' => 'You can track your application through GOV.UK',
+      'removal details' => 'we’ve withdrawn your application through UCAS',
+    )
+  end
+
   describe '.ucas_match_resolved_on_apply_email' do
     let(:email) { mailer.ucas_match_resolved_on_apply_email(application_form.application_choices.first) }
 

--- a/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match.resolved_on_ucas.subject'),
+      'Duplicate application withdrawn',
       'heading' => 'Dear Ada Lovelace',
       'course_code_and_option' => 'to study Primary (33WA) at Wonderland University',
       'tracking' => 'use Apply for teacher training',
@@ -28,7 +28,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match.resolved_on_apply.subject'),
+      'Duplicate application withdrawn',
       'heading' => 'Dear Ada Lovelace',
       'course_code_and_option' => 'to study Primary (33WA) at Wonderland University',
       'tracking' => 'use [UCAS Teacher Training]',

--- a/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_emails_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe CandidateMailer, type: :mailer do
       'a mail with subject and content',
       'Duplicate application withdrawn',
       'heading' => 'Dear Ada Lovelace',
-      'course_code_and_option' => 'to study Primary (33WA) at Wonderland University',
-      'tracking' => 'use Apply for teacher training',
-      'removal details' => 'the course choice was removed from your UCAS application',
+      'course_code_and_option' => 'to study Primary (33WA) with Wonderland University',
+      'tracking' => 'You can track your application through GOV.UK',
+      'removal details' => 'You’ve withdrawn your application through UCAS',
     )
   end
 

--- a/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_initial_email_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match.duplicate_applications.subject', withdraw_by_date: '1 February 2021'),
+      'Withdraw your duplicate application by 1 February 2021',
       'heading' => 'Dear Jane',
       'course' => 'Physics (3PH5)',
       'provider' => 'Coventry University',
@@ -33,7 +33,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject', withdraw_by_date: '1 February 2021'),
+      'Withdraw from one of your offers by 1 February 2021',
       'heading' => 'Dear Jane',
       'withdrawal day' => '1 February 2021',
     )

--- a/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
+++ b/spec/mailers/candidate_mailer_ucas_match_reminder_email_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match.duplicate_applications.subject', withdraw_by_date: '30 November 2020'),
+      'Withdraw your duplicate application by 30 November 2020',
       'heading' => 'Dear Jane',
       'course name and code' => 'Physics (3PH5)',
       'provider' => 'City University',
@@ -36,7 +36,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it_behaves_like(
       'a mail with subject and content',
-      I18n.t!('candidate_mailer.ucas_match.multiple_acceptances.subject'),
+      'Withdraw from one of your offers by 30 November 2020',
       'heading' => 'Dear Jane',
       'initial email date' => '16 November 2020',
       'withdraw by date' => '30 November 2020',

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -549,6 +549,16 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.ucas_match_resolved_on_ucas_email(application_choice)
   end
 
+  def ucas_match_resolved_on_ucas_at_our_request_email
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form,
+      course_option: course_option,
+    )
+
+    CandidateMailer.ucas_match_resolved_on_ucas_at_our_request_email(application_choice)
+  end
+
   def ucas_match_resolved_on_apply_email
     application_choice = FactoryBot.build_stubbed(
       :application_choice,

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -539,6 +539,26 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.ucas_match_reminder_email_multiple_acceptances(ucas_match)
   end
 
+  def ucas_match_resolved_on_ucas_email
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form,
+      course_option: course_option,
+    )
+
+    CandidateMailer.ucas_match_resolved_on_ucas_email(application_choice)
+  end
+
+  def ucas_match_resolved_on_apply_email
+    application_choice = FactoryBot.build_stubbed(
+      :application_choice,
+      application_form: application_form,
+      course_option: course_option,
+    )
+
+    CandidateMailer.ucas_match_resolved_on_apply_email(application_choice)
+  end
+
 private
 
   def candidate

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -42,6 +42,14 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.ucas_match_initial_email_duplicate_applications(provider_user, application_choice)
   end
 
+  def ucas_match_resolved_on_ucas_email
+    ProviderMailer.ucas_match_resolved_on_ucas_email(provider_user, application_choice)
+  end
+
+  def ucas_match_resolved_on_apply_email
+    ProviderMailer.ucas_match_resolved_on_apply_email(provider_user, application_choice)
+  end
+
   def fallback_sign_in_email
     ProviderMailer.fallback_sign_in_email(
       FactoryBot.build_stubbed(:provider_user),

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
 
     it_behaves_like('a mail with subject and content',
-                    I18n.t('provider_mailer.ucas_match.resolved_on_ucas.subject'),
+                    'Duplicate application withdrawn',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')
@@ -186,7 +186,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
 
     it_behaves_like('a mail with subject and content',
-                    I18n.t('provider_mailer.ucas_match.resolved_on_apply.subject'),
+                    'Duplicate application withdrawn',
                     'provider name' => 'Dear Johny English',
                     'candidate name' => 'Harry Potter',
                     'course name and code' => 'Computer Science (6IND)')

--- a/spec/services/ucas_matches/resolve_on_ucas_spec.rb
+++ b/spec/services/ucas_matches/resolve_on_ucas_spec.rb
@@ -1,20 +1,38 @@
 require 'rails_helper'
 
-RSpec.describe UCASMatches::ResolveOnUCAS do
-  let(:ucas_match) { create(:ucas_match) }
-  let(:send_resolved_on_ucas_emails) { instance_double(UCASMatches::SendResolvedOnUCASEmails, call: true) }
+RSpec.describe UCASMatches::ResolveOnUCAS, sidekiq: true do
+  let(:ucas_match) { create(:ucas_match, :with_dual_application) }
 
   context 'when the application has a ucas_match' do
     before do
-      allow(UCASMatches::SendResolvedOnUCASEmails).to receive(:new).with(ucas_match)
-                                                                   .and_return(send_resolved_on_ucas_emails)
+      ucas_match.application_choices_for_same_course_on_both_services.first.provider.provider_users = [create(:provider_user)]
       described_class.new(ucas_match).call
     end
 
     it 'sets the application as resolved on UCAS and sends the relevant emails' do
-      expect(ucas_match.action_taken).to eq('resolved_on_ucas')
+      candidate_email = ActionMailer::Base.deliveries.find { |e| e.header['rails-mailer'].value == 'candidate_mailer' }
+      provider_email = ActionMailer::Base.deliveries.find { |e| e.header['rails-mailer'].value == 'provider_mailer' }
 
-      expect(UCASMatches::SendResolvedOnUCASEmails).to have_received(:new).with(ucas_match)
+      expect(ucas_match.action_taken).to eq('resolved_on_ucas')
+      expect(candidate_email.header['rails-mail-template'].value).to eq('ucas_match_resolved_on_ucas_email')
+      expect(provider_email.header['rails-mail-template'].value).to eq('ucas_match_resolved_on_ucas_email')
+    end
+  end
+
+  context 'when we requested withdrawal from UCAS' do
+    before do
+      ucas_match.ucas_withdrawal_requested!
+      ucas_match.application_choices_for_same_course_on_both_services.first.provider.provider_users = [create(:provider_user)]
+      described_class.new(ucas_match).call
+    end
+
+    it 'sets the application as resolved on UCAS and sends the relevant emails' do
+      candidate_email = ActionMailer::Base.deliveries.find { |e| e.header['rails-mailer'].value == 'candidate_mailer' }
+      provider_email = ActionMailer::Base.deliveries.find { |e| e.header['rails-mailer'].value == 'provider_mailer' }
+
+      expect(ucas_match.action_taken).to eq('resolved_on_ucas')
+      expect(candidate_email.header['rails-mail-template'].value).to eq('ucas_match_resolved_on_ucas_at_our_request_email')
+      expect(provider_email.header['rails-mail-template'].value).to eq('ucas_match_resolved_on_ucas_email')
     end
   end
 end

--- a/spec/services/ucas_matches/send_resolved_on_ucas_emails_spec.rb
+++ b/spec/services/ucas_matches/send_resolved_on_ucas_emails_spec.rb
@@ -16,11 +16,30 @@ RSpec.describe UCASMatches::SendResolvedOnUCASEmails do
       create(:provider_permissions, provider_id: course.provider.id, provider_user_id: provider_user.id)
       allow(CandidateMailer).to receive(:ucas_match_resolved_on_ucas_email).and_return(mail)
       allow(ProviderMailer).to receive(:ucas_match_resolved_on_ucas_email).and_return(mail)
-      described_class.new(ucas_match).call
+      described_class.new(ucas_match, at_our_request: false).call
     end
 
     it 'sends the candidate the ucas_match_resolved_on_ucas_email' do
       expect(CandidateMailer).to have_received(:ucas_match_resolved_on_ucas_email).with(application_choice)
+    end
+
+    it 'sends the provider the ucas_match_resolved_on_ucas_email' do
+      expect(ProviderMailer).to have_received(:ucas_match_resolved_on_ucas_email).with(provider_user, application_choice)
+    end
+  end
+
+  context 'when the application has been resolved on ucas at our request' do
+    let(:ucas_match) { create(:ucas_match, action_taken: 'resolved_on_ucas', application_form: application_form, scheme: %w[B]) }
+
+    before do
+      create(:provider_permissions, provider_id: course.provider.id, provider_user_id: provider_user.id)
+      allow(CandidateMailer).to receive(:ucas_match_resolved_on_ucas_at_our_request_email).and_return(mail)
+      allow(ProviderMailer).to receive(:ucas_match_resolved_on_ucas_email).and_return(mail)
+      described_class.new(ucas_match, at_our_request: true).call
+    end
+
+    it 'sends the candidate the ucas_match_resolved_on_ucas_at_our_request_email' do
+      expect(CandidateMailer).to have_received(:ucas_match_resolved_on_ucas_at_our_request_email).with(application_choice)
     end
 
     it 'sends the provider the ucas_match_resolved_on_ucas_email' do

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-ucas_match_reminder_email_duplicate_applications
       candidate_mailer-ucas_match_reminder_email_multiple_acceptances
       candidate_mailer-ucas_match_resolved_on_ucas_email
+      candidate_mailer-ucas_match_resolved_on_ucas_at_our_request_email
       provider_mailer-ucas_match_resolved_on_ucas_email
       candidate_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-ucas_match_resolved_on_apply_email

--- a/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
+++ b/spec/system/ucas_matching/process_matching_data_from_ucas_spec.rb
@@ -119,7 +119,7 @@ RSpec.feature 'Processing matching data from UCAS', sidekiq: true do
 
   def then_we_have_sent_email_to_the_provider_that_the_match_was_resolved_on_ucas
     provider_email = ActionMailer::Base.deliveries.find { |e| e.header['to'].value == @provider_user1.email_address }
-    expect(provider_email.subject).to include 'Duplicate applicant removed from UTT'
+    expect(provider_email.subject).to include 'Duplicate application withdrawn'
   end
 
   def then_we_have_sent_emails_about_dual_application_to_the_candidate_and_the_provider


### PR DESCRIPTION
## Context

We need better copy.

## Changes proposed in this pull request

- Don't use translations to test UCAS matches emails subjects
- Add missing email previews for resolved on UCAS and Apply
- Send resolved on UCAS automatically email when we requested withdrawal from UCAS
- Update email copy for UCAS match resolved on UCAS

## Guidance to review

See mailer previews

## Link to Trello card

https://trello.com/c/j9YmgCWM/3276-update-ucas-matches-emails-content-dual-applications

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
