### PR TITLE
Interview wizard fixes

### DIFF
--- a/app/components/provider_interface/interview_details_component.rb
+++ b/app/components/provider_interface/interview_details_component.rb
@@ -21,6 +21,7 @@ module ProviderInterface
       {
         key: key,
         value: value,
+        action: "Change #{key.downcase}",
         change_path: change_path,
       }
     end

--- a/app/components/provider_interface/interview_details_component.rb
+++ b/app/components/provider_interface/interview_details_component.rb
@@ -12,7 +12,7 @@ module ProviderInterface
       time_row = build_row('Time', @interview_form.date_and_time.to_s(:govuk_time))
       organisation_row = build_row('Organisation carrying out interview', @interview_form.provider.name)
       location_row = build_row('Address or online meeting details', @interview_form.location)
-      details_row = build_row('Additional details', @interview_form.additional_details)
+      details_row = build_row('Additional details', @interview_form.additional_details.presence || 'None')
 
       [date_row, time_row, organisation_row, location_row, details_row]
     end

--- a/app/components/provider_interface/interview_details_component.rb
+++ b/app/components/provider_interface/interview_details_component.rb
@@ -8,29 +8,72 @@ module ProviderInterface
     end
 
     def rows
-      date_row = build_row('Date', @interview_form.date_and_time.to_s(:govuk_date))
-      time_row = build_row('Time', @interview_form.date_and_time.to_s(:govuk_time))
-      organisation_row = build_row('Organisation carrying out interview', @interview_form.provider.name)
-      location_row = build_row('Address or online meeting details', @interview_form.location)
-      details_row = build_row('Additional details', @interview_form.additional_details.presence || 'None')
-
-      [date_row, time_row, organisation_row, location_row, details_row]
+      [
+        date_row,
+        time_row,
+        organisation_row,
+        location_row,
+        details_row,
+      ]
     end
 
-    def build_row(key, value)
+  private
+
+    def date_row
+      build_row(:date, @interview_form.date_and_time.to_s(:govuk_date))
+    end
+
+    def time_row
+      build_row(:time, @interview_form.date_and_time.to_s(:govuk_time))
+    end
+
+    def organisation_row
+      build_row(:provider_id, @interview_form.provider.name)
+    end
+
+    def location_row
+      build_row(:location, @interview_form.location)
+    end
+
+    def details_row
+      build_row(:additional_details, @interview_form.additional_details.presence || 'None')
+    end
+
+    def build_row(field, value)
+      key = key_for_field(field)
       {
         key: key,
         value: value,
-        action: "Change #{key.downcase}",
-        change_path: change_path,
+        action: key.downcase,
+        change_path: change_path(field),
       }
     end
 
-    def change_path
-      if @interview.present?
-        edit_provider_interface_application_choice_interview_path(@interview_form.application_choice, @interview)
+    def key_for_field(field)
+      if %i[date provider_id].include?(field)
+        I18n.t!("helpers.legend.provider_interface_interview_wizard.#{field}")
       else
-        new_provider_interface_application_choice_interview_path(@interview_form.application_choice)
+        I18n.t!("helpers.label.provider_interface_interview_wizard.#{field}")
+      end
+    end
+
+    def change_path(field)
+      anchor_to = anchor_id(field)
+      if @interview.present?
+        edit_provider_interface_application_choice_interview_path(@interview_form.application_choice, @interview, anchor: anchor_to)
+      else
+        new_provider_interface_application_choice_interview_path(@interview_form.application_choice, anchor: anchor_to)
+      end
+    end
+
+    def anchor_id(field)
+      case field
+      when :date
+        'provider_interface_interview_wizard_date_3i'
+      when :provider_id
+        "provider-interface-interview-wizard-provider-id-#{@interview_form.provider.id}-field"
+      else
+        "provider-interface-interview-wizard-#{field.to_s.dasherize}-field"
       end
     end
   end

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -20,7 +20,8 @@ module ProviderInterface
                                        unless: ->(c) { %i[date time].any? { |d| c.errors.keys.include?(d) } }
     validate :date_after_rbd_date, if: %i[date_and_time date_and_time_in_future]
     validates :provider_id, presence: true, if: %i[application_choice provider_user multiple_application_providers?]
