### PR TITLE
Add notifications export with daily schedule

### DIFF
--- a/app/exports/notifications_export.yml
+++ b/app/exports/notifications_export.yml
@@ -1,0 +1,31 @@
+common_columns:
+- provider_code
+- provider_name
+
+custom_columns:
+  applications_received:
+    type: integer
+
+  applications_awaiting_decisions:
+    type: integer
+
+  applications_receiving_decisions:
+    type: integer
+
+  applications_rbd:
+    type: integer
+
+  applications_withdrawn:
+    type: integer
+
+  number_of_provider_users:
+    type: integer
+
+  users_with_make_decisions:
+    type: integer
+
+  users_with_make_decisions_and_notifications_disabled:
+    type: integer
+
+  users_with_make_decisions_and_notifications_enabled:
+    type: integer

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -100,6 +100,11 @@ class DataExport < ApplicationRecord
       description: 'A list of qualifications for each application choice',
       class: SupportInterface::QualificationsExport,
     },
+    notifications_export: {
+      name: 'Notifications',
+      description: 'Data to enable performance assesment of Notification feature',
+      class: SupportInterface::NotificationsExport,
+    },
   }.freeze
 
   belongs_to :initiator, polymorphic: true, optional: true

--- a/app/services/support_interface/notifications_export.rb
+++ b/app/services/support_interface/notifications_export.rb
@@ -1,0 +1,57 @@
+module SupportInterface
+  class NotificationsExport
+    def data_for_export
+      courses = Course.where(recruitment_cycle_year: RecruitmentCycle.current_year, open_on_apply: true)
+      providers = Provider.includes(:provider_users, :application_choices).joins(:courses).merge(courses).group('providers.id')
+      providers.flat_map do |provider|
+        data_for_provider(provider, provider_users_with_make_decisions(provider), visible_applications(provider))
+      end
+    end
+
+  private
+
+    def data_for_provider(provider, users_with_make_decisions, applications)
+      {
+        provider_code: provider.code,
+        provider_name: provider.name,
+        applications_received: applications.count,
+        applications_awaiting_decisions: awaiting_decisions_count(applications),
+        applications_receiving_decisions: receiving_decisions_count(applications) - rbd_count(applications) - applications.count(&:withdrawn?),
+        applications_rbd: rbd_count(applications),
+        applications_withdrawn: applications.count(&:withdrawn?),
+        number_of_provider_users: provider.provider_users.count,
+        users_with_make_decisions: users_with_make_decisions.count,
+        users_with_make_decisions_and_notifications_disabled: users_with_make_decisions.count { |u| !u.send_notifications },
+        users_with_make_decisions_and_notifications_enabled: users_with_make_decisions.count(&:send_notifications),
+      }
+    end
+
+    def provider_users_with_make_decisions(provider)
+      provider.provider_permissions.includes(:provider_user).where(make_decisions: true).map(&:provider_user)
+    end
+
+    def visible_applications(provider)
+      provider.application_choices.where(status: ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER)
+    end
+
+    def awaiting_decisions_count(applications)
+      applications.count do |application|
+        ApplicationStateChange::DECISION_PENDING_STATUSES.include?(application.status.to_sym)
+      end
+    end
+
+    def receiving_decisions_count(applications)
+      applications.count do |application|
+        decision_receiving_states.include?(application.status.to_sym)
+      end
+    end
+
+    def rbd_count(applications)
+      applications.count { |a| a.rejected? && a.rejected_by_default? }
+    end
+
+    def decision_receiving_states
+      ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - ApplicationStateChange::DECISION_PENDING_STATUSES
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -50,4 +50,9 @@ class Clock
       TeacherTrainingPublicAPI::SyncAllProvidersAndCoursesWorker.perform_async
     end
   end
+
+  every(1.day, 'Generate export for Notifications', at: '23:57') do
+    data_export = DataExport.create!(name: 'Daily export of notifications breakdown')
+    DataExporter.perform_async(SupportInterface::NotificationsExport, data_export.id)
+  end
 end

--- a/spec/services/support_interface/notifications_export_spec.rb
+++ b/spec/services/support_interface/notifications_export_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::NotificationsExport do
+  describe '#data_for_export' do
+    let!(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_options.sample) }
+    let!(:decided_application_choice) { create(:application_choice, :with_offer, course_option: course_options.sample) }
+    let!(:rbd_application_choice) { create(:application_choice, :with_rejection_by_default, course_option: course_options.sample) }
+    let!(:withdrawn_application_choice) { create(:application_choice, :withdrawn, course_option: course_options.sample) }
+    let!(:interview_application_choice) { create(:application_choice, :with_scheduled_interview, course_option: course_options.sample) }
+    let!(:rejected_application_choice) { create(:application_choice, :with_rejection, course_option: course_options.sample) }
+    let(:course_options) { courses.map { |course| create(:course_option, course: course) } }
+    let(:courses) { create_list(:course, 4, :open_on_apply, provider: provider) }
+    let(:provider) { create(:provider) }
+
+    before do
+      create(:provider_user, :with_make_decisions, providers: [provider], send_notifications: false)
+      create(:provider_user, :with_make_decisions, providers: [provider], send_notifications: true)
+      create(:provider_user, providers: [provider], send_notifications: true)
+    end
+
+    it_behaves_like 'a data export'
+
+    it 'returns the correct count for user notification related events' do
+      expect(described_class.new.data_for_export).to match_array([
+        {
+          provider_code: provider.code,
+          provider_name: provider.name,
+          applications_received: 6,
+          applications_awaiting_decisions: 2,
+          applications_receiving_decisions: 2,
+          applications_rbd: 1,
+          applications_withdrawn: 1,
+          number_of_provider_users: 3,
+          users_with_make_decisions: 2,
+          users_with_make_decisions_and_notifications_disabled: 1,
+          users_with_make_decisions_and_notifications_enabled: 1,
+        },
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Context

https://trello.com/c/oyKg6VVy/3329-create-csv-extract-for-minimal-notifications-analysis

Creating a new export, which breaks down how many users have notifications on for each provider, and how many notifiable events are taking place.

## Changes proposed in this pull request

Added a new export in the export list

![image](https://user-images.githubusercontent.com/25597009/107927623-25bb0a80-6f6f-11eb-832d-94c2923948cd.png)

## Guidance to review

Try and run the export from support/performance/data-exports/new (it'll be at the bottom of the page)

## Link to Trello card

https://trello.com/c/oyKg6VVy/3329-create-csv-extract-for-minimal-notifications-analysis

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
