### PR TITLE
Reasons for rejection support search page

### DIFF
--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.html.erb
@@ -1,5 +1,12 @@
 <section id="<%= @heading.parameterize %>" class="app-section">
-  <h2 class="govuk-heading-m govuk-!-font-size-27"><%= @heading %></h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= govuk_link_to(
+      @heading,
+      support_interface_reasons_for_rejection_application_choices_path(
+        "structured_rejection_reasons[#{@reason_key}]" => 'Yes',
+      ),
+    ) %>
+  </h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <%= render SupportInterface::TileComponent.new(
@@ -26,9 +33,9 @@
       ) %>
     </div>
   </div>
-  <% if @sub_reasons_key %>
+  <% if @sub_reasons_result %>
     <%= render SupportInterface::SubReasonsForRejectionTableComponent.new(
-      reason: @sub_reasons_key,
+      reason: @reason_key,
       sub_reasons: @sub_reasons_result,
       total: @total_structured_rejection_reasons_count
     )

--- a/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
+++ b/app/components/support_interface/reason_for_rejection_dashboard_section_component.rb
@@ -1,12 +1,14 @@
 module SupportInterface
   class ReasonForRejectionDashboardSectionComponent < ViewComponent::Base
-    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_structured_rejection_reasons_count:, sub_reasons_key: nil, sub_reasons_result: nil)
+    include ViewHelper
+
+    def initialize(heading:, total_count:, this_month:, percentage_rejected:, total_structured_rejection_reasons_count:, reason_key:, sub_reasons_result: nil)
       @heading = heading
       @total_count = total_count
       @this_month = this_month
       @percentage_rejected = percentage_rejected
       @total_structured_rejection_reasons_count = total_structured_rejection_reasons_count
-      @sub_reasons_key = sub_reasons_key
+      @reason_key = reason_key
       @sub_reasons_result = sub_reasons_result
     end
 

--- a/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_dashboard_component.html.erb
@@ -4,6 +4,7 @@
   this_month: current_month_rejection_count("course_full_y_n"),
   percentage_rejected: percentage_rejected_for_reason("course_full_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  reason_key: :course_full_y_n,
 )
 %>
 
@@ -13,7 +14,7 @@
   this_month: current_month_rejection_count("candidate_behaviour_y_n"),
   percentage_rejected: percentage_rejected_for_reason("candidate_behaviour_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
-  sub_reasons_key: :candidate_behaviour_y_n,
+  reason_key: :candidate_behaviour_y_n,
   sub_reasons_result: sub_reasons_for(:candidate_behaviour_y_n),
 )
 %>
@@ -24,7 +25,7 @@
   this_month: current_month_rejection_count("honesty_and_professionalism_y_n"),
   percentage_rejected: percentage_rejected_for_reason("honesty_and_professionalism_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
-  sub_reasons_key: :honesty_and_professionalism_y_n,
+  reason_key: :honesty_and_professionalism_y_n,
   sub_reasons_result: sub_reasons_for(:honesty_and_professionalism_y_n),
 )
 %>
@@ -35,6 +36,7 @@
   this_month: current_month_rejection_count("offered_on_another_course_y_n"),
   percentage_rejected: percentage_rejected_for_reason("offered_on_another_course_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  reason_key: :offered_on_another_course_y_n,
 )
 %>
 
@@ -44,6 +46,7 @@
   this_month: current_month_rejection_count("performance_at_interview_y_n"),
   percentage_rejected: percentage_rejected_for_reason("performance_at_interview_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  reason_key: :performance_at_interview_y_n,
 )
 %>
 
@@ -53,7 +56,7 @@
   this_month: current_month_rejection_count("qualifications_y_n"),
   percentage_rejected: percentage_rejected_for_reason("qualifications_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
-  sub_reasons_key: :qualifications_y_n,
+  reason_key: :qualifications_y_n,
   sub_reasons_result: sub_reasons_for(:qualifications_y_n),
 )
 %>
@@ -64,7 +67,7 @@
   this_month: current_month_rejection_count("quality_of_application_y_n"),
   percentage_rejected: percentage_rejected_for_reason("quality_of_application_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
-  sub_reasons_key: :quality_of_application_y_n,
+  reason_key: :quality_of_application_y_n,
   sub_reasons_result: sub_reasons_for(:quality_of_application_y_n),
 )
 %>
@@ -75,7 +78,7 @@
   this_month: current_month_rejection_count("safeguarding_y_n"),
   percentage_rejected: percentage_rejected_for_reason("safeguarding_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
-  sub_reasons_key: :safeguarding_y_n,
+  reason_key: :safeguarding_y_n,
   sub_reasons_result: sub_reasons_for(:safeguarding_y_n),
 )
 %>
@@ -86,6 +89,7 @@
   this_month: current_month_rejection_count("interested_in_future_applications_y_n"),
   percentage_rejected: percentage_rejected_for_reason("interested_in_future_applications_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  reason_key: :interested_in_future_applications_y_n,
 )
 %>
 
@@ -95,5 +99,6 @@
   this_month: current_month_rejection_count("other_advice_or_feedback_y_n"),
   percentage_rejected: percentage_rejected_for_reason("other_advice_or_feedback_y_n"),
   total_structured_rejection_reasons_count: total_structured_rejection_reasons_count,
+  reason_key: :other_advice_or_feedback_y_n,
 )
 %>

--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.html.erb
@@ -1,0 +1,1 @@
+<%= render BreadcrumbComponent.new(items: items) %>

--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
@@ -11,11 +11,11 @@ module SupportInterface
       items = [
         {
           text: 'Performance',
-          path: support_interface_performance_path
+          path: support_interface_performance_path,
         },
         {
           text: 'Structured reasons for rejection',
-          path: support_interface_reasons_for_rejection_dashboard_path
+          path: support_interface_reasons_for_rejection_dashboard_path,
         },
       ]
       if top_level_reason?
@@ -33,7 +33,7 @@ module SupportInterface
           ),
         }
         items << {
-          text: t("reasons_for_rejection.#{i18n_key}.#{@search_value}")
+          text: t("reasons_for_rejection.#{i18n_key}.#{@search_value}"),
         }
       end
 

--- a/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_breadcrumb_component.rb
@@ -1,0 +1,49 @@
+module SupportInterface
+  class ReasonsForRejectionSearchBreadcrumbComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(search_attribute:, search_value:)
+      @search_attribute = search_attribute
+      @search_value = search_value
+    end
+
+    def items
+      items = [
+        {
+          text: 'Performance',
+          path: support_interface_performance_path
+        },
+        {
+          text: 'Structured reasons for rejection',
+          path: support_interface_reasons_for_rejection_dashboard_path
+        },
+      ]
+      if top_level_reason?
+        i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
+        items << {
+          text: t("reasons_for_rejection.#{i18n_key}.title"),
+        }
+      else
+        top_level_reason = ::ReasonsForRejectionCountQuery::SUBREASONS_TO_TOP_LEVEL_REASONS[@search_attribute]
+        i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
+        items << {
+          text: t("reasons_for_rejection.#{i18n_key}.title"),
+          path: support_interface_reasons_for_rejection_application_choices_path(
+            "structured_rejection_reasons[#{top_level_reason}]" => 'Yes',
+          ),
+        }
+        items << {
+          text: t("reasons_for_rejection.#{i18n_key}.#{@search_value}")
+        }
+      end
+
+      items
+    end
+
+  private
+
+    def top_level_reason?
+      @search_attribute =~ /_y_n$/ && @search_value == 'Yes'
+    end
+  end
+end

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
@@ -15,3 +15,5 @@
     </div>
   </section>
 <% end %>
