### PR TITLE
Use EFL qualification description string only in the english_language_qualifications API field

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -9,16 +9,28 @@ module VendorAPI
     end
 
     def show
-      application_choice = GetApplicationChoicesForProviders.call(providers: current_provider, vendor_api: true)
-        .find(params[:application_id])
+      application_choice = application_choices_visible_to_provider.find(params[:application_id])
 
       render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
     end
 
   private
 
+    def application_choices_visible_to_provider
+      GetApplicationChoicesForProviders
+        .call(
+          providers: current_provider,
+          vendor_api: true,
+          includes: [
+            application_form: %i[candidate application_qualifications application_work_experiences application_work_history_breaks application_volunteering_experiences english_proficiency],
+            course_option: [{ course: %i[provider] }, :site],
+            offered_course_option: [{ course: %i[provider] }, :site],
+          ],
+        )
+    end
+
     def get_application_choices_for_provider_since(since:)
-      GetApplicationChoicesForProviders.call(providers: current_provider, vendor_api: true)
+      application_choices_visible_to_provider
         .where('application_choices.updated_at > ?', since)
     end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -340,7 +340,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def english_language_qualification_details
-    english_proficiency&.formatted_qualification_description
+    english_proficiency&.formatted_qualification_description.presence || self[:english_language_details]
   end
 
   def has_rejection_reason?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -83,7 +83,7 @@ class ApplicationForm < ApplicationRecord
     first_name last_name support_reference phase submitted_at
     becoming_a_teacher subject_knowledge interview_preferences
     date_of_birth domicile right_to_work_or_study_details
-    english_main_language english_language_details other_language_details
+    english_main_language other_language_details
     disability_disclosure further_information safeguarding_issues_status
     address_line1 address_line2 address_line3 address_line4
     international_address country postcode equality_and_diversity
@@ -337,6 +337,10 @@ class ApplicationForm < ApplicationRecord
 
   def english_language_details
     self[:english_language_details].presence || english_proficiency&.formatted_qualification_description
+  end
+
+  def english_language_qualification_details
+    english_proficiency&.formatted_qualification_description
   end
 
   def has_rejection_reason?

--- a/app/models/english_proficiency.rb
+++ b/app/models/english_proficiency.rb
@@ -1,4 +1,6 @@
 class EnglishProficiency < ApplicationRecord
+  include PublishedInAPI
+
   audited associated_with: :application_form
 
   belongs_to :application_form

--- a/app/models/ielts_qualification.rb
+++ b/app/models/ielts_qualification.rb
@@ -21,7 +21,7 @@ class IeltsQualification < ApplicationRecord
     9.0
   ].freeze
 
-  has_one :english_proficiency, as: :efl_qualification
+  has_one :english_proficiency, as: :efl_qualification, touch: true
 
   def name
     'IELTS'

--- a/app/models/other_efl_qualification.rb
+++ b/app/models/other_efl_qualification.rb
@@ -1,5 +1,5 @@
 class OtherEflQualification < ApplicationRecord
-  has_one :english_proficiency, as: :efl_qualification
+  has_one :english_proficiency, as: :efl_qualification, touch: true
 
   def unique_reference_number
     nil

--- a/app/models/toefl_qualification.rb
+++ b/app/models/toefl_qualification.rb
@@ -1,5 +1,5 @@
 class ToeflQualification < ApplicationRecord
-  has_one :english_proficiency, as: :efl_qualification
+  has_one :english_proficiency, as: :efl_qualification, touch: true
 
   def name
     'TOEFL'

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -30,7 +30,7 @@ module VendorAPI
             domicile: application_form.domicile,
             uk_residency_status: uk_residency_status,
             english_main_language: application_form.english_main_language,
-            english_language_qualifications: application_form.english_language_details,
+            english_language_qualifications: application_form.english_language_qualification_details,
             other_languages: application_form.other_language_details,
             disability_disclosure: application_form.disability_disclosure,
           },

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -601,10 +601,8 @@ components:
           type: string
           maxLength: 10240
           nullable: true
-          description: About this candidate’s English language qualifications, if
-            English is not their main language
-          example: I have a degree in English Language and Literature from the University
-            of Munich
+          description: Details of this candidate's English language qualification, if English is not their main language
+          example: 'Name: TOEFL, Grade: 20, Awarded: 1999'
         other_languages:
           type: string
           maxLength: 10240

--- a/spec/components/efl_qualification_card_component_spec.rb
+++ b/spec/components/efl_qualification_card_component_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe EflQualificationCardComponent, type: :component do
       end
 
       context 'which is an "Other" qualification' do
-        let(:english_proficiency) { create(:english_proficiency, :with_other_qualification) }
+        let(:english_proficiency) { create(:english_proficiency, :with_other_efl_qualification) }
 
         before { application_form.english_proficiency = english_proficiency }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1216,18 +1216,24 @@ FactoryBot.define do
     end
 
     trait :with_ielts_qualification do
-      association :efl_qualification, factory: :ielts_qualification
-      qualification_status { 'has_qualification' }
+      after(:build) do |english_proficiency|
+        english_proficiency.efl_qualification ||= create(:ielts_qualification, english_proficiency: english_proficiency)
+        english_proficiency.qualification_status = 'has_qualification'
+      end
     end
 
     trait :with_toefl_qualification do
