### PR TITLE
Fix structured_grades data migration rake task

### DIFF
--- a/lib/tasks/backfill_constituent_grades.rake
+++ b/lib/tasks/backfill_constituent_grades.rake
@@ -3,10 +3,18 @@ task backfill_constituent_grades: :environment do
   structured_qualifications = ApplicationQualification.where(constituent_grades: nil).where.not(structured_grades: nil)
 
   structured_qualifications.each do |qualification|
-    grades = JSON.parse(qualification.structured_grades)
+    grades = get_structured_grades_hash(qualification)
 
-    constituent_grades = grades.transform_values { |grade| { grade: grade } }.to_json
+    constituent_grades = grades.transform_values { |grade| { grade: grade } }
 
     qualification.update(constituent_grades: constituent_grades)
+  end
+end
+
+def get_structured_grades_hash(qualification)
+  if qualification.structured_grades.is_a?(Hash)
+    qualification.structured_grades
+  else
+    JSON.parse(qualification.structured_grades)
   end
 end


### PR DESCRIPTION
## Changes proposed in this pull request
Update rake data migration to account for both hashes and JSON strings being stored in the structured_grades column

The constituent_grades will now be populated by hashes rather than JSON strings.

## Guidance to review
I think we should prefer hashes over JSON strings and more importantly be consistent, happy to hear counterpoints to that though!

## Link to Trello card
https://trello.com/c/54vJ4u9D/3288-gcses-in-api-response-have-duplicate-ids-causing-sits-to-discard-them

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
