### PR TITLE
Ensure conditions status is correct for deferred offers

### DIFF
--- a/app/components/provider_interface/conditions_component.rb
+++ b/app/components/provider_interface/conditions_component.rb
@@ -26,6 +26,8 @@ module ProviderInterface
     end
 
     def conditions_met?
+      return application_choice.status_before_deferral == 'recruited' if application_choice.status == 'offer_deferred'
+
       application_state.current_state >= :recruited
     end
 

--- a/spec/components/provider_interface/conditions_component_spec.rb
+++ b/spec/components/provider_interface/conditions_component_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ConditionsComponent do
+  describe 'rendered component' do
+    let(:conditions) { ['Fitness to teach check'] }
+
+    it 'renders the conditions' do
+      application_with_conditions_met = build(:application_choice, status: 'recruited', offer: { 'conditions' => conditions })
+      result = render_inline(described_class.new(application_choice: application_with_conditions_met))
+
+      expect(result.to_html).to include('Fitness to teach check')
+    end
+
+    it 'indicates whether conditions are met' do
+      application_with_conditions_met = build(:application_choice, status: 'recruited', offer: { 'conditions' => conditions })
+      result = render_inline(described_class.new(application_choice: application_with_conditions_met))
+
+      expect(result.css('.app-tag').text).to eq('Met')
+    end
+
+    it 'indicates whether conditions are pending' do
+      application_with_pending_conditions = build(:application_choice, status: 'awaiting_provider_decision', offer: { 'conditions' => conditions })
+      result = render_inline(described_class.new(application_choice: application_with_pending_conditions))
+
+      expect(result.css('.app-tag').text).to eq('Pending')
+    end
+
+    it 'indicates whether conditions are met for deferred offers' do
+      application_with_conditions_met = build(:application_choice,
+                                              status: 'offer_deferred',
+                                              status_before_deferral: 'recruited',
+                                              offer: { 'conditions' => conditions })
+
+      result = render_inline(described_class.new(application_choice: application_with_conditions_met))
+
+      expect(result.css('.app-tag').text).to eq('Met')
+    end
+
+    it 'indicates whether conditions are pending for deferred offers' do
+      application_with_pending_conditions = build(:application_choice,
+                                                  status: 'offer_deferred',
+                                                  status_before_deferral: 'pending_conditions',
+                                                  offer: { 'conditions' => conditions })
+
+      result = render_inline(described_class.new(application_choice: application_with_pending_conditions))
+
+      expect(result.css('.app-tag').text).to eq('Pending')
+    end
+  end
+end


### PR DESCRIPTION
## Context

Deferring an offer with pending conditions currently results in the conditions on the deferred offer conditions being marked as 'Met'. This is a display/rendering bug as there is no state saved on the conditions themselves.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Update conditions component to inspect `status_before_deferral` when labelling conditions 'Pending' or 'Met'
- Add component spec.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Steps to reproduce original bug:

 -  View an 'Accepted' application with pending condition(s)
 -  Click on the 'Offer' tab
 -  Click 'Defer offer' link and confirm deferral
 -  View same application offer tab, conditions are now marked as 'Met' rather than pending.


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/a5spqa06/3309-conditions-pending-met-labelling-wrong-for-deferred-offers
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
