### PR TITLE
Add Candidate ID to application page in Support

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -17,6 +17,7 @@ module SupportInterface
       [
         recruitment_cycle_year,
         support_reference_row,
+        candidate_id_row,
         submitted_row,
         last_updated_row,
         state_row,
@@ -69,6 +70,13 @@ module SupportInterface
           value: support_reference,
         }
       end
+    end
+
+    def candidate_id_row
+      {
+        key: 'Candidate ID',
+        value: application_form.candidate.id,
+      }
     end
 
     def state_row


### PR DESCRIPTION
## Context

I wanted to look for Sentry errors associated with a certain candidate ID, but I only had their email address from Zendesk. Once #4007 is in we could turn this into a link to Sentry so we could see any errors they'd seen.

## Changes proposed in this pull request

<img width="1101" alt="Screenshot 2021-02-05 at 15 04 39" src="https://user-images.githubusercontent.com/642279/107050782-8b670400-67c3-11eb-8121-373288933b8c.png">