### PR TITLE
Fix bugs on work history flow

### DIFF
--- a/app/controllers/candidate_interface/restructured_work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/break_controller.rb
@@ -8,6 +8,8 @@ module CandidateInterface
       @work_break = RestructuredWorkHistory::WorkHistoryBreakForm.new(work_history_break_params)
 
       if @work_break.save(current_application)
+        current_application.update!(work_history_completed: false)
+
         redirect_to candidate_interface_restructured_work_history_review_path
       else
         track_validation_error(@work_break)
@@ -23,6 +25,8 @@ module CandidateInterface
       @work_break = RestructuredWorkHistory::WorkHistoryBreakForm.new(work_history_break_params)
 
       if @work_break.update(current_work_history_break)
+        current_application.update!(work_history_completed: false)
+
         redirect_to candidate_interface_restructured_work_history_review_path
       else
         track_validation_error(@work_break)
@@ -36,6 +40,7 @@ module CandidateInterface
 
     def destroy
       current_work_history_break.destroy!
+      current_application.update!(work_history_completed: false)
 
       if current_application.application_work_experiences.present? || current_application.application_work_history_breaks.present?
         redirect_to candidate_interface_restructured_work_history_review_path

--- a/app/controllers/candidate_interface/restructured_work_history/job_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/job_controller.rb
@@ -12,6 +12,7 @@ module CandidateInterface
         redirect_to candidate_interface_restructured_work_history_review_path
       else
         track_validation_error(@job_form)
+        @job_form.cast_booleans
         render :new
       end
     end

--- a/app/controllers/candidate_interface/restructured_work_history/job_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/job_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
         redirect_to candidate_interface_restructured_work_history_review_path
       else
         track_validation_error(@job_form)
+        @job_form.cast_booleans
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/restructured_work_history/start_controller.rb
+++ b/app/controllers/candidate_interface/restructured_work_history/start_controller.rb
@@ -8,6 +8,8 @@ module CandidateInterface
       @choice_form = RestructuredWorkHistory::ChoiceForm.new(choice_params)
 
       if @choice_form.save(current_application)
+        current_application.update!(work_history_completed: false)
+
         redirect_to candidate_interface_restructured_work_history_review_path
       else
         track_validation_error(@choice_form)

--- a/app/forms/candidate_interface/restructured_work_history/choice_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/choice_form.rb
@@ -7,6 +7,7 @@ module CandidateInterface
 
       validates :choice, presence: true
       validates :explanation, presence: true, if: -> { can_not_complete_work_history? }
+      validates :explanation, word_count: { maximum: 400 }
 
       def save(application_form)
         return false unless valid?

--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -18,8 +18,8 @@ module CandidateInterface
                     :end_date_unknown,
                     :relevant_skills
 
-      validates :role,
-                :organisation,
+      validates :organisation,
+                :role,
                 :commitment,
                 :currently_working,
                 :relevant_skills,

--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -61,10 +61,10 @@ module CandidateInterface
           commitment: commitment,
           start_date: start_date,
           end_date: not_currently_employed_in_this_role? ? end_date : nil,
-          start_date_unknown: ActiveModel::Type::Boolean.new.cast(start_date_unknown),
-          end_date_unknown: ActiveModel::Type::Boolean.new.cast(end_date_unknown),
-          currently_working: ActiveModel::Type::Boolean.new.cast(currently_working),
-          relevant_skills: ActiveModel::Type::Boolean.new.cast(relevant_skills),
+          start_date_unknown: start_date_unknown,
+          end_date_unknown: end_date_unknown,
+          currently_working: currently_working,
+          relevant_skills: relevant_skills,
           details: set_details_field,
         )
       end
@@ -96,6 +96,13 @@ module CandidateInterface
 
       def not_currently_employed_in_this_role?
         currently_working == 'false'
+      end
+
+      def cast_booleans
+        self.start_date_unknown = ActiveModel::Type::Boolean.new.cast(start_date_unknown)
+        self.end_date_unknown = ActiveModel::Type::Boolean.new.cast(end_date_unknown)
+        self.currently_working = ActiveModel::Type::Boolean.new.cast(currently_working)
+        self.relevant_skills = ActiveModel::Type::Boolean.new.cast(relevant_skills)
       end
 
     private

--- a/app/forms/candidate_interface/restructured_work_history/work_history_break_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/work_history_break_form.rb
@@ -7,7 +7,7 @@ module CandidateInterface
       attr_accessor :start_date_day, :start_date_month, :start_date_year,
                     :end_date_day, :end_date_month, :end_date_year, :reason
 
