### PR TITLE
Correct policy on when we show the Interviews tab and when interviews are editable

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -66,7 +66,7 @@ module ProviderInterface
     def interviews_present?
       return false unless FeatureFlag.active?(:interviews)
 
-      application_choice.interviewing? && application_choice.interviews.kept.any?
+      application_choice.interviews.kept.any?
     end
 
     def respond_to_application?

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -5,10 +5,14 @@ module ProviderInterface
     before_action :requires_make_decisions_permission, except: %i[index]
 
     def index
+      application_at_interviewable_stage = ApplicationStateChange::INTERVIEWABLE_STATES.include?(
+        @application_choice.status.to_sym,
+      )
       @provider_can_make_decisions = current_provider_user.authorisation.can_make_decisions?(
         application_choice: @application_choice,
         course_option_id: @application_choice.offered_option.id,
       )
+      @interviews_can_be_created_and_edited = application_at_interviewable_stage && @provider_can_make_decisions
 
       interviews = @application_choice.interviews.kept.includes(:provider).order(:date_and_time)
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -4,6 +4,7 @@ class ApplicationStateChange
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted cancelled application_not_sent].freeze
   STATES_VISIBLE_TO_PROVIDER = %i[awaiting_provider_decision interviewing offer pending_conditions recruited rejected declined withdrawn conditions_not_met offer_withdrawn offer_deferred].freeze
 
+  INTERVIEWABLE_STATES = %i[awaiting_provider_decision interviewing].freeze
   ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited offer_deferred].freeze
   OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer offer_withdrawn]).freeze
   POST_OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer_withdrawn]).freeze

--- a/app/views/provider_interface/interviews/index.html.erb
+++ b/app/views/provider_interface/interviews/index.html.erb
@@ -2,11 +2,10 @@
 
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions) %>
 
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="app-interviews">
-      <% if @provider_can_make_decisions %>
+      <% if @interviews_can_be_created_and_edited %>
         <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(@application_choice), class: 'govuk-button govuk-button--secondary' %>
       <% end %>
 
@@ -16,7 +15,7 @@
         </h2>
 
         <% @upcoming_interviews.each do |interview| %>
-          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @provider_can_make_decisions) %>
+          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @interviews_can_be_created_and_edited) %>
         <% end %>
       <% end %>
 
@@ -26,7 +25,7 @@
         </h2>
 
         <% @past_interviews.each do |interview| %>
-          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @provider_can_make_decisions) %>
+          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @interviews_can_be_created_and_edited) %>
         <% end %>
       <% end %>
     </div>

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
     end
 
     describe '#sub_navigation_items' do
-      let(:application_choice) { build_stubbed(:application_choice, status: :interviewing, reject_by_default_at: reject_by_default_at) }
+      let(:application_choice) { build_stubbed(:application_choice, reject_by_default_at: reject_by_default_at) }
 
       before do
         allow(application_choice).to receive(:interviews).and_return(interviews)

--- a/spec/components/provider_interface/application_choice_header_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_header_component_spec.rb
@@ -56,18 +56,31 @@ RSpec.describe ProviderInterface::ApplicationChoiceHeaderComponent do
     end
 
     describe '#sub_navigation_items' do
-      let(:status) { :interviewing }
-      let(:interview) { build_stubbed(:interview) }
-      let(:interviews) { class_double(Interview, kept: [interview]) }
-      let(:application_choice) { build_stubbed(:application_choice, status: status, reject_by_default_at: reject_by_default_at) }
+      let(:application_choice) { build_stubbed(:application_choice, status: :interviewing, reject_by_default_at: reject_by_default_at) }
 
-      it 'renders the interview tab when the application is in the interviewing state and there are interviews available' do
+      before do
         allow(application_choice).to receive(:interviews).and_return(interviews)
-
         FeatureFlag.activate(:interviews)
-        expect(result.css('.app-tab-navigation li:nth-child(2) a').text).to include(
-          'Interviews',
-        )
+      end
+
+      context 'when there are no interviews' do
+        let(:interviews) { class_double(Interview, kept: []) }
+
+        it 'does not show the interview tab' do
+          expect(result.css('.app-tab-navigation li:nth-child(2) a').text).not_to include(
+            'Interviews',
+          )
+        end
+      end
+
+      context 'when there are interviews' do
+        let(:interviews) { class_double(Interview, kept: [build_stubbed(:interview)]) }
+
+        it 'shows the interview tab' do
+          expect(result.css('.app-tab-navigation li:nth-child(2) a').text).to include(
+            'Interviews',
+          )
+        end
       end
     end
   end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     then_i_see_a_success_message
     and_an_interview_has_been_created('2 March 2020')
 
