### PR TITLE
Dashboard: show stats about where candidates are applying

### DIFF
--- a/app/views/support_interface/performance/service_performance_dashboard.html.erb
+++ b/app/views/support_interface/performance/service_performance_dashboard.html.erb
@@ -78,7 +78,34 @@
   </div>
 </div>
 
-<h3 class="govuk-heading-m govuk-!-font-size-27">Application form breakdown</h3>
+<h2 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-font-size-27">Course choices</h2>
+
+<div class="govuk-!-margin-bottom-4">
+  <%= render SupportInterface::TileComponent.new(count: @statistics.total_application_choice_count, label: 'courses applied to', colour: :blue) %>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <%= render SupportInterface::TileComponent.new(count: @statistics.application_choices_by_provider_type['lead_school'], label: 'School Direct courses', size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: @statistics.application_choices_by_provider_type['scitt'], label: 'SCITT courses', size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: @statistics.application_choices_by_provider_type['university'], label: 'HEI courses', size: :reduced) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: @statistics.application_choices_by_provider_type['ratified_by_scitt'], label: 'Ratified by SCITTs', size: :reduced) %>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render SupportInterface::TileComponent.new(count: @statistics.application_choices_by_provider_type['ratified_by_university'], label: 'Ratified by HEIs', size: :reduced) %>
+  </div>
+</div>
+
+<h3 class="govuk-heading-m govuk-!-margin-top-8 govuk-!-font-size-27">Application form breakdown</h3>
 
 <h4 class="govuk-heading-s" id="unsubmitted">Unsubmitted applications</h4>
 <p class="govuk-body">


### PR DESCRIPTION
## Context

To help us keep in mind the volumes of applications coming through the various different types of provider, show the breakdown on the performance dashboard. Include a breakdown of School Direct courses ratified by HEIs (ie arriving via API) vs ratified by SCITTs (ie arriving via manage).

## Changes proposed in this pull request

Add a section:

<img width="1045" alt="Screenshot 2021-02-08 at 10 12 14" src="https://user-images.githubusercontent.com/642279/107205971-61495800-69f6-11eb-8663-b4985d5b0405.png">

## Guidance to review

Do the queries make sense? Is the markup ok?

## Link to Trello card

N/A — got curious when looking at the dashboard!