### PR TITLE
Enable Degree year editing via support

### DIFF
--- a/app/components/degree_qualification_cards_component.html.erb
+++ b/app/components/degree_qualification_cards_component.html.erb
@@ -38,6 +38,10 @@
                   </dd>
                 <% end %>
               <% end %>
+              <% if in_support_console? %>
+                <br>
+                <%= govuk_link_to 'Change', support_interface_application_form_edit_degree_path(degree_id: degree.id) %>
+              <% end %>
             </dl>
           </div>
         </div>

--- a/app/components/degree_qualification_cards_component.rb
+++ b/app/components/degree_qualification_cards_component.rb
@@ -1,5 +1,8 @@
 # NOTE: This component is used by both provider and support UIs
 class DegreeQualificationCardsComponent < ViewComponent::Base
+  include ApplicationHelper
+  include ViewHelper
+
   attr_reader :degrees, :application_choice_state, :show_hesa_codes
 
   alias_method :show_hesa_codes?, :show_hesa_codes
@@ -74,5 +77,9 @@ private
 
   def institution(degree)
     degree.institution_name
+  end
+
+  def in_support_console?
+    current_namespace == 'support_interface'
   end
 end

--- a/app/controllers/support_interface/application_forms/degrees_controller.rb
+++ b/app/controllers/support_interface/application_forms/degrees_controller.rb
@@ -1,0 +1,34 @@
+module SupportInterface
+  module ApplicationForms
+    class DegreesController < SupportInterfaceController
+      def edit
+        @degree_form = EditDegreeForm.new(
+          ApplicationQualification.find(params[:degree_id]),
+        )
+      end
+
+      def update
+        @degree_form = EditDegreeForm.new(
+          ApplicationQualification.find(params[:degree_id]),
+        )
+
+        @degree_form.assign_attributes(edit_application_params)
+        if @degree_form.valid?
+          @degree_form.save!
+          flash[:success] = 'Degree updated'
+          redirect_to support_interface_application_form_path(@degree_form.application_form)
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def edit_application_params
+        params.require(
+          :support_interface_application_forms_edit_degree_form,
+        ).permit(:start_year, :award_year, :audit_comment)
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_degree_form.rb
+++ b/app/forms/support_interface/application_forms/edit_degree_form.rb
@@ -1,0 +1,35 @@
+module SupportInterface
+  module ApplicationForms
+    class EditDegreeForm
+      include ActiveModel::Model
+
+      attr_reader :degree
+      attr_accessor :award_year
+      attr_accessor :start_year
+      attr_accessor :audit_comment
+
+      validates :start_year, presence: true
+      validates :award_year, presence: true
+      validates :audit_comment, presence: true
+
+      delegate :application_form, :subject, to: :degree
+
+      def initialize(degree)
+        @degree = degree
+
+        super(
+          award_year: @degree.award_year,
+          start_year: @degree.start_year,
+        )
+      end
+
+      def save!
+        @degree.update!(
+          start_year: start_year,
+          award_year: award_year,
+          audit_comment: audit_comment,
+        )
+      end
+    end
+  end
+end

--- a/app/forms/support_interface/application_forms/edit_gcse_form.rb
+++ b/app/forms/support_interface/application_forms/edit_gcse_form.rb
@@ -25,8 +25,6 @@ module SupportInterface
           award_year: award_year,
           audit_comment: audit_comment,
         )
-
-        @gcse.save!
       end
     end
   end

