### PR TITLE
Add ERB Lint to CI workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ serve: ## Run the service
 ci.lint-ruby: ## Run Rubocop with results formatted for CI
 	docker-compose run --rm web /bin/sh -c "bundle exec rubocop --format clang --parallel"
 
+.PHONY: ci.lint-erb
+ci.lint-erb: ## Run the ERB linter
+	docker-compose run --rm web /bin/sh -c "bundle exec rake erblint"
+
 .PHONY: ci.brakeman
 ci.brakeman: ## Run Brakeman tests
 	docker-compose run --rm web /bin/sh -c "bundle exec rake brakeman"

--- a/azure/pipelines/build.yml
+++ b/azure/pipelines/build.yml
@@ -152,7 +152,7 @@ stages:
   - group: APPLY - ENV - QA
   jobs:
   - job: test_docker_image_batch_1
-    displayName: 'Rubocop & Brakeman'
+    displayName: 'Rubocop, Brakeman, ERB lint'
     condition: and(succeeded(), eq(variables['deployOnly'], false))
     pool:
       vmImage: 'Ubuntu-16.04'
@@ -195,6 +195,20 @@ stages:
     - script: make ci.lint-ruby
       name: ci_lint_ruby
       displayName: 'Rubocop'
+      env:
+        dockerHubUsername: $(dockerHubUsername)
+        dockerHubImageName: $(imageName)
+        dockerHubImageTag: $(Build.BuildNumber)
+        RAILS_ENV: test
+        GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
+        AUTHORISED_HOSTS: $(authorisedHosts)
+        FIND_BASE_URL: $(findBaseUrl)
+        GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+        SANDBOX: $(sandbox)
+
+    - script: make ci.lint-erb
+      name: ci_lint_erb
+      displayName: 'ERB lint'
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -41,8 +41,13 @@ task :rubocop do
   sh 'bundle exec rubocop --parallel'
 end
 
+desc 'Run ERB Lint'
+task :erblint do
+  sh 'bundle exec erblint --lint-all'
+end
+
 desc 'Run all the linters'
-task linting: %i[rubocop]
+task linting: %i[rubocop erblint]
 
 desc 'Compile assets for testing'
 task :compile_assets do


### PR DESCRIPTION
## Context

Restores running ERB Lint as part of CI workflow.

## Changes proposed in this pull request

Restores what was removed in as removed in 46f24cceccef68c551df75e89fd17ad3d6352022.

## Guidance to review

* Rather than just run ERB Lint in `app/views` as before, not using `--lint-all` flag, which uses the following glob `**/*.html{+*,}.erb`
* Since this was removed, the way Azure pipelines are organised has changed. So I’m not sure where this should now go:

  ```yaml
    - script: make ci.lint-erb
       name: ci_lint_erb
       displayName: 'ERB lint'
       condition: and(succeededOrFailed(), eq(variables['deployOnly'], false))
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         RAILS_ENV: test
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         AUTHORISED_HOSTS: $(authorisedHosts)
         FIND_BASE_URL: $(findBaseUrl)
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
         SANDBOX: $(sandbox)
  ```

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
