### PR TITLE
Update the application review page to show the new work history design

### DIFF
--- a/app/components/candidate_interface/restructured_work_history/job_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/job_component.html.erb
@@ -9,7 +9,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= formatted_start_date %> to <%= formatted_end_date %>
+      <%= formatted_start_date %> <%= formatted_end_date %>
     </p>
 
     <% if @work_experience.relevant_skills %>

--- a/app/components/candidate_interface/restructured_work_history/job_component.rb
+++ b/app/components/candidate_interface/restructured_work_history/job_component.rb
@@ -21,12 +21,14 @@ module CandidateInterface
       end
 
       def formatted_end_date
-        return 'Present' if @work_experience.currently_working
-
-        if @work_experience.end_date_unknown
-          "#{@work_experience.end_date.to_s(:short_month_and_year)} (estimate)"
+        if @work_experience.currently_working
+          'to Present'
+        elsif @work_experience.start_date == @work_experience.end_date
+          nil
+        elsif @work_experience.end_date_unknown
+          "to #{@work_experience.end_date.to_s(:short_month_and_year)} (estimate)"
         else
-          @work_experience.end_date.to_s(:short_month_and_year)
+          "to #{@work_experience.end_date.to_s(:short_month_and_year)}"
         end
       end
     end

--- a/app/components/candidate_interface/restructured_work_history/review_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/review_component.html.erb
@@ -1,28 +1,38 @@
-<section>
-  <% @work_history_with_breaks.each do |entry| %>
-    <% if entry.is_a?(ApplicationWorkExperience) %>
+<% if show_missing_banner? %>
+  <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :work_experience, section_path: CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path, error: @missing_error)) %>
+<% else %>
 
-      <%= render(CandidateInterface::RestructuredWorkHistory::JobComponent.new(work_experience: entry, editable: @editable)) %>
+  <section class="app-summary-card govuk-!-margin-bottom-6">
+    <div class="app-summary-card__body">
+      <section>
+        <% @work_history_with_breaks.each do |entry| %>
+          <% if entry.is_a?(ApplicationWorkExperience) %>
 
-    <% elsif @editable && entry.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) %>
+            <%= render(CandidateInterface::RestructuredWorkHistory::JobComponent.new(work_experience: entry, editable: @editable)) %>
 
-      <%= render(CandidateInterface::RestructuredWorkHistory::GapComponent.new(break_period: entry)) %>
+          <% elsif @editable && entry.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) %>
 
-    <% elsif entry.is_a?(ApplicationWorkHistoryBreak) %>
+            <%= render(CandidateInterface::RestructuredWorkHistory::GapComponent.new(break_period: entry)) %>
 
-      <%= render(CandidateInterface::RestructuredWorkHistory::WorkBreakComponent.new(work_break: entry, editable: @editable)) %>
+          <% elsif entry.is_a?(ApplicationWorkHistoryBreak) %>
 
-    <% end %>
+            <%= render(CandidateInterface::RestructuredWorkHistory::WorkBreakComponent.new(work_break: entry, editable: @editable)) %>
 
-    <% if @work_history_with_breaks.last != entry %>
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m ">
-    <% end %>
+          <% end %>
 
-  <% end %>
-</section>
+          <% if @work_history_with_breaks.last != entry %>
+            <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m ">
+          <% end %>
 
-<% if !show_missing_banner? && @application_form.application_work_experiences.empty? && @application_form.application_work_history_breaks.empty? %>
-  <div class="app-summary-card__body govuk-!-padding-0">
-    <%= render SummaryListComponent.new(rows: no_work_experience_rows) %>
-  </div>
+        <% end %>
+      </section>
+
+      <% if !show_missing_banner? && @application_form.application_work_experiences.empty? && @application_form.application_work_history_breaks.empty? %>
+        <div class="app-summary-card__body govuk-!-padding-0">
+          <%= render SummaryListComponent.new(rows: no_work_experience_rows) %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
 <% end %>

--- a/app/components/candidate_interface/restructured_work_history/review_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/review_component.html.erb
@@ -10,7 +10,7 @@
 
             <%= render(CandidateInterface::RestructuredWorkHistory::JobComponent.new(work_experience: entry, editable: @editable)) %>
 
-          <% elsif @editable && entry.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) %>
+          <% elsif @editable && entry.is_a?(RestructuredWorkHistoryWithBreaks::BreakPlaceholder) %>
 
             <%= render(CandidateInterface::RestructuredWorkHistory::GapComponent.new(break_period: entry)) %>
 