-    validates :location, presence: true
+    validates :location, presence: true, length: { maximum: 10240 }
+    validates :additional_details, length: { maximum: 10240 }
 
     def initialize(state_store, attrs = {})
       @state_store = state_store

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -12,13 +12,15 @@ module ProviderInterface
     attribute 'date(2i)', :string
     attribute 'date(1i)', :string
 
+    validates :provider_user, :application_choice, presence: true
     validates :date, date: { presence: true }
+    validates :time, presence: true
+    validate :time_is_valid, unless: -> { time.blank? }
     validate :date_and_time_in_future, if: %i[date_and_time],
                                        unless: ->(c) { %i[date time].any? { |d| c.errors.keys.include?(d) } }
-    validate :time_is_valid?, if: :time
     validate :date_after_rbd_date, if: %i[date_and_time date_and_time_in_future]
-    validates :time, :provider_user, :location, :application_choice, presence: true
     validates :provider_id, presence: true, if: %i[application_choice provider_user multiple_application_providers?]
+    validates :location, presence: true
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
@@ -39,33 +41,7 @@ module ProviderInterface
     end
 
     def date_and_time
-      Time.zone.local(date.year, date.month, date.day, parsed_time.hour, parsed_time.min) if date.is_a?(Date)
-    end
-
-    def date_and_time_in_future
-      return true if date_and_time > Time.zone.now
-
-      if date.past?
-        errors.add(:date, :past) unless errors.added?(:date, :past)
-      else
-        errors.add(:time, :past) unless errors.added?(:time, :past)
-      end
-      false
-    end
-
-    def date_after_rbd_date
-      errors.add(:date, :after_rdb) if date > application_choice.reject_by_default_at
-    end
-
-    def parsed_time
-      Time.zone.parse(time.gsub(/[ .]/, ':'))
-    end
-
-    def time_is_valid?
-      return true if time.match(VALID_TIME_FORMAT)
-
-      errors.add(:time, :invalid)
-      false
+      Time.zone.local(date.year, date.month, date.day, parsed_time.hour, parsed_time.min) if date.is_a?(Date) && parsed_time.is_a?(Time)
     end
 
     def provider
@@ -108,6 +84,37 @@ module ProviderInterface
     end
 
   private
+
+    def date_and_time_in_future
+      return true if date_and_time > Time.zone.now
+
+      if date.past?
+        errors.add(:date, :past) unless errors.added?(:date, :past)
+      else
+        errors.add(:time, :past) unless errors.added?(:time, :past)
+      end
+      false
+    end
+
+    def date_after_rbd_date
+      errors.add(:date, :after_rdb) if date > application_choice.reject_by_default_at
+    end
+
+    def time_in_correct_format?
+      time.match(VALID_TIME_FORMAT)
+    end
+
+    def parsed_time
+      return unless time_in_correct_format?
+
+      Time.zone.parse(time.gsub(/[ .]/, ':'))
+    end
+
+    def time_is_valid
+      return if time_in_correct_format?
+
+      errors.add(:time, :invalid)
+    end
 
     def last_saved_state
       saved_state = @state_store.read

--- a/app/views/provider_interface/interviews/_form.html.erb
+++ b/app/views/provider_interface/interviews/_form.html.erb
@@ -1,5 +1,3 @@
-<%= f.govuk_error_summary %>
-
 <%= f.govuk_date_field :date, legend: { size: 'm' } %>
 
 <%= f.govuk_text_field :time, width: 5, label: { size: 'm' } %>

--- a/app/views/provider_interface/interviews/_form.html.erb
+++ b/app/views/provider_interface/interviews/_form.html.erb
@@ -1,9 +1,9 @@
-<%= f.govuk_date_field :date, legend: { size: 'm' } %>
+<%= f.govuk_date_field :date %>
 
 <%= f.govuk_text_field :time, width: 5, label: { size: 'm' } %>
 
 <% if @wizard.multiple_application_providers? %>
