### PR TITLE
Link to Get Into Teaching from footer and sidebar

### DIFF
--- a/app/views/candidate_interface/shared/_support.html.erb
+++ b/app/views/candidate_interface/shared/_support.html.erb
@@ -1,7 +1,16 @@
 <aside class="app-related" role="complementary">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="support-title"><%= t('layout.support.title') %></h2>
+
+  <h3 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-1"><%= t('layout.support.telephone') %></h3>
   <ul class="govuk-list govuk-!-font-size-16">
-    <li>Email: <%= bat_contact_mail_to(html_options: { subject: "Query about application #{support_reference}" }) %></li>
-    <li><%= t('layout.support.response_time') %></li>
+    <li><%= t('get_into_teaching.tel') %></li>
+    <li><%= t('get_into_teaching.opening_times') %></li>
+    <li>Free of charge</li>
+  </ul>
+
+  <h3 class="govuk-heading-s govuk-!-font-size-16 govuk-!-margin-bottom-1"><%= t('layout.support.online_chat') %></h3>
+  <ul class="govuk-list govuk-!-font-size-16">
+    <li><%= govuk_link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat') %></li>
+    <li><%= t('get_into_teaching.opening_times') %></li>
   </ul>
 </aside>

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -1,8 +1,21 @@
 <h2 class="govuk-heading-m"><%= t('layout.support.title') %></h2>
-<ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-  <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
-  <li><%= t('layout.support.response_time') %></li>
-</ul>
+<div class="govuk-grid-row govuk-!-margin-bottom-5">
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t('layout.support.telephone') %></h2>
+    <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
+      <li><%= t('get_into_teaching.tel') %></li>
+      <li><%= t('get_into_teaching.opening_times') %></li>
+      <li>Free of charge</li>
+    </ul>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t('layout.support.online_chat') %></h2>
+    <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
+      <li><%= link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat'), class: "govuk-footer__link" %></li>
+      <li><%= t('get_into_teaching.opening_times') %></li>
+    </ul>
+  </div>
+</div>
 <h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
 <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
   <li class="govuk-footer__inline-list-item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,6 +219,9 @@ en:
   layout:
     support:
       title: Get support
+      telephone: Telephone
+      online_chat: Online chat
+      talk_to_advisor: Talk to an adviser online
       response_time: We respond within 5 working days, or one working day for more urgent queries
       provider_service_guidance: How to use Manage teacher training applications
     support_links:


### PR DESCRIPTION
## Context

~~**NOTE:** Dependent on #3995~~

We are now pointing candidates to Get Into Teaching as the first point of contact for support.

## Changes proposed in this pull request

Uses the same footer as that shown on Find, and uses this same content in the sidebar.

| Before | After |
| - | - |
| ![footer-before](https://user-images.githubusercontent.com/813383/107364748-c58e1980-6ad3-11eb-92f8-2672aabab3f3.png) | ![footer-after](https://user-images.githubusercontent.com/813383/107364763-ca52cd80-6ad3-11eb-994b-8ac26be0f0ed.png) |
| ![sidebar-before](https://user-images.githubusercontent.com/813383/107364787-cf178180-6ad3-11eb-9251-6c6fa6f65d6a.png) | ![sidebar-after](https://user-images.githubusercontent.com/813383/107364807-d50d6280-6ad3-11eb-8f06-36afcc26032a.png) |

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/ycLBGKQA/2971-use-find-footer-on-apply

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
