### PR TITLE
Update SortApplicationChoices spec and remove TODOs

### DIFF
--- a/app/components/provider_interface/change_offer/change_location_component.rb
+++ b/app/components/provider_interface/change_offer/change_location_component.rb
@@ -20,7 +20,6 @@ module ProviderInterface
         CourseOption.where(
           course_id: change_offer_form.course_id,
           study_mode: change_offer_form.study_mode,
-          # TODO: check vacancy_status, e.g. 'B'
         ).includes(:site).order('sites.name')
       end
 

--- a/app/queries/get_all_change_options_from_offered_option.rb
+++ b/app/queries/get_all_change_options_from_offered_option.rb
@@ -16,13 +16,11 @@ class GetAllChangeOptionsFromOfferedOption
 
     @available_study_modes = CourseOption.where(
       course: application_choice.offered_course,
-      # TODO: check vacancy_status, e.g. 'B'
     ).pluck(:study_mode).uniq
 
     @available_course_options = CourseOption.where(
       course: application_choice.offered_course,
       study_mode: application_choice.offered_option.study_mode, # preserving study_mode
-      # TODO: check vacancy_status, e.g. 'B'
     ).includes(:site).order('sites.name')
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -548,7 +548,7 @@ FactoryBot.define do
 
       after(:build) do |choice, _evaluator|
         choice.status = :interviewing
-        choice.interviews = [create(:interview)]
+        choice.interviews = [create(:interview, application_choice: choice)]
       end
     end
 
@@ -586,7 +586,7 @@ FactoryBot.define do
 
     trait :with_rejection_by_default do
       status { 'rejected' }
-      rejected_at { Time.zone.now }
+      rejected_at { 2.minutes.ago }
       rejected_by_default { true }
     end
 

--- a/spec/services/provider_interface/sort_application_choices_spec.rb
+++ b/spec/services/provider_interface/sort_application_choices_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::SortApplicationChoices do
   around do |example|
-    Timecop.travel(2020, 1, 1) { example.run }
+    Timecop.travel(2021, 1, 1) { example.run }
   end
 
   describe 'decorates models with' do
@@ -111,24 +111,31 @@ RSpec.describe ProviderInterface::SortApplicationChoices do
 
   describe 'sorts application choices' do
     let(:application_choices) do
-      # TODO: groups 1, 3, 9 require the relevant EoC implementation first
       [
         # --- 999
         create(:application_choice, :offer, status: 'offer_withdrawn'),
-        # --- 8
+        # --- 10
+        create(:application_choice, :with_deferred_offer),
+        # --- 9
         create(:application_choice, :recruited),
-        # --- 7
+        # --- 8
         create(:application_choice, :pending_conditions),
-        # --- 6
+        # --- 7
         create(:application_choice, :offer),
-        # --- 5
+        # --- 6
         create(:application_choice, :pending_conditions, :previous_year),
+        # --- 5
+        create(:application_choice, :with_scheduled_interview),
         # --- 4
         create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 6.business_days.from_now),
         create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 6.business_days.from_now), # has more recent updated_at, will appear first
+        # --- 3
+        create(:application_choice, :with_rejection_by_default),
         # --- 2
         create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 5.business_days.from_now),
         create(:application_choice, :awaiting_provider_decision, reject_by_default_at: 5.business_days.from_now), # has more recent updated_at, will appear first
+        # --- 1
+        create(:application_choice, :with_deferred_offer, :previous_year),
       ]
     end
 


### PR DESCRIPTION
## Context

The spec for `SortApplicationChoices` needs updating and vacancy status will be tackled as part of re-working the `ChangeOffer` flow.

## Changes proposed in this pull request

Remove these TODOs and update the `SortApplicationChoices` spec.

## Guidance to review

Easy

## Link to Trello card

Dev Retro action

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
