### PR TITLE
Add structured rejection reasons to the ApplicationChoicesExport

### DIFF
--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -23,6 +23,7 @@ module SupportInterface
             offer_response: offer_response_interpretation(choice: choice),
             offer_response_at: choice.accepted_at || choice.declined_at,
             rejection_reason: choice.rejection_reason,
+            structured_rejection_reasons: format_structured_rejection_reasons(choice.structured_rejection_reasons),
           }
         end
       end
@@ -67,6 +68,25 @@ module SupportInterface
         .where('candidates.hide_in_reporting' => false)
         .where.not(submitted_at: nil)
         .order('submitted_at asc')
+    end
+
+    def format_structured_rejection_reasons(structured_rejection_reasons)
+      return nil if structured_rejection_reasons.blank?
+
+      select_high_level_rejection_reasons(structured_rejection_reasons)
+      .keys
+      .map { |reason| format_reason(reason) }
+      .join("\n")
+    end
+
+    def select_high_level_rejection_reasons(structured_rejection_reasons)
+      structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
+    end
+
+    def format_reason(reason)
+      reason
+      .delete_suffix('_y_n')
+      .humanize
     end
   end
 end

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           offer_response: nil,
           offer_response_at: nil,
           rejection_reason: nil,
+          structured_rejection_reasons: nil,
         },
         {
           candidate_id: submitted_form.candidate_id,
@@ -48,6 +49,7 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           offer_response: nil,
           offer_response_at: nil,
           rejection_reason: nil,
+          structured_rejection_reasons: nil,
         },
       )
     end
@@ -132,6 +134,24 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
         choice_row = described_class.new.application_choices.first
         expect(choice_row).to include(offer_response_at: decision_time)
         expect(choice_row).to include(offer_response: :declined_by_default)
+      end
+    end
+
+    context 'for choices rejected with structured rejection reasons' do
+      it 'returns formatted high level rejection reasons (those that include y_n)' do
+        create(
+          :application_choice,
+          structured_rejection_reasons: {
+            course_full_y_n: 'No',
+            candidate_behaviour_y_n: 'Yes',
+            candidate_behaviour_other: 'Persistent scratching',
+            honesty_and_professionalism_y_n: 'Yes',
+            honesty_and_professionalism_concerns: %w[references],
+          },
+        )
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(structured_rejection_reasons: "Candidate behaviour\nHonesty and professionalism")
       end
     end
   end


### PR DESCRIPTION
## Context

Recently, we've given providers the opportunity to provide their rejection feedback in a structured way. This PR adds a structured rejection reasons column to the ApplicationChoicesExport. 

I discussed the granularity of details Mike wanted for this column with him and he would like the high level reasons (qualifications, candidate behaviour etc.). Later on, we will create a more detailed reasons for rejections export.

## Changes proposed in this pull request

- Select the high-level rejection reasons 
- Put these rejection reasons into a new structured_rejection_reasons column

This is what the new column looks like.

![image](https://user-images.githubusercontent.com/42515961/106393511-71a67500-63ef-11eb-80e2-1c17d504b156.png)

## Guidance to review

I was interested to see how performant this was. I created 500 choices with structured rejection reasons. It took 2 seconds with and without the new column.

## Link to Trello card

https://trello.com/c/x8aB4hnp/2949-update-applicationchoicesexport-to-include-structured-rejection-reasons

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
