### PR TITLE
Add more filtering to the Support /providers view

### DIFF
--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -2,23 +2,19 @@ module SupportInterface
   class ProvidersFilter
     attr_reader :applied_filters
     ONBOARDING_STAGES = {
-      'synced' => 'Courses synced',
-      'dsa_signed' => 'DSA signed',
+      'synced_only' => 'With synced courses',
+      'dsa_signed_only' => 'With signed DSAs',
     }.freeze
 
     PROVIDER_TYPES = {
       'lead_school' => 'School Direct',
       'scitt' => 'SCITT',
       'university' => 'HEI',
-    }
+    }.freeze
 
     RATIFIED_BY = {
       'scitt' => 'SCITT',
       'university' => 'HEI',
-    }
-
-    DEFAULT_STATE = {
-      onboarding_stages: ONBOARDING_STAGES.keys,
     }.freeze
 
     def initialize(params:)
@@ -28,7 +24,7 @@ module SupportInterface
         :ratified_by,
         :onboarding_stages,
         :q,
-      ).presence || DEFAULT_STATE
+      )
     end
 
     def filters
@@ -68,16 +64,12 @@ module SupportInterface
         @search_count = 0
       end
 
-      if applied_filters[:onboarding_stages]&.include?('synced')
+      if applied_filters[:onboarding_stages]&.include?('synced_only')
         providers = providers.where(sync_courses: true)
-      else
-        providers = providers.where(sync_courses: false)
       end
 
-      if applied_filters[:onboarding_stages]&.include?('dsa_signed')
+      if applied_filters[:onboarding_stages]&.include?('dsa_signed_only')
         providers = providers.joins(:provider_agreements)
-      else
-        providers = providers.includes(:provider_agreements).where(provider_agreements: { provider_id: nil })
       end
 
       if applied_filters[:provider_types].present?

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -49,8 +49,11 @@ module SupportInterface
     end
 
     def filter_records(providers)
-      if applied_filters[:q]
+      if applied_filters[:q].present?
         providers = providers.where("CONCAT(providers.name, ' ', providers.code) ILIKE ?", "%#{applied_filters[:q]}%")
+        @search_count = providers.count
+      else
+        @search_count = 0
       end
 
       if applied_filters[:onboarding_stages]&.include?('synced')
@@ -69,7 +72,12 @@ module SupportInterface
         providers = providers.where(provider_type: applied_filters[:provider_types])
       end
 
+      @filtered_count = providers.count
       providers
+    end
+
+    def search_results_filtered_out_count
+      @search_count - @filtered_count
     end
 
   private

--- a/app/models/support_interface/providers_filter.rb
+++ b/app/models/support_interface/providers_filter.rb
@@ -6,35 +6,44 @@ module SupportInterface
       'dsa_signed' => 'DSA signed',
     }.freeze
 
+    PROVIDER_TYPES = {
+      'lead_school' => 'School Direct',
+      'scitt' => 'SCITT',
+      'university' => 'HEI',
+    }
+
     DEFAULT_STATE = {
       onboarding_stages: ONBOARDING_STAGES.keys,
     }.freeze
 
     def initialize(params:)
-      @applied_filters = params.slice(:remove, :onboarding_stages, :q).presence || DEFAULT_STATE
+      @applied_filters = params.slice(
+        :remove,
+        :provider_types,
+        :onboarding_stages,
+        :q,
+      ).presence || DEFAULT_STATE
     end
 
     def filters
-      onboarding_state_options = ONBOARDING_STAGES.map do |name, label|
-        {
-          value: name,
-          label: label,
-          checked: applied_filters[:onboarding_stages]&.include?(name),
-        }
-      end
-
       [
-        {
-          type: :checkboxes,
-          heading: 'Onboarding stage',
-          options: onboarding_state_options,
-          name: 'onboarding_stages',
-        },
         {
           type: :search,
           heading: 'Name or code',
           value: applied_filters[:q],
           name: 'q',
+        },
+        {
+          type: :checkboxes,
+          heading: 'Onboarding stage',
+          options: hash_to_checkbox_options(:onboarding_stages, ONBOARDING_STAGES),
+          name: 'onboarding_stages',
+        },
+        {
+          type: :checkboxes,
+          heading: 'Provider type',
+          options: hash_to_checkbox_options(:provider_types, PROVIDER_TYPES),
+          name: 'provider_types',
         },
       ]
     end
