### PR TITLE
Migrate to use constituent grades

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -96,7 +96,7 @@ module CandidateInterface
     end
 
     def present_constituent_grades
-      grades = JSON.parse(application_qualification.constituent_grades)
+      grades = application_qualification.constituent_grades
       grades.map do |k, v,|
         grade = v['grade']
         case k

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -78,37 +78,38 @@ module CandidateInterface
     def present_grades
       case application_qualification.subject
       when ApplicationQualification::SCIENCE_TRIPLE_AWARD
-        grades = application_qualification.structured_grades
+        grades = application_qualification.constituent_grades
         [
-          "#{grades['biology']} (Biology)",
-          "#{grades['chemistry']} (Chemistry)",
-          "#{grades['physics']} (Physics)",
+          "#{grades['biology']['grade']} (Biology)",
+          "#{grades['chemistry']['grade']} (Chemistry)",
+          "#{grades['physics']['grade']} (Physics)",
         ]
       when ApplicationQualification::SCIENCE_DOUBLE_AWARD
         "#{application_qualification.grade} (Double award)"
       when ApplicationQualification::SCIENCE_SINGLE_AWARD
         "#{application_qualification.grade} (Single award)"
-      when ->(_n) { application_qualification.structured_grades }
-        present_structured_grades
+      when ->(_n) { application_qualification.constituent_grades }
+        present_constituent_grades
       else
         application_qualification.grade
       end
     end
 
-    def present_structured_grades
-      grades = JSON.parse(application_qualification.structured_grades)
+    def present_constituent_grades
+      grades = JSON.parse(application_qualification.constituent_grades)
       grades.map do |k, v,|
+        grade = v['grade']
         case k
         when 'english_single_award'
-          "#{v} (English Single award)"
+          "#{grade} (English Single award)"
         when 'english_double_award'
-          "#{v} (English Double award)"
+          "#{grade} (English Double award)"
         when 'english_studies_single_award'
-          "#{v} (English Studies Single award)"
+          "#{grade} (English Studies Single award)"
         when 'english_studies_double_award'
-          "#{v} (English Studies Double award)"
+          "#{grade} (English Studies Double award)"
         else
-          "#{v} (#{k.humanize.titleize})"
+          "#{grade} (#{k.humanize.titleize})"
         end
       end
     end

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -73,7 +73,7 @@ class GcseQualificationCardsComponent < ViewComponent::Base
   end
 
   def present_constituent_grades(qualification)
-    grades = JSON.parse(qualification.constituent_grades)
+    grades = qualification.constituent_grades
     grades.map do |k, v,|
       grade = v['grade']
       case k

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -55,37 +55,38 @@ class GcseQualificationCardsComponent < ViewComponent::Base
   def grade_details(qualification)
     case qualification.subject
     when ApplicationQualification::SCIENCE_TRIPLE_AWARD
-      grades = qualification.structured_grades
+      grades = qualification.constituent_grades
       [
-        "#{grades['biology']} (Biology)",
-        "#{grades['chemistry']} (Chemistry)",
-        "#{grades['physics']} (Physics)",
+        "#{grades['biology']['grade']} (Biology)",
+        "#{grades['chemistry']['grade']} (Chemistry)",
+        "#{grades['physics']['grade']} (Physics)",
       ]
     when ApplicationQualification::SCIENCE_DOUBLE_AWARD
       ["#{qualification.grade} (Double award)"]
     when ApplicationQualification::SCIENCE_SINGLE_AWARD
       ["#{qualification.grade} (Single award)"]
-    when ->(_n) { qualification.structured_grades }
-      present_structured_grades(qualification)
+    when ->(_n) { qualification.constituent_grades }
+      present_constituent_grades(qualification)
     else
       [qualification.grade]
     end
   end
 
-  def present_structured_grades(qualification)
-    grades = JSON.parse(qualification.structured_grades)
+  def present_constituent_grades(qualification)
+    grades = JSON.parse(qualification.constituent_grades)
     grades.map do |k, v,|
+      grade = v['grade']
       case k
       when 'english_single_award'
-        "#{v} (English Single award)"
+        "#{grade} (English Single award)"
       when 'english_double_award'
