### PR TITLE
Enforce use of govuk_link_to et al

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,9 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
-require: rubocop-rspec
+require:
+- rubocop-rspec
+- ./lib/rubocop/cop/govuk/govuk_link_to.rb
 
 AllCops:
   Exclude:
@@ -124,6 +126,10 @@ Naming/MemoizedInstanceVariableName:
 # sometimes reduce is fine
 Style/EachWithObject:
   Enabled: false
+
+Govuk:
+  Include:
+    - 'app/views/**/*'
 
 # Pending cops
 # These will be enabled by default at Rubocop 1.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -145,6 +145,10 @@ Govuk/GovukLinkTo:
     # link_to in manual error summaries
     - 'app/views/candidate_interface/references/review/show.html.erb'
     - 'app/views/candidate_interface/unsubmitted_application_form/review.html.erb'
+    # link_to in footers
+    - 'app/views/layouts/_footer.html'
+    - 'app/views/layouts/_footer_meta_candidate.html.erb'
+    - 'app/views/layouts/_footer_meta_provider.html.erb'
     # link_to for kaminari pagination links
     - 'app/views/kaminari/_next_page.html.erb'
     - 'app/views/kaminari/_prev_page.html.erb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ require:
 - rubocop-rspec
 - ./lib/rubocop/cop/govuk/govuk_button_to.rb
 - ./lib/rubocop/cop/govuk/govuk_link_to.rb
+- ./lib/rubocop/cop/govuk/govuk_submit.rb
 
 AllCops:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,12 +132,20 @@ Style/EachWithObject:
 Govuk:
   Include:
     - 'app/views/**/*'
+    - 'app/components/**/*'
+
+Govuk/GovukLinkTo:
   Exclude:
+    # link_to in components that use their own link classes
+    - 'app/components/breadcrumb_component.html.erb'
+    - 'app/components/header_component.html.erb'
+    - 'app/components/product_header_component.html.erb'
+    # link_to in filter component
+    - 'app/components/filter_component.html.erb'
     # link_to in manual error summaries
     - 'app/views/candidate_interface/references/review/show.html.erb'
     - 'app/views/candidate_interface/unsubmitted_application_form/review.html.erb'
-    - 'app/views/candidate_interface/unsubmitted_application_form/review.html.erb'
-    # kaminari pagination links
+    # link_to for kaminari pagination links
     - 'app/views/kaminari/_next_page.html.erb'
     - 'app/views/kaminari/_prev_page.html.erb'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,6 +132,14 @@ Style/EachWithObject:
 Govuk:
   Include:
     - 'app/views/**/*'
+  Exclude:
+    # link_to in manual error summaries
+    - 'app/views/candidate_interface/references/review/show.html.erb'
+    - 'app/views/candidate_interface/unsubmitted_application_form/review.html.erb'
+    - 'app/views/candidate_interface/unsubmitted_application_form/review.html.erb'
+    # kaminari pagination links
+    - 'app/views/kaminari/_next_page.html.erb'
+    - 'app/views/kaminari/_prev_page.html.erb'
 
 # Pending cops
 # These will be enabled by default at Rubocop 1.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ inherit_gem:
 
 require:
 - rubocop-rspec
+- ./lib/rubocop/cop/govuk/govuk_button_to.rb
 - ./lib/rubocop/cop/govuk/govuk_link_to.rb
 
 AllCops:

--- a/app/components/candidate_interface/break_in_work_history_component.html.erb
+++ b/app/components/candidate_interface/break_in_work_history_component.html.erb
@@ -2,7 +2,7 @@
   <%= render(SummaryCardHeaderComponent.new(title: "Break in work history (#{format_months_to_years_and_months(@work_break.length)})", heading_level: @heading_level)) do %>
     <% if @editable %>
       <div class="app-summary-card__actions">
-        <%= link_to candidate_interface_destroy_work_history_break_path(@work_break), class: 'govuk-link' do %>
+        <%= govuk_link_to candidate_interface_destroy_work_history_break_path(@work_break) do %>
           Delete entry <span class="govuk-visually-hidden">for break between <%= formatted_start_date %> and <%= formatted_end_date %></span>
         <% end %>
       </div>

--- a/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/candidate_interface/break_placeholder_in_work_history_component.html.erb
@@ -3,7 +3,7 @@
     <div class="app-summary-card__actions">
       <ul class="app-summary-card__actions-list">
         <li class="app-summary-card__actions-list-item">
-          <%= link_to candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
+          <%= govuk_link_to candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date) do %>
             Explain break <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
           <% end %>
         </li>
@@ -11,7 +11,7 @@
           or
         </li>
         <li class="app-summary-card__actions-list-item">
-          <%= link_to candidate_interface_new_work_history_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
+          <%= govuk_link_to candidate_interface_new_work_history_path(start_date: work_break.start_date, end_date: work_break.end_date) do %>
             add another job <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
           <% end %>
         </li>

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -84,17 +84,17 @@
     <%= render(SummaryCardHeaderComponent.new(title: application_choice.offered_course.provider.name, heading_level: @heading_level)) do %>
       <div class="app-summary-card__actions">
         <% if application_choice.offer? %>
-          <%= link_to candidate_interface_offer_path(application_choice.id), class: 'govuk-link', data: { action: :respond } do %>
+          <%= govuk_link_to candidate_interface_offer_path(application_choice.id), data: { action: :respond } do %>
             <%= t('application_form.courses.view_and_respond_to_offer') %>
             <span class="govuk-visually-hidden"> <%= application_choice.offered_course.name_and_code %></span>
           <% end %>
         <% elsif withdrawable?(application_choice) %>
