### PR TITLE
Use path helpers in Markdown files

### DIFF
--- a/app/views/content/accessibility.md
+++ b/app/views/content/accessibility.md
@@ -10,7 +10,7 @@ We have taken steps to make this service accessible:
 
 ## What to do if you cannot access parts of this website
 
-If you need information on this website in a different format, such as accessible PDF, large print, easy read, audio recording or braille, please email us on <becomingateacher@digital.education.gov.uk>.
+If you need information on this website in a different format, such as accessible PDF, large print, easy read, audio recording or braille, please email us on <%= bat_contact_mail_to %>.
 
 We’ll consider your request and respond to you within 5 working days.
 
@@ -18,7 +18,7 @@ We’ll consider your request and respond to you within 5 working days.
 
 ## Reporting accessibility problems with this website
 
-If you have any problems accessing the service or want to give us feedback, please email us on <becomingateacher@digital.education.gov.uk>.
+If you have any problems accessing the service or want to give us feedback, please email us on <%= bat_contact_mail_to %>.
 
 ## Enforcement procedure
 

--- a/app/views/content/complaints.md
+++ b/app/views/content/complaints.md
@@ -2,12 +2,14 @@ The Department for Education is committed to providing a high level of customer 
 
 ## Giving feedback
 
-If you have feedback about the service, or want to give suggestions for improvement, you can email us as <becomingateacher@digital.education.gov.uk>.
+If you have feedback about the service, or want to give suggestions for improvement, you can email us as <%= bat_contact_mail_to %>.
 
 ## How to make a complaint
