### PR TITLE
Fix top-level R4R questions without sub-questions

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -99,7 +99,9 @@ module SupportInterface
     end
 
     def detail_reason_for(application_choice, top_level_reason)
-      detail_questions = ReasonsForRejection::INITIAL_QUESTIONS[top_level_reason.to_sym].keys
+      detail_questions = ReasonsForRejection::INITIAL_QUESTIONS[top_level_reason.to_sym]&.keys
+      return '' if detail_questions.nil?
+
       values_as_list(
         detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,
       )

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
           quality_of_application_y_n: 'Yes',
           quality_of_application_which_parts_needed_improvement: %w[other],
           quality_of_application_other_details: 'Too many emojis',
+          interested_in_future_applications_y_n: 'Yes',
         },
         application_form_id: 123,
       )
@@ -46,6 +47,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       expect(@rendered_result.text).to include('Quality of application')
       expect(@rendered_result.text).to include('Performance at interview')
       expect(@rendered_result.text).to include('Avoid humming')
+      expect(@rendered_result.text).to include('Future applications')
       expect(@rendered_result.text).not_to include('Something you did')
     end
 


### PR DESCRIPTION
## Context

Fixes production issue on the support interface R4R search page
https://sentry.io/organizations/dfe-bat/issues/2208990700/events/0c2af8897cb14696bfd5ebe0087fe9f1/?environment=qa&project=1765973&query=is%3Aunresolved

## Changes proposed in this pull request

- Handle top-level questions that have no sub-questions (the ones that don't appear in `INITIAL_QUESTIONS`

## Guidance to review

- Does this fully handle reasons for rejection that include `interested_in_future_applications_y_n = 'Yes'` etc.?

## Link to Trello card

https://trello.com/c/aWsSjWyQ/2888-dev-r4r-support-search-page

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