-          <%= link_to candidate_interface_withdraw_path(application_choice.id), class: 'govuk-link', data: { action: :withdraw } do %>
+          <%= govuk_link_to candidate_interface_withdraw_path(application_choice.id), data: { action: :withdraw } do %>
             <%= t('application_form.courses.withdraw') %>
             <span class="govuk-visually-hidden"> <%= application_choice.offered_course.name_and_code %></span>
           <% end %>
         <% elsif @editable %>
-          <%= link_to candidate_interface_confirm_destroy_course_choice_path(application_choice.id), class: 'govuk-link', data: { action: :delete } do %>
+          <%= govuk_link_to candidate_interface_confirm_destroy_course_choice_path(application_choice.id), data: { action: :delete } do %>
             <%= t('application_form.courses.delete') %>
             <span class="govuk-visually-hidden"> <%= application_choice.offered_course.name_and_code %></span>
           <% end %>

--- a/app/components/candidate_interface/degrees_review_component.html.erb
+++ b/app/components/candidate_interface/degrees_review_component.html.erb
@@ -3,7 +3,7 @@
     <%= render(SummaryCardHeaderComponent.new(title: title(degree), heading_level: @heading_level)) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to candidate_interface_confirm_degree_destroy_path(degree.id), class: 'govuk-link' do %>
+          <%= govuk_link_to candidate_interface_confirm_degree_destroy_path(degree.id) do %>
             <%= t('application_form.degree.delete') %><span class="govuk-visually-hidden"><%= generate_action(degree: degree) %></span>
           <% end %>
         </div>

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class DegreesReviewComponent < ViewComponent::Base
+    include ViewHelper
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)

--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -6,7 +6,7 @@
     <%= render(SummaryCardHeaderComponent.new(title: qualification.title, heading_level: @heading_level)) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id), class: 'govuk-link' do %>
+          <%= govuk_link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id) do %>
             <%= t('application_form.other_qualification.delete') %><span class="govuk-visually-hidden"><%= generate_action(qualification: qualification) %></span>
           <% end %>
         </div>

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class OtherQualificationsReviewComponent < ViewComponent::Base
+    include ViewHelper
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, missing_error: false, submitting_application: false)

--- a/app/components/candidate_interface/references_review_component.html.erb
+++ b/app/components/candidate_interface/references_review_component.html.erb
@@ -15,14 +15,14 @@
           <ul class="app-summary-card__actions-list">
             <% if reference.feedback_requested? %>
               <div class="app-summary-card__actions">
-                <%= link_to candidate_interface_confirm_cancel_reference_path(reference.id), class: 'govuk-link' do %>
+                <%= govuk_link_to candidate_interface_confirm_cancel_reference_path(reference.id) do %>
                   <%= t('application_form.references.cancel_request.action') %>
                   <span class="govuk-visually-hidden"> <%= reference.name %></span>
                 <% end %>
               </div>
             <% elsif can_retry?(reference) %>
               <li class="app-summary-card__actions-list-item">
-                <%= link_to candidate_interface_references_retry_request_path(reference.id), class: 'govuk-link' do %>
+                <%= govuk_link_to candidate_interface_references_retry_request_path(reference.id) do %>
                   <%= t('application_form.references.retry_request.action') %>
                   <span class="govuk-visually-hidden"> to <%= reference.name %></span>
                 <% end %>
@@ -31,21 +31,21 @@
 
             <% if reference.not_requested_yet? %>
               <li class="app-summary-card__actions-list-item">
-                <%= link_to candidate_interface_confirm_destroy_referee_path(reference), class: 'govuk-link' do %>
+                <%= govuk_link_to candidate_interface_confirm_destroy_referee_path(reference) do %>
                   <%= t('application_form.references.delete_referee.action') %>
                   <span class="govuk-visually-hidden"> <%= reference.name %></span>
                 <% end %>
               </li>
             <% elsif reference.feedback_provided? %>
               <li class="app-summary-card__actions-list-item">
-                <%= link_to candidate_interface_confirm_destroy_reference_path(reference), class: 'govuk-link' do %>
+                <%= govuk_link_to candidate_interface_confirm_destroy_reference_path(reference) do %>
                   <%= t('application_form.references.delete_reference.action') %>
                   <span class="govuk-visually-hidden"> <%= reference.name %></span>
                 <% end %>
               </li>
             <% elsif request_can_be_deleted?(reference) %>
               <li class="app-summary-card__actions-list-item">
-                <%= link_to candidate_interface_confirm_destroy_reference_request_path(reference), class: 'govuk-link' do %>
+                <%= govuk_link_to candidate_interface_confirm_destroy_reference_request_path(reference) do %>
                   <%= t('application_form.references.delete_request.action') %>
                   <span class="govuk-visually-hidden"> <%= reference.name %></span>
                 <% end %>
@@ -54,14 +54,14 @@
 
             <% if can_send?(reference) %>
               <li class="app-summary-card__actions-list-item">
-                <%= link_to candidate_interface_references_new_request_path(reference.id), class: 'govuk-link' do %>
+                <%= govuk_link_to candidate_interface_references_new_request_path(reference.id) do %>
                   <%= t('application_form.references.send_request.action') %>
                   <span class="govuk-visually-hidden"> <%= reference.name %></span>
                 <% end %>
               </li>
             <% elsif can_resend?(reference) %>
               <li class="app-summary-card__actions-list-item">
-                <%= link_to candidate_interface_references_new_request_path(reference.id), class: 'govuk-link' do %>
+                <%= govuk_link_to candidate_interface_references_new_request_path(reference.id) do %>
                   <%= t('application_form.references.resend_request.action') %>
                   <span class="govuk-visually-hidden"> to <%= reference.name %></span>
                 <% end %>

