### PR TITLE
Conform to Sentry's user_context schema

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -10,7 +10,7 @@ module CandidateInterface
 
     def add_identity_to_log(candidate_id = current_candidate&.id)
       RequestLocals.store[:identity] = { candidate_id: candidate_id }
-      Raven.user_context(candidate_id: candidate_id)
+      Raven.user_context(id: "candidate_#{candidate_id}")
 
       return unless current_candidate
 

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -57,7 +57,7 @@ module Integrations
     def log_params
       relevant_parameters = params.permit(:reference, :status).to_h
       RequestLocals.store[:identity] = relevant_parameters
-      Raven.user_context(relevant_parameters)
+      Raven.extra_context(relevant_parameters)
     end
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -72,7 +72,8 @@ module ProviderInterface
       end
 
       RequestLocals.store[:identity] = useful_debugging_info
-      Raven.user_context(useful_debugging_info)
+      Raven.user_context(id: "provider_#{current_provider_user.id}")
+      Raven.extra_context(useful_debugging_info)
     end
 
     # Set the `@application_choice` instance variable for use in views.

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -149,8 +149,10 @@ module RefereeInterface
       return if reference.blank?
 
       RequestLocals.store[:identity] = { reference_id: reference.id }
-      Raven.user_context(reference_id: reference.id)
-      Raven.extra_context(application_support_url: support_interface_application_form_url(reference.application_form))
+      Raven.extra_context(
+        application_support_url: support_interface_application_form_url(reference.application_form),
+        reference_id: reference.id,
+      )
     end
 
     def reference

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -35,7 +35,7 @@ module SupportInterface
       return unless current_support_user
 
       RequestLocals.store[:identity] = { support_user_id: current_support_user.id }
-      Raven.user_context(support_user_id: current_support_user.id)
+      Raven.user_context(id: "support_#{current_support_user.id}")
     end
   end
 end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -85,7 +85,7 @@ module VendorAPI
       }
 
       RequestLocals.store[:identity] = user_info
-      Raven.user_context(user_info)
+      Raven.user_context(id: "api_token_#{@current_vendor_api_token&.id}")
     end
 
     def validate_metadata!


### PR DESCRIPTION
## Context

We're not able to search or filter on the values we set in `Raven.user_context` because it doesn't allow unlisted params: https://docs.sentry.io/product/sentry-basics/guides/enrich-data/#types-of-data.

## Changes proposed in this pull request

Only set `id` param in `user_context`. Send everything else in `extra_context`.

## Link to Trello card

Noticed while doing support trying to track down an error seen by a candidate.