### PR TITLE
Add constants for GIT contact numbers and URLs

### DIFF
--- a/app/components/personal_statement_component.html.erb
+++ b/app/components/personal_statement_component.html.erb
@@ -9,7 +9,7 @@
     <h2 class="govuk-heading-m">Why do you want to be a teacher?</h2>
     <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
     <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
-    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <a href="https://beta-getintoteaching.education.gov.uk/" class="govuk-body">Get into Teaching</a> for help from a teacher training adviser.</p>
+    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url') %> for help from a teacher training adviser.</p>
     <p class="govuk-body govuk-!-font-weight-bold">Suggested topics to cover include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>why you want to be a teacher</li>

--- a/app/components/personal_statement_component.rb
+++ b/app/components/personal_statement_component.rb
@@ -1,5 +1,7 @@
 # NOTE: This component is used by both provider and support UIs
 class PersonalStatementComponent < ViewComponent::Base
+  include ViewHelper
+
   validates :application_form, presence: true
 
   delegate :becoming_a_teacher,

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -17,7 +17,7 @@
     </ul>
     <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <a href="https://www.gov.uk/access-to-work" class="govuk-link">Access to Work</a>. This could include a grant to help cover the costs of practical support in the workplace.</p>
     <h4 class="govuk-heading-s">It’s against the law to discriminate</h4>
-    <p class="govuk-body">If you’re disabled, <a href="https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability" class="govuk-link">it’s against the law to discriminate against you</a>. Training providers must not:</p>
+    <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', t('get_into_teaching.url_training_with_a_disability') %>. Training providers must not:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
       <li>reject your application because you’re disabled</li>

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -9,7 +9,7 @@
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
       <%= t('page_titles.apply_from_find') %>
     </h1>
-    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit Get Into Teaching for <a class="govuk-link" target="_blank" href="https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5">guidance on applying for teacher training</a>.</p>
+    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit <%= t('service_name.get_into_teaching') %> for <%= govuk_link_to 'guidance on applying for teacher training', t('get_into_teaching.url_applying'), target: '_blank' %>.</p>
 
     <p class="govuk-body">When you apply you’ll need these codes for the Choices section of your application form:</p>
 

--- a/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
@@ -19,7 +19,7 @@
     </ul>
 
     <p class="govuk-body govuk-!-margin-bottom-6">
-      For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5' %>
+      For more information, see our <%= govuk_link_to "#{t('service_name.get_into_teaching')} guidance on applying for teacher training", t('get_into_teaching.url_applying') %>
     </p>
 
     <p class="govuk-body govuk-!-margin-bottom-0">

--- a/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
@@ -20,7 +20,7 @@
 
     <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to "#{t('service_name.get_into_teaching')} guidance on applying for teacher training", t('get_into_teaching.url_applying') %></p>
 
-    <h2 class=govuk-heading-m>Make a note of your choice</h2>
+    <h2 class="govuk-heading-m">Make a note of your choice</h2>
     <p class="govuk-body">When you apply through UCAS, you’ll need these details for the course choices section of your application:</p>
 
     <div class="govuk-inset-text govuk-!-margin-top-0 govuk-body">

--- a/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
@@ -18,7 +18,7 @@
       <li>still submit your current application with other course choices</li>
     </ul>
 
-    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5' %></p>
+    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to "#{t('service_name.get_into_teaching')} guidance on applying for teacher training", t('get_into_teaching.url_applying') %></p>
 
     <h2 class=govuk-heading-m>Make a note of your choice</h2>
     <p class="govuk-body">When you apply through UCAS, you’ll need these details for the course choices section of your application:</p>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -22,7 +22,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>you can only accept one offer, across both Apply for teacher training and UCAS teacher training</li>
         <li>if you fail to respond, or you decline all your offers, you can still apply to other courses this year through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %></li>
-        <li>you can register with <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk' %> to get help from a teacher training advisor</li>
+        <li>you can register with <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url') %> to get help from a teacher training advisor</li>
       </ul>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -22,8 +22,9 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>you can only accept one offer, across both Apply for teacher training and UCAS teacher training</li>
         <li>if you fail to respond, or you decline all your offers, you can still apply to other courses this year through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %></li>
-        <li>you can register with <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url') %> to get help from a teacher training advisor</li>
       </ul>
+
+      <p class="govuk-body">If you need help, you can speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %> adviser. They’re all experienced teachers who can give you advice on applying for teacher training.</p>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { text: t('decisions.response.legend'), size: 'm' } do %>
         <%= f.govuk_radio_button :response, 'accept', label: { text: t('decisions.response.accept.label') }, link_errors: true %>

--- a/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
@@ -29,7 +29,7 @@
     <% end %>
   <% end %>
   <%= f.govuk_radio_button :have_naric_reference, 'no', label: { text: 'No' } do %>
