### PR TITLE
Don’t render automated reminder text on reference reminder page, if already sent

### DIFF
--- a/app/views/candidate_interface/references/reminder/new.html.erb
+++ b/app/views/candidate_interface/references/reminder/new.html.erb
@@ -17,9 +17,11 @@
         You can only send one reminder to this referee.
       </p>
 
-      <p class="govuk-body">
-        The referee will also get an automatic reminder on <%= @reference.next_automated_chase_at.strftime('%-d %B %Y') %>.
-      </p>
+      <% if @reference.next_automated_chase_at.present? %>
+        <p class="govuk-body">
+          The referee will also get an automatic reminder on <%= @reference.next_automated_chase_at.strftime('%-d %B %Y') %>.
+        </p>
+      <% end %>
 
       <%= f.govuk_submit t('application_form.references.send_reminder.confirm') %>
 


### PR DESCRIPTION
This causes an error on the reference reminder page

Related sentry error:
https://sentry.io/organizations/dfe-bat/issues/2213340729

Related Zendesk ticket: 
https://becomingateacher.zendesk.com/agent/tickets/11969

## Context

When a reminder has already been sent to the referee and the candidate attempts to send a manual reminder the page falls over. This is due to the `next_automated_chase_at` returning a nil value as there is no next reminder, and the form attempting to format its value with `.strftime('%-d %B %Y'`

As the candidate has not send any manual reminders yet there is nothing preventing them from getting here.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