--- a/app/components/candidate_interface/restructured_work_history/review_component.rb
+++ b/app/components/candidate_interface/restructured_work_history/review_component.rb
@@ -9,7 +9,7 @@ module CandidateInterface
         @heading_level = heading_level
         @show_incomplete = show_incomplete
         @missing_error = missing_error
-        @work_history_with_breaks = WorkHistoryWithBreaks.new(@application_form).timeline
+        @work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(@application_form).timeline
       end
 
       def show_missing_banner?

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -5,9 +5,32 @@ module CandidateInterface
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @application_form = current_application
 
-      redirect_to candidate_interface_application_form_path
+      if section_marked_as_complete? && unexplained_gaps?
+        flash[:warning] = 'You cannot mark this section complete with unexplained work breaks.'
+
+        render :show
+      else
+        current_application.update!(application_form_params)
+
+        redirect_to candidate_interface_application_form_path
+      end
+    end
+
+  private
+
+    def unexplained_gaps?
+      breaks = WorkHistoryWithBreaks.new(current_application).timeline
+      breaks.any? { |entry| entry.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) }
+    end
+
+    def application_form_params
+      strip_whitespace params.require(:application_form).permit(:work_history_completed)
+    end
+
+    def section_marked_as_complete?
+      application_form_params[:work_history_completed] == 'true'
     end
   end
 end

--- a/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/review_controller.rb
@@ -5,32 +5,15 @@ module CandidateInterface
     end
 
     def complete
-      @application_form = current_application
+      current_application.update!(application_form_params)
 
-      if section_marked_as_complete? && unexplained_gaps?
-        flash[:warning] = 'You cannot mark this section complete with unexplained work breaks.'
-
-        render :show
-      else
-        current_application.update!(application_form_params)
-
-        redirect_to candidate_interface_application_form_path
-      end
+      redirect_to candidate_interface_application_form_path
     end
 
   private
 
-    def unexplained_gaps?
-      breaks = WorkHistoryWithBreaks.new(current_application).timeline
-      breaks.any? { |entry| entry.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) }
-    end
-
     def application_form_params
       strip_whitespace params.require(:application_form).permit(:work_history_completed)
-    end
-
-    def section_marked_as_complete?
-      application_form_params[:work_history_completed] == 'true'
     end
   end
 end

--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -62,7 +62,7 @@ module CandidateInterface
           organisation: organisation,
           commitment: commitment,
           start_date: start_date,
-          end_date: end_date,
+          end_date: not_currently_employed_in_this_role? ? end_date : nil,
           start_date_unknown: ActiveModel::Type::Boolean.new.cast(start_date_unknown),
           end_date_unknown: ActiveModel::Type::Boolean.new.cast(end_date_unknown),
           currently_working: ActiveModel::Type::Boolean.new.cast(currently_working),

