### PR TITLE
Use public IDs for qualifications in the API

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -147,7 +147,7 @@ class ApplicationQualification < ApplicationRecord
 private
 
   def set_public_id
-    if constituent_grades.present?
+    if constituent_grades.present? && subject != SCIENCE_TRIPLE_AWARD
       set_public_ids_for_constituent_grades
     elsif public_id.blank?
       self.public_id = next_available_public_id

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -58,7 +58,7 @@ class ApplicationQualification < ApplicationRecord
 
   audited associated_with: :application_form
 
-  after_save :set_public_id
+  before_save :set_public_id
 
   def missing_qualification?
     qualification_type == 'missing'
@@ -150,7 +150,7 @@ private
     if constituent_grades.present?
       set_public_ids_for_constituent_grades
     elsif public_id.blank?
-      update_column(:public_id, next_available_public_id)
+      self.public_id = next_available_public_id
     end
   end
 
@@ -161,7 +161,7 @@ private
       grade.merge({ public_id: next_available_public_id })
     end
 
-    update_column(:constituent_grades, grades_with_ids)
+    self.constituent_grades = grades_with_ids
   end
 
   def next_available_public_id

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -207,13 +207,13 @@ module VendorAPI
       constituent_grades = gcse[:constituent_grades]
       constituent_grades.reduce([]) do |array, (subject, hash)|
         array << qualification_to_hash(gcse)
-                     .merge(subject: subject.humanize, grade: hash['grade'])
+                     .merge(subject: subject.humanize, grade: hash['grade'], id: hash['public_id'])
       end
     end
 
     def qualification_to_hash(qualification)
       {
-        id: qualification.id,
+        id: qualification.public_id,
         qualification_type: qualification.qualification_type,
         non_uk_qualification_type: qualification.non_uk_qualification_type,
         subject: qualification.subject,

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe ApplicationQualification, type: :model do
     end
   end
 
-  describe '#after_save' do
+  describe '#before_save' do
     let(:constituent_grades_without_public_ids) { { english_language: { grade: 'A' }, english_literature: { grade: 'B' } } }
     let(:constituent_grades_with_public_ids) { { english_language: { grade: 'C', public_id: 10 }, english_literature: { grade: 'A', public_id: 11 } } }
 

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -228,6 +228,17 @@ RSpec.describe ApplicationQualification, type: :model do
         expect(qualification.public_id).not_to be_nil
       end
 
+      it 'a triple science qualification' do
+        qualification = create(
+          :application_qualification,
+          subject: ApplicationQualification::SCIENCE_TRIPLE_AWARD,
+          constituent_grades: { biology: { grade: 'A' }, chemistry: { grade: 'B' }, physics: { grade: 'A*' } },
+        )
+
+        expect(qualification.constituent_grades).not_to be_nil
+        expect(qualification.public_id).not_to be_nil
+      end
+
       it 'a qualification with constituent_grades' do
         qualification = create(:application_qualification, constituent_grades: constituent_grades_without_public_ids)
 

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -515,6 +515,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
       create(
         :gcse_qualification,
+        public_id: 4,
         grade: nil,
         subject: 'science triple award',
         constituent_grades: science_triple_awards,
@@ -527,16 +528,20 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :gcses,
       ).find { |q| q[:subject] == 'science triple award' }
 
+      expect(qualification[:id]).to eq 4
       expect(qualification[:grade]).to eq 'ABC'
     end
 
     it 'parses English GCSE structured grades' do
       create(
         :gcse_qualification,
-        id: 1,
         subject: 'english',
         grade: nil,
-        constituent_grades: { english_language: { grade: 'E' }, english_literature: { grade: 'E' }, "Cockney Rhyming Slang": { grade: 'A*' } },
+        constituent_grades: {
+          english_language: { grade: 'E', public_id: 1 },
+          english_literature: { grade: 'E', public_id: 2 },
+          "Cockney Rhyming Slang": { grade: 'A*', public_id: 3 },
+        },
         award_year: 2006,
         predicted_grade: false,
         application_form: application_choice.application_form,
@@ -557,7 +562,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :gcses,
       ).find { |q| q[:subject] == 'English literature' }
 
-      expect(english_literature[:id]).to eq 1
+      expect(english_literature[:id]).to eq 2
       expect(english_literature[:grade]).to eq 'E'
 
       rhyming_slang = presenter.as_json.dig(
@@ -566,7 +571,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         :gcses,
       ).find { |q| q[:subject] == 'Cockney rhyming slang' }
 
-      expect(rhyming_slang[:id]).to eq 1
+      expect(rhyming_slang[:id]).to eq 3
       expect(rhyming_slang[:grade]).to eq 'A*'
     end
   end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -435,6 +435,21 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     let(:application_choice) { create(:application_choice, :with_offer) }
     let(:presenter) { VendorAPI::SingleApplicationPresenter.new(application_choice) }
 
+    it 'uses the public_id of a qualification as the id' do
+      qualification = create(
+        :other_qualification,
+        application_form: application_choice.application_form,
+      )
+
+      qualification_hash = presenter.as_json.dig(
+        :attributes,
+        :qualifications,
+        :other_qualifications,
+      ).first
+
+      expect(qualification_hash[:id]).to eq qualification.public_id
+    end
+
     it 'contains HESA qualification fields' do
       create(
         :other_qualification,

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
         qualifications: {
           gcses: [
             {
-              id: @application.english_gcse.id,
+              id: @application.english_gcse.constituent_grades['english_single_award']['public_id'],
               qualification_type: 'gcse',
               non_uk_qualification_type: nil,
               subject: 'English single award',
@@ -90,7 +90,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
               hesa_degtype: nil,
             },
             {
-              id: @application.maths_gcse.id,
+              id: @application.maths_gcse.public_id,
               qualification_type: 'gcse',
               non_uk_qualification_type: nil,
               subject: 'maths',
@@ -111,7 +111,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
           ],
           degrees: [
             {
-              id: @application.qualification_in_subject(:degree, 'Doge').id,
+              id: @application.qualification_in_subject(:degree, 'Doge').public_id,
               qualification_type: 'BA',
               non_uk_qualification_type: nil,
               subject: 'Doge',
@@ -132,7 +132,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
           ],
           other_qualifications: [
             {
-              id: @application.qualification_in_subject(:other, 'Believing in the Heart of the Cards').id,
+              id: @application.qualification_in_subject(:other, 'Believing in the Heart of the Cards').public_id,
               qualification_type: 'A level',
               non_uk_qualification_type: nil,
               subject: 'Believing in the Heart of the Cards',


### PR DESCRIPTION
## Context
The final PR for this change!

Qualifications need a public id to display in the API. This cannot be the db id because some qualifications in the API share the same row in the db due to structured qualifications. 

## Changes proposed in this pull request
Set public ids for qualifications that are new, or being edited. 
Use public_id rather than id when showing qualifications on the API

## Guidance to review
Are there any edge cases I missed?

## Link to Trello card
https://trello.com/c/54vJ4u9D/3288-gcses-in-api-response-have-duplicate-ids-causing-sits-to-discard-them

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
