### PR TITLE
Change BLAZER_DATABASE_URL format

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -463,7 +463,7 @@
         "storageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'str'), '-', '')]",
         "databaseServerName": "[concat(variables('resourceNamePrefix'), '-psql')]",
         "replicaServerName": "[concat(variables('databaseServerName'), '-replica')]",
-        "replicaServerConnectionString": "[concat('postgres://', variables('replicaServerName'), '.postgres.database.azure.com:5432/', parameters('databaseName'), '?user=', parameters('databaseUsername'), '@', variables('replicaServerName'), '&password=', parameters('databasePassword'))]",
+        "replicaServerConnectionString": "[concat('postgres://', parameters('databaseUsername'), '%40', variables('replicaServerName'), ':', uriComponent(parameters('databasePassword')), '@', variables('replicaServerName'), '.postgres.database.azure.com:5432/', parameters('databaseName'))]",
         "useCustomDomains": "[greater(length(parameters('customDomains')), 0)]",
         "databaseReplicaExists": "[bool(parameters('databaseReplicaExists'))]",
         "rubyAuthHosts": "[parameters('authorisedHosts')]",


### PR DESCRIPTION
## Context

`BLAZER_DATABASE_URL` needs to be in `postgres://username:password@dbServer:5432/database`
Username Password also needs to be url encoded.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