+
+<%= render(PaginatorComponent.new(scope: @application_choices)) %>

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">
-  Showing application choices with rejection reason <strong><%= search_value_text %></strong>
+  Showing application choices with rejection reason <strong><%= search_title_text %></strong>
 </p>
 
 <% @application_choices.each do |application_choice| %>

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
@@ -1,0 +1,30 @@
+<p class="govuk-body">
+  Showing application choices with rejection reason <strong><%= search_value_text %></strong>
+</p>
+
+<% @application_choices.each do |application_choice| %>
+  <section class="app-summary-card govuk-!-margin-bottom-6" id="application-choice-section-<%= application_choice.id %>">
+    <%= render(
+      SummaryCardHeaderComponent.new(
+        title: "Application choice #{govuk_link_to("##{application_choice.id}", support_interface_application_form_path(application_form_id: application_choice.application_form_id))}".html_safe,
+      ),
+    ) %>
+
+    <div class="app-summary-card__body">
+      <table class="govuk-table">
+        <% application_choice.structured_rejection_reasons.each do |reason, value| %>
+          <% if top_level_reason?(reason, value) %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-!-width-one-half">
+                <%= reason_text_for(reason) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= sub_reason_text_for(application_choice, reason) %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </table>
+    </div>
+  </section>
+<% end %>

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
@@ -11,20 +11,7 @@
     ) %>
 
     <div class="app-summary-card__body">
-      <table class="govuk-table">
-        <% application_choice.structured_rejection_reasons.each do |reason, value| %>
-          <% if top_level_reason?(reason, value) %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell govuk-!-width-one-half">
-                <%= reason_text_for(reason) %>
-              </td>
-              <td class="govuk-table__cell">
-                <%= sub_reason_text_for(application_choice, reason) %>
-              </td>
-            </tr>
-          <% end %>
-        <% end %>
-      </table>
+      <%= render SummaryListComponent.new(rows: summary_list_rows_for(application_choice)) %>
     </div>
   </section>
 <% end %>

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.html.erb
@@ -15,5 +15,3 @@
     </div>
   </section>
 <% end %>
-
-<%= render(PaginatorComponent.new(scope: @application_choices)) %>

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -1,0 +1,46 @@
+module SupportInterface
+  class ReasonsForRejectionSearchResultsComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(search_attribute:, search_value:, application_choices:)
+      @search_attribute = search_attribute
+      @search_value = search_value
+      @application_choices = application_choices
+    end
+
+    def search_value_text
+      if @search_value == 'Yes'
+        i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
+        t("reasons_for_rejection.#{i18n_key}.title")
+      else
+        [
+          t("reasons_for_rejection.#{@search_attribute}.title"),
+          t("reasons_for_rejection.#{@search_attribute}.#{@search_value}"),
+        ].join(' - ')
+      end
+    end
+
+    def sub_reason_text_for(application_choice, top_level_reason)
+      sub_reason = sub_reason_for(top_level_reason)
+      application_choice
+        .structured_rejection_reasons[sub_reason]
+        &.map { |value| t("reasons_for_rejection.#{sub_reason}.#{value}") }
+        &.join('<br/>')
+        &.html_safe
+    end
+
+    def reason_text_for(top_level_reason)
+      t("reasons_for_rejection.#{sub_reason_for(top_level_reason)}.title")
+    end
+
+    def top_level_reason?(reason, value)
+      reason =~ /_y_n$/ && value == 'Yes'
+    end
+
+  private
+
+    def sub_reason_for(top_level_reason)
+      SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
+    end
+  end
+end

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -8,6 +8,17 @@ module SupportInterface
       @application_choices = application_choices
     end
 
+    def summary_list_rows_for(application_choice)
+      rows = application_choice.structured_rejection_reasons.map do |reason, value|
+        if top_level_reason?(reason, value)
+          {
+            key: reason_text_for(reason),
+            value: sub_reason_text_for(application_choice, reason),
+          }
+        end
+      end.compact
+    end
+
     def search_value_text
       if @search_value == 'Yes'
         i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -24,9 +24,11 @@ module SupportInterface
         i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
         t("reasons_for_rejection.#{i18n_key}.title")
       else
+        top_level_reason = ReasonsForRejectionCountQuery::SUBREASONS_TO_TOP_LEVEL_REASONS[@search_attribute.to_sym]
+        i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
         [
-          t("reasons_for_rejection.#{@search_attribute}.title"),
-          t("reasons_for_rejection.#{@search_attribute}.#{@search_value}"),
+          t("reasons_for_rejection.#{i18n_key}.title"),
+          t("reasons_for_rejection.#{i18n_key}.#{@search_value}"),
         ].join(' - ')
       end
     end
@@ -39,14 +41,14 @@ module SupportInterface
             &.map { |value| sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value) },
         )
       else
-        detail_reason = detail_reason_for(application_choice, top_level_reason)
+        detail_reason_for(application_choice, top_level_reason)
       end
     end
 
     def sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value)
       i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
       text = mark_search_term(
-        I18n.t("reasons_for_rejection.#{i18n_key}.#{value}"), 
+        I18n.t("reasons_for_rejection.#{i18n_key}.#{value}"),
         value.to_s == @search_value.to_s,
       )
 
@@ -62,7 +64,7 @@ module SupportInterface
           application_choice.structured_rejection_reasons[detail_questions.to_s]
         end
 
-      [text, additional_text].reject(&:blank?).join(' - ')
+      [text, additional_text].reject(&:blank?).join(' - ').html_safe
     end
 
     def reason_text_for(top_level_reason)
@@ -80,10 +82,9 @@ module SupportInterface
       return nil if values.blank?
       return values[0] if values.size == 1
 
-      content_tag(
-        'ul',
-        values.map { |value| content_tag('li', value) }.join.html_safe,
-        class: 'govuk-list govuk-list--bullet govuk-!-margin-left-0 govuk-!-margin-right-0'
+      tag.ul(
+        values.map { |value| tag.li(value) }.join.html_safe,
+        class: 'govuk-list govuk-list--bullet govuk-!-margin-left-0 govuk-!-margin-right-0',
       ).html_safe
     end
 

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -45,7 +45,10 @@ module SupportInterface
 
     def sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value)
       i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