-        "#{v} (English Double award)"
+        "#{grade} (English Double award)"
       when 'english_studies_single_award'
-        "#{v} (English Studies Single award)"
+        "#{grade} (English Studies Single award)"
       when 'english_studies_double_award'
-        "#{v} (English Studies Double award)"
+        "#{grade} (English Studies Double award)"
       else
-        "#{v} (#{k.humanize.titleize})"
+        "#{grade} (#{k.humanize.titleize})"
       end
     end
   end

--- a/app/forms/candidate_interface/english_gcse_grade_form.rb
+++ b/app/forms/candidate_interface/english_gcse_grade_form.rb
@@ -52,7 +52,7 @@ module CandidateInterface
         }
 
         if qualification.constituent_grades
-          constituent_grades = JSON.parse(qualification.constituent_grades)
+          constituent_grades = qualification.constituent_grades
           english_gcses = []
 
           if grades.keys.include? 'english_single_award'
@@ -177,7 +177,7 @@ module CandidateInterface
         model[:english_studies_double_award] = grade_hash(grade_english_studies_double) if english_studies_double_award
         model[other_english_gcse_name] = grade_hash(grade_other_english_gcse) if other_english_gcse
       end
-      grades.to_json if grades.any?
+      grades if grades.any?
     end
 
     def grade_hash(grade)

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -74,7 +74,7 @@ class ApplicationQualification < ApplicationRecord
   end
 
   def incomplete_gcse_information?
-    return true if grade.nil? && structured_grades.nil?
+    return true if grade.nil? && constituent_grades.nil?
 
     return true if EXPECTED_GCSE_DATA.any? do |field_name|
       send(field_name).blank?

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -185,7 +185,7 @@ module VendorAPI
       # This is to split structured GCSEs in to separate GCSE qualifications for the API
       # Science triple award grades are already properly formatted and so are left out here
       to_structure, already_structured = gcses.partition do |gcse|
-        gcse[:subject] != 'science triple award' && gcse[:structured_grades].present?
+        gcse[:subject] != 'science triple award' && gcse[:constituent_grades].present?
       end
 
       separated_gcse_hashes = to_structure.flat_map { |q| structured_gcse_to_hashes(q) }
@@ -204,10 +204,10 @@ module VendorAPI
     end
 
     def structured_gcse_to_hashes(gcse)
-      structured_grades = JSON.parse(gcse[:structured_grades])
-      structured_grades.reduce([]) do |array, (subject, grade)|
+      constituent_grades = JSON.parse(gcse[:constituent_grades])
+      constituent_grades.reduce([]) do |array, (subject, hash)|
         array << qualification_to_hash(gcse)
-                     .merge(subject: subject.humanize, grade: grade)
+                     .merge(subject: subject.humanize, grade: hash['grade'])
       end
     end
 
@@ -237,12 +237,12 @@ module VendorAPI
         end
       end
 
-      grades = qualification.structured_grades
+      constituent_grades = qualification.constituent_grades
 
       # For triple award science we need to serialize 'grades' to the 'grade' field
       # in the specified order
-      if qualification.subject == 'science triple award' && grades
-        grade = "#{grades['biology']}#{grades['chemistry']}#{grades['physics']}"
+      if qualification.subject == 'science triple award' && constituent_grades
+        grade = "#{constituent_grades['biology']['grade']}#{constituent_grades['chemistry']['grade']}#{constituent_grades['physics']['grade']}"
       end
 
       grade

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -204,7 +204,7 @@ module VendorAPI
     end
 
     def structured_gcse_to_hashes(gcse)
-      constituent_grades = JSON.parse(gcse[:constituent_grades])
+      constituent_grades = gcse[:constituent_grades]
       constituent_grades.reduce([]) do |array, (subject, hash)|
         array << qualification_to_hash(gcse)
                      .merge(subject: subject.humanize, grade: hash['grade'])

--- a/app/services/support_interface/qualifications_export.rb
+++ b/app/services/support_interface/qualifications_export.rb
@@ -102,14 +102,14 @@ module SupportInterface
 
     def english_structured_gcse_grades(qualifications, subject)
       constituent_grades = qualifications.where(level: :gcse, subject: :english).first.constituent_grades
