### PR TITLE
Change Redis wizard persistence from 24 hours to 4 hours

### DIFF
--- a/app/lib/wizard_state_stores/redis_store.rb
+++ b/app/lib/wizard_state_stores/redis_store.rb
@@ -8,7 +8,7 @@ module WizardStateStores
     end
 
     def write(value)
-      @redis.set(@key, value, ex: ActiveSupport::Duration::SECONDS_PER_DAY)
+      @redis.set(@key, value, ex: 4.hours.to_i)
     end
 
     def read

--- a/spec/lib/wizard_state_stores/redis_store_spec.rb
+++ b/spec/lib/wizard_state_stores/redis_store_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe WizardStateStores::RedisStore do
-  it 'expires the key after 24 hours' do
+  it 'expires the key after 4 hours' do
     store = described_class.new(key: 'any_old_key')
 
     store.write('value')
 
     redis = Redis.current
-    expect(redis.ttl('any_old_key')).to be_within(5).of(1.day.to_i)
+    expect(redis.ttl('any_old_key')).to be_within(5).of(4.hours.to_i)
   end
 end

--- a/spec/lib/wizard_state_stores/redis_store_spec.rb
+++ b/spec/lib/wizard_state_stores/redis_store_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe WizardStateStores::RedisStore do
+  it 'expires the key after 24 hours' do
+    store = described_class.new(key: 'any_old_key')
+
+    store.write('value')
+
+    redis = Redis.current
+    expect(redis.ttl('any_old_key')).to be_within(5).of(1.day.to_i)
+  end
+end


### PR DESCRIPTION
## Context

We discussed this with @adamsilver and decided to change the timeout to 4 hours.

## Changes proposed in this pull request

Add a test, then change the timeout.

## Link to Trello card

https://trello.com/c/w0h5XssZ/3373-revisit-how-long-redis-caches-last-in-manage

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