-      text = t("reasons_for_rejection.#{i18n_key}.#{value}")
+      text = mark_search_term(
+        I18n.t("reasons_for_rejection.#{i18n_key}.#{value}"), 
+        value.to_s == @search_value.to_s,
+      )
 
       detail_questions = ProviderInterface::ReasonsForRejectionWizard::INITIAL_QUESTIONS.dig(
         top_level_reason.to_sym, sub_reason.to_sym, value.to_sym
@@ -62,7 +65,7 @@ module SupportInterface
 
     def reason_text_for(top_level_reason)
       i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
-      t("reasons_for_rejection.#{i18n_key}.title")
+      mark_search_term(t("reasons_for_rejection.#{i18n_key}.title"), top_level_reason.to_s == @search_attribute.to_s)
     end
 
     def top_level_reason?(reason, value)
@@ -70,6 +73,10 @@ module SupportInterface
     end
 
   private
+
+    def mark_search_term(text, mark)
+      mark ? "<mark>#{text}</mark>".html_safe : text
+    end
 
     def sub_reason_for(top_level_reason)
       ReasonsForRejectionCountQuery::TOP_LEVEL_REASONS_TO_SUB_REASONS[top_level_reason.to_sym].to_s

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -34,10 +34,10 @@ module SupportInterface
     def reason_detail_text_for(application_choice, top_level_reason)
       sub_reason = sub_reason_for(top_level_reason)
       if sub_reason.present?
-        application_choice.structured_rejection_reasons[sub_reason]
-          &.map { |value| sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value) }
-          &.join('<br/>')
-          &.html_safe
+        values_as_list(
+          application_choice.structured_rejection_reasons[sub_reason]
+            &.map { |value| sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value) },
+        )
       else
         detail_reason = detail_reason_for(application_choice, top_level_reason)
       end
@@ -55,7 +55,9 @@ module SupportInterface
       )
       additional_text =
         if detail_questions.is_a?(Array)
-          detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact.join('<br/>')
+          values_as_list(
+            detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,
+          )
         else
           application_choice.structured_rejection_reasons[detail_questions.to_s]
         end
@@ -74,6 +76,17 @@ module SupportInterface
 
   private
 
+    def values_as_list(values)
+      return nil if values.blank?
+      return values[0] if values.size == 1
+
+      content_tag(
+        'ul',
+        values.map { |value| content_tag('li', value) }.join.html_safe,
+        class: 'govuk-list govuk-list--bullet govuk-!-margin-left-0 govuk-!-margin-right-0'
+      ).html_safe
+    end
+
     def mark_search_term(text, mark)
       mark ? "<mark>#{text}</mark>".html_safe : text
     end
@@ -84,7 +97,9 @@ module SupportInterface
 
     def detail_reason_for(application_choice, top_level_reason)
       detail_questions = ProviderInterface::ReasonsForRejectionWizard::INITIAL_QUESTIONS[top_level_reason.to_sym].keys
-      detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact.join('<br/>')
+      values_as_list(
+        detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,
+      )
     end
   end
 end

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -9,14 +9,14 @@ module SupportInterface
     end
 
     def summary_list_rows_for(application_choice)
-      rows = application_choice.structured_rejection_reasons.map do |reason, value|
-        if top_level_reason?(reason, value)
-          {
-            key: reason_text_for(reason),
-            value: sub_reason_text_for(application_choice, reason),
-          }
-        end
-      end.compact
+      application_choice.structured_rejection_reasons.map { |reason, value|
+        next unless top_level_reason?(reason, value)
+
+        {
+          key: reason_text_for(reason),
+          value: sub_reason_text_for(application_choice, reason),
+        }
+      }.compact
     end
 
     def search_value_text
@@ -33,15 +33,34 @@ module SupportInterface
 
     def sub_reason_text_for(application_choice, top_level_reason)
       sub_reason = sub_reason_for(top_level_reason)
-      application_choice
-        .structured_rejection_reasons[sub_reason]
-        &.map { |value| t("reasons_for_rejection.#{sub_reason}.#{value}") }
+      return '' if sub_reason.blank?
+
+      application_choice.structured_rejection_reasons[sub_reason]
+        &.map { |value| sub_reason_value_text(application_choice, top_level_reason, sub_reason, value) }
         &.join('<br/>')
         &.html_safe
     end
 
+    def sub_reason_value_text(application_choice, top_level_reason, sub_reason, value)
+      i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
+      text = t("reasons_for_rejection.#{i18n_key}.#{value}")
+
+      detail_questions = ProviderInterface::ReasonsForRejectionWizard::INITIAL_QUESTIONS.dig(
+        top_level_reason.to_sym, sub_reason.to_sym, value.to_sym
+      )
+      additional_text =
+        if detail_questions.is_a?(Array)
+          detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact.join('<br/>')
+        else
+          application_choice.structured_rejection_reasons[detail_questions.to_s]
+        end
+
+      [text, additional_text].reject(&:blank?).join(' - ')
+    end
+
     def reason_text_for(top_level_reason)
-      t("reasons_for_rejection.#{sub_reason_for(top_level_reason)}.title")
+      i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
+      t("reasons_for_rejection.#{i18n_key}.title")
     end
 
     def top_level_reason?(reason, value)
@@ -51,7 +70,7 @@ module SupportInterface
   private
 
     def sub_reason_for(top_level_reason)
-      SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
+      ReasonsForRejectionCountQuery::TOP_LEVEL_REASONS_TO_SUB_REASONS[top_level_reason.to_sym].to_s
     end
   end
 end

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -14,12 +14,12 @@ module SupportInterface
 
         {
           key: reason_text_for(reason),
-          value: sub_reason_text_for(application_choice, reason),
+          value: reason_detail_text_for(application_choice, reason),
         }
       }.compact
     end
 
-    def search_value_text
+    def search_title_text
       if @search_value == 'Yes'
         i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
         t("reasons_for_rejection.#{i18n_key}.title")
@@ -31,17 +31,19 @@ module SupportInterface
       end
     end
 
-    def sub_reason_text_for(application_choice, top_level_reason)
+    def reason_detail_text_for(application_choice, top_level_reason)
       sub_reason = sub_reason_for(top_level_reason)
-      return '' if sub_reason.blank?
-
-      application_choice.structured_rejection_reasons[sub_reason]
-        &.map { |value| sub_reason_value_text(application_choice, top_level_reason, sub_reason, value) }
-        &.join('<br/>')
-        &.html_safe
+      if sub_reason.present?
+        application_choice.structured_rejection_reasons[sub_reason]
+          &.map { |value| sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value) }
+          &.join('<br/>')
+          &.html_safe
+      else
+        detail_reason = detail_reason_for(application_choice, top_level_reason)
+      end
     end
 
-    def sub_reason_value_text(application_choice, top_level_reason, sub_reason, value)
+    def sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value)
       i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
       text = t("reasons_for_rejection.#{i18n_key}.#{value}")
 
@@ -71,6 +73,11 @@ module SupportInterface
 
     def sub_reason_for(top_level_reason)
       ReasonsForRejectionCountQuery::TOP_LEVEL_REASONS_TO_SUB_REASONS[top_level_reason.to_sym].to_s
+    end
+
+    def detail_reason_for(application_choice, top_level_reason)
+      detail_questions = ProviderInterface::ReasonsForRejectionWizard::INITIAL_QUESTIONS[top_level_reason.to_sym].keys
+      detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact.join('<br/>')
     end
   end
 end

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -52,7 +52,7 @@ module SupportInterface
         value.to_s == @search_value.to_s,
       )
 
