### PR TITLE
Hard code sequence start value so schema.rb does not change based on which db it is run on

### DIFF
--- a/db/migrate/20210203160529_add_qualification_public_id_sequence.rb
+++ b/db/migrate/20210203160529_add_qualification_public_id_sequence.rb
@@ -3,7 +3,7 @@ class AddQualificationPublicIdSequence < ActiveRecord::Migration[6.0]
     # We set the start of the sequence to be twice the max id for qualifications that currently exist.
     # It is important that the public_id does not clash with any existing ids from the database
     # See adr/0018-public-ids-for-qualifications.md for more details
-    max_qualification_id = ApplicationQualification.maximum(:id)
+    max_qualification_id = 60000
     create_sequence :qualifications_public_id_seq, start: max_qualification_id * 2
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2021_02_08_105018) do
   create_sequence "provider_users_id_seq"
   create_sequence "provider_users_providers_id_seq"
   create_sequence "providers_id_seq"
-  create_sequence "qualifications_public_id_seq", start: 196
+  create_sequence "qualifications_public_id_seq", start: 120000
   create_sequence "reference_tokens_id_seq"
   create_sequence "references_id_seq"
   create_sequence "site_settings_id_seq"


### PR DESCRIPTION
With the addition of public ids to qualifications, we inadvertently added a minor annoyance: People running this migration locally will get different values for the start of the sequence. Then the schema file changes to reflect that

## Guidance to review
- This migration has already been run on all environments, each environment's sequence has a different starting value
- Are there any risks to this change? My understanding is that only test and dev environments consult the schema.rb to generate the database, so this change in number will have no effect unless we rollback and reapply the migration.
- To properly fix this, people who have already run the migration locally will need to roll back and reapply the migration.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