--- a/app/components/candidate_interface/references_review_component.rb
+++ b/app/components/candidate_interface/references_review_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class ReferencesReviewComponent < ViewComponent::Base
+    include ViewHelper
     attr_reader :references, :editable, :show_history, :is_errored
 
     def initialize(references:, editable: true, show_history: false, is_errored: false, heading_level: 2)

--- a/app/components/candidate_interface/restructured_work_history/review_component.html.erb
+++ b/app/components/candidate_interface/restructured_work_history/review_component.html.erb
@@ -1,29 +1,21 @@
 <% if show_missing_banner? %>
   <%= render(CandidateInterface::IncompleteSectionComponent.new(section: :work_experience, section_path: CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path, error: @missing_error)) %>
 <% else %>
-
   <section class="app-summary-card govuk-!-margin-bottom-6">
     <div class="app-summary-card__body">
       <section>
         <% @work_history_with_breaks.each do |entry| %>
           <% if entry.is_a?(ApplicationWorkExperience) %>
-
             <%= render(CandidateInterface::RestructuredWorkHistory::JobComponent.new(work_experience: entry, editable: @editable)) %>
-
           <% elsif @editable && entry.is_a?(RestructuredWorkHistoryWithBreaks::BreakPlaceholder) %>
-
             <%= render(CandidateInterface::RestructuredWorkHistory::GapComponent.new(break_period: entry)) %>
-
           <% elsif entry.is_a?(ApplicationWorkHistoryBreak) %>
-
             <%= render(CandidateInterface::RestructuredWorkHistory::WorkBreakComponent.new(work_break: entry, editable: @editable)) %>
-
           <% end %>
 
           <% if @work_history_with_breaks.last != entry %>
             <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m ">
           <% end %>
-
         <% end %>
       </section>
 
@@ -34,5 +26,4 @@
       <% end %>
     </div>
   </section>
-
 <% end %>

--- a/app/components/candidate_interface/volunteering_review_component.html.erb
+++ b/app/components/candidate_interface/volunteering_review_component.html.erb
@@ -3,7 +3,7 @@
     <%= render(SummaryCardHeaderComponent.new(title: volunteering_role.role, heading_level: @heading_level)) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' do %>
+          <%= govuk_link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id) do %>
             <%= t('application_form.volunteering.delete.action') %><span class="govuk-visually-hidden"><%= generate_action(volunteering_role: volunteering_role) %></span>
           <% end %>
         </div>
@@ -21,7 +21,7 @@
     <div class="app-summary-card__body">
       The Department for Education have made it easier for teacher training
       applicants to gain experience in school. Learn more at
-      <%= link_to 'Get school experience', 'https://schoolexperience.education.gov.uk/', class: 'govuk-link', target: :_blank, rel: 'noopener' %>.
+      <%= govuk_link_to 'Get school experience', 'https://schoolexperience.education.gov.uk/', target: :_blank, rel: 'noopener' %>.
     </div>
   </section>
 <% end %>

--- a/app/components/candidate_interface/volunteering_review_component.rb
+++ b/app/components/candidate_interface/volunteering_review_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class VolunteeringReviewComponent < ViewComponent::Base
+    include ViewHelper
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)

--- a/app/components/candidate_interface/work_history_review_component.html.erb
+++ b/app/components/candidate_interface/work_history_review_component.html.erb
@@ -4,7 +4,7 @@
       <%= render(SummaryCardHeaderComponent.new(title: entry.role, heading_level: @heading_level)) do %>
         <% if @editable %>
           <div class="app-summary-card__actions">
-            <%= link_to candidate_interface_work_history_destroy_path(entry.id), class: 'govuk-link' do %>
+            <%= govuk_link_to candidate_interface_work_history_destroy_path(entry.id) do %>
               <%= t('application_form.work_history.delete_entry.action') %><span class="govuk-visually-hidden"><%= generate_action(work: entry) %></span>
             <% end %>
           </div>

--- a/app/components/candidate_interface/work_history_review_component.rb
+++ b/app/components/candidate_interface/work_history_review_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class WorkHistoryReviewComponent < ViewComponent::Base
+    include ViewHelper
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)

--- a/app/components/dfe_sign_in_button_component.html.erb
+++ b/app/components/dfe_sign_in_button_component.html.erb
@@ -1,1 +1,1 @@
-<%= button_to title, path, class: 'govuk-button' %>
+<%= govuk_button_to title, path %>

--- a/app/components/filter_component.html.erb
+++ b/app/components/filter_component.html.erb
@@ -95,7 +95,7 @@
       </div>
       <% if primary_filter[:value].present? %>
         <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-bottom-7">
-          <%= link_to('Clear search', remove_search_tag_link(primary_filter[:name]), class: 'govuk-link govuk-link--no-visited-state') %>
+          <%= govuk_link_to('Clear search', remove_search_tag_link(primary_filter[:name]), class: 'govuk-link--no-visited-state') %>
         </p>
       <% end %>
     <% end %>

--- a/app/components/provider_interface/application_timeline_component.html.erb
+++ b/app/components/provider_interface/application_timeline_component.html.erb
@@ -11,7 +11,7 @@
       </p>
       <div class="app-timeline__event_link">
         <% if event.link_name && event.link_path %>
-          <%= link_to event.link_name, event.link_path, class: 'govuk-link govuk-link--no-visited-state' %>
+          <%= govuk_link_to event.link_name, event.link_path, class: 'govuk-link--no-visited-state' %>
         <% end %>
       </div>
     </div>

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -1,5 +1,6 @@
 module ProviderInterface
   class ApplicationTimelineComponent < ViewComponent::Base
+    include ViewHelper
     attr_reader :application_choice
     validates :application_choice, presence: true
 

