### PR TITLE
Update E&D export to include rejection reasons

### DIFF
--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -1,7 +1,8 @@
 module SupportInterface
   class EqualityAndDiversityExport
     def data_for_export
-      data_for_export = application_forms.map do |application_form|
+      data_for_export = application_forms.includes(:application_choices).map do |application_form|
+        rejected_application_choices = application_form.application_choices.rejected
         output = {
           'Month' => application_form.submitted_at&.strftime('%B'),
           'Recruitment cycle year' => application_form.recruitment_cycle_year,
@@ -9,6 +10,12 @@ module SupportInterface
           'Ethnic group' => application_form.equality_and_diversity['ethnic_group'],
           'Ethnic background' => application_form.equality_and_diversity['ethnic_background'],
           'Application status' => I18n.t!("candidate_flow_application_states.#{ProcessState.new(application_form).state}.name"),
+          'First rejection reason' => rejected_application_choices[0]&.rejection_reason,
+          'Second rejection reason' => rejected_application_choices[1]&.rejection_reason,
+          'Third rejection reason' => rejected_application_choices[2]&.rejection_reason,
+          'First structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[0]&.structured_rejection_reasons),
+          'Second structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[1]&.structured_rejection_reasons),
+          'Third structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[2]&.structured_rejection_reasons),
         }
 
         disabilities = application_form.equality_and_diversity['disabilities']
@@ -31,6 +38,25 @@ module SupportInterface
       ApplicationForm
         .includes(:application_choices)
         .where.not(equality_and_diversity: nil)
+    end
+
+    def format_structured_rejection_reasons(structured_rejection_reasons)
+      return nil if structured_rejection_reasons.blank?
+
+      select_high_level_rejection_reasons(structured_rejection_reasons)
+      .keys
+      .map { |reason| format_reason(reason) }
+      .join("\n")
+    end
+
+    def select_high_level_rejection_reasons(structured_rejection_reasons)
+      structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
+    end
+
+    def format_reason(reason)
+      reason
+      .delete_suffix('_y_n')
+      .humanize
     end
   end
 end

--- a/spec/services/support_interface/equality_and_diversity_export_spec.rb
+++ b/spec/services/support_interface/equality_and_diversity_export_spec.rb
@@ -14,30 +14,81 @@ RSpec.describe SupportInterface::EqualityAndDiversityExport do
         disabilities: %w[unexplained amnesia],
       }
 
+      three_disabilities = {
+        sex: 'female',
+        ethnic_background: 'Kiwi',
+        ethnic_group: 'Cantabrian',
+        disabilities: %w[unexplained amnesia blind],
+      }
+
       application_form_one = create(:completed_application_form, equality_and_diversity: two_disabilities)
       application_form_two = create(:completed_application_form, equality_and_diversity: one_disability)
+      application_form_three = create(:completed_application_form, equality_and_diversity: three_disabilities)
+
       create(:completed_application_form, equality_and_diversity: nil)
-      create(:application_choice, :awaiting_provider_decision, application_form: application_form_two)
+      create(
+        :application_choice,
+        :with_structured_rejection_reasons,
+        structured_rejection_reasons: {
+          course_full_y_n: 'No',
+          candidate_behaviour_y_n: 'Yes',
+          candidate_behaviour_other: 'Persistent scratching',
+          honesty_and_professionalism_y_n: 'Yes',
+          honesty_and_professionalism_concerns: %w[references],
+        },
+        application_form: application_form_two,
+      )
+
+      create(:application_choice, :with_rejection, rejection_reason: 'Abscence of English GCSE.', application_form: application_form_three)
 
       expect(described_class.new.data_for_export).to contain_exactly(
+        {
+          'Month' => application_form_three.submitted_at&.strftime('%B'),
+          'Recruitment cycle year' => application_form_three.recruitment_cycle_year,
+          'Sex' => application_form_three.equality_and_diversity['sex'],
+          'Ethnic group' => application_form_three.equality_and_diversity['ethnic_group'],
+          'Ethnic background' => application_form_three.equality_and_diversity['ethnic_background'],
+          'Application status' => 'Ended without success',
+          'First rejection reason' => 'Abscence of English GCSE.',
+          'Second rejection reason' => nil,
+          'Third rejection reason' => nil,
+          'First structured rejection reasons' => nil,
+          'Second structured rejection reasons' => nil,
+          'Third structured rejection reasons' => nil,
+          'Disability 1' => application_form_three.equality_and_diversity['disabilities'].first,
+          'Disability 2' => application_form_three.equality_and_diversity['disabilities'].second,
+          'Disability 3' => application_form_three.equality_and_diversity['disabilities'].last,
+        },
         {
           'Month' => application_form_one.submitted_at&.strftime('%B'),
           'Recruitment cycle year' => application_form_one.recruitment_cycle_year,
           'Sex' => application_form_one.equality_and_diversity['sex'],
-          'Ethnic background' => application_form_one.equality_and_diversity['ethnic_background'],
           'Ethnic group' => application_form_one.equality_and_diversity['ethnic_group'],
+          'Ethnic background' => application_form_one.equality_and_diversity['ethnic_background'],
+          'Application status' => 'Have not started form',
+          'First rejection reason' => nil,
+          'Second rejection reason' => nil,
+          'Third rejection reason' => nil,
+          'First structured rejection reasons' => nil,
+          'Second structured rejection reasons' => nil,
+          'Third structured rejection reasons' => nil,
           'Disability 1' => application_form_one.equality_and_diversity['disabilities'].first,
           'Disability 2' => application_form_one.equality_and_diversity['disabilities'].last,
-          'Application status' => 'Have not started form',
         },
         {
           'Month' => application_form_two.submitted_at&.strftime('%B'),
           'Recruitment cycle year' => application_form_two.recruitment_cycle_year,
           'Sex' => application_form_two.equality_and_diversity['sex'],
-          'Ethnic background' => application_form_two.equality_and_diversity['ethnic_background'],
           'Ethnic group' => application_form_two.equality_and_diversity['ethnic_group'],
+          'Ethnic background' => application_form_two.equality_and_diversity['ethnic_background'],
+          'Application status' => 'Ended without success',
+          'First rejection reason' => nil,
+          'Second rejection reason' => nil,
+          'Third rejection reason' => nil,
+          'First structured rejection reasons' => "Candidate behaviour\nHonesty and professionalism",
+          'Second structured rejection reasons' => nil,
+          'Third structured rejection reasons' => nil,
           'Disability 1' => application_form_two.equality_and_diversity['disabilities'].first,
-          'Application status' => 'Awaiting decisions from providers',
         },
       )
     end


### PR DESCRIPTION
## Context

Reasons for rejections need to be added to the E&D export for analysis.

This PR adds six columns for application choices rejection reasons. 3 for rejection reasons and 3 for structured rejection reasons.

## Changes proposed in this pull request

- Add three rejection reasons columns to the E&D export

## Guidance to review

I'm going to create a follow-up card to create a model/service that deals with mapping structured rejection reasons into an object as quite a bit of this logic is duped from the ApplicationChoiceExport

## Link to Trello card

https://trello.com/c/x4zV9AZS/2977-add-structured-and-unstructured-r4r-to-the-ed-data-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
