### PR TITLE
Interview cancellation flow bugfixes

### DIFF
--- a/app/forms/provider_interface/cancel_interview_wizard.rb
+++ b/app/forms/provider_interface/cancel_interview_wizard.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     attr_accessor :cancellation_reason
 
-    validates :cancellation_reason, presence: true
+    validates :cancellation_reason, presence: true, length: { maximum: 10240 }
 
     def initialize(state_store, attrs = {})
       @state_store = state_store

--- a/app/views/provider_interface/interviews/cancel.html.erb
+++ b/app/views/provider_interface/interviews/cancel.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, t('.page_title') %>
+<% content_for :browser_title, title_with_error_prefix(t('.page_title'), @cancellation_wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(request.referer) %>
 
 <div class="govuk-grid-row">

--- a/app/views/provider_interface/interviews/cancel.html.erb
+++ b/app/views/provider_interface/interviews/cancel.html.erb
@@ -25,5 +25,9 @@
       </div>
       <%= f.govuk_submit 'Continue' %>
     <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_application_choice_interviews_path(@application_choice), class: 'govuk-link--no-visited-state' %>
+    </p>
   </div>
 </div>

--- a/app/views/provider_interface/interviews/cancel.html.erb
+++ b/app/views/provider_interface/interviews/cancel.html.erb
@@ -3,17 +3,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @cancellation_wizard,
+      url: cancel_review_provider_interface_application_choice_interview_path(@application_choice, @interview),
+      method: :get,
+    ) do |f| %>
 
-    <h1 class="govuk-label-wrapper">
-      <label class="govuk-label govuk-label--l">
-        <span class="govuk-caption-l">
-          <%= @interview.application_choice.application_form.full_name %>
-        </span>
-        <%= t('.title') %>
-      </label>
-    </h1>
+      <%= f.govuk_error_summary %>
 
-    <%= form_with model: @cancellation_wizard, url: cancel_review_provider_interface_application_choice_interview_path(@application_choice, @interview), method: :get do |f| %>
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label govuk-label--l">
+          <span class="govuk-caption-l">
+            <%= @interview.application_choice.application_form.full_name %>
+          </span>
+          <%= t('.title') %>
+        </label>
+      </h1>
+
       <div class='govuk-form-group'>
         <%= f.govuk_text_area :cancellation_reason, label: -> { nil } %>
       </div>

--- a/app/views/provider_interface/interviews/check.html.erb
+++ b/app/views/provider_interface/interviews/check.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t('.cancel'), provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
     </p>
   </div>
 </div>

--- a/app/views/provider_interface/interviews/edit.html.erb
+++ b/app/views/provider_interface/interviews/edit.html.erb
@@ -24,6 +24,6 @@
 
     <% end %>
 
-    <p class="govuk-body"><%= govuk_link_to 'Cancel', provider_interface_application_choice_interviews_path(@application_choice, @interview) %></p>
+    <p class="govuk-body"><%= govuk_link_to t('cancel'), provider_interface_application_choice_interviews_path(@application_choice, @interview) %></p>
   </div>
 </div>

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -24,6 +24,6 @@
 
     <% end %>
 
-    <p class="govuk-body"><%= govuk_link_to 'Cancel', provider_interface_application_choice_interviews_path(@application_choice) %></p>
+    <p class="govuk-body"><%= govuk_link_to t('cancel'), provider_interface_application_choice_interviews_path(@application_choice) %></p>
   </div>
 </div>

--- a/app/views/provider_interface/interviews/review_cancel.html.erb
+++ b/app/views/provider_interface/interviews/review_cancel.html.erb
@@ -29,5 +29,9 @@
       </div>
       <%= f.govuk_submit 'Send cancellation' %>
     <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_application_choice_interviews_path(@application_choice), class: 'govuk-link--no-visited-state' %>
+    </p>
   </div>
 </div>

--- a/app/views/provider_interface/interviews/review_cancel.html.erb
+++ b/app/views/provider_interface/interviews/review_cancel.html.erb
@@ -17,6 +17,7 @@
       {
         key: t('.cancellation_reason'),
         value: @cancellation_wizard.cancellation_reason,
+        action: t('.cancellation_reason').downcase,
         change_path: cancel_provider_interface_application_choice_interview_path(@application_choice, @interview),
       },
       {},

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   continue: Continue
   save_and_continue: Save and continue
+  cancel: Cancel
   validation_errors:
     email_address_format: Enter an email address in the correct format, like name@example.com
   service_name:

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -13,7 +13,6 @@ en:
         page_title: Set up Interview
         title: Check and send interview details
         confirm: Send interview details
-        cancel: Cancel
         update:
           page_title: Change interview details
           title: Check and send new interview details

--- a/spec/forms/provider_interface/cancel_interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/cancel_interview_wizard_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe ProviderInterface::CancelInterviewWizard do
 
   describe '.validations' do
     it { is_expected.to validate_presence_of(:cancellation_reason) }
+    it { is_expected.to validate_length_of(:cancellation_reason).is_at_most(10240) }
   end
 end


### PR DESCRIPTION
## Context
Initial design review uncovered these small UI bugs

## Changes proposed in this pull request
1. Add a GOVUK error summary to the form, above the H1 of the page

2. Add a validation on the length of the cancellation reason. It should be fewer than 10240 characters

3. Add visually hidden text to the cancellation reason change link on the check answers page. It should read Change cancellation reason

4. Add Cancel links to the cancel form and its check answers pages to abort the process of cancelling the interview and go back to the interviews tab (as per the prototype)

5. Add the "Error - " prefix to page/browser tab title when validation errors occur (as per some other forms)

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/IKhgMo2w/3368-interview-cancellation-form-bugs

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