-      JSON.parse(constituent_grades).dig(subject, 'grade')
+      constituent_grades.dig(subject, 'grade')
     rescue StandardError
       nil
     end
 
     def english_other_gcse_grade(qualifications)
       constituent_grades = qualifications.where(level: :gcse, subject: :english).first.constituent_grades
-      JSON.parse(constituent_grades).each do |subject, hash|
+      constituent_grades.each do |subject, hash|
         return hash['grade'] if ENGLISH_GCSE_SUBJECTS.exclude?(subject)
       end
     rescue StandardError

--- a/app/services/support_interface/qualifications_export.rb
+++ b/app/services/support_interface/qualifications_export.rb
@@ -88,29 +88,29 @@ module SupportInterface
       return unstructured_grade if unstructured_grade.present? && not_single_or_double_award?(unstructured_grade)
 
       science_triple_gcse = qualifications.where(level: :gcse, subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD).first
-      return if science_triple_gcse.try(:structured_grades).blank?
+      return if science_triple_gcse.try(:constituent_grades).blank?
 
-      science_triple_gcse[:structured_grades].values.join
+      science_triple_gcse[:constituent_grades].values.map { |hash| hash['grade'] }.join
     end
 
     def english_unstructured_gcse_grade(qualifications)
       english_unstructured_gcse = qualifications.where(level: :gcse, subject: :english).first
-      return nil if english_unstructured_gcse.try(:structured_grades).present?
+      return nil if english_unstructured_gcse.try(:constituent_grades).present?
 
       english_unstructured_gcse.try(:grade)
     end
 
     def english_structured_gcse_grades(qualifications, subject)
-      structured_grades = qualifications.where(level: :gcse, subject: :english).first.structured_grades
-      JSON.parse(structured_grades).dig(subject)
+      constituent_grades = qualifications.where(level: :gcse, subject: :english).first.constituent_grades
+      JSON.parse(constituent_grades).dig(subject, 'grade')
     rescue StandardError
       nil
     end
 
     def english_other_gcse_grade(qualifications)
-      structured_grades = qualifications.where(level: :gcse, subject: :english).first.structured_grades
-      JSON.parse(structured_grades).each do |subject, grade|
-        return grade if ENGLISH_GCSE_SUBJECTS.exclude?(subject)
+      constituent_grades = qualifications.where(level: :gcse, subject: :english).first.constituent_grades
+      JSON.parse(constituent_grades).each do |subject, hash|
+        return hash['grade'] if ENGLISH_GCSE_SUBJECTS.exclude?(subject)
       end
     rescue StandardError
       nil

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         qualification_type: 'gcse',
         level: 'gcse',
         grade: nil,
-        structured_grades: { physics: 'A', chemistry: 'B', biology: 'C' },
+        constituent_grades: { physics: { grade: 'A' }, chemistry: { grade: 'B' }, biology: { grade: 'C' } },
         subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
       )
 
@@ -117,7 +117,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         qualification_type: 'gcse',
         level: 'gcse',
         grade: nil,
-        structured_grades: '{"english":"E","english_literature":"D","Cockney Rhyming Slang":"A*"}',
+        constituent_grades: '{"english":{"grade":"E"},"english_literature":{"grade":"D"},"Cockney Rhyming Slang":{"grade":"A*"}}',
         subject: 'english',
       )
 

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
         qualification_type: 'gcse',
         level: 'gcse',
         grade: nil,
-        constituent_grades: '{"english":{"grade":"E"},"english_literature":{"grade":"D"},"Cockney Rhyming Slang":{"grade":"A*"}}',
+        constituent_grades: { english: { grade: 'E' }, english_literature: { grade: 'D' }, 'Cockney Rhyming Slang': { grade: 'A*' } },
         subject: 'english',
       )
 

--- a/spec/components/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/gcse_qualification_cards_component_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
       create(
         :application_form,
         application_qualifications: [
-          create(:gcse_qualification, subject: 'english', structured_grades: '{"english_language":"E","english_literature":"E","Cockney Rhyming Slang":"A*"}', award_year: 2006),
+          create(:gcse_qualification, subject: 'english', constituent_grades: '{"english_language":{"grade":"E"},"english_literature":{"grade":"E"},"Cockney Rhyming Slang":{"grade":"A*"}}', award_year: 2006),
         ],
       )
     end
