### PR TITLE
change course details to course applied for. clears up confusion in c…

### DIFF
--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="course-details">Course details</h2>
+<h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8" id="course-details">Course applied for</h2>
 <%= render SummaryListComponent.new(rows: [
   { key: 'Provider', value: provider_name_and_code },
   { key: 'Accredited body', value: accredited_body },


### PR DESCRIPTION
…ase that a different course is offered than applied for

## Context

Course Details as a title is incorrect in the instance where to course offered is different to the course applied for. Changing the name to course applied for clears up this confusion.

## Changes proposed in this pull request

Change the title of a subheading from Course Details to Course applied for 
## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/CTnjuGnm/3244-manage-shows-the-course-the-candidate-applied-to-rather-than-the-course-offered-by-the-provider

## Things to check

- [X ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
