### PR TITLE
Require confirmation when flipping a feature flag (attempt 2)

### DIFF
--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -1,5 +1,6 @@
 require.context("govuk-frontend/govuk/assets");
 
+import Rails from '@rails/ujs';
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
 import initApiTokenProviderAutocomplete from "./autocompletes/api-token-autocomplete";
 import "../styles/application-support.scss";
@@ -7,7 +8,7 @@ import filter from "./components/paginated_filter";
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import initCountryAutocomplete from "./autocompletes/country-autocomplete";
 
-
+Rails.start();
 govUKFrontendInitAll();
 initApiTokenProviderAutocomplete();
 filter();

--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -29,11 +29,15 @@
   ) do %>
     <%= render SummaryCardHeaderComponent.new(title: feature_name.humanize, heading_level: 2) do %>
       <% if FeatureFlag.active?(feature_name) %>
-        <%= button_to support_interface_deactivate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' do %>
+        <%= button_to support_interface_deactivate_feature_flag_path(feature_name),
+               class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0',
+               data: { confirm: "Are you sure you want to deactivate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
           Deactivate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
         <% end %>
       <% else %>
-        <%= button_to support_interface_activate_feature_flag_path(feature_name), class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0' do %>
+        <%= button_to support_interface_activate_feature_flag_path(feature_name),
+               class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0',
+               data: { confirm: "Are you sure you want to activate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
           Activate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
         <% end %>
       <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,7 @@ module ApplyForPostgraduateTeacherTraining
     config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
     config.action_view.raise_on_missing_translations = true
+    config.action_view.form_with_generates_remote_forms = false
 
     config.active_job.queue_adapter = :sidekiq
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^0.2.1",
+    "@rails/ujs": "^6.1.1",
     "@rails/webpacker": "^5.2.1",
     "accessible-autocomplete": "^2.0.3",
     "govuk-frontend": "^3.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,6 +1269,11 @@
   dependencies:
     mkdirp "^1.0.4"
 
+"@rails/ujs@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.1.tgz#25c4e60018274b37e5ba0850134f6445429de2f5"
+  integrity sha512-uF6zEbXpGkNa7Vvxrd9Yqas8xsbc3lsC733V6I7fXgPuj8xXiuZakdE4uIyQSFRVmZKe12qmC6CNJNtIEvt4bA==
+
 "@rails/webpacker@^5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.2.1.tgz#87cdbd4af2090ae2d74bdc51f6f04717d907c5b3"


### PR DESCRIPTION
Second attempt at #4010 incorporating @cwrw's suggestion about setting `config.action_view.form_with_generates_remote_forms`

This is now the default in Rails:
https://github.com/rails/rails/pull/40708