-  <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { text: 'Organisation carrying out interview', size: 'm' } do %>
+  <%= f.govuk_radio_buttons_fieldset :provider_id do %>
     <% @wizard.application_providers.each_with_index do |provider, index| %>
       <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name }, link_errors: index.zero? %>
     <% end %>
@@ -12,6 +12,6 @@
 
 <%= f.govuk_text_area :location, label: { size: 'm' } %>
 
-<%= f.govuk_text_area :additional_details, label: { size: 'm' } %>
+<%= f.govuk_text_area :additional_details, label: { text: "#{t('helpers.label.provider_interface_interview_wizard.additional_details')} (optional)", size: 'm' } %>
 
 <%= f.govuk_submit t('.continue') %>

--- a/app/views/provider_interface/interviews/_form.html.erb
+++ b/app/views/provider_interface/interviews/_form.html.erb
@@ -6,8 +6,8 @@
 
 <% if @wizard.multiple_application_providers? %>
   <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { text: 'Organisation carrying out interview', size: 'm' } do %>
-    <% @wizard.application_providers.each do |provider| %>
-      <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name } %>
+    <% @wizard.application_providers.each_with_index do |provider, index| %>
+      <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name }, link_errors: index.zero? %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/provider_interface/interviews/edit.html.erb
+++ b/app/views/provider_interface/interviews/edit.html.erb
@@ -3,22 +3,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
-    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-
-    <% if @application_choice.application_form.interview_preferences.present? %>
-      <div class="app-banner app-banner--details">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= t('.interview_preferences.title') %></h2>
-        <p class="govuk-body"><%= @application_choice.application_form.interview_preferences %></p>
-      </div>
-    <% end %>
-
     <%= form_with(
       model: @wizard,
       url: check_provider_interface_application_choice_interview_path(@application_choice, @interview),
       method: :post,
     ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+      <% if @application_choice.application_form.interview_preferences.present? %>
+        <div class="app-banner app-banner--details">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= t('.interview_preferences.title') %></h2>
+          <p class="govuk-body"><%= @application_choice.application_form.interview_preferences %></p>
+        </div>
+      <% end %>
 
       <%= render 'form', f: f %>
 

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -3,22 +3,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
-    <h1 class="govuk-heading-l"><%= t('.title') %></h1>
-
-    <% if @application_choice.application_form.interview_preferences.present? %>
-      <div class="app-banner app-banner--details">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= t('.interview_preferences.title') %></h2>
-        <p class="govuk-body govuk-!-margin-bottom-0"><%= @application_choice.application_form.interview_preferences %></p>
-      </div>
-    <% end %>
-
     <%= form_with(
       model: @wizard,
       url: new_check_provider_interface_application_choice_interviews_path(@application_choice),
       method: :post,
     ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+      <h1 class="govuk-heading-l"><%= t('.title') %></h1>
+
+      <% if @application_choice.application_form.interview_preferences.present? %>
+        <div class="app-banner app-banner--details">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-2"><%= t('.interview_preferences.title') %></h2>
+          <p class="govuk-body govuk-!-margin-bottom-0"><%= @application_choice.application_form.interview_preferences %></p>
+        </div>
+      <% end %>
 
       <%= render 'form', f: f %>
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -13,6 +13,8 @@ Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
              '%e %B %Y at %l%P (midday)'
            elsif time >= time.midnight && time <= time.midnight.end_of_minute
              '%e %B %Y at %l%P (midnight)'
+           elsif time.min.zero?
+             '%e %B %Y at %l%P'
            else
              '%e %B %Y at %l:%M%P'
            end
@@ -25,6 +27,8 @@ Time::DATE_FORMATS[:govuk_time] = lambda do |time|
              '%l%P (midday)'
            elsif time >= time.midnight && time <= time.midnight.end_of_minute
              '%l%P (midnight)'
+           elsif time.min.zero?
+             '%l%P'
            else
              '%l:%M%P'
            end

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -56,6 +56,9 @@ en:
               past: Time must be in the future
             location:
               blank: Enter address or online meeting details
+              too_long: Address or online meeting details must be %{count} characters or fewer
+            additional_details:
+              too_long: Additional details must be %{count} characters or fewer
             provider_id:
               blank: Select which organisation is carrying out the interview
         provider_interface/cancel_interview_wizard:

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -36,12 +36,17 @@ en:
   helpers:
     label:
       provider_interface_interview_wizard:
+        time: Time
         location: Address or online meeting details
-        additional_details: Additional details (optional)
+        additional_details: Additional details
     hint:
       provider_interface_interview_wizard:
         date: For example, 31 3 2020
         time: For example, 9am or 2:30pm - enter 12pm for midday
+    legend:
+      provider_interface_interview_wizard:
+        date: Date
+        provider_id: Organisation carrying out interview
   activemodel:
     errors:
       models:

--- a/spec/components/candidate_interface/reference_history_component_spec.rb
+++ b/spec/components/candidate_interface/reference_history_component_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe CandidateInterface::ReferenceHistoryComponent, type: :component d
 
     list_items = result.css('li')
     expect(list_items[0].text).to include 'Request sent'
-    expect(list_items[0].text.squish).to include '1 January 2020 at 9:00am'
+    expect(list_items[0].text.squish).to include '1 January 2020 at 9am'
     expect(list_items[1].text).to include 'Reference given'
-    expect(list_items[1].text.squish).to include '2 January 2020 at 9:00am'
+    expect(list_items[1].text.squish).to include '2 January 2020 at 9am'
   end
 
   it 'uses a special title format for request_bounced events', with_audited: true do

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Timeline'
       expect(rendered.text).to include 'Application received'
       expect(rendered.text).to include 'Candidate'
-      expect(rendered.text).to include '6 February 2020 at 10:00pm'
+      expect(rendered.text).to include '6 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View application'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}"
     end
@@ -71,7 +71,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Timeline'
       expect(rendered.text).to include 'Offer made'
       expect(rendered.text).to include 'Bob Roberts'
-      expect(rendered.text).to include '8 February 2020 at 10:00pm'
+      expect(rendered.text).to include '8 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View offer'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/offer"
     end
@@ -89,7 +89,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Note added'
       expect(rendered.text).to include 'Bob Roberts'
-      expect(rendered.text).to include '11 February 2020 at 10:00pm'
+      expect(rendered.text).to include '11 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View note'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/notes/#{note.id}"
     end
@@ -100,7 +100,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       application_choice = create(:application_choice, :with_rejection_by_default_and_feedback)
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Feedback sent'
-      expect(rendered.text).to include '11 February 2020 at 10:00pm'
+      expect(rendered.text).to include '11 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View feedback'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}"
     end