@@ -56,7 +65,23 @@ module SupportInterface
         providers = providers.includes(:provider_agreements).where(provider_agreements: { provider_id: nil })
       end
 
+      if applied_filters[:provider_types].present?
+        providers = providers.where(provider_type: applied_filters[:provider_types])
+      end
+
       providers
+    end
+
+  private
+
+    def hash_to_checkbox_options(option_name, hash)
+      hash.map do |name, label|
+        {
+          value: name,
+          label: label,
+          checked: applied_filters[option_name]&.include?(name),
+        }
+      end
     end
   end
 end

--- a/app/views/support_interface/providers/_providers_navigation.html.erb
+++ b/app/views/support_interface/providers/_providers_navigation.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, 'Providers' %>
 
 <%= render TabNavigationComponent.new(items: [
-  { name: 'Providers', url: support_interface_providers_path(onboarding_stages: ['synced', 'dsa_signed']) },
+  { name: 'Providers', url: support_interface_providers_path },
   { name: 'API tokens', url: support_interface_api_tokens_path },
   { name: 'Provider users', url: support_interface_provider_users_path, current: local_assigns[:current] == 'Provider users' },
 ]) %>

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -10,6 +10,12 @@
       </tr>
     </thead>
 
+    <% if @filter.search_results_filtered_out_count.positive? %>
+      <p class="govuk-body">
+      <%= pluralize(@filter.search_results_filtered_out_count, 'search result') %> filtered out.
+      </p>
+    <% end %>
+
     <tbody class="govuk-table__body">
       <% @providers.each do |provider| %>
         <tr class="govuk-table__row">

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -36,6 +36,34 @@ RSpec.describe SupportInterface::ProvidersFilter do
       expect(filter.filter_records(Provider.all)).to match_array [scitt, lead_school]
     end
 
+    it 'filters by ratifying relationship' do
+      ratified_by_scitt = create(:provider)
+      scitt = create(:provider, provider_type: 'scitt')
+      create(:provider_relationship_permissions,
+             training_provider: ratified_by_scitt,
+             ratifying_provider: scitt)
+
+      ratified_by_hei = create(:provider)
+      hei = create(:provider, provider_type: 'university')
+      create(:provider_relationship_permissions,
+             training_provider: ratified_by_hei,
+             ratifying_provider: hei)
+
+      filter = described_class.new(params: { ratified_by: %w[scitt] })
+      expect(filter.filter_records(Provider.all)).to eq [ratified_by_scitt]
+
+      filter = described_class.new(params: { ratified_by: %w[university] })
+      expect(filter.filter_records(Provider.all)).to eq [ratified_by_hei]
+
+      filter = described_class.new(params: { remove: true })
+      expect(filter.filter_records(Provider.all)).to match_array([
+        ratified_by_hei,
+        ratified_by_scitt,
+        hei,
+        scitt,
+      ])
+    end
+
     it 'defaults to showing providers with synced courses and DSAs' do
       synced_and_signed = create(:provider, :with_signed_agreement, sync_courses: true)
       neither_synced_not_signed = create(:provider)

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SupportInterface::ProvidersFilter do
       create(:provider, sync_courses: false)
 
       providers = Provider.all
-      filter = described_class.new(params: { onboarding_stages: %w[synced] })
+      filter = described_class.new(params: { onboarding_stages: %w[synced_only] })
 
       expect(filter.filter_records(providers)).to eq [provider_with_synced_courses]
     end
@@ -17,7 +17,7 @@ RSpec.describe SupportInterface::ProvidersFilter do
       create(:provider)
 
       providers = Provider.all
-      filter = described_class.new(params: { onboarding_stages: %w[dsa_signed] })
+      filter = described_class.new(params: { onboarding_stages: %w[dsa_signed_only] })
 
       expect(filter.filter_records(providers)).to eq [provider_with_signed_dsa]
     end
@@ -64,22 +64,16 @@ RSpec.describe SupportInterface::ProvidersFilter do
       ])
     end
 
-    it 'defaults to showing providers with synced courses and DSAs' do
-      synced_and_signed = create(:provider, :with_signed_agreement, sync_courses: true)
-      neither_synced_not_signed = create(:provider)
+    it 'defaults to showing all providers' do
+      create(:provider, :with_signed_agreement, sync_courses: true)
+      create(:provider)
       create(:provider, sync_courses: true) # only synced
       create(:provider, :with_signed_agreement) # only signed
 
       providers = Provider.all
       filter = described_class.new(params: {})
 
