### PR TITLE
Use simple past in Slack updates

### DIFF
--- a/config/locales/support_interface/slack_notifications.yml
+++ b/config/locales/support_interface/slack_notifications.yml
@@ -18,25 +18,25 @@ en:
     withdrawn:
       message:
         primary:
-          one: ":runner: %{applicant} has withdrawn their application from %{providers}"
-          other: ":runner: %{applicant} has withdrawn their applications from %{providers}"
+          one: ":runner: %{applicant} withdrew their application from %{providers}"
+          other: ":runner: %{applicant} withdrew their applications from %{providers}"
         other_applications: "withdrew from %{providers}"
     recruited:
       message:
-        primary: ":handshake: %{applicant} has been recruited to %{providers}"
+        primary: ":handshake: %{applicant} was recruited to %{providers}"
     declined:
       message:
         primary:
-          one: ":no_good: %{applicant} has declined an offer from %{providers}"
-          other: ":no_good: %{applicant} has declined offers from %{providers}"
+          one: ":no_good: %{applicant} declined an offer from %{providers}"
+          other: ":no_good: %{applicant} declined offers from %{providers}"
         other_applications:
           one: "declined an offer from %{providers}"
           other: "declined offers from %{providers}"
     declined_by_default:
       message:
         primary:
-          one: ":no_good: %{applicant} has declined by default %{providers}'s offer"
-          other: ":no_good: %{applicant} has declined by default offers from %{providers}"
+          one: ":no_good: %{applicant} declined by default %{providers}'s offer"
+          other: ":no_good: %{applicant} declined by default offers from %{providers}"
         other_applications:
           one: "declined by default an offer from %{providers}"
           other: "declined by default offers from %{providers}"

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe StateChangeNotifier do
 
         StateChangeNotifier.new(:declined, application_choice).application_outcome_notification
 
-        message = /:no_good: #{applicant} has declined offers from #{provider_name} and #{declined_choice.provider.name}/
+        message = /:no_good: #{applicant} declined offers from #{provider_name} and #{declined_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
     end
@@ -120,7 +120,7 @@ RSpec.describe StateChangeNotifier do
 
         StateChangeNotifier.new(:declined_by_default, application_choice).application_outcome_notification
 
-        message = /:no_good: #{applicant} has declined by default offers from #{provider_name} and #{declined_by_default_choice.provider.name}/
+        message = /:no_good: #{applicant} declined by default offers from #{provider_name} and #{declined_by_default_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe StateChangeNotifier do
 
         StateChangeNotifier.new(:withdrawn, application_choice).application_outcome_notification
 
-        message = /:runner: #{applicant} has withdrawn their applications from #{provider_name} and #{withdrawn_choice.provider.name}/
+        message = /:runner: #{applicant} withdrew their applications from #{provider_name} and #{withdrawn_choice.provider.name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe StateChangeNotifier do
       it 'and no other applications' do
         StateChangeNotifier.new(:recruited, application_choice).application_outcome_notification
 
-        message = /:handshake: #{applicant} has been recruited to #{provider_name}/
+        message = /:handshake: #{applicant} was recruited to #{provider_name}/
         expect(SlackNotificationWorker).to have_received(:perform_async).with(message, anything)
       end
     end


### PR DESCRIPTION
eg "withdrew" means the candidate withdrew at some point in the past (which will always be true) but "has withdrawn" implies it happened just now (which won’t).
