### PR TITLE
Fix double error in other efl qualifications view

### DIFF
--- a/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
+++ b/app/views/candidate_interface/english_foreign_language/other_efl_qualification/_form_fields.html.erb
@@ -1,5 +1,3 @@
-<%= f.govuk_error_summary %>
-
 <%= f.govuk_text_field(
   :name,
   label: { text: 'Assessment name', size: 'm' },


### PR DESCRIPTION
## Context

At the moment we're rendering two error summaries on the other efl qualifications page

## Changes proposed in this pull request

- Remove the error from the shared form 

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