--- a/app/services/restructured_work_history_with_breaks.rb
+++ b/app/services/restructured_work_history_with_breaks.rb
@@ -1,0 +1,92 @@
+class RestructuredWorkHistoryWithBreaks
+  class BreakPlaceholder
+    def initialize(month_range:)
+      @month_range = month_range
+    end
+
+    def start_date
+      @month_range.first.prev_month
+    end
+
+    def end_date
+      @month_range.last.next_month
+    end
+
+    def length
+      @month_range.count
+    end
+  end
+
+  def initialize(application_form)
+    @application_form = application_form
+    @work_history = application_form.application_work_experiences.sort_by(&:start_date)
+    @existing_breaks = application_form.application_work_history_breaks.sort_by(&:start_date)
+    @current_job = nil
+  end
+
+  def timeline
+    work_history_with_breaks = []
+
+    @work_history.each { |job| work_history_with_breaks << job }
+    @existing_breaks.each { |existing_break| work_history_with_breaks << existing_break }
+
+    if @work_history.any?
+      timeline_in_months = month_range(
+        start_date: work_history_with_breaks.first.start_date,
+        end_date: submitted_at - 1.month,
+      )
+      break_months_in_timeline = remove_months(timeline: timeline_in_months, entries: @work_history)
+      remaining_months = remove_months(timeline: break_months_in_timeline, entries: @existing_breaks)
+      break_placeholders = break_placeholder_entries(remaining_months)
+      work_history_with_breaks += break_placeholders if break_placeholders.any?
+    end
+
+    work_history_with_breaks.sort_by(&:start_date)
+  end
+
+private
+
+  def submitted_at
+    @application_form.submitted_at || Time.zone.now
+  end
+
+  def month_range(start_date:, end_date:)
+    (start_date.to_date..end_date.to_date).map(&:beginning_of_month).uniq
+  end
+
+  def remove_months(timeline:, entries:)
+    remaining_months_in_timeline = timeline
+
+    entries.each do |entry|
+      if entries.last == entry && entry.is_a?(ApplicationWorkExperience) && entry.end_date.nil?
+        entry_end_date = Time.zone.now
+      else
+        entry_end_date = entry.end_date.nil? ? submitted_at : entry.end_date
+      end
+
+      months_in_entry_period = month_range(start_date: entry.start_date, end_date: entry_end_date)
+
+      remaining_months_in_timeline -= months_in_entry_period
+    end
+
+    remaining_months_in_timeline
+  end
+
+  def break_placeholder_entries(break_months_in_timeline)
+    return [] if break_months_in_timeline.empty?
+
+    breaks = []
+    current_break = [break_months_in_timeline.first]
+
+    break_months_in_timeline.drop(1).each do |month|
+      if current_break.last.next_month == month
+        current_break << month
+      else
+        breaks << BreakPlaceholder.new(month_range: current_break)
+        current_break = [month]
+      end
+    end
+
+    breaks << BreakPlaceholder.new(month_range: current_break)
+  end
+end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -86,8 +86,12 @@
 
 <section class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('section_groups.work_experience') %></h2>