-    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling Get Into Teaching on Freephone 0800 389 2501.</p>
+    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>.</p>
   <% end %>
 <% end %>
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
+++ b/app/views/candidate_interface/degrees/naric/_form_fields.html.erb
@@ -29,7 +29,7 @@
     <% end %>
   <% end %>
   <%= f.govuk_radio_button :have_naric_reference, 'no', label: { text: 'No' } do %>
-    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>.</p>
+    <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>. Or <%= govuk_link_to 'chat to an adviser using the online chat service', t('get_into_teaching.url_online_chat') %>.</p>
   <% end %>
 <% end %>
 <%= f.govuk_submit t('save_and_continue') %>

--- a/app/views/candidate_interface/gcse/naric/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric/edit.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         <% end %>
         <%= f.govuk_radio_button :have_naric_reference, 'No', label: { text: 'No' } do %>
-          <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>.</p>
+          <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>. Or <%= govuk_link_to 'chat to an adviser using the online chat service', t('get_into_teaching.url_online_chat') %>.</p>
         <% end %>
       <% end %>
 

--- a/app/views/candidate_interface/gcse/naric/edit.html.erb
+++ b/app/views/candidate_interface/gcse/naric/edit.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         <% end %>
         <%= f.govuk_radio_button :have_naric_reference, 'No', label: { text: 'No' } do %>
