### PR TITLE
Fix validation for SupportUser#email_address uniqueness

### DIFF
--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -6,7 +6,7 @@ class SupportUser < ActiveRecord::Base
   validates :dfe_sign_in_uid, presence: true
   validates :email_address, presence: true, uniqueness: true
 
-  before_save :downcase_email_address
+  before_validation :downcase_email_address
 
   audited except: [:last_signed_in_at]
 

--- a/spec/models/support_user_spec.rb
+++ b/spec/models/support_user_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe SupportUser, type: :model do
+  describe 'validations' do
+    it 'flags email addresses that differ only by case as duplicates' do
+      create :support_user, email_address: 'bob@example.com'
+      duplicate_support_user = build :support_user, email_address: 'Bob@example.com'
+      expect(duplicate_support_user).not_to be_valid
+    end
+  end
+
   describe '#downcase_email_address' do
     it 'saves email_address in lower case' do
       support_user = create :support_user, email_address: 'Bob.Roberts@example.com'


### PR DESCRIPTION
## Context

Downcasing of email address in the model should happen before validation. Otherwise a mixed case email address could still pass validation, then be downcased and violate the unique index when it hits the database.

## Changes proposed in this pull request

Just changes the `SupportUser#downcase_email_address` callback to be to be called `before_validation` rather than `before_save` and add a test to verify.

## Guidance to review

- Does this make sense?

## Link to Trello card

https://trello.com/c/3gKAM4de/3054-add-new-support-users-with-duplicate-email-causes-crash

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