@@ -112,7 +112,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       create(:application_choice_audit, :with_changed_offer, application_choice: application_choice)
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Offer changed'
-      expect(rendered.text).to include '11 February 2020 at 10:00pm'
+      expect(rendered.text).to include '11 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View offer'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/offer"
     end
@@ -131,7 +131,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
 
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview set up'
-      expect(rendered.text).to include '11 February 2020 at 10:00pm'
+      expect(rendered.text).to include '11 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View interview'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
@@ -148,7 +148,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
 
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview updated'
-      expect(rendered.text).to include '11 February 2020 at 10:00pm'
+      expect(rendered.text).to include '11 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View interview'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
@@ -165,7 +165,7 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
 
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview cancelled'
-      expect(rendered.text).to include '11 February 2020 at 10:00pm'
+      expect(rendered.text).to include '11 February 2020 at 10pm'
       expect(rendered.css('a').text).to eq 'View interview'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end

--- a/spec/components/provider_interface/interview_details_component_spec.rb
+++ b/spec/components/provider_interface/interview_details_component_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::InterviewDetailsComponent do
+  let(:date_and_time) { Time.zone.local(2020, 1, 12, 15, 30) }
+  let(:provider) { build_stubbed(:provider, name: 'Teaching School') }
+  let(:application_choice) { build_stubbed(:application_choice, id: 1) }
+  let(:location) { 'Zoom' }
+  let(:additional_details) { 'Do not be late' }
+  let(:interview_form) do
+    instance_double(
+      ProviderInterface::InterviewWizard,
+      date_and_time: date_and_time,
+      provider: provider,
+      location: location,
+      additional_details: additional_details,
+      application_choice: application_choice,
+    )
+  end
+  let(:render) { render_inline(described_class.new(interview_form)).text }
+
+  it 'renders the interview date' do
+    expect(render).to include('12 January 2020')
+  end
+
+  it 'renders the interview time' do
+    expect(render).to include('3:30pm')
+  end
+
+  it 'renders the provider name' do
+    expect(render).to include('Teaching School')
+  end
+
+  it 'renders the interview location' do
+    expect(render).to include('Zoom')
+  end
+
+  it 'renders additional_details' do
+    expect(render).to include('Do not be late')
+  end
+
+  context 'no additional_details are set' do
+    let(:additional_details) { '' }
+
+    it 'renders None in the additional details row' do
+      expect(render).to include('Additional details')
+      expect(render).to include('None')
+    end
+  end
+end

