### PR TITLE
Fix setup_local_dev_data task by syncing courses and sites synchronously

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -54,12 +54,12 @@ task sync_dev_providers_and_open_courses: :environment do
         .where(year: RecruitmentCycle.current_year)
         .find(code).first
 
-    TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.previous_year).call
+    TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.previous_year).call(run_in_background: false, force_sync_courses: true)
     FindSync::SyncProviderFromFind.call(run_in_background: false, provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.previous_year)
 
     Provider.find_by_code(code).courses.previous_cycle.exposed_in_find.update_all(open_on_apply: true)
 
-    TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year).call
+    TeacherTrainingPublicAPI::SyncProvider.new(provider_from_api: provider_from_api, recruitment_cycle_year: RecruitmentCycle.current_year).call(run_in_background: false, force_sync_courses: true)
     FindSync::SyncProviderFromFind.call(run_in_background: false, provider_code: code, sync_courses: true, provider_recruitment_cycle_year: RecruitmentCycle.current_year)
   end
 


### PR DESCRIPTION
## Context

Our recent refactor of syncing courses (https://github.com/DFE-Digital/apply-for-teacher-training/pull/3922) broke the `setup_local_dev_data` task by not making any courses available when the system attempts to create test applications.

This is because:
- Providers added as part of `setup_local_dev_data` do not have `sync_courses` set to `true`
- `SyncCourses` and `SyncSites` run parallelised in the background by default, but no sidekiq is running when `setup_local_dev_data` is invoked locally

## Changes proposed in this pull request

Add a `force_sync_courses:` parameter to `SyncProvider`.

Add a `run_in_background:` parameter to `SyncCourses` to control whether `SyncSites` are synchronous or not 

## Guidance to review

Drop your database and re-create it, `rake db:migrate`, then `rake setup_local_dev_data`. The setup should complete without errors.

## Link to Trello card

https://trello.com/c/NCkdrmel

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
