### PR TITLE
change static link to rails route to ensure user is linked to the cor…

### DIFF
--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -232,7 +232,7 @@ Candidates will also be able to use UCAS’s Apply 2 service for this part of th
 
 ### Informing candidates your courses are on Apply
 
-Your courses will automatically be uploaded to [Apply for teacher training](https://www.apply-for-teacher-training.service.gov.uk) as part of our onboarding process.
+Your courses will automatically be uploaded to [Apply for teacher training](<%= candidate_interface_path %>) as part of our onboarding process.
 
 When candidates use [Find postgraduate teacher training](https://www.find-postgraduate-teacher-training.service.gov.uk/) and select one of your courses, they will have the option to continue via Apply for teacher training. (They will also be able to apply via UCAS, if you’ve decided to keep your courses listed on both services.)
 


### PR DESCRIPTION
## Context

Link incorrectly took providers to the candidate login page, now directs them correctly to the first landing page (depending on environment). 

## Changes proposed in this pull request

No UI changes.

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/ytjkLIA3/3292-link-to-apply-from-manage-qa-could-be-more-specific

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)

