### PR TITLE
Partition interviews into past and upcoming

### DIFF
--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -10,9 +10,13 @@ module ProviderInterface
         course_option_id: @application_choice.offered_option.id,
       )
 
-      @interviews = @application_choice.interviews.kept.includes([:provider])
+      interviews = @application_choice.interviews.kept.includes(:provider).order(:date_and_time)
 
-      redirect_to provider_interface_application_choice_path if @interviews.none?
+      @upcoming_interviews, @past_interviews = interviews.partition do |interview|
+        interview.date_and_time > Time.zone.now
+      end
+
+      redirect_to provider_interface_application_choice_path if interviews.none?
     end
 
     def new

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -102,7 +102,7 @@ module ProviderInterface
       wizard.send('date(3i)=', interview.date_and_time.day) if wizard.send('date(3i)').blank?
       wizard.location ||= interview.location
       wizard.provider_id ||= interview.provider_id
-      wizard.time ||= interview.date_and_time.strftime('%l:%M%P')
+      wizard.time ||= interview.date_and_time.strftime('%-l:%M%P')
 
       wizard
     end

--- a/app/views/provider_interface/interview_schedules/past.html.erb
+++ b/app/views/provider_interface/interview_schedules/past.html.erb
@@ -1,12 +1,12 @@
-<% content_for :browser_title, 'Interview schedule - Past interviews' %>
+<% content_for :browser_title, "Interview schedule - #{t('provider_interface.interviews.past')}" %>
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-third">
     <h1 class="govuk-heading-l">Interview schedule</h1>
 
     <%= render TabNavigationComponent.new(items: [
-      { name: 'Upcoming interviews', url: provider_interface_interview_schedule_path },
-      { name: 'Past interviews', url: past_provider_interface_interview_schedule_path },
+      { name: t('provider_interface.interviews.upcoming'), url: provider_interface_interview_schedule_path },
+      { name: t('provider_interface.interviews.past'), url: past_provider_interface_interview_schedule_path },
     ]) %>
     <% if @grouped_interviews.any? %>
       <div class="app-interviews">

--- a/app/views/provider_interface/interview_schedules/show.html.erb
+++ b/app/views/provider_interface/interview_schedules/show.html.erb
@@ -1,12 +1,12 @@
-<% content_for :browser_title, 'Interview schedule - Upcoming interviews' %>
+<% content_for :browser_title, "Interview schedule - #{t('provider_interface.interviews.upcoming')}" %>
 
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-third">
     <h1 class="govuk-heading-l">Interview schedule</h1>
 
     <%= render TabNavigationComponent.new(items: [
-      { name: 'Upcoming interviews', url: provider_interface_interview_schedule_path },
-      { name: 'Past interviews', url: past_provider_interface_interview_schedule_path },
+      { name: t('provider_interface.interviews.upcoming'), url: provider_interface_interview_schedule_path },
+      { name: t('provider_interface.interviews.past'), url: past_provider_interface_interview_schedule_path },
     ]) %>
     <% if @grouped_interviews.any? %>
       <div class="app-interviews">

--- a/app/views/provider_interface/interviews/index.html.erb
+++ b/app/views/provider_interface/interviews/index.html.erb
@@ -12,7 +12,7 @@
 
       <% if @upcoming_interviews.any? %>
         <h2 class="govuk-heading-m">
-          Upcoming interviews
+          <%= t('provider_interface.interviews.upcoming') %>
         </h2>
 
         <% @upcoming_interviews.each do |interview| %>
@@ -22,7 +22,7 @@
 
       <% if @past_interviews.any? %>
         <h2 class="govuk-heading-m">
-          Past interviews
+          <%= t('provider_interface.interviews.past') %>
         </h2>
 
         <% @past_interviews.each do |interview| %>

