### PR TITLE
Add note about Publish and TTAPI to API docs

### DIFF
--- a/app/views/api_docs/pages/home.md
+++ b/app/views/api_docs/pages/home.md
@@ -17,6 +17,12 @@ To get an idea of how the API works, we recommend you [review the example usage 
 
 ## Codes and reference data
 
+### Course data
+
+The source of course data such as provider codes, course codes, training locations, vacancy status and study modes for both Apply and UCAS Teacher Training is the DfE [Teacher Training Courses API](https://api.publish-teacher-training-courses.service.gov.uk/api-reference.html#teacher-training-courses-api). This data is managed via [Publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk/sign-in).
+
+### Application data
+
 Before each application cycle, UCAS provides vendors with reference data defining how certain values appear in API responses.
 
 DfE Apply will avoid prioprietary codes wherever possible, preferring existing data formats such as ISO-certified standards or HESA codes.


### PR DESCRIPTION
## Context

A vendor referred to course data as "Reference data" and we realised we didn't say anything about the Teacher Training Courses API in the Apply API docs.

## Changes proposed in this pull request

Add a link to the TTAPI from the Apply docs. ("Course data" section below)

<img width="697" alt="Screenshot 2021-02-10 at 13 01 41" src="https://user-images.githubusercontent.com/642279/107513666-74982700-6ba0-11eb-8761-3ea95527f1da.png">

## Guidance to review

Does the wording make sense?