### PR TITLE
Issues with pdf application downloads

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-header <%= classes %>" role="banner" data-module="govuk-header">
+<header class="govuk-header govuk-!-display-none-print <%= classes %>" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <%= link_to 'https://gov.uk', class: 'govuk-header__link govuk-header__link--homepage' do %>

--- a/app/components/interview_preferences_component.html.erb
+++ b/app/components/interview_preferences_component.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="interview">Interview</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>

--- a/app/components/personal_statement_component.html.erb
+++ b/app/components/personal_statement_component.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>

--- a/app/components/primary_navigation_component.html.erb
+++ b/app/components/primary_navigation_component.html.erb
@@ -1,4 +1,4 @@
-<div class="moj-primary-navigation">
+<div class="moj-primary-navigation govuk-!-display-none-print">
   <div class="moj-primary-navigation__container">
     <div class="moj-primary-navigation__nav">
       <nav class="moj-primary-navigation" aria-label="Primary navigation">

--- a/app/components/product_header_component.html.erb
+++ b/app/components/product_header_component.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-header app-header <%= classes %>" role="banner" data-module="govuk-header">
+<header class="govuk-header app-header govuk-!-display-none-print <%= classes %>" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo app-header__logo--provider">
       <%= link_to service_url, class: 'govuk-header__link govuk-header__link--homepage' do %>

--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -4,7 +4,7 @@
 </h1>
 
 <% if show_inset_text? -%>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row govuk-!-display-none-print">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <div class="govuk-inset-text govuk-!-margin-top-0">
         <% if respond_to_application? -%>

--- a/app/components/provider_interface/diversity_information_component.html.erb
+++ b/app/components/provider_interface/diversity_information_component.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="diversity-information">Diversity information</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -2,7 +2,7 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="criminal-convictions-and-professional-misconduct">Criminal convictions and professional misconduct</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="disability-access-and-other-needs">Disability, access and other needs</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -1,7 +1,9 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">View guidance given to candidate</span>
+  <summary class="govuk-details__summary govuk-!-display-none-print">
+    <span class="govuk-details__summary-text">
+      View guidance given to candidate
+    </span>
   </summary>
   <div class="govuk-details__text">
     <h3 class="govuk-heading-m"><%= t('page_titles.other_qualification') %></h3>

--- a/app/components/sandbox_feature_component.html.erb
+++ b/app/components/sandbox_feature_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-status-box app-status-box--sandbox govuk-!-margin-bottom-6">
+<div class="app-status-box app-status-box--sandbox govuk-!-margin-bottom-6 govuk-!-display-none-print">
   <p class="govuk-body">
     <%= render TagComponent.new(text: 'Sandbox feature', type: 'purple') %>
   </p>

--- a/app/components/tab_navigation_component.html.erb
+++ b/app/components/tab_navigation_component.html.erb
@@ -1,5 +1,5 @@
 <nav class="app-tab-navigation" aria-label="Sub navigation" data-qa="sub-navigation">
-  <ul class="app-tab-navigation__list">
+  <ul class="app-tab-navigation__list govuk-!-display-none-print">
     <% items.each do |item| %>
       <li class="app-tab-navigation__item">
         <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>

--- a/app/components/volunteering_history_component.html.erb
+++ b/app/components/volunteering_history_component.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="unpaid-experience-and-volunteering">Unpaid experience and volunteering</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>

--- a/app/components/work_history_component.html.erb
+++ b/app/components/work_history_component.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="work-history">Work history</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>

--- a/app/views/provider_interface/application_choices/_references_context.html.erb
+++ b/app/views/provider_interface/application_choices/_references_context.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8 govuk-!-margin-bottom-2" id="references">References</h2>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to candidate
     </span>
@@ -19,7 +19,7 @@
   </div>
 </details>
 <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
+  <summary class="govuk-details__summary govuk-!-display-none-print">
     <span class="govuk-details__summary-text">
       View guidance given to referee
     </span>

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,7 +59,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.middleware.insert_after ActionDispatch::HostAuthorization, RedirectToServiceGovUkMiddleware
     config.middleware.use VendorAPIRequestMiddleware
-    config.middleware.use PDFKit::Middleware, { print_media_type: true }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
+    config.middleware.use PDFKit::Middleware, { print_media_type: true, page_size: "A4" }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
     config.skylight.environments = ENV['SKYLIGHT_ENABLE'].to_s == 'true' ? [Rails.env] : []
 
     config.after_initialize do |app|


### PR DESCRIPTION
## Context
https://trello.com/c/AZSwZwcx/2568-issues-with-pdf-application-downloads

Applications can be downloaded as PDFs, but they were being formatted as American Letter pages, rather than A4 pages. Additionally, they took a relatively unmodified version of the page, which included a lot of 'webby' bits that weren't very high value, and took up page space unecessarily. 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
* Change application PDF downloads to A4 sizing
* Added no print flags to a selection of elements on the page, so that they don't show up in the PDF.
<!-- If there are UI changes, please include Before and After screenshots. -->
### Before
![image](https://user-images.githubusercontent.com/25597009/106271733-de6f1300-6227-11eb-9255-6675702fb55c.png)

### After
![image](https://user-images.githubusercontent.com/25597009/106271647-c0091780-6227-11eb-8764-01554b1ff910.png)

## Guidance to review

You can check the PDF page sizing by downloading an application as a PDF using the link on the application page here 

![image](https://user-images.githubusercontent.com/25597009/106160648-f5f1c180-617d-11eb-9261-c3467fa64783.png)

If you're on a Mac, you can open the PDF from the finder, and from the top menu under Tools, use the inspector to view the page dimensions. A4 pages should be 210mm x 297mm. 

You can check the components that have been removed by downloading the PDF for an application as well, but if you want to inspect the code itself, the class `govuk-!-display-none-print` has been added to any elements that are deliberately being ignored

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/AZSwZwcx/2568-issues-with-pdf-application-downloads
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
