### PR TITLE
Fix hesa migration

### DIFF
--- a/app/services/backfill_application_form_hesa_sex_and_ethnicity_code.rb
+++ b/app/services/backfill_application_form_hesa_sex_and_ethnicity_code.rb
@@ -1,4 +1,4 @@
-class BackfillHesaSexAndEthnicityCodes
+class BackfillApplicationFormHesaSexAndEthnicityCode
   def self.call(application_form)
     equality_and_diversity = application_form.equality_and_diversity
     equality_and_diversity['hesa_sex'] = equality_and_diversity['hesa_sex'].presence&.to_s

--- a/db/migrate/20210203130641_backfill_hesa_sex_and_ethnicity_codes.rb
+++ b/db/migrate/20210203130641_backfill_hesa_sex_and_ethnicity_codes.rb
@@ -2,7 +2,7 @@ class BackfillHesaSexAndEthnicityCodes < ActiveRecord::Migration[6.0]
   def change
     application_forms_with_equality_and_diversity_data = ApplicationForm.where.not(equality_and_diversity: nil)
     application_forms_with_equality_and_diversity_data.each do |application_form|
-      BackfillHesaSexAndEthnicityCodes.call(application_form)
+      BackfillApplicationFormHesaSexAndEthnicityCode.call(application_form)
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2021_02_08_105018) do
 
   create_sequence "application_choices_id_seq"


### PR DESCRIPTION
## Context

Migration error caused by use of same classname in two seperate places. Editing the classname to ensure uniqueness should fix the issue.

## Changes proposed in this pull request



## Guidance to review

Not much to say, simple renaming refactor. 


## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X ] API release notes have been updated if necessary
- [X ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
