### PR TITLE
Spec enhancements -  stubbing in factories

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,20 @@
 FactoryBot.define do
+  factory :dual_application_ucas_match, class: 'UCASMatch' do
+    trait :need_to_send_reminder_emails do
+      action_taken { 'initial_emails_sent' }
+      candidate_last_contacted_at { 5.business_days.before(Time.zone.now) }
+    end
+
+    trait :need_to_request_withdrawal_from_ucas do
+      action_taken { 'reminder_emails_sent' }
+      candidate_last_contacted_at { 5.business_days.before(Time.zone.now) }
+    end
+
+    after(:stub) do |ucas_match, _|
+      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+    end
+  end
+
   factory :ucas_match do
     candidate { application_form.candidate }
     matching_data { nil }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,20 +1,4 @@
 FactoryBot.define do
-  factory :dual_application_ucas_match, class: 'UCASMatch' do
-    trait :need_to_send_reminder_emails do
-      action_taken { 'initial_emails_sent' }
-      candidate_last_contacted_at { 5.business_days.before(Time.zone.now) }
-    end
-
-    trait :need_to_request_withdrawal_from_ucas do
-      action_taken { 'reminder_emails_sent' }
-      candidate_last_contacted_at { 5.business_days.before(Time.zone.now) }
-    end
-
-    after(:stub) do |ucas_match, _|
-      allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
-    end
-  end
-
   factory :ucas_match do
     candidate { application_form.candidate }
     matching_data { nil }

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe UCASMatch do
   let(:candidate) { create(:candidate) }
   let(:course) { create(:course) }
-  let!(:application_form_awaiting_provider_decision) { create(:completed_application_form, candidate_id: candidate.id, application_choices_count: 1) }
+  let(:application_form_awaiting_provider_decision) { create(:completed_application_form, candidate_id: candidate.id, application_choices_count: 1) }
   let(:course1) { application_form_awaiting_provider_decision.application_choices.first.course_option.course }
   let(:both_schemes_match) do
     { 'Scheme' => 'B',

--- a/spec/models/ucas_match_spec.rb
+++ b/spec/models/ucas_match_spec.rb
@@ -11,24 +11,24 @@ RSpec.describe UCASMatch do
       'Apply candidate ID' => candidate.id.to_s,
       'Provider code' => course.provider.code.to_s }
   end
-  let(:ucas_match) { create(:ucas_match) }
+  let(:ucas_match) { build_stubbed(:ucas_match) }
 
   describe '#action_needed?' do
     it 'returns false if ucas match has been manually resolved' do
-      ucas_match = create(:ucas_match, action_taken: 'manually_resolved')
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'manually_resolved')
 
       expect(ucas_match.action_needed?).to eq(false)
     end
 
     it 'returns false if ucas match is resolved' do
-      ucas_match = create(:ucas_match, action_taken: 'resolved_on_ucas')
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'resolved_on_ucas')
 
       expect(ucas_match.action_needed?).to eq(false)
     end
 
     it 'returns false if initial emails were sent and we do not need to send the reminders yet' do
       initial_emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, :with_dual_application, action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: initial_emails_sent_at)
 
       Timecop.travel(1.business_days.after(initial_emails_sent_at)) do
         expect(ucas_match.action_needed?).to eq(false)
@@ -36,31 +36,31 @@ RSpec.describe UCASMatch do
     end
 
     it 'returns true if initial emails were sent and it is time to send a reminder email' do
-      ucas_match = create(:ucas_match, :with_dual_application, :need_to_send_reminder_emails)
+      ucas_match = build_stubbed(:dual_application_ucas_match, :need_to_send_reminder_emails)
 
       expect(ucas_match.action_needed?).to eq(true)
     end
 
     it 'returns false if reminder emails were sent and we do not need to request withdrawal from UCAS yet' do
-      ucas_match = create(:ucas_match, :with_dual_application, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: Time.zone.now)
 
       expect(ucas_match.action_needed?).to eq(false)
     end
 
     it 'returns true if reminder emails were sent and it is time to request withdrawal from UCAS' do
-      ucas_match = create(:ucas_match, :with_dual_application, :need_to_request_withdrawal_from_ucas)
+      ucas_match = build_stubbed(:dual_application_ucas_match, :need_to_request_withdrawal_from_ucas)
 
       expect(ucas_match.action_needed?).to eq(true)
     end
 
     it 'returns false if we requested withdrawal from UCAS' do
-      ucas_match = create(:ucas_match, :with_dual_application, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: Time.zone.now)
 
       expect(ucas_match.action_needed?).to eq(false)
     end
 
     it 'returns true if there is a dual application or dual acceptance' do
-      ucas_match = create(:ucas_match, :with_dual_application)
+      ucas_match = build_stubbed(:dual_application_ucas_match)
 
       expect(ucas_match.action_needed?).to eq(true)
     end
@@ -74,7 +74,7 @@ RSpec.describe UCASMatch do
 
   describe '#resolved?' do
     it 'returns true if action_taken is resolved_on_apply or resolved_on_ucas' do
-      ucas_match = create(:ucas_match, action_taken: 'resolved_on_ucas')
+      ucas_match = build_stubbed(:ucas_match, action_taken: 'resolved_on_ucas')
 
       expect(ucas_match.resolved?).to eq(true)
     end
@@ -82,13 +82,13 @@ RSpec.describe UCASMatch do
 
   describe '#ready_to_resolve?' do
     it 'returns true if no further action is required and the match is not resolved' do
-      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested')
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'ucas_withdrawal_requested')
 
       expect(ucas_match.ready_to_resolve?).to eq(true)
     end
 
     it 'returns false if no further action is required and the match is resolved' do
