### PR TITLE
Implement interview schedule

### DIFF
--- a/app/components/provider_interface/interview_card_component.html.erb
+++ b/app/components/provider_interface/interview_card_component.html.erb
@@ -1,0 +1,30 @@
+<div class="app-interview-card">
+  <div class="app-interview-card__time">
+    <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">
+    <%= link_to provider_interface_application_choice_interviews_path(interview.application_choice), class: "govuk-link govuk-link--no-visited-state" do %>
+      <time datetime=<%= interview.date_and_time %>>
+        <%= time %>
+      </time>
+      <span class="govuk-visually-hidden">on <%= date %> with <%= candidate_name %></span>
+
+    <% end %>
+    </p>
+  </div>
+  <div class="app-interview-card__candidate">
+    <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">
+      <%= candidate_name %>
+    </p>
+    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1 govuk-!-margin-top-0">
+      <%= preferences %>
+    </p>
+  </div>
+
+  <div class="app-interview-card__course">
+    <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">
+      <%= application_choice.course.name %>
+    </p>
+    <p class="govuk-caption-m govuk-!-margin-top-0 govuk-!-margin-bottom-1">
+      <%= application_choice.course_option.site.name %>
+    </p>
+  </div>
+</div>

--- a/app/components/provider_interface/interview_card_component.rb
+++ b/app/components/provider_interface/interview_card_component.rb
@@ -1,0 +1,24 @@
+module ProviderInterface
+  class InterviewCardComponent < ViewComponent::Base
+    attr_reader :interview, :application_choice
+
+    def initialize(interview:)
+      @interview = interview
+      @application_choice = interview.application_choice
+    end
+
+    def candidate_name
+      application_choice.application_form.full_name
+    end
+
+    delegate :date, to: :interview
+
+    def time
+      interview.date_and_time.to_s(:govuk_time)
+    end
+
+    def preferences
+      'Has interview preferences' if application_choice.application_form.interview_preferences.present?
+    end
+  end
+end

--- a/app/controllers/provider_interface/interview_schedules_controller.rb
+++ b/app/controllers/provider_interface/interview_schedules_controller.rb
@@ -1,0 +1,15 @@
+module ProviderInterface
+  class InterviewSchedulesController < ProviderInterfaceController
+    def show
+      application_choices = GetApplicationChoicesForProviders.call(
+        providers: current_provider_user.providers,
+      )
+
+      @grouped_interviews = Interview.for_application_choices(application_choices)
+        .undiscarded
+        .includes([:provider, application_choice: [:course_option, application_form: [:candidate]]])
+        .where('date_and_time >= ?', Time.zone.now)
+        .order(:date_and_time).group_by(&:date)
+    end
+  end
+end

--- a/app/controllers/provider_interface/interview_schedules_controller.rb
+++ b/app/controllers/provider_interface/interview_schedules_controller.rb
@@ -1,19 +1,27 @@
 module ProviderInterface
   class InterviewSchedulesController < ProviderInterfaceController
+    before_action :interview_flag_enabled?
+
     def show
-      @grouped_interviews = Interview.for_application_choices(application_choices_for_user_providers)
+      @interviews = Interview.for_application_choices(application_choices_for_user_providers)
         .undiscarded
         .includes([:provider, application_choice: [:course_option, application_form: [:candidate]]])
         .where('date_and_time >= ?', Time.zone.now)
-        .order(:date_and_time).group_by(&:date)
+        .order(:date_and_time)
+        .page(params[:page] || 1).per(50)
+
+      @grouped_interviews = @interviews.group_by(&:date)
     end
 
     def past
-      @grouped_interviews = Interview.for_application_choices(application_choices_for_user_providers)
+      @interviews = Interview.for_application_choices(application_choices_for_user_providers)
         .undiscarded
         .includes([:provider, application_choice: [:course_option, application_form: [:candidate]]])
         .where('date_and_time < ?', Time.zone.now)
-        .order(date_and_time: :desc).group_by(&:date)
+        .order(date_and_time: :desc)
+        .page(params[:page] || 1).per(50)
+
+      @grouped_interviews = @interviews.group_by(&:date)
     end
 
   private
