### PR TITLE
Include interview feature info on service guidance page

### DIFF
--- a/app/views/content/service_guidance_provider.md
+++ b/app/views/content/service_guidance_provider.md
@@ -77,11 +77,24 @@ You can filter applications by candidate name, application status, training prov
 Users in your team will be able to:
 
 * make an offer
+* set up interviews
 * set conditions
 * offer a different course, location or provider
 * defer an offer
 * withdraw
 * reject, with reasons
+
+### Setting up interviews
+
+When you set up an interview, you’ll see any preferences the candidate gave in their application.
+
+The candidate will receive an email with details of the interview. They will not need to reply to the email.
+
+The details will also appear in the ‘interview’ page of the candidate’s application and in your organisation’s interview schedule.
+
+The status of the candidate’s application will change to ‘Interviewing’. You cannot mark an interview as completed. The status will change again when you make an offer or the application is either rejected or withdrawn.
+
+The candidate will receive an email if you change or cancel an interview.
 
 ### Setting permissions for your team members
 


### PR DESCRIPTION
## Context

Update service guidance page to help let providers know they can use the interview feature

## Changes proposed in this pull request

<img width="1107" alt="service-guidance-interview-info" src="https://user-images.githubusercontent.com/159200/108053550-769d3280-7045-11eb-9985-cbe4092981e5.png">


## Link to Trello card
https://trello.com/c/5yavUt5c/3389-update-service-guidance-page-to-help-let-providers-know-they-can-use-the-interview-feature


## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
