### PR TITLE
Improve loading time of /support/providers and resolve timeout issues

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -5,7 +5,7 @@ module SupportInterface
 
       @providers = @filter.filter_records(
         Provider
-          .includes(:sites, :courses, :provider_agreements, :provider_users)
+          .includes(:courses, :provider_agreements, :provider_users)
           .order(:name)
           .page(params[:page] || 1).per(30),
       )


### PR DESCRIPTION
Resolves timeout issues identified in staging environment when entering the providers view with the default filters applied.

---

Including `sites` when retrieving providers causes a significant delay. Sites is not utilised neither as part of the conditions or displayed data so it should be okay to remove. 250ms down to 12.4ms on a small dataset.

In addition to this, I tested a couple of other scenarios but none had any visible impact.

e.g. adding an index on  the provider name and code  
>  add_index :providers, "((name || code))", using: 'btree', name: :provider_name_and_code_index

and updating the applied filter to utilise that

> providers = providers.where("(providers.name || providers.code) ILIKE ?", "%#{applied_filters[:q]}%")

Also removing the `provide_agreements` inclusion (as it's included when required as part of the filter), but neither has a significant/visible impact on the retrieval time.


If the issue still persists it might be worth generating more data on the local environment and retesting these.


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