-      detail_questions = ProviderInterface::ReasonsForRejectionWizard::INITIAL_QUESTIONS.dig(
+      detail_questions = ReasonsForRejection::INITIAL_QUESTIONS.dig(
         top_level_reason.to_sym, sub_reason.to_sym, value.to_sym
       )
       additional_text =
@@ -97,7 +97,7 @@ module SupportInterface
     end
 
     def detail_reason_for(application_choice, top_level_reason)
-      detail_questions = ProviderInterface::ReasonsForRejectionWizard::INITIAL_QUESTIONS[top_level_reason.to_sym].keys
+      detail_questions = ReasonsForRejection::INITIAL_QUESTIONS[top_level_reason.to_sym].keys
       values_as_list(
         detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,
       )

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.html.erb
@@ -11,7 +11,12 @@
     <% sub_reasons.each do |sub_reason, sub_reason_result| %>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">
-          <%= sub_reason_label(sub_reason) %>
+          <%= govuk_link_to(
+            sub_reason_label(sub_reason),
+            support_interface_reasons_for_rejection_application_choices_path(
+              "structured_rejection_reasons[#{sub_reason_key}]": sub_reason,
+            ),
+          ) %>
         </th>
         <td class="govuk-table__cell govuk-table__cell--numeric">
           <%= sub_reason_percentage(sub_reason) %>

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -26,7 +26,7 @@ module SupportInterface
     end
 
     def sub_reason_key
-      TOP_LEVEL_REASONS_TO_I18N_KEYS[reason]
+      ReasonsForRejectionCountQuery::TOP_LEVEL_REASONS_TO_SUB_REASONS[reason]
     end
 
     def sub_reason_label(sub_reason)

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -25,6 +25,10 @@ module SupportInterface
       I18n.t("reasons_for_rejection.#{reason}.title")
     end
 
+    def sub_reason_key
+      TOP_LEVEL_REASONS_TO_I18N_KEYS[reason]
+    end
+
     def sub_reason_label(sub_reason)
       I18n.t("reasons_for_rejection.#{TOP_LEVEL_REASONS_TO_I18N_KEYS[reason]}.#{sub_reason}")
     end

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -36,6 +36,5 @@ module SupportInterface
     def unavailable_choices
       @monitor = SupportInterface::ApplicationMonitor.new
     end
-
   end
 end

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -28,9 +28,7 @@ module SupportInterface
     end
 
     def reasons_for_rejection_application_choices
-      @application_choices = ReasonsForRejectionApplicationsQuery.new(
-        reasons_for_rejection_filter_params,
-      ).call
+      @application_choices = ReasonsForRejectionApplicationsQuery.new(params).call
     end
 
     def ucas_matches_dashboard; end
@@ -39,10 +37,5 @@ module SupportInterface
       @monitor = SupportInterface::ApplicationMonitor.new
     end
 
-  private
-
-    def reasons_for_rejection_filter_params
-      params.require(:structured_rejection_reasons)
-    end
   end
 end

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -27,10 +27,22 @@ module SupportInterface
       @reasons_for_rejection = ReasonsForRejectionCountQuery.new.sub_reason_counts
     end
 
+    def reasons_for_rejection_application_choices
+      @application_choices = ReasonsForRejectionApplicationsQuery.new(
+        reasons_for_rejection_filter_params,
+      ).call
+    end
+
     def ucas_matches_dashboard; end
 
     def unavailable_choices
       @monitor = SupportInterface::ApplicationMonitor.new
+    end
+
+  private
+
+    def reasons_for_rejection_filter_params
+      params.require(:structured_rejection_reasons)
     end
   end
 end

--- a/app/forms/provider_interface/reasons_for_rejection_wizard.rb
+++ b/app/forms/provider_interface/reasons_for_rejection_wizard.rb
@@ -2,54 +2,6 @@ module ProviderInterface
   class ReasonsForRejectionWizard
     include ActiveModel::Model
 
-    INITIAL_TOP_LEVEL_QUESTIONS = %i[
-      candidate_behaviour_y_n
-      quality_of_application_y_n
-      qualifications_y_n
-      performance_at_interview_y_n
-      course_full_y_n
-      offered_on_another_course_y_n
-      honesty_and_professionalism_y_n
-      safeguarding_y_n
-    ].freeze
-
-    INITIAL_QUESTIONS = {
-      candidate_behaviour_y_n: {
-        candidate_behaviour_what_did_the_candidate_do: {
-          other: %i[candidate_behaviour_other candidate_behaviour_what_to_improve],
-        },
-      },
-      quality_of_application_y_n: {
-        quality_of_application_which_parts_needed_improvement: {
-          personal_statement: :quality_of_application_personal_statement_what_to_improve,
-          subject_knowledge: :quality_of_application_subject_knowledge_what_to_improve,
-          other: %i[quality_of_application_other_details quality_of_application_other_what_to_improve],
-        },
-      },
-      qualifications_y_n: {
-        qualifications_which_qualifications: {
-          other: :qualifications_other_details,
-        },
-      },
-      performance_at_interview_y_n: { performance_at_interview_what_to_improve: nil },
-      offered_on_another_course_y_n: { offered_on_another_course_details: nil },
-      honesty_and_professionalism_y_n: {
-        honesty_and_professionalism_concerns: {
-          information_false_or_inaccurate: :honesty_and_professionalism_concerns_information_false_or_inaccurate_details,
-          plagiarism: :honesty_and_professionalism_concerns_plagiarism_details,
-          references: :honesty_and_professionalism_concerns_references_details,
-          other: :honesty_and_professionalism_concerns_other_details,
-        },
-      },
-      safeguarding_y_n: {
-        safeguarding_concerns: {
-          candidate_disclosed_information: :safeguarding_concerns_candidate_disclosed_information_details,
-          vetting_disclosed_information: :safeguarding_concerns_vetting_disclosed_information_details,
-          other: :safeguarding_concerns_other_details,
-        },
-      },
-    }.freeze
-
     class NestedAnswerValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         return unless options.key?(:collection_name) && options.key?(:selected_option)
@@ -75,7 +27,7 @@ module ProviderInterface
       end
     end
 
-    INITIAL_QUESTIONS.each do |top_level_question, children|
+    ReasonsForRejection::INITIAL_QUESTIONS.each do |top_level_question, children|
       children.each do |options_collection_name, options|
         next unless options.present? && options.is_a?(Hash)
 
@@ -115,7 +67,7 @@ module ProviderInterface
     end
 
     def reason_not_captured_by_initial_questions?
-      INITIAL_TOP_LEVEL_QUESTIONS.all? { |attr| send(attr) == 'No' }
+      ReasonsForRejection::INITIAL_TOP_LEVEL_QUESTIONS.all? { |attr| send(attr) == 'No' }
     end
 
     def needs_other_reasons?
@@ -274,11 +226,11 @@ module ProviderInterface
     end
 
     def clean_answers_for_initial_questions(attrs)
-      INITIAL_QUESTIONS.each_key { |k| clean_initial_question(attrs, k) }
+      ReasonsForRejection::INITIAL_QUESTIONS.each_key { |k| clean_initial_question(attrs, k) }
     end
 
     def clean_initial_question(attrs, key)
-      options_attribute_name, options = INITIAL_QUESTIONS[key].first
+      options_attribute_name, options = ReasonsForRejection::INITIAL_QUESTIONS[key].first
       # Clear the immediate child options if the Yes/No top level answer is No
       attrs.merge!(options_attribute_name => nil) if attrs[key] == 'No'
 
@@ -297,7 +249,7 @@ module ProviderInterface
 
     def clean_answers_for_other_reasons(attrs)
       attrs[:other_advice_or_feedback_details] = nil if attrs[:other_advice_or_feedback_y_n] == 'No'
-      answers_for_initial_top_level_questions = last_saved_state.slice(*INITIAL_TOP_LEVEL_QUESTIONS.map(&:to_s)).values
+      answers_for_initial_top_level_questions = last_saved_state.slice(*ReasonsForRejection::INITIAL_TOP_LEVEL_QUESTIONS.map(&:to_s)).values
       attrs[:why_are_you_rejecting_this_application] = nil unless answers_for_initial_top_level_questions.uniq == %w[No]
     end
 

--- a/app/frontend/styles/_mark.scss
+++ b/app/frontend/styles/_mark.scss
@@ -1,0 +1,4 @@
+mark {
+  background-color: govuk-tint(govuk-colour("yellow"), 65);
+  padding: 2px 5px;
+}

--- a/app/frontend/styles/_overrides.scss
+++ b/app/frontend/styles/_overrides.scss
@@ -1,0 +1,3 @@
+.app-\!-colour-muted {
+  color: $govuk-secondary-text-colour;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -50,3 +50,6 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 @import "_summary-card";
 @import "_feedback";
 @import "_cookies-banner";
+
+// Override utilities
+@import "_overrides";

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -24,6 +24,7 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 
 // Shared (base HTML elements)
 @import "_code";
+@import "_mark";
 
 // Shared (govuk-frontend component overrides)
 @import "_header";

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -332,6 +332,9 @@ class TestApplications
           performance_at_interview_y_n: 'Yes',
           performance_at_interview_what_to_improve: 'We felt that pyjamas were a little too casual',
           qualifications_y_n: 'Yes',
+          qualifications_which_qualifications: %w[no_english_gcse no_science_gcse no_maths_gcse no_degree other].sample(2),
+          quality_of_application_y_n: 'Yes',
+          quality_of_application: %w[personal_statement subject_knowledge other].sample(2),
         },
       ).save
       choice.update_columns(rejected_at: time, updated_at: time)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -332,9 +332,11 @@ class TestApplications
           performance_at_interview_y_n: 'Yes',
           performance_at_interview_what_to_improve: 'We felt that pyjamas were a little too casual',
           qualifications_y_n: 'Yes',
