### PR TITLE
Deduplicate help text in candidate email footer

### DIFF
--- a/app/views/candidate_mailer/apply_again_call_to_action.text.erb
+++ b/app/views/candidate_mailer/apply_again_call_to_action.text.erb
@@ -14,10 +14,4 @@ Sign in to apply again:
 
 <%= candidate_magic_link(@application_form.candidate) %>
 
-# Get help
-
-Call Get Into Teaching for free on 0800 389 2500 or chat to an adviser online:
-
-https://beta-getintoteaching.education.gov.uk/#talk-to-us
-
-For any technical issues using Apply for teacher training, contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+<%= render 'get_help' %>


### PR DESCRIPTION
Noticed while [checking for duplication in GiT details](https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1612456633180200). We use a standard 'get_help' block elsewhere - use that here.

## Context

The wording is very slightly different:

used to be 

```
# Get help

Call Get Into Teaching for free on 0800 389 2500 or chat to an adviser online:

https://beta-getintoteaching.education.gov.uk/#talk-to-us

For any technical issues using Apply for teacher training, contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
```

Is now

```
# Get help

For advice on becoming a teacher, call Get Into Teaching for free on 0800 389 2500 or chat to an adviser online:

https://beta-getintoteaching.education.gov.uk/#talk-to-us

For any technical issues using Apply for teacher training, contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
```

We're using the new text everywhere else and no information is lost, so I don't think this is a controversial change.