-          <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling Get Into Teaching on Freephone 0800 389 2501.</p>
+          <p class="govuk-body">Ask your training provider if they need a UK NARIC statement of comparability. You can get a free statement (this usually costs £49.50 plus VAT) by calling <%= t('service_name.get_into_teaching') %> for free on <%= t('get_into_teaching.tel') %>.</p>
         <% end %>
       <% end %>
 

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -25,8 +25,8 @@
 
           <% elsif option.id == :missing %>
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
-              <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
-              <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>.</p>
+              <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, you will need to have completed it by the start of your course.</p>
+              <p class="govuk-hint">For advice, contact your training provider or speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_online_chat') %> adviser.</p>
               <%= f.govuk_text_area :missing_explanation, label: { text: t('application_form.gcse.missing_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
               <% end %>
             <% end %>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -26,7 +26,7 @@
           <% elsif option.id == :missing %>
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
               <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
-              <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %>.</p>
+              <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>.</p>
               <%= f.govuk_text_area :missing_explanation, label: { text: t('application_form.gcse.missing_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
               <% end %>
             <% end %>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -7,14 +7,14 @@
 
   <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
     <div class="govuk-body">
-      Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
-      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
+      Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
+      You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
     </div>
   <% end %>
   <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
     <div class="govuk-body">
-      Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
-      You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
+      Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
+      You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
     </div>
   <% end %>
 <% end %>

--- a/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
+++ b/app/views/candidate_interface/personal_details/right_to_work_or_study/_shared_form.html.erb
@@ -6,16 +6,10 @@
   <% end %>
 
   <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
-    <div class="govuk-body">
-      Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
-      You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
-    </div>
+    <p class="govuk-body">Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration. You can also <%= govuk_link_to 'speak to an adviser', t('get_into_teaching.url_online_chat') %> if you need help.</p>
   <% end %>
   <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
-    <div class="govuk-body">
-      Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
-      You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
-    </div>
+    <p class="govuk-body">Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration. You can also <%= govuk_link_to 'speak to an adviser', t('get_into_teaching.url_online_chat') %> if you need help.</p>
   <% end %>
 <% end %>
 

--- a/app/views/candidate_interface/personal_statement/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/edit.html.erb
@@ -19,7 +19,7 @@
         <li>any past experience working with children or young people, and what you learnt</li>
         <li>your thoughts on welfare and education</li>
       </ul>
-      <p class="govuk-body">If you need help, <%= govuk_link_to 'register with Get Into Teaching to talk to a teacher training adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %>.</p>
+      <p class="govuk-body">If you need help, <%= govuk_link_to "register with #{t('service_name.get_into_teaching')} to talk to a teacher training adviser", t('get_into_teaching.url_get_an_advisor') %>.</p>
 
       <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
       <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/personal_statement/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/edit.html.erb
@@ -19,7 +19,7 @@
         <li>any past experience working with children or young people, and what you learnt</li>
         <li>your thoughts on welfare and education</li>
       </ul>
-      <p class="govuk-body">If you need help, <%= govuk_link_to "register with #{t('service_name.get_into_teaching')} to talk to a teacher training adviser", t('get_into_teaching.url_get_an_advisor') %>.</p>
+      <p class="govuk-body">If you need help, you can speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %> adviser. They’re all experienced teachers who can give you advice on applying for teacher training.</p>
 
       <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
       <%= f.govuk_submit t('continue') %>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -20,7 +20,7 @@
       </ul>
       <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <%= govuk_link_to 'Access to Work', 'https://www.gov.uk/access-to-work' %>. This could include a grant to help cover the costs of practical support in the workplace.</p>
       <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
-      <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability' %>. Training providers must not:</p>
+      <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', t('get_into_teaching.url_training_with_a_disability') %>. Training providers must not:</p>
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
         <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
         <li>reject your application because you’re disabled</li>

--- a/app/views/candidate_mailer/_get_support.text.erb
+++ b/app/views/candidate_mailer/_get_support.text.erb
@@ -1,7 +1,7 @@
 # Get support
 
-You can chat to a Get Into Teaching adviser online for help and advice:
+You can chat to a <%= t('service_name.get_into_teaching') %> adviser online for help and advice:
 
-[https://beta-getintoteaching.education.gov.uk/#talk-to-us](https://beta-getintoteaching.education.gov.uk/#talk-to-us)
+<<%= t('get_into_teaching.url_online_chat') %>>
 
-You can also call for free on 0800 389 2501, Monday-Friday between 8:30am and 5pm.
+You can also call for free on <%= t('get_into_teaching.tel') %>, <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -23,7 +23,7 @@ If you apply for a course or accept an offer on both, we’ll get in touch with 
 
 You can apply for another course at this stage if you do not get an offer or if you choose not to accept your offers.
 
-[Get Into Teaching](https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher) can guide you through the process of applying for more courses. Contact them for free on 0800 389 2500, or [chat to an adviser using the online chat service](https://beta-getintoteaching.education.gov.uk/#talk-to-us).
+[<%= t('service_name.get_into_teaching') %>](<%= t('get_into_teaching.url') %>) can guide you through the process of applying for more courses. Contact them for free on <%= t('get_into_teaching.tel') %>, or [chat to an adviser using the online chat service](<%= t('get_into_teaching.url_online_chat') %>).
 
 ### Making changes to your application
 

--- a/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
+++ b/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
@@ -12,18 +12,18 @@
         <% end %>
         <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
           <p class="govuk-body">
-            Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
+            Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
           </p>
           <p class="govuk-body">
-            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
+            You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
           </p>
         <% end %>
         <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
           <p class="govuk-body">
-            Visit <%= govuk_link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %> for guidance on immigration.
+            Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
           </p>
           <p class="govuk-body">
-            You can also <%= govuk_link_to 'register to talk to an adviser', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher' %> if you need help.
+            You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
           </p>
         <% end %>
       <% end %>

--- a/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
+++ b/app/views/support_interface/application_forms/right_to_work_or_study/edit.html.erb
@@ -10,22 +10,8 @@
         <%= f.govuk_radio_button :right_to_work_or_study, 'yes', label: { text: 'Yes – I have the right to work or study in the UK' }, link_errors: true do %>
           <%= f.govuk_text_area :right_to_work_or_study_details, label: { text: 'Give details' }, hint: { text: 'For example, you have settled status or a permanent residence card' } %>
         <% end %>
-        <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } do %>
-          <p class="govuk-body">
-            Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
-          </p>
-          <p class="govuk-body">
-            You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
-          </p>
-        <% end %>
-        <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } do %>
-          <p class="govuk-body">
-            Visit <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_international_candidates') %> for guidance on immigration.
-          </p>
-          <p class="govuk-body">
-            You can also <%= govuk_link_to 'register to talk to an adviser', t('get_into_teaching.url_get_an_advisor') %> if you need help.
-          </p>
-        <% end %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'no', label: { text: 'Not yet – I will need to apply for permission to work or study in the UK' } %>
+        <%= f.govuk_radio_button :right_to_work_or_study, 'decide_later', label: { text: 'I do not know' } %>
       <% end %>
 
       <%= f.govuk_text_field(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,18 @@ en:
     manage: Manage teacher training applications
     support: Support for Apply
     api: Apply for teacher training API
+    get_into_teaching: Get Into Teaching
+  get_into_teaching:
+    # TODO: Update to 0800 389 2500 when GIT leaves beta
+    tel: 0800 389 2501
+    opening_times: "Monday to Friday, 8.30am to 5pm (except public\u00A0holidays)"
+    # TODO: Update domain names when GIT leaves beta
+    url: https://beta-getintoteaching.education.gov.uk
+    url_applying: https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher#step-5
+    url_get_an_advisor: https://beta-adviser-getintoteaching.education.gov.uk
+    url_international_candidates: https://beta-getintoteaching.education.gov.uk/international-candidates
+    url_training_with_a_disability: https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#training-to-teach-if-you-have-a-disability
+    url_online_chat: https://beta-getintoteaching.education.gov.uk/#talk-to-us
   page_titles:
     application_form: Your application
     application_dashboard: Application dashboard


### PR DESCRIPTION
## Context

We reference a number of contact values that relate to Get into teaching, which we should store in one place.

## Changes proposed in this pull request

* Adds constants for GIT’s beta website URL and phone number, opening times and other GIT URLs we use
* Uses those constants throughout the application
* Removes guidance around right to work for the form that’s shown in support

## Guidance to review

This PR was reviewed once when it was in draft, but I’ve made a few more changes since, so worth another gander, I reckon.

## Link to Trello card

https://trello.com/c/wpgn9P98

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
