### PR TITLE
Dup the middleware object for thread safety

### DIFF
--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -18,6 +18,10 @@ class VendorAPIRequestMiddleware
   end
 
   def call(env)
+    dup._call(env)
+  end
+
+  def _call(env)
     @request = Rack::Request.new(env)
     status, @headers, @response = @app.call(env)
 


### PR DESCRIPTION
## Context

We suspect that the instance variables in the `call` method are not thread safe and this is leading to unexpected log entries. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Calls `dup` on the middleware object so that instance variables within the `call` method are thread-safe.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

See https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L929 for an example of how Sinatra does this.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/LBHHTB9x/3248-single-api-request-to-qa-produces-two-three-vendorapirequest-entries
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
