### PR TITLE
Restore interviews in the provider activity log

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -5,7 +5,7 @@ module ProviderInterface
 
     def initialize(application_choice:)
       @application_choice = application_choice
-      audits = GetActivityLogEvents.call(application_choices: [application_choice])
+      audits = GetActivityLogEvents.call(application_choices: ApplicationChoice.where(id: application_choice.id))
       @activity_log_events = audits.map { |audit| ActivityLogEvent.new(audit: audit) }
     end
 

--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -25,6 +25,26 @@ class GetActivityLogEvents
   def self.call(application_choices:, since: nil)
     since ||= Time.zone.local(2018, 1, 1) # before the pilot began, i.e. all records
 
+    application_choices_join_sql = <<~COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER.squish
+      INNER JOIN (#{application_choices.to_sql}) ac
+        ON (
+          auditable_type = 'ApplicationChoice'
+          AND auditable_id = ac.id
+          AND action = 'update'
+          AND ( #{application_choice_audits_filter_sql} )
+        ) OR (
+          associated_type = 'ApplicationChoice'
+          AND associated_id = ac.id
+        )
+    COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER
+
+    Audited::Audit.includes(INCLUDES)
+                  .joins(application_choices_join_sql)
+                  .where('audits.created_at >= ?', since)
+                  .order('audits.created_at DESC')
+  end
+
+  def self.application_choice_audits_filter_sql
     application_choice_audits_filter = INCLUDE_APPLICATION_CHOICE_CHANGES_TO.map { |f|
       "jsonb_exists(audited_changes, '#{f}')"
     }.join(' OR ')
@@ -32,27 +52,6 @@ class GetActivityLogEvents
     filtered_statuses = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - IGNORE_STATUS
     status_transitions_to_include = filtered_statuses.map { |status| "'#{status}'" }.join(', ')
 
-    application_choice_audits_filter += " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"
-
-    Audited::Audit.includes(INCLUDES).from <<~COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER.squish
-      (
-        SELECT a.*
-          FROM audits a
-
-          INNER JOIN (#{application_choices.to_sql}) ac
-            ON (
-              auditable_type = 'ApplicationChoice'
-              AND auditable_id = ac.id
-              AND action = 'update'
-              AND ( #{application_choice_audits_filter} )
-            ) OR (
-              associated_type = 'ApplicationChoice'
-              AND associated_id = ac.id
-            )
-
-          WHERE a.created_at >= '#{since.iso8601}'::TIMESTAMPTZ
-          ORDER BY a.created_at DESC
-      ) AS audits
-    COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER
+    application_choice_audits_filter + " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"
   end
 end

--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -15,21 +15,44 @@ class GetActivityLogEvents
     ],
   }.freeze
 
-  CHANGES_TO = %w[
+  INCLUDE_APPLICATION_CHOICE_CHANGES_TO = %w[
     reject_by_default_feedback_sent_at
     offer_changed_at
   ].freeze
 
+  IGNORE_STATUS = %i[interviewing].freeze
+
   def self.call(application_choices:, since: nil)
     since ||= Time.zone.local(2018, 1, 1) # before the pilot began, i.e. all records
 
-    filter_query = "audited_changes ?| array[:changes] OR audited_changes #>> '{status, 1}' IN (:statuses)"
+    application_choice_audits_filter = INCLUDE_APPLICATION_CHOICE_CHANGES_TO.map { |f|
+      "jsonb_exists(audited_changes, '#{f}')"
+    }.join(' OR ')
 
-    Audited::Audit.includes(INCLUDES)
-                  .where(auditable: application_choices)
-                  .where(action: :update)
-                  .where(filter_query, changes: CHANGES_TO, statuses: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
-                  .where('created_at > ?', since)
-                  .order(created_at: :desc)
+    filtered_statuses = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - IGNORE_STATUS
+    status_transitions_to_include = filtered_statuses.map { |status| "'#{status}'" }.join(', ')
+
+    application_choice_audits_filter += " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"
+
+    Audited::Audit.includes(INCLUDES).from <<~COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER.squish
+      (
+        SELECT a.*
+          FROM audits a
+
+          INNER JOIN (#{application_choices.to_sql}) ac
+            ON (
+              auditable_type = 'ApplicationChoice'
+              AND auditable_id = ac.id
+              AND action = 'update'
+              AND ( #{application_choice_audits_filter} )
+            ) OR (
+              associated_type = 'ApplicationChoice'
+              AND associated_id = ac.id
+            )
+
+          WHERE a.created_at >= '#{since.iso8601}'::TIMESTAMPTZ
+          ORDER BY a.created_at DESC
+      ) AS audits
+    COMBINE_AUDITS_WITH_APPLICATION_CHOICES_SCOPE_AND_FILTER
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -101,6 +101,26 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "53c8ba33ea76005585e7380e66bbc196385862111c7cb27fe2f0e6793c1ed630",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/queries/get_activity_log_events.rb",
+      "line": 42,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Audited::Audit.includes(:user => ([:provider_user, :support_user]), :auditable => ([:application_form, :course_option, :course, :site, :provider, :accredited_provider, :offered_course_option])).joins(\"INNER JOIN (#{application_choices.to_sql}) ac\\n  ON (\\n    auditable_type = 'ApplicationChoice'\\n    AND auditable_id = ac.id\\n    AND action = 'update'\\n    AND ( #{application_choice_audits_filter_sql} )\\n  ) OR (\\n    associated_type = 'ApplicationChoice'\\n    AND associated_id = ac.id\\n  )\\n\".squish)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "GetActivityLogEvents",
+        "method": "s(:self).call"
+      },
+      "user_input": "application_choice_audits_filter_sql",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Unscoped Find",
       "warning_code": 82,
       "fingerprint": "6ef6028f663074c27a5022a598ab480021906f24a15525d47be3a5be44348320",
@@ -201,6 +221,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-02-10 09:46:46 +0000",
+  "updated": "2021-02-12 10:44:14 +0000",
   "brakeman_version": "5.0.0"
 }

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
   def application_choice_with_audits(audits)
     application_choice = audits.first&.auditable || create(:application_choice)
     allow(GetActivityLogEvents).to receive(:call).with(
-      application_choices: [application_choice],
+      application_choices: ApplicationChoice.where(id: application_choice.id),
     ).and_return(audits)
     allow(application_choice).to receive(:notes).and_return([])
     application_choice
@@ -127,7 +127,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
       allow(interview_audit).to receive(:auditable).and_return(interview)
       allow(GetActivityLogEvents).to receive(:call)
-        .with(application_choices: [application_choice])
         .and_return([interview_audit, application_choice_audit])
 
       rendered = render_inline(described_class.new(application_choice: application_choice))
@@ -145,7 +144,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
       allow(interview_audit).to receive(:auditable).and_return(interview)
       allow(GetActivityLogEvents).to receive(:call)
-        .with(application_choices: [application_choice])
         .and_return([interview_audit, application_choice_audit])
 
       rendered = render_inline(described_class.new(application_choice: application_choice))
@@ -163,7 +161,6 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       allow(application_choice_audit).to receive(:auditable).and_return(application_choice)
       allow(interview_audit).to receive(:auditable).and_return(interview)
       allow(GetActivityLogEvents).to receive(:call)
-        .with(application_choices: [application_choice])
         .and_return([interview_audit, application_choice_audit])
 
       rendered = render_inline(described_class.new(application_choice: application_choice))

--- a/spec/queries/get_activity_log_events_spec.rb
+++ b/spec/queries/get_activity_log_events_spec.rb
@@ -186,9 +186,7 @@ RSpec.describe GetActivityLogEvents, with_audited: true do
     let(:application_choice) { create(:application_choice, :with_scheduled_interview) }
 
     it 'returns events associated with interviews' do
-      pending 'excluding interviews until query is faster'
-
-      result = GetActivityLogEvents.call(application_choices: [application_choice])
+      result = GetActivityLogEvents.call(application_choices: ApplicationChoice.where(id: application_choice.id))
 
       expect(result.first.auditable).to eq(application_choice.interviews.first)
       expect(result.first.associated).to eq(application_choice)


### PR DESCRIPTION
## Context

Our last attempt at including interviews (reverted in https://github.com/DFE-Digital/apply-for-teacher-training/pull/4020) produced SQL which specified the OR logic needed for an .own_and_associated_audits query in the WHERE clause of a query and included the application_choices visibility
rules twice. By making this OR logic a part of the INNER JOIN between audits and the application_choices from GetApplicationChoicesForProviders, we can scan the audits table more efficiently and take advantage of the
existing [auditable_type, auditable_id] and [associated_type, associated_id] indexes.

Besides speed, this approach should work well for any other ApplicationChoice-associated audits we add in the future, similar to interviews. We filter so much on ApplicationChoice statuses and other fields because not all state transitions are relevant for Manage, but associated models (such as interviews) should either be included in the feed for all their changes or not at all.

## Changes proposed in this pull request

The SQL produced changes from

```sql
SELECT 
  "audits".* 
FROM 
  "audits" 
WHERE 
  (
    "audits"."auditable_type" = 'ApplicationChoice' 
    AND "audits"."auditable_id" IN (
      SELECT 
        "application_choices"."id" 
      FROM 
        "application_choices" 
        INNER JOIN course_options AS current_option ON COALESCE(
          offered_course_option_id, course_option_id
        ) = current_option.id 
        INNER JOIN course_options AS original_option ON course_option_id = original_option.id 
        INNER JOIN courses AS current_course ON current_option.course_id = current_course.id 
        INNER JOIN courses AS original_course ON original_option.course_id = original_course.id 
      WHERE 
        (
          (
            "original_course"."recruitment_cycle_year" IN (2021, 2020) 
            AND (
              "original_course"."provider_id" IN (1593, 77, 404, 1538) 
              OR "original_course"."accredited_provider_id" IN (1593, 77, 404, 1538)
            ) 
            OR "current_course"."provider_id" IN (1593, 77, 404, 1538) 
            AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
          ) 
          OR "current_course"."accredited_provider_id" IN (1593, 77, 404, 1538) 
          AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
        ) 
        AND (
          status IN (
            'awaiting_provider_decision', 'offer', 
            'pending_conditions', 'recruited', 
            'rejected', 'declined', 'withdrawn', 
            'conditions_not_met', 'offer_withdrawn', 
            'offer_deferred'
          )
        )
    ) 
    AND "audits"."action" = 'update' 
    AND (
      jsonb_exists(
        audited_changes, 'reject_by_default_feedback_sent_at'
      ) 
      OR jsonb_exists(
        audited_changes, 'offer_changed_at'
      ) 
      OR audited_changes :: json #>>'{status, 1}' IN ('awaiting_provider_decision', 'interviewing', 'offer', 'pending_conditions', 'recruited', 'rejected', 'declined', 'withdrawn', 'conditions_not_met', 'offer_withdrawn', 'offer_deferred'))
      OR "audits"."associated_type" = 'ApplicationChoice'
      AND "audits"."associated_id" IN (
        SELECT
          "application_choices"."id"
        FROM
          "application_choices"
          INNER JOIN course_options AS current_option ON COALESCE(
            offered_course_option_id, course_option_id
          ) = current_option.id
          INNER JOIN course_options AS original_option ON course_option_id = original_option.id
          INNER JOIN courses AS current_course ON current_option.course_id = current_course.id
          INNER JOIN courses AS original_courseON original_option.course_id = original_course.id
        WHERE
          (
            (
              "original_course"."recruitment_cycle_year" IN (2021, 2020)
              AND (
                "original_course"."provider_id" IN (1593, 77, 404, 1538)
                OR "original_course"."accredited_provider_id" IN (1593, 77, 404, 1538)
              )
              OR "current_course"."provider_id" IN(1593, 77, 404, 1538)
              AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
            )
            OR "current_course"."accredited_provider_id" IN (1593, 77, 404, 1538)
            AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
          )
          AND (
            status IN (
              'awaiting_provider_decision', 'offer',
              'pending_conditions', 'recruited',
              'rejected', 'declined', 'withdrawn',
              'conditions_not_met', 'offer_withdrawn',
              'offer_deferred'
            )
          )
      )
      AND "audits"."action" IN ('create', 'update')
  )
  AND (created_at > '2018-01-01 00:00:00') ORDER BY "audits"."created_at" DESC LIMIT 50 OFFSET 0
```

which doesn't complete, to

```sql
SELECT
  "audits".*
FROM
  (
    SELECT
      a.*
    FROM
      audits a
      INNER JOIN (
        SELECT
          "application_choices".*
        FROM
          "application_choices"
          INNER JOIN course_options AS current_option ON COALESCE(
            offered_course_option_id, course_option_id
          ) = current_option.id
          INNER JOIN course_options AS original_option ON course_option_id = original_option.id
          INNER JOIN courses AS current_course ON current_option.course_id = current_course.id
          INNER JOIN courses AS original_course ON original_option.course_id = original_course.id
        WHERE
          (
            (
              "original_course"."recruitment_cycle_year" IN (2021, 2020)
              AND (
                "original_course"."provider_id" IN (1593, 77, 404, 1538)
                OR "original_course"."accredited_provider_id" IN (1593, 77, 404, 1538)
              )
              OR "current_course"."provider_id" IN (1593, 77, 404, 1538)
              AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
            )
            OR "current_course"."accredited_provider_id" IN (1593, 77, 404, 1538)
            AND "current_course"."recruitment_cycle_year" IN (2021, 2020)
          )
          AND (
            status IN (
              'awaiting_provider_decision', 'offer',
              'pending_conditions', 'recruited',
              'rejected', 'declined', 'withdrawn',
              'conditions_not_met', 'offer_withdrawn',
              'offer_deferred'
            )
          )
      ) ac ON
        (
          auditable_type = 'ApplicationChoice'
          AND auditable_id = ac.id
          AND action = 'update'
          AND (
            jsonb_exists(
              audited_changes, 'reject_by_default_feedback_sent_at'
            )
            OR jsonb_exists(
              audited_changes, 'offer_changed_at'
            )
	    OR audited_changes :: json #>>'{status, 1}' IN
	      ('awaiting_provider_decision', 'interviewing', 'offer', 'pending_conditions', 'recruited', 'rejected', 'declined', 'withdrawn', 'conditions_not_met', 'offer_withdrawn', 'offer_deferred')
          )
        ) OR (
	  associated_type = 'ApplicationChoice'
	  AND associated_id = ac.id
        )
    WHERE a.created_at >= '2018-01-01T00:00:00+00:00'::TIMESTAMPTZ
    ORDER BY a.created_at DESC
  ) AS audits
```

which completes in 75ms (faster than the 100ms the version in https://github.com/DFE-Digital/apply-for-teacher-training/pull/4020, without associated audits, takes)

## Guidance to review

The multiple INNER JOINs on courses and course options are coming from the `GetApplicationChoicesForProviders` service. In the controller, we call `GetActivityLogEvents` like this:

```ruby
      @events = GetActivityLogEvents.call(
        application_choices: GetApplicationChoicesForProviders.call(
          providers: current_provider_user.providers,
        ),
      ).page(params[:page] || 1).per(50)
```

Yes, we've gone back to hand-crafted/embedded SQL in the service, but I don't know how to specify such a join using ActiveRecord syntax. Any suggestions welcome!

UPDATE: I've moved the raw SQL to a `.joins` expression, because this is the bit ActiveRecord can't do, made everything else standard AR.

## Link to Trello card

https://trello.com/c/B79CEysQ

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
