### PR TITLE
Exclude interviews from activity log for now

### DIFF
--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -29,18 +29,11 @@ class GetActivityLogEvents
     statuses_visible_to_providers = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER.map { |status| "'#{status}'" }.join(', ')
     filter += " OR audited_changes::json#>>'{status, 1}' IN (#{statuses_visible_to_providers})"
 
-    Audited::Audit
-      .includes(INCLUDES)
-      .where(auditable: application_choices)
-      .where(action: :update)
-      .where(filter)
-      .or(
-        Audited::Audit
-          .includes(INCLUDES)
-          .where(associated: application_choices)
-          .where(action: %i[create update]),
-      )
-      .where('created_at > ?', since)
-      .order(created_at: :desc)
+    Audited::Audit.includes(INCLUDES)
+                  .where(auditable: application_choices)
+                  .where(action: :update)
+                  .where(filter)
+                  .where('created_at > ?', since)
+                  .order(created_at: :desc)
   end
 end

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -186,6 +186,8 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
     let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
 
     it 'returns events associated with interviews' do
+      pending 'excluding interviews until query is faster'
+
       result = GetActivityLogEvents.call(application_choices: [application_choice])
 
       expect(result.first.auditable).to eq(application_choice.interviews.first)


### PR DESCRIPTION
## Context

Adding associated models (for interviews) seems to have killed the activity log events query, leading to statement timeouts. The original query takes about 100ms so this PR reverts changes to the activity log, which is fine because the interviews feature has not been launched yet.

## Changes proposed in this pull request

Revert activity log events query to previous version. Mark associated spec as pending.

## Guidance to review

Easy-peasy

## Link to Trello card

https://trello.com/c/B79CEysQ

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
