### PR TITLE
Add location codes to 'Apply with UCAS' page

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,6 +2,7 @@ class Course < ApplicationRecord
   belongs_to :provider
   has_many :course_options
   has_many :application_choices, through: :course_options
+  has_many :sites, through: :course_options
   belongs_to :accredited_provider, class_name: 'Provider', optional: true
 
   audited associated_with: :provider

--- a/app/models/find_api/course.rb
+++ b/app/models/find_api/course.rb
@@ -23,6 +23,7 @@ module FindAPI
 
     def self.fetch(provider_code, course_code)
       where(year: RecruitmentCycle.current_year)
+        .includes(:sites)
         .where(provider_code: provider_code)
         .find(course_code)
         .first

--- a/app/models/find_api/site.rb
+++ b/app/models/find_api/site.rb
@@ -2,5 +2,15 @@ module FindAPI
   class Site < FindAPI::Resource
     belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
     belongs_to :provider, param: :provider_code
+
+    def name
+      location_name
+    end
+
+    def full_address
+      [address1, address2, address3, address4, postcode]
+        .reject(&:blank?)
+        .join(', ')
+    end
   end
 end

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -7,9 +7,13 @@
 
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
-      <%= t('page_titles.apply_from_find') %>
+      <%= t('page_titles.apply_from_find_with_ucas') %>
     </h1>
-    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit <%= t('service_name.get_into_teaching') %> for <%= govuk_link_to 'guidance on applying for teacher training', t('get_into_teaching.url_applying'), target: '_blank' %>.</p>
+
+    <p class="govuk-body">
+      You’ll need to register with UCAS before you can apply.
+      Visit <%= t('service_name.get_into_teaching') %> for <%= govuk_link_to 'guidance on applying for teacher training', t('get_into_teaching.url_applying'), target: '_blank' %>.
+    </p>
 
     <p class="govuk-body">When you apply you’ll need these codes for the Choices section of your application form:</p>
 
@@ -28,6 +32,30 @@
           </span>
         </li>
       </ul>
+
+      <p class="govuk-body">
+        You’ll also need to choose a training location – select the relevant location name on the application form.
+      </p>
+
+      <table class="govuk-table app-table--vertical-align-middle" data-qa="locations-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header govuk-!-width-three-quarters">Location</th>
+            <th class="govuk-table__header">Code</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @course.sites.each do |site| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><span class='govuk-!-font-weight-bold'><%= site.name %></span>
+                <br/>
+                <%= site.full_address %>
+              </td>
+              <td class="govuk-table__cell"><%= site.code %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     </div>
 
     <a href="<%= UCAS.apply_url %>" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Apply for this course' %>
+<% content_for :title, t('page_titles.apply_from_find') %>
 <% content_for :service_link, candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code) %>
 
 <div class="govuk-grid-row">
@@ -10,7 +10,7 @@
 
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
-          Apply for this course
+          <%= t('page_titles.apply_from_find') %>
       </h1>
 
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     success_prefix: "Success: "
     course_not_found: Course not found
     apply_from_find: Apply for this course
+    apply_from_find_with_ucas: Apply for this course with UCAS
     apply_to_course_on_ucas: You need to apply to this course on UCAS
     apply_to_provider_on_ucas: You need to apply to this provider on UCAS
     submitted_application: Your submitted application

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -316,7 +316,31 @@ module FindAPIHelper
               'name' => course_name,
               'provider_code' => provider_code,
             },
+            'relationships': {
+              'sites': {
+                'data': [
+                  { 'id': '1', 'type': 'sites' },
+                ],
+              },
+            },
           },
+          'included': [
+            {
+              'id': '1',
+              'type': 'sites',
+              'attributes': {
+                'code': 'A',
+                'location_name': 'Main site',
+                'address1': 'Gorse SCITT ',
+                'address2': '',
+                'address3': 'Bruntcliffe Lane',
+                'address4': 'MORLEY, LEEDS',
+                'postcode': 'LS27 0LZ',
+                'longitude': -1.620208,
+                'latitude': 53.745587,
+              },
+            },
+          ],
           'jsonapi' => { 'version' => '1.0' },
         }.to_json,
       )
@@ -338,10 +362,13 @@ module FindAPIHelper
   end
 
   def stub_find_api_course(provider_code, course_code)
-    stub_request(:get, ENV.fetch('FIND_BASE_URL') +
+    stub_request(
+      :get, ENV.fetch('FIND_BASE_URL') +
       "recruitment_cycles/#{stubbed_recruitment_cycle_year}" \
       "/providers/#{provider_code}" \
-      "/courses/#{course_code}")
+      "/courses/#{course_code}" \
+      '?include=sites'
+    )
   end
 
   def stub_find_api_provider_200_with_subject_codes(

--- a/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
@@ -14,9 +14,11 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
     and_i_should_see_the_provider_and_course_codes
     and_i_should_see_the_course_name
     then_i_should_be_able_to_apply_through_ucas_only
+    and_i_should_see_locations_info_for_a_synced_course
 
     when_i_arrive_from_find_to_a_course_that_is_not_synced_in_apply
     then_i_should_be_able_to_apply_through_ucas_only
+    and_i_should_see_locations_info_for_an_unsynced_course
 
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
     then_i_should_be_able_to_apply_through_apply
@@ -60,7 +62,10 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def when_i_arrive_from_find_to_a_course_that_is_ucas_only
-    create(:course, exposed_in_find: true, open_on_apply: false, code: 'XYZ1', name: 'Biology', provider: create(:provider, code: 'ABC'))
+    course = create(:course, exposed_in_find: true, open_on_apply: false, code: 'XYZ1', name: 'Biology', provider: create(:provider, code: 'ABC'))
+    site = create(:site, name: 'Site for a UCAS-only course', code: 'OOO', provider: course.provider)
+    create(:course_option, course: course, site: site)
+
     visit candidate_interface_apply_from_find_path providerCode: 'ABC', courseCode: 'XYZ1'
   end
 
@@ -84,7 +89,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def then_i_should_be_able_to_apply_through_ucas_only
-    expect(page).to have_content 'You must apply for this course on UCAS'
+    expect(page).to have_content 'You’ll need to register with UCAS before you can apply.'
   end
 
   def then_i_should_be_able_to_apply_through_apply
@@ -125,5 +130,23 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   def then_i_see_the_sign_up_page
     expect(page).to have_content 'Create an Apply for teacher training account'
+  end
+
+  def and_i_should_see_locations_info_for_an_unsynced_course
+    within '[data-qa="locations-table"]' do
+      table_data = all('td')
+
+      expect(table_data.first).to have_content 'Main site'
+      expect(table_data.last).to have_content 'A'
+    end
+  end
+
+  def and_i_should_see_locations_info_for_a_synced_course
+    within '[data-qa="locations-table"]' do
+      table_data = all('td')
+
+      expect(table_data.first).to have_content 'Site for a UCAS-only course'
+      expect(table_data.last).to have_content 'OOO'
+    end
   end
 end


### PR DESCRIPTION
## Context
Candidates see this page when arriving from Find and applying for a
course through UCAS. This change provides additional location info in
the form of a sites table underneath the provider and course code.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
- Make sites for a given course available by adding a new ActiveRecord
  association to the Course model.
- Fetch sites data from the API when dealing with an unsynced course.
- Augment the FindAPI::Site model with methods that match the interface
  of the Site model.
- Render a table with name, address, and code information.
## Guidance to review
- Review diff
- Test locally or on a review app, viewing the following:
    - A synced course that's available on Apply
    - A synced course that's not available on Apply
    - An unsynced course (if possible)
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
