### PR TITLE
Configure teacherTrainingApiBaseUrl

### DIFF
--- a/azure/pipelines/release.yml
+++ b/azure/pipelines/release.yml
@@ -143,6 +143,7 @@ stages:
       logstashSsl: '$(logstashSsl)'
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
+      teacherTrainingApiBaseUrl: '$(teacherTrainingApiBaseUrl)'
       dfeSignInClientId: '$(dfeSignInClientId)'
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'


### PR DESCRIPTION
## Context

Teacher Training API now has its own sandbox environment.

## Changes proposed in this pull request

Set `teacherTrainingApiBaseUrl` to `https://sandbox.api.publish-teacher-training-courses.service.gov.uk/api/public/v1` in `APPLY - ENV - Sandbox` variable group

## Guidance to review


## Link to Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
