### PR TITLE
Adds `data:migrate` task

### DIFF
--- a/app/models/data_migration.rb
+++ b/app/models/data_migration.rb
@@ -1,4 +1,5 @@
 class DataMigration < ApplicationRecord
+  audited
 
   validates :service_name, uniqueness: { scope: :timestamp }
 end

--- a/app/models/data_migration.rb
+++ b/app/models/data_migration.rb
@@ -1,0 +1,4 @@
+class DataMigration < ApplicationRecord
+
+  validates :service_name, uniqueness: { scope: :timestamp }
+end

--- a/app/services/data_migration_runner.rb
+++ b/app/services/data_migration_runner.rb
@@ -1,0 +1,57 @@
+# This service is used by the data migration rake task found in `lib/tasks/data.rake`
+# Read more in `docs/data-migrations.md`
+
+class DataMigrationRunner
+  class MigrationAlreadyRanError < StandardError
+    def message
+      'The migration has already been executed'
+    end
+  end
+
+  class ManualRanOnlyError < StandardError
+    def message
+      'The migration only allows for manual execution. Run rake -T to find out how to run it manually.'
+    end
+  end
+
+  class AutomatedRanOnlyError < StandardError
+    def message
+      'The migration only allows for automated execution.'
+    end
+  end
+
+  attr_reader :service, :manual
+
+  def initialize(service_name, manual: false)
+    @service = Object.const_get(service_name)
+    @manual = manual
+
+    raise ManualRanOnlyError if service::MANUAL_RUN && !manual
+    raise AutomatedRanOnlyError if !service::MANUAL_RUN && manual
+    raise MigrationAlreadyRanError if migration_ran?
+  end
+
+  def execute(audit_user: 'system', audit_comment: nil)
+    Rails.logger.info("Executing #{service}...")
+    ActiveRecord::Base.transaction do
+      log_migration(audit_user: audit_user, audit_comment: audit_comment)
+      service.new.change
+    end
+    Rails.logger.info("#{service}##{service::TIMESTAMP} data migration completed successfully")
+  end
+
+private
+
+  def migration_ran?
+    DataMigration.exists?(service_name: service.to_s, timestamp: service::TIMESTAMP)
+  end
+
+  def log_migration(audit_user: 'system', audit_comment: nil)
+    data = { service_name: service.to_s, timestamp: service::TIMESTAMP }
+    data.merge!(audit_comment: audit_comment) if audit_comment
+
+    Audited.audit_class.as_user(audit_user) do
+      DataMigration.create(data)
+    end
+  end
+end

--- a/db/migrate/20210213002839_create_data_migrations.rb
+++ b/db/migrate/20210213002839_create_data_migrations.rb
@@ -1,0 +1,11 @@
+class CreateDataMigrations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :data_migrations do |t|
+      t.string :service_name
+      t.string :timestamp
+
+      t.timestamps
+    end
+    add_index :data_migrations, %i[service_name timestamp], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_02_24_115745) do
   create_sequence "course_options_id_seq"
   create_sequence "courses_id_seq"
   create_sequence "data_exports_id_seq"
+  create_sequence "data_migrations_id_seq"
   create_sequence "emails_id_seq"
   create_sequence "english_proficiencies_id_seq"
   create_sequence "feature_metrics_dashboards_id_seq"
@@ -408,6 +409,14 @@ ActiveRecord::Schema.define(version: 2021_02_24_115745) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["initiator_type", "initiator_id"], name: "index_data_exports_on_initiator_type_and_initiator_id"
+  end
+
+  create_table "data_migrations", force: :cascade do |t|
+    t.string "service_name"
+    t.string "timestamp"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["service_name", "timestamp"], name: "index_data_migrations_on_service_name_and_timestamp", unique: true
   end
 
   create_table "emails", force: :cascade do |t|