--- a/spec/components/provider_interface/interview_details_component_spec.rb
+++ b/spec/components/provider_interface/interview_details_component_spec.rb
@@ -16,34 +16,70 @@ RSpec.describe ProviderInterface::InterviewDetailsComponent do
       application_choice: application_choice,
     )
   end
-  let(:render) { render_inline(described_class.new(interview_form)).text }
+  let(:render) { render_inline(described_class.new(interview_form)) }
 
   it 'renders the interview date' do
-    expect(render).to include('12 January 2020')
+    date_row = find_table_row('Date')
+    expect(date_row.text).to include('12 January 2020')
   end
 
   it 'renders the interview time' do
-    expect(render).to include('3:30pm')
+    time_row = find_table_row('Time')
+    expect(time_row.text).to include('3:30pm')
   end
 
   it 'renders the provider name' do
-    expect(render).to include('Teaching School')
+    provider_row = find_table_row('Organisation carrying out interview')
+    expect(provider_row.text).to include('Teaching School')
   end
 
   it 'renders the interview location' do
-    expect(render).to include('Zoom')
+    location_row = find_table_row('Address or online meeting details')
+    expect(location_row.text).to include('Zoom')
   end
 
   it 'renders additional_details' do
-    expect(render).to include('Do not be late')
+    additional_details_row = find_table_row('Additional details')
+    expect(additional_details_row.text).to include('Do not be late')
   end
 
   context 'no additional_details are set' do
     let(:additional_details) { '' }
 
     it 'renders None in the additional details row' do
-      expect(render).to include('Additional details')
-      expect(render).to include('None')
+      additional_details_row = find_table_row('Additional details')
+      expect(additional_details_row.text).to include('None')
     end
+  end
+
+  describe 'renders change links with the correct anchor for' do
+    it 'date' do
+      date_row = find_table_row('Date')
+      expect(date_row.css('a').attr('href').value).to eq('/provider/applications/1/interviews/new#provider_interface_interview_wizard_date_3i')
+    end
+
+    it 'time' do
+      time_row = find_table_row('Time')
+      expect(time_row.css('a').attr('href').value).to eq('/provider/applications/1/interviews/new#provider-interface-interview-wizard-time-field')
+    end
+
+    it 'provider' do
+      provider_row = find_table_row('Organisation carrying out interview')
+      expect(provider_row.css('a').attr('href').value).to eq("/provider/applications/1/interviews/new#provider-interface-interview-wizard-provider-id-#{provider.id}-field")
+    end
+
+    it 'location' do
+      location_row = find_table_row('Address or online meeting details')
+      expect(location_row.css('a').attr('href').value).to eq('/provider/applications/1/interviews/new#provider-interface-interview-wizard-location-field')
+    end
+
+    it 'additional_details' do
+      additional_details_row = find_table_row('Additional details')
+      expect(additional_details_row.css('a').attr('href').value).to eq('/provider/applications/1/interviews/new#provider-interface-interview-wizard-additional-details-field')
+    end
+  end
+
+  def find_table_row(key)
+    render.css('.govuk-summary-list__row').select { |row| row.to_html.include?(key) }.first
   end
 end

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     result = render_inline(described_class.new(application_choice))
 
     expect(result.text).to include('Rejected at')
