### PR TITLE
Add 'Has interviews' filter to support console

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -25,6 +25,10 @@ module SupportInterface
         application_forms = application_forms.where('phase IN (?)', applied_filters[:phase])
       end
 
+      if applied_filters[:interviews]
+        application_forms = application_forms.joins(application_choices: [:interviews])
+      end
+
       if applied_filters[:year]
         application_forms = application_forms.where('recruitment_cycle_year IN (?)', applied_filters[:year])
       end
@@ -33,7 +37,7 @@ module SupportInterface
     end
 
     def filters
-      @filters ||= [search_filter, search_by_application_choice_filter, year_filter, phase_filter]
+      @filters ||= [search_filter, search_by_application_choice_filter, year_filter, phase_filter, interviews_filter]
     end
 
   private
@@ -89,6 +93,21 @@ module SupportInterface
             value: 'apply_2',
             label: 'Apply 2',
             checked: applied_filters[:phase]&.include?('apply_2'),
+          },
+        ],
+      }
+    end
+
+    def interviews_filter
+      {
+        type: :checkboxes,
+        heading: 'Interviews',
+        name: 'interviews',
+        options: [
+          {
+            value: 'has_interviews',
+            label: 'Has interviews',
+            checked: applied_filters[:interviews]&.include?('has_interviews'),
           },
         ],
       }

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -29,6 +29,14 @@ class ProcessState
       event :no_offers, transitions_to: :ended_without_success
       event :all_rejected, transitions_to: :ended_without_success
       event :all_withdrawn, transitions_to: :ended_without_success
+      event :interview, transitions_to: :interviewing
+    end
+
+    state :interviewing do
+      event :at_least_one_offer, transitions_to: :awaiting_candidate_response
+      event :no_offers, transitions_to: :ended_without_success
+      event :all_rejected, transitions_to: :ended_without_success
+      event :all_withdrawn, transitions_to: :ended_without_success
     end
 
     state :awaiting_candidate_response do
@@ -62,7 +70,7 @@ class ProcessState
       :never_signed_in
     elsif application_choices.empty? || all_states_are?('unsubmitted')
       unchanged?(application_form) ? :unsubmitted_not_started_form : :unsubmitted_in_progress
-    elsif any_state_is?('awaiting_provider_decision')
+    elsif any_state_is?('awaiting_provider_decision') || any_state_is?('interviewing')
       :awaiting_provider_decisions
     elsif any_state_is?('offer')
       # Offer, but no awaiting means we're waiting on the candidate

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -449,6 +449,11 @@ en:
       by: candidate
       description: ""
 
+    awaiting_provider_decisions-interview:
+      name: At least one interview
+      by: provider
+      description: ""
+
     awaiting_provider_decisions-at_least_one_offer:
       name: At least one offer
       by: provider
@@ -465,6 +470,26 @@ en:
       description: ""
 
     awaiting_provider_decisions-all_withdrawn:
+      name: Withdraw
+      by: candidate
+      description: ""
+
+    interviewing-at_least_one_offer:
+      name: At least one offer
+      by: provider
+      description: ""
+
+    interviewing-no_offers:
+      name: No offers
+      by: provider
+      description: ""
+
+    interviewing-all_rejected:
+      name: All rejected
+      by: provider
+      description: ""
+
+    interviewing-all_withdrawn:
       name: Withdraw
       by: candidate
       description: ""

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -740,10 +740,20 @@ FactoryBot.define do
 
     trait :previous_year do
       course_option { create(:course_option, :previous_year) }
+      after(:create) do |choice, _evaluator|
+        choice.application_form.update_columns(
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+        )
+      end
     end
 
     trait :previous_year_but_still_available do
       course_option { create(:course_option, :previous_year_but_still_available) }
+      after(:create) do |choice, _evaluator|
+        choice.application_form.update_columns(
+          recruitment_cycle_year: RecruitmentCycle.previous_year,
+        )
+      end
     end
   end
 

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationsFilter do
+  let!(:application_choice_with_offer) { create(:application_choice, :with_offer, :previous_year) }
+  let!(:application_choice_with_interview) { create(:application_choice, :with_scheduled_interview) }
+
+  def verify_filtered_applications_for_params(expected_applications, params:)
+    applications = ApplicationForm.all
+    filter = described_class.new(params: params)
+    expect(filter.filter_records(applications)).to match_array expected_applications
+  end
+
+  describe '#filter_records' do
+    it 'supports search by name' do
+      expected_form = application_choice_with_offer.application_form
+
+      verify_filtered_applications_for_params(
+        [expected_form],
+        params: {
+          q: application_choice_with_offer.application_form.full_name,
+        },
+      )
+    end
+
+    it 'supports application choice id lookups' do
+      expected_form = application_choice_with_offer.application_form
+
+      verify_filtered_applications_for_params(
+        [expected_form],
+        params: {
+          application_choice_id: application_choice_with_offer.id,
+        },
+      )
+    end
+
+    it 'can filter by year' do
+      expected_form = application_choice_with_offer.application_form
+
+      verify_filtered_applications_for_params(
+        [expected_form],
+        params: {
+          year: [RecruitmentCycle.previous_year],
+        },
+      )
+    end
+
+    it 'can show applications with interviews' do
+      expected_form = application_choice_with_interview.application_form
+
+      verify_filtered_applications_for_params(
+        [expected_form],
+        params: {
+          interviews: %w[has_interviews],
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

For supporting and tracking usage of interviews feature.

## Changes proposed in this pull request

Add a 'Has interviews' filter to support console.

![image](https://user-images.githubusercontent.com/107591/106452652-1a9cb080-6480-11eb-92e6-2a57f94df109.png)

Add support for `interviewing` state to `ProcessState`. This adds the following segment to our process docs:

![image](https://user-images.githubusercontent.com/107591/106467158-2abe8b00-6494-11eb-813f-7e8cc2249d48.png)

## Guidance to review

Navigate to support, use the filter.

## Link to Trello card

https://trello.com/c/1fkhJzrW

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