-      association :efl_qualification, factory: :toefl_qualification
-      qualification_status { 'has_qualification' }
+      after(:build) do |english_proficiency|
+        english_proficiency.efl_qualification ||= create(:toefl_qualification, english_proficiency: english_proficiency)
+        english_proficiency.qualification_status = 'has_qualification'
+      end
     end
 
-    trait :with_other_qualification do
-      association :efl_qualification, factory: :other_efl_qualification
-      qualification_status { 'has_qualification' }
+    trait :with_other_efl_qualification do
+      after(:build) do |english_proficiency|
+        english_proficiency.efl_qualification ||= create(:other_efl_qualification, english_proficiency: english_proficiency)
+        english_proficiency.qualification_status = 'has_qualification'
+      end
     end
 
     trait :qualification_not_needed do

--- a/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
+++ b/spec/forms/candidate_interface/english_foreign_language/other_efl_qualification_form_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CandidateInterface::EnglishForeignLanguage::OtherEflQualification
       it 'replaces the record' do
         proficiency = create(
           :english_proficiency,
-          :with_other_qualification,
+          :with_other_efl_qualification,
         )
         expect(proficiency.efl_qualification.grade).to eq '10'
         application_form = proficiency.application_form

--- a/spec/models/last_updated_at_spec.rb
+++ b/spec/models/last_updated_at_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe '#update' do
     expect(application_choices.map(&:updated_at)).not_to include(original_time)
   end
 
-  %w[reference application_volunteering_experience application_work_experience application_qualification application_work_history_break].each do |form_attribute|
+  %i[reference application_volunteering_experience application_work_experience application_qualification application_work_history_break].each do |form_attribute|
     it "updates the application_choices when a #{form_attribute} is added" do
       application_form = create(:completed_application_form, application_choices_count: 1)
 
@@ -50,14 +50,38 @@ RSpec.describe '#update' do
       .not_to(change { application_form.application_choices.first.updated_at })
   end
 
-  %w[application_choice reference application_volunteering_experience application_work_experience application_qualification].each do |form_attribute|
-    it "updates the form when a #{form_attribute} is added" do
-      original_time = Time.zone.now - 1.day
-      application_form = create(:application_form, updated_at: original_time)
+  describe 'EFL qualifications' do
+    %i[ielts_qualification toefl_qualification other_efl_qualification].each do |qualification_type|
+      it "updates the application_choices when a #{qualification_type} is added" do
+        application_form = create(:completed_application_form, application_choices_count: 1)
 
-      create(form_attribute, application_form: application_form)
+        qualification_type_trait = :"with_#{qualification_type}"
 
-      expect(application_form.updated_at).not_to eql(original_time)
+        expect { create(:english_proficiency, qualification_type_trait, application_form: application_form) }
+          .to(change { application_form.application_choices.first.updated_at })
+      end
+
+      it "updates the application_choices when a #{qualification_type} is updated" do
+        application_form = create(:completed_application_form, application_choices_count: 1)
+
+        qualification_type_trait = :"with_#{qualification_type}"
+
+        english_proficiency = create(:english_proficiency, qualification_type_trait, application_form: application_form)
+
+        expect { english_proficiency.efl_qualification.update(updated_at: Time.zone.now) }
+            .to(change { english_proficiency.updated_at })
+      end
+
+      it "updates the application_choices when a #{qualification_type} is deleted" do
+        application_form = create(:completed_application_form, application_choices_count: 1)
+
+        qualification_type_trait = :"with_#{qualification_type}"
+
+        english_proficiency = create(:english_proficiency, qualification_type_trait, application_form: application_form)
+
+        expect { english_proficiency.efl_qualification.destroy! }
+          .to(change { application_form.application_choices.first.updated_at })
+      end
     end
   end
 end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -237,6 +237,28 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.candidate.english_language_qualifications' do
+    it 'returns a description of the candidate\'s EFL qualification' do
+      application_form = create(:completed_application_form, english_proficiency: create(:english_proficiency, :with_toefl_qualification))
+
+      application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to eq('Name: TOEFL, Grade: 20, Awarded: 1999')
+    end
+
+    it 'does not return the english_language_details free text provided by the candidate' do
+      application_form = create(:completed_application_form, english_language_details: 'I have taken some exams but I do not remember the names')
+
+      application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
+
+      response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :candidate, :english_language_qualifications)).to be_nil
+    end
+  end
+
   describe 'attributes.contact_details' do
     it 'returns contact details in correct format for UK addresses' do
       application_form_attributes = {

--- a/spec/services/candidate_interface/choose_efl_review_component_spec.rb
+++ b/spec/services/candidate_interface/choose_efl_review_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::ChooseEflReviewComponent do
     end
 
     context 'when english_proficiency has an Other EFL qualification' do
-      let(:english_proficiency) { build(:english_proficiency, :with_other_qualification) }
+      let(:english_proficiency) { build(:english_proficiency, :with_other_efl_qualification) }
 
       it 'returns an instance of OtherEflQualificationReviewComponent' do
         component = described_class.call(english_proficiency)


### PR DESCRIPTION
## Context
Tribal need to get data about a candidate's EFL qualifications if they are provided

## Guidance to review
Is this worthy of a release note? Or would that be confusing

## Changes proposed in this pull request
Do not expose the deprecated `english_language_details` field over the API if it is present

## Link to Trello card
https://trello.com/c/nb0tCACC/3401-only-include-esl-qualification-data-in-the-api-when-it-is-provided-as-a-qualification-by-the-candidate
## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
