### PR TITLE
Small fixes to interviews

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -24,7 +24,7 @@
           </p>
 
           <% if FeatureFlag.active?(:interviews) %>
-            <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice) %>
+            <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
             <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button--secondary' %>
           <% else %>
             <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button' %>

--- a/app/components/provider_interface/interview_and_course_summary_component.html.erb
+++ b/app/components/provider_interface/interview_and_course_summary_component.html.erb
@@ -1,0 +1,16 @@
+<div class="app-interviews__interview">
+  <%= render SummaryCardComponent.new(editable: true, border: true, rows: rows) do %>
+    <%= render SummaryCardHeaderComponent.new(title: interview.date_and_time.to_s(:govuk_date_and_time), heading_level: 2) do %>
+      <div class="app-summary-card__actions">
+        <ul class= "app-summary-card__actions-list">
+          <li class="app-summary-card__actions-list-item">
+            <%= link_to 'Change details', edit_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
+          </li>
+          <li class="app-summary-card__actions-list-item">
+            <%= link_to 'Cancel interview', cancel_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/provider_interface/interview_and_course_summary_component.html.erb
+++ b/app/components/provider_interface/interview_and_course_summary_component.html.erb
@@ -1,16 +1,18 @@
 <div class="app-interviews__interview">
   <%= render SummaryCardComponent.new(editable: true, border: true, rows: rows) do %>
     <%= render SummaryCardHeaderComponent.new(title: interview.date_and_time.to_s(:govuk_date_and_time), heading_level: 2) do %>
-      <div class="app-summary-card__actions">
-        <ul class= "app-summary-card__actions-list">
-          <li class="app-summary-card__actions-list-item">
-            <%= link_to 'Change details', edit_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
-          </li>
-          <li class="app-summary-card__actions-list-item">
-            <%= link_to 'Cancel interview', cancel_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
-          </li>
-        </ul>
-      </div>
+      <% if user_can_change_interview %>
+        <div class="app-summary-card__actions">
+          <ul class= "app-summary-card__actions-list">
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to 'Change details', edit_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
+            </li>
+            <li class="app-summary-card__actions-list-item">
+              <%= link_to 'Cancel interview', cancel_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/components/provider_interface/interview_and_course_summary_component.rb
+++ b/app/components/provider_interface/interview_and_course_summary_component.rb
@@ -15,7 +15,7 @@ module ProviderInterface
         },
         {
           key: 'Funding type',
-          value: interview.offered_course.funding_type,
+          value: Course.human_attribute_name("funding_type.#{interview.offered_course.funding_type}"),
         },
         {
           key: 'Organisation carrying out interview',

--- a/app/components/provider_interface/interview_and_course_summary_component.rb
+++ b/app/components/provider_interface/interview_and_course_summary_component.rb
@@ -19,6 +19,10 @@ module ProviderInterface
           value: Course.human_attribute_name("funding_type.#{interview.offered_course.funding_type}"),
         },
         {
+          key: 'Interview preferences',
+          value: @application_choice.application_form.interview_preferences,
+        },
+        {
           key: 'Organisation carrying out interview',
           value: interview.provider.name,
         },

--- a/app/components/provider_interface/interview_and_course_summary_component.rb
+++ b/app/components/provider_interface/interview_and_course_summary_component.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class InterviewAndCourseSummaryComponent < ViewComponent::Base
+    attr_reader :interview, :application_choice
+
+    def initialize(interview:)
+      @application_choice = interview.application_choice
+      @interview = interview
+    end
+
+    def rows
+      [
+        {
+          key: 'Course',
+          value: interview.offered_course.name,
+        },
+        {
+          key: 'Funding type',
+          value: interview.offered_course.funding_type,
+        },
+        {
+          key: 'Organisation carrying out interview',
+          value: interview.provider.name,
+        },
+        {
+          key: 'Address or online meeting details',
+          value: interview.location,
+        },
+        {
+          key: 'Additional details',
+          value: interview.additional_details,
+        },
+      ]
+    end
+  end
+end

--- a/app/components/provider_interface/interview_and_course_summary_component.rb
+++ b/app/components/provider_interface/interview_and_course_summary_component.rb
@@ -1,10 +1,11 @@
 module ProviderInterface
   class InterviewAndCourseSummaryComponent < ViewComponent::Base
-    attr_reader :interview, :application_choice
+    attr_reader :interview, :application_choice, :user_can_change_interview
 
-    def initialize(interview:)
+    def initialize(interview:, user_can_change_interview:)
       @application_choice = interview.application_choice
       @interview = interview
