### PR TITLE
API: Correct documented enum values for Reference.referee_type

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+## 29th January
+
+- The documented enum values for `Reference.referee_type` have been corrected to remove commas and replace `school-based` with `school_based`.
+
 ## 17th December
 
 - The `Rejection` `reason` field may now return more complex 'structured' reasons for rejection. The field type remains `string`. The field contains details and advice about the rejected application as seen by the candidate, grouped under relevant headings.

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -938,10 +938,10 @@ components:
           type: string
           example: professional
           enum:
-          - academic,
-          - professional,
-          - school-based,
-          - character,
+          - academic
+          - professional
+          - school_based
+          - character
     Rejection:
       type: object
       additionalProperties: false

--- a/spec/lib/openapi_spec.rb
+++ b/spec/lib/openapi_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe 'OpenAPI spec' do
     expect(document).to be_valid, document.errors.to_a.inspect
   end
 
+  describe 'referee types' do
+    it 'matches the enum' do
+      enum_in_api = VendorAPISpecification.as_hash['components']['schemas']['Reference']['properties']['referee_type']['enum']
+
+      expect(enum_in_api).to match_array(ApplicationReference.referee_types.keys)
+    end
+  end
+
   document.components.schemas.each do |schema_name, schema|
     describe schema_name do
       it 'requires all of the keys to be present' do


### PR DESCRIPTION
## Context

Pointed out by a vendor: https://ukgovernmentdfe.slack.com/archives/C01G2BZC6P2/p1611852496005700

## Changes proposed in this pull request

Correct the examples

## Guidance to review

Are the examples correct?