### PR TITLE
 Add submitted_at to TAD export 

### DIFF
--- a/app/exports/tad_export.yml
+++ b/app/exports/tad_export.yml
@@ -47,3 +47,9 @@ custom_columns:
     - rejected_by_default
     - withdrawn
     example: awaiting_provider_decision
+
+  submitted_at:
+    type: string
+    format: date-time
+    description: When the candidate submitted their application
+    example: 2019-06-13T10:44:31Z

--- a/app/services/data_api/tad_application_export.rb
+++ b/app/services/data_api/tad_application_export.rb
@@ -9,12 +9,12 @@ module DataAPI
       @application_choice = application_choice
     end
 
+    # Documented in app/exports/tad_export.yml
     def as_json
       accrediting_provider = application_choice.accredited_provider || application_choice.provider
       degree = application_form.application_qualifications.find { |q| q.level == 'degree' }
       equality_and_diversity = application_form.equality_and_diversity.to_h
 
-      # https://docs.google.com/spreadsheets/d/1TBQiWpx7Nks4lD2JyXCYp6M69VIGpf-Oi0s_nGK8arA
       {
         extract_date: Time.zone.now.iso8601,
 
@@ -26,6 +26,7 @@ module DataAPI
         # State
         status: status,
         phase: application_form.phase,
+        submitted_at: application_form.submitted_at.iso8601,
 
         # Personal information
         first_name: application_form.first_name,

--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -25,7 +25,7 @@ module DataAPI
   private
 
     def relevant_applications
-      # Should be the same as UCAS.
+      # Should be the same as the UCAS sync export (app/services/ucas_matching/matching_data_export.rb).
       ApplicationForm
         .current_cycle
         .includes(


### PR DESCRIPTION
## Context

This is requested so the TAD analysts can figure out which apply 2 application is the latest for a given candidate.

## Changes proposed in this pull request

Add column and document it.

## Guidance to review


## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