--- a/app/components/provider_interface/interview_and_course_summary_component.html.erb
+++ b/app/components/provider_interface/interview_and_course_summary_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-interviews__interview" id="interview-<%=interview.id%>">
+<div class="app-interviews__interview" id="interview-<%= interview.id %>">
   <%= render SummaryCardComponent.new(editable: true, border: true, rows: rows) do %>
     <%= render SummaryCardHeaderComponent.new(title: interview.date_and_time.to_s(:govuk_date_and_time), heading_level: 2) do %>
       <% if user_can_change_interview %>

--- a/app/components/provider_interface/interview_and_course_summary_component.html.erb
+++ b/app/components/provider_interface/interview_and_course_summary_component.html.erb
@@ -5,10 +5,10 @@
         <div class="app-summary-card__actions">
           <ul class="app-summary-card__actions-list">
             <li class="app-summary-card__actions-list-item">
-              <%= link_to 'Change details', edit_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
+              <%= govuk_link_to 'Change details', edit_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link--no-visited-state' %>
             </li>
             <li class="app-summary-card__actions-list-item">
-              <%= link_to 'Cancel interview', cancel_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link govuk-link--no-visited-state' %>
+              <%= govuk_link_to 'Cancel interview', cancel_provider_interface_application_choice_interview_path(application_choice, interview), class: 'app-summary-card__actions-list-item govuk-link--no-visited-state' %>
             </li>
           </ul>
         </div>

--- a/app/components/provider_interface/interview_and_course_summary_component.rb
+++ b/app/components/provider_interface/interview_and_course_summary_component.rb
@@ -1,5 +1,6 @@
 module ProviderInterface
   class InterviewAndCourseSummaryComponent < ViewComponent::Base
+    include ViewHelper
     attr_reader :interview, :user_can_change_interview, :application_choice
 
     def initialize(interview:, user_can_change_interview:)

--- a/app/components/provider_interface/interview_card_component.html.erb
+++ b/app/components/provider_interface/interview_card_component.html.erb
@@ -1,12 +1,11 @@
 <div class="app-interview-card">
   <div class="app-interview-card__time">
     <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">
-    <%= link_to provider_interface_application_choice_interviews_path(interview.application_choice, anchor: "interview-#{interview.id}"), class: 'govuk-link govuk-link--no-visited-state' do %>
+    <%= govuk_link_to provider_interface_application_choice_interviews_path(interview.application_choice, anchor: "interview-#{interview.id}"), class: 'govuk-link--no-visited-state' do %>
       <time datetime="<%= interview.date_and_time %>">
         <%= time %>
       </time>
       <span class="govuk-visually-hidden">on <%= date %> with <%= candidate_name %></span>
-
     <% end %>
     </p>
   </div>

--- a/app/components/provider_interface/interview_card_component.rb
+++ b/app/components/provider_interface/interview_card_component.rb
@@ -1,5 +1,6 @@
 module ProviderInterface
   class InterviewCardComponent < ViewComponent::Base
+    include ViewHelper
     attr_reader :interview, :application_choice
 
     def initialize(interview:)

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -18,13 +18,13 @@
 
       <% if row[:change_path] %>
         <dd class="govuk-summary-list__actions">
-          <%= link_to row[:change_path], class: 'govuk-link govuk-!-display-none-print' do %>
+          <%= govuk_link_to row[:change_path], class: 'govuk-!-display-none-print' do %>
             Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
           <% end %>
         </dd>
       <% elsif row[:action_path] %>
         <dd class="govuk-summary-list__actions">
-          <%= link_to row[:action], row[:action_path], class: 'govuk-link govuk-!-display-none-print' %>
+          <%= govuk_link_to row[:action], row[:action_path], class: 'govuk-!-display-none-print' %>
         </dd>
       <% elsif any_row_has_action_span? %>
         <dd class="govuk-summary-list__actions"></dd>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -1,4 +1,5 @@
 class SummaryListComponent < ViewComponent::Base
+  include ViewHelper
   validates :rows, presence: true
 
   def initialize(rows:)

--- a/app/components/support_interface/anchor_link_component.html.erb
+++ b/app/components/support_interface/anchor_link_component.html.erb
@@ -1,3 +1,3 @@
-<%= link_to "##{link_to_id}", style: 'text-decoration: none; color: inherit;' do %>
+<%= govuk_link_to "##{link_to_id}", style: 'text-decoration: none; color: inherit;' do %>
   <%= content %>
 <% end %>

--- a/app/components/support_interface/anchor_link_component.rb
+++ b/app/components/support_interface/anchor_link_component.rb
@@ -1,5 +1,6 @@
 module SupportInterface
   class AnchorLinkComponent < ViewComponent::Base
+    include ViewHelper
     attr_reader :link_to_id
 
     def initialize(link_to_id:)

--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -3,13 +3,13 @@
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: 3)) do %>
       <% if reference.cancelled? || reference.feedback_refused? %>
         <div class='app-summary-card__actions'>
-          <%= link_to support_interface_reinstate_reference_path(reference), class: 'govuk-link' do %>
+          <%= govuk_link_to support_interface_reinstate_reference_path(reference) do %>
           Reinstate reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>
           <% end %>
         </div>
       <% elsif reference.feedback_requested? %>
         <div class='app-summary-card__actions'>
-          <%= link_to support_interface_cancel_reference_path(reference), class: 'govuk-link' do %>
+          <%= govuk_link_to support_interface_cancel_reference_path(reference) do %>
             Cancel reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>
           <% end %>
         </div>

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -69,6 +69,11 @@ module ViewHelper
   end
 
   def govuk_button_to(name, options = {}, html_options = {})