-    expect(result.text).to include('1 January 2020 at 10:00am')
+    expect(result.text).to include('1 January 2020 at 10am')
   end
 
   it 'displays the date an application was rejected by default' do
@@ -16,7 +16,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     result = render_inline(described_class.new(application_choice))
 
     expect(result.text).to include('Rejected by default at')
-    expect(result.text).to include('1 January 2020 at 10:00am')
+    expect(result.text).to include('1 January 2020 at 10am')
   end
 
   it 'displays reasons for rejection on rejected application with structured reasons' do
@@ -49,10 +49,10 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
     result = render_inline(described_class.new(application_choice))
 
     expect(result.text).to include('Offer made at')
-    expect(result.text).to include('1 January 2020 at 10:00am')
+    expect(result.text).to include('1 January 2020 at 10am')
 
     expect(result.text).to include('Decline by default at')
-    expect(result.text).to include('10 January 2020 at 10:00am')
+    expect(result.text).to include('10 January 2020 at 10am')
   end
 
   it 'does not display DBD date for offered applications when it has not yet been set' do

--- a/spec/components/support_interface/audit_trail_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SupportInterface::AuditTrailComponent, with_audited: true do
 
   it 'renders a create application form audit record' do
     expect(render_result.text).to include('1 October 2019')
-    expect(render_result.text).to include('12:00')
+    expect(render_result.text).to include('12')
     expect(render_result.text).to include('Create Application Form')
     expect(render_result.text).to include('bob@example.com (Candidate)')
     expect(render_result.text).to match(/candidate_id\s*#{candidate.id}/m)

--- a/spec/components/support_interface/feature_audit_trail_component_spec.rb
+++ b/spec/components/support_interface/feature_audit_trail_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
 
     it 'renders the create audit entry' do
       expect(render_result.text).to include('Created inactive by bob@example.com')
-      expect(render_result.text).to include('1 May 2020 at 12:00')
+      expect(render_result.text).to include('1 May 2020 at 12')
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
 
     it 'renders the create audit entry' do
       expect(render_result.text).to include('Created active')
-      expect(render_result.text).to include('1 May 2020 at 12:00')
+      expect(render_result.text).to include('1 May 2020 at 12')
     end
 
     it 'renders the update audit entry' do

--- a/spec/config/initializers/date_formats_spec.rb
+++ b/spec/config/initializers/date_formats_spec.rb
@@ -14,16 +14,22 @@ RSpec.describe 'Time::DATE_FORMATS' do
       expect(date_and_time.to_s(:govuk_time)).to eq('12am (midnight)')
     end
 
-    it 'formats time with minutes otherwise' do
+    it 'formats time with minutes if the time is not on the hour' do
       date_and_time = Time.zone.local(2020, 12, 25, 12, 1, 0)
       expect(date_and_time.to_s(:govuk_date_and_time)).to eq('25 December 2020 at 12:01pm')
       expect(date_and_time.to_s(:govuk_time)).to eq('12:01pm')
     end
 
+    it 'formats time without minutes if the time is on the hour' do
+      date_and_time = Time.zone.local(2020, 12, 25, 15)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq('25 December 2020 at 3pm')
+      expect(date_and_time.to_s(:govuk_time)).to eq('3pm')
+    end
+
     it 'does not pad single-digit day and hour with whitespace' do
-      date_and_time = Time.zone.local(2020, 12, 5, 6, 0, 0)
-      expect(date_and_time.to_s(:govuk_date_and_time)).to eq('5 December 2020 at 6:00am')
-      expect(date_and_time.to_s(:govuk_time)).to eq('6:00am')
+      date_and_time = Time.zone.local(2020, 12, 5, 6, 10, 0)
+      expect(date_and_time.to_s(:govuk_date_and_time)).to eq('5 December 2020 at 6:10am')
+      expect(date_and_time.to_s(:govuk_time)).to eq('6:10am')
     end
   end
 end

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe ProviderInterface::InterviewWizard do
   let(:month) { '2' }
   let(:year) { '2021' }
   let(:time) { '10am' }
-  let(:application_choice) { nil }
-  let(:provider_user) { nil }
+  let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: Time.zone.local(2021, 2, 14)) }
+  let(:provider_user) { build_stubbed(:provider_user) }
+  let(:location) { 'Zoom' }
 
   let(:wizard) do
     described_class.new(
@@ -16,6 +17,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
       'date(2i)' => month,
       'date(1i)' => year,
       time: time,
+      location: location,
       application_choice: application_choice,
       provider_user: provider_user,
     )
