### PR TITLE
Remove ApplicationResponseCache model

### DIFF
--- a/app/models/application_response_cache.rb
+++ b/app/models/application_response_cache.rb
@@ -1,5 +1,0 @@
-class ApplicationResponseCache < ApplicationRecord
-  belongs_to :application_choice
-
-  attr_accessor :response_body
-end


### PR DESCRIPTION
 Missed removing this model when we removed the unused table.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
