### PR TITLE
Expose API for TAD data exports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'json_api_client'
 # This gem adds support for sequences in the schema.rb
 gem 'ar-sequence'
 
+gem 'active_hash'
+
 gem 'sentry-raven'
 
 gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.0.3.5)
       activesupport (= 6.0.3.5)
       globalid (>= 0.3.6)
@@ -563,6 +565,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   ar-sequence
   archive-zip
   audited!

--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -1,0 +1,38 @@
+module DataAPI
+  class TADDataExportsController < ActionController::API
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+
+    before_action :verify_token!
+
+    def latest
+      data_export = DataAPI::TADExport.latest
+      data_export.update!(audit_comment: "File downloaded via API using token ID #{@authenticating_token.id}")
+      send_data data_export.data, filename: data_export.filename
+    end
+
+  private
+
+    def verify_token!
+      unless authorized?
+        render_error(
+          name: 'Unauthorized',
+          message: 'Please provide a valid API token',
+          status: :unauthorized,
+        )
+      end
+    end
+
+    def authorized?
+      authenticate_with_http_token do |token|
+        @authenticating_token = AuthenticationToken.find_by_hashed_token(user_type: 'DataAPIUser', raw_token: token)
+        @authenticating_token.user_id == 2
+      end
+    end
+
+    def render_error(name:, message:, status:)
+      response = { errors: [{ error: name, message: message }] }
+
+      render json: response, status: status
+    end
+  end
+end

--- a/app/controllers/data_api/tad_data_exports_controller.rb
+++ b/app/controllers/data_api/tad_data_exports_controller.rb
@@ -25,7 +25,7 @@ module DataAPI
     def authorized?
       authenticate_with_http_token do |token|
         @authenticating_token = AuthenticationToken.find_by_hashed_token(user_type: 'DataAPIUser', raw_token: token)
-        @authenticating_token.user_id == 2
+        @authenticating_token.user_id == DataAPIUser.tad_user.id
       end
     end
 

--- a/app/models/concerns/authenticated_using_magic_links.rb
+++ b/app/models/concerns/authenticated_using_magic_links.rb
@@ -7,7 +7,7 @@ module AuthenticatedUsingMagicLinks
 
   def create_magic_link_token!(path: nil)
     magic_link_token = MagicLinkToken.new
-    authentication_tokens.create!(hashed_token: magic_link_token.encrypted, path: path)
+    AuthenticationToken.create!(user: self, hashed_token: magic_link_token.encrypted, path: path)
     magic_link_token.raw
   end
 

--- a/app/models/data_api_user.rb
+++ b/app/models/data_api_user.rb
@@ -1,0 +1,13 @@
+class DataAPIUser < ActiveHash::Base
+  include ActiveHash::Associations
+  include AuthenticatedUsingMagicLinks
+
+  self.data = [
+    { id: 1, name: 'User for testing, not used in production' },
+    { id: 2, name: 'DfE TAD' },
+  ]
+
+  def self.polymorphic_name
+    'DataAPIUser'
+  end
+end

--- a/app/models/data_api_user.rb
+++ b/app/models/data_api_user.rb
@@ -1,3 +1,10 @@
+# ActiveHash allows you to create ActiveRecord-like objects that are hard
+# coded. This saves us from having to make changes to the database to create
+# this model.
+#
+# To obtain an API token for a user, run this in the console:
+#
+#   DataAPIUser.tad_user.create_magic_link_token!
 class DataAPIUser < ActiveHash::Base
   include ActiveHash::Associations
   include AuthenticatedUsingMagicLinks
@@ -7,6 +14,16 @@ class DataAPIUser < ActiveHash::Base
     { id: 2, name: 'DfE TAD' },
   ]
 
