### PR TITLE
Handle empty POST data in Vendor API request log

### DIFF
--- a/app/middlewares/vendor_api_request_middleware.rb
+++ b/app/middlewares/vendor_api_request_middleware.rb
@@ -11,6 +11,7 @@ class VendorAPIRequestMiddleware
     HTTP_AUTHORIZATION
     HTTP_CONNECTION
     HTTP_CACHE_CONTROL
+    QUERY_STRING
   ].freeze
 
   def initialize(app)

--- a/app/workers/vendor_api_request_worker.rb
+++ b/app/workers/vendor_api_request_worker.rb
@@ -52,6 +52,8 @@ private
 
   def request_body(request_data)
     if request_data['method'] == 'POST'
+      return if request_data['body'].blank?
+
       JSON.parse(request_data['body'])
     else
       request_data['params']

--- a/spec/workers/vendor_api_request_worker_spec.rb
+++ b/spec/workers/vendor_api_request_worker_spec.rb
@@ -69,4 +69,14 @@ RSpec.describe VendorAPIRequestWorker do
 
     expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to eq('error' => 'request data did not contain valid JSON')
   end
+
+  it 'handles empty POST data' do
+    described_class.new.perform({
+      'body' => '',
+      'path' => '/api/v1/bar',
+      'method' => 'POST',
+    }, {}.to_json, 500, Time.zone.now)
+
+    expect(VendorAPIRequest.find_by(request_path: '/api/v1/bar').request_body).to be_nil
+  end
 end


### PR DESCRIPTION
## Context

Some POST requests to the API do not require data, so there's no need to parse as JSON, currently this shows an error that the requests data was not valid JSON.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Handle empty request data for POST requests. 

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/EtKnhZQM/3352-support-vendor-api-requests-screen-post-requests-with-no-request-body-display-incorrect-data
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