+    if block_given?
+      html_options = options
+      options = name
+    end
+
     html_options = {
       class: prepend_css_class('govuk-button', html_options[:class]),
       role: 'button',
@@ -76,7 +81,7 @@ module ViewHelper
       draggable: false,
     }.merge(html_options)
 
-    return button_to(name, options, html_options) { yield } if block_given?
+    return button_to(options, html_options) { yield } if block_given?
 
     button_to(name, options, html_options)
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -76,6 +76,8 @@ module ViewHelper
       draggable: false,
     }.merge(html_options)
 
+    return button_to(name, options, html_options) { yield } if block_given?
+
     button_to(name, options, html_options)
   end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -33,16 +33,6 @@ module ViewHelper
     link_to(body, url, class: classes)
   end
 
-  def break_email_address(email_address)
-    email_address.gsub(/@/, '<wbr>@').html_safe
-  end
-
-  def bat_contact_mail_to(name = 'becomingateacher<wbr>@digital.education.gov.uk', html_options: {})
-    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
-
-    mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
-  end
-
   def govuk_button_link_to(body = nil, url = nil, html_options = nil, &block)
     if block_given?
       html_options = url
@@ -79,6 +69,16 @@ module ViewHelper
     return button_to(options, html_options) { yield } if block_given?
 
     button_to(name, options, html_options)
+  end
+
+  def break_email_address(email_address)
+    email_address.gsub(/@/, '<wbr>@').html_safe
+  end
+
+  def bat_contact_mail_to(name = 'becomingateacher<wbr>@digital.education.gov.uk', html_options: {})
+    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
+
+    mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
   end
 
   def submitted_at_date

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -63,7 +63,7 @@ module ViewHelper
     link_to(body, url, html_options)
   end
 
-  def govuk_button_to(name, options = {}, html_options = {})
+  def govuk_button_to(name, options = {}, html_options = {}, &_block)
     if block_given?
       html_options = options
       options = name

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -33,6 +33,11 @@ module ViewHelper
     link_to(body, url, class: classes)
   end
 
+  def govuk_footer_link_to(body = nil, url = nil, html_options = {}, &block)
+    html_options[:class] = prepend_css_class('govuk-footer__link', html_options[:class])
+    govuk_link_to(body, url, html_options, &block)
+  end
+
   def break_email_address(email_address)
     email_address.gsub(/@/, '<wbr>@').html_safe
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -33,11 +33,6 @@ module ViewHelper
     link_to(body, url, class: classes)
   end
 
-  def govuk_footer_link_to(body = nil, url = nil, html_options = {}, &block)
-    html_options[:class] = prepend_css_class('govuk-footer__link', html_options[:class])
-    govuk_link_to(body, url, html_options, &block)
-  end
-
   def break_email_address(email_address)
     email_address.gsub(/@/, '<wbr>@').html_safe
   end

--- a/app/views/candidate_interface/carry_over/start.html.erb
+++ b/app/views/candidate_interface/carry_over/start.html.erb
@@ -14,10 +14,12 @@
       Your courses have been removed. You can add them again now.
     </p>
 
-    <%= button_to 'Apply again', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+    <%= govuk_button_to 'Apply again', candidate_interface_carry_over_path, class: 'govuk-!-margin-bottom-5' %>
 
     <p class="govuk-body">or</p>
 
-    <%= govuk_link_to 'Go to dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Go to dashboard', candidate_interface_application_form_path %>
+    </p>
   </div>
 </div>

--- a/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles.html.erb
@@ -31,11 +31,12 @@
       <% end %>
     </p>
 
-    <%= button_to 'Apply again', candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+    <%= govuk_button_to 'Apply again', candidate_interface_carry_over_path, class: 'govuk-!-margin-bottom-5' %>
 
     <p class="govuk-body">or</p>
 
-    <%= govuk_link_to 'Go to dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
-
+    <p class="govuk-body">
+      <%= govuk_link_to 'Go to dashboard', candidate_interface_application_form_path %>
+    </p>
   </div>
 </div>

--- a/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
+++ b/app/views/candidate_interface/carry_over/start_between_cycles_unsubmitted.html.erb
@@ -25,6 +25,6 @@
       <% end %>
     </p>
 
-    <%= button_to t('continue'), candidate_interface_carry_over_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+    <%= govuk_button_to t('continue'), candidate_interface_carry_over_path, class: 'govuk-!-margin-bottom-5' %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/course_selection/full.html.erb
+++ b/app/views/candidate_interface/course_choices/course_selection/full.html.erb
@@ -11,10 +11,9 @@
     <p class="govuk-body">You can:</p>
     <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
       <li>
