### PR TITLE
Only show Decline by default at row if the date is present

### DIFF
--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -15,7 +15,7 @@ module SupportInterface
 
       if application_choice.offer?
         rows << { key: 'Offer made at', value: application_choice.offered_at.to_s(:govuk_date_and_time) }
-        rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) }
+        rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at
       end
 
       if application_choice.different_offer?

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -4,9 +4,6 @@ class AcceptOffer
   end
 
   def save!
-    declined = []
-    withdrawn = []
-
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).accept!
       @application_choice.update!(accepted_at: Time.zone.now)
@@ -14,12 +11,10 @@ class AcceptOffer
       StateChangeNotifier.disable_notifications do
         other_application_choices_with_offers.each do |application_choice|
           DeclineOffer.new(application_choice: application_choice).save!
-          declined << application_choice
         end
 
         application_choices_awaiting_provider_decision.each do |application_choice|
           WithdrawApplication.new(application_choice: application_choice).save!
-          withdrawn << application_choice
         end
       end
     end

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -54,4 +54,17 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     expect(result.text).to include('Decline by default at')
     expect(result.text).to include('10 January 2020 at 10:00am')
   end
+
+  it 'does not display DBD date for offered applications when it has not yet been set' do
+    application_choice = create(
+      :application_choice,
+      :with_offer,
+      offered_at: Time.zone.local(2020, 1, 1, 10),
+      decline_by_default_at: nil,
+    )
+
+    result = render_inline(described_class.new(application_choice))
+
+    expect(result.text).not_to include('Decline by default at')
+  end
 end


### PR DESCRIPTION
## Context

Application choice view component was breaking when 1 offer was made but the candidate was still awaiting decisions from other providers as the DBD was nil.
[Sentry error](https://sentry.io/organizations/dfe-bat/issues/2172022470/?project=1765973)
<img width="697" alt="Screenshot 2021-01-29 at 13 13 12" src="https://user-images.githubusercontent.com/38078064/106279061-c00f1480-6233-11eb-9716-7e9f17c86891.png">

It is possible to have an application choice in `offered` state without decline by default date, as DBD is only set once all the candidate's application choices have either an offer, been rejected by provider, withdrawn by the candidate, or have the offer withdrawn.

The `decline_by_default_at` for all offered choices is set when the last offer is made.

SetDeclineByDefault (which sets DBD for all choices on the form) is called as a part of:
- Make offer
- Change offer
- Reject
- Reject by default
- Withdraw application
- Withdraw offer

So this functionality is working as expected.

It is also possible for DBD to be nil for choices in the post offer states. For instance when a candidate accepted an offer before other providers made the decision.

## Changes proposed in this pull request

Only show Decline by default at row if the date is present

## Guidance to review

I may be wrong but it doesn't seem anywhere near as bad as we thought so no need to backfill data etc as described on the card.

## Link to Trello card

https://trello.com/c/E7CHETph/3300-applications-lacking-dbd


## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