-          qualifications_which_qualifications: %w[no_english_gcse no_science_gcse no_maths_gcse no_degree other].sample(2),
+          qualifications_which_qualifications: %w[no_maths_gcse no_degree other],
+          qualifications_other_details: 'Cycling proficiency badge',
           quality_of_application_y_n: 'Yes',
-          quality_of_application: %w[personal_statement subject_knowledge other].sample(2),
+          quality_of_application_which_parts_needed_improvement: %w[subject_knowledge other],
+          quality_of_application_other_details: 'Too many emojis',
         },
       ).save
       choice.update_columns(rejected_at: time, updated_at: time)

--- a/app/models/reasons_for_rejection.rb
+++ b/app/models/reasons_for_rejection.rb
@@ -1,6 +1,54 @@
 class ReasonsForRejection
   include ActiveModel::Model
 
+  INITIAL_TOP_LEVEL_QUESTIONS = %i[
+    candidate_behaviour_y_n
+    quality_of_application_y_n
+    qualifications_y_n
+    performance_at_interview_y_n
+    course_full_y_n
+    offered_on_another_course_y_n
+    honesty_and_professionalism_y_n
+    safeguarding_y_n
+  ].freeze
+
+  INITIAL_QUESTIONS = {
+    candidate_behaviour_y_n: {
+      candidate_behaviour_what_did_the_candidate_do: {
+        other: %i[candidate_behaviour_other candidate_behaviour_what_to_improve],
+      },
+    },
+    quality_of_application_y_n: {
+      quality_of_application_which_parts_needed_improvement: {
+        personal_statement: :quality_of_application_personal_statement_what_to_improve,
+        subject_knowledge: :quality_of_application_subject_knowledge_what_to_improve,
+        other: %i[quality_of_application_other_details quality_of_application_other_what_to_improve],
+      },
+    },
+    qualifications_y_n: {
+      qualifications_which_qualifications: {
+        other: :qualifications_other_details,
+      },
+    },
+    performance_at_interview_y_n: { performance_at_interview_what_to_improve: nil },
+    offered_on_another_course_y_n: { offered_on_another_course_details: nil },
+    honesty_and_professionalism_y_n: {
+      honesty_and_professionalism_concerns: {
+        information_false_or_inaccurate: :honesty_and_professionalism_concerns_information_false_or_inaccurate_details,
+        plagiarism: :honesty_and_professionalism_concerns_plagiarism_details,
+        references: :honesty_and_professionalism_concerns_references_details,
+        other: :honesty_and_professionalism_concerns_other_details,
+      },
+    },
+    safeguarding_y_n: {
+      safeguarding_concerns: {
+        candidate_disclosed_information: :safeguarding_concerns_candidate_disclosed_information_details,
+        vetting_disclosed_information: :safeguarding_concerns_vetting_disclosed_information_details,
+        other: :safeguarding_concerns_other_details,
+      },
+    },
+  }.freeze
+
   attr_accessor :candidate_behaviour_y_n
   attr_writer :candidate_behaviour_what_did_the_candidate_do
   attr_accessor :candidate_behaviour_what_to_improve

--- a/app/models/reasons_for_rejection_feature_metrics.rb
+++ b/app/models/reasons_for_rejection_feature_metrics.rb
@@ -4,7 +4,7 @@ class ReasonsForRejectionFeatureMetrics
     start_time,
     end_time = Time.zone.now.beginning_of_day
   )
-    raise ArgumentError unless ProviderInterface::ReasonsForRejectionWizard::INITIAL_TOP_LEVEL_QUESTIONS.include?(reason)
+    raise ArgumentError unless ReasonsForRejection::INITIAL_TOP_LEVEL_QUESTIONS.include?(reason)
 
     ApplicationChoice
       .rejected

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -1,0 +1,31 @@
+class ReasonsForRejectionApplicationsQuery
+  attr_accessor :filters
+
+  def initialize(filters)
+    self.filters = filters
+  end
+
+  def call
+    application_choices = ApplicationChoice.where.not(structured_rejection_reasons: nil)
+
+    apply_filters(application_choices)
+  end
+
+private
+
+  def apply_filters(application_choices)
+    filters.each do |key, value|
+      if key =~ /_y_n$/
+        application_choices = application_choices.where(
+          "application_choices.structured_rejection_reasons->>'#{key}' = '#{value}'",
+        )
+      else
+        application_choices = application_choices.where(
+          "application_choices.structured_rejection_reasons->'#{key}' ? '#{value}'",
+        )
+      end
+    end
+
+    application_choices
+  end
+end

