### PR TITLE
Enable GCSE year editing via support

### DIFF
--- a/app/components/gcse_qualification_cards_component.html.erb
+++ b/app/components/gcse_qualification_cards_component.html.erb
@@ -50,6 +50,10 @@
                 <% end %>
               </dl>
             <% end %>
+            <% if in_support_console? %>
+              <br>
+              <%= govuk_link_to 'Change', support_interface_application_form_edit_gcse_path(gcse_id: qualification.id) %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/components/gcse_qualification_cards_component.rb
+++ b/app/components/gcse_qualification_cards_component.rb
@@ -1,5 +1,8 @@
 # NOTE: This component is used by both provider and support UIs
 class GcseQualificationCardsComponent < ViewComponent::Base
+  include ApplicationHelper
+  include ViewHelper
+
   attr_reader :application_form
 
   def initialize(application_form)
@@ -88,5 +91,9 @@ class GcseQualificationCardsComponent < ViewComponent::Base
         "#{v} (#{k.humanize.titleize})"
       end
     end
+  end
+
+  def in_support_console?
+    current_namespace == 'support_interface'
   end
 end

--- a/app/controllers/support_interface/application_forms/gcses_controller.rb
+++ b/app/controllers/support_interface/application_forms/gcses_controller.rb
@@ -1,0 +1,34 @@
+module SupportInterface
+  module ApplicationForms
+    class GcsesController < SupportInterfaceController
+      def edit
+        @gcse_form = EditGcseForm.new(
+          ApplicationQualification.find(params[:gcse_id]),
+        )
+      end
+
+      def update
+        @gcse_form = EditGcseForm.new(
+          ApplicationQualification.find(params[:gcse_id]),
+        )
+
+        @gcse_form.assign_attributes(edit_application_params)
+        if @gcse_form.valid?
+          @gcse_form.save!
+          flash[:success] = 'GCSE updated'
+          redirect_to support_interface_application_form_path(@gcse_form.application_form)
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def edit_application_params
+        params.require(
+          :support_interface_application_forms_edit_gcse_form,
+        ).permit(:award_year, :audit_comment)
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_gcse_form.rb
+++ b/app/forms/support_interface/application_forms/edit_gcse_form.rb
@@ -1,0 +1,33 @@
+module SupportInterface
+  module ApplicationForms
+    class EditGcseForm
+      include ActiveModel::Model
+
+      attr_reader :gcse
+      attr_accessor :award_year
+      attr_accessor :audit_comment
+
+      validates :award_year, presence: true
+      validates :audit_comment, presence: true
+
+      delegate :application_form, :subject, to: :gcse
+
+      def initialize(gcse)
+        @gcse = gcse
+
+        super(
+          award_year: @gcse.award_year,
+        )
+      end
+
+      def save!
+        @gcse.update!(
+          award_year: award_year,
+          audit_comment: audit_comment,
+        )
+
+        @gcse.save!
+      end
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/gcses/edit.html.erb
+++ b/app/views/support_interface/application_forms/gcses/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :browser_title, title_with_error_prefix('Edit GCSE', @gcse_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@gcse_form.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @gcse_form, url: support_interface_application_form_update_gcse_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_fieldset legend: { text: "Edit #{@gcse_form.subject.capitalize} GCSE details", size: 'l' } do %>
+        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' } %>
+      <% end %>
+
+        <%= f.govuk_text_field :audit_comment, label: {text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm'}, hint: {text: t('support_interface.edit_address_details_form.audit_comment.hint')} %>
+
+      <%= f.govuk_submit 'Update details' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -100,6 +100,12 @@ en:
               too_long: Relationship must be %{count} characters or fewer
             audit_comment:
               blank: You must provide an audit comment
+        support_interface/application_forms/edit_gcse_form:
+          attributes:
+            award_year:
+              blank: Award year cannot be blank
+            audit_comment:
+              blank: You must provide an audit comment
         support_interface/application_forms/edit_reference_feedback_form:
           attributes:
             feedback:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -757,6 +757,9 @@ Rails.application.routes.draw do
       get '/applicant-details' => 'application_forms/applicant_details#edit', as: :application_form_edit_applicant_details
       post '/applicant-details' => 'application_forms/applicant_details#update', as: :application_form_update_applicant_details
 
+      get '/gcses/:gcse_id' => 'application_forms/gcses#edit', as: :application_form_edit_gcse
+      post '/gcses/:gcse_id' => 'application_forms/gcses#update', as: :application_form_update_gcse
+
       get '/references/:reference_id/details' => 'application_forms/references#edit_reference_details', as: :application_form_edit_reference_details
       post '/references/:reference_id/details' => 'application_forms/references#update_reference_details', as: :application_form_update_reference_details
 

--- a/spec/system/support_interface/editing_gcse_spec.rb
+++ b/spec/system/support_interface/editing_gcse_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing GCSE' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits GCSE', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_the_first_gcse
+    then_i_should_see_a_prepopulated_form
+
+    when_i_update_the_form
+    and_i_submit_the_form
+    then_i_should_see_a_flash_message
+    and_i_should_see_the_new_details
+    and_i_should_see_my_details_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form)
+    create(:gcse_qualification, subject: 'maths', award_year: '1999', application_form: @form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_next_to_the_first_gcse
+    within('[data-qa="gcse-qualification"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_form
+    expect(page).to have_content('Edit Maths GCSE')
+    expect(page).to have_selector("input[value='1999']")
+  end
+
+  def when_i_update_the_form
+    fill_in 'Award year', with: '2001'
+    fill_in 'Audit log comment', with: 'Got to change it'
+  end
+
+  def and_i_submit_the_form
+    click_button 'Update'
+  end
+
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'GCSE updated'
+  end
+
+  def and_i_should_see_the_new_details
+    within('.app-qualification') do
+      expect(page).to have_content '2001'
+    end
+  end
+
+  def and_i_should_see_my_details_comment_in_the_audit_log
+    click_link 'History'
+    expect(page).to have_content 'Got to change it'
+  end
+end


### PR DESCRIPTION
## Context

A few support requests have come in for this recently

## Changes proposed in this pull request

Create an edit-GCSE form in support and link from the view.

Slightly icky `if` in the component but I don't think it's _too_ bad? In future could maybe improve by passing down a flag through the QualificationsComponent into the GcseQualificationCardsComponent to put it in `support mode` or sth. Or split and duplicate the components.

<img width="729" alt="Screenshot 2021-02-03 at 20 00 50" src="https://user-images.githubusercontent.com/642279/106802218-8cc8ed00-665a-11eb-9953-bacccf094846.png">
<img width="1012" alt="Screenshot 2021-02-03 at 20 00 29" src="https://user-images.githubusercontent.com/642279/106802223-8e92b080-665a-11eb-95bf-6fd67c8b22fa.png">

## Link to Trello card

Support tickets

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