-        <%= link_to(
+        <%= govuk_link_to(
           'choose another course',
           candidate_interface_course_choices_course_path(@course.provider),
-          class: 'govuk-link',
         ) %>
       </li>
       <li>

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -15,6 +15,6 @@
       <p class="govuk-body">If you withdraw this course choice (and all your other course choices) you can still apply for more courses this year.</p>
     <% end %>
 
-    <%= button_to t('decisions.withdraw.confirm'), candidate_interface_withdraw_path, class: 'govuk-button govuk-button--warning' %>
+    <%= govuk_button_to t('decisions.withdraw.confirm'), candidate_interface_withdraw_path, class: 'govuk-button--warning' %>
   </div>
 </div>

--- a/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
+++ b/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
@@ -8,8 +8,8 @@
       </h1>
 
       <div class="govuk-inset-text govuk-!-margin-top-0">
-        <%= link_to @course_selection_form.course.find_url,
-                    class: 'govuk-!-font-weight-bold govuk-link',
+        <%= govuk_link_to @course_selection_form.course.find_url,
+                    class: 'govuk-!-font-weight-bold',
                     style: 'text-decoration: none' do %>
         <span class="govuk-!-font-size-19">
           <%= @course_selection_form.course.provider.name %>

--- a/app/views/candidate_interface/submitted_application_form/start_apply_again.html.erb
+++ b/app/views/candidate_interface/submitted_application_form/start_apply_again.html.erb
@@ -16,10 +16,12 @@
     </p>
     <p class="govuk-body">You can only apply to one course at a time at this stage of your application.</p>
 
-    <%= button_to 'Start now', candidate_interface_apply_again_path, class: 'govuk-button govuk-button govuk-!-margin-bottom-5' %>
+    <%= govuk_button_to 'Start now', candidate_interface_apply_again_path %>
 
     <p class="govuk-body">or</p>
 
-    <%= govuk_link_to 'Go to your dashboard', candidate_interface_application_form_path, class: 'govuk-body' %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Go to your dashboard', candidate_interface_application_form_path %>
+    </p>
   </div>
 </div>

--- a/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
+++ b/app/views/candidate_interface/unsubmitted_application_form/show.html.erb
@@ -65,9 +65,9 @@
       <ol class="app-task-list">
         <li class="app-task-list__item">
           <% all_sections_completed = @application_form.first_name.present? &&
-            @application_form.first_nationality.present? &&
-            (!@application_form.english_main_language.nil? ||
-            @application_form.right_to_work_or_study.present?) %>
+               @application_form.first_nationality.present? &&
+               (!@application_form.english_main_language.nil? ||
+                 @application_form.right_to_work_or_study.present?) %>
           <%= render(TaskListItemComponent.new(
             text: t('page_titles.personal_information'),
             completed: @application_form_presenter.personal_details_completed?,

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t('layout.support.online_chat') %></h2>
     <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-      <li><%= link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></li>
+      <li><%= govuk_footer_link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat') %></li>
       <li><%= t('get_into_teaching.opening_times') %></li>
     </ul>
   </div>
@@ -19,18 +19,18 @@
 <h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
 <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.accessibility'), candidate_interface_accessibility_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.accessibility'), candidate_interface_accessibility_path %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.cookies'), candidate_interface_cookies_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.cookies'), candidate_interface_cookies_path %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.complaints'), candidate_interface_complaints_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.complaints'), candidate_interface_complaints_path %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.privacy_policy'), candidate_interface_privacy_policy_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.privacy_policy'), candidate_interface_privacy_policy_path %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.terms_of_use'), candidate_interface_terms_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.terms_of_use'), candidate_interface_terms_path %>
   </li>
 </ul>

--- a/app/views/layouts/_footer_meta_candidate.html.erb
+++ b/app/views/layouts/_footer_meta_candidate.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-s govuk-!-margin-bottom-1"><%= t('layout.support.online_chat') %></h2>
     <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-      <li><%= govuk_footer_link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat') %></li>
+      <li><%= link_to t('layout.support.talk_to_advisor'), t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></li>
       <li><%= t('get_into_teaching.opening_times') %></li>
     </ul>
   </div>
@@ -19,18 +19,18 @@
 <h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
 <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.accessibility'), candidate_interface_accessibility_path %>
+    <%= link_to t('layout.support_links.accessibility'), candidate_interface_accessibility_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.cookies'), candidate_interface_cookies_path %>
+    <%= link_to t('layout.support_links.cookies'), candidate_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.complaints'), candidate_interface_complaints_path %>
+    <%= link_to t('layout.support_links.complaints'), candidate_interface_complaints_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.privacy_policy'), candidate_interface_privacy_policy_path %>
+    <%= link_to t('layout.support_links.privacy_policy'), candidate_interface_privacy_policy_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.terms_of_use'), candidate_interface_terms_path %>
+    <%= link_to t('layout.support_links.terms_of_use'), candidate_interface_terms_path, class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -2,23 +2,23 @@
 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
   <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
   <li><%= t('layout.support.response_time') %></li>
-  <li>Alternatively, <%= govuk_footer_link_to 'give feedback through our survey', ProviderInterface::FEEDBACK_LINK %></li>
+  <li>Alternatively, <%= link_to 'give feedback through our survey', ProviderInterface::FEEDBACK_LINK, class: 'govuk-footer__link' %></li>
 </ul>
 <p class="govuk-body govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-  <%= govuk_footer_link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path %>
+  <%= link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>
 </p>
 <h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
 <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.accessibility'), provider_interface_accessibility_path %>
+    <%= link_to t('layout.support_links.accessibility'), provider_interface_accessibility_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.cookies'), provider_interface_cookies_path %>
+    <%= link_to t('layout.support_links.cookies'), provider_interface_cookies_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.complaints'), provider_interface_complaints_path %>
+    <%= link_to t('layout.support_links.complaints'), provider_interface_complaints_path, class: 'govuk-footer__link' %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= govuk_footer_link_to t('layout.support_links.privacy_policy'), provider_interface_privacy_policy_path %>
+    <%= link_to t('layout.support_links.privacy_policy'), provider_interface_privacy_policy_path, class: 'govuk-footer__link' %>
   </li>
 </ul>

--- a/app/views/layouts/_footer_meta_provider.html.erb
+++ b/app/views/layouts/_footer_meta_provider.html.erb
@@ -2,23 +2,23 @@
 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
   <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
   <li><%= t('layout.support.response_time') %></li>
-  <li>Alternatively, <%= link_to 'give feedback through our survey', ProviderInterface::FEEDBACK_LINK, class: 'govuk-footer__link' %></li>
+  <li>Alternatively, <%= govuk_footer_link_to 'give feedback through our survey', ProviderInterface::FEEDBACK_LINK %></li>
 </ul>
 <p class="govuk-body govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-  <%= link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path, class: 'govuk-footer__link' %>