-      validates :start_date, date: { future: true, month_and_year: true }
+      validates :start_date, date: { presence: true, future: true, month_and_year: true }
       validates :end_date, date: { presence: true, future: true, month_and_year: true }, if: :start_date
       validate :start_date_before_end_date, unless: ->(c) { %i[start_date end_date].any? { |d| c.errors.keys.include?(d) } }
 

--- a/app/views/candidate_interface/restructured_work_history/job/_form.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/job/_form.html.erb
@@ -2,7 +2,7 @@
 <%= f.govuk_text_field :role, label: { text: t('application_form.restructured_work_history.role.label'), size: 'm' }, hint: { text: t('application_form.restructured_work_history.role.hint_text') } %>
 
 <%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: t('application_form.restructured_work_history.commitment.label'), size: 'm' } do %>
-  <%= f.govuk_radio_button :commitment, 'full_time', label: { text: t('application_form.restructured_work_history.commitment.full_time.label') } %>
+  <%= f.govuk_radio_button :commitment, 'full_time', link_errors: true, label: { text: t('application_form.restructured_work_history.commitment.full_time.label') } %>
   <%= f.govuk_radio_button :commitment, 'part_time', label: { text: t('application_form.restructured_work_history.commitment.part_time.label') } %>
 <% end %>
 

--- a/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
+++ b/app/views/candidate_interface/restructured_work_history/start/choice.html.erb
@@ -6,27 +6,16 @@
     <%= form_with model: @choice_form, url: candidate_interface_restructured_work_history_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.work_history') %>
-      </h1>
-
-      <p class="govuk-body">
-        Training providers need a complete picture of your
-        work history, including time out of the workplace, to safeguard
-        children.
-      </p>
-
-      <p class="govuk-body">
-        Breaks in work history will not impact your application if you have an explanation for them.
-        For example this could be raising children, unemployment, redundancy, illness, study or travel.
-      </p>
-
       <div class="govuk-!-margin-top-6">
-        <%= f.govuk_radio_buttons_fieldset :work_history_status, legend: { text: 'Do you have any work history to add?', size: 'm' } do %>
-          <%= f.govuk_radio_button :choice, :can_complete, label: { text: t('application_form.restructured_work_history.can_complete.label') }, hint: { text: t('application_form.restructured_work_history.can_complete.hint_text') }, link_errors: true %>
+        <%= f.govuk_radio_buttons_fieldset :work_history_status, legend: { text: t('page_titles.restructured_work_history_choice'), size: 'xl' } do %>
+          <%= f.govuk_radio_button :choice, :can_complete, label: { text: t('application_form.restructured_work_history.can_complete.label') }, link_errors: true %>
           <%= f.govuk_radio_button :choice, :full_time_education, label: { text: t('application_form.restructured_work_history.full_time_education.label') } %>
           <%= f.govuk_radio_button :choice, :can_not_complete, label: { text: t('application_form.restructured_work_history.can_not_complete.label') } do %>
-            <%= f.govuk_text_area :explanation, label: { text: t('application_form.restructured_work_history.explanation.label') }, hint: { text: t('application_form.restructured_work_history.explanation.hint_text') } %>
+            <%= f.govuk_text_area :explanation,
+                                  label: { text: t('application_form.restructured_work_history.explanation.label') },
+                                  hint: { text: t('application_form.restructured_work_history.explanation.hint_text') },
+                                  max_words: 400,
+                                  threshold: 90 %>
           <% end %>
         <% end %>
 

--- a/config/locales/candidate_interface/restructured_work_history.yml
+++ b/config/locales/candidate_interface/restructured_work_history.yml
@@ -3,7 +3,6 @@ en:
     restructured_work_history:
       can_complete:
         label: 'Yes'
-        hint_text: You’ll be able to give details of any breaks once you’ve entered your employment history
       full_time_education:
         label: No, I have always been in full time education
         review_label: Do you have any work history?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
     when_did_you_study_for_your_degree: When did you study for your degree?
     what_year_did_you_graduate: What year did you graduate?
     work_history_destroy: Are you sure you want to delete this entry?
+    restructured_work_history_choice: Do you have any work history?
     restructured_work_history_destroy: Are you sure you want to delete this job?
     edit_job: Edit job
     add_another_degree: Add another degree

--- a/spec/forms/candidate_interface/restructured_work_history/choice_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/choice_form_spec.rb
@@ -11,38 +11,44 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::ChoiceForm, type: :m
     it { is_expected.to validate_presence_of(:choice) }
     it { is_expected.to validate_presence_of(:explanation) }
 