@@ -67,27 +69,43 @@ RSpec.describe ProviderInterface::InterviewWizard do
       end
     end
 
-    describe '#time_is_valid?' do
-      let(:tomorrow) { 1.day.from_now }
-      let(:day) { tomorrow.day }
-      let(:month) { tomorrow.month }
-      let(:year) { tomorrow.year }
+    describe '#time' do
+      let(:time) { '' }
 
-      context 'checks if the time is in the rights format' do
-        let(:invalid_times) { %w[noon 1700 12:30 12:3pm 1800pm] }
+      it 'is invalid with the correct error when blank' do
+        expect(wizard).to be_invalid
+        expect(wizard.errors[:time]).to contain_exactly('Enter time')
+      end
+    end
+
+    describe '#time_is_valid' do
+      let(:day) { '2' }
+      let(:month) { '2' }
+      let(:year) { '2021' }
+
+      around do |example|
+        Timecop.freeze(Time.zone.local(2021, 2, 1)) do
+          example.run
+        end
+      end
+
+      context 'checks if the time is in the correct format' do
+        let(:invalid_times) { %w[noon 1700 12:30 12:3pm 1800pm 6767] }
         let(:valid_times) { %w[12:30pm 2pm 1.30am 01.24AM 3\ 30am] }
 
-        it 'returns false when the time is invalid' do
+        it 'the wizard is invalid and contains the right error when time is invalid' do
           invalid_times.each do |time|
             wizard.time = time
-            expect(wizard.time_is_valid?).to eq(false)
+            expect(wizard).to be_invalid
+            expect(wizard.errors[:time]).to contain_exactly('Enter a time in the correct format')
           end
         end
 
-        it 'returns true when the time is valid' do
+        it 'the wizard is valid when time is valid' do
           valid_times.each do |time|
             wizard.time = time
-            expect(wizard.time_is_valid?).to eq(true)
+            expect(wizard).to be_valid, "Time invalid #{time}, #{day} #{month} #{year} #{Time.zone.now}"
+            expect(wizard.errors[:time]).to be_empty
           end
         end
       end
@@ -100,7 +118,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
 
         it 'returns true and adds no errors' do
           Timecop.freeze(2021, 2, 13, 12, 0, 0) do
-            expect(wizard.date_and_time_in_future).to eq(true)
+            expect(wizard).to be_valid
           end
         end
       end
@@ -147,8 +165,6 @@ RSpec.describe ProviderInterface::InterviewWizard do
   end
 
   describe '#provider_id' do
-    let(:provider_user) { build_stubbed(:provider_user) }
-    let(:application_choice) { build_stubbed(:application_choice) }
     let(:wizard) { described_class.new(store, provider_user: provider_user, application_choice: application_choice) }
 
     context 'when the application has multiple providers' do

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe ProviderInterface::InterviewWizard do
       it { is_expected.to validate_presence_of(:application_choice) }
     end
 