@@ -22,6 +30,13 @@ module ProviderInterface
       GetApplicationChoicesForProviders.call(
         providers: current_provider_user.providers,
       )
+    end
+
+    def interview_flag_enabled?
+      unless FeatureFlag.active?(:interviews)
+        fallback_path = provider_interface_application_choice_path(@application_choice)
+        redirect_back(fallback_location: fallback_path)
+      end
     end
   end
 end

--- a/app/controllers/provider_interface/interview_schedules_controller.rb
+++ b/app/controllers/provider_interface/interview_schedules_controller.rb
@@ -1,15 +1,27 @@
 module ProviderInterface
   class InterviewSchedulesController < ProviderInterfaceController
     def show
-      application_choices = GetApplicationChoicesForProviders.call(
-        providers: current_provider_user.providers,
-      )
-
-      @grouped_interviews = Interview.for_application_choices(application_choices)
+      @grouped_interviews = Interview.for_application_choices(application_choices_for_user_providers)
         .undiscarded
         .includes([:provider, application_choice: [:course_option, application_form: [:candidate]]])
         .where('date_and_time >= ?', Time.zone.now)
         .order(:date_and_time).group_by(&:date)
+    end
+
+    def past
+      @grouped_interviews = Interview.for_application_choices(application_choices_for_user_providers)
+        .undiscarded
+        .includes([:provider, application_choice: [:course_option, application_form: [:candidate]]])
+        .where('date_and_time < ?', Time.zone.now)
+        .order(date_and_time: :desc).group_by(&:date)
+    end
+
+  private
+
+    def application_choices_for_user_providers
+      GetApplicationChoicesForProviders.call(
+        providers: current_provider_user.providers,
+      )
     end
   end
 end

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class InterviewsController < ProviderInterfaceController
     before_action :set_application_choice
     before_action :interview_flag_enabled?
-    before_action :requires_make_decisions_permission
+    before_action :requires_make_decisions_permission, except: %i[index]
 
     def index
       @provider_can_respond = current_provider_user.authorisation.can_make_decisions?(

--- a/app/frontend/styles/provider/_all.scss
+++ b/app/frontend/styles/provider/_all.scss
@@ -13,3 +13,4 @@
 @import "_offer";
 @import "_rejection";
 @import "_timeline";
+@import "_interview_card";

--- a/app/frontend/styles/provider/_interview_card.scss
+++ b/app/frontend/styles/provider/_interview_card.scss
@@ -1,0 +1,36 @@
+/* ==========================================================================
+   # INTERVIEW CARDS
+   ========================================================================== */
+
+.app-interviews {
+  margin-bottom: govuk-spacing(4);
+
+  .app-interview-card {
+    padding-bottom: govuk-spacing(2);
+    padding-top: govuk-spacing(2);
+    border-bottom: 1px solid govuk-colour('mid-grey');
+
+    display: flex;
+  }
+
+  h2 + .app-interview-card {
+    border-top: 1px solid govuk-colour('mid-grey');
+  }
+
+  .app-interview-card__time {
+    box-sizing: border-box;
+    padding-right: govuk-spacing(2);
+    width: 15%;
+  }
+
+  .app-interview-card__candidate {
+    box-sizing: border-box;
+    padding-right: govuk-spacing(2);
+    width: 40%;
+  }
+
+  .app-interview-card__course {
+    width: 45%;
+    box-sizing: border-box;
+  }
+}

--- a/app/helpers/navigation_items.rb
+++ b/app/helpers/navigation_items.rb
@@ -52,6 +52,9 @@ class NavigationItems
 
       if current_provider_user && !performing_setup
         items << NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decisions offer_changes notes interviews feedback conditions reconfirm_deferred_offers]))
+        if FeatureFlag.active?(:interviews)
+          items << NavigationItem.new('Interview schedule', provider_interface_interview_schedule_path, is_active(current_controller, %w[interview_schedules]))
+        end
 
         if FeatureFlag.active?(:provider_activity_log)
           items << NavigationItem.new('Activity log', provider_interface_activity_log_path, is_active(current_controller, %w[activity_log]))

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -12,4 +12,10 @@ class Interview < ApplicationRecord
   validates :application_choice, :provider, :date_and_time, presence: true
 
   delegate :offered_course, to: :application_choice