--- a/app/views/provider_interface/interviews/index.html.erb
+++ b/app/views/provider_interface/interviews/index.html.erb
@@ -2,22 +2,33 @@
 
 <%= render ProviderInterface::ApplicationChoiceHeaderComponent.new(application_choice: @application_choice, provider_can_respond: @provider_can_make_decisions) %>
 
-<% if @interviews.any? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="app-interviews">
-        <% if @provider_can_make_decisions %>
-          <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(@application_choice), class: 'govuk-button govuk-button--secondary' %>
-        <% end %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-interviews">
+      <% if @provider_can_make_decisions %>
+        <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(@application_choice), class: 'govuk-button govuk-button--secondary' %>
+      <% end %>
+
+      <% if @upcoming_interviews.any? %>
         <h2 class="govuk-heading-m">
           Upcoming interviews
         </h2>
 
-        <% @interviews.each do |interview| %>
+        <% @upcoming_interviews.each do |interview| %>
           <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @provider_can_make_decisions) %>
         <% end %>
-      </div>
+      <% end %>
+
+      <% if @past_interviews.any? %>
+        <h2 class="govuk-heading-m">
+          Past interviews
+        </h2>
+
+        <% @past_interviews.each do |interview| %>
+          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @provider_can_make_decisions) %>
+        <% end %>
+      <% end %>
     </div>
   </div>
-<% end %>
+</div>

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -1,6 +1,8 @@
 en:
   provider_interface:
     interviews:
+      upcoming: Upcoming interviews
+      past: Past interviews
       new:
         title: Set up an interview
         interview_preferences:

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_i_can_set_up_another_interview(days_in_future: 2)
     and_another_interview_has_been_created('3 March 2020')
 
+    when_the_first_interview_has_happened
+    then_i_see_the_upcoming_interview_under_the_correct_heading
+    and_i_see_the_past_interview_under_the_correct_heading
+
     when_i_change_the_interview_details
     then_i_can_see_interview_was_updated
 
@@ -114,13 +118,29 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   alias_method :and_another_interview_has_been_created, :and_an_interview_has_been_created
 
+  def when_the_first_interview_has_happened
+    Timecop.travel(2020, 3, 2, 13, 0, 0)
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_application_choice_interviews_path(application_choice)
+  end
+
+  def then_i_see_the_upcoming_interview_under_the_correct_heading
+    expect(page).to have_css('.app-interviews > :nth-child(2)', text: 'Upcoming interviews')
+    expect(page).to have_css('.app-interviews > :nth-child(3)', text: '3 March 2020')
+  end
+
+  def and_i_see_the_past_interview_under_the_correct_heading
+    expect(page).to have_css('.app-interviews > :nth-child(4)', text: 'Past interviews')
+    expect(page).to have_css('.app-interviews > :nth-child(5)', text: '2 March 2020')
+  end
+
   def when_i_change_the_interview_details
     click_on 'Change details', match: :first
 
-    expect(page).to have_field('Day', with: '2')
+    expect(page).to have_field('Day', with: '3')
     expect(page).to have_field('Month', with: '3')
     expect(page).to have_field('Year', with: '2020')
-    expect(page).to have_field('Time', with: '12:00pm')
+    expect(page).to have_field('Time', with: '7:00pm')
     expect(page).to have_field('Address or online meeting details', with: 'N/A')
     expect(page).to have_field('Additional details (optional)', with: '')
 
@@ -200,7 +220,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def and_i_can_see_the_second_interview
     visit provider_interface_application_choice_interviews_path(application_choice)
 
-    expect(page).to have_content('Upcoming interviews')
+    expect(page).to have_content('Past interviews')
     expect(page).to have_css('.app-interviews__interview')
   end
 


### PR DESCRIPTION

## Context
Something we missed when originally implementing interviews

## Changes proposed in this pull request
Split interviews on an application page into past and upcoming, also sorting by date and time

## Guidance to review
Hopefully simple!

## Link to Trello card
https://trello.com/c/eI5OACOF/3367-interviews-tab-group-upcoming-and-past-interviews

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