+  <%= govuk_footer_link_to t('layout.support.provider_service_guidance'), provider_interface_service_guidance_path %>
 </p>
 <h2 class="govuk-visually-hidden"><%= t('layout.support_links.title') %></h2>
 <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.accessibility'), provider_interface_accessibility_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.accessibility'), provider_interface_accessibility_path %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.cookies'), provider_interface_cookies_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.cookies'), provider_interface_cookies_path %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.complaints'), provider_interface_complaints_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.complaints'), provider_interface_complaints_path %>
   </li>
   <li class="govuk-footer__inline-list-item">
-    <%= link_to t('layout.support_links.privacy_policy'), provider_interface_privacy_policy_path, class: 'govuk-footer__link' %>
+    <%= govuk_footer_link_to t('layout.support_links.privacy_policy'), provider_interface_privacy_policy_path %>
   </li>
 </ul>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -27,7 +27,7 @@
     <%= render SandboxFeatureComponent.new(
       description: "See what this application looks like from the candidate side by signing in as #{@application_choice.application_form.full_name}:",
     ) do %>
-      <%= button_to 'Sign in as this candidate', provider_interface_impersonate_candidate_path(@application_choice.application_form.candidate), class: 'govuk-button govuk-!-margin-bottom-0' %>
+      <%= govuk_button_to 'Sign in as this candidate', provider_interface_impersonate_candidate_path(@application_choice.application_form.candidate), class: 'govuk-!-margin-bottom-0' %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content do %>
-  <%= link_to 'Back', previous_page, class: 'govuk-back-link' %>
+  <%= govuk_back_link_to 'Back', previous_page %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions_setup/setup_permissions.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_content do %>
-  <%= link_to 'Back', previous_page, class: 'govuk-back-link' %>
+  <%= govuk_back_link_to 'Back', previous_page %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -84,11 +84,11 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <dl class="app-count">
-          <%= link_to candidate_interface_providers_path, class: 'app-count__item govuk-link govuk-link--no-visited-state' do %>
+          <%= govuk_link_to candidate_interface_providers_path, class: 'app-count__item govuk-link--no-visited-state' do %>
             <dt class="app-count__key">Providers</dt>
             <dd class="app-count__value"><%= number_with_delimiter(@provider_count) %></dd>
           <% end %>
-          <%= link_to candidate_interface_providers_path, class: 'app-count__item govuk-link govuk-link--no-visited-state' do %>
+          <%= govuk_link_to candidate_interface_providers_path, class: 'app-count__item govuk-link--no-visited-state' do %>
             <dt class="app-count__key">Courses</dt>
             <dd class="app-count__value"><%= number_with_delimiter(@course_count) %></dd>
           <% end %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -8,13 +8,13 @@
 
 <div class="govuk-button-group">
   <% unless HostingEnvironment.production? %>
-    <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+    <%= govuk_button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), form_class: 'govuk-!-display-inline-block' %>
   <% end %>
 
   <% if @application_form.candidate.hide_in_reporting? %>
-    <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+    <%= govuk_button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
   <% else %>
-    <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+    <%= govuk_button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
   <% end %>
 </div>
 

--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -14,13 +14,13 @@
 <% end %>
 
 <% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@candidate), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+  <%= govuk_button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@candidate), form_class: 'govuk-!-display-inline-block' %>
 <% end %>
 
 <% if @candidate.hide_in_reporting? %>
-  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+  <%= govuk_button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@candidate), class: 'govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
 <% else %>
-  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+  <%= govuk_button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@candidate), class: 'govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
 <% end %>
 
 <% unless @application_forms.empty? %>

--- a/app/views/support_interface/data_exports/new.html.erb
+++ b/app/views/support_interface/data_exports/new.html.erb
@@ -25,7 +25,7 @@
           </p>
         <% end %>
 
-        <%= button_to "Generate #{export.fetch(:name)} export", support_interface_data_exports_path(export_type_id: id), class: 'govuk-button govuk-button--secondary' %>
+        <%= govuk_button_to "Generate #{export.fetch(:name)} export", support_interface_data_exports_path(export_type_id: id), class: 'govuk-button--secondary' %>
       </div>
     </div>
   </section>

--- a/app/views/support_interface/docs/missing_test_data.html.erb
+++ b/app/views/support_interface/docs/missing_test_data.html.erb
@@ -9,5 +9,5 @@
 </p>
 
 <p class="govuk-body">
-  <%= button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button' %>
+  <%= govuk_button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications') %>
 </p>

--- a/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
+++ b/app/views/support_interface/provider_users/_provider_user_impersonation.html.erb
@@ -5,7 +5,7 @@
     to see what they see. Any changes made will be linked to you.
   </p>
 
-  <%= link_to 'Stop impersonating this user', support_interface_end_impersonation_path, class: 'govuk-button govuk-button--secondary' %>
+  <%= govuk_button_link_to 'Stop impersonating this user', support_interface_end_impersonation_path, class: 'govuk-button--secondary' %>
 <% else %>
-  <%= button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), class: 'govuk-button', form_class: 'govuk-!-display-inline-block' %>
+  <%= govuk_button_to 'Sign in as this provider user', support_interface_provider_user_impersonate_path(provider_user), form_class: 'govuk-!-display-inline-block' %>
 <% end %>

--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -28,14 +28,14 @@
   ].compact) do %>
     <%= render SummaryCardHeaderComponent.new(title: feature_name.humanize, heading_level: 2) do %>
       <% if FeatureFlag.active?(feature_name) %>
