### PR TITLE
Change offered course option column type to BIGINT

### DIFF
--- a/db/migrate/20210217131741_change_offered_course_option_column_type.rb
+++ b/db/migrate/20210217131741_change_offered_course_option_column_type.rb
@@ -1,0 +1,9 @@
+class ChangeOfferedCourseOptionColumnType < ActiveRecord::Migration[6.0]
+  def up
+    change_column :application_choices, :offered_course_option_id, :bigint
+  end
+
+  def down
+    change_column :application_choices, :offered_course_option_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_17_080844) do
+ActiveRecord::Schema.define(version: 2021_02_17_131741) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2021_02_17_080844) do
     t.datetime "withdrawn_at"
     t.datetime "declined_at"
     t.boolean "declined_by_default", default: false, null: false
-    t.integer "offered_course_option_id"
+    t.bigint "offered_course_option_id"
     t.datetime "accepted_at"
     t.datetime "recruited_at"
     t.datetime "conditions_not_met_at"


### PR DESCRIPTION
## Context

Some columns referring to the same tables are defined interchangeably as `integer` and `BIGINT`, this is due to us referencing the same table under different ids.

## Changes proposed in this pull request

Course option ids are defined as `BIGINT` in our schema, make sure the offered course option id is also of type `BIGINT` as well, as it also refers to the same `course_options` table.

## Guidance to review

Making sure that running the migration and rolling back works.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
