### PR TITLE
Interviews tab summary component content changes

### DIFF
--- a/app/components/provider_interface/interview_and_course_summary_component.rb
+++ b/app/components/provider_interface/interview_and_course_summary_component.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class InterviewAndCourseSummaryComponent < ViewComponent::Base
-    attr_reader :interview, :application_choice, :user_can_change_interview
+    attr_reader :interview, :user_can_change_interview, :application_choice
 
     def initialize(interview:, user_can_change_interview:)
       @application_choice = interview.application_choice
@@ -12,7 +12,7 @@ module ProviderInterface
       [
         {
           key: 'Course',
-          value: interview.offered_course.name,
+          value: interview.offered_course.name_and_code,
         },
         {
           key: 'Funding type',
@@ -32,9 +32,13 @@ module ProviderInterface
         },
         {
           key: 'Additional details',
-          value: interview.additional_details,
+          value: get_additional_details,
         },
       ]
+    end
+
+    def get_additional_details
+      interview.additional_details.presence || 'None'
     end
   end
 end

--- a/app/components/provider_interface/interview_card_component.html.erb
+++ b/app/components/provider_interface/interview_card_component.html.erb
@@ -21,7 +21,7 @@
 
   <div class="app-interview-card__course">
     <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">
-      <%= application_choice.course.name %>
+      <%= application_choice.course.name_and_code %>
     </p>
     <p class="govuk-caption-m govuk-!-margin-top-0 govuk-!-margin-bottom-1">
       <%= application_choice.course_option.site.name %>

--- a/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
@@ -16,12 +16,24 @@ RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
     expect(component).to include(interview.application_choice.course.provider.name)
   end
 
-  it 'displays the course name' do
-    expect(component).to include(interview.application_choice.course.name)
+  it 'displays the course name and code' do
+    expect(component).to include(interview.application_choice.course.name_and_code)
   end
 
   it 'displays interview location' do
     expect(component).to include(interview.location)
+  end
+
+  context 'additional details' do
+    it 'displays the additional details' do
+      interview.additional_details = 'Test'
+      expect(component).to include('Test')
+    end
+
+    it 'displays additional details as None when no additional details provided' do
+      interview.additional_details = ''
+      expect(component).to include('None')
+    end
   end
 
   context 'user_can_change_interview is false' do


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Course name and code are now correctly displayed (previously was just course name). Additionally if no additional_details are provided for the interview the interview_and_course_summary_component now displayed the value of Additional Details as 'None', rather than leaving the field blank.

## Link to Trello card

https://trello.com/c/oNK4U6fK/3366-interviews-tab-summary-component-content-changes

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