+
 To make a complaint about the Apply for teacher training service, please [complete our complaints form](https://docs.google.com/forms/d/e/1FAIpQLSdkaYmy03JP0s9gxfEOkBMvMwNuU7IYO_MLwFONg5GdVFBuFg/viewform).
 
 ## How we’ll respond
+
 Our support team will respond to your complaint within 5-7 working days.
 
 If we need more time to complete our investigation we’ll get in touch, and keep you updated regularly.

--- a/app/views/content/covid_19_guidance.md
+++ b/app/views/content/covid_19_guidance.md
@@ -36,7 +36,7 @@ You can find candidates’ new DBD dates in [Manage teacher training application
 
 ### Keeping candidates up to date
 
-We’ll let candidates know if they have longer to respond to an offer and tell them their new DBD date.  
+We’ll let candidates know if they have longer to respond to an offer and tell them their new DBD date.
 
 ## What we ask of you during this time
 
@@ -44,10 +44,8 @@ We’ll let candidates know if they have longer to respond to an offer and tell 
 
 Please update the statuses of your training programmes to tell potential applicants if you’re not recruiting at the moment.
 
-
-Providers in England can do this using [Publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk/).  
-
+Providers in England can do this using [Publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk/).
 
 ## Get help
 
-If you have any questions, you can contact your relationship manager or email us at <becomingateacher@education.gov.uk>
+If you have any questions, you can contact your relationship manager or email us at <%= bat_contact_mail_to %>

--- a/app/views/content/guidance_for_the_new_cycle.md
+++ b/app/views/content/guidance_for_the_new_cycle.md
@@ -1,17 +1,20 @@
 ## Dates for your diary
 
 ### 3 October 2020
-Close of the 2019 to 2020 cycle — any applications without a response by this date will have been rejected automatically. 
 
-### 6 October 2020 
-[Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) opens, featuring courses for 2021 to 2022. 
+Close of the 2019 to 2020 cycle — any applications without a response by this date will have been rejected automatically.
+
+### 6 October 2020
+
+[Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) opens, featuring courses for 2021 to 2022.
 
 ### 13 October 2020
-[Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk/candidate) and UCAS Teacher Training both open for applications. 
+
+[Apply for teacher training](<%= candidate_interface_path %>) and UCAS Teacher Training both open for applications.
 
 ## Deferring offers
 
-The [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider) team has launched a new feature allowing training providers to defer offers to the next cycle. Please bear in mind that you can only defer offers at the request of the candidate.
+The [Manage teacher training applications](<%= provider_interface_path %>) team has launched a new feature allowing training providers to defer offers to the next cycle. Please bear in mind that you can only defer offers at the request of the candidate.
 
 You can:
 
@@ -23,12 +26,11 @@ You can:
 
 You’ll be able to change the details of a deferred offer at the start of the next cycle (2021 to 2022). If you need to alter any details – for example, the location, course or conditions – you should agree those changes with the candidate first, by email or phone.
 
-You can then use [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider) to send an amended offer to the candidate, who will receive a formal notification.
+You can then use [Manage teacher training applications](<%= provider_interface_path %>) to send an amended offer to the candidate, who will receive a formal notification.
 
 For the purposes of data reporting, deferred offers will not appear as rejected offers in the current cycle. This will allow you to submit accurate figures for rejections in each cycle.
 
-If you have to withdraw a deferred offer and cannot provide the candidate with an alternative, please contact us immediately on [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk).
-
+If you have to withdraw a deferred offer and cannot provide the candidate with an alternative, please contact us immediately on <%= bat_contact_mail_to %>.
 
 ## Storing and carrying over application data
 
@@ -40,41 +42,36 @@ By the end of November 2020, training providers will have access to and be able 
 
 Your notes and actions, including reasons for rejection, will be stored along with the application data so you can easily refer to them.
 
-
 ## Data reporting
 
 We understand that data reporting to both the Higher Education Statistics Agency (HESA) and the database of teacher trainees and providers (DTTP) can be time-consuming.
 
 We’re currently developing a feature allowing training providers to download their application data as a csv file. This should make this process easier – however, we’ll continue to work on further improvements, and welcome your feedback in the meantime.
 
-
 ## Helping candidates apply again
 
-Candidates who are unsuccessful in the current cycle are strongly encouraged to apply again. Training providers and the Becoming a Teacher team can help them by: 
+Candidates who are unsuccessful in the current cycle are strongly encouraged to apply again. Training providers and the Becoming a Teacher team can help them by:
 
-* offering constructive feedback through [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider)
-* providing supportive communications through the [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk/candidate) support team
+* offering constructive feedback through [Manage teacher training applications](<%= provider_interface_path %>)
+* providing supportive communications through the [Apply for teacher training](<%= candidate_interface_path %>) support team
 * allowing applications to be carried over from the current cycle to the next cycle
-
 
 ## UCAS Teacher Training
 
-UCAS will continue to run alongside [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk/candidate) for the 2020 to 2021 cycle.
+UCAS will continue to run alongside [Apply for teacher training](<%= candidate_interface_path %>) for the 2020 to 2021 cycle.
 
 For the 2021 to 2022 cycle, Apply for teacher training will process all teacher training applications received by all teacher training providers in England.
 
-Check our [guidance on how to use Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider/service-guidance) for more about the dual running of these two services.
-
+Check our [guidance on how to use Manage teacher training applications](<%= provider_interface_service_guidance_path %>) for more about the dual running of these two services.
 
 ## Recruiting trainees from overseas after 1 January 2021
 
-Trainee teachers from overseas will need a visa if they arrive in the UK on or after 1 January 2021. This includes those from the [European Economic Area](https://www.gov.uk/eu-eea) and Switzerland. 
+Trainee teachers from overseas will need a visa if they arrive in the UK on or after 1 January 2021. This includes those from the [European Economic Area](https://www.gov.uk/eu-eea) and Switzerland.
 
-Training providers may need to become visa sponsors if they want to recruit trainees who are not UK or Irish nationals. There are some restrictions on state schools becoming visa sponsors. 
+Training providers may need to become visa sponsors if they want to recruit trainees who are not UK or Irish nationals. There are some restrictions on state schools becoming visa sponsors.
 
 Find out more about [recruiting trainee teachers from overseas](https://www.gov.uk/guidance/recruit-trainee-teachers-from-overseas-accredited-itt-providers).
 
-
 ## Help and support
 
-Contact the support team at [becomingateacher@digital.education.gov.uk](becomingateacher@digital.education.gov.uk).
+Contact the support team at <%= bat_contact_mail_to %>.

--- a/app/views/content/privacy_policy.md
+++ b/app/views/content/privacy_policy.md
@@ -105,7 +105,7 @@ We have a data sharing agreement with providers so they can only use your data t
 
 ### Sharing candidate data with referees
 
-We’ll share candidate names with referees so  the referee can identify the candidate and give a reference.
+We’ll share candidate names with referees so the referee can identify the candidate and give a reference.
 
 We may need to share a bit more information to help the referee identify the candidate, such as how the candidate knows the referee.
 
@@ -161,7 +161,7 @@ You can find more information about how we handle personal data in our [personal
 
 If you want to ask us to remove your data or get access to the data we have about you, you can email us:
 
-<becomingateacher@digital.education.gov.uk>
+<%= bat_contact_mail_to %>
 
 You can also use our contact form to [get in touch with our Data Protection Officer](https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen).
 

--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -18,11 +18,11 @@ We’ll continue to make improvements to the service as we roll out. We’ll kee
 
 [Troubleshooting](#troubleshooting)
 
-[Publicising Apply for teacher training](#publicising-apply)
+[Publicising Apply for teacher training](#publicising-apply-for-teacher-training)
 
 [Help, support and feedback](#help-support-and-feedback)
 
-## <a name="what-you-can-expect-from-us"></a>What you can expect from us
+## What you can expect from us
 
 ### Support for training providers
 
@@ -44,7 +44,7 @@ Apply and Manage are free services for both candidates and providers.
 
 For now, we do not provide fraud and plagiarism checks on candidate applications.
 
-## <a name="onboarding"></a>Onboarding
+## Onboarding
 
 Onboarding is quick and easy, usually taking place over a single working day.
 
@@ -60,7 +60,7 @@ Onboarding is quick and easy, usually taking place over a single working day.
 
 We’re available to give you full support at every stage.
 
-## <a name="using-the-service"></a>Using the service
+## Using the service
 
 [Manage teacher training applications](<%= provider_interface_path %>) allows you to process applications from submission through to conditions met.
 
@@ -181,7 +181,7 @@ You can download and print applications to distribute to your team. Compliance w
 
 For now, interview scheduling is not part of the Manage service.
 
-## <a name="deadlines-and-terms-of-use"></a>Deadlines and terms of use
+## Deadlines and terms of use
 
 For clarity and fairness, while [Apply for teacher training](<%= candidate_interface_path %>) and UCAS Teacher Training run side by side (until October 2021), we’ve kept the rules governing applications closely aligned.
 
@@ -228,7 +228,7 @@ As currently, in this phase candidates can make an unlimited number of single, s
 
 Candidates will also be able to use UCAS’s Apply 2 service for this part of their journey.
 
-## <a name="troubleshooting"></a>Troubleshooting
+## Troubleshooting
 
 ### Informing candidates your courses are on Apply
 
@@ -276,7 +276,7 @@ The Department for Education has not changed delivery timetables for the roll-ou
 For questions related to COVID-19, please email our dedicated helpline on <dfe.coronavirushelpline@education.gov.uk> or call us at <a href="tel:0800 046 8687">0800 046 8687</a>.
 Lines are open 8am to 6pm (Monday to Friday) 10am to 4pm (Saturday and Sunday).
 
-## <a name="publicising-apply"></a>Publicising Apply for teacher training
+## Publicising Apply for teacher training
 
 Some providers find that becoming an early adopter of a streamlined, modern GOV.UK service is a useful marketing aid.
 
@@ -284,7 +284,7 @@ You can direct candidates to the new service by linking from your website to you
 
 Our [marketing tool kit](https://docs.google.com/presentation/d/1dCZ5HF_mpJMAOpmr305VqlUo_wqW2jWmzOWi9vxStI0/edit#slide=id.g73a2eda7b8_0_40) may be helpful for your website and social media feeds.
 
-## <a name="help-support-and-feedback"></a>Help, support and feedback
+## Help, support and feedback
 
 ### See a demo
 

--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -1,4 +1,4 @@
-Thank you for signing up to the Department for Education’s [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider).
+Thank you for signing up to the Department for Education’s [Manage teacher training applications](<%= provider_interface_path %>).
 
 The service is now being rolled out to training providers throughout England. By October 2021, all teacher training applications will be made through [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk) and processed through Manage teacher training applications service.
 
@@ -48,11 +48,11 @@ For now, we do not provide fraud and plagiarism checks on candidate applications
 
 Onboarding is quick and easy, usually taking place over a single working day.
 
-1. We’ll ask for contact details for your admissions team so we can give them access to [Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider). We’ll also ask you for the names of any other organisations you partner with – for example, accredited bodies who ratify your courses.
+1. We’ll ask for contact details for your admissions team so we can give them access to [Manage teacher training applications](<%= provider_interface_path %>). We’ll also ask you for the names of any other organisations you partner with – for example, accredited bodies who ratify your courses.
 
 2. Taking data from [Publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk/), we’ll upload your courses to Manage teacher training applications.
 
-3. We’ll then update [Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) so that candidates know they can apply for your courses through [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk/candidate).
+3. We’ll then update [Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) so that candidates know they can apply for your courses through [Apply for teacher training](<%= candidate_interface_path %>).
 
 4. We’ll ask you to sign a data-sharing agreement and create a DfE Sign-in account (if you do not already have one).
 
@@ -61,7 +61,8 @@ Onboarding is quick and easy, usually taking place over a single working day.
 We’re available to give you full support at every stage.
 
 ## <a name="using-the-service"></a>Using the service
-[Manage teacher training applications](https://www.apply-for-teacher-training.service.gov.uk/provider) allows you to process applications from submission through to conditions met.
+
+[Manage teacher training applications](<%= provider_interface_path %>) allows you to process applications from submission through to conditions met.
 
 ### Viewing applications
 
@@ -108,11 +109,11 @@ The ‘Manage users’ permission allows you to:
 
 #### ‘Manage users’ for training providers who are already part of our pilot
 
-We have automatically given the person in your organisation who signed the data-sharing agreement ‘Manage users’ permission. (If you’re not sure who signed the agreement, get in touch with us on <becomingateacher@digital.education.gov.uk>.)
+We have automatically given the person in your organisation who signed the data-sharing agreement ‘Manage users’ permission. (If you’re not sure who signed the agreement, get in touch with us on <%= bat_contact_mail_to %>.)
 
 #### ‘Manage users’ for training providers now being onboarded
 
-As part of your onboarding, we asked you to nominate team members to fill the ‘Manage users’ role. (Get in touch with us on <becomingateacher@digital.education.gov.uk> if you’ve yet to nominate a person for this role.)
+As part of your onboarding, we asked you to nominate team members to fill the ‘Manage users’ role. (Get in touch with us on <%= bat_contact_mail_to %> if you’ve yet to nominate a person for this role.)
 
 #### Resetting the ‘Manage users’ permission
 
@@ -144,9 +145,9 @@ We’ve set the following default permissions for accredited bodies:
 * all their users can make decisions on applications
 * none of their users can access sensitive candidate information
 
-Only training providers can change these settings - accredited bodies will not be able to do this themselves. You should agree permissions with your partners before changing their settings. 
+Only training providers can change these settings - accredited bodies will not be able to do this themselves. You should agree permissions with your partners before changing their settings.
 
-Once you assign a permission to an accredited body, they can customise it for their own users. For example, if they have decision-making power at an organisational level, they can switch this on and off for particular colleagues. 
+Once you assign a permission to an accredited body, they can customise it for their own users. For example, if they have decision-making power at an organisational level, they can switch this on and off for particular colleagues.
 
 ### Deferring an offer
 
@@ -154,9 +155,9 @@ You can defer an existing offer to the next cycle. Please bear in mind that you 
 
 Once you’ve agreed on a deferral with the candidate, you’ll need to confirm it in Manage. Search for the relevant application in your applications list, select the ‘Offer’ menu item and click ‘Defer offer’. The application will be marked as deferred and an email will be sent to the candidate confirming this.
 
-You’ll need to review and confirm your offer again at the start of the next cycle. You can also change the details of the offer at that stage - for example, if a location is no longer available. (You’ll be notified within Manage if any course details need to be changed). In addition, you can reset the conditions of the offer, for instance if another criminal record check needs to be carried out. 
+You’ll need to review and confirm your offer again at the start of the next cycle. You can also change the details of the offer at that stage - for example, if a location is no longer available. (You’ll be notified within Manage if any course details need to be changed). In addition, you can reset the conditions of the offer, for instance if another criminal record check needs to be carried out.
 
-Note that you can defer an offer at any point in the cycle, and with conditions in a state of either ‘pending’ or ‘met’. 
+Note that you can defer an offer at any point in the cycle, and with conditions in a state of either ‘pending’ or ‘met’.
 
 ### Email alerts
 
@@ -182,12 +183,12 @@ For now, interview scheduling is not part of the Manage service.
 
 ## <a name="deadlines-and-terms-of-use"></a>Deadlines and terms of use
 
-For clarity and fairness, while [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk/candidate) and UCAS Teacher Training run side by side (until October 2021), we’ve kept the rules governing applications closely aligned.
+For clarity and fairness, while [Apply for teacher training](<%= candidate_interface_path %>) and UCAS Teacher Training run side by side (until October 2021), we’ve kept the rules governing applications closely aligned.
 
 Candidates can:
 
- - submit a new application through either service until 7 September 2021
- - apply again through either service until 21 September 2021
+* submit a new application through either service until 7 September 2021
+* apply again through either service until 21 September 2021
 
 Applications will be automatically rejected on 4 October 2021 if you have not responded to them.
 
@@ -209,11 +210,11 @@ The candidate will receive a formal notification of the changed offer, but you s
 
 Once the candidate has accepted your offer, you cannot change the terms of the offer without their permission.
 
-### Confirming the conditions of an offer 
+### Confirming the conditions of an offer
 
 There is no deadline for confirming that a candidate has satisfied the conditions of an offer. You can update the status of the conditions in Manage whenever the candidate meets them.
 
-To do this, find the relevant application in your applications list, select the ‘Offer’ menu item, and click ‘Update status of conditions’. The application will be marked as ‘Conditions met’. 
+To do this, find the relevant application in your applications list, select the ‘Offer’ menu item, and click ‘Update status of conditions’. The application will be marked as ‘Conditions met’.
 
 ### Apply again (Apply 2)
 
@@ -226,7 +227,6 @@ We’ve made it easier for providers to give helpful feedback to candidates, and
 As currently, in this phase candidates can make an unlimited number of single, sequential applications, until they accept an offer, or the application cycle for the academic year closes. Providers still have 40 days to respond to each application.
 
 Candidates will also be able to use UCAS’s Apply 2 service for this part of their journey.
-
 
 ## <a name="troubleshooting"></a>Troubleshooting
 
@@ -257,13 +257,13 @@ We provide a clear route to UCAS for candidates who choose non-onboarded provide
 
 3. We suggest candidates use Apply for teacher training if all their chosen training providers are available through the service and they are interested in becoming an early adopter. We suggest candidates use UCAS Teacher Training if they’ve already started applying via UCAS, or some of their chosen training providers are not available through Apply for teacher training.
 
-4. Within [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk), if candidates select a non-onboarded provider as one of their additional course choices, they are directed back to UCAS to apply using that service.
+4. Within [Apply for teacher training](<%= candidate_interface_path %>), if candidates select a non-onboarded provider as one of their additional course choices, they are directed back to UCAS to apply using that service.
 
 ### Onboarding for providers with courses ratified by an accredited body
 
 If your courses are ratified by an accredited body, or you are part of a partnership of teacher training organisations, you will need to make sure your partners are ready to be onboarded to Manage.
 
-They may find our [introduction to the service](https://www.apply-for-teacher-training.service.gov.uk/provider) helpful. We’re available to answer any questions they may have on <becomingateacher@digital.education.gov.uk>.
+They may find our [introduction to the service](<%= provider_interface_path %>) helpful. We’re available to answer any questions they may have on <%= bat_contact_mail_to %>.
 
 ### Candidates who apply for your courses through UCAS
 
@@ -287,14 +287,15 @@ Our [marketing tool kit](https://docs.google.com/presentation/d/1dCZ5HF_mpJMAOpm
 ## <a name="help-support-and-feedback"></a>Help, support and feedback
 
 ### See a demo
-To request a remote demonstration of the service as a whole or a particular feature, email us on <becomingateacher@digital.education.gov.uk>.
+
+To request a remote demonstration of the service as a whole or a particular feature, email us on <%= bat_contact_mail_to %>.
 
 ### Report a problem
 
-To report a problem or get help, email us on <becomingateacher@digital.education.gov.uk>.
+To report a problem or get help, email us on <%= bat_contact_mail_to %>.
 
 ### Take part in user research and give feedback
 
 We welcome feedback on all aspects of Manage teacher training applications. When you participate in user research, you help shape current and future service features.
 
-Please [complete this 30-second form](https://docs.google.com/forms/d/1QgmaQzLsQ9dMcIgnTjr-7faAz7VpKuPXjHoF6hU22Po) and we’ll be in touch. Or, simply give us your feedback over email at <becomingateacher@digital.education.gov.uk>.
+Please [complete this 30-second form](https://docs.google.com/forms/d/1QgmaQzLsQ9dMcIgnTjr-7faAz7VpKuPXjHoF6hU22Po) and we’ll be in touch. Or, simply give us your feedback over email at <%= bat_contact_mail_to %>.

--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -6,7 +6,7 @@ Other things to know:
 
 - All information you give must be truthful and as accurate as possible.
 - Wherever you’re applying from, you must not use our website for illegal or fraudulent reasons.
-- You must not gather or use data from our website, or use data in a way that is not allowed by our [privacy policy](https://www.apply-for-teacher-training.service.gov.uk/candidate/privacy-policy).
+- You must not gather or use data from our website, or use data in a way that is not allowed by our [privacy policy](<%= candidate_interface_privacy_policy_path %>).
 - You must not use abusive language or behaviour towards anyone you come into contact with.
 
 ## Applying for teacher training courses
@@ -27,7 +27,7 @@ You can apply for another course at this stage if you do not get an offer or if 
 
 ### Making changes to your application
 
-Contact us at <becomingateacher@digital.education.gov.uk> if you need to make changes. We only have 5 working days to make changes for you.
+Contact us at <%= bat_contact_mail_to %> if you need to make changes. We only have 5 working days to make changes for you.
 
 Once we’ve processed your request, we will not be able to make any more changes.
 
@@ -41,7 +41,7 @@ If you have heard back from your training provider, for example if they have tur
 
 You can withdraw your application at any point, even after you have accepted an offer.
 
-[Sign in to your account](https://qa.apply-for-teacher-training.service.gov.uk/candidate/sign-in) and click ‘withdraw’ next to the course you want to withdraw.
+[Sign in to your account](<%= candidate_interface_sign_in_path %>) and click ‘withdraw’ next to the course you want to withdraw.
 
 ### Outcome of your application
 
@@ -59,7 +59,7 @@ Your name will also be checked against a DBS list of people who have been barred
 
 ## Questions or support
 
-If you need our help, email <becomingateacher@digital.education.gov.uk>.
+If you need our help, email <%= bat_contact_mail_to %>.
 
 We respond within 5 working days, or 1 working day for more urgent queries.
 
@@ -71,6 +71,6 @@ Our service is always evolving, and we will make changes from time to time. We w
 
 ## About your online account
 
-When you start your application, we’ll create an account for you automatically. Any information you give will be stored there. We’ll keep your data safe and only use it in line with our [privacy policy](https://www.apply-for-teacher-training.service.gov.uk/candidate/privacy-policy).
+When you start your application, we’ll create an account for you automatically. Any information you give will be stored there. We’ll keep your data safe and only use it in line with our [privacy policy](<%= candidate_interface_privacy_policy_path %>).
 
 You do not need a password for your account. Instead, each time you log in, we’ll email you a unique and secure link.


### PR DESCRIPTION
## Context

Now that we can use ERB in Markdown files (#3999), we should use path helpers to ensure links in these files reference the paths they relate to in the application’s routes.

## Changes proposed in this pull request

* Use `bat_contact_mail_to` helper in Markdown files
* Use path helpers in Markdown files
* Fix incorrect link to sign up form on QA 😱
* Use RedCarpet’s `with_toc_data` option to auto-generate heading ids

## Guidance to review

* ~~I’m using `candidate_interface_path` to link to Apply/candidate path (this route either points to GOV.UK start page or the application route depending on the environment). However, this appears to be rendering a link to the Find feedback page, oddly? Any idea why this might be @davidgisbey~~ Fixed in #4018
* ~~I was going to update the Markdown in API docs in a similar fashion, but looks like those pages use a different Markdown rendering method; should this be a globally available helper, used by the different interfaces @duncanjbrown?~~ Investigated this, and while it is possible to use the same helper with a little modification, doesn’t deliver much value as most of the links in the API docs wouldn’t benefit from using path helpers.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