-    describe '.build_from_application' do
-      it 'sets the choice and explanation values' do
-        application_form = create(
-          :application_form,
-          work_history_status: :can_not_complete,
-          work_history_explanation: 'I have been a full time parent',
-        )
-        choice_form = described_class.build_from_application(application_form)
+    valid_text = Faker::Lorem.sentence(word_count: 400)
+    invalid_text = Faker::Lorem.sentence(word_count: 401)
 
-        expect(choice_form.choice).to eq 'can_not_complete'
-        expect(choice_form.explanation).to eq 'I have been a full time parent'
-      end
+    it { is_expected.to allow_value(valid_text).for(:explanation) }
+    it { is_expected.not_to allow_value(invalid_text).for(:explanation) }
+  end
+
+  describe '.build_from_application' do
+    it 'sets the choice and explanation values' do
+      application_form = create(
+        :application_form,
+        work_history_status: :can_not_complete,
+        work_history_explanation: 'I have been a full time parent',
+      )
+      choice_form = described_class.build_from_application(application_form)
+
+      expect(choice_form.choice).to eq 'can_not_complete'
+      expect(choice_form.explanation).to eq 'I have been a full time parent'
+    end
+  end
+
+  describe '.save' do
+    it 'returns false if not valid' do
+      choice_form = described_class.new
+
+      expect(choice_form.save(ApplicationForm.new)).to eq(false)
     end
 
-    describe '.save' do
-      it 'returns false if not valid' do
-        choice_form = described_class.new
+    it 'updates the work_history_status and work_history_explanation values' do
+      application_form = create(:application_form)
+      choice_form = described_class.new(
+        choice: 'can_not_complete',
+        explanation: 'I have been a full time parent',
+      )
 
-        expect(choice_form.save(ApplicationForm.new)).to eq(false)
-      end
-
-      it 'updates the work_history_status and work_history_explanation values' do
-        application_form = create(:application_form)
-        choice_form = described_class.new(
-          choice: 'can_not_complete',
-          explanation: 'I have been a full time parent',
-        )
-
-        expect(choice_form.save(application_form)).to eq(true)
-        expect(application_form.work_history_status).to eq 'can_not_complete'
-        expect(application_form.work_history_explanation).to eq 'I have been a full time parent'
-      end
+      expect(choice_form.save(application_form)).to eq(true)
+      expect(application_form.work_history_status).to eq 'can_not_complete'
+      expect(application_form.work_history_explanation).to eq 'I have been a full time parent'
     end
   end
 end

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -191,4 +191,28 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
       )
     end
   end
+
+  describe '.cast_booleans' do
+    let(:cast_attributes) do
+      {
+        start_date_unknown: false,
+        end_date_unknown: true,
+        currently_working: false,
+        relevant_skills: true,
+      }
+    end
+
+    it 'casts booleans for the start_date_unknown, end_date_unknown, currently_working and relevant_skills attrs' do
+      job_form = described_class.new(
+        start_date_unknown: false,
+        end_date_unknown: true,
+        currently_working: false,
+        relevant_skills: true,
+      )
+
+      job_form.cast_booleans
+
+      expect(job_form).to have_attributes(cast_attributes)
+    end
+  end
 end

--- a/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
     it { is_expected.to allow_value(okay_text).for(:reason) }
     it { is_expected.not_to allow_value(long_text).for(:reason) }
 
-    include_examples 'validation for a start date', 'restructured_work_history/work_history_break_form'
+    include_examples 'validation for a start date', 'restructured_work_history/work_history_break_form', verify_presence: true
     include_examples 'validation for an end date that cannot be blank', 'restructured_work_history/work_history_break_form'
   end
 
@@ -53,7 +53,6 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
     it 'creates a new work experience if valid' do
       application_form = create(:application_form)
       work_break = CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm.new(form_data)
-
       saved_work_break = work_break.save(application_form)
 
       expect(saved_work_break).to have_attributes(data)

--- a/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/entering_details/restructured_work_history/candidate_entering_work_history_breaks_spec.rb
@@ -33,11 +33,19 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     when_i_enter_a_reason_for_my_break_between_august_2019_and_november_2019
     then_i_see_my_reason_for_my_break_between_august_2019_and_november_2019_on_the_review_page
 