-  <h3 class="govuk-heading-m"><%= t('page_titles.work_history') %></h3>
-  <%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
+  <% if FeatureFlag.active?(:restructured_work_history) %>
+    <h3 class="govuk-heading-m"><%= t('page_titles.work_history') %></h3>
+    <%= render(CandidateInterface::WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
+  <% else %>
+    <%= render(CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
+  <% end %>
   <h3 class="govuk-heading-m"><%= t('page_titles.volunteering.short') %></h3>
   <%= render(CandidateInterface::VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
 </section>

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -19,11 +19,7 @@
 <% end %>
 
 <% unless @application_form.can_complete? && @application_form.application_work_experiences.blank? %>
-  <section class="app-summary-card govuk-!-margin-bottom-6">
-    <div class="app-summary-card__body">
-      <%= render(CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form)) %>
-    </div>
-  </section>
+  <%= render(CandidateInterface::RestructuredWorkHistory::ReviewComponent.new(application_form: @application_form)) %>
 
   <%= form_with model: @application_form, url: candidate_interface_restructured_work_history_complete_path do |f| %>
     <div class="govuk-form-group">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,7 +266,7 @@ Rails.application.routes.draw do
         delete '/explain-break/delete/:id' => 'restructured_work_history/break#destroy'
 
         get '/review' => 'restructured_work_history/review#show', as: :restructured_work_history_review
-        patch '/review' => 'work_history/review#complete', as: :restructured_work_history_complete
+        patch '/review' => 'restructured_work_history/review#complete', as: :restructured_work_history_complete
       end
 
       scope '/school-experience' do

--- a/spec/services/restructured_work_history_with_breaks_spec.rb
+++ b/spec/services/restructured_work_history_with_breaks_spec.rb
@@ -1,0 +1,359 @@
+require 'rails_helper'
+
+RSpec.describe RestructuredWorkHistoryWithBreaks do
+  describe '#timeline' do
+    let(:january2014) { Time.zone.local(2014, 1, 1) }
+    let(:march2014) { Time.zone.local(2014, 3, 1) }
+    let(:october2014) { Time.zone.local(2014, 10, 1) }
+    let(:february2015) { Time.zone.local(2015, 2, 1) }
+    let(:february2016) { Time.zone.local(2016, 2, 1) }
+    let(:january2019) { Time.zone.local(2019, 1, 1) }
+    let(:february2019) { Time.zone.local(2019, 2, 1) }
+    let(:march2019) { Time.zone.local(2019, 3, 1) }
+    let(:april2019) { Time.zone.local(2019, 4, 1) }
+    let(:september2019) { Time.zone.local(2019, 9, 1) }
+    let(:october2019) { Time.zone.local(2019, 10, 1) }
+    let(:november2019) { Time.zone.local(2019, 11, 1) }
+    let(:december2019) { Time.zone.local(2019, 12, 1) }
+    let(:january2020) { Time.zone.local(2020, 1, 1) }
+    let(:february2020) { Time.zone.local(2020, 2, 1) }
+    let(:april2020) { Time.zone.local(2020, 4, 1) }
+    let(:current_date) { april2020 }
+    let(:submitted_at) { february2020 }
+
+    around do |example|
+      Timecop.freeze(current_date) do
+        example.run
+      end
+    end
+
+    context 'when there are no jobs' do
+      it 'returns an empty array' do
+        work_history = []
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks).to eq([])
+      end
+    end
+
+    context 'when there is one job with a nil end date i.e. current job' do
+      it 'returns the job' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: nil)
+        work_history = [job1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0]).to eq(job1)
+      end
+    end
+
+    context 'when there is one job that ends at current date i.e. current job' do
+      it 'returns the job' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: current_date)
+        work_history = [job1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0]).to eq(job1)
+      end
+    end
+
+    context 'when there is one job that ends at submission_date' do
+      it 'returns the job' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2020)
+        work_history = [job1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0]).to eq(job1)
+      end
+    end
+
+    context 'when there is one job and a one month break between the end date and current date' do
+      it 'returns the job then a break placeholder with a length of one month' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: december2019)
+        work_history = [job1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(RestructuredWorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[1].length).to eq(1)
+        expect(work_history_with_breaks[1].start_date).to eq(Date.new(2019, 12, 1))
+        expect(work_history_with_breaks[1].end_date).to eq(Date.new(2020, 2, 1))
+      end
+    end
+
+    context 'when there is one job and more than a month break between the end date and current date' do
+      it 'returns the job then a break placeholder with a length of three months' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: october2019)
+        work_history = [job1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(RestructuredWorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[1].length).to eq(3)
+      end
+    end
+
+    context 'when there are multiple jobs with no breaks' do
+      it 'returns all jobs and sorted by start date' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: october2019)
+        job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: december2019)
+        job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
+        work_history = [job2, job1, job3]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to eq(job3)
+      end
+    end
+
+    context 'when there is a break between two jobs' do
+      it 'returns all jobs with a break inbetween two jobs' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: october2019)
+        job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: november2019)
+        job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
+        work_history = [job1, job2, job3]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(4)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to be_instance_of(RestructuredWorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[2].length).to eq(1)
+        expect(work_history_with_breaks[3]).to eq(job3)
+      end
+    end
+
+    context 'when the first job is the current job and there is a break between following jobs' do
+      it 'returns all jobs without a break as current job covers the break between following jobs' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: nil)
+        job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
+        job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
+        work_history = [job1, job2, job3]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to eq(job3)
+      end
+    end
+
+    context 'when there is a break before the current job and a break between following jobs' do
+      it 'returns only the break before the current job as current job covers the break between following jobs' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2019)
+        job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
+        job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
+        work_history = [job1, job2, job3]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(4)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(RestructuredWorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[1].length).to eq(1)
+        expect(work_history_with_breaks[2]).to eq(job2)
+        expect(work_history_with_breaks[3]).to eq(job3)
+      end
+    end
+
+    context 'when there is one job that covers the break between following jobs' do
+      it 'returns all jobs without a break' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: december2019)
+        job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
+        job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: nil)
+        work_history = [job1, job2, job3]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to eq(job3)
+      end
+    end
+
+    context 'when there are multiple jobs and an existing break' do
+      it 'returns all jobs and the existing break and sorted by start date' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2019)
+        job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
+        work_history = [job1, job2]
+        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[1].start_date).to eq(february2019)
+        expect(work_history_with_breaks[1].end_date).to eq(april2019)
+        expect(work_history_with_breaks[1].length).to eq(1)
+        expect(work_history_with_breaks[2]).to eq(job2)
+      end
+    end
+
+    context 'when there are no jobs but an existing break' do
+      it 'returns the existing break' do
+        work_history = []
+        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[0].start_date).to eq(february2019)
+        expect(work_history_with_breaks[0].end_date).to eq(april2019)
+        expect(work_history_with_breaks[0].length).to eq(1)
+      end
+    end
+
+    context 'when there are no jobs and multiple existing breaks' do
+      it 'returns all existing breaks and sorted by start date' do
+        work_history = []
+        break1 = build_stubbed(:application_work_history_break, start_date: november2019, end_date: submitted_at)
+        break2 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break2, break1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[0].start_date).to eq(february2019)
+        expect(work_history_with_breaks[0].end_date).to eq(april2019)
+        expect(work_history_with_breaks[0].length).to eq(1)
+        expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[1].start_date).to eq(november2019)
+        expect(work_history_with_breaks[1].end_date).to eq(submitted_at)
+        expect(work_history_with_breaks[1].length).to eq(2)
+      end
+    end
+
+    context 'when there is an existing break that overlaps with a job' do
+      it 'returns the job and existing break, it does not include a break placeholder' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2016)
+        work_history = [job1]
+        break1 = build_stubbed(:application_work_history_break, start_date: february2015, end_date: submitted_at)
+        breaks = [break1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = RestructuredWorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[1].start_date).to eq(february2015)
+        expect(work_history_with_breaks[1].end_date).to eq(submitted_at)
+        expect(work_history_with_breaks[1].length).to eq(59)
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
@@ -21,12 +21,10 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     and_i_click_add_a_first_job
     then_i_should_see_the_add_a_job_page
     and_i_add_a_job_between_february_2015_to_august_2019