--- a/docs/data-migrations.md
+++ b/docs/data-migrations.md
@@ -1,0 +1,42 @@
+# Data migrations
+
+In order to be able to test, track and if required, remove from the codebase data migrations, we have decided to add a rake task to manage this in a consistent way. Along with the rake task, a complimentary generator has been added that creates and configures the service to be used for each data migration.
+
+## How to use this service
+
+### Generating a new data migration service
+
+`rails g data_migration NAME`
+
+For example, running `rails generate data_migration backfill_data` will generate a new data migration service `DataMigrations::BackfillData` in `app/services/data_migrations`, similar to the example displayed below.
+
+```ruby
+module DataMigrations
+  class BackfillData
+    TIMESTAMP = 20210311005059
+    MANUAL_RUN = false
+
+    def change
+      # add any changes here
+    end
+  end
+end
+```
+
+### Running a data migration manually
+
+If you want to control over when the data migration is executed, `MANUAL_RUN` must be set to true.
+The service can then be executed manually from the terminal
+
+`rake data:migrate:manual[DataMigrations::BackfillData]`
+
+### Removing a service
+
+To remove a data migration service
+
+1. Delete the file and corresponding spec
+2. Remove the line referencing the service from the rake task found at `/lib/tasks/data.rake` (make sure to delete the entire line and not to introduce any space, or change the `DATA_MIGRATION_SERVICES` array structure)
+
+### Tracking executed services
+
+You can retrieve information about executed services by quering the `DataMigration` model.

--- a/lib/generators/data_migration_generator.rb
+++ b/lib/generators/data_migration_generator.rb
@@ -1,0 +1,16 @@
+class DataMigrationGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  desc 'This generates a data migration service in app/services/data_migrations and adds it to the data migration rake task'
+  def create_data_migration_file
+    name = "DataMigrations::#{file_name.camelize}"
+    copy_file 'data_migration.rb.tt', "app/services/data_migrations/#{file_name}.rb"
+    gsub_file "app/services/data_migrations/#{file_name}.rb", '%{service_name}', file_name.camelize
+    gsub_file "app/services/data_migrations/#{file_name}.rb", '%{timestamp}', Time.zone.now.to_s(:number)
+
+    copy_file 'data_migration_spec.rb.tt', "spec/services/data_migrations/#{file_name}_spec.rb"
+    gsub_file "spec/services/data_migrations/#{file_name}_spec.rb", '%{service_name}', file_name.camelize
+
+    inject_into_file 'lib/tasks/data.rake', "  '#{name}',\n", after: "# do not delete or edit this line - services added below by generator\n"
+  end
+end

--- a/lib/generators/templates/data_migration.rb.tt
+++ b/lib/generators/templates/data_migration.rb.tt
@@ -1,0 +1,9 @@
+module DataMigrations
+  class %{service_name}
+    TIMESTAMP = %{timestamp}
+
+    def change
+      # add any changes here
+    end
+  end
+end

--- a/lib/generators/templates/data_migration.rb.tt
+++ b/lib/generators/templates/data_migration.rb.tt
@@ -1,6 +1,7 @@
 module DataMigrations
   class %{service_name}
     TIMESTAMP = %{timestamp}
+    MANUAL_RUN = false
 
     def change
       # add any changes here

--- a/lib/generators/templates/data_migration_spec.rb.tt
+++ b/lib/generators/templates/data_migration_spec.rb.tt
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrations::%{service_name} do
+  pending "add some examples to  #{__FILE__}"
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,5 +1,12 @@
+DATA_MIGRATION_SERVICES = [
+  # do not delete or edit this line - services added below by generator
+].freeze
+
 def data_migrations
   puts 'Running data migrations configured in lib/tasks/data.rake...'
+
+  DATA_MIGRATION_SERVICES.each do |data_migration|
+  end
 end
 
 namespace :data do

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -6,30 +6,9 @@ def data_migrations
   puts 'Running data migrations configured in lib/tasks/data.rake...'
 
   DATA_MIGRATION_SERVICES.each do |data_migration_service_name|
-    service = Object.const_get(data_migration_service_name)
-
-    next if service::MANUAL_RUN || migration_ran?(service)
-
-    puts "Executing #{service}..."
-    ActiveRecord::Base.transaction do
-      log_migration(service)
-      service.new.change
-    end
-    puts "#{service}##{service::TIMESTAMP} data migration completed successfully"
-  end
-end
-
-def migration_ran?(service)
-  DataMigration.exists?(service_name: service.to_s, timestamp: service::TIMESTAMP)
-end
-
-def log_migration(service, audit_user: 'system', audit_comment: nil)
-  data = { service_name: service.to_s,
-           timestamp: service::TIMESTAMP }
-  data.merge!(audit_comment: audit_comment) if audit_comment
-
-  Audited.audit_class.as_user(audit_user) do
-    DataMigration.create(data)
+    DataMigrationRunner.new(data_migration_service_name).execute
+  rescue StandardError => e
+    STDOUT.puts "#{data_migration_service_name} skipped with error: #{e.message}"
   end
 end
 
