### PR TITLE
Reinstate styles on buttons in the call to action to match the prototype

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.html.erb
+++ b/app/components/provider_interface/application_choice_header_component.html.erb
@@ -25,8 +25,8 @@
 
           <% if FeatureFlag.active?(:interviews) %>
             <div class="govuk-button-group">
-              <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice) %>
-              <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button--secondary' %>
+              <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
+              <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-button--secondary govuk-!-margin-bottom-0 govuk-!-margin-right-2' %>
             </div>
           <% else %>
             <%= govuk_button_link_to 'Make decision', provider_interface_application_choice_respond_path(application_choice) %>


### PR DESCRIPTION
## Context
This button styling was removed in a refactor, but it's necessary in order to match the prototype

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
