### PR TITLE
Revert changes to E&D export

### DIFF
--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -1,13 +1,9 @@
 module SupportInterface
   class EqualityAndDiversityExport
     def data_for_export
-      data_for_export = application_forms.includes(:application_choices, :candidate, :application_feedback).map do |application_form|
+      data_for_export = application_forms.includes(:application_choices).map do |application_form|
         rejected_application_choices = application_form.application_choices.rejected
         output = {
-          'Name' => "#{application_form.first_name} #{application_form.last_name}",
-          'Email' => application_form.candidate.email_address,
-          'Phone number' => application_form.phone_number,
-          'Consent to be contacted' => flatten_consent(application_form.application_feedback),
           'Month' => application_form.submitted_at&.strftime('%B'),
           'Recruitment cycle year' => application_form.recruitment_cycle_year,
           'Sex' => application_form.equality_and_diversity['sex'],
@@ -40,7 +36,7 @@ module SupportInterface
 
     def application_forms
       ApplicationForm
-        .includes(:application_choices, :candidate, :application_feedback)
+        .includes(:application_choices)
         .where.not(equality_and_diversity: nil)
     end
 
@@ -61,15 +57,6 @@ module SupportInterface
       reason
       .delete_suffix('_y_n')
       .humanize
-    end
-
-    def flatten_consent(application_feedback)
-      consent_responses = application_feedback.map(&:consent_to_be_contacted)
-      if consent_responses.include?(false)
-        false
-      elsif consent_responses.include?(true)
-        true
-      end
     end
   end
 end

--- a/spec/services/support_interface/equality_and_diversity_export_spec.rb
+++ b/spec/services/support_interface/equality_and_diversity_export_spec.rb
@@ -1,96 +1,96 @@
-# require 'rails_helper'
-#
-# RSpec.describe SupportInterface::EqualityAndDiversityExport do
-#   describe '#data_for_export' do
-#     it 'returns an array of hashes containing equality and diversity data' do
-#       one_disability = {
-#         disabilities: %w[unexplained],
-#       }
-#
-#       two_disabilities = {
-#         sex: 'female',
-#         ethnic_background: 'Kiwi',
-#         ethnic_group: 'Cantabrian',
-#         disabilities: %w[unexplained amnesia],
-#       }
-#
-#       three_disabilities = {
-#         sex: 'female',
-#         ethnic_background: 'Kiwi',
-#         ethnic_group: 'Cantabrian',
-#         disabilities: %w[unexplained amnesia blind],
-#       }
-#
-#       application_form_one = create(:completed_application_form, equality_and_diversity: two_disabilities)
-#       application_form_two = create(:completed_application_form, equality_and_diversity: one_disability)
-#       application_form_three = create(:completed_application_form, equality_and_diversity: three_disabilities)
-#
-#       create(:completed_application_form, equality_and_diversity: nil)
-#       create(
-#         :application_choice,
-#         :with_structured_rejection_reasons,
-#         structured_rejection_reasons: {
-#           course_full_y_n: 'No',
-#           candidate_behaviour_y_n: 'Yes',
-#           candidate_behaviour_other: 'Persistent scratching',
-#           honesty_and_professionalism_y_n: 'Yes',
-#           honesty_and_professionalism_concerns: %w[references],
-#         },
-#         application_form: application_form_two,
-#       )
-#
-#       create(:application_choice, :with_rejection, rejection_reason: 'Abscence of English GCSE.', application_form: application_form_three)
-#
-#       expect(described_class.new.data_for_export).to contain_exactly(
-#         {
-#           'Month' => application_form_three.submitted_at&.strftime('%B'),
-#           'Recruitment cycle year' => application_form_three.recruitment_cycle_year,
-#           'Sex' => application_form_three.equality_and_diversity['sex'],
-#           'Ethnic group' => application_form_three.equality_and_diversity['ethnic_group'],
-#           'Ethnic background' => application_form_three.equality_and_diversity['ethnic_background'],
-#           'Application status' => 'Ended without success',
-#           'First rejection reason' => 'Abscence of English GCSE.',
-#           'Second rejection reason' => nil,
-#           'Third rejection reason' => nil,
-#           'First structured rejection reasons' => nil,
-#           'Second structured rejection reasons' => nil,
-#           'Third structured rejection reasons' => nil,
-#           'Disability 1' => application_form_three.equality_and_diversity['disabilities'].first,
-#           'Disability 2' => application_form_three.equality_and_diversity['disabilities'].second,
-#           'Disability 3' => application_form_three.equality_and_diversity['disabilities'].last,
-#         },
-#         {
-#           'Month' => application_form_one.submitted_at&.strftime('%B'),
-#           'Recruitment cycle year' => application_form_one.recruitment_cycle_year,
-#           'Sex' => application_form_one.equality_and_diversity['sex'],
-#           'Ethnic group' => application_form_one.equality_and_diversity['ethnic_group'],
-#           'Ethnic background' => application_form_one.equality_and_diversity['ethnic_background'],
-#           'Application status' => 'Have not started form',
-#           'First rejection reason' => nil,
-#           'Second rejection reason' => nil,
-#           'Third rejection reason' => nil,
-#           'First structured rejection reasons' => nil,
-#           'Second structured rejection reasons' => nil,
-#           'Third structured rejection reasons' => nil,
-#           'Disability 1' => application_form_one.equality_and_diversity['disabilities'].first,
-#           'Disability 2' => application_form_one.equality_and_diversity['disabilities'].last,
-#         },
-#         {
-#           'Month' => application_form_two.submitted_at&.strftime('%B'),
-#           'Recruitment cycle year' => application_form_two.recruitment_cycle_year,
-#           'Sex' => application_form_two.equality_and_diversity['sex'],
-#           'Ethnic group' => application_form_two.equality_and_diversity['ethnic_group'],
-#           'Ethnic background' => application_form_two.equality_and_diversity['ethnic_background'],
-#           'Application status' => 'Ended without success',
-#           'First rejection reason' => nil,
-#           'Second rejection reason' => nil,
-#           'Third rejection reason' => nil,
-#           'First structured rejection reasons' => "Candidate behaviour\nHonesty and professionalism",
-#           'Second structured rejection reasons' => nil,
-#           'Third structured rejection reasons' => nil,
-#           'Disability 1' => application_form_two.equality_and_diversity['disabilities'].first,
-#         },
-#       )
-#     end
-#   end
-# end
+require 'rails_helper'
+
+RSpec.describe SupportInterface::EqualityAndDiversityExport do
+  describe '#data_for_export' do
+    it 'returns an array of hashes containing equality and diversity data' do
+      one_disability = {
+        disabilities: %w[unexplained],
+      }
+
+      two_disabilities = {
+        sex: 'female',
+        ethnic_background: 'Kiwi',
+        ethnic_group: 'Cantabrian',
+        disabilities: %w[unexplained amnesia],
+      }
+
+      three_disabilities = {
+        sex: 'female',
+        ethnic_background: 'Kiwi',
+        ethnic_group: 'Cantabrian',
+        disabilities: %w[unexplained amnesia blind],
+      }
+
+      application_form_one = create(:completed_application_form, equality_and_diversity: two_disabilities)
+      application_form_two = create(:completed_application_form, equality_and_diversity: one_disability)
+      application_form_three = create(:completed_application_form, equality_and_diversity: three_disabilities)
+
+      create(:completed_application_form, equality_and_diversity: nil)
+      create(
+        :application_choice,
+        :with_structured_rejection_reasons,
+        structured_rejection_reasons: {
+          course_full_y_n: 'No',
+          candidate_behaviour_y_n: 'Yes',
+          candidate_behaviour_other: 'Persistent scratching',
+          honesty_and_professionalism_y_n: 'Yes',
+          honesty_and_professionalism_concerns: %w[references],
+        },
+        application_form: application_form_two,
+      )
+
+      create(:application_choice, :with_rejection, rejection_reason: 'Abscence of English GCSE.', application_form: application_form_three)
+
+      expect(described_class.new.data_for_export).to contain_exactly(
+        {
+          'Month' => application_form_three.submitted_at&.strftime('%B'),
+          'Recruitment cycle year' => application_form_three.recruitment_cycle_year,
+          'Sex' => application_form_three.equality_and_diversity['sex'],
+          'Ethnic group' => application_form_three.equality_and_diversity['ethnic_group'],
+          'Ethnic background' => application_form_three.equality_and_diversity['ethnic_background'],
+          'Application status' => 'Ended without success',
+          'First rejection reason' => 'Abscence of English GCSE.',
+          'Second rejection reason' => nil,
+          'Third rejection reason' => nil,
+          'First structured rejection reasons' => nil,
+          'Second structured rejection reasons' => nil,
+          'Third structured rejection reasons' => nil,
+          'Disability 1' => application_form_three.equality_and_diversity['disabilities'].first,
+          'Disability 2' => application_form_three.equality_and_diversity['disabilities'].second,
+          'Disability 3' => application_form_three.equality_and_diversity['disabilities'].last,
+        },
+        {
+          'Month' => application_form_one.submitted_at&.strftime('%B'),
+          'Recruitment cycle year' => application_form_one.recruitment_cycle_year,
+          'Sex' => application_form_one.equality_and_diversity['sex'],
+          'Ethnic group' => application_form_one.equality_and_diversity['ethnic_group'],
+          'Ethnic background' => application_form_one.equality_and_diversity['ethnic_background'],
+          'Application status' => 'Have not started form',
+          'First rejection reason' => nil,
+          'Second rejection reason' => nil,
+          'Third rejection reason' => nil,
+          'First structured rejection reasons' => nil,
+          'Second structured rejection reasons' => nil,
+          'Third structured rejection reasons' => nil,
+          'Disability 1' => application_form_one.equality_and_diversity['disabilities'].first,
+          'Disability 2' => application_form_one.equality_and_diversity['disabilities'].last,
+        },
+        {
+          'Month' => application_form_two.submitted_at&.strftime('%B'),
+          'Recruitment cycle year' => application_form_two.recruitment_cycle_year,
+          'Sex' => application_form_two.equality_and_diversity['sex'],
+          'Ethnic group' => application_form_two.equality_and_diversity['ethnic_group'],
+          'Ethnic background' => application_form_two.equality_and_diversity['ethnic_background'],
+          'Application status' => 'Ended without success',
+          'First rejection reason' => nil,
+          'Second rejection reason' => nil,
+          'Third rejection reason' => nil,
+          'First structured rejection reasons' => "Candidate behaviour\nHonesty and professionalism",
+          'Second structured rejection reasons' => nil,
+          'Third structured rejection reasons' => nil,
+          'Disability 1' => application_form_two.equality_and_diversity['disabilities'].first,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

We recently added personal information to the E&D export so that user research could arrange interviews (https://github.com/DFE-Digital/apply-for-teacher-training/pull/4069). They have now taken an export and these changes should be reverted ASAP.

## Guidance to review

These changes were autogenerated by git by reverting the previous changes. 

## Link to Trello card

https://trello.com/c/pUUyeFDN/84-adding-contact-details-to-ed-data-extract (Impact Squad board)

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
