### PR TITLE
Remove the feedback prompts feature flag

### DIFF
--- a/app/components/candidate_interface/application_feedback_component.html.erb
+++ b/app/components/candidate_interface/application_feedback_component.html.erb
@@ -1,19 +1,17 @@
-<% if FeatureFlag.active?(:feedback_prompts) %>
-  <div class="govuk-width-container">
-    <div class="app-feedback">
-      <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-4">
-        <%= govuk_link_to(
-          t('application_feedback.feedback_link'),
-          candidate_interface_application_feedback_path(
-            path: path,
-            page_title: page_title,
-            original_controller: params[:controller],
-          ),
-          class: 'govuk-!-margin-top-4',
-          target: '_blank',
-          rel: 'noopener'
-        ) %>
-      </p>
-    </div>
+<div class="govuk-width-container">
+  <div class="app-feedback">
+    <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-4">
+      <%= govuk_link_to(
+        t('application_feedback.feedback_link'),
+        candidate_interface_application_feedback_path(
+          path: path,
+          page_title: page_title,
+          original_controller: params[:controller],
+        ),
+        class: 'govuk-!-margin-top-4',
+        target: '_blank',
+        rel: 'noopener'
+      ) %>
+    </p>
   </div>
-<% end %>
+</div>

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,7 +23,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:feedback_prompts, 'Candidates can give feedback while completing their application form', 'David Gisbey'],
     [:sync_from_public_teacher_training_api, 'Pull data from the public Teacher training API as well as the old "Find" API', 'Duncan Brown'],
     [:provider_activity_log, 'Show provider users a log of all application activity', 'Michael Nacos'],
     [:export_application_data, 'Providers can export a customised selection of application data', 'Ben Swannack'],

--- a/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
+++ b/spec/system/candidate_interface/feedback/candidate_provides_feedback_while_completing_their_application_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate provides feedback during the application process' do
 
   scenario 'Candidate gives feedback while completing their applications' do
     given_i_am_signed_in
-    and_the_feedback_prompts_flag_is_active
 
     when_i_visit_the_site
     and_i_click_on_the_references_section
@@ -21,10 +20,6 @@ RSpec.feature 'Candidate provides feedback during the application process' do
     @candidate = create(:candidate)
     login_as(@candidate)
     @application = @candidate.current_application
-  end
-
-  def and_the_feedback_prompts_flag_is_active
-    FeatureFlag.activate(:feedback_prompts)
   end
 
   def when_i_visit_the_site


### PR DESCRIPTION
## Context

This feature flag has been active for quite a while now so it can be removed.

## Changes proposed in this pull request

- Remove the feedback_prompts feature flag

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