+      @user_can_change_interview = user_can_change_interview
     end
 
     def rows

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -5,7 +5,7 @@ module ProviderInterface
     before_action :requires_make_decisions_permission, except: %i[index]
 
     def index
-      @provider_can_respond = current_provider_user.authorisation.can_make_decisions?(
+      @provider_can_make_decisions = current_provider_user.authorisation.can_make_decisions?(
         application_choice: @application_choice,
         course_option_id: @application_choice.offered_option.id,
       )

--- a/app/forms/provider_interface/cancel_interview_wizard.rb
+++ b/app/forms/provider_interface/cancel_interview_wizard.rb
@@ -1,0 +1,34 @@
+module ProviderInterface
+  class CancelInterviewWizard
+    include ActiveModel::Model
+
+    attr_accessor :cancellation_reason
+
+    validates :cancellation_reason, presence: true
+
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(last_saved_state.deep_merge(attrs))
+    end
+
+    def save_state!
+      @state_store.write(state)
+    end
+
+    def clear_state!
+      @state_store.delete
+    end
+
+  private
+
+    def last_saved_state
+      saved_state = @state_store.read
+      saved_state ? JSON.parse(saved_state) : {}
+    end
+
+    def state
+      as_json(except: %w[state_store errors validation_context]).to_json
+    end
+  end
+end

--- a/app/views/provider_interface/interviews/cancel.html.erb
+++ b/app/views/provider_interface/interviews/cancel.html.erb
@@ -14,7 +14,7 @@
     </h1>
 
 
-    <%= form_with model: @interview, url: cancel_review_provider_interface_application_choice_interview_path(@application_choice, @interview), method: :get do |f| %>
+    <%= form_with model: @cancellation_wizard, url: cancel_review_provider_interface_application_choice_interview_path(@application_choice, @interview), method: :get do |f| %>
       <div class='govuk-form-group'>
         <%= f.govuk_text_area :cancellation_reason, label: -> { nil } %>
       </div>

--- a/app/views/provider_interface/interviews/index.html.erb
+++ b/app/views/provider_interface/interviews/index.html.erb
@@ -12,46 +12,7 @@
         </h2>
 
         <% @interviews.each do |interview| %>
-          <div class="app-interviews__interview">
-
-            <%= render SummaryCardComponent.new(editable: true, border: true, rows: [
-              {
-                key: 'Course',
-                value: interview.offered_course.name
-              },
-              {
-                key: 'Funding type',
-                value: interview.offered_course.funding_type
-              },
-              {
-                key: 'Organisation carrying out interview',
-                value: interview.provider.name
-              },
-              {
-                key: 'Address or online meeting details',
-                value: interview.location
-              },
-              {
-                key: 'Additional details',
-                value: interview.additional_details
-              }
-            ].compact
-             ) do %>
-             <%= render SummaryCardHeaderComponent.new(title: interview.date_and_time.to_s(:govuk_date_and_time), heading_level: 2) do %>
-               <div class="app-summary-card__actions">
-               <ul class= "app-summary-card__actions-list">
-                 <li class="app-summary-card__actions-list-item">
-                   <%= govuk_link_to 'Change details', edit_provider_interface_application_choice_interview_path(@application_choice, interview), class: 'app-summary-card__actions-list-item' %>
-                 </li>
-                 <li class="app-summary-card__actions-list-item">
-                   <%= govuk_link_to 'Cancel interview', cancel_provider_interface_application_choice_interview_path(@application_choice, interview), class: 'app-summary-card__actions-list-item' %>
-                 </li>
-               </ul>
-               </div>
-             <% end %>
-            <% end %>
-
-          </div>
+          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview) %>
         <% end %>
       </div>
     </div>

--- a/app/views/provider_interface/interviews/index.html.erb
+++ b/app/views/provider_interface/interviews/index.html.erb
@@ -1,18 +1,21 @@
 <% content_for :browser_title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Interviews" %>
 
-<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_respond) %>
+<%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions) %>
 
 <% if @interviews.any? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="app-interviews">
-        <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(@application_choice), class: 'govuk-button govuk-button--secondary' %>
+        <% if @provider_can_make_decisions %>
+          <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(@application_choice), class: 'govuk-button govuk-button--secondary' %>
+        <% end %>
+
         <h2 class="govuk-heading-m">
           Upcoming interviews
         </h2>
 
         <% @interviews.each do |interview| %>
-          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview) %>
+          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @provider_can_make_decisions) %>
         <% end %>
       </div>
     </div>

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -10,7 +10,7 @@
       <% if @application_choice.application_form.interview_preferences.present? %>
         <div class="app-banner app-banner--details">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= t('.interview_preferences.title') %></h2>
-          <p class="govuk-body"><%= @application_choice.application_form.interview_preferences %></p>
+          <p class="govuk-body govuk-!-margin-bottom-0"><%= @application_choice.application_form.interview_preferences %></p>
         </div>
       <% end %>
 

--- a/app/views/provider_interface/interviews/review_cancel.html.erb
+++ b/app/views/provider_interface/interviews/review_cancel.html.erb
@@ -16,15 +16,16 @@
     <%= render SummaryCardComponent.new(editable: true, border: false, rows: [
     {
       key: t('.cancellation_reason'),
-      value: @interview.cancellation_reason
+      value: @cancellation_wizard.cancellation_reason,
+      change_path: cancel_provider_interface_application_choice_interview_path(@application_choice, @interview)
     },
     {}
     ]
     ) %>
 
-    <%= form_with model: @interview, url: cancel_confirm_provider_interface_application_choice_interview_path(@application_choice, @interview), method: :post do |f| %>
+    <%= form_with model: @cancellation_wizard, url: cancel_confirm_provider_interface_application_choice_interview_path(@application_choice, @interview), method: :post do |f| %>
       <div class='govuk-form-group'>
-        <%= f.hidden_field :cancellation_reason, value: @interview.cancellation_reason %>
+        <%= f.hidden_field :cancellation_reason, value: @cancellation_wizard.cancellation_reason %>
       </div>
       <%= f.govuk_submit 'Send cancellation' %>
     <% end %>

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -49,18 +49,17 @@ en:
         provider_interface/interview_wizard:
           attributes:
             date:
-              invalid: The interview date must be a real date
-              missing_values: The interview date must include a %{missing_details}
-              blank: Enter the interview date
-              past: The interview date must be in the future
-              after_rdb: The interview date must be before the application closing date
+              past: Date must be today or in the future
+              after_rdb: Date must be before the application closing date
             time:
               invalid: Enter a time in the correct format
-              blank: Enter the interview time
-              past: The interview time must be in the future
+              blank: Enter time
+              past: Time must be in the future
             location:
-              blank: Enter the interview location
+              blank: Enter address or online meeting details
+            provider_id:
+              blank: Select which organisation is carrying out the interview
         provider_interface/cancel_interview_wizard:
           attributes:
             cancellation_reason:
-              blank: Enter a cancellation reason
+              blank: Enter reason for cancelling interview

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -60,3 +60,7 @@ en:
               past: The interview time must be in the future
             location:
               blank: Enter the interview location
+        provider_interface/cancel_interview_wizard:
+          attributes:
+            cancellation_reason:
+              blank: Enter a cancellation reason

--- a/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
   let(:interview) { create(:interview) }
-  let(:component) { render_inline(described_class.new(interview: interview)).text }
+  let(:component) { render_inline(described_class.new(interview: interview, user_can_change_interview: true)).text }
 
   it 'capitalises funding type' do
     expect(component).to include(interview.application_choice.course.funding_type.capitalize)
@@ -23,4 +23,14 @@ RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
   it 'displays interview location' do
     expect(component).to include(interview.location)
   end
+
+  context 'user_can_change_interview is false' do
+    let(:component) { render_inline(described_class.new(interview: interview, user_can_change_interview: false)).text }
+
+    it 'does not render the edit or cancel buttons' do
+      expect(component).not_to include('Change details')
+      expect(component).not_to include('Cancel interview')
+    end
+  end
+
 end

--- a/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
+  let(:interview) { create(:interview) }
+  let(:component) { render_inline(described_class.new(interview: interview)).text }
+
+  it 'displays interview preferences' do
+    expect(component).to include(interview.application_choice.application_form.interview_preferences)
+  end
+
+  it 'displays the provider name' do
+    expect(component).to include(interview.application_choice.course.provider.name)
+  end
+
+  it 'displays the course name' do
+    expect(component).to include(interview.application_choice.course.name)
+  end
+
+  it 'displays interview location' do
+    expect(component).to include(interview.location)
+  end
+end

--- a/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
@@ -32,5 +32,4 @@ RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
       expect(component).not_to include('Cancel interview')
     end
   end
-
 end

--- a/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
   let(:interview) { create(:interview) }
   let(:component) { render_inline(described_class.new(interview: interview)).text }
 
+  it 'capitalises funding type' do
+    expect(component).to include(interview.application_choice.course.funding_type.capitalize)
+  end
+
   it 'displays interview preferences' do
     expect(component).to include(interview.application_choice.application_form.interview_preferences)
   end

--- a/spec/forms/provider_interface/cancel_interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/cancel_interview_wizard_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::CancelInterviewWizard do
+  let(:store) { instance_double(WizardStateStores::RedisStore, read: nil) }
+  let(:subject) { described_class.new(store) }
+
+  describe '.validations' do
+    it { is_expected.to validate_presence_of(:cancellation_reason) }
+  end
+end

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
         it 'is invalid with the correct error' do
           Timecop.freeze(2021, 1, 13) do
             expect(wizard).to be_invalid
-            expect(wizard.errors[:date]).to contain_exactly('The interview date must be before the application closing date')
+            expect(wizard.errors[:date]).to contain_exactly('Date must be before the application closing date')
           end
         end
       end
@@ -112,7 +112,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
         it 'returns false and adds a date error' do
           Timecop.freeze(2021, 2, 13, 11, 0, 0) do
             expect(wizard).to be_invalid
-            expect(wizard.errors[:date]).to contain_exactly('The interview date must be in the future')
+            expect(wizard.errors[:date]).to contain_exactly('Date must be today or in the future')
           end
         end
       end
@@ -124,7 +124,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
         it 'returns false and adds a time error' do
           Timecop.freeze(2021, 2, 13, 11, 0, 0) do
             expect(wizard).to be_invalid
-            expect(wizard.errors[:time]).to contain_exactly('The interview time must be in the future')
+            expect(wizard.errors[:time]).to contain_exactly('Time must be in the future')
           end
         end
       end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   def then_i_see_a_validation_error
-    expect(page).to have_content 'Enter a cancellation reason'
+    expect(page).to have_content 'Enter reason for cancelling interview'
   end
 
   def when_i_enter_a_valid_cancellation_reason

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -37,7 +37,14 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     when_i_change_the_interview_details
     then_i_can_see_interview_was_updated
 
-    when_i_cancel_an_interview
+    when_i_click_to_cancel_an_interview
+    and_i_do_not_enter_a_cancellation_reason
+    then_i_see_a_validation_error
+
+    when_i_enter_a_valid_cancellation_reason
+    then_i_see_the_check_page_with_working_edit_links
+
+    when_i_confirm_the_cancellation
     i_can_see_the_application_is_still_in_the_interviewing_state
     and_i_can_see_the_second_interview
 
@@ -149,13 +156,41 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_content("Additional details\nBusiness casual, first impressions are important")
   end
 
-  def when_i_cancel_an_interview
+  def when_i_click_to_cancel_an_interview
     first(:link, 'Cancel').click
-    fill_in 'interview[cancellation_reason]', with: 'A cancellation reason'
-    click_on 'Continue'
+  end
 
+  def and_i_do_not_enter_a_cancellation_reason
+    click_on 'Continue'
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content 'Enter a cancellation reason'
+  end
+
+  def when_i_enter_a_valid_cancellation_reason
+    fill_in 'provider_interface_cancel_interview_wizard[cancellation_reason]', with: 'A cancellation reason'
+    click_on 'Continue'
+  end
+
+  def then_i_see_the_check_page_with_working_edit_links
+    expect(page).to have_content 'A cancellation reason'
+    expect(page).to have_content 'Change'
+
+    click_link 'Change'
+    expect(page).to have_field('provider_interface_cancel_interview_wizard[cancellation_reason]', with: 'A cancellation reason')
+    click_on 'Continue'
+  end
+
+  def when_i_confirm_the_cancellation
     click_on 'Send cancellation'
     expect(page).to have_content('Interview cancelled')
+  end
+
+  def when_i_cancel_an_interview
+    when_i_click_to_cancel_an_interview
+    when_i_enter_a_valid_cancellation_reason
+    when_i_confirm_the_cancellation
   end
 
   def i_can_see_the_application_is_still_in_the_interviewing_state


### PR DESCRIPTION
## Context
There are a few obvious bugs in the interviews feature that we've noticed already

## Changes proposed in this pull request
- Display interview preferences in the interview summary card
- Capitalise fee status
- Validate presence of cancellation reason when cancelling interview
- Add change links to cancellation check page
- Hide links that provider users do not have permission to view

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/TgL7U1Tr/3305-review-interview-flow-with-designers-and-implement-fixes-where-necessary

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
