### PR TITLE
Use POST for check answers pages in interview flows rather than GET

### DIFF
--- a/app/views/provider_interface/interviews/cancel.html.erb
+++ b/app/views/provider_interface/interviews/cancel.html.erb
@@ -6,7 +6,7 @@
     <%= form_with(
       model: @cancellation_wizard,
       url: cancel_review_provider_interface_application_choice_interview_path(@application_choice, @interview),
-      method: :get,
+      method: :post,
     ) do |f| %>
 
       <%= f.govuk_error_summary %>

--- a/app/views/provider_interface/interviews/edit.html.erb
+++ b/app/views/provider_interface/interviews/edit.html.erb
@@ -17,7 +17,7 @@
     <%= form_with(
       model: @wizard,
       url: check_provider_interface_application_choice_interview_path(@application_choice, @interview),
-      method: :get,
+      method: :post,
     ) do |f| %>
 
       <%= render 'form', f: f %>

--- a/app/views/provider_interface/interviews/new.html.erb
+++ b/app/views/provider_interface/interviews/new.html.erb
@@ -17,7 +17,7 @@
     <%= form_with(
       model: @wizard,
       url: new_check_provider_interface_application_choice_interviews_path(@application_choice),
-      method: :get,
+      method: :post,
     ) do |f| %>
 
       <%= render 'form', f: f %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -651,15 +651,15 @@ Rails.application.routes.draw do
 
       resources :interviews, only: %i[new edit index], as: :application_choice_interviews do
         collection do
-          get '/new/check', to: 'interviews#check'
+          post '/new/check', to: 'interviews#check'
           post '/confirm', to: 'interviews#commit'
         end
 
         member do
           get :cancel
-          get '/cancel/review/', to: 'interviews#review_cancel'
+          post '/cancel/review/', to: 'interviews#review_cancel'
           post '/cancel/confirm/', to: 'interviews#confirm_cancel'
-          get '/check', to: 'interviews#check'
+          post '/check', to: 'interviews#check'
           put '/update', to: 'interviews#update'
         end
       end


### PR DESCRIPTION
POST needs to be used because GET requires parameters to be passed in the query string which has a 10240 character limit. This is exceeded by putting in a large value in free text fields

## Guidance to review
Should we change this for other check answers endpoints too?

## Link to Trello card
https://trello.com/c/7xsitKQ7/3378-interview-check-answers-page-error-when-submitting-form-with-too-much-content

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
