### PR TITLE
Fix vulnerability in fallback support authentication

### DIFF
--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -41,6 +41,8 @@ module SupportInterface
 
       support_user = SupportInterface::MagicLinkAuthentication.get_user_from_token!(token: params.fetch(:token))
 
+      render_404 and return unless support_user
+
       # Equivalent to calling DfESignInUser.begin_session!
       session['dfe_sign_in_user'] = {
         'email_address' => support_user.email_address,

--- a/app/services/support_interface/magic_link_authentication.rb
+++ b/app/services/support_interface/magic_link_authentication.rb
@@ -8,10 +8,12 @@ module SupportInterface
     end
 
     def self.get_user_from_token!(token:)
-      hashed_token = MagicLinkToken.from_raw(token)
-      AuthenticationToken.where('created_at > ?', TOKEN_DURATION.ago)
-        .find_by!(hashed_token: hashed_token)
-        .user
+      authentication_token = AuthenticationToken.find_by_hashed_token(
+        user_type: 'SupportUser',
+        raw_token: token,
+      )
+
+      authentication_token && authentication_token.still_valid? && authentication_token.user
     end
   end
 end

--- a/spec/services/support_interface/magic_link_authentication_spec.rb
+++ b/spec/services/support_interface/magic_link_authentication_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SupportInterface::MagicLinkAuthentication do
     end
 
     context 'when the token has expired' do
-      it 'raises an ActiveRecord::RecordNotFound error' do
+      it 'returns a falsey value' do
         user = create(:support_user)
         create(:authentication_token,
                user: user,
@@ -37,9 +37,7 @@ RSpec.describe SupportInterface::MagicLinkAuthentication do
 
         allow(MagicLinkToken).to receive(:from_raw).and_return('known_token')
 
-        expect {
-          SupportInterface::MagicLinkAuthentication.get_user_from_token!(token: 'known_token')
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(SupportInterface::MagicLinkAuthentication.get_user_from_token!(token: 'known_token')).to be(false)
       end
     end
   end

--- a/spec/system/support_interface/authentication_fallback_spec.rb
+++ b/spec/system/support_interface/authentication_fallback_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe 'A support authenticates via the fallback mechanism' do
     when_i_sign_out
     then_i_am_not_signed_in
 
+    when_i_click_an_incorrect_sign_in_link
+    then_i_see_a_404
+
     given_the_feature_flag_is_switched_off
     when_i_click_on_the_link_in_my_email
     then_i_am_not_signed_in
@@ -68,5 +71,13 @@ RSpec.describe 'A support authenticates via the fallback mechanism' do
     within 'header' do
       expect(page).not_to have_content @email
     end
+  end
+
+  def when_i_click_an_incorrect_sign_in_link
+    visit support_interface_authenticate_with_token_path(token: 'NOT_A_REAL_TOKEN')
+  end
+
+  def then_i_see_a_404
+    expect(page).to have_content 'Page not found'
   end
 end


### PR DESCRIPTION
## Context

Recently we've started using the `AuthenticationToken` that's used in support for for candidate authentication.

The method to look up the token doesn't scope the lookup to support users. This means that an attacker could request a sign in link on the candidate interface, and craft a URL to use the token in the link to gain access to the support console.

## Changes proposed in this pull request

Properly scope the lookup.

## Guidance to review

Any new issues?

## Link to Trello card

https://trello.com/c/VohxOZiV/309-high-magic-link-token-has-a-lot-of-duplication

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
