### PR TITLE
rename backfill_hesa_sex_and_ethnicity_codes.rb -> backfill_applicati…

### DIFF
--- a/app/services/backfill_application_form_hesa_sex_and_ethnicity_code.rb
+++ b/app/services/backfill_application_form_hesa_sex_and_ethnicity_code.rb
@@ -1,4 +1,4 @@
-class BackfillHesaSexAndEthnicityCodes
+class BackfillApplicationFormHesaSexAndEthnicityCode
   def self.call(application_form)
     equality_and_diversity = application_form.equality_and_diversity
     equality_and_diversity['hesa_sex'] = equality_and_diversity['hesa_sex'].presence&.to_s

--- a/db/migrate/20210203130641_backfill_hesa_sex_and_ethnicity_codes.rb
+++ b/db/migrate/20210203130641_backfill_hesa_sex_and_ethnicity_codes.rb
@@ -2,7 +2,7 @@ class BackfillHesaSexAndEthnicityCodes < ActiveRecord::Migration[6.0]
   def change
     application_forms_with_equality_and_diversity_data = ApplicationForm.where.not(equality_and_diversity: nil)
     application_forms_with_equality_and_diversity_data.each do |application_form|
-      BackfillHesaSexAndEthnicityCodes.call(application_form)
+      BackfillApplicationFormHesaSexAndEthnicityCode.call(application_form)
     end
   end
 end

--- a/spec/services/backfill_application_form_hesa_sex_and_ethnicity_code_spec.rb
+++ b/spec/services/backfill_application_form_hesa_sex_and_ethnicity_code_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BackfillHesaSexAndEthnicityCodes do
+RSpec.describe BackfillApplicationFormHesaSexAndEthnicityCode do
   describe '#change' do
     it 'converts integer hesa codes into strings' do
       application_form = create(:application_form,


### PR DESCRIPTION
## Context

Duplicating a classname caused migration failure, renaming one instance of the class fixes the issue. 

## Changes proposed in this pull request

renaming a single class.

## Guidance to review

N/A

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