--- a/app/views/support_interface/application_forms/degrees/edit.html.erb
+++ b/app/views/support_interface/application_forms/degrees/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :browser_title, title_with_error_prefix('Edit GCSE', @degree_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@degree_form.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @degree_form, url: support_interface_application_form_update_degree_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_fieldset legend: { text: "Edit #{@degree_form.subject.capitalize} degree details", size: 'l' } do %>
+        <%= f.govuk_text_field :start_year, label: { text: 'Start year', size: 'm' } %>
+        <%= f.govuk_text_field :award_year, label: { text: 'Award year', size: 'm' } %>
+      <% end %>
+
+        <%= f.govuk_text_field :audit_comment, label: {text: t('support_interface.edit_address_details_form.audit_comment.label'), size: 'm'}, hint: {text: t('support_interface.edit_address_details_form.audit_comment.hint')} %>
+
+      <%= f.govuk_submit 'Update details' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/support_interface/support_interface.yml
+++ b/config/locales/support_interface/support_interface.yml
@@ -106,6 +106,14 @@ en:
               blank: Award year cannot be blank
             audit_comment:
               blank: You must provide an audit comment
+        support_interface/application_forms/edit_degree_form:
+          attributes:
+            award_year:
+              blank: Award year cannot be blank
+            start_year:
+              blank: Start year cannot be blank
+            audit_comment:
+              blank: You must provide an audit comment
         support_interface/application_forms/edit_reference_feedback_form:
           attributes:
             feedback:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -760,6 +760,9 @@ Rails.application.routes.draw do
       get '/gcses/:gcse_id' => 'application_forms/gcses#edit', as: :application_form_edit_gcse
       post '/gcses/:gcse_id' => 'application_forms/gcses#update', as: :application_form_update_gcse
 
+      get '/degrees/:degree_id' => 'application_forms/degrees#edit', as: :application_form_edit_degree
+      post '/degrees/:degree_id' => 'application_forms/degrees#update', as: :application_form_update_degree
+
       get '/references/:reference_id/details' => 'application_forms/references#edit_reference_details', as: :application_form_edit_reference_details
       post '/references/:reference_id/details' => 'application_forms/references#update_reference_details', as: :application_form_update_reference_details
 

--- a/spec/system/support_interface/editing_degree_spec.rb
+++ b/spec/system/support_interface/editing_degree_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing degree' do
+  include DfESignInHelpers
+
+  scenario 'Support user edits degree', with_audited: true do
+    given_i_am_a_support_user
+    and_an_application_exists
+
+    when_i_visit_the_application_page
+    and_i_click_the_change_link_next_to_the_first_degree
+    then_i_should_see_a_prepopulated_form
+
+    when_i_update_the_form
+    and_i_submit_the_form
+    then_i_should_see_a_flash_message
+    and_i_should_see_the_new_details
+    and_i_should_see_my_details_comment_in_the_audit_log
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_an_application_exists
+    @form = create(:completed_application_form)
+    create(:degree_qualification, subject: 'maths', start_year: '1995', award_year: '1999', application_form: @form)
+  end
+
+  def when_i_visit_the_application_page
+    visit support_interface_application_form_path(@form)
+  end
+
+  def and_i_click_the_change_link_next_to_the_first_degree
+    within('[data-qa="degree-qualification"]') do
+      click_link 'Change'
+    end
+  end
+
+  def then_i_should_see_a_prepopulated_form
+    expect(page).to have_content('Edit Maths degree')
+    expect(page).to have_selector("input[value='1999']")
+  end
+
+  def when_i_update_the_form
+    fill_in 'Award year', with: '2001'
+    fill_in 'Start year', with: '1996'
+    fill_in 'Audit log comment', with: 'Got to change it'
+  end
+
+  def and_i_submit_the_form
+    click_button 'Update'
+  end
+
+  def then_i_should_see_a_flash_message
+    expect(page).to have_content 'Degree updated'
+  end
+
+  def and_i_should_see_the_new_details
+    within('.app-qualification') do
+      expect(page).to have_content '1996'
+      expect(page).to have_content '2001'
+    end
+  end
+
+  def and_i_should_see_my_details_comment_in_the_audit_log
+    click_link 'History'
+    expect(page).to have_content 'Got to change it'
+  end
+end


### PR DESCRIPTION
## Context

Following #3985 

## Changes proposed in this pull request

<img width="786" alt="Screenshot 2021-02-03 at 20 22 33" src="https://user-images.githubusercontent.com/642279/106804651-94d65c00-665d-11eb-965d-f24770dae46d.png">
<img width="331" alt="Screenshot 2021-02-03 at 20 22 28" src="https://user-images.githubusercontent.com/642279/106804658-96a01f80-665d-11eb-99a2-eaa48ca8e4d2.png">

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
