### PR TITLE
Moved respond_by_date out of ViewHelper and into ApplicationCompleteContentComponent

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -32,6 +32,11 @@ module CandidateInterface
       application_form.application_choices.size
     end
 
+    def respond_by_date
+      dates = ApplicationDates.new(@application_form)
+      dates.reject_by_default_at.to_s(:govuk_date).strip if dates.reject_by_default_at
+    end
+
   private
 
     attr_reader :application_form

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -54,11 +54,6 @@ module ViewHelper
     dates.submitted_at.to_s(:govuk_date).strip
   end
 
-  def respond_by_date
-    dates = ApplicationDates.new(@application_form)
-    dates.reject_by_default_at.to_s(:govuk_date).strip if dates.reject_by_default_at
-  end
-
   def title_with_error_prefix(title, error)
     "#{t('page_titles.error_prefix') if error}#{title}"
   end

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
   end
 
-  before do
-    view_helper = instance_double(ViewHelper)
-    allow(view_helper).to receive(:respond_by_date).and_return('1 January 2020')
-  end
-
   context 'when the application is waiting for a decision from providers' do
     it 'renders the respond date for providers' do
       stub_application_dates_with_form

--- a/spec/components/dfe_sign_in_button_component_spec.rb
+++ b/spec/components/dfe_sign_in_button_component_spec.rb
@@ -2,11 +2,6 @@ require 'rails_helper'
 
 # rubocop:disable RSpec/FilePath
 RSpec.describe DfESignInButtonComponent do
-  before do
-    view_helper = instance_double(ViewHelper)
-    allow(view_helper).to receive(:respond_by_date).and_return('1 January 2020')
-  end
-
   context 'when bypass is set' do
     it 'renders with button with link to the development route' do
       render_result = render_inline(described_class.new(bypass: true))

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -104,12 +104,6 @@ RSpec.describe ViewHelper, type: :helper do
         expect(helper.submitted_at_date).to include('22 October 2019')
       end
     end
-
-    describe '#respond_by_date' do
-      it 'renders with correct respond by date' do
-        expect(helper.respond_by_date).to include('17 December 2019')
-      end
-    end
   end
 
   describe '#format_months_to_years_and_months' do


### PR DESCRIPTION
## Context

The `respond_by_date` method in the `ViewHelper` module is only used by `ApplicationCompleteContentComponent`. It can be moved there.

## Changes proposed in this pull request

- `respond_by_date` has been moved out of `view_helper.rb` and into `application_complete_content_component.rb`

## Guidance to review

Two points I'd like to confirm:

The method also appeared in `dfe_sign_in_button_component_spec.rb`:

>   before do
    view_helper = instance_double(ViewHelper)
    allow(view_helper).to receive(:respond_by_date).and_return('1 January 2020')
  end

I've removed it as I couldn't see where it was being used in the actual tests (all still passing) - have I missed something here?

I've also not updated the specs, as a lot of the tests are checking the respond by value with the following line, or similar:
`expect(render_result.text).to include(t('application_complete.dashboard.providers_respond_by', date: '1 January 2020'))` - is this ok?

## Link to Trello card

https://trello.com/c/ZdH1Qp4Y/2984-dev-move-respondbydate-into-applicationcompletecontentcomponent

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
