### PR TITLE
Fix errors on support interface R4R search page

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -22,13 +22,13 @@ module SupportInterface
     def search_title_text
       if @search_value == 'Yes'
         i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[@search_attribute].to_s
-        t("reasons_for_rejection.#{i18n_key}.title")
+        t("reasons_for_rejection.#{i18n_key}.title", default: '')
       else
         top_level_reason = ReasonsForRejectionCountQuery::SUBREASONS_TO_TOP_LEVEL_REASONS[@search_attribute.to_sym]
         i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
         [
-          t("reasons_for_rejection.#{i18n_key}.title"),
-          t("reasons_for_rejection.#{i18n_key}.#{@search_value}"),
+          t("reasons_for_rejection.#{i18n_key}.title", default: ''),
+          t("reasons_for_rejection.#{i18n_key}.#{@search_value}", default: ''),
         ].join(' - ')
       end
     end
@@ -38,7 +38,8 @@ module SupportInterface
       if sub_reason.present?
         values_as_list(
           application_choice.structured_rejection_reasons[sub_reason]
-            &.map { |value| sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value) },
+            &.map { |value| sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value) }
+            &.reject(&:blank?),
         )
       else
         detail_reason_for(application_choice, top_level_reason)
@@ -48,7 +49,7 @@ module SupportInterface
     def sub_reason_detail_text(application_choice, top_level_reason, sub_reason, value)
       i18n_key = SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS[top_level_reason].to_s
       text = mark_search_term(
-        I18n.t("reasons_for_rejection.#{i18n_key}.#{value}"),
+        I18n.t("reasons_for_rejection.#{i18n_key}.#{value}", default: ''),
         value.to_s == @search_value.to_s,
       )
 
@@ -73,7 +74,8 @@ module SupportInterface
     end
 
     def top_level_reason?(reason, value)
-      reason =~ /_y_n$/ && value == 'Yes'
+      SupportInterface::SubReasonsForRejectionTableComponent::TOP_LEVEL_REASONS_TO_I18N_KEYS.key?(reason) &&
+        value == 'Yes'
     end
 
   private

--- a/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
+++ b/app/components/support_interface/sub_reasons_for_rejection_table_component.rb
@@ -13,6 +13,7 @@ module SupportInterface
       offered_on_another_course_y_n: :offered_on_another_course,
       performance_at_interview_y_n: :interview_performance,
       interested_in_future_applications_y_n: :interested_in_future_applications,
+      other_advice_or_feedback_y_n: :additional_advice,
     }.with_indifferent_access
 
     def initialize(reason:, sub_reasons:, total:)

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -86,4 +86,27 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       expect(@rendered_result.css('mark').text).to eq 'No degree'
     end
   end
+
+  context 'error handling' do
+    it 'handles an invalid top-level attribute param' do
+      expect { render_result([], :velocity_of_application_y_n, 'Yes') }.not_to raise_error
+    end
+
+    it 'handles an invalid sub-reason value param' do
+      expect { render_result([], :qualifications_which_qualifications, 'no_pilots_licence') }.not_to raise_error
+    end
+
+    it 'handles an invalid reason and sub-reason' do
+      @application_choice = build(
+        :application_choice,
+        structured_rejection_reasons: {
+          performance_at_singing_y_n: 'Yes',
+          qualifications_y_n: 'Yes',
+          qualifications_which_qualifications: %w[no_cycling_proficiency],
+        },
+        application_form_id: 123,
+      )
+      expect { render_result([@application_choice], :qualifications_which_qualifications, 'no_degree') }.not_to raise_error
+    end
+  end
 end

--- a/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
+++ b/spec/system/support_interface/reasons_for_rejection_dashboard_spec.rb
@@ -94,13 +94,14 @@ private
         honesty_and_professionalism_y_n: 'No',
         performance_at_interview_y_n: 'No',
         qualifications_y_n: 'Yes',
-        qualifications_which_qualifications: %w[no_maths_gcse no_degree],
+        qualifications_which_qualifications: %w[no_maths_gcse no_degree no_phd],
         quality_of_application_y_n: 'No',
         safeguarding_y_n: 'Yes',
         safeguarding_concerns: %w[other],
         offered_on_another_course_y_n: 'No',
         interested_in_future_applications_y_n: 'No',
         other_advice_or_feedback_y_n: 'No',
+        fashion_sense_y_n: 'Yes',
       },
       rejected_at: Time.zone.now,
     )
@@ -293,6 +294,8 @@ private
       expect(page).to have_content('Safeguarding issues')
       expect(page).to have_content("Qualifications\nNo Maths GCSE grade 4 (C) or above, or valid equivalentNo degree")
       expect(page).to have_content('Something you did Didn’t reply to our interview offer')
+      expect(page).not_to have_content('fashion_sense')
+      expect(page).not_to have_content('no_phd')
     end
     within "#application-choice-section-#{@application_choice2.id}" do
       expect(page).not_to have_content('Safeguarding issues')


### PR DESCRIPTION
## Context

Errors occurred on the support interface R4R search page because we didn't have a key for `other_advice_or_feedback_y_n` in the hash of top-level reasons. This change fills in the missing key and adds tests and defensive code to prevent similar issues that happen due to data that doesn't match our assumptions.

https://sentry.io/organizations/dfe-bat/issues/2208115277/?environment=qa&project=1765973&query=is%3Aunresolved#grouping-info

## Changes proposed in this pull request

- Add the missing metadata for `other_advice_or_feedback_y_n`
- Handle any unknown R4R attributes/values that may exist in the database or be used as params to this page.

## Guidance to review

- Is it reasonable to ignore attributes and values that we don't know about? (rather than crash)

## Link to Trello card

n/a - see https://sentry.io/organizations/dfe-bat/issues/2208115277/?environment=qa&project=1765973&query=is%3Aunresolved#grouping-info

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
