### PR TITLE
Attempt to protect against doing things in the wrong environment

### DIFF
--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -55,5 +55,12 @@ module SupportInterface
 
       redirect_to support_interface_candidates_path
     end
+
+    def confirmed_environment
+      if params[:environment] == HostingEnvironment.environment_name
+        session[:confirmed_environment_at] = Time.zone.now
+        redirect_to params[:from]
+      end
+    end
   end
 end

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -56,10 +56,18 @@ module SupportInterface
       redirect_to support_interface_candidates_path
     end
 
+    def confirm_environment
+      @confirmation = SupportInterface::ConfirmEnvironment.new(from: params[:from])
+    end
+
     def confirmed_environment
-      if params[:environment] == HostingEnvironment.environment_name
+      @confirmation = SupportInterface::ConfirmEnvironment.new(params.require(:support_interface_confirm_environment).permit(:from, :environment))
+
+      if @confirmation.valid?
         session[:confirmed_environment_at] = Time.zone.now
-        redirect_to params[:from]
+        redirect_to @confirmation.from
+      else
+        render :confirm_environment
       end
     end
   end

--- a/app/forms/support_interface/confirm_environment.rb
+++ b/app/forms/support_interface/confirm_environment.rb
@@ -1,0 +1,14 @@
+module SupportInterface
+  class ConfirmEnvironment
+    include ActiveModel::Model
+    attr_accessor :from, :environment
+
+    validate :correct_environment
+
+    def correct_environment
+      if environment != HostingEnvironment.environment_name
+        errors[:environment] << "That’s not ’#{HostingEnvironment.environment_name}’!"
+      end
+    end
+  end
+end

--- a/app/frontend/packs/application-support.js
+++ b/app/frontend/packs/application-support.js
@@ -1,6 +1,5 @@
 require.context("govuk-frontend/govuk/assets");
 
-import Rails from '@rails/ujs';
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
 import initApiTokenProviderAutocomplete from "./autocompletes/api-token-autocomplete";
 import "../styles/application-support.scss";
@@ -8,7 +7,6 @@ import filter from "./components/paginated_filter";
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import initCountryAutocomplete from "./autocompletes/country-autocomplete";
 
-Rails.start();
 govUKFrontendInitAll();
 initApiTokenProviderAutocomplete();
 filter();

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -153,6 +153,14 @@ module ViewHelper
     number_to_percentage(percentage, precision: precision)
   end
 
+  def protect_against_mistakes
+    if session[:confirmed_environment_at] && session[:confirmed_environment_at] > 5.minutes.ago
+      yield
+    else
+      govuk_link_to 'Confirm environment to make changes', support_interface_confirm_environment_path(from: request.fullpath)
+    end
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/support_interface/sessions/confirm_environment.html.erb
+++ b/app/views/support_interface/sessions/confirm_environment.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Confirm you want to make changes to #{HostingEnvironment.environment_name}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body-l">This is the <strong><%= HostingEnvironment.environment_name %></strong> environment.</p>
+
+    <%= form_with(url: support_interface_confirm_environment_path) do |f| %>
+      <%= f.hidden_field :from, value: params[:from] %>
+      <%= f.govuk_text_field :environment, label: { text: "Type '#{HostingEnvironment.environment_name}' to confirm that you want to proceed", size: 'm' } %>
+      <%= f.govuk_submit t('continue') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/sessions/confirm_environment.html.erb
+++ b/app/views/support_interface/sessions/confirm_environment.html.erb
@@ -4,8 +4,8 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body-l">This is the <strong><%= HostingEnvironment.environment_name %></strong> environment.</p>
 
-    <%= form_with(url: support_interface_confirm_environment_path) do |f| %>
-      <%= f.hidden_field :from, value: params[:from] %>
+    <%= form_with(url: support_interface_confirm_environment_path, model: @confirmation) do |f| %>
+      <%= f.hidden_field :from %>
       <%= f.govuk_text_field :environment, label: { text: "Type '#{HostingEnvironment.environment_name}' to confirm that you want to proceed", size: 'm' } %>
       <%= f.govuk_submit t('continue') %>
     <% end %>

--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -30,14 +30,12 @@
       <% protect_against_mistakes do %>
         <% if FeatureFlag.active?(feature_name) %>
           <%= govuk_button_to support_interface_deactivate_feature_flag_path(feature_name),
-                 class: 'app-button--tertiary govuk-!-margin-bottom-0',
-                 data: { confirm: "Are you sure you want to deactivate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
+                 class: 'app-button--tertiary govuk-!-margin-bottom-0' do %>
             Deactivate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
           <% end %>
         <% else %>
           <%= govuk_button_to support_interface_activate_feature_flag_path(feature_name),
-                 class: 'app-button--tertiary govuk-!-margin-bottom-0',
-                 data: { confirm: "Are you sure you want to activate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
+                 class: 'app-button--tertiary govuk-!-margin-bottom-0' do %>
             Activate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
           <% end %>
         <% end %>

--- a/app/views/support_interface/settings/feature_flags.html.erb
+++ b/app/views/support_interface/settings/feature_flags.html.erb
@@ -27,17 +27,19 @@
     },
   ].compact) do %>
     <%= render SummaryCardHeaderComponent.new(title: feature_name.humanize, heading_level: 2) do %>