@@ -41,25 +20,20 @@ namespace :data do
 
   namespace :migrate do
     desc "Executes specified migration if it's pending"
+
     task :manual, [:service_name] => :environment do |_, args|
       abort('You must specify a migration service e.g. rake data:migrate:manual[DataMigrations::UpdateApplicationChoiceData]') if args[:service_name].blank?
-      service = Object.const_get(args[:service_name])
-      abort('Migration already executed') if migration_ran?(service)
 
+      data_migration_runner = DataMigrationRunner.new(args[:service_name], manual: true)
       STDOUT.puts 'Hello! Who are you? This name will be used in the audit log for any changes you make.'
-      user = STDIN.gets.strip
+      user = STDIN.gets
       STDOUT.puts 'Type your audit comment or hit return to continue'
-      audit_comment = STDIN.gets.strip
+      comment = STDIN.gets
 
-      puts "Executing #{service}..."
-      ActiveRecord::Base.transaction do
-        log_migration(service, audit_user: user, audit_comment: audit_comment)
-        service.new.change
-      end
-      puts "#{service}##{service::TIMESTAMP} data migration completed successfully"
+      data_migration_runner.execute(audit_user: user, audit_comment: comment)
 
     rescue StandardError => e
-      abort("Something went wrong and the migration was not executed: #{e}")
+      STDOUT.puts "#{args[:service_name]} skipped with error: #{e.message}"
     end
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -8,20 +8,58 @@ def data_migrations
   DATA_MIGRATION_SERVICES.each do |data_migration_service_name|
     service = Object.const_get(data_migration_service_name)
 
-    next if DataMigration.exists?(service_name: data_migration_service_name, timestamp: service::TIMESTAMP)
+    next if service::MANUAL_RUN || migration_ran?(service)
 
+    puts "Executing #{service}..."
     ActiveRecord::Base.transaction do
-      DataMigration.create(service_name: data_migration_service_name, timestamp: service::TIMESTAMP)
+      log_migration(service)
       service.new.change
-      puts "#{service::TIMESTAMP} #{data_migration_service_name} executed"
     end
+    puts "#{service}##{service::TIMESTAMP} data migration completed successfully"
+  end
+end
+
+def migration_ran?(service)
+  DataMigration.exists?(service_name: service.to_s, timestamp: service::TIMESTAMP)
+end
+
+def log_migration(service, audit_user: 'system', audit_comment: nil)
+  data = { service_name: service.to_s,
+           timestamp: service::TIMESTAMP }
+  data.merge!(audit_comment: audit_comment) if audit_comment
+
+  Audited.audit_class.as_user(audit_user) do
+    DataMigration.create(data)
   end
 end
 
 namespace :data do
-  desc 'Migrates data'
+  desc 'Executes all pending data migrations'
   task migrate: :environment do
     at_exit { data_migrations }
+  end
+
+  namespace :migrate do
+    desc "Executes specified migration if it's pending"
+    task :manual, [:service_name] => :environment do |_, args|
+      abort('You must specify a migration service e.g. rake data:migrate:manual[DataMigrations::UpdateApplicationChoiceData]') if args[:service_name].blank?
+
+      STDOUT.puts 'Hello! Who are you? This name will be used in the audit log for any changes you make.'
+      user = STDIN.gets.strip
+      STDOUT.puts 'Type your audit comment or hit return to continue'
+      audit_comment = STDIN.gets.strip
+
+      service = Object.const_get(args[:service_name])
+
+      abort('Migration already executed') if migration_ran?(service)
+
+      puts "Executing #{service}..."
+      ActiveRecord::Base.transaction do
+        log_migration(service, audit_user: user, audit_comment: audit_comment)
+        service.new.change
+      end
+      puts "#{service}##{service::TIMESTAMP} data migration completed successfully"
+    end
   end
 end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,14 @@