-      expect(filter.filter_records(providers)).to match_array([
-        synced_and_signed,
-      ])
-
-      filter = described_class.new(params: { remove: true })
-
-      expect(filter.filter_records(providers)).to eq [neither_synced_not_signed]
+      expect(filter.filter_records(providers).count).to eq(4)
     end
   end
 end

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ProvidersFilter do
-  let!(:provider_with_synced_courses) { create(:provider, sync_courses: true) }
-  let!(:provider_without_synced_courses) { create(:provider, sync_courses: false) }
-  let!(:provider_with_signed_dsa) { create(:provider, :with_signed_agreement) }
-  let!(:provider_with_nothing) { create(:provider) }
-
   describe '#filter_records' do
     it 'filters by synced courses' do
+      provider_with_synced_courses = create(:provider, sync_courses: true)
+      create(:provider, sync_courses: false)
+
       providers = Provider.all
       filter = described_class.new(params: { onboarding_stages: %w[synced] })
 
@@ -15,17 +13,31 @@ RSpec.describe SupportInterface::ProvidersFilter do
     end
 
     it 'filters by DSA signed' do
+      provider_with_signed_dsa = create(:provider, :with_signed_agreement)
+      create(:provider)
+
       providers = Provider.all
       filter = described_class.new(params: { onboarding_stages: %w[dsa_signed] })
 
       expect(filter.filter_records(providers)).to eq [provider_with_signed_dsa]
     end
 
-    it 'excludes providers when the boxes aren’t ticked' do
+    it 'defaults to showing providers with synced courses and DSAs' do
+      synced_and_signed = create(:provider, :with_signed_agreement, sync_courses: true)
+      neither_synced_not_signed = create(:provider)
+      create(:provider, sync_courses: true) # only synced
+      create(:provider, :with_signed_agreement) # only signed
+
       providers = Provider.all
+      filter = described_class.new(params: {})
+
+      expect(filter.filter_records(providers)).to match_array([
+        synced_and_signed,
+      ])
+
       filter = described_class.new(params: { remove: true })
 
-      expect(filter.filter_records(providers)).to match_array [provider_with_nothing, provider_without_synced_courses]
+      expect(filter.filter_records(providers)).to eq [neither_synced_not_signed]
     end
   end
 end

--- a/spec/models/support_interface/providers_filter_spec.rb
+++ b/spec/models/support_interface/providers_filter_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe SupportInterface::ProvidersFilter do
       expect(filter.filter_records(providers)).to eq [provider_with_signed_dsa]
     end
 
+    it 'filters by provider type' do
+      lead_school = create(:provider, provider_type: 'lead_school')
+      scitt = create(:provider, provider_type: 'scitt')
+
+      filter = described_class.new(params: { provider_types: %w[lead_school] })
+      expect(filter.filter_records(Provider.all)).to eq [lead_school]
+
+      filter = described_class.new(params: { provider_types: %w[scitt] })
+      expect(filter.filter_records(Provider.all)).to eq [scitt]
+
+      filter = described_class.new(params: { remove: true })
+      expect(filter.filter_records(Provider.all)).to match_array [scitt, lead_school]
+    end
+
     it 'defaults to showing providers with synced courses and DSAs' do
       synced_and_signed = create(:provider, :with_signed_agreement, sync_courses: true)
       neither_synced_not_signed = create(:provider)

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -30,9 +30,6 @@ RSpec.feature 'See provider course syncing' do
 
   def when_i_visit_the_providers_page
     visit support_interface_providers_path
-    uncheck('Courses synced')
-    uncheck('DSA signed')
-    click_button 'Apply filters'
   end
 
   def then_i_see_that_the_provider_is_not_configured_to_sync_courses


### PR DESCRIPTION
## Context

As requested on the Support board filter by what sort of body accredits courses.
Also introduce filtering by provider type.

## Changes proposed in this pull request

Add those two filters:

<img width="1002" alt="Screenshot 2021-02-05 at 14 12 50" src="https://user-images.githubusercontent.com/642279/107044484-44294500-67bc-11eb-96f1-a1ed38b6a2e6.png">

Make two improvements to existing behaviour:

- if there's a search term and some of the results have been filtered out, show a message saying "n search results were filtered out"
- add an 'any' option to the "onboarding stage" to avoid having to test various combinations of those checkboxes

## Link to Trello card

https://trello.com/c/n5Wzfm2U/157-ability-to-filter-courses-by-accredited-body-ie-scitt-or-hei