-      <% if FeatureFlag.active?(feature_name) %>
-        <%= govuk_button_to support_interface_deactivate_feature_flag_path(feature_name),
-               class: 'app-button--tertiary govuk-!-margin-bottom-0',
-               data: { confirm: "Are you sure you want to deactivate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
-          Deactivate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
-        <% end %>
-      <% else %>
-        <%= govuk_button_to support_interface_activate_feature_flag_path(feature_name),
-               class: 'app-button--tertiary govuk-!-margin-bottom-0',
-               data: { confirm: "Are you sure you want to activate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
-          Activate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
+      <% protect_against_mistakes do %>
+        <% if FeatureFlag.active?(feature_name) %>
+          <%= govuk_button_to support_interface_deactivate_feature_flag_path(feature_name),
+                 class: 'app-button--tertiary govuk-!-margin-bottom-0',
+                 data: { confirm: "Are you sure you want to deactivate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
+            Deactivate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
+          <% end %>
+        <% else %>
+          <%= govuk_button_to support_interface_activate_feature_flag_path(feature_name),
+                 class: 'app-button--tertiary govuk-!-margin-bottom-0',
+                 data: { confirm: "Are you sure you want to activate “#{feature_name.humanize}” in #{HostingEnvironment.environment_name.upcase}?" } do %>
+            Activate<span class="govuk-visually-hidden"> ‘<%= feature_name.humanize %>’ feature</span>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -936,6 +936,9 @@ Rails.application.routes.draw do
     get '/sign-in' => 'sessions#new', as: :sign_in
     get '/sign-out' => 'sessions#destroy', as: :sign_out
 
+    get '/confirm-environment' => 'sessions#confirm_environment', as: :confirm_environment
+    post '/confirm-environment' => 'sessions#confirmed_environment'
+
     post '/request-sign-in-by-email' => 'sessions#sign_in_by_email', as: :sign_in_by_email
     get '/sign-in/check-email', to: 'sessions#check_your_email', as: :check_your_email
     get '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^0.2.1",
-    "@rails/ujs": "^6.1.1",
     "@rails/webpacker": "^5.2.1",
     "accessible-autocomplete": "^2.0.3",
     "govuk-frontend": "^3.11.0",

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Feature flags', with_audited: true do
 
   def when_i_activate_the_feature
     within(pilot_open_summary_card) { click_link 'Confirm environment to make changes' }
-    fill_in :environment, with: 'test'
+    fill_in 'Type \'test\' to confirm that you want to proceed', with: 'test'
     click_button 'Continue'
 
     within(pilot_open_summary_card) { click_button 'Activate' }

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -40,6 +40,10 @@ RSpec.feature 'Feature flags', with_audited: true do
   end
 
   def when_i_activate_the_feature
+    within(pilot_open_summary_card) { click_link 'Confirm environment to make changes' }
+    fill_in :environment, with: 'test'
+    click_button 'Continue'
+
     within(pilot_open_summary_card) { click_button 'Activate' }
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,11 +1269,6 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@rails/ujs@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.1.tgz#25c4e60018274b37e5ba0850134f6445429de2f5"
-  integrity sha512-uF6zEbXpGkNa7Vvxrd9Yqas8xsbc3lsC733V6I7fXgPuj8xXiuZakdE4uIyQSFRVmZKe12qmC6CNJNtIEvt4bA==
-
 "@rails/webpacker@^5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.2.1.tgz#87cdbd4af2090ae2d74bdc51f6f04717d907c5b3"


### PR DESCRIPTION
## Context

We sometimes accidentally do stuff on production that we intended to do in development or QA. This is not good!

## Changes proposed in this pull request

This is a proposal to wrap "dangerous" features in a `protect_against_mistakes` block. This requires the user to confirm the environment, after which they will have 5 minutes to perform the dangerous tasks until they have to confirm again.

<img width="1189" alt="Screenshot 2021-02-17 at 13 49 07" src="https://user-images.githubusercontent.com/233676/108206826-3a420300-7127-11eb-86a1-41f975f9be6a.png">
<img width="1189" alt="Screenshot 2021-02-17 at 13 49 10" src="https://user-images.githubusercontent.com/233676/108206819-39a96c80-7127-11eb-9b0b-5e4bb05b8fad.png">
<img width="1189" alt="Screenshot 2021-02-17 at 13 49 13" src="https://user-images.githubusercontent.com/233676/108206817-3910d600-7127-11eb-9a48-b277fc1a9736.png">
<img width="1189" alt="Screenshot 2021-02-17 at 13 49 15" src="https://user-images.githubusercontent.com/233676/108206805-34e4b880-7127-11eb-8dcc-7caddde1ce26.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
