### PR TITLE
Allow bulk creation of test applications for ratified courses via API

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -56,7 +56,7 @@ module VendorAPI
     end
 
     def for_ratified_courses_param
-      params[:for_ratified_courses].present?
+      params[:for_ratified_courses] == 'true'
     end
   end
 end

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -17,6 +17,7 @@ module VendorAPI
         provider: current_provider,
         courses_per_application: courses_per_application_param,
         count: count_param,
+        for_ratified_courses: for_ratified_courses_param,
       )
 
       render json: { data: { ids: application_choices.map { |ac| ac.id.to_s } } }
@@ -52,6 +53,10 @@ module VendorAPI
 
     def courses_per_application_param
       [(params[:courses_per_application] || DEFAULT_COURSES_COUNT).to_i, MAX_COURSES_COUNT].min
+    end
+
+    def for_ratified_courses_param
+      params[:for_ratified_courses].present?
     end
   end
 end

--- a/app/queries/get_courses_ratified_by_provider.rb
+++ b/app/queries/get_courses_ratified_by_provider.rb
@@ -1,0 +1,9 @@
+class GetCoursesRatifiedByProvider
+  DEFAULT_RECRUITMENT_CYCLE_YEAR = RecruitmentCycle.current_year
+
+  def self.call(provider:, recruitment_cycle_year: DEFAULT_RECRUITMENT_CYCLE_YEAR)
+    provider.accredited_courses
+      .where(recruitment_cycle_year: recruitment_cycle_year)
+      .where.not(provider: provider)
+  end
+end

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+## 5th February
+
+The following experimental/sandbox endpoint has been updated:
+
+- `/test-data/generate` now accepts an optional `for_ratified_courses` query param. If this parameter is supplied and set to a non-empty string, applications will be generated for courses the organisation awards, not runs. This means subsequent calls to `/test-data/clear` will NOT delete these applications.
+
 ## 29th January
 
 - The documented enum values for `Reference.referee_type` have been corrected to remove commas and replace `school-based` with `school_based`.

--- a/config/vendor-api-experimental.yml
+++ b/config/vendor-api-experimental.yml
@@ -25,6 +25,11 @@ paths:
           default: 1
           minimum: 1
           maximum: 3
+      - name: for_ratified_courses
+        description: Generate applications for courses your organisation awards Qualified Teacher Status (QTS) for but does not run. For example, your organisation may be a Higher Education Institution ratifying School Direct courses. Please specify 'true', for example for_ratified_courses=true
+        in: query
+        schema:
+          type: string
       responses:
         '201':
           "$ref": "#/components/responses/TestDataGenerated"

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -151,4 +151,27 @@ RSpec.describe TestApplications do
       expect(application_choice.interviews.count).to eq(1)
     end
   end
+
+  describe 'generate_for_provider' do
+    it 'can generate applications only for courses the provider ratifies' do
+      provider = create(:provider)
+      create(:course_option)
+      create(:course_option, course: create(:course, provider: provider))
+      # rubocop:disable FactoryBot/CreateList
+      3.times do
+        create(:course_option, course: create(:course, accredited_provider: provider))
+      end
+      # rubocop:enable FactoryBot/CreateList
+
+      choices = TestApplications.new.generate_for_provider(
+        provider: provider,
+        courses_per_application: 3,
+        count: 2,
+        for_ratified_courses: true,
+      )
+
+      expect(choices.map(&:application_form).uniq.count).to eq(2)
+      expect(choices.map(&:course).map(&:accredited_provider).uniq).to eq([provider])
+    end
+  end
 end

--- a/spec/queries/get_courses_ratified_by_provider_spec.rb
+++ b/spec/queries/get_courses_ratified_by_provider_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe GetCoursesRatifiedByProvider do
+  let!(:provider) { create(:provider) }
+  let!(:course_current_year) { create(:course, accredited_provider: provider) }
+  let!(:course_previous_year) { create(:course, :previous_year, accredited_provider: provider) }
+  let!(:course_run_by_provider) { create(:course, provider: provider, accredited_provider: provider) }
+  let!(:course_unrelated) { create(:course) }
+
+  it 'uses the current recruitment cycle year by default' do
+    result = described_class.call(provider: provider)
+    expect(result).to match_array([course_current_year])
+  end
+
+  it 'can return courses for a different year if required' do
+    result = described_class.call(provider: provider, recruitment_cycle_year: RecruitmentCycle.previous_year)
+    expect(result).to match_array([course_previous_year])
+  end
+
+  it 'excludes courses a provider runs' do
+    result = described_class.call(provider: provider)
+    expect(result).not_to include(course_run_by_provider)
+  end
+end


### PR DESCRIPTION
## Context

We already allow API calls to generate test data for a given provider. Providers that ratify many courses would also like to test visibility of applications to courses they ratify, not run, via the API.

## Changes proposed in this pull request

Allow providers to specify `for_ratified_courses` when calling `/test-data/generate`. If this param is passed, then `count` and `courses_per_application` are still honoured, but test applications are created against random courses the provider ratifies, not runs. Note: API keys are scoped to a single provider.

![image](https://user-images.githubusercontent.com/107591/107051024-d8e37100-67c3-11eb-9954-9dba38411b23.png)

## Guidance to review

Inspect code changes. Is the documentation easy to understand?

If a provider tries to use `/test-data/clear`, this won't delete applications generated `for_ratified_courses`.

## Link to Trello card

https://trello.com/c/9HLwGYID

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