@@ -184,16 +184,16 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
 
   describe 'rendering multiple Science GCSEs' do
     science_triple_awards = {
-      biology: 'A',
-      chemistry: 'B',
-      physics: 'C',
+      biology: { grade: 'A' },
+      chemistry: { grade: 'B' },
+      physics: { grade: 'C' },
     }
 
     let(:application_form) do
       create(
         :application_form,
         application_qualifications: [
-          create(:gcse_qualification, subject: 'science triple award', structured_grades: science_triple_awards, award_year: 2006),
+          create(:gcse_qualification, subject: 'science triple award', constituent_grades: science_triple_awards, award_year: 2006),
         ],
       )
     end

--- a/spec/components/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/gcse_qualification_cards_component_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
       create(
         :application_form,
         application_qualifications: [
-          create(:gcse_qualification, subject: 'english', constituent_grades: '{"english_language":{"grade":"E"},"english_literature":{"grade":"E"},"Cockney Rhyming Slang":{"grade":"A*"}}', award_year: 2006),
+          create(:gcse_qualification, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E'}, "Cockney Rhyming Slang": { grade: 'A*' } }, award_year: 2006),
         ],
       )
     end

--- a/spec/components/gcse_qualification_cards_component_spec.rb
+++ b/spec/components/gcse_qualification_cards_component_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe GcseQualificationCardsComponent, type: :component do
       create(
         :application_form,
         application_qualifications: [
-          create(:gcse_qualification, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E'}, "Cockney Rhyming Slang": { grade: 'A*' } }, award_year: 2006),
+          create(:gcse_qualification, subject: 'english', constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, "Cockney Rhyming Slang": { grade: 'A*' } }, award_year: 2006),
         ],
       )
     end

--- a/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/english_gcse_grade_form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
 
       it 'returns validation error if no GCSE is selected' do
         form.english_gcses = []
-        form.validate(:structured_grades)
+        form.validate(:constituent_grades)
 
         expect(form.errors[:english_gcses]).to include('Select at least one GCSE')
       end
@@ -31,7 +31,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
       it 'returns validation error if GCSE is selected but no grade is entered' do
         form.english_single_award = true
         form.grade_english_single = ''
-        form.validate(:structured_grades)
+        form.validate(:constituent_grades)
 
         expect(form.errors[:grade_english_single]).to include('Enter your English (Single award) grade')
       end
@@ -39,7 +39,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
       it 'returns validation error if GCSE is selected and an invalid grade is entered' do
         form.english_single_award = true
         form.grade_english_single = 'AWESOME'
-        form.validate(:structured_grades)
+        form.validate(:constituent_grades)
 
         expect(form.errors[:grade_english_single]).to include('Enter a real English (Single award) grade')
       end
@@ -47,7 +47,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
       it 'returns no errors if GCSE is selected and a valid grade is entered' do
         form.english_single_award = true
         form.grade_english_single = 'A*'
-        form.validate(:structured_grades)
+        form.validate(:constituent_grades)
 
         expect(form.errors[:grade_english_single]).to be_empty
       end
@@ -56,7 +56,7 @@ RSpec.describe CandidateInterface::EnglishGcseGradeForm, type: :model do
         form.other_english_gcse = true
         form.other_english_gcse_name = ''
         form.grade_other_english_gcse = ''
-        form.validate(:structured_grades)
+        form.validate(:constituent_grades)
 
         expect(form.errors[:other_english_gcse_name]).to include('Enter an English GCSE')
         expect(form.errors[:grade_other_english_gcse]).to include('Enter your other English subject grade')

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -301,10 +301,10 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
         details_form.save
         qualification.reload
 
-        expect(qualification.structured_grades).to eq({
-          'biology' => 'A*',
-          'chemistry' => 'A*',
-          'physics' => 'A*',
+        expect(qualification.constituent_grades).to eq({
+          'biology' => { 'grade' => 'A*' },
+          'chemistry' => { 'grade' => 'A*' },
+          'physics' => { 'grade' => 'A*' },
         })
       end
 
@@ -328,7 +328,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           qualification.reload
 
           expect(qualification.grade).to eq(nil)
-          expect(qualification.structured_grades).to eq({ 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' })
+          expect(qualification.constituent_grades).to eq({ 'biology' => { 'grade' => 'B' }, 'physics' => { 'grade' => 'B' }, 'chemistry' => { 'grade' => 'B' } })
         end
       end
 
@@ -338,7 +338,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           qualification = ApplicationQualification.create(
             level: 'gcse',
             grade: nil,
-            structured_grades: { 'biology' => 'B', 'physics' => 'B', 'chemistry' => 'B' },
+            constituent_grades: { 'biology' => { grade: 'B' }, 'physics' => { grade: 'B' }, 'chemistry' => { grade: 'B' } },
             subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
             application_form: application_form,
           )
@@ -351,7 +351,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
           qualification.reload
 
           expect(qualification.grade).to eq('A')
-          expect(qualification.structured_grades).to eq(nil)
+          expect(qualification.constituent_grades).to eq(nil)
         end
       end
     end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -508,16 +508,16 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
     it 'adds GCSE science triple award information' do
       science_triple_awards = {
-        biology: 'A',
-        chemistry: 'B',
-        physics: 'C',
+        biology: { grade: 'A' },
+        chemistry: { grade: 'B' },
+        physics: { grade: 'C' },
       }
 
       create(
         :gcse_qualification,
         grade: nil,
         subject: 'science triple award',
-        structured_grades: science_triple_awards,
+        constituent_grades: science_triple_awards,
         application_form: application_choice.application_form,
       )
 
@@ -536,7 +536,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         id: 1,
         subject: 'english',
         grade: nil,
-        structured_grades: '{"english_language":"E","english_literature":"E","Cockney Rhyming Slang":"A*"}',
+        constituent_grades: '{"english_language":{"grade":"E"},"english_literature":{"grade":"E"},"Cockney Rhyming Slang":{"grade":"A*"}}',
         award_year: 2006,
         predicted_grade: false,
         application_form: application_choice.application_form,

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         id: 1,
         subject: 'english',
         grade: nil,
-        constituent_grades: '{"english_language":{"grade":"E"},"english_literature":{"grade":"E"},"Cockney Rhyming Slang":{"grade":"A*"}}',
+        constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, "Cockney Rhyming Slang": { grade: 'A*' } },
         award_year: 2006,
         predicted_grade: false,
         application_form: application_choice.application_form,

--- a/spec/services/support_interface/qualifications_export_spec.rb
+++ b/spec/services/support_interface/qualifications_export_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe SupportInterface::QualificationsExport do
              application_form: application_form_two,
              level: 'gcse',
              subject: 'english',
-             constituent_grades: '{"english_language":{"grade":"E"},"english_literature":{"grade":"E"},"Cockney Rhyming Slang":{"grade":"A*"}}')
+             constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, "Cockney Rhyming Slang": { grade: 'A*' } })
       create(:application_qualification,
              application_form: application_form_two,
              qualification_type: 'A level',

--- a/spec/services/support_interface/qualifications_export_spec.rb
+++ b/spec/services/support_interface/qualifications_export_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe SupportInterface::QualificationsExport do
              application_form: application_form_two,
              level: 'gcse',
              subject: 'english',
-             structured_grades: '{"english_language":"E","english_literature":"E","Cockney Rhyming Slang":"A*"}')
+             constituent_grades: '{"english_language":{"grade":"E"},"english_literature":{"grade":"E"},"Cockney Rhyming Slang":{"grade":"A*"}}')
       create(:application_qualification,
              application_form: application_form_two,
              qualification_type: 'A level',


### PR DESCRIPTION
## Context
We need to migrate structured grades so that there is space in the data model to include public ids for each qualification.

## Changes proposed in this pull request
Change all forms to use the new constituent_grades column for an application, rather than the structured_grades column

The structure will change from:
```
{ "English Lit": "A", "English Lang": "B" }
```
to:
```
{ "English Lit": { "grade": "A" },  "English Lang": { "grade": "B" } }
```

There will be a follow up PR to actually populate the public_id section of this JSON

## Guidance to review
There should be no change in behaviour!

## Link to Trello card
https://trello.com/c/54vJ4u9D/3288-gcses-in-api-response-have-duplicate-ids-causing-sits-to-discard-them

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
