### PR TITLE
Create new exports for longitudinal permissions analysis

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -65,6 +65,11 @@ class DataExport < ApplicationRecord
       description: 'A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.',
       class: SupportInterface::OfferConditionsExport,
     },
+    organisation_permissions: {
+      name: 'Organisation permissions',
+      description: 'A list of changes to organisational permissions and audit information about the changes',
+      class: SupportInterface::OrganisationPermissionsExport,
+    },
     provider_access_controls: {
       name: 'Provider Access Controls',
       description: 'A list of providers and information about their permissions',
@@ -109,6 +114,11 @@ class DataExport < ApplicationRecord
       name: 'Unexplained breaks in work history',
       description: 'A list of candidates with unexplained breaks in their work history.',
       class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
+    },
+    user_permissions_: {
+      name: 'User permissions',
+      description: 'A list of changes to user permissions and audit information about the changes',
+      class: SupportInterface::UserPermissionsExport,
     },
   }.freeze
 

--- a/app/services/support_interface/organisation_permissions_export.rb
+++ b/app/services/support_interface/organisation_permissions_export.rb
@@ -13,7 +13,12 @@ module SupportInterface
         .pluck(
           'audits.created_at',
           'audits.user_id',
-          'audits.username',
+          Arel.sql(
+            "CASE audits.user_type
+              WHEN 'ProviderUser' THEN (SELECT CONCAT(first_name, ' ', last_name) FROM provider_users WHERE id = audits.user_id)
+              WHEN 'SupportUser' THEN (SELECT CONCAT(first_name, ' ', last_name) FROM support_users WHERE id = audits.user_id)
+            END".squish,
+          ),
           'ups.code',
           'ups.name',
           'tp.code',

--- a/app/services/support_interface/organisation_permissions_export.rb
+++ b/app/services/support_interface/organisation_permissions_export.rb
@@ -1,0 +1,78 @@
+module SupportInterface
+  class OrganisationPermissionsExport
+    def data_for_export
+      data = Audited::Audit
+        .joins('INNER JOIN provider_relationship_permissions prp ON audits.auditable_id = prp.id')
+        .joins('INNER JOIN providers tp ON prp.training_provider_id = tp.id')
+        .joins('INNER JOIN providers rp ON prp.ratifying_provider_id = rp.id')
+        .joins('LEFT JOIN provider_users_providers pup ON audits.user_id = pup.provider_user_id')
+        .joins('LEFT JOIN providers ups ON pup.provider_id = ups.id')
+        .where(auditable_type: 'ProviderRelationshipPermissions')
+        .where(action: %w[create update])
+        .where(permissions_clauses)
+        .pluck(
+          'audits.created_at',
+          'audits.user_id',
+          'audits.username',
+          'ups.code',
+          'ups.name',
+          'tp.code',
+          'tp.name',
+          'rp.code',
+          'rp.name',
+          'audits.audited_changes',
+        )
+
+      data.map do |row|
+        ratifying_provider_code, ratifying_provider_name, audited_changes = row.pop(3)
+        row << permissions_changes(audited_changes, 'training')
+        row << permissions_changes(audited_changes, 'training', false)
+        row << ratifying_provider_code << ratifying_provider_name
+        row << permissions_changes(audited_changes, 'ratifying')
+        row << permissions_changes(audited_changes, 'ratifying', false)
+
+        Hash[labels.zip(row)]
+      end
+    end
+
+  private
+
+    def labels
+      [
+        'Date',
+        'User ID',
+        'User making change',
+        'Provider code',
+        'Provider',
+        'Training provider code',
+        'Training provider',
+        'Training provider permissions added',
+        'Training provider permissions removed',
+        'Ratifying provider code',
+        'Ratifying provider',
+        'Ratifying provider permissions added',
+        'Ratifying provider permissions removed',
+      ]
+    end
+
+    def permissions_changes(audited_changes, provider_type, enabled = true)
+      permissions_attr_names = ProviderRelationshipPermissions::PERMISSIONS.map { |p| "#{provider_type}_provider_can_#{p}" }
+      changes = audited_changes.select do |k, v|
+        permissions_attr_names.include?(k) && (v.is_a?(Array) ? v.last == enabled : v == enabled)
+      end
+
+      changes.keys.map { |k| k.sub(/^(training_provider_can_|ratifying_provider_can_)/, '') }.join(', ')
+    end
+
+    def permissions_clauses
+      clauses = ProviderRelationshipPermissions::PERMISSIONS.map do |p|
+        [
+          "jsonb_exists(audits.audited_changes, 'training_provider_can_#{p}')",
+          "jsonb_exists(audits.audited_changes, 'ratifying_provider_can_#{p}')",
+        ].join(' OR ')
+      end
+
+      clauses.join(' OR ')
+    end
+  end
+end

--- a/app/services/support_interface/user_permissions_export.rb
+++ b/app/services/support_interface/user_permissions_export.rb
@@ -1,0 +1,61 @@
+module SupportInterface
+  class UserPermissionsExport
+    def data_for_export
+      data = Audited::Audit
+        .joins('JOIN provider_users_providers pup1 ON audits.auditable_id = pup1.id')
+        .joins('JOIN provider_users ON pup1.provider_user_id = provider_users.id')
+        .joins('LEFT JOIN provider_users_providers pup2 ON audits.user_id = pup2.provider_user_id')
+        .joins('LEFT JOIN providers ON pup2.provider_id = providers.id')
+        .where(auditable_type: 'ProviderPermissions')
+        .where(action: %w[create update])
+        .where(permissions_clauses)
+        .pluck(
+          'audits.created_at',
+          'audits.user_id',
+          'audits.username',
+          'providers.code',
+          'providers.name',
+          Arel.sql("CONCAT(provider_users.first_name, ' ' , provider_users.last_name)"),
+          'audits.audited_changes',
+        )
+
+      data.map do |row|
+        audited_changes = row.pop
+        row << permissions_changes(audited_changes)
+        row << permissions_changes(audited_changes, false)
+        Hash[labels.zip(row)]
+      end
+    end
+
+  private
+
+    def labels
+      [
+        'Date',
+        'User ID',
+        'User making change',
+        'Provider code', 'Provider',
+        'User whose permission(s) have changed',
+        'Permissions added',
+        'Permissions removed'
+      ]
+    end
+
+    def permissions_changes(audited_changes, enabled = true)
+      changes = audited_changes.select do |k, v|
+        ProviderPermissions::VALID_PERMISSIONS.map(&:to_s).include?(k) &&
+          (v.is_a?(Array) ? v.last == enabled : v == enabled)
+      end
+
+      changes.keys.sort.join(', ')
+    end
+
+    def permissions_clauses
+      clauses = ProviderPermissions::VALID_PERMISSIONS.map do |p|
+        "jsonb_exists(audits.audited_changes, '#{p}')"
+      end
+
+      clauses.join(' OR ')
+    end
+  end
+end

--- a/app/services/support_interface/user_permissions_export.rb
+++ b/app/services/support_interface/user_permissions_export.rb
@@ -12,7 +12,12 @@ module SupportInterface
         .pluck(
           'audits.created_at',
           'audits.user_id',
-          'audits.username',
+          Arel.sql(
+            "CASE audits.user_type
+              WHEN 'ProviderUser' THEN (SELECT CONCAT(first_name, ' ', last_name) FROM provider_users WHERE id = audits.user_id)
+              WHEN 'SupportUser' THEN (SELECT CONCAT(first_name, ' ', last_name) FROM support_users WHERE id = audits.user_id)
+            END".squish,
+          ),
           'providers.code',
           'providers.name',
           Arel.sql("CONCAT(provider_users.first_name, ' ' , provider_users.last_name)"),

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1310,4 +1310,23 @@ FactoryBot.define do
       audit.audited_changes = evaluator.changes
     end
   end
+
+  factory :provider_relationship_permissions_audit, class: 'Audited::Audit' do
+    action { 'update' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    created_at { Time.zone.now }
+
+    transient do
+      provider_relationship_permissions { build_stubbed(:provider_relationship_permissions) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ProviderRelationshipPermissions'
+      audit.auditable_id = evaluator.provider_relationship_permissions.id
+      audit.audited_changes = evaluator.changes
+    end
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1291,4 +1291,23 @@ FactoryBot.define do
     mail_template { 'some_mail_template' }
     body { 'Hi' }
   end
+
+  factory :provider_permissions_audit, class: 'Audited::Audit' do
+    action { 'update' }
+    user { create(:provider_user) }
+    version { 1 }
+    request_uuid { SecureRandom.uuid }
+    created_at { Time.zone.now }
+
+    transient do
+      provider_permissions { build_stubbed(:provider_permissions) }
+      changes { {} }
+    end
+
+    after(:build) do |audit, evaluator|
+      audit.auditable_type = 'ProviderPermissions'
+      audit.auditable_id = evaluator.provider_permissions.id
+      audit.audited_changes = evaluator.changes
+    end
+  end
 end

--- a/spec/services/support_interface/organisation_permissions_export_spec.rb
+++ b/spec/services/support_interface/organisation_permissions_export_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::OrganisationPermissionsExport do
+  let(:training_provider) { create(:provider) }
+  let(:ratifying_provider) { create(:provider) }
+  let(:provider_relationship_permissions) do
+    create(:provider_relationship_permissions,
+           ratifying_provider: ratifying_provider,
+           training_provider: training_provider)
+  end
+  let(:audit_entry) { create(:provider_relationship_permissions_audit, provider_relationship_permissions: provider_relationship_permissions, changes: changes) }
+  let(:changes) do
+    {
+      'training_provider_can_make_decisions' => [false, true],
+      'ratifying_provider_can_make_decisions' => [false, true],
+      'training_provider_can_view_diversity_information' => [false, true],
+      'ratifying_provider_can_view_diversity_information' => [true, false],
+      'training_provider_can_view_safeguarding_information' => true,
+      'ratifying_provider_can_view_safeguarding_information' => false,
+    }
+  end
+
+  describe '#data_for_export' do
+    it 'exports permissions changes' do
+      audit_user = ProviderUser.find(audit_entry.user_id)
+      audit_user.providers << create(:provider)
+
+      exported_data = described_class.new.data_for_export
+      created_at, user_id, username, provider_code, provider_name,
+        training_provider_code, training_provider_name,
+        training_provider_permissions_enabled, training_provider_permissions_disabled,
+        ratifying_provider_code, ratifying_provider_name,
+        ratifying_provider_permissions_enabled, ratifying_provider_permissions_disabled = exported_data.first.values
+
+      expect(created_at.to_s).to eq(audit_entry.created_at.to_s)
+      expect(user_id).to eq(audit_entry.user_id)
+      expect(username).to eq(audit_entry.username)
+      expect(provider_code).to eq(audit_user.providers.first.code)
+      expect(provider_name).to eq(audit_user.providers.first.name)
+      expect(training_provider_code).to eq(training_provider.code)
+      expect(training_provider_name).to eq(training_provider.name)
+      expect(training_provider_permissions_enabled).to eq('make_decisions, view_diversity_information, view_safeguarding_information')
+      expect(training_provider_permissions_disabled).to eq('')
+      expect(ratifying_provider_code).to eq(ratifying_provider.code)
+      expect(ratifying_provider_name).to eq(ratifying_provider.name)
+      expect(ratifying_provider_permissions_enabled).to eq('make_decisions')
+      expect(ratifying_provider_permissions_disabled).to eq('view_diversity_information, view_safeguarding_information')
+    end
+
+    context 'for audit entries made by support users' do
+      it 'omits provider information' do
+        audit_entry.update(user_id: create(:support_user).id)
+
+        exported_data = described_class.new.data_for_export
+        created_at, user_id, username, provider_code, provider_name,
+          _training_provider_code, _training_provider_name,
+          _training_provider_permissions_enabled, _training_provider_permissions_disabled,
+          _ratifying_provider_code, _ratifying_provider_name,
+          _ratifying_provider_permissions_enabled, _ratifying_provider_permissions_disabled = exported_data.first.values
+
+        expect(created_at.to_s).to eq(audit_entry.created_at.to_s)
+        expect(user_id).to eq(audit_entry.user_id)
+        expect(username).to eq(audit_entry.username)
+        expect(provider_code).to be_nil
+        expect(provider_name).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/user_permissions_export_spec.rb
+++ b/spec/services/support_interface/user_permissions_export_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::UserPermissionsExport do
+  let(:provider) { create(:provider) }
+  let(:provider_user) { create(:provider_user) }
+  let(:provider_permissions) { create(:provider_permissions, provider: provider, provider_user: provider_user) }
+  let(:audit_entry) { create(:provider_permissions_audit, provider_permissions: provider_permissions, changes: changes) }
+  let(:changes) do
+    {
+      'make_decisions' => [false, true],
+      'manage_organisations' => [true, false],
+      'manage_users' => true,
+      'view_diversity_information' => [true, false],
+      'view_safeguarding_information' => false,
+    }
+  end
+
+  describe '#data_for_export' do
+    it 'exports permissions changes' do
+      audit_user = ProviderUser.find(audit_entry.user_id)
+      audit_user.providers << create(:provider)
+
+      exported_data = described_class.new.data_for_export
+      created_at, user_id, username, provider_code, provider_name,
+        provider_user_name, enabled, disabled = exported_data.first.values
+
+      expect(created_at.to_s).to eq(audit_entry.created_at.to_s)
+      expect(user_id).to eq(audit_entry.user_id)
+      expect(username).to eq(audit_entry.username)
+      expect(provider_code).to eq(audit_user.providers.first.code)
+      expect(provider_name).to eq(audit_user.providers.first.name)
+      expect(provider_user_name).to eq(provider_user.full_name)
+      expect(enabled).to eq('make_decisions, manage_users')
+      expect(disabled).to eq('manage_organisations, view_diversity_information, view_safeguarding_information')
+    end
+
+    context 'for audit entries made by support users' do
+      it 'omits provider information' do
+        audit_entry.update(user_id: create(:support_user).id)
+
+        exported_data = described_class.new.data_for_export
+        created_at, user_id, username, provider_code, provider_name,
+          provider_user_name, enabled, disabled = exported_data.first.values
+
+        expect(created_at.to_s).to eq(audit_entry.created_at.to_s)
+        expect(user_id).to eq(audit_entry.user_id)
+        expect(username).to eq(audit_entry.username)
+        expect(provider_code).to be_nil
+        expect(provider_name).to be_nil
+        expect(provider_user_name).to eq(provider_user.full_name)
+        expect(enabled).to eq('make_decisions, manage_users')
+        expect(disabled).to eq('manage_organisations, view_diversity_information, view_safeguarding_information')
+      end
+    end
+  end
+end

--- a/spec/services/support_interface/user_permissions_export_spec.rb
+++ b/spec/services/support_interface/user_permissions_export_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe SupportInterface::UserPermissionsExport do
   let(:provider) { create(:provider) }
   let(:provider_user) { create(:provider_user) }
+  let(:audit_user) { create(:provider_user) }
   let(:provider_permissions) { create(:provider_permissions, provider: provider, provider_user: provider_user) }
-  let(:audit_entry) { create(:provider_permissions_audit, provider_permissions: provider_permissions, changes: changes) }
+  let(:audit_entry) { create(:provider_permissions_audit, provider_permissions: provider_permissions, changes: changes, user: audit_user) }
   let(:changes) do
     {
       'make_decisions' => [false, true],
@@ -17,34 +18,37 @@ RSpec.describe SupportInterface::UserPermissionsExport do
 
   describe '#data_for_export' do
     it 'exports permissions changes' do
-      audit_user = ProviderUser.find(audit_entry.user_id)
-      audit_user.providers << create(:provider)
+      audit_user_provider = create(:provider)
+      audit_user.providers << audit_user_provider
+      audit_entry
 
       exported_data = described_class.new.data_for_export
       created_at, user_id, username, provider_code, provider_name,
         provider_user_name, enabled, disabled = exported_data.first.values
 
       expect(created_at.to_s).to eq(audit_entry.created_at.to_s)
-      expect(user_id).to eq(audit_entry.user_id)
-      expect(username).to eq(audit_entry.username)
-      expect(provider_code).to eq(audit_user.providers.first.code)
-      expect(provider_name).to eq(audit_user.providers.first.name)
+      expect(user_id).to eq(audit_user.id)
+      expect(username).to eq(audit_user.full_name)
+      expect(provider_code).to eq(audit_user_provider.code)
+      expect(provider_name).to eq(audit_user_provider.name)
       expect(provider_user_name).to eq(provider_user.full_name)
       expect(enabled).to eq('make_decisions, manage_users')
       expect(disabled).to eq('manage_organisations, view_diversity_information, view_safeguarding_information')
     end
 
     context 'for audit entries made by support users' do
+      let(:audit_user) { create(:support_user) }
+
       it 'omits provider information' do
-        audit_entry.update(user_id: create(:support_user).id)
+        audit_entry
 
         exported_data = described_class.new.data_for_export
         created_at, user_id, username, provider_code, provider_name,
           provider_user_name, enabled, disabled = exported_data.first.values
 
         expect(created_at.to_s).to eq(audit_entry.created_at.to_s)
-        expect(user_id).to eq(audit_entry.user_id)
-        expect(username).to eq(audit_entry.username)
+        expect(user_id).to eq(audit_user.id)
+        expect(username).to eq("#{audit_user.first_name} #{audit_user.last_name}")
         expect(provider_code).to be_nil
         expect(provider_name).to be_nil
         expect(provider_user_name).to eq(provider_user.full_name)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds two support interface exports:

- User permissions changes
- Organisational permissions changes

![image](https://user-images.githubusercontent.com/93511/108046806-f672cf00-703c-11eb-992f-ffc3c9c259ae.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

I've attempted to make the necessary database joins to retrieve the information without multiple queries. Do they make sense in terms of the audit user belonging to multiple providers?

https://trello.com/c/mAgTgskS/3327-create-new-export-for-longitudinal-permissions-analysis
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
