### PR TITLE
Add interview emails to 'When emails are sent' doc

### DIFF
--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -196,6 +196,8 @@ en:
       by: provider
       description: |
         Providers can set up an interview with candidates before making a decision.
+      emails:
+        - candidate_mailer-new_interview
 
     awaiting_provider_decision-make_offer:
       name: Provider makes offer
@@ -292,12 +294,17 @@ en:
       by: provider
       description: |
         Provider cancels the interview with the candidate.
+      emails:
+        - candidate_mailer-interview_cancelled
 
     interviewing-interview:
-      name: Provider sets up an interview
+      name: Provider sets up or updates an interview
       by: provider
       description: |
-        Providers can set up additional interviews with candidates before making a decision.
+        Providers can set up additional interviews or update existing interviews before making a decision.
+      emails:
+        - candidate_mailer-new_interview
+        - candidate_mailer-interview_updated
 
     offer-make_offer:
       name: Provider updates offer

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -42,9 +42,6 @@ RSpec.feature 'Docs' do
       candidate_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-courses_open_on_apply
-      candidate_mailer-new_interview
-      candidate_mailer-interview_updated
-      candidate_mailer-interview_cancelled
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

We've added these candidate emails and they are present as previews, but they don't show up in 'When emails are sent' doc in support.

## Changes proposed in this pull request

### Before:

![image](https://user-images.githubusercontent.com/107591/108063794-ace1ae80-7053-11eb-93e6-5e7bc2011f89.png)
![image](https://user-images.githubusercontent.com/107591/108063816-b23ef900-7053-11eb-92c4-3222157ae079.png)

### After:

![image](https://user-images.githubusercontent.com/107591/108063835-ba973400-7053-11eb-9d9a-a7110c128e11.png)
![image](https://user-images.githubusercontent.com/107591/108063846-bd922480-7053-11eb-9405-10116124d33e.png)

## Guidance to review

Is the doc correct?

## Link to Trello card

No Trello card

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