+  def self.test_data_user
+    find(1)
+  end
+
+  def self.tad_user
+    find(2)
+  end
+
+  # Fix a bug in ActiveHash that causes the user_type in a AuthenticationToken to
+  # be set to `ActiveHash::Base` instead of `DataAPIUser`.
   def self.polymorphic_name
     'DataAPIUser'
   end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -98,7 +98,7 @@ class DataExport < ApplicationRecord
     tad_applications: {
       name: 'TAD applications',
       description: 'A list of all applications for TAD.',
-      class: SupportInterface::TADExport,
+      class: DataAPI::TADExport,
     },
     tad_provider_performance: {
       name: 'TAD provider performance',

--- a/app/services/data_api/tad_application_export.rb
+++ b/app/services/data_api/tad_application_export.rb
@@ -1,4 +1,4 @@
-module SupportInterface
+module DataAPI
   class TADApplicationExport
     attr_reader :application_choice
 

--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -1,5 +1,19 @@
-module SupportInterface
+module DataAPI
   class TADExport
+    EXPORT_NAME = 'Daily export of applications for TAD'.freeze
+
+    def self.run_daily
+      data_export = DataExport.create!(name: EXPORT_NAME)
+      DataExporter.perform_async(TADExport::TADExport, data_export.id)
+    end
+
+    def self.latest
+      DataExport
+        .where(name: EXPORT_NAME)
+        .where('completed_at IS NOT NULL')
+        .last
+    end
+
     def data_for_export
       relevant_applications.flat_map do |application_form|
         application_form.application_choices.map do |application_choice|

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -18,10 +18,7 @@ class Clock
   every(1.hour, 'SendChaseEmailToProviders', at: '**:35') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
 
-  every(1.day, 'Generate export for TAD', at: '23:59') do
-    data_export = DataExport.create!(name: 'Daily export of applications for TAD')
-    DataExporter.perform_async(SupportInterface::TADExport, data_export.id)
-  end
+  every(1.day, 'Generate export for TAD', at: '23:59') { TADExport.run_daily }
 
   every(1.day, 'UCASMatching::UploadMatchingData', at: '06:23') do
     if Time.zone.today.weekday?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -752,6 +752,10 @@ Rails.application.routes.draw do
     get '/performance-dashboard' => redirect('support/performance/service')
   end
 
+  namespace :data_api, path: '/data-api' do
+    get '/tad-data-exports/latest' => 'tad_data_exports#latest'
+  end
+
   namespace :support_interface, path: '/support' do
     get '/' => redirect('/support/applications')
 

--- a/spec/lib/namespaces_spec.rb
+++ b/spec/lib/namespaces_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Namespace' do
-  namespaces = %w[CandidateInterface ProviderInterface SupportInterface APIDocs RefereeInterface VendorAPI UCASMatching]
+  namespaces = %w[CandidateInterface ProviderInterface SupportInterface APIDocs RefereeInterface VendorAPI UCASMatching DataAPI]
 
   namespaces.each do |namespace|
     describe namespace.constantize do

--- a/spec/requests/data_api/tad_api_spec.rb
+++ b/spec/requests/data_api/tad_api_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'GET /data-api/tad-data-exports/latest', type: :request, sidekiq:
     expect(response).to have_http_status(:unauthorized)
   end
 
-  it 'only allows access to the API for TAD' do
-    api_token = DataAPIUser.find(1).create_magic_link_token!
+  it 'only allows access to the API for TAD, and not other data users' do
+    api_token = DataAPIUser.test_data_user.create_magic_link_token!
 
     headers = { 'Authorization' => "Bearer #{api_token}" }
 
@@ -23,7 +23,7 @@ RSpec.describe 'GET /data-api/tad-data-exports/latest', type: :request, sidekiq:
     data_export = DataExport.create!(name: 'Daily export of applications for TAD')
     DataExporter.perform_async(DataAPI::TADExport, data_export.id)
 
-    api_token = DataAPIUser.find(2).create_magic_link_token!
+    api_token = DataAPIUser.tad_user.create_magic_link_token!
 
     headers = { 'Authorization' => "Bearer #{api_token}" }
 

--- a/spec/requests/data_api/tad_api_spec.rb
+++ b/spec/requests/data_api/tad_api_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /data-api/tad-data-exports/latest', type: :request, sidekiq: true do
+  it 'verifies the API token' do
+    get '/data-api/tad-data-exports/latest', headers: {}
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'only allows access to the API for TAD' do
+    api_token = DataAPIUser.find(1).create_magic_link_token!
+
+    headers = { 'Authorization' => "Bearer #{api_token}" }
+
+    get '/data-api/tad-data-exports/latest', headers: headers
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'returns the latest data export' do
+    create(:submitted_application_choice, status: 'rejected')
+
+    data_export = DataExport.create!(name: 'Daily export of applications for TAD')
+    DataExporter.perform_async(DataAPI::TADExport, data_export.id)
+
+    api_token = DataAPIUser.find(2).create_magic_link_token!
+
+    headers = { 'Authorization' => "Bearer #{api_token}" }
+
+    get '/data-api/tad-data-exports/latest', headers: headers
+
+    expect(response).to have_http_status(:success)
+    expect(response.body).to start_with('extract_date,candidate_id,application_choice_id,application_form_id')
+  end
+end

--- a/spec/services/data_api/tad_export_spec.rb
+++ b/spec/services/data_api/tad_export_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SupportInterface::TADExport do
+RSpec.describe DataAPI::TADExport do
   before do
     create(:submitted_application_choice, status: 'rejected', rejected_by_default: true)
     create(:submitted_application_choice, status: 'declined', declined_by_default: true)


### PR DESCRIPTION
## Context

TAD are currently downloading data exports manually. We'd like an API.

## Changes proposed in this pull request

We need API keys for authentication. I wanted to avoid modifying the database for this, and reuse as much as possible. To do this I've added a static `DataAPIUser` model, which has hard coded records. This model is used to generate an AuthenticationToken, which we're currently using for magic links. This means we can generate multiple API keys for TAD.

In the future we can more easily add API authentication schemes. For example, I'm thinking that we might expose an "API" for data analysts to download other exports.

## Guidance to review

- What do you think of the auth?
- What do you think of the data export code?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