+
+  scope :for_application_choices, ->(application_choices) { joins(:application_choice).merge(application_choices).kept }
+
+  def date
+    date_and_time.to_s(:govuk_date)
+  end
 end

--- a/app/views/provider_interface/interview_schedules/past.html.erb
+++ b/app/views/provider_interface/interview_schedules/past.html.erb
@@ -21,6 +21,7 @@
           <% end %>
         <% end %>
       </div>
+      <%= render(PaginatorComponent.new(scope: @interviews)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/interview_schedules/past.html.erb
+++ b/app/views/provider_interface/interview_schedules/past.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Interview schedule - Upcoming interviews' %>
+<% content_for :browser_title, 'Interview schedule - Past interviews' %>
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-third">
@@ -14,7 +14,7 @@
       <div class="app-interviews">
         <% @grouped_interviews.each do |date, interviews| %>
           <h2 class="govuk-heading-s govuk-!-margin-top-7 govuk-!-margin-bottom-3">
-            <%= Date.parse(date).today? ? "Today (#{date})" : date %>
+            <%= date %>
           </h2>
           <% interviews.each do |interview| %>
             <%= render ProviderInterface::InterviewCardComponent.new(interview: interview) %>

--- a/app/views/provider_interface/interview_schedules/show.html.erb
+++ b/app/views/provider_interface/interview_schedules/show.html.erb
@@ -21,6 +21,7 @@
           <% end %>
         <% end %>
       </div>
+      <%= render(PaginatorComponent.new(scope: @interviews)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/interview_schedules/show.html.erb
+++ b/app/views/provider_interface/interview_schedules/show.html.erb
@@ -1,0 +1,20 @@
+<% content_for :browser_title, 'Interview Schedule' %>
+
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-two-third">
+    <h1 class="govuk-heading-l">Interview schedule</h1>
+
+    <% if @grouped_interviews.any? %>
+      <div class="app-interviews">
+        <% @grouped_interviews.each do |date, interviews| %>
+          <h2 class="govuk-heading-s govuk-!-margin-top-7 govuk-!-margin-bottom-3">
+            <%= Date.parse(date).today? ? "Today (#{date})" : date %>
+          </h2>
+          <% interviews.each do |interview| %>
+            <%= render ProviderInterface::InterviewCardComponent.new(interview: interview) %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -662,7 +662,9 @@ Rails.application.routes.draw do
       end
     end
 
-    resource :interview_schedule, path: 'interview-schedule', only: :show
+    resource :interview_schedule, path: 'interview-schedule', only: :show do
+      get :past, on: :collection
+    end
 
     post '/candidates/:candidate_id/impersonate' => 'candidates#impersonate', as: :impersonate_candidate
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -662,6 +662,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resource :interview_schedule, path: 'interview-schedule', only: :show
+
     post '/candidates/:candidate_id/impersonate' => 'candidates#impersonate', as: :impersonate_candidate
 
     get '/sign-in' => 'sessions#new'

--- a/spec/components/provider_interface/interview_card_component_spec.rb
+++ b/spec/components/provider_interface/interview_card_component_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::InterviewCardComponent do
+  let(:application_choice) { build_stubbed(:application_choice, application_form: application_form, course_option: course_option) }
+  let(:course_option) { create(:course_option, course: build(:course)) }
+  let(:application_form) do
+    build_stubbed(:application_form,
+                  interview_preferences: 'Only available Tuesdays and Thursdays',
+                  first_name: 'Kara',
+                  last_name: 'Thrace')
+  end
+  let(:interview) { build_stubbed(:interview, application_choice: application_choice) }
+  let(:render) { render_inline(described_class.new(interview: interview)) }
+
+  it 'renders the candidate name' do
+    expect(render.css('.app-interview-card__candidate').text).to include('Kara Thrace')
+  end
+
+  it 'renders the application course' do
+    expect(render.css('.app-interview-card__course').text).to include(course_option.course.name)
+  end
+
+  it 'renders the interview time' do
+    expect(render.css('.app-interview-card__time').text).to include(interview.date_and_time.to_s(:govuk_time))
+  end
+
+  it 'renders text indicating there are interview preferences if any' do
+    expect(render.css('.app-interview-card__candidate').text).to include('Has interview preferences')
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -769,8 +769,12 @@ FactoryBot.define do
       end
     end
 
-    trait :randomise_date_and_time do
-      date_and_time { (1...10).to_a.sample.business_days.from_now + (0..8).to_a.sample.business_hours.from_now }
+    trait :future_date_and_time do
+      date_and_time { (1...10).to_a.sample.business_days.from_now + (0..8).to_a.sample.hours }
+    end
+
+    trait :past_date_and_time do
+      date_and_time { (2...10).to_a.sample.business_days.ago - (0..8).to_a.sample.hours }
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -768,6 +768,10 @@ FactoryBot.define do
         interview.provider = interview.application_choice.offered_course.provider
       end
     end
+
+    trait :randomise_date_and_time do
+      date_and_time { (1...10).to_a.sample.business_days.from_now + (0..8).to_a.sample.business_hours.from_now }
+    end
   end
 
   factory :vendor_api_user, class: 'VendorApiUser' do
@@ -939,6 +943,14 @@ FactoryBot.define do
     trait :with_provider do
       after(:create) do |user, _evaluator|
         create(:provider).provider_users << user
+      end
+    end
+
+    trait :with_dfe_sign_in do
+      dfe_sign_in_uid { 'DFE_SIGN_IN_UID' }
+
+      after(:create) do |user, _evaluator|
+        create(:provider, :with_signed_agreement).provider_users << user
       end
     end
 

--- a/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
+++ b/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'A Provider user' do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { create(:application_form) }
+  let(:course) { create(:course, :open_on_apply, provider: provider) }
+  let(:course_options) { create_list(:course_option, 4, course: course) }
+
+  before do
+    FeatureFlag.activate(:interviews)
+  end
+
+  scenario 'can view all interviews scheduled for their provider' do
+    given_i_am_a_provider_user
+    and_i_sign_in_to_the_provider_interface
+
+    given_there_are_organised_interviews
+    when_i_visit_the_provider_interface
+
+    and_i_click_interview_schedule
+    then_i_see_those_interviews
+    and_i_can_verify_that_the_correct_information_is_presented
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def given_there_are_organised_interviews
+    application_choices = course_options.map do |course_option|
+      create(:application_choice,
+             :awaiting_provider_decision,
+             course_option: course_option,
+             application_form: application_form)
+    end
+    @interviews = application_choices[0...3].map do |application_choice|
+      create(:interview,
+             :randomise_date_and_time,
+             application_choice: application_choice)
+    end
+    @application_choice = application_choices[3]
+    @interviews << create(:interview, application_choice: @application_choice, date_and_time: 2.hours.from_now)
+  end
+
+  def and_i_click_interview_schedule
+    click_on 'Interview schedule'
+  end
+
+  def then_i_see_those_interviews
+    within '.app-interviews' do
+      expect(page.assert_selector('.app-interview-card', count: @interviews.count)).to eq(true)
+    end
+  end
+
+  def and_i_can_verify_that_the_correct_information_is_presented
+    expect(page).to have_content("Today (#{@interviews.last.date_and_time.to_s(:govuk_date)})")
+    within(:xpath, "////div[@class='app-interview-card'][1]") do
+      expect(page).to have_content(@application_choice.course.name)
+      expect(page).to have_content(@application_choice.course_option.site.name)
+    end
+
+    page.first(:css, '.app-interview-card__time:first a', text: @interviews.last.date_and_time.to_s(:govuk_time)).click
+    expect(page).to have_content(@interviews.last.date_and_time.to_s(:govuk_date_and_time))
+  end
+end


### PR DESCRIPTION
## Context

Implement provider interview schedule

## Guidance to review

- Activate `interviews` feature flag 
- Create interviews for provider (add interviews that take place in the next couple of minutes to test past interviews)
- Access feature through provider view 'Interviews schedule'
 
## Link to Trello card

https://trello.com/c/SSpYIqsG/3215-implement-interview-list-view

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