-    when_i_click_to_change_my_reason_for_my_break_between_august_2019_and_november_2019
+    when_i_mark_this_section_as_completed
+    then_i_should_see_the_section_is_completed
+
+    when_i_click_on_work_history
+    and_i_click_to_change_my_reason_for_my_break_between_august_2019_and_november_2019
     and_i_change_my_reason_for_my_break_between_august_2019_and_november_2019
     then_i_see_my_updated_reason_for_my_break_between_august_2019_and_november_2019_on_the_review_page
 
-    when_i_click_to_delete_my_break_between_august_2019_and_november_2019
+    when_i_visit_the_application_form_page
+    then_the_work_history_section_is_incomplete
+
+    when_i_click_on_work_history
+    and_i_click_to_delete_my_break_between_august_2019_and_november_2019
     and_i_confirm_i_want_to_delete_my_break_between_august_2019_and_november_2019
     then_i_no_longer_see_my_reason_on_the_review_page
   end
@@ -154,6 +162,16 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     visit candidate_interface_restructured_work_history_review_path
   end
 
+  def when_i_mark_this_section_as_completed
+    check t('application_form.work_history.review.completed_checkbox')
+    click_button t('save_and_continue')
+    expect(page).to have_content(t('page_titles.application_form'))
+  end
+
+  def then_i_should_see_the_section_is_completed
+    expect(page).to have_css('#work-history-badge-id', text: 'Completed')
+  end
+
   def when_i_click_to_explain_my_break_between_august_2019_and_november_2019
     click_link 'add a reason for this break', match: :first
   end
@@ -168,19 +186,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     expect(page).to have_content('Painting is tiring.')
   end
 
-  def when_i_click_to_delete_my_break_between_august_2019_and_november_2019
-    click_link 'Delete entry for break between Aug 2019 and Nov 2019'
-  end
-
-  def and_i_confirm_i_want_to_delete_my_break_between_august_2019_and_november_2019
-    click_button 'Yes I’m sure - delete this entry'
-  end
-
-  def then_i_no_longer_see_my_reason_on_the_review_page
-    expect(page).not_to have_content('Painting is tiring.')
-  end
-
-  def when_i_click_to_change_my_reason_for_my_break_between_august_2019_and_november_2019
+  def and_i_click_to_change_my_reason_for_my_break_between_august_2019_and_november_2019
     click_link 'Change entry for break between Aug 2019 and Nov 2019'
   end
 
@@ -192,5 +198,25 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
   def then_i_see_my_updated_reason_for_my_break_between_august_2019_and_november_2019_on_the_review_page
     expect(page).to have_content('Some updated reason about painting.')
+  end
+
+  def when_i_visit_the_application_form_page
+    visit candidate_interface_application_form_path
+  end
+
+  def then_the_work_history_section_is_incomplete
+    expect(page).to have_css('#work-history-badge-id', text: 'Incomplete')
+  end
+
+  def and_i_click_to_delete_my_break_between_august_2019_and_november_2019
+    click_link 'Delete entry for break between Aug 2019 and Nov 2019'
+  end
+
+  def and_i_confirm_i_want_to_delete_my_break_between_august_2019_and_november_2019
+    click_button 'Yes I’m sure - delete this entry'
+  end
+
+  def then_i_no_longer_see_my_reason_on_the_review_page
+    expect(page).not_to have_content('Painting is tiring.')
   end
 end


### PR DESCRIPTION
## Context

As part of the work history cleanup card, I tried to break the new flow. This flushed out a few small bugs.

1. If you edit or add a work break then while the section is complete, then the section does not become incomplete
2. Errors are not linked on the full-time/part-time radios
3. The `I’m not sure the exact month or year I started` and `I’m not sure the exact month or year I left` checkboxes aren't retaining values if validations are hit
4.  If you don't add a start date on a work history break it blows up 
5. The explanation field on the choice page should have a 400 word limit and a 90% threshold (also the UI needs tweaking)

## Changes proposed in this pull request

For the above:

1. Added  `current_application.update!(work_history_completed: false)` to the work history breaks controller edit/update/destroy actions
2. Link the errors on the commitment radio buttons
3. Cast the booleans on the jobs form before trying to save/update the job. This ensures the checkbox values are retained when validations are hit
4. add a presence validation to start date on work history breaks form 
5. Updated the explanation field on the choice page should have a 400 word limit and a 90% threshold and updated the UI

## Guidance to review

Per commit will be easiest. The errors are all easy to replicate, so it's probably just worth having a quick check locally. 

## Link to Trello card

https://trello.com/c/6pH5Wy1U/3004-work-history-cleanup

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