--- a/app/queries/reasons_for_rejection_applications_query.rb
+++ b/app/queries/reasons_for_rejection_applications_query.rb
@@ -6,7 +6,12 @@ class ReasonsForRejectionApplicationsQuery
   end
 
   def call
-    application_choices = ApplicationChoice.where.not(structured_rejection_reasons: nil)
+    application_choices = ApplicationChoice
+      .where
+      .not(structured_rejection_reasons: nil)
+      .order(created_at: :desc)
+      .page(filters[:page])
+      .per(30)
 
     apply_filters(application_choices)
   end
@@ -14,7 +19,7 @@ class ReasonsForRejectionApplicationsQuery
 private
 
   def apply_filters(application_choices)
-    filters.each do |key, value|
+    filters[:structured_rejection_reasons].each do |key, value|
       if key =~ /_y_n$/
         application_choices = application_choices.where(
           "application_choices.structured_rejection_reasons->>'#{key}' = '#{value}'",

--- a/app/queries/reasons_for_rejection_count_query.rb
+++ b/app/queries/reasons_for_rejection_count_query.rb
@@ -39,6 +39,7 @@ private
     honesty_and_professionalism_concerns: :honesty_and_professionalism_y_n,
     safeguarding_concerns: :safeguarding_y_n,
   }.with_indifferent_access
+  TOP_LEVEL_REASONS_TO_SUB_REASONS = SUBREASONS_TO_TOP_LEVEL_REASONS.map { |k, v| [v, k] }.to_h
 
   SUBREASON_VALUES = {
     qualifications_y_n: %i[no_maths_gcse no_english_gcse no_science_gcse no_degree other],

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -22,3 +22,5 @@
   search_value: params[:structured_rejection_reasons].values.first,
   application_choices: @application_choices,
 ) %>
+
+<%= render(PaginatorComponent.new(scope: @application_choices)) %>

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -2,19 +2,10 @@
 <% content_for :title, 'Search' %>
 
 <% content_for :before_content do %>
-  <%= render BreadcrumbComponent.new(items: [
-    {
-      text: 'Performance',
-      path: support_interface_performance_path
-    },
-    {
-      text: 'Structured reasons for rejection',
-      path: support_interface_reasons_for_rejection_dashboard_path
-    },
-    {
-      text: 'Search'
-    }
-  ]) %>
+  <%= render SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent.new(
+    search_attribute: params[:structured_rejection_reasons].keys.first,
+    search_value: params[:structured_rejection_reasons].values.first,
+  ) %>
 <% end %>
 
 <%= render SupportInterface::ReasonsForRejectionSearchResultsComponent.new(

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -16,53 +16,8 @@
   ]) %>
 <% end %>
 
-<p class="govuk-body">
-  Showing application choices with rejection reason
-  <strong>
-    <%=
-      # TODO: refactor to component
-      key = params[:structured_rejection_reasons].keys.first
-      value = params[:structured_rejection_reasons][key]
-      if value == 'Yes'
-        i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[key].to_s
-        t("reasons_for_rejection.#{i18n_key}.title")
-      else
-        t("reasons_for_rejection.#{key}.title") + ' - ' + t("reasons_for_rejection.#{key}.#{value}")
-      end
-    %>
-  </strong>
-</p>
-
-<% @application_choices.each do |application_choice| %>
-  <section class="app-summary-card govuk-!-margin-bottom-6" id="application-choice-section-<%= application_choice.id %>">
-    <%= render(
-      SummaryCardHeaderComponent.new(
-        title: "Application choice #{govuk_link_to("##{application_choice.id}", support_interface_application_form_path(application_form_id: application_choice.application_form_id))}".html_safe,
-      ),
-    ) %>
-
-    <div class="app-summary-card__body">
-      <table class="govuk-table">
-        <% application_choice.structured_rejection_reasons.each do |reason, details| %>
-          <% sub_reason = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[reason].to_s %>
-          <% if reason =~ /_y_n$/ && details == 'Yes' %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell govuk-!-width-one-half">
-                <%= t("reasons_for_rejection.#{sub_reason}.title") %>
-              </td>
-              <td class="govuk-table__cell">
-                <%=
-                  application_choice
-                    .structured_rejection_reasons[sub_reason]
-                    &.map { |value| t("reasons_for_rejection.#{sub_reason}.#{value}") }
-                    &.join('<br/>')
-                    &.html_safe
-                %>
-              </td>
-            </tr>
-          <% end %>
-        <% end %>
-      </table>
-    </div>
-  </section>
-<% end %>
+<%= render SupportInterface::ReasonsForRejectionSearchResultsComponent.new(
+  search_attribute: params[:structured_rejection_reasons].keys.first,
+  search_value: params[:structured_rejection_reasons].values.first,
+  application_choices: @application_choices,
+) %>

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -1,4 +1,5 @@
-<% content_for :title, 'Reasons for rejection search' %>
+<% content_for :context, 'Structured reasons for rejection' %>
+<% content_for :title, 'Search' %>
 
 <% content_for :before_content do %>
   <%= render BreadcrumbComponent.new(items: [
@@ -7,11 +8,11 @@
       path: support_interface_performance_path
     },
     {
-      text: 'Reasons for rejection',
+      text: 'Structured reasons for rejection',
       path: support_interface_reasons_for_rejection_dashboard_path
     },
     {
-      text: 'Reasons for rejection search'
+      text: 'Search'
     }
   ]) %>
 <% end %>

--- a/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
+++ b/app/views/support_interface/performance/reasons_for_rejection_application_choices.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, 'Reasons for rejection search' %>
+
+<% content_for :before_content do %>
+  <%= render BreadcrumbComponent.new(items: [
+    {
+      text: 'Performance',
+      path: support_interface_performance_path
+    },
+    {
+      text: 'Reasons for rejection',
+      path: support_interface_reasons_for_rejection_dashboard_path
+    },
+    {
+      text: 'Reasons for rejection search'
+    }
+  ]) %>
+<% end %>
+
+<p class="govuk-body">
+  Showing application choices with rejection reason
+  <strong>
+    <%=
+      # TODO: refactor to component
+      key = params[:structured_rejection_reasons].keys.first
+      value = params[:structured_rejection_reasons][key]
+      if value == 'Yes'
+        i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[key].to_s
+        t("reasons_for_rejection.#{i18n_key}.title")
+      else
+        t("reasons_for_rejection.#{key}.title") + ' - ' + t("reasons_for_rejection.#{key}.#{value}")
+      end
+    %>
+  </strong>
+</p>
+
+<% @application_choices.each do |application_choice| %>
+  <section class="app-summary-card govuk-!-margin-bottom-6" id="application-choice-section-<%= application_choice.id %>">
+    <%= render(
+      SummaryCardHeaderComponent.new(
+        title: "Application choice #{govuk_link_to("##{application_choice.id}", support_interface_application_form_path(application_form_id: application_choice.application_form_id))}".html_safe,
+      ),
+    ) %>
+
+    <div class="app-summary-card__body">
+      <table class="govuk-table">
+        <% application_choice.structured_rejection_reasons.each do |reason, details| %>
+          <% sub_reason = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[reason].to_s %>
+          <% if reason =~ /_y_n$/ && details == 'Yes' %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-!-width-one-half">
+                <%= t("reasons_for_rejection.#{sub_reason}.title") %>
+              </td>
+              <td class="govuk-table__cell">
+                <%=
+                  application_choice
+                    .structured_rejection_reasons[sub_reason]
+                    &.map { |value| t("reasons_for_rejection.#{sub_reason}.#{value}") }
+                    &.join('<br/>')
+                    &.html_safe
+                %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </table>
+    </div>
+  </section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -845,6 +845,7 @@ Rails.application.routes.draw do
       get '/course-statistics', to: 'performance#courses_dashboard', as: :courses_dashboard
       get '/feature-metrics' => 'performance#feature_metrics_dashboard', as: :feature_metrics_dashboard
       get '/reasons-for-rejection' => 'performance#reasons_for_rejection_dashboard', as: :reasons_for_rejection_dashboard
+      get '/reasons-for-rejection/application_choices' => 'performance#reasons_for_rejection_application_choices', as: :reasons_for_rejection_application_choices
       get '/service' => 'performance#service_performance_dashboard', as: :service_performance_dashboard
       get '/ucas-matches' => 'performance#ucas_matches_dashboard', as: :ucas_matches_dashboard
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -845,7 +845,7 @@ Rails.application.routes.draw do
       get '/course-statistics', to: 'performance#courses_dashboard', as: :courses_dashboard
       get '/feature-metrics' => 'performance#feature_metrics_dashboard', as: :feature_metrics_dashboard
       get '/reasons-for-rejection' => 'performance#reasons_for_rejection_dashboard', as: :reasons_for_rejection_dashboard
-      get '/reasons-for-rejection/application_choices' => 'performance#reasons_for_rejection_application_choices', as: :reasons_for_rejection_application_choices
+      get '/reasons-for-rejection/application-choices' => 'performance#reasons_for_rejection_application_choices', as: :reasons_for_rejection_application_choices
       get '/service' => 'performance#service_performance_dashboard', as: :service_performance_dashboard
       get '/ucas-matches' => 'performance#ucas_matches_dashboard', as: :ucas_matches_dashboard
 

--- a/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_breadcrumb_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ReasonsForRejectionSearchBreadcrumbComponent do
+  def render_result(
+    search_attribute = :quality_of_application_y_n,
+    search_value = 'Yes'
+  )
+    @rendered_result ||= render_inline(
+      described_class.new(
+        search_attribute: search_attribute,
+        search_value: search_value,
+      ),
+    )
+  end
+
+  context 'for a top-level reason' do
+    before do
+      render_result
+    end
+
+    it 'renders the correct title' do
+      expect(@rendered_result.text).to include('Quality of application')
+    end
+  end
+
+  context 'for a sub-reason' do
+    before do
+      render_result(:qualifications_which_qualifications, :no_degree)
+    end
+
+    it 'renders the correct title' do
+      expect(@rendered_result.text).to include('No degree')
+    end
+
+    it 'renders the link back to qualifications' do
+      expect(@rendered_result.css("a[href='/support/performance/reasons-for-rejection/application-choices?structured_rejection_reasons%5Bqualifications_y_n%5D=Yes']")).to be_present
+    end
+  end
+end

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
+  def render_result(
+    application_choices,
+    search_attribute = :quality_of_application_y_n,
+    search_value = 'Yes'
+  )
+    @rendered_result ||= render_inline(
+      described_class.new(
+        search_attribute: search_attribute,
+        search_value: search_value,
+        application_choices: application_choices,
+      ),
+    )
+  end
+
+  context 'for a top-level reason' do
+    before do
+      application_choice = build(
+        :application_choice,
+        structured_rejection_reasons: {
+          qualifications_y_n: 'Yes',
+          qualifications_which_qualifications: %w[no_maths_gcse no_degree],
+          quality_of_application_y_n: 'Yes',
+        },
+        application_form_id: 123,
+      )
+      render_result([application_choice])
+    end
+
+    it 'renders the correct title' do
+      expect(@rendered_result.text).to include('Showing application choices with rejection reason Quality of application')
+    end
+
+    it 'renders a link to the application form' do
+      expect(@rendered_result.css("a[href='support/application_form/123']"))
+    end
+
+    it 'renders top-level reasons' do
+      expect(@rendered_result.text).to include('Qualifications')
+      expect(@rendered_result.text).to include('Quality of application')
+      expect(@rendered_result.text).not_to include('Performance at interview')
+      expect(@rendered_result.text).not_to include('Something you did')
+    end
+
+    it 'renders sub-reasons' do
+      expect(@rendered_result.text).to include('No Maths GCSE')
+      expect(@rendered_result.text).to include('No degree')
+      expect(@rendered_result.text).not_to include('No Science GCSE')
+      expect(@rendered_result.text).not_to include('No English GCSE')
+    end
+  end
+
+  context 'for a sub-reason' do
+    before do
+      application_choice = build(
+        :application_choice,
+        structured_rejection_reasons: {
+          qualifications_y_n: 'Yes',
+          qualifications_which_qualifications: %w[no_maths_gcse no_degree],
+          quality_of_application_y_n: 'Yes',
+        },
+        application_form_id: 123,
+      )
+      render_result([application_choice], :qualifications_which_qualifications, :no_degree)
+    end
+
+    it 'renders the correct title' do
+      expect(@rendered_result.text).to include(
+        'Showing application choices with rejection reason Qualifications - No degree'
+      )
+    end
+  end
+end

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       expect(@rendered_result.text).not_to include('No Science GCSE')
       expect(@rendered_result.text).not_to include('No English GCSE')
     end
+
+    it 'highlights the search term' do
+      expect(@rendered_result.css('mark').text).to eq 'Quality of application'
+    end
   end
 
   context 'for a sub-reason' do
@@ -76,6 +80,10 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       expect(@rendered_result.text).to include(
         'Showing application choices with rejection reason Qualifications - No degree',
       )
+    end
+
+    it 'highlights the search term' do
+      expect(@rendered_result.css('mark').text).to eq 'No degree'
     end
   end
 end

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -17,9 +17,11 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
 
   context 'for a top-level reason' do
     before do
-      application_choice = build(
+      @application_choice = build(
         :application_choice,
         structured_rejection_reasons: {
+          performance_at_interview_y_n: 'Yes',
+          performance_at_interview_what_to_improve: 'Avoid humming',
           qualifications_y_n: 'Yes',
           qualifications_which_qualifications: %w[no_maths_gcse no_degree],
           quality_of_application_y_n: 'Yes',
@@ -28,7 +30,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
         },
         application_form_id: 123,
       )
-      render_result([application_choice])
+      render_result([@application_choice])
     end
 
     it 'renders the correct title' do
@@ -36,13 +38,14 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
     end
 
     it 'renders a link to the application form' do
-      expect(@rendered_result.css("a[href='support/application_form/123']")).to be_present
+      expect(@rendered_result.css("a[href='/support/applications/123']")).to be_present
     end
 
     it 'renders top-level reasons' do
       expect(@rendered_result.text).to include('Qualifications')
       expect(@rendered_result.text).to include('Quality of application')
-      expect(@rendered_result.text).not_to include('Performance at interview')
+      expect(@rendered_result.text).to include('Performance at interview')
+      expect(@rendered_result.text).to include('Avoid humming')
       expect(@rendered_result.text).not_to include('Something you did')
     end
 
@@ -57,7 +60,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
 
   context 'for a sub-reason' do
     before do
-      application_choice = build(
+      @application_choice = build(
         :application_choice,
         structured_rejection_reasons: {
           qualifications_y_n: 'Yes',
@@ -66,7 +69,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
         },
         application_form_id: 123,
       )
-      render_result([application_choice], :qualifications_which_qualifications, :no_degree)
+      render_result([@application_choice], :qualifications_which_qualifications, :no_degree)
     end
 
     it 'renders the correct title' do

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
           qualifications_y_n: 'Yes',
           qualifications_which_qualifications: %w[no_maths_gcse no_degree],
           quality_of_application_y_n: 'Yes',
+          quality_of_application_which_parts_needed_improvement: %w[other],
+          quality_of_application_other_details: 'Too many emojis',
         },
         application_form_id: 123,
       )
