### PR TITLE
Add interview events to ApplicationForm history in Support

### DIFF
--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -10,7 +10,9 @@ module SupportInterface
 
     def audits
       audits = if audited_thing.is_a? Provider
-                 audits_for_provider
+                 provider_audits
+               elsif audited_thing.is_a? ApplicationForm
+                 application_audits
                else
                  standard_audits
                end
@@ -19,18 +21,29 @@ module SupportInterface
         audits = audits.where(auditable_type: params[:auditable_type])
       end
 
-      audits.includes(:user).order('id desc').page(params[:page] || 1).per(60)
+      audits.includes(:user).order('created_at desc').page(params[:page] || 1).per(60)
     end
 
     attr_reader :audited_thing
 
   private
 
-    def audits_for_provider
-      standard_audits.or(Audited::Audit.where(
-                           auditable_type: 'ProviderRelationshipPermissions',
-                           auditable_id: ProviderRelationshipPermissions.where(ratifying_provider_id: audited_thing.id),
-                         ))
+    def provider_audits
+      audited_thing.own_and_associated_audits.unscope(:order).or(
+        Audited::Audit.where(
+          auditable_type: 'ProviderRelationshipPermissions',
+          auditable_id: ProviderRelationshipPermissions.where(ratifying_provider_id: audited_thing.id),
+        ),
+      )
+    end
+
+    def application_audits
+      standard_audits.or(
+        Audited::Audit.where(
+          associated_type: 'ApplicationChoice',
+          associated_id: audited_thing.application_choices.pluck(&:id),
+        ),
+      )
     end
 
     def standard_audits

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -3,12 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Add comments to the application history', with_audited: true do
   include DfESignInHelpers
 
-  around do |example|
-    Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
-      example.run
-    end
-  end
-
   scenario 'Support user adds a comment to the application audit page' do
     given_i_am_a_support_user
     and_there_is_an_application_in_the_system_logged_by_a_candidate
@@ -39,9 +33,7 @@ RSpec.feature 'Add comments to the application history', with_audited: true do
   end
 
   def and_a_vendor_updates_the_application_status
-    Timecop.freeze(Time.zone.local(2019, 10, 2, 12, 0, 0)) do
-      @application_choice.update(status: 'rejected')
-    end
+    @application_choice.update(status: 'rejected')
   end
 
   def and_i_visit_the_support_page
@@ -70,8 +62,6 @@ RSpec.feature 'Add comments to the application history', with_audited: true do
 
   def then_i_should_see_my_comment_in_application_history
     within('tbody tr:eq(1)') do
-      expect(page).to have_content '1 October 2019'
-      expect(page).to have_content '12:00'
       expect(page).to have_content 'Comment on Application Form'
       expect(page).to have_content 'I did a thing to this application'
     end

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -84,14 +84,14 @@ RSpec.feature 'See application history', with_audited: true do
   end
 
   def then_i_should_be_able_to_see_history_events
-    within('tbody tr:eq(2)') do
+    within('tbody tr:eq(1)') do
       expect(page).to have_content '3 October 2019'
       expect(page).to have_content '09:00'
       expect(page).to have_content 'Update Application Choice'
       expect(page).to have_content 'derek@example.com (Provider user)'
       expect(page).to have_content 'status rejected → offer'
     end
-    within('tbody tr:eq(4)') do
+    within('tbody tr:eq(3)') do
       expect(page).to have_content '2 October 2019'
       expect(page).to have_content '12:00'
       expect(page).to have_content 'Update Application Choice'


### PR DESCRIPTION
## Context

ApplicationForm history in support does not show interview creation/cancellation etc. events because we call `.own_and_associated_audits` on the ApplicationForm, and interviews are associated audits for the ApplicationChoice.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/107591/106475276-ac66e680-649d-11eb-8d34-4c02ff9f4093.png)

## Guidance to review

Read the code, run the specs

## Link to Trello card

https://trello.com/c/fEog5Q0H/3304-show-interview-events-in-support-application-history

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