-      ucas_match = create(:ucas_match, action_taken: 'resolved_on_ucas')
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'resolved_on_ucas')
 
       expect(ucas_match.ready_to_resolve?).to eq(false)
     end
@@ -186,7 +186,7 @@ RSpec.describe UCASMatch do
   describe '#need_to_send_reminder_emails?' do
     it 'returns false if last action taken in not initial emails sent' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(1.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_send_reminder_emails?).to eq(false)
@@ -195,7 +195,7 @@ RSpec.describe UCASMatch do
 
     it 'returns false if initial emails were sent and we do not need to send the reminders yet' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'initial_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(1.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_send_reminder_emails?).to eq(false)
@@ -203,7 +203,7 @@ RSpec.describe UCASMatch do
     end
 
     it 'returns true if initial emails were sent and it is time to send a reminder email' do
-      ucas_match = create(:ucas_match, :need_to_send_reminder_emails)
+      ucas_match = build_stubbed(:dual_application_ucas_match, :need_to_send_reminder_emails)
 
       expect(ucas_match.need_to_send_reminder_emails?).to eq(true)
     end
@@ -212,14 +212,14 @@ RSpec.describe UCASMatch do
   describe '#need_to_request_withdrawal_from_ucas?' do
     it 'returns false if last action taken in not reminder emails sent' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'ucas_withdrawal_requested', candidate_last_contacted_at: emails_sent_at)
 
       expect(ucas_match.need_to_request_withdrawal_from_ucas?).to eq(false)
     end
 
     it 'returns false if reminder emails were sent and we do not need to request withdrawal from ucas yet' do
       emails_sent_at = Time.zone.now
-      ucas_match = create(:ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: emails_sent_at)
+      ucas_match = build_stubbed(:dual_application_ucas_match, action_taken: 'reminder_emails_sent', candidate_last_contacted_at: emails_sent_at)
 
       Timecop.travel(1.business_days.after(emails_sent_at)) do
         expect(ucas_match.need_to_request_withdrawal_from_ucas?).to eq(false)
@@ -227,7 +227,7 @@ RSpec.describe UCASMatch do
     end
 
     it 'returns true if reminder emails were sent and it is time to request withdrawal from ucas' do
-      ucas_match = create(:ucas_match, :need_to_request_withdrawal_from_ucas)
+      ucas_match = build_stubbed(:dual_application_ucas_match, :need_to_request_withdrawal_from_ucas)
 
       expect(ucas_match.need_to_request_withdrawal_from_ucas?).to eq(true)
     end
@@ -235,17 +235,19 @@ RSpec.describe UCASMatch do
 
   describe '#next_action' do
     it 'returns :initial_emails_sent if the candidate has never been contacted' do
+      ucas_match = build_stubbed(:dual_application_ucas_match)
+
       expect(ucas_match.next_action).to eq(:initial_emails_sent)
     end
 
     it 'returns :reminder_emails_sent if initial emails were sent and it time to send reminder emails' do
-      ucas_match = create(:ucas_match, :need_to_send_reminder_emails)
+      ucas_match = build_stubbed(:dual_application_ucas_match, :need_to_send_reminder_emails)
 
       expect(ucas_match.next_action).to eq(:reminder_emails_sent)
     end
 
     it 'returns :ucas_withdrawal_requested if reminder emails were sent and it time to request withdrawal from UCAS' do
-      ucas_match = create(:ucas_match, :need_to_request_withdrawal_from_ucas)
+      ucas_match = build_stubbed(:dual_application_ucas_match, :need_to_request_withdrawal_from_ucas)
 
       expect(ucas_match.next_action).to eq(:ucas_withdrawal_requested)
     end

--- a/spec/models/ucas_matched_application_spec.rb
+++ b/spec/models/ucas_matched_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe UCASMatchedApplication do
+RSpec.describe UCASMatchedApplication, create_dual_application_ucas_match_stub: true do
   let(:recruitment_cycle_year) { 2020 }
   let(:candidate) { build_stubbed(:candidate) }
   let(:provider) { build_stubbed(:provider) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,4 +96,8 @@ RSpec.configure do |config|
   config.define_derived_metadata(file_path: Regexp.new('/spec/forms/')) do |metadata|
     metadata[:type] = 'model'
   end
+
+  FactoryBot::SyntaxRunner.class_eval do
+    include RSpec::Mocks::ExampleMethods
+  end
 end

--- a/spec/support/factory_stubs/dual_application_ucas_match_stub.rb
+++ b/spec/support/factory_stubs/dual_application_ucas_match_stub.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite, :create_dual_application_ucas_match_stub) do
+    FactoryBot.define do
+      factory :dual_application_ucas_match, class: 'UCASMatch' do
+        trait :need_to_send_reminder_emails do
+          action_taken { 'initial_emails_sent' }
+          candidate_last_contacted_at { 5.business_days.before(Time.zone.now) }
+        end
+
+        trait :need_to_request_withdrawal_from_ucas do
+          action_taken { 'reminder_emails_sent' }
+          candidate_last_contacted_at { 5.business_days.before(Time.zone.now) }
+        end
+
+        after(:stub) do |ucas_match, _|
+          allow(ucas_match).to receive(:dual_application_or_dual_acceptance?).and_return(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Enables stubbing in factories, as discussed in last week's dev retro, and updates ucas_match spec to utilise stubbed factory where data retrieval is not required.

## Changes proposed in this pull request

- Update rspec configuration to enable stubs in factories
- Use new stubeed factory in UCASMatch spec
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
