### PR TITLE
Update API docs with field lengths summary

### DIFF
--- a/app/presenters/api_docs/api_reference.rb
+++ b/app/presenters/api_docs/api_reference.rb
@@ -25,5 +25,31 @@ module APIDocs
         APISchema.new(name: name, schema: schema)
       end
     end
+
+    def field_lengths_summary
+      rows = flatten_hash(VendorAPISpecification.as_hash)
+
+      rows.reduce([]) do |arr, (field, length)|
+        if field.include?('Length')
+          arr << [field.gsub('components.schemas.', ''), length]
+        else
+          arr
+        end
+      end
+    end
+
+  private
+
+    def flatten_hash(hash)
+      hash.each_with_object({}) do |(k, v), h|
+        if v.is_a? Hash
+          flatten_hash(v).map do |h_k, h_v|
+            h["#{k}.#{h_k}"] = h_v
+          end
+        else
+          h[k] = v
+        end
+      end
+    end
   end
 end

--- a/app/views/api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/reference/reference.html.erb
@@ -26,6 +26,9 @@
       <% end %>
     </ol>
   </li>
+  <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+    <%= govuk_link_to 'Field lengths summary', '#field-lengths', class: 'app-contents-list__link' %>
+  </li>
 </ol>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
@@ -34,6 +37,10 @@
 
 <p class="govuk-body">
   The OpenAPI spec from which this documentation is generated is <%= govuk_link_to 'available in YAML format', api_docs_spec_url %>.
+</p>
+
+<p class="govuk-body">
+  You can find a  <%= govuk_link_to 'summary of the field length limits', '#field-lengths' %> at the foot of this page.
 </p>
 
 <h3 class="govuk-heading-m">Environments</h3>
@@ -113,3 +120,22 @@
 <% @api_reference.schemas.each do |schema| %>
   <%= render 'schema', schema: schema %>
 <% end %>
+
+<h2 class="govuk-heading-l" id="field-lengths">Field lengths summary</h2>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Rule</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Limit</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @api_reference.field_lengths_summary.each do |(rule, limit)| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= rule %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%=  number_with_delimiter(limit) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/spec/system/api_docs/api_docs_spec.rb
+++ b/spec/system/api_docs/api_docs_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'API docs' do
 
     click_link 'API reference'
     expect(page).to have_content 'Developing on the API'
+    expect(page).to have_content 'Field lengths summary'
 
     click_link 'Release notes'
     expect(page).to have_content 'For a log of pre-release changes, see the alpha release notes'


### PR DESCRIPTION
## Context

Request from a provider for us to show the character limits on various fields

## Changes proposed in this pull request

Added a line to the api docs about the field lengths summary 

Before
![image](https://user-images.githubusercontent.com/25597009/107241123-97043600-6a22-11eb-9011-18a012076e1c.png)

After
![image](https://user-images.githubusercontent.com/25597009/107241196-a84d4280-6a22-11eb-8aa1-e8934bc4373b.png)

And added a table at the bottom of the docs page which shows the Fields and their corresponding limits, where applicable
![image](https://user-images.githubusercontent.com/25597009/107345742-cca92d80-6abb-11eb-90f6-e334da17b461.png)


## Guidance to review

Head to the /api-docs/reference page

## Link to Trello card

https://trello.com/c/5oTJXnEe/3328-update-api-docs-add-field-lengths-summary

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
