### PR TITLE
One time export for Monica (to be deleted after run)

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -233,6 +233,11 @@ class ApplicationForm < ApplicationRecord
       application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }
   end
 
+  def ended_with_success?
+    application_choices.present? &&
+      application_choices.map(&:status).map(&:to_sym).all? { |status| ApplicationStateChange::ACCEPTED_STATES.include?(status) }
+  end
+
   def can_add_reference?
     application_references.size < MINIMUM_COMPLETE_REFERENCES
   end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -100,6 +100,11 @@ class DataExport < ApplicationRecord
       description: 'A list of qualifications for each application choice',
       class: SupportInterface::QualificationsExport,
     },
+    rejected_candidates_export: {
+      name: 'RejectedCandidatesExport',
+      description: 'A one time export for Monica. A bit too tough to run this one via a container',
+      class: SupportInterface::RejectedCandidatesExport,
+    },
   }.freeze
 
   belongs_to :initiator, polymorphic: true, optional: true

--- a/app/services/support_interface/rejected_candidates_export.rb
+++ b/app/services/support_interface/rejected_candidates_export.rb
@@ -1,0 +1,99 @@
+module SupportInterface
+  class RejectedCandidatesExport
+    def data_for_export
+      application_forms = ApplicationForm.current_cycle.joins(:application_choices).includes(:application_choices, :candidate, :application_qualifications)
+
+      rejected_applicants = application_forms.find_each.select(&:ended_without_success?)
+
+      rejected_candidates = rejected_applicants.map(&:candidate).uniq
+
+      output = rejected_candidates.map do |candidate|
+        application_form = candidate.application_forms.current_cycle.first
+        apply_again_application = candidate.application_forms.current_cycle.second
+        qualifications = application_form.application_qualifications
+        a_levels = a_levels(qualifications).sort_by(&:subject)
+        degrees = degrees(qualifications).sort_by(&:subject)
+
+        {
+          'First name' => application_form.first_name.split(' ').first,
+          'Other names' => application_form.first_name.split(' ')[1..].join(' '),
+          'Last name' => application_form.last_name,
+          'Email address' => application_form.candidate.email_address,
+          'Phone number' => application_form.phone_number,
+          'Link to first application' => "https://www.apply-for-teacher-training.service.gov.uk/support/applications/#{application_form.id}",
+          'First application sumbitted application on' => application_form&.submitted_at&.to_date&.to_s,
+          'First application choice status' => application_form.application_choices[0].status,
+          'Second application choice status' => application_form.application_choices[1]&.status,
+          'Third application choice status' => application_form.application_choices[2]&.status,
+          'Applied again' => apply_again_application.present? ? 'Yes' : 'No',
+          'Link to second application' => link_to_second_application_if_candidate_applied_again(apply_again_application),
+          'Second application submitted on' => apply_again_application&.submitted_at&.to_date&.to_s,
+          'Second application successful' => second_application_successful(apply_again_application),
+          'Total applications this cycle' => candidate.application_forms.current_cycle.count,
+          'GCSE maths grade' => maths_gcse_grade(qualifications),
+          'GCSE science grade' => science_gcse_grade(qualifications),
+          'GCSE English grade' => english_gcse_grade(qualifications),
+          'A level 1 subject' => a_levels[0].try(:subject),
+          'A level 1 grade' => a_levels[0].try(:grade),
+          'A level 2 subject' => a_levels[1].try(:subject),
+          'A level 2 grade' => a_levels[1].try(:grade),
+          'A level 3 subject' => a_levels[2].try(:subject),
+          'A level 3 grade' => a_levels[2].try(:grade),
+          'A level 4 subject' => a_levels[3].try(:subject),
+          'A level 4 grade' => a_levels[3].try(:grade),
+          'A level 5 subject' => a_levels[4].try(:subject),
+          'A level 5 grade' => a_levels[4].try(:grade),
+          'Degree 1 type' => degrees[0].try(:qualification_type),
+          'Degree 1 grade' => degrees[0].try(:grade),
+          'Degree 2 type' => degrees[1].try(:qualification_type),
+          'Degree 2 grade' => degrees[1].try(:grade),
+          'Number of other qualifications provided' => other_qualification_count(qualifications),
+        }
+      end
+      output
+    end
+
+  private
+
+    def second_application_successful(application_form)
+      if application_form&.ended_with_success?
+        'Yes'
+      else
+        (application_form&.submitted_at.present? ? 'No' : nil)
+      end
+    end
+
+    def link_to_second_application_if_candidate_applied_again(application_form)
+      return nil if application_form.blank?
+
+      "https://www.apply-for-teacher-training.service.gov.uk/support/applications/#{application_form.id}"
+    end
+
+    def maths_gcse_grade(qualifications)
+      maths_gcse = qualifications.where(level: :gcse, subject: :maths).first
+      maths_gcse&.grade
+    end
+
+    def english_gcse_grade(qualifications)
+      gcse = qualifications.where(level: :gcse, subject: :english).first
+      gcse&.structured_grades || gcse&.grade
+    end
+
+    def science_gcse_grade(qualifications)
+      gcse = qualifications.where(level: :gcse, subject: :science).first
+      gcse&.structured_grades || gcse&.grade
+    end
+
+    def a_levels(qualifications)
+      qualifications.where(qualification_type: 'A level').or(qualifications.where(qualification_type: 'AS level')).reject(&:incomplete_other_qualification?).take(5)
+    end
+
+    def degrees(qualifications)
+      qualifications.where(level: 'degree').reject(&:incomplete_degree_information?).take(2)
+    end
+
+    def other_qualification_count(qualifications)
+      qualifications.where(level: 'other').count
+    end
+  end
+end


### PR DESCRIPTION
## Context

Monica needs a one-time data export which combines a bunch of information about rejected applications and the candidate's qualifications.

## Changes proposed in this pull request

- One time export added

## Guidance to review

This will be removed after being run once
I've tested it locally and a with limited prod data

### Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
