### PR TITLE
Enforce `start_date` presence on candidate work history

### DIFF
--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -30,7 +30,7 @@ module CandidateInterface
       validates :currently_working, inclusion: { in: %w[true false] }
       validates :relevant_skills, inclusion: { in: %w[true false] }
 
-      validates :start_date, date: { future: true, month_and_year: true }
+      validates :start_date, date: { future: true, month_and_year: true, presence: true }
       validates :end_date, date: { future: true, month_and_year: true, presence: true }, if: :not_currently_employed_in_this_role?
       validate :start_date_before_end_date, unless: ->(c) { %i[start_date end_date].any? { |d| c.errors.keys.include?(d) } }
 

--- a/app/forms/candidate_interface/work_experience_form.rb
+++ b/app/forms/candidate_interface/work_experience_form.rb
@@ -14,7 +14,7 @@ module CandidateInterface
 
     validates :working_with_children, inclusion: { in: %w[true false] }
 
-    validates :start_date, date: { future: true, month_and_year: true }
+    validates :start_date, date: { future: true, month_and_year: true, presence: true }
     validates :end_date, date: { future: true, month_and_year: true }
     validate :start_date_before_end_date, unless: ->(c) { %i[start_date end_date].any? { |d| c.errors.keys.include?(d) } }
 

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
     it { is_expected.to validate_length_of(:role).is_at_most(60) }
     it { is_expected.to validate_length_of(:organisation).is_at_most(60) }
 
-    include_examples 'validation for a start date', 'restructured_work_history/job_form'
+    include_examples 'validation for a start date', 'restructured_work_history/job_form', verify_presence: true
 
     context "'currently working' is 'false'" do
       it 'is invalid if left completely blank' do

--- a/spec/forms/candidate_interface/work_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/work_experience_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', 'work_experience_form'
+    include_examples 'validation for a start date', 'work_experience_form', verify_presence: true
     include_examples 'validation for an end date that can be blank', 'work_experience_form'
 
     it 'does not accept negative integers in the year field' do

--- a/spec/support/candidate_interface/shared_examples/start_date_validation.rb
+++ b/spec/support/candidate_interface/shared_examples/start_date_validation.rb
@@ -1,5 +1,15 @@
-RSpec.shared_examples 'validation for a start date' do |error_scope|
+RSpec.shared_examples 'validation for a start date' do |error_scope, verify_presence|
   describe 'start date' do
+    it 'is invalid if the date is not present', if: verify_presence do
+      form = described_class.new(start_date_month: nil, start_date_year: nil)
+
+      form.validate
+
+      expect(form.errors.full_messages_for(:start_date)).to eq(
+        ["Start date #{t('errors.messages.blank_date', article: 'a', attribute: 'start date')}"],
+      )
+    end
+
     it 'is invalid if not well-formed' do
       form = described_class.new(start_date_month: '99', start_date_year: '99')
 


### PR DESCRIPTION
## Context

Enforce `start_date` presence check on work experience and restructured work history job.
The check was missed when switching to the DateValidator as it was previously done as part of checking for the validity of the date object.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
