### PR TITLE
Always show provider interface calls to action when applicable

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -90,10 +90,9 @@ module ProviderInterface
     end
 
     def show_inset_text?
-      flash.empty? && (
-        respond_to_application? || deferred_offer_wizard_applicable? ||
-        rejection_reason_required? || provider_cannot_respond?
-      ) || waiting_for_interview?
+      respond_to_application? || deferred_offer_wizard_applicable? ||
+        rejection_reason_required? || provider_cannot_respond? ||
+        waiting_for_interview?
     end
   end
 end


### PR DESCRIPTION
## Context

... regardless of any flash messages present

## Changes proposed in this pull request

One-liner to change the current weird behaviour.

## Guidance to review

Easiest review ever.

Thought about adding a component test for `show_inset_text?` but it's not particularly worth it, especially if we're going to be stubbing methods like `:awaiting_provider_decision?` etc.

## Link to Trello card

https://trello.com/c/dI0l2hyl

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
