### PR TITLE
Add safe navigation operator to one time export

### DIFF
--- a/app/services/support_interface/rejected_candidates_export.rb
+++ b/app/services/support_interface/rejected_candidates_export.rb
@@ -23,7 +23,7 @@ module SupportInterface
           'Phone number' => application_form.phone_number,
           'Link to first application' => "https://www.apply-for-teacher-training.service.gov.uk/support/applications/#{application_form.id}",
           'First application submitted application on' => application_form.submitted_at&.to_date&.to_s,
-          'First application choice status' => application_form.application_choices[0].status,
+          'First application choice status' => application_form.application_choices[0]&.status,
           'Second application choice status' => application_form.application_choices[1]&.status,
           'Third application choice status' => application_form.application_choices[2]&.status,
           'Applied again' => apply_again_application.present? ? 'Yes' : 'No',


### PR DESCRIPTION
## Context

This shouldn't be failing as it's not possible to have a submitted application form without an application choice. I'm going to run the export and investigate 🔍 

## Changes proposed in this pull request

- Add safe navigation operator to export

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
