### PR TITLE
Resolves sentry error caused by lack of validation of volunteering role start date

### DIFF
--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
     validates :details, word_count: { maximum: 150 }
 
-    validates :start_date, date: { future: true, month_and_year: true }
+    validates :start_date, date: { presence: true, future: true, month_and_year: true }
     validates :end_date, date: { presence: true, future: true, month_and_year: true }, if: :start_date
     validate :start_date_before_end_date, unless: ->(c) { %i[start_date end_date].any? { |d| c.errors.keys.include?(d) } }, if: %i[start_date end_date]
 

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', 'volunteering_role_form'
+    include_examples 'validation for a start date', 'volunteering_role_form', verify_presence: true
     include_examples 'validation for an end date that can be blank', 'volunteering_role_form'
   end
 end


### PR DESCRIPTION
Resolves sentry error caused by lack of validation of volunteering role start date
https://sentry.io/organizations/dfe-bat/issues/2214915270/?project=1765973&referrer=slack

The error is caused due to the validation being enforced on ApplicationExperience which is the base model of ApplicationVolunteeringExperience where volunteering_role_form data is stored on.

The PR also extends volunteering_role_form_spec to test the start_date presence.