-    and_i_can_set_up_another_interview(days_in_future: 2)
+    and_i_set_up_another_interview(days_in_future: 2)
     and_another_interview_has_been_created('3 March 2020')
 
     when_the_first_interview_has_happened
@@ -39,7 +39,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_i_see_the_past_interview_under_the_correct_heading
 
     when_i_change_the_interview_details
-    then_i_can_see_interview_was_updated
+    and_i_confirm_the_interview_details
+    then_i_can_see_the_interview_was_updated
 
     when_i_click_to_cancel_an_interview
     and_i_do_not_enter_a_cancellation_reason
@@ -82,7 +83,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_content('Interview successfully created')
   end
 
-  def and_i_can_set_up_another_interview(days_in_future:)
+  def and_i_set_up_another_interview(days_in_future:)
     and_i_click_set_up_an_interview
     and_i_fill_out_the_interview_form(days_in_future: days_in_future, time: '7pm')
     and_i_click_send_interview_details
@@ -152,7 +153,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     click_on 'Continue'
   end
 
-  def then_i_can_see_interview_was_updated
+  def and_i_confirm_the_interview_details
     expect(page).to have_content('Check and send new interview details')
     expect(page).to have_content("Date\n4 March 2020")
     expect(page).to have_content("Time\n10am")
@@ -168,10 +169,11 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_content("Additional details\nBusiness casual, first impressions are important")
 
     click_on 'Send new interview details'
+  end
 
+  def then_i_can_see_the_interview_was_updated
     expect(page).to have_content('Interview changed')
-
-    expect(page).to have_content("Upcoming interviews\n4 March 2020 at 10am")
+    expect(page).to have_content('4 March 2020 at 10am')
     expect(page).to have_content("Address or online meeting details\nZoom meeting")
     expect(page).to have_content("Additional details\nBusiness casual, first impressions are important")
   end

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -56,6 +56,43 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     when_i_cancel_an_interview
     i_can_see_the_application_is_awaiting_provider_decision
     and_the_interview_tab_is_not_available
+
+    # TODO: the "make decision" prompt does not show here because of the flash message
+    # should be fixed with https://trello.com/c/dI0l2hyl/3364-call-to-action-inset-text-is-hidden-when-flash-banner-is-shown-on-provider-application-page
+    when_i_reload_the_page
+    and_i_set_up_another_interview(days_in_future: 4)
+    and_another_interview_has_been_created('6 March 2020')
+
+    when_i_click_make_decision
+    and_i_make_an_offer
+    then_i_should_see_the_interview_on_the_interview_tab('6 March 2020')
+    but_i_should_not_see_the_set_up_change_or_cancel_interview_controls
+  end
+
+  def when_i_reload_the_page
+    visit current_path
+  end
+
+  def when_i_click_make_decision
+    click_link 'Make decision'
+  end
+
+  def and_i_make_an_offer
+    choose 'Make an offer'
+    click_button 'Continue'
+    click_button 'Continue' # conditions page
+    click_button 'Make offer'
+  end
+
+  def then_i_should_see_the_interview_on_the_interview_tab(date)
+    click_link 'Interviews'
+    and_an_interview_has_been_created(date)
+  end
+
+  def but_i_should_not_see_the_set_up_change_or_cancel_interview_controls
+    expect(page).not_to have_button('Set up interview')
+    expect(page).not_to have_link('Cancel interview')
+    expect(page).not_to have_link('Change interview')
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in


### PR DESCRIPTION
## Context

Discovered during a pre-release walkthrough of the interviews feature.

## Changes proposed in this pull request

- show the interviews tab when there are any non-cancelled interviews associated with the application. Previously interviews were shown when those interviews existed _and_ the application was in the "Interviewing" state.
- now that the tab is visible whenever there are interviews associated with the application, hide the create/change/cancel controls if the application has already received a decision

## Guidance to review

See commits

## Link to Trello card

https://trello.com/c/GN4dbuQS/3365-interviews-tab-do-not-show-change-cancel-setup-interview-buttons-when-application-is-not-in-awaiting-decision-state

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
