### PR TITLE
Fix link to online chat in candidate email support footer

### DIFF
--- a/app/views/candidate_mailer/_get_support.text.erb
+++ b/app/views/candidate_mailer/_get_support.text.erb
@@ -2,6 +2,6 @@
 
 You can chat to a <%= t('service_name.get_into_teaching') %> adviser online for help and advice:
 
-<<%= t('get_into_teaching.url_online_chat') %>>
+<%= t('get_into_teaching.url_online_chat') %>
 
 You can also call for free on <%= t('get_into_teaching.tel') %>, <%= t('get_into_teaching.opening_times') %>.


### PR DESCRIPTION
## Context

Link to GIT online chat is currently rendering incorrectly:

<img width="550" alt="Screenshot 2021-02-16 at 13 51 33" src="https://user-images.githubusercontent.com/813383/108071840-1cf53200-705e-11eb-8694-6dc3cbad1489.png">

## Changes proposed in this pull request

Expectation was that needed to use Markdown syntax for linked URLs, but this is not the case with Notify templates (?), and so the brackets where getting rendered. Removing the brackets fixes the presentation and ensure link goes to the right location. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