-        <%= button_to support_interface_deactivate_feature_flag_path(feature_name),
-               class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0',
+        <%= govuk_button_to support_interface_deactivate_feature_flag_path(feature_name),
+               class: 'app-button--tertiary govuk-!-margin-bottom-0',
                data: { confirm: "Are you sure you want to deactivate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
           Deactivate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
         <% end %>
       <% else %>
-        <%= button_to support_interface_activate_feature_flag_path(feature_name),
-               class: 'govuk-button app-button--tertiary govuk-!-margin-bottom-0',
+        <%= govuk_button_to support_interface_activate_feature_flag_path(feature_name),
+               class: 'app-button--tertiary govuk-!-margin-bottom-0',
                data: { confirm: "Are you sure you want to activate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
           Activate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
         <% end %>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -7,7 +7,7 @@
       <p class="govuk-body">This task downloads providers, and the related entities (courses, course options etc.) from the Teacher Training API and Find.</p>
     </div>
     <div class="govuk-grid-column-one-third">
-      <%= button_to 'Sync providers', support_interface_run_task_path('sync_providers'), class: 'govuk-button govuk-button--secondary' %>
+      <%= govuk_button_to 'Sync providers', support_interface_run_task_path('sync_providers'), class: 'govuk-button--secondary' %>
     </div>
   </div>
 </section>
@@ -19,7 +19,7 @@
       <p class="govuk-body">This task runs the <code>RecalculateDates</code> worker when we add or remove business time holidays in response to things like COVID-19.</p>
     </div>
     <div class="govuk-grid-column-one-third">
-      <%= button_to 'Recalculate dates', support_interface_run_task_path('recalculate_dates'), class: 'govuk-button govuk-button--secondary' %>
+      <%= govuk_button_to 'Recalculate dates', support_interface_run_task_path('recalculate_dates'), class: 'govuk-button--secondary' %>
     </div>
   </div>
 </section>
@@ -32,7 +32,7 @@
       <p class="govuk-body">It should be run shortly after the cycle begins.</p>
     </div>
     <div class="govuk-grid-column-one-third">
-      <%= button_to 'Send reminder emails', support_interface_run_task_path('send_deferred_offer_reminder_emails'), class: 'govuk-button govuk-button--secondary' %>
+      <%= govuk_button_to 'Send reminder emails', support_interface_run_task_path('send_deferred_offer_reminder_emails'), class: 'govuk-button--secondary' %>
     </div>
   </div>
 </section>
@@ -72,7 +72,7 @@
         <p class="govuk-body">This task generates ~10 mostly-random test applications in all of the states.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button govuk-button--secondary' %>
+        <%= govuk_button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button--secondary' %>
       </div>
     </div>
   </section>
@@ -84,7 +84,7 @@
         <p class="govuk-body">This task creates a fake provider with 10 courses and 3 ratified courses. You will be shown their name, code and vendor API token.</p>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= button_to 'Create a fake provider', support_interface_tasks_create_fake_provider_path, class: 'govuk-button govuk-button--secondary' %>
+        <%= govuk_button_to 'Create a fake provider', support_interface_tasks_create_fake_provider_path, class: 'govuk-button--secondary' %>
       </div>
     </div>
   </section>

--- a/app/views/support_interface/validation_errors/summary.html.erb
+++ b/app/views/support_interface/validation_errors/summary.html.erb
@@ -41,7 +41,7 @@
                 },
               ) %>
         </div>
-        <%= f.submit('Update', name: nil, class: 'govuk-button') %>
+        <%= f.govuk_submit('Update') %>
       <% end %>
     </div>
   </div>

--- a/lib/rubocop/cop/govuk/govuk_button_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_button_to.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukButtonTo < Base
+        def on_send(node)
+          return unless node.method_name == :button_to
+
+          add_offense(node, message: 'Use govuk_button_to instead of button_to')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -5,7 +5,7 @@ module RuboCop
         def on_send(node)
           return unless node.method_name == :link_to
 
-          add_offense(node, message: 'Use govuk_link_to, govuk_footer_link_to, govuk_back_link_to or govuk_button_link_to instead of link_to')
+          add_offense(node, message: 'Use govuk_link_to, govuk_back_link_to or govuk_button_link_to instead of link_to')
         end
       end
     end

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukLinkTo < Base
+        def on_send(node)
+          return unless node.method_name == :link_to
+
+          add_offense(node, message: 'Use govuk_link_to or govuk_button_link_to instead of link_to')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -5,7 +5,7 @@ module RuboCop
         def on_send(node)
           return unless node.method_name == :link_to
 
-          add_offense(node, message: 'Use govuk_link_to or govuk_button_link_to instead of link_to')
+          add_offense(node, message: 'Use govuk_link_to, govuk_footer_link_to, govuk_back_link_to or govuk_button_link_to instead of link_to')
         end
       end
     end

--- a/lib/rubocop/cop/govuk/govuk_submit.rb
+++ b/lib/rubocop/cop/govuk/govuk_submit.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukSubmit < Base
+        def on_send(node)
+          return unless node.method_name == :submit
+
+          add_offense(node, message: 'Use govuk_submit instead of submit')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Follow up to #4060, where @paulrobertlloyd came up with the ingenious idea of using `erblint` to check that we're using the proper `govuk_link_to` helper for links.

## Changes proposed in this pull request

Add Rubocop cops for `govuk_link_to`, `govuk_button_link_to`, `govuk_back_link_to`, `govuk_button_to` and `govuk_submit`. Introduce `govuk_footer_link_to` and check for that as well. Then fix all the violations.

## Guidance to review

What do you think? We've ignored a tiny set of files where it's not appropriate to use these helpers, but apart from that it seems that it's more or less always right to use the `govuk_` helper.   

## Link to Trello card

N/A

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