@@ -34,7 +36,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
     end
 
     it 'renders a link to the application form' do
-      expect(@rendered_result.css("a[href='support/application_form/123']"))
+      expect(@rendered_result.css("a[href='support/application_form/123']")).to be_present
     end
 
     it 'renders top-level reasons' do
@@ -47,6 +49,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
     it 'renders sub-reasons' do
       expect(@rendered_result.text).to include('No Maths GCSE')
       expect(@rendered_result.text).to include('No degree')
+      expect(@rendered_result.text).to include('Other - Too many emojis')
       expect(@rendered_result.text).not_to include('No Science GCSE')
       expect(@rendered_result.text).not_to include('No English GCSE')
     end
@@ -68,7 +71,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
 
     it 'renders the correct title' do
       expect(@rendered_result.text).to include(
-        'Showing application choices with rejection reason Qualifications - No degree'
+        'Showing application choices with rejection reason Qualifications - No degree',
       )
     end
   end

--- a/spec/forms/provider_interface/reasons_for_rejection_wizard_spec.rb
+++ b/spec/forms/provider_interface/reasons_for_rejection_wizard_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe ProviderInterface::ReasonsForRejectionWizard do
     # candidate_behaviour_what_did_the_candidate_do: [didnt_attend_interview]
     # candidate_behaviour_other: 'Some text' <- this value should be cleared
     it 'ignores nested answers when parent is not selected' do
-      described_class::INITIAL_TOP_LEVEL_QUESTIONS.each { |q| attrs_with_nested_answers[q] = 'Yes' }
+      ReasonsForRejection::INITIAL_TOP_LEVEL_QUESTIONS.each { |q| attrs_with_nested_answers[q] = 'Yes' }
 
       attrs_with_nested_answers[:candidate_behaviour_what_did_the_candidate_do] = %w[didnt_attend_interview]
       attrs_with_nested_answers[:quality_of_application_which_parts_needed_improvement] = %w[personal_statement]

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -291,13 +291,13 @@ private
 
     within "#application-choice-section-#{@application_choice1.id}" do
       expect(page).to have_content('Safeguarding issues')
-      expect(page).to have_content('Qualifications No Maths GCSE grade 4 (C) or above, or valid equivalentNo degree')
-      expect(page).to have_content('Something you did Didn’t reply to our interview offer')
+      expect(page).to have_content("Qualifications\nNo Maths GCSE grade 4 (C) or above, or valid equivalentNo degree")
+      expect(page).to have_content("Something you did Didn’t reply to our interview offer")
     end
     within "#application-choice-section-#{@application_choice2.id}" do
       expect(page).not_to have_content('Safeguarding issues')
-      expect(page).to have_content('Qualifications No English GCSE grade 4 (C) or above, or valid equivalentOther')
-      expect(page).to have_content('Something you did Didn’t attend interview')
+      expect(page).to have_content("Qualifications\nNo English GCSE grade 4 (C) or above, or valid equivalentOther")
+      expect(page).to have_content("Something you did Didn’t attend interview")
     end
     within "#application-choice-section-#{@application_choice3.id}" do
       expect(page).not_to have_content('Safeguarding issues')
@@ -330,8 +330,8 @@ private
 
     within "#application-choice-section-#{@application_choice2.id}" do
       expect(page).not_to have_content('Safeguarding issues')
-      expect(page).to have_content('Qualifications No English GCSE grade 4 (C) or above, or valid equivalentOther')
-      expect(page).to have_content('Something you did Didn’t attend interview')
+      expect(page).to have_content("Qualifications\nNo English GCSE grade 4 (C) or above, or valid equivalentOther")
+      expect(page).to have_content("Something you did Didn’t attend interview")
     end
   end
 end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -292,12 +292,12 @@ private
     within "#application-choice-section-#{@application_choice1.id}" do
       expect(page).to have_content('Safeguarding issues')
       expect(page).to have_content("Qualifications\nNo Maths GCSE grade 4 (C) or above, or valid equivalentNo degree")
-      expect(page).to have_content("Something you did Didn’t reply to our interview offer")
+      expect(page).to have_content('Something you did Didn’t reply to our interview offer')
     end
     within "#application-choice-section-#{@application_choice2.id}" do
       expect(page).not_to have_content('Safeguarding issues')
       expect(page).to have_content("Qualifications\nNo English GCSE grade 4 (C) or above, or valid equivalentOther")
-      expect(page).to have_content("Something you did Didn’t attend interview")
+      expect(page).to have_content('Something you did Didn’t attend interview')
     end
     within "#application-choice-section-#{@application_choice3.id}" do
       expect(page).not_to have_content('Safeguarding issues')
@@ -331,7 +331,7 @@ private
     within "#application-choice-section-#{@application_choice2.id}" do
       expect(page).not_to have_content('Safeguarding issues')
       expect(page).to have_content("Qualifications\nNo English GCSE grade 4 (C) or above, or valid equivalentOther")
-      expect(page).to have_content("Something you did Didn’t attend interview")
+      expect(page).to have_content('Something you did Didn’t attend interview')
     end
   end
 end


### PR DESCRIPTION
## Context

The Delivery team needs a summary view of structured R4R in Support UI so that they can observe trends and adjust/intervene accordingly

## Changes proposed in this pull request

- [x] Add links to the rejection reasons dashboard to a new page that displays the matching applications

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/450843/107028361-5d72c700-67a5-11eb-93b7-5a4c02df7712.png">

- [x] Use `SummaryListComponent` for results
- [x] Include free-text reasons (a) under top-level reasons and (b) sub-reasons
- [x] Use `mark` element to highlight the search reason
- [x] Add pagination
- [x] Extend breadcrumbs to show top-level reason when viewing sub-reasons

## Guidance to review

- The search page only displays the bare minimum, application choice and link, top-level reasons and sub-reasons. We can add more details about each application.
- Do the links on the dashboard (including the one in the `h2`) make sense? Is the layout of the search results logical?
- I'm getting a spec failing due to a cross module reference (lookup from a ProviderInterface data structure). Ideas about how to resolve this? Longer term we want to extract all the R4R 'metadata' to somewhere common.

## Link to Trello card

https://trello.com/c/aWsSjWyQ/2888-dev-r4r-support-search-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
