### PR TITLE
Fix candidate_interface_path URL helper

### DIFF
--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Use <%= govuk_link_to service_name, candidate_interface_root_path %> if the courses you want to do are listed on this page.</p>
+    <p class="govuk-body">Use <%= govuk_link_to service_name, candidate_interface_path %> if the courses you want to do are listed on this page.</p>
     <p class="govuk-body">Otherwise, apply through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %>.</p>
     <p class="govuk-body">Do not apply for the same courses on both services.<p>
     <p class="govuk-body">You can apply for up to 3 courses in total.<p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,9 +16,9 @@ Rails.application.routes.draw do
 
   namespace :candidate_interface, path: '/candidate' do
     if HostingEnvironment.production?
-      root to: redirect(GOVUK_APPLY_START_PAGE_URL)
+      get '/' => redirect(GOVUK_APPLY_START_PAGE_URL)
     else
-      root to: redirect('/')
+      get '/' => redirect('/')
     end
 
     get '/accessibility', to: 'content#accessibility'


### PR DESCRIPTION
## Context

`candidate_interface_path` points to `/candidate/find-feedback`, I think because it's the first `/` route without a named helper. 

## Changes proposed in this pull request

This commit makes sure that `candidate_interface_path` works similarly to `provider_interface_path` etc.

## Guidance to review

Ok?

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1612540901210600

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