+def data_migrations
+  puts 'Running data migrations configured in lib/tasks/data.rake...'
+end
+
+namespace :data do
+  desc 'Migrates data'
+  task migrate: :environment do
+    at_exit { data_migrations }
+  end
+end
+
+Rake::Task['db:migrate'].enhance do
+  Rake::Task['data:migrate'].invoke
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -5,7 +5,16 @@ DATA_MIGRATION_SERVICES = [
 def data_migrations
   puts 'Running data migrations configured in lib/tasks/data.rake...'
 
-  DATA_MIGRATION_SERVICES.each do |data_migration|
+  DATA_MIGRATION_SERVICES.each do |data_migration_service_name|
+    service = Object.const_get(data_migration_service_name)
+
+    next if DataMigration.exists?(service_name: data_migration_service_name, timestamp: service::TIMESTAMP)
+
+    ActiveRecord::Base.transaction do
+      DataMigration.create(service_name: data_migration_service_name, timestamp: service::TIMESTAMP)
+      service.new.change
+      puts "#{service::TIMESTAMP} #{data_migration_service_name} executed"
+    end
   end
 end
 

--- a/spec/models/data_migration_spec.rb
+++ b/spec/models/data_migration_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DataMigration, type: :model do
+  it { is_expected.to validate_uniqueness_of(:service_name).scoped_to(:timestamp) }
+end

--- a/spec/services/data_migration_runner_spec.rb
+++ b/spec/services/data_migration_runner_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrationRunner do
+  before do
+    test_service = Class.new do
+      const_set(:TIMESTAMP, 20210311005059)
+      const_set(:MANUAL_RUN, false)
+
+      def change; end
+    end
+
+    stub_const('TestService', test_service)
+  end
+
+  it 'throws an NameError if the service does not exist' do
+    expect { described_class.new('NoSuchClass') }.to raise_error(NameError)
+  end
+
+  context 'when the service has already been migrated' do
+    it 'throws a MigrationAlreadyRanError' do
+      DataMigration.create(service_name: TestService.to_s, timestamp: TestService::TIMESTAMP)
+
+      expect { described_class.new(TestService.to_s) }.to raise_error(DataMigrationRunner::MigrationAlreadyRanError)
+    end
+  end
+
+  context 'when the service has not been migrated before' do
+    it 'executes the migration and updates the DataMigration table' do
+      service = described_class.new(TestService.to_s)
+
+      expect { service.execute }
+        .to change { DataMigration.where(service_name: TestService.to_s, timestamp: TestService::TIMESTAMP).count }.by(1)
+    end
+
+    it 'adds an audit entry', with_audited: true do
+      service = described_class.new(TestService.to_s)
+
+      expect { service.execute }
+        .to change { Audited::Audit.count }.by(1)
+    end
+  end
+
+  context 'when Service::MANUAL_RUN is set to false' do
+    context 'when manual: true' do
+      it 'throws a AutomatedRanOnlyError' do
+        expect { described_class.new(TestService.to_s, manual: true) }.to raise_error(DataMigrationRunner::AutomatedRanOnlyError)
+      end
+    end
+  end
+
+  context 'when Service::MANUAL_RUN is set to true' do
+    before do
+      test_service = Class.new do
+        const_set(:TIMESTAMP, 20210311005059)
+        const_set(:MANUAL_RUN, true)
+
+        def change; end
+      end
+
+      stub_const('TestManualService', test_service)
+    end
+
+    context 'when manual: false' do
+      it 'throws a ManualRanOnlyError' do
+        expect { described_class.new(TestManualService.to_s, manual: false) }.to raise_error(DataMigrationRunner::ManualRanOnlyError)
+      end
+    end
+
+    context 'when manual: true' do
+      it 'executes the service' do
+        service = described_class.new(TestManualService.to_s, manual: true)
+
+        expect { service.execute }
+          .to change { DataMigration.where(service_name: TestManualService.to_s, timestamp: TestManualService::TIMESTAMP).count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Using migration files to run one off services to update data will make the services permanent dependencies of the project.

Using a rake task instead to perform any migrations, enables us to add/remove any data updating services as we see fit.

As the task is configured to be executed after `db:migrate` exits, it also eliminates the need to either have to configure or manually run any data migrations on any environment.


**UPDATE**

Extended PR to add a `DataMigration` model that tracks data migrations and enables us to check that they've not run before, and a generator that deals with creating the new service in the expected format. It also updates the data migration rake task with the new service, simplifying the process, as developers don't need to be concerned about any configuration but simply implement their changes in the generated service and test them.


## Changes proposed in this pull request

Adds a `data:migrate` rake task and configures it to be executed after `db:migrate`

## Related PR

https://github.com/DFE-Digital/apply-for-teacher-training/pull/4057

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
