### PR TITLE
Re-hydrate job form check boxes when editing job

### DIFF
--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -44,11 +44,11 @@ module CandidateInterface
           start_date_day: job.start_date&.day,
           start_date_month: job.start_date&.month,
           start_date_year: job.start_date&.year,
-          start_date_unknown: job.start_date_unknown.to_s,
+          start_date_unknown: job.start_date_unknown,
           end_date_day: job.end_date&.day || '',
           end_date_month: job.end_date&.month || '',
           end_date_year: job.end_date&.year || '',
-          end_date_unknown: job.end_date_unknown.to_s,
+          end_date_unknown: job.end_date_unknown,
           currently_working: job.currently_working.to_s,
           relevant_skills: job.relevant_skills.to_s,
         )

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -179,6 +179,8 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
   describe '.build_form' do
     it 'creates an object based on the provided experience' do
+      form_data[:start_date_unknown] = data[:start_date_unknown]
+      form_data[:end_date_unknown] = data[:end_date_unknown]
       application_work_experience = ApplicationWorkExperience.new(data)
       job_form = CandidateInterface::RestructuredWorkHistory::JobForm.build_form(application_work_experience)
 


### PR DESCRIPTION

## Context

If a user selects that they do not know when a job starts or end, saves, then edits, the check box values are not being populated in the form.

## Changes proposed in this pull request

- 'start_date_unknown' and 'end_date_unknown' were incorrectly converted to strings. They should be booleans.

## Guidance to review

- When editing a job, check boxes should now be populated with previously saved values.

## Link to Trello card

https://trello.com/c/sffK0zKF/2980-restructured-work-history-re-hydrate-checkbox-values-when-editing-job

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
