### PR TITLE
Link to ApplicationChoices from API log

### DIFF
--- a/app/components/support_interface/vendor_api_request_details_component.html.erb
+++ b/app/components/support_interface/vendor_api_request_details_component.html.erb
@@ -1,0 +1,1 @@
+<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/support_interface/vendor_api_request_details_component.rb
+++ b/app/components/support_interface/vendor_api_request_details_component.rb
@@ -1,5 +1,6 @@
 module SupportInterface
   class VendorAPIRequestDetailsComponent < ViewComponent::Base
+    include ViewHelper
     attr_reader :vendor_api_request
 
     def initialize(vendor_api_request)
@@ -9,18 +10,31 @@ module SupportInterface
     delegate :status_code, :request_method, :request_path, :provider, to: :vendor_api_request
 
     def rows
-      [
+      rows = [
         { key: 'Status', value: status_code },
         { key: 'Method', value: request_method },
         { key: 'Path', value: request_path },
         { key: 'Provider', value: provider_name },
       ]
+
+      if application_choice_id.present?
+        rows << {
+          key: 'Application details',
+          value: govuk_link_to('View in support', Rails.application.routes.url_helpers.support_interface_application_choice_path(application_choice_id)),
+        }
+      end
+
+      rows
     end
 
   private
 
     def provider_name
       provider.present? ? vendor_api_request.provider.name : 'Unknown'
+    end
+
+    def application_choice_id
+      request_path.match(/applications\/(\d+)/).to_a.last
     end
   end
 end

--- a/app/components/support_interface/vendor_api_request_details_component.rb
+++ b/app/components/support_interface/vendor_api_request_details_component.rb
@@ -1,0 +1,26 @@
+module SupportInterface
+  class VendorAPIRequestDetailsComponent < ViewComponent::Base
+    attr_reader :vendor_api_request
+
+    def initialize(vendor_api_request)
+      @vendor_api_request = vendor_api_request
+    end
+
+    delegate :status_code, :request_method, :request_path, :provider, to: :vendor_api_request
+
+    def rows
+      [
+        { key: 'Status', value: status_code },
+        { key: 'Method', value: request_method },
+        { key: 'Path', value: request_path },
+        { key: 'Provider', value: provider_name },
+      ]
+    end
+
+  private
+
+    def provider_name
+      provider.present? ? vendor_api_request.provider.name : 'Unknown'
+    end
+  end
+end

--- a/app/views/support_interface/vendor_api_requests/index.html.erb
+++ b/app/views/support_interface/vendor_api_requests/index.html.erb
@@ -15,12 +15,7 @@
             <%= vendor_api_request.created_at.to_s(:govuk_date_and_time) %>
           </td>
           <td class="govuk-table__cell govuk-!-padding-top-0">
-            <%= render SummaryListComponent.new(rows: [
-              { key: 'Status', value: vendor_api_request.status_code },
-              { key: 'Method', value: vendor_api_request.request_method },
-              { key: 'Path', value: vendor_api_request.request_path },
-              { key: 'Provider', value: vendor_api_request.provider.present? ? vendor_api_request.provider.name : 'Unknown' },
-            ]) %>
+            <%= render SupportInterface::VendorAPIRequestDetailsComponent.new(vendor_api_request) %>
             <details class="govuk-details app-details" data-module="govuk-details">
               <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">

--- a/spec/components/support_interface/vendor_api_request_details_component_spec.rb
+++ b/spec/components/support_interface/vendor_api_request_details_component_spec.rb
@@ -8,4 +8,22 @@ RSpec.describe SupportInterface::VendorAPIRequestDetailsComponent do
 
     expect(component.text).to include('Unknown')
   end
+
+  it 'includes a link to the application if the request identifies a single application' do
+    req = build(:vendor_api_request, request_path: '/api/v1/applications/11/offer')
+
+    component = render_inline(described_class.new(req))
+    link_to_application = component.at_css('a:contains("View in support")')
+
+    expect(link_to_application).to be_present
+    expect(link_to_application['href']).to match(%r{/support/application-choices/11})
+  end
+
+  it 'does not includes a link to the application if the request does not identify a single application' do
+    req = build(:vendor_api_request, request_path: '/api/v1/applications')
+
+    component = render_inline(described_class.new(req))
+
+    expect(component.at_css('a:contains("View in support")')).not_to be_present
+  end
 end

--- a/spec/components/support_interface/vendor_api_request_details_component_spec.rb
+++ b/spec/components/support_interface/vendor_api_request_details_component_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::VendorAPIRequestDetailsComponent do
+  it 'renders Unknown for an unknown provider' do
+    req = build(:vendor_api_request, provider: nil)
+
+    component = render_inline(described_class.new(req))
+
+    expect(component.text).to include('Unknown')
+  end
+end


### PR DESCRIPTION
## Context

It's a bit fiddly going back and forth between the API log and application choices

## Changes proposed in this pull request

Put in a link if the request pertains to a single ApplicationChoice

<img width="696" alt="Screenshot 2021-02-08 at 20 34 33" src="https://user-images.githubusercontent.com/642279/107278039-2de5e800-6a4d-11eb-9ef4-592082f86b27.png">