### PR TITLE
Update E&D export to include rejection reasons

### DIFF
--- a/spec/services/support_interface/equality_and_diversity_export_spec.rb
+++ b/spec/services/support_interface/equality_and_diversity_export_spec.rb
@@ -16,8 +16,25 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
 
       application_form_one = create(:completed_application_form, equality_and_diversity: two_disabilities)
       application_form_two = create(:completed_application_form, equality_and_diversity: one_disability)
+      application_form_three = create(:completed_application_form, equality_and_diversity: two_disabilities)
+
       create(:completed_application_form, equality_and_diversity: nil)
-      create(:application_choice, :awaiting_provider_decision, application_form: application_form_two)
+      create(
+        :application_choice,
+        :with_structured_rejection_reasons,
+        structured_rejection_reasons: {
+          course_full_y_n: 'No',
+          candidate_behaviour_y_n: 'Yes',
+          candidate_behaviour_other: 'Persistent scratching',
+          honesty_and_professionalism_y_n: 'Yes',
+          honesty_and_professionalism_concerns: %w[references],
+        },
+        application_form: application_form_two,
+      )
+
+      create(:application_choice, :with_rejection, rejection_reason: 'No English GCSE provided.', application_form: application_form_three)
+      create(:application_choice, :with_rejection, rejection_reason: 'No maths GCSE provided.', application_form: application_form_three)
+      create(:application_choice, :with_rejection, rejection_reason: 'No degree provided.', application_form: application_form_three)
 
       expect(described_class.new.data_for_export).to contain_exactly(
         {
@@ -29,6 +46,9 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           'Disability 1' => application_form_one.equality_and_diversity['disabilities'].first,
           'Disability 2' => application_form_one.equality_and_diversity['disabilities'].last,
           'Application status' => 'Have not started form',
+          'First choices rejection reasons' => nil,
+          'Second choices rejection reasons' => nil,
+          'Third choices rejection reasons' => nil,
         },
         {
           'Month' => application_form_two.submitted_at&.strftime('%B'),
@@ -37,7 +57,23 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
           'Ethnic background' => application_form_two.equality_and_diversity['ethnic_background'],
           'Ethnic group' => application_form_two.equality_and_diversity['ethnic_group'],
           'Disability 1' => application_form_two.equality_and_diversity['disabilities'].first,
-          'Application status' => 'Awaiting decisions from providers',
+          'Application status' => 'Ended without success',
+          'First choices rejection reasons' => "Candidate behaviour\nHonesty and professionalism",
+          'Second choices rejection reasons' => nil,
+          'Third choices rejection reasons' => nil,
+        },
+        {
+          'Month' => application_form_three.submitted_at&.strftime('%B'),
+          'Recruitment cycle year' => application_form_three.recruitment_cycle_year,
+          'Sex' => application_form_three.equality_and_diversity['sex'],
+          'Ethnic background' => application_form_three.equality_and_diversity['ethnic_background'],
+          'Ethnic group' => application_form_three.equality_and_diversity['ethnic_group'],
+          'Disability 1' => application_form_three.equality_and_diversity['disabilities'].first,
+          'Disability 2' => application_form_three.equality_and_diversity['disabilities'].last,
+          'Application status' => 'Ended without success',
+          'First choices rejection reasons' => 'No English GCSE provided.',
+          'Second choices rejection reasons' => 'No maths GCSE provided.',
+          'Third choices rejection reasons' => 'No degree provided.',
         },
       )
     end


### PR DESCRIPTION
## Context

Reasons for rejections need to be added to the E&D export for analysis.

This PR adds three columns, 1 for application choices rejection reasons.

 
## Changes proposed in this pull request

- Add three rejection reasons columns to the E&D export

## Guidance to review

Milan and Mike have said they're happy with 3 columns, 1 for each application choice, rather than 6 (3 for rejection reasons and 3 for structured rejection reasons).

I'm going to create a follow-up card to create a model/service that deals with mapping structured rejection reasons into an object as quite a bit of this logic is duped from the ApplicationChoiceExport

## Link to Trello card

https://trello.com/c/x4zV9AZS/2977-add-structured-and-unstructured-r4r-to-the-ed-data-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
