### PR TITLE
3363 interview schedule page bugs

### DIFF
--- a/app/components/provider_interface/interview_and_course_summary_component.html.erb
+++ b/app/components/provider_interface/interview_and_course_summary_component.html.erb
@@ -1,3 +1,4 @@
+<a id="interview-<%=interview.id%>"></a>
 <div class="app-interviews__interview">
   <%= render SummaryCardComponent.new(editable: true, border: true, rows: rows) do %>
     <%= render SummaryCardHeaderComponent.new(title: interview.date_and_time.to_s(:govuk_date_and_time), heading_level: 2) do %>

--- a/app/components/provider_interface/interview_and_course_summary_component.html.erb
+++ b/app/components/provider_interface/interview_and_course_summary_component.html.erb
@@ -1,5 +1,4 @@
-<a id="interview-<%=interview.id%>"></a>
-<div class="app-interviews__interview">
+<div class="app-interviews__interview" id="interview-<%=interview.id%>">
   <%= render SummaryCardComponent.new(editable: true, border: true, rows: rows) do %>
     <%= render SummaryCardHeaderComponent.new(title: interview.date_and_time.to_s(:govuk_date_and_time), heading_level: 2) do %>
       <% if user_can_change_interview %>

--- a/app/components/provider_interface/interview_card_component.html.erb
+++ b/app/components/provider_interface/interview_card_component.html.erb
@@ -1,7 +1,7 @@
 <div class="app-interview-card">
   <div class="app-interview-card__time">
     <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">
-    <%= link_to provider_interface_application_choice_interviews_path(interview.application_choice), class: 'govuk-link govuk-link--no-visited-state' do %>
+    <%= link_to provider_interface_application_choice_interviews_path(interview.application_choice, anchor: "interview-#{interview.id}"), class: 'govuk-link govuk-link--no-visited-state' do %>
       <time datetime="<%= interview.date_and_time %>">
         <%= time %>
       </time>

--- a/app/views/provider_interface/interview_schedules/past.html.erb
+++ b/app/views/provider_interface/interview_schedules/past.html.erb
@@ -20,6 +20,8 @@
         <% end %>
       </div>
       <%= render(PaginatorComponent.new(scope: @interviews)) %>
+    <% elsif @grouped_interviews.empty? %>
+      <p>No past interviews</p>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/interview_schedules/past.html.erb
+++ b/app/views/provider_interface/interview_schedules/past.html.erb
@@ -20,7 +20,7 @@
         <% end %>
       </div>
       <%= render(PaginatorComponent.new(scope: @interviews)) %>
-    <% elsif @grouped_interviews.empty? %>
+    <% else %>
       <p>No past interviews</p>
     <% end %>
   </div>

--- a/app/views/provider_interface/interview_schedules/show.html.erb
+++ b/app/views/provider_interface/interview_schedules/show.html.erb
@@ -20,7 +20,7 @@
         <% end %>
       </div>
       <%= render(PaginatorComponent.new(scope: @interviews)) %>
-    <% elsif @grouped_interviews.empty? %>
+    <% else %>
       <p>No upcoming interviews</p>
     <% end %>
   </div>

--- a/app/views/provider_interface/interview_schedules/show.html.erb
+++ b/app/views/provider_interface/interview_schedules/show.html.erb
@@ -20,6 +20,8 @@
         <% end %>
       </div>
       <%= render(PaginatorComponent.new(scope: @interviews)) %>
+    <% elsif @grouped_interviews.empty? %>
+      <p>No upcoming interviews</p>
     <% end %>
   </div>
 </div>

--- a/spec/components/provider_interface/interview_card_component_spec.rb
+++ b/spec/components/provider_interface/interview_card_component_spec.rb
@@ -27,4 +27,8 @@ RSpec.describe ProviderInterface::InterviewCardComponent do
   it 'renders text indicating there are interview preferences if any' do
     expect(render.css('.app-interview-card__candidate').text).to include('Has interview preferences')
   end
+
+  it 'renders the application choice interviews anchored url' do
+    expect(render.css('a').attr('href').value).to eq("/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}")
+  end
 end

--- a/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
+++ b/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe 'A Provider user' do
     given_i_am_a_provider_user
     and_i_sign_in_to_the_provider_interface
 
+    when_i_visit_the_provider_interface
+    and_i_click_interview_schedule
+    then_i_see_no_upcoming_interviews
+
+    and_i_click_past_interviews
+    then_i_see_no_past_interviews
+
     given_there_are_past_and_present_interviews
     when_i_visit_the_provider_interface
 
@@ -73,6 +80,10 @@ RSpec.describe 'A Provider user' do
     end
   end
 
+  def then_i_see_no_upcoming_interviews
+    expect(page).to have_content('No upcoming interviews')
+  end
+
   def and_i_click_past_interviews
     click_on 'Past interviews'
   end
@@ -81,6 +92,10 @@ RSpec.describe 'A Provider user' do
     within '.app-interviews' do
       expect(page.assert_selector('.app-interview-card', count: @past_interviews.count)).to eq(true)
     end
+  end
+
+  def then_i_see_no_past_interviews
+    expect(page).to have_content('No past interviews')
   end
 
   def and_i_can_verify_that_the_correct_information_is_presented


### PR DESCRIPTION
## Context

In order to match the live version with the prototype, messages needed to be added to the past and upcoming interviews tabs declaring there were no interviews of that type present. In addition anchor tags were added to the interview time links.

## Changes proposed in this pull request

Add helpful paragraphs that display in the case of no interviews (for the past and upcoming tabs).

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/qYfTVTkv/3363-interview-schedule-page-bugs

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