-
     then_i_click_on_add_another_job
     and_i_add_another_job_between_november_2019_and_december_2019
     then_i_see_a_two_months_break_between_my_first_job_and_my_second_job
     and_i_see_a_one_month_break_between_my_second_job_and_now
-    and_i_cannot_mark_this_section_as_complete
 
     given_i_am_on_review_work_history_page
     when_i_click_to_explain_my_break_between_august_2019_and_november_2019
@@ -139,13 +137,6 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
   def and_i_see_a_one_month_break_between_my_second_job_and_now
     expect(page).to have_content('You have a break in your work history (1 month)')
-  end
-
-  def and_i_cannot_mark_this_section_as_complete
-    check t('application_form.work_history.review.completed_checkbox')
-    click_button t('save_and_continue')
-    expect(page).to have_content 'You cannot mark this section complete with unexplained work breaks.'
-    expect(current_candidate.current_application).not_to be_work_history_completed
   end
 
   def then_i_see_the_start_and_end_date_filled_in_for_my_break_between_august_2019_and_november_2019

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
@@ -21,10 +21,12 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     and_i_click_add_a_first_job
     then_i_should_see_the_add_a_job_page
     and_i_add_a_job_between_february_2015_to_august_2019
+
     then_i_click_on_add_another_job
     and_i_add_another_job_between_november_2019_and_december_2019
     then_i_see_a_two_months_break_between_my_first_job_and_my_second_job
     and_i_see_a_one_month_break_between_my_second_job_and_now
+    and_i_cannot_mark_this_section_as_complete
 
     given_i_am_on_review_work_history_page
     when_i_click_to_explain_my_break_between_august_2019_and_november_2019
@@ -137,6 +139,13 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
   def and_i_see_a_one_month_break_between_my_second_job_and_now
     expect(page).to have_content('You have a break in your work history (1 month)')
+  end
+
+  def and_i_cannot_mark_this_section_as_complete
+    check t('application_form.work_history.review.completed_checkbox')
+    click_button t('save_and_continue')
+    expect(page).to have_content 'You cannot mark this section complete with unexplained work breaks.'
+    expect(current_candidate.current_application).not_to be_work_history_completed
   end
 
   def then_i_see_the_start_and_end_date_filled_in_for_my_break_between_august_2019_and_november_2019


### PR DESCRIPTION
## Context

The work history section & flow has been redesigned. This change also needs to be reflected within the application review page.

it is an extension of [3960](https://github.com/DFE-Digital/apply-for-teacher-training/pull/3960).

## Changes proposed in this pull request

The application review page will now show the new design:
|Previous design|Restructured design|
|-----|-----|
|![Screenshot 2021-02-09 at 20 41 14](https://user-images.githubusercontent.com/47917431/107514415-8a5a1c00-6ba1-11eb-963e-f01f45dfdac5.png)|![Screenshot 2021-02-09 at 20 36 05](https://user-images.githubusercontent.com/47917431/107514439-9219c080-6ba1-11eb-95cb-3a1b92b45838.png)|

## Guidance to review

- Make sure the Restructured work history feature flag is on
- The candidate needs to have a fresh application in order to be presented with the new flow

Prototype: https://apply-beta-prototype.herokuapp.com/application/12345/review

## Link to Trello card

https://trello.com/c/43SrdCXy/3002-dev-update-the-application-review-page-to-show-the-new-work-history-design

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
