### PR TITLE
Add a spec to cover more of the english gcse form

### DIFF
--- a/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_english_gcse_spec.rb
@@ -38,6 +38,13 @@ RSpec.feature 'Candidate entering GCSE English details' do
     and_i_enter_a_valid_other_english_grade
     and_i_click_save_and_continue
     then_i_see_the_grade_year_page
+
+    when_i_fill_in_the_award_year
+    and_i_click_save_and_continue
+    then_i_see_the_check_answers_page
+
+    when_i_click_to_change_my_grades
+    then_i_see_the_grades_i_entered_in_the_form
   end
 
   def given_i_am_signed_in
@@ -127,5 +134,23 @@ RSpec.feature 'Candidate entering GCSE English details' do
 
   def then_i_see_the_grade_year_page
     expect(page).to have_content t('gcse_edit_year.page_title', subject: 'English', qualification_type: 'GCSE')
+  end
+
+  def when_i_fill_in_the_award_year
+    fill_in('Enter year', with: '2010')
+  end
+
+  def then_i_see_the_check_answers_page
+    expect(page).to have_content('A* (Cockney Rhyming Slang)')
+    expect(page).to have_content('Change grade for GCSE')
+  end
+
+  def when_i_click_to_change_my_grades
+    click_on 'Change grade for GCSE'
+  end
+
+  def then_i_see_the_grades_i_entered_in_the_form
+    expect(page).to have_selector("input[value='A*']")
+    expect(page).to have_selector("input[value='Cockney rhyming slang']")
   end
 end


### PR DESCRIPTION

## Context
The build from grade method was previously untested, and that resulted in a bug during a refactor.
This PR fixed the bug, this is a follow up to add test coverage for it:
https://github.com/DFE-Digital/apply-for-teacher-training/pull/4001