### PR TITLE
Add interview emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -66,6 +66,20 @@ class CandidateMailer < ApplicationMailer
       subject: I18n.t!('candidate_mailer.interview_updated.subject', provider_name: @provider_name),
     )
   end
+
+  def interview_cancelled(application_choice, interview, reason)
+    @application_form = application_choice.application_form
+    @interview = interview
+    @provider_name = interview.provider.name
+    @course_name = application_choice.offered_option.course.name
+    @reason = reason
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.interview_cancelled.subject', provider_name: @provider_name),
+    )
+  end
+
   def application_rejected_all_applications_rejected(application_choice)
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -43,6 +43,18 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def new_interview(application_choice, interview)
+    @application_form = application_choice.application_form
+    @interview = interview
+    @provider_name = interview.provider.name
+    @course_name = application_choice.offered_option.course.name
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.new_interview.subject', provider_name: @provider_name),
+    )
+  end
+
   def application_rejected_all_applications_rejected(application_choice)
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -55,6 +55,17 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def interview_updated(application_choice, interview)
+    @application_form = application_choice.application_form
+    @interview = interview
+    @provider_name = interview.provider.name
+    @course_name = application_choice.offered_option.course.name
+
+    email_for_candidate(
+      @application_form,
+      subject: I18n.t!('candidate_mailer.interview_updated.subject', provider_name: @provider_name),
+    )
+  end
   def application_rejected_all_applications_rejected(application_choice)
     @course = application_choice.course_option.course
     @application_choice = RejectedApplicationChoicePresenter.new(application_choice)

--- a/app/services/cancel_interview.rb
+++ b/app/services/cancel_interview.rb
@@ -28,6 +28,8 @@ class CancelInterview
 
         ApplicationStateChange.new(application_choice).cancel_interview!
       end
+
+      CandidateMailer.interview_cancelled(application_choice, interview, cancellation_reason).deliver_later
     else
       raise "Interview cannot be cancelled when the application_choice is in #{application_choice.status} state"
     end

--- a/app/services/create_interview.rb
+++ b/app/services/create_interview.rb
@@ -26,12 +26,14 @@ class CreateInterview
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(application_choice).interview!
 
-      interview = Interview.new(application_choice: application_choice,
-                                provider: provider,
-                                date_and_time: date_and_time,
-                                location: location,
-                                additional_details: additional_details)
-      interview.save!
+      @interview = Interview.new(application_choice: application_choice,
+                                 provider: provider,
+                                 date_and_time: date_and_time,
+                                 location: location,
+                                 additional_details: additional_details)
+      @interview.save!
     end
+
+    CandidateMailer.new_interview(application_choice, @interview).deliver_later
   end
 end

--- a/app/services/update_interview.rb
+++ b/app/services/update_interview.rb
@@ -29,5 +29,7 @@ class UpdateInterview
       location: location,
       additional_details: additional_details,
     )
+
+    CandidateMailer.interview_updated(interview.application_choice, interview).deliver_later
   end
 end

--- a/app/views/candidate_mailer/interview_cancelled.text.erb
+++ b/app/views/candidate_mailer/interview_cancelled.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @application_form.first_name %>,
+
+# Interview cancelled
+
+<%= @provider_name %> has cancelled the interview on <%= @interview.date_and_time.to_s(:govuk_date_and_time) %> about your application to study <%= @course_name %>.
+
+They’ve given the following reason for cancelling the interview:
+
+^ <%= @reason %>
+
+Contact <%= @provider_name %> if you have any questions.
+
+<%= render 'get_support' %>

--- a/app/views/candidate_mailer/interview_updated.text.erb
+++ b/app/views/candidate_mailer/interview_updated.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @application_form.first_name %>,
+
+# Interview details updated
+
+<%= @provider_name %> has updated the details of the interview about your application to study <%= @course_name %>.
+
+The new details are as follows:
+
+^ <%= @interview.date_and_time.to_s(:govuk_date_and_time) %>
+
+^ <%= @interview.location %>
+
+^ <%= @interview.additional_details %>
+
+Contact <%= @provider_name %> if you have any questions or you will not be able to attend the interview.
+
+<%= render 'get_support' %>

--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @application_form.first_name %>,
+
+# Interview arranged
+
+You have an interview with <%= @provider_name %> about your application to study <%= @course_name %>.
+
+The details are as follows:
+
+^ <%= @interview.date_and_time.to_s(:govuk_date_and_time) %>
+
+^ <%= @interview.location %>
+
+^ <%= @interview.additional_details %>
+
+Contact <%= @provider_name %> if you have any questions or you will not be able to attend the interview.
+
+<%= render 'get_support' %>

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -103,3 +103,5 @@ en:
       subject: Interview arranged - %{provider_name}
     interview_updated:
       subject: Interview details updated - %{provider_name}
+    interview_cancelled:
+      subject: Interview cancelled - %{provider_name}

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -99,3 +99,5 @@ en:
         subject: Duplicate application automatically withdrawn
       resolved:
         subject: Duplicate application withdrawn
+    new_interview:
+      subject: Interview arranged - %{provider_name}

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -101,3 +101,5 @@ en:
         subject: Duplicate application withdrawn
     new_interview:
       subject: Interview arranged - %{provider_name}
+    interview_updated:
+      subject: Interview details updated - %{provider_name}

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -756,17 +756,14 @@ FactoryBot.define do
 
   factory :interview do
     application_choice
-    provider
 
     date_and_time { 7.business_days.from_now }
     location { [Faker::Address.full_address, 'Link to video conference'].sample }
     additional_details { [nil, 'Use staff entrance', 'Ask for John at the reception'].sample }
 
     after(:build) do |interview|
-      if interview.application_choice.present?
-        interview.application_choice.status = 'interviewing'
-        interview.provider = interview.application_choice.offered_course.provider
-      end
+      interview.application_choice.status = 'interviewing'
+      interview.provider ||= interview.application_choice.offered_course.provider
     end
 
     trait :future_date_and_time do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -242,4 +242,37 @@ RSpec.describe CandidateMailer, type: :mailer do
       'course start' => 'September 2021',
     )
   end
+
+  context 'Interview emails' do
+    let(:provider)  { create(:provider, name: 'Hogwards') }
+    let(:interview) do
+      create(:interview,
+             date_and_time: Time.zone.local(2021, 1, 15, 9, 30),
+             location: 'Hogwarts Castle',
+             additional_details: 'Bring your magic wand for the spells test',
+             provider: provider)
+    end
+    let(:application_choice_with_interview) { interview.application_choice }
+
+    before do
+      build_stubbed(:application_form,
+                    first_name: 'Fred',
+                    candidate: candidate,
+                    application_choices: [application_choice_with_interview])
+    end
+
+    describe '.new_interview' do
+      let(:email) { mailer.new_interview(application_choice_with_interview, interview) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Interview arranged - Hogwards',
+        'greeting' => 'Dear Fred,',
+        'details' => 'You have an interview with Hogwards',
+        'interview date and time' => '15 January 2021 at 9:30am',
+        'interview location' => 'Hogwarts Castle',
+        'additional interview details' => 'Bring your magic wand for the spells test',
+      )
+    end
+  end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -288,5 +288,17 @@ RSpec.describe CandidateMailer, type: :mailer do
         'additional interview details' => 'Bring your magic wand for the spells test',
       )
     end
+
+    describe '.interview_cancelled' do
+      let(:email) { mailer.interview_cancelled(application_choice_with_interview, interview, 'We recruited someone else') }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Interview cancelled - Hogwards',
+        'greeting' => 'Dear Fred,',
+        'details' => 'Hogwards has cancelled the interview on 15 January 2021 at 9:30am',
+        'cancellation reason' => 'We recruited someone else',
+      )
+    end
   end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -274,5 +274,19 @@ RSpec.describe CandidateMailer, type: :mailer do
         'additional interview details' => 'Bring your magic wand for the spells test',
       )
     end
+
+    describe '.interview_updated' do
+      let(:email) { mailer.interview_updated(application_choice_with_interview, interview) }
+
+      it_behaves_like(
+        'a mail with subject and content',
+        'Interview details updated - Hogwards',
+        'greeting' => 'Dear Fred,',
+        'details' => 'Hogwards has updated the details of the interview',
+        'interview date and time' => '15 January 2021 at 9:30am',
+        'interview location' => 'Hogwarts Castle',
+        'additional interview details' => 'Bring your magic wand for the spells test',
+      )
+    end
   end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -65,6 +65,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.interview_updated(application_choice, interview)
   end
 
+  def interview_cancelled
+    application_choice = FactoryBot.build(:application_choice, :with_scheduled_interview)
+    interview = application_choice.interviews.first
+    CandidateMailer.interview_cancelled(application_choice, interview, 'You contacted us to say you didn’t want to apply for this course any more.')
+  end
+
   def chase_candidate_decision_with_one_offer
     application_form = application_form_with_course_choices([application_choice_with_offer])
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -59,6 +59,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.new_interview(application_choice, interview)
   end
 
