### PR TITLE
Show all interviews against applications in support

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -56,7 +56,7 @@ module SupportInterface
         rows << { key: 'Interviews', value: interview_blocks }
       end
 
-      rows.flatten
+      rows
     end
 
   private

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -48,7 +48,15 @@ module SupportInterface
         rows << { key: 'API', value: 'This application hasn’t been sent to the provider yet, so it isn’t available over the API' }
       end
 
-      rows
+      if application_choice.interviews.present?
+        interview_blocks = application_choice.interviews.order('created_at').map do |interview|
+          render(SupportInterface::InterviewDetailsComponent.new(interview: interview))
+        end
+
+        rows << { key: 'Interviews', value: interview_blocks }
+      end
+
+      rows.flatten
     end
 
   private

--- a/app/components/support_interface/interview_details_component.html.erb
+++ b/app/components/support_interface/interview_details_component.html.erb
@@ -1,0 +1,13 @@
+<section class="interview app-summary-card govuk-!-margin-top-3">
+  <header class="app-summary-card__header">
+    <span class="date-and-time">
+      <%= interview.date_and_time.to_s(:govuk_date_and_time) %>
+    </span>
+    <span class="interview-status">
+      Status: <strong><%= interview_status %></strong>
+    </span>
+  </header>
+  <div class="app-summary-card__body">
+    <%= render SummaryListComponent.new(rows: rows) %>
+  </div>
+</section>

--- a/app/components/support_interface/interview_details_component.rb
+++ b/app/components/support_interface/interview_details_component.rb
@@ -15,10 +15,6 @@ module SupportInterface
           value: interview.provider.name,
         },
         {
-          key: 'Meeting details',
-          value: interview.location,
-        },
-        {
           key: 'Created at',
           value: interview.created_at.to_s(:govuk_date_and_time),
         },
@@ -32,7 +28,7 @@ module SupportInterface
   private
 
     def interview_status
-      interview.cancelled_at.present? ? 'Cancelled' : 'Active'
+      interview.cancelled? ? 'Cancelled' : 'Active'
     end
   end
 end

--- a/app/components/support_interface/interview_details_component.rb
+++ b/app/components/support_interface/interview_details_component.rb
@@ -1,0 +1,38 @@
+module SupportInterface
+  class InterviewDetailsComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :interview
+
+    def initialize(interview:)
+      @interview = interview
+    end
+
+    def rows
+      [
+        {
+          key: 'Provider',
+          value: interview.provider.name,
+        },
+        {
+          key: 'Meeting details',
+          value: interview.location,
+        },
+        {
+          key: 'Created at',
+          value: interview.created_at.to_s(:govuk_date_and_time),
+        },
+        {
+          key: 'Updated at',
+          value: interview.created_at.to_s(:govuk_date_and_time),
+        },
+      ]
+    end
+
+  private
+
+    def interview_status
+      interview.cancelled_at.present? ? 'Cancelled' : 'Active'
+    end
+  end
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -2,6 +2,7 @@ class Interview < ApplicationRecord
   include Discard::Model
 
   self.discard_column = :cancelled_at
+  alias_method :cancelled?, :discarded?
 
   audited associated_with: :application_choice
 

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -25,6 +25,8 @@ class GenerateTestApplications
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision awaiting_provider_decision awaiting_provider_decision]
+    create recruitment_cycle_year: 2021, states: %i[interviewing awaiting_provider_decision offer]
+    create recruitment_cycle_year: 2021, states: %i[interviewing interviewing]
     create recruitment_cycle_year: 2021, states: %i[awaiting_provider_decision], apply_again: true
     create recruitment_cycle_year: 2021, states: %i[offer offer]
     create recruitment_cycle_year: 2021, states: %i[offer_changed]


### PR DESCRIPTION
## Context

We are about to launch the interviews feature and we'd like to see any interviews scheduled against applications in the support console for support reasons.

## Changes proposed in this pull request

Add a `SupportInterface::InterviewDetailsComponent`. Show interviews at the end of each application choice, if present. This is not restricted to applications in the `interviewing` state on purpose.

![image](https://user-images.githubusercontent.com/107591/106182920-6f49de00-6197-11eb-8bf7-c7df11424f4e.png)

## Guidance to review

Use the review app. This component has been dev-designed!

## Link to Trello card

https://trello.com/c/1fkhJzrW

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
