### PR TITLE
Use new `govuk-button-group` component

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -24,10 +24,12 @@
           </p>
 
           <% if FeatureFlag.active?(:interviews) %>
-            <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
-            <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button--secondary' %>
+            <div class="govuk-button-group">
+              <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice) %>
+              <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button--secondary' %>
+            </div>
           <% else %>
-            <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button' %>
+            <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice) %>
           <% end %>
         <% elsif waiting_for_interview? %>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">

--- a/app/frontend/styles/_button.scss
+++ b/app/frontend/styles/_button.scss
@@ -1,0 +1,4 @@
+// TODO: Remove once implemented cookie banner from design system
+.app-button--cookies {
+  min-width: 12em;
+}

--- a/app/frontend/styles/_cookies-banner.scss
+++ b/app/frontend/styles/_cookies-banner.scss
@@ -1,7 +1,0 @@
-.cookies_banner__button {
-  padding: 0;
-}
-
-.cookies_banner__button .govuk-button {
-  width: 90%;
-}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -40,17 +40,17 @@ $moj-images-path: "~@ministryofjustice/frontend/moj/assets/images/";
 @import "_application-card";
 @import "_autocomplete";
 @import "_banner";
+@import "_button";
 @import "_card";
 @import "_contents-list";
 @import "_diagram";
+@import "_feedback";
 @import "_flex-grid";
 @import "_grid";
 @import "_qualification";
 @import "_section";
 @import "_status-box";
 @import "_summary-card";
-@import "_feedback";
-@import "_cookies-banner";
 
 // Override utilities
 @import "_overrides";

--- a/app/views/shared/_cookies_banner.html.erb
+++ b/app/views/shared/_cookies_banner.html.erb
@@ -1,22 +1,15 @@
 <div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-width-container govuk-!-padding-top-4">
-        <h1 class="govuk-heading-m govuk-!-margin-bottom-4">
-          Tell us whether you accept cookies
-        </h1>
-        <p class="govuk-body">
-        We use <%= govuk_link_to 'cookies to collect information', cookies_path %> about how you use ‘<%= service_name %>’. We use this information to make the website work as well as possible and improve government services.
-        </p>
-        <div class="cookies_banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-          <%= form_with model: CookiePreferencesForm.new(consent: 'yes'), url: cookie_preferences_path, method: :post do |f| %>
-            <%= f.govuk_submit 'Accept all cookies' %>
-          <% end %>
-        </div>
-        <div class="cookies_banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
-          <a class="govuk-button" href="<%= cookies_path %>">Set cookie preferences</a>
-        </div>
-      </div>
-    </div>
+  <div class="govuk-!-width-two-thirds govuk-!-padding-top-4">
+    <h1 class="govuk-heading-m govuk-!-margin-bottom-4">
+      Tell us whether you accept cookies
+    </h1>
+    <p class="govuk-body">
+      We use <%= govuk_link_to 'cookies to collect information', cookies_path %> about how you use ‘<%= service_name %>’. We use this information to make the website work as well as possible and improve government services.
+    </p>
+    <%= form_with model: CookiePreferencesForm.new(consent: 'yes'), url: cookie_preferences_path, method: :post do |f| %>
+      <%= f.govuk_submit('Accept all cookies', classes: 'app-button--cookies') do %>
+        <%= govuk_button_link_to 'Set cookie preferences', cookies_path, class: 'app-button--cookies' %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -6,15 +6,17 @@
 
 <%= render SupportInterface::ApplicationSummaryComponent.new(application_form: @application_form) %>
 
-<% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
-<% end %>
+<div class="govuk-button-group">
+  <% unless HostingEnvironment.production? %>
+    <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+  <% end %>
 
-<% if @application_form.candidate.hide_in_reporting? %>
-  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
-<% else %>
-  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
-<% end %>
+  <% if @application_form.candidate.hide_in_reporting? %>
+    <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+  <% else %>
+    <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+  <% end %>
+</div>
 
 <%= render SupportInterface::PersonalDetailsComponent.new(application_form: @application_form) %>
 

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -1,8 +1,9 @@
 <%= render 'support_interface/providers/providers_navigation', title: 'Provider users' %>
 
-<%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
-
-<%= govuk_button_link_to 'Download active provider users (CSV)', "#{new_support_interface_data_export_path}#providers_export", class: 'govuk-button--secondary' %>
+<div class="govuk-button-group">
+  <%= govuk_button_link_to 'Add provider user', new_support_interface_provider_user_path %>
+  <%= govuk_button_link_to 'Download active provider users (CSV)', "#{new_support_interface_data_export_path}#providers_export", class: 'govuk-button--secondary' %>
+</div>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @provider_users) do %>
   <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider_users)) %>


### PR DESCRIPTION
## Context

`govuk-frontend` now has styles for a button group: `govuk-button-group`; when two or more buttons or links appear next to each other.

## Changes proposed in this pull request

* Adds a button group to candidate application form and provider users page in the Support interface (only minor spacing change)
* Adds a button group to ‘Make a decision’ inset text on Manage interface (only minor spacing change)
* Uses button group in cookie banner (which is part of the reason why this new style was introduced). Possible a whole other bit of design work to bring our cookie banner inline with the new guidance, ~~but for now updated our cookie banner to use this new button group style~~ updated the code so that the button and link appear within `govuk-button-group` (thanks to the form builder magic), adding a modifier to ensure the buttons are the same width:

| Before | After |
| - | - |
| ![cookies-before](https://user-images.githubusercontent.com/813383/107633996-c99b7200-6c60-11eb-9777-ec91d15d0e83.png) | ![cookies-after](https://user-images.githubusercontent.com/813383/107633993-c86a4500-6c60-11eb-95a8-a1f05d7c16ee.png)

Honestly, I thought this might be needed in more places… 😆

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