+  def interview_updated
+    application_choice = FactoryBot.build(:application_choice, :with_scheduled_interview)
+    interview = application_choice.interviews.first
+    CandidateMailer.interview_updated(application_choice, interview)
+  end
+
   def chase_candidate_decision_with_one_offer
     application_form = application_form_with_course_choices([application_choice_with_offer])
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -53,6 +53,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.new_referee_request(reference, reason: :email_bounced)
   end
 
+  def new_interview
+    application_choice = FactoryBot.build(:application_choice, :with_scheduled_interview)
+    interview = application_choice.interviews.first
+    CandidateMailer.new_interview(application_choice, interview)
+  end
+
   def chase_candidate_decision_with_one_offer
     application_form = application_form_with_course_choices([application_choice_with_offer])
 

--- a/spec/services/cancel_interview_spec.rb
+++ b/spec/services/cancel_interview_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CancelInterview do
       end
     end
 
-    it 'creates an audit entry', with_audited: true do
+    it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
       CancelInterview.new(service_params).save!
 
       associated_audit = application_choice.associated_audits.last
@@ -44,6 +44,8 @@ RSpec.describe CancelInterview do
         cancelled_at cancellation_reason
       ])
       expect(associated_audit.audited_changes['cancellation_reason']).to eq([nil, 'There is a global pandemic going on'])
+
+      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_cancelled')
     end
   end
 end

--- a/spec/services/create_interview_spec.rb
+++ b/spec/services/create_interview_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CreateInterview do
       expect { service.save! }.to change { application_choice.status }.to('interviewing')
     end
 
-    it 'creates an audit entry', with_audited: true do
+    it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
       CreateInterview.new(service_params).save!
 
       associated_audit = application_choice.associated_audits.first
@@ -40,6 +40,8 @@ RSpec.describe CreateInterview do
         'cancelled_at',
       )
       expect(associated_audit.audited_changes['location']).to eq('Zoom call')
+
+      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('new_interview')
     end
   end
 end

--- a/spec/services/update_interview_spec.rb
+++ b/spec/services/update_interview_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe UpdateInterview do
       expect(interview.additional_details).to eq('Business casual')
     end
 
-    it 'creates an audit entry', with_audited: true do
+    it 'creates an audit entry and sends an email', with_audited: true, sidekiq: true do
       UpdateInterview.new(service_params).save!
 
       associated_audit = application_choice.associated_audits.last
@@ -45,6 +45,8 @@ RSpec.describe UpdateInterview do
 
       expect(associated_audit.audited_changes['location'].last).to eq('Zoom call')
       expect(associated_audit.audited_changes['additional_details'].last).to eq('Business casual')
+
+      expect(ActionMailer::Base.deliveries.first['rails-mail-template'].value).to eq('interview_updated')
     end
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature 'Docs' do
       provider_mailer-courses_open_on_apply
       candidate_mailer-new_interview
       candidate_mailer-interview_updated
+      candidate_mailer-interview_cancelled
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -43,6 +43,7 @@ RSpec.feature 'Docs' do
       provider_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-courses_open_on_apply
       candidate_mailer-new_interview
+      candidate_mailer-interview_updated
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-courses_open_on_apply
+      candidate_mailer-new_interview
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

Add candidate email templates for new, edited and cancelled interviews and amend the relevant services to trigger emails

https://bat-design-history.netlify.app/manage-teacher-training-applications/interviews-iteration-3

## Changes proposed in this pull request

Add all templates and emails. 
Sending emails when an interview is updated will need to be implemented once the service is added.

## Guidance to review

<kbd><img width="386" alt="Screenshot 2021-02-03 at 16 16 51" src="https://user-images.githubusercontent.com/38078064/106775732-487a2480-663b-11eb-9312-7b41d07bb00b.png"></kbd>

<kbd><img width="394" alt="Screenshot 2021-02-03 at 16 16 59" src="https://user-images.githubusercontent.com/38078064/106775763-4e700580-663b-11eb-8658-62c58162e8d6.png"></kbd>

<kbd><img width="397" alt="Screenshot 2021-02-03 at 16 17 05" src="https://user-images.githubusercontent.com/38078064/106775775-52038c80-663b-11eb-8347-e025ac0624b4.png"></kbd>


## Link to Trello card

https://trello.com/c/hEhNASC5/3242-interview-emails

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
