### PR TITLE
Change govuk_link_to/govuk_button_link_to be consistent with Rails

### DIFF
--- a/app/components/candidate_interface/restructured_work_history/job_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/job_component.html.erb
@@ -19,11 +19,11 @@
 
   <% if @editable %>
     <div class="govuk-grid-column-one-third govuk-body app-grid-column-one-third--actions">
-      <%= govuk_link_to(nil, candidate_interface_edit_restructured_work_history_path(@work_experience.id), class: 'govuk-!-margin-right-2') do %>
+      <%= govuk_link_to(candidate_interface_edit_restructured_work_history_path(@work_experience.id), class: 'govuk-!-margin-right-2') do %>
         Change <span class="govuk-visually-hidden">job <%= @work_experience.role %> for <%= @work_experience.organisation %></span>
       <% end %>
 
-      <%= govuk_link_to(nil, candidate_interface_destroy_restructured_work_history_path(@work_experience.id)) do %>
+      <%= govuk_link_to(candidate_interface_destroy_restructured_work_history_path(@work_experience.id)) do %>
         Delete <span class="govuk-visually-hidden">job <%= @work_experience.role %> for <%= @work_experience.organisation %></span>
       <% end %>
     </div>

--- a/app/components/candidate_interface/restructured_work_history/work_break_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/work_break_component.html.erb
@@ -9,11 +9,11 @@
 
   <% if @editable %>
     <div class="govuk-grid-column-one-third govuk-body app-grid-column-one-third--actions">
-      <%= govuk_link_to(nil, candidate_interface_edit_restructured_work_history_break_path(@work_break.id), class: 'govuk-!-margin-right-2') do %>
+      <%= govuk_link_to(candidate_interface_edit_restructured_work_history_break_path(@work_break.id), class: 'govuk-!-margin-right-2') do %>
         Change <span class="govuk-visually-hidden">entry for break between <%= formatted_start_date %> and <%= formatted_end_date %></span>
       <% end %>
 
-      <%= govuk_link_to(nil, candidate_interface_destroy_restructured_work_history_break_path(@work_break.id)) do %>
+      <%= govuk_link_to(candidate_interface_destroy_restructured_work_history_break_path(@work_break.id)) do %>
         Delete <span class="govuk-visually-hidden">entry for break between <%= formatted_start_date %> and <%= formatted_end_date %></span>
       <% end %>
     </div>

--- a/app/components/provider_interface/provider_relationship_permissions_list_component.html.erb
+++ b/app/components/provider_interface/provider_relationship_permissions_list_component.html.erb
@@ -29,7 +29,7 @@
         </dd>
         <% if editable %>
           <dd class="govuk-summary-list__actions">
-            <%= govuk_link_to(nil, row[:change_path]) do %>
+            <%= govuk_link_to(row[:change_path]) do %>
               Change<span class="govuk-visually-hidden"><%= row[:action] %></span>
             <% end if row[:change_path] %>
           </dd>

--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -23,7 +23,7 @@
             </ul>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_link_to(nil, edit_support_interface_provider_user_path(row[:provider_user])) do %>
+            <%= govuk_link_to(edit_support_interface_provider_user_path(row[:provider_user])) do %>
               Update permissions<span class="govuk-visually-hidden"> for <%= row[:provider_user].display_name %></span>
             <% end %>
           </td>

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,5 +1,12 @@
 module ViewHelper
-  def govuk_link_to(body, url, html_options = {}, &_block)
+  def govuk_link_to(body = nil, url = nil, html_options = nil, &block)
+    if block_given?
+      html_options = url
+      url = body
+      body = block
+    end
+    html_options ||= {}
+
     html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
 
     return link_to(url, html_options) { yield } if block_given?
@@ -36,7 +43,14 @@ module ViewHelper
     mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
   end
 
-  def govuk_button_link_to(body, url, html_options = {}, &_block)
+  def govuk_button_link_to(body = nil, url = nil, html_options = nil, &block)
+    if block_given?
+      html_options = url
+      url = body
+      body = block
+    end
+    html_options ||= {}
+
     html_options = {
       class: prepend_css_class('govuk-button', html_options[:class]),
       role: 'button',

--- a/app/views/candidate_interface/course_choices/have_you_chosen/go_to_find.html.erb
+++ b/app/views/candidate_interface/course_choices/have_you_chosen/go_to_find.html.erb
@@ -9,7 +9,7 @@
 
     <p class="govuk-body-l">Search for courses near you on Find postgraduate teacher&nbsp;training.</p>
 
-    <%= govuk_button_link_to nil, 'https://www.find-postgraduate-teacher-training.service.gov.uk', class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-2 govuk-button--start', target: '_blank', rel: 'noopener', 'aria-describedby': 'find-new-window' do %>
+    <%= govuk_button_link_to 'https://www.find-postgraduate-teacher-training.service.gov.uk', class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-2 govuk-button--start', target: '_blank', rel: 'noopener', 'aria-describedby': 'find-new-window' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/candidate_interface/restructured_work_history/review/show.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/review/show.html.erb
@@ -12,7 +12,7 @@
   <% if @application_form.application_work_experiences.blank? %>
     <%= govuk_button_link_to 'Add a job', candidate_interface_new_restructured_work_history_path  %>
   <% else %>
-    <%= govuk_button_link_to nil, candidate_interface_new_restructured_work_history_path, class: 'govuk-button--secondary' do %>
+    <%= govuk_button_link_to candidate_interface_new_restructured_work_history_path, class: 'govuk-button--secondary' do %>
       <%= @application_form.application_work_experiences.any? ? t('application_form.work_history.another.button') : t('application_form.work_history.add.button') %>
     <% end%>
   <% end %>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.volunteering.short') %>
     </h1>
 
-    <%= govuk_button_link_to nil, candidate_interface_new_volunteering_role_path, class: 'govuk-button--secondary' do %>
+    <%= govuk_button_link_to candidate_interface_new_volunteering_role_path, class: 'govuk-button--secondary' do %>
       <%= @application_form.application_volunteering_experiences.any? ? t('application_form.volunteering.another.button') : t('application_form.volunteering.add.button') %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.work_history') %>
     </h1>
 
-    <%= govuk_button_link_to nil, candidate_interface_new_work_history_path, class: 'govuk-button--secondary' do %>
+    <%= govuk_button_link_to candidate_interface_new_work_history_path, class: 'govuk-button--secondary' do %>
       <%= @application_form.application_work_experiences.any? ? t('application_form.work_history.another.button') : t('application_form.work_history.add.button') %>
     <% end %>
   </div>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -8,7 +8,7 @@
         <div class="app-masthead__description">
           <p class="govuk-body-l">Try our new service to see how easy it is to use. It’s free for providers and candidates.</p>
         </div>
-        <%= govuk_button_link_to nil, @pilot_enrolment_form_url, class: 'govuk-!-margin-bottom-0 govuk-button--start app-button--inverted' do %>
+        <%= govuk_button_link_to @pilot_enrolment_form_url, class: 'govuk-!-margin-bottom-0 govuk-button--start app-button--inverted' do %>
           Get started
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/support_interface/data_exports/index.html.erb
+++ b/app/views/support_interface/data_exports/index.html.erb
@@ -22,7 +22,7 @@
             ) %>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_link_to '', support_interface_data_export_path(data_export) do %>
+            <%= govuk_link_to support_interface_data_export_path(data_export) do %>
               <%= data_export.created_at.to_s(:govuk_date_and_time) %> - <%= data_export.name %>
             <% end %>
           </td>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -25,7 +25,7 @@
             link_action = support_user.discarded? ? 'Restore' : 'Remove'
             link_path = support_user_account_management_path(support_user)
           %>
-          <%= govuk_link_to(nil, link_path) do %>
+          <%= govuk_link_to(link_path) do %>
             <%= link_action %> user<span class="govuk-visually-hidden"> <%= support_user.display_name %></span>
           <% end %>
         </td>

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ViewHelper, type: :helper do
     end
 
     it 'accepts a block' do
-      anchor_tag = helper.govuk_link_to(nil, 'https://localhost:0103/bee/buzz') do
+      anchor_tag = helper.govuk_link_to('https://localhost:0103/bee/buzz') do
         'Buzz'
       end
       expect(anchor_tag).to eq('<a class="govuk-link" href="https://localhost:0103/bee/buzz">Buzz</a>')
@@ -82,7 +82,7 @@ RSpec.describe ViewHelper, type: :helper do
     end
 
     it 'accepts a block' do
-      anchor_tag = helper.govuk_button_link_to(nil, 'https://localhost:0103/bee/buzz') do
+      anchor_tag = helper.govuk_button_link_to('https://localhost:0103/bee/buzz') do
         'Buzz'
       end
       expect(anchor_tag).to eq('<a class="govuk-button" role="button" data-module="govuk-button" draggable="false" href="https://localhost:0103/bee/buzz">Buzz</a>')


### PR DESCRIPTION
## Context

The `govuk_link_to` and `govuk_button_link_to` helpers should follow the principle of least surprise by being consistent with Rails. The `body` param should be 'optional' when a block is given (as an alternative way to specify the content of the link). 

## Changes proposed in this pull request

- Because we cannot make a first parameter optional in the true sense we shift the params by interpreting the first as the `url`, second as `html_options` etc. when a block is given just the way Rails does. https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/actionview/lib/action_view/helpers/url_helper.rb#L196-L206
- Update references to these helpers that specify a block.

## Guidance to review

- Anything missing?

## Link to Trello card

https://trello.com/c/Qw9Q80Bq/2983-dev-refactor-govuklinkto-and-govukbuttonlinkto-to-make-body-param-optional

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