+    context 'field length checks' do
+      let(:subject) { described_class.new(store) }
+
+      it { is_expected.to validate_length_of(:location).is_at_most(10240) }
+      it { is_expected.to validate_length_of(:additional_details).is_at_most(10240) }
+    end
+
     describe '#date' do
       context 'when blank' do
         let(:day) { '' }

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -163,13 +163,13 @@ RSpec.describe ViewHelper, type: :helper do
   describe '#time_today_or_tomorrow' do
     it 'returns the time tomorrow for a time tomorrow' do
       time = Time.zone.tomorrow.midnight + 3.hours
-      expect(helper.time_today_or_tomorrow(time)).to eq '3:00am tomorrow'
+      expect(helper.time_today_or_tomorrow(time)).to eq '3am tomorrow'
     end
 
     it 'returns the bare time for a time today' do
       Timecop.freeze(Time.zone.now.midnight) do
         time = Time.zone.now + 6.hours
-        expect(helper.time_today_or_tomorrow(time)).to eq '6:00am'
+        expect(helper.time_today_or_tomorrow(time)).to eq '6am'
       end
     end
 

--- a/spec/system/candidate_interface/references/candidate_views_reference_history_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_views_reference_history_spec.rb
@@ -53,9 +53,9 @@ RSpec.feature 'Reference history on review page' do
     visit candidate_interface_references_review_path
     expect(page).to have_content 'History'
     expected_history = [
-      { event_name: 'Request sent', timestamp: '1 January 2020 at 2:00pm' },
-      { event_name: 'Reminder sent', timestamp: '2 January 2020 at 2:00pm' },
-      { event_name: 'Automated reminder sent', timestamp: '8 January 2020 at 2:00pm' },
+      { event_name: 'Request sent', timestamp: '1 January 2020 at 2pm' },
+      { event_name: 'Reminder sent', timestamp: '2 January 2020 at 2pm' },
+      { event_name: 'Automated reminder sent', timestamp: '8 January 2020 at 2pm' },
     ]
 
     within '[data-qa="reference-history"]' do

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def then_i_can_see_interview_was_updated
     expect(page).to have_content('Check and send new interview details')
     expect(page).to have_content("Date\n4 March 2020")
-    expect(page).to have_content("Time\n10:00am")
+    expect(page).to have_content("Time\n10am")
     expect(page).to have_content("Address or online meeting details\nZoom meeting")
     expect(page).to have_content("Additional details\nBusiness casual")
 
@@ -151,7 +151,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
     expect(page).to have_content('Interview changed')
 
-    expect(page).to have_content("Upcoming interviews\n4 March 2020 at 10:00am")
+    expect(page).to have_content("Upcoming interviews\n4 March 2020 at 10am")
     expect(page).to have_content("Address or online meeting details\nZoom meeting")
     expect(page).to have_content("Additional details\nBusiness casual, first impressions are important")
   end


### PR DESCRIPTION
## Context
Initial review of the interviews feature resulted in a few bugs being spotted

## Changes proposed in this pull request
1. The validation error summary appears above the h1 in the forms
2. Validate the length of the freetext fields.
3. Add visually hidden text for screen reader users to the change links to go back to the form
4. Validation messages in the error summary appear in the correct order. They are in the same order as they appear in the form now
5. Fix error when leaving the time blank in the form (and nothing else)
6. The check answers page displays times in the correct format. 8 in the morning is now displayed as 8am rather than 8:00am
7. The check answers page now displays the text "None" in the "Additional details" row if the user doesn't enter a value

Still to fix:
- The change links should anchor link to the first element (e.g first radio button) in the field for which it is changing.
## Guidance to review
Per commit
Test in the review app!

## Link to Trello card
https://trello.com/c/DZ1Dz10H/3369-interview-create-edit-form-bugs

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
