### PR TITLE
Add region to the locations export

### DIFF
--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -13,6 +13,7 @@ module SupportInterface
           'Candidate’s postcode' => application_form.postcode,
           'Provider’s postcode' => application_choice.provider.postcode,
           'Site’s postcode' => application_choice.site.postcode,
+          'Site’s region' => application_choice.site.region,
           'Provider type' => application_choice.provider.provider_type,
           'Accrediting provider type' => application_choice.course.accredited_provider&.provider_type,
           'Program type' => application_choice.course.program_type,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -382,6 +382,7 @@ FactoryBot.define do
     address_line2 { Faker::Address.city }
     address_line3 { Faker::Address.county }
     address_line4 { '' }
+    region { 'north_west' }
     postcode { Faker::Address.postcode }
   end
 

--- a/spec/services/support_interface/locations_export_spec.rb
+++ b/spec/services/support_interface/locations_export_spec.rb
@@ -40,6 +40,7 @@ private
       'Candidate’s postcode' => application_form.postcode,
       'Provider’s postcode' => application_choice.provider.postcode,
       'Site’s postcode' => application_choice.site.postcode,
+      'Site’s region' => application_choice.site.region,
       'Provider type' => 'lead_school',
       'Accrediting provider type' => 'scitt',
       'Program type' => 'scitt_programme',


### PR DESCRIPTION
## Context

Sarah has asked if we can add a site's region to the locations export.

This attr will be populated once we merge in https://github.com/DFE-Digital/apply-for-teacher-training/pull/3922

## Changes proposed in this pull request

- Add a region column to the locations export

## Trello card 

https://trello.com/c/JOuDw1sf/2979-dev-update-locations-export-to-include-region-code

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
