### PR TITLE
Automatically set up provider relationships on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "apply-for-teacher-training",
   "scripts": {
-    "postdeploy": "bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
+    "postdeploy": "bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data setup_all_provider_relationships"
   },
   "env": {
     "AUTHORISED_HOSTS": {

--- a/app/models/provider_relationship_permissions.rb
+++ b/app/models/provider_relationship_permissions.rb
@@ -7,6 +7,12 @@ class ProviderRelationshipPermissions < ApplicationRecord
   validate :at_least_one_active_permission_in_pair, if: -> { setup_at.present? }
   audited associated_with: :training_provider
 
+  def self.possible_permissions
+    PERMISSIONS.flat_map do |permission|
+      ["ratifying_provider_can_#{permission}", "training_provider_can_#{permission}"]
+    end
+  end
+
   def training_provider_can_view_applications_only?
     PERMISSIONS.map { |permission| send("training_provider_can_#{permission}") }.all?(false)
   end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -77,3 +77,12 @@ task copy_feature_flags_from_production: :environment do
     end
   end
 end
+
+desc 'Set up all ProviderPermissionRelationships to be open'
+task setup_all_provider_relationships: :environment do
+  possible_permissions = ProviderRelationshipPermissions.possible_permissions
+  permissions_config = possible_permissions.index_with { true }
+  ProviderRelationshipPermissions.all.each do |p|
+    p.update(permissions_config.merge(setup_at: Time.zone.now))
+  end
+end


### PR DESCRIPTION
99% of the time we don't need to test this

## Context

Tired of clicking on checkboxes!

## Changes proposed in this pull request

Add a rake task to set permissions and run it whenever we deploy to Heroku
