### PR TITLE
Add data export for candidate email counts

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -25,6 +25,11 @@ class DataExport < ApplicationRecord
       description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
       class: SupportInterface::CandidateApplicationFeedbackExport,
     },
+    candidate_email_send_counts: {
+      name: 'Candidate email send counts',
+      description: "A list of all emails sent by the service, and how many we've sent to date",
+      class: SupportInterface::CandidateEmailSendCountsExport,
+    },
     candidate_feedback: {
       name: 'Candidate feedback',
       description: 'This provides the compiled results of all the single-page candidate feedback forms.',

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -1,29 +1,24 @@
 class DataExport < ApplicationRecord
   EXPORT_TYPES = {
+    active_provider_user_permissions: {
+      name: 'Active provider user permissions',
+      description: 'The list of provider users with the permissions they have for each of their organisations.',
+      class: SupportInterface::ActiveProviderUserPermissionsExport,
+    },
+    active_provider_users: {
+      name: 'Active provider users',
+      description: 'The list of provider users that have signed in to apply at least once.',
+      class: SupportInterface::ActiveProviderUsersExport,
+    },
+    application_references: {
+      name: 'Application references',
+      description: 'A list of all application references which have been selected by candidates to date.',
+      class: SupportInterface::ApplicationReferencesExport,
+    },
     application_timings: {
       name: 'Application timings',
       description: 'The application timings provides data on when an application form attribute was last updated by the candidate.',
       class: SupportInterface::ApplicationsExport,
-    },
-    submitted_application_choices: {
-      name: 'Submitted application choices',
-      description: 'The submitted application choices export provides data about which courses candidates applied to, as well as info about offers and candidate decisions.',
-      class: SupportInterface::ApplicationChoicesExport,
-    },
-    candidate_journey_tracking: {
-      name: 'Candidate journey tracking',
-      description: 'Candidate journey tracking provides data on when each application choice progressed through the various steps in the candidate application journey.',
-      class: SupportInterface::CandidateJourneyTrackingExport,
-    },
-    providers_export: {
-      name: 'Providers',
-      description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
-      class: SupportInterface::ProvidersExport,
-    },
-    referee_survey: {
-      name: 'Referee survey',
-      description: 'This provides the compiled results of all the referee surveys.',
-      class: SupportInterface::RefereeSurveyExport,
     },
     candidate_application_feedback: {
       name: 'Candidate application feedback',
@@ -35,75 +30,80 @@ class DataExport < ApplicationRecord
       description: 'This provides the compiled results of all the single-page candidate feedback forms.',
       class: SupportInterface::CandidateFeedbackExport,
     },
-    active_provider_users: {
-      name: 'Active provider users',
-      description: 'The list of provider users that have signed in to apply at least once.',
-      class: SupportInterface::ActiveProviderUsersExport,
-    },
-    active_provider_user_permissions: {
-      name: 'Active provider user permissions',
-      description: 'The list of provider users with the permissions they have for each of their organisations.',
-      class: SupportInterface::ActiveProviderUserPermissionsExport,
+    candidate_journey_tracking: {
+      name: 'Candidate journey tracking',
+      description: 'Candidate journey tracking provides data on when each application choice progressed through the various steps in the candidate application journey.',
+      class: SupportInterface::CandidateJourneyTrackingExport,
     },
     course_choice_withdrawal: {
       name: 'Candidate course choice withdrawal survey',
       description: 'A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.',
       class: SupportInterface::CourseChoiceWithdrawalSurveyExport,
     },
-    tad_provider_performance: {
-      name: 'Provider performance for TAD',
-      description: 'A list of all application/offered/accepted counts for all courses in Apply.',
-      class: SupportInterface::TADProviderStatsExport,
-    },
-    offer_conditions: {
-      name: 'Offer conditions',
-      description: 'A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.',
-      class: SupportInterface::OfferConditionsExport,
-    },
-    application_references: {
-      name: 'Application references',
-      description: 'A list of all application references which have been selected by candidates to date.',
-      class: SupportInterface::ApplicationReferencesExport,
-    },
-    tad_applications: {
-      name: 'Applications for TAD',
-      description: 'A list of all applications for TAD.',
-      class: SupportInterface::TADExport,
-    },
     equality_and_diversity: {
       name: 'Equality and diversity data',
       description: 'Anonymised candidate equality and diversity data.',
       class: SupportInterface::EqualityAndDiversityExport,
-    },
-    unexplained_breaks_in_work_history: {
-      name: 'Unexplained breaks in work history',
-      description: 'A list of candidates with unexplained breaks in their work history.',
-      class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
-    },
-    provider_access_controls: {
-      name: 'Provider Access Controls',
-      description: 'A list of providers and information about their permissions',
-      class: SupportInterface::ProviderAccessControlsExport,
     },
     locations_export: {
       name: 'Locations',
       description: 'A list of application choices with the associated postcodes for the candidate, provider and site.',
       class: SupportInterface::LocationsExport,
     },
-    sites_export: {
-      name: 'Sites',
-      description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
-      class: SupportInterface::SitesExport,
+    notifications_export: {
+      name: 'Notifications',
+      description: 'Data to enable performance assesment of Notification feature',
+      class: SupportInterface::NotificationsExport,
+    },
+    offer_conditions: {
+      name: 'Offer conditions',
+      description: 'A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.',
+      class: SupportInterface::OfferConditionsExport,
+    },
+    provider_access_controls: {
+      name: 'Provider Access Controls',
+      description: 'A list of providers and information about their permissions',
+      class: SupportInterface::ProviderAccessControlsExport,
+    },
+    providers_export: {
+      name: 'Providers',
+      description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
+      class: SupportInterface::ProvidersExport,
     },
     qualifications: {
       name: 'Qualifications',
       description: 'A list of qualifications for each application choice',
       class: SupportInterface::QualificationsExport,
     },
-    notifications_export: {
-      name: 'Notifications',
-      description: 'Data to enable performance assesment of Notification feature',
-      class: SupportInterface::NotificationsExport,
+    referee_survey: {
+      name: 'Referee survey',
+      description: 'This provides the compiled results of all the referee surveys.',
+      class: SupportInterface::RefereeSurveyExport,
+    },
+    sites_export: {
+      name: 'Sites',
+      description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
+      class: SupportInterface::SitesExport,
+    },
+    submitted_application_choices: {
+      name: 'Submitted application choices',
+      description: 'The submitted application choices export provides data about which courses candidates applied to, as well as info about offers and candidate decisions.',
+      class: SupportInterface::ApplicationChoicesExport,
+    },
+    tad_applications: {
+      name: 'TAD applications',
+      description: 'A list of all applications for TAD.',
+      class: SupportInterface::TADExport,
+    },
+    tad_provider_performance: {
+      name: 'TAD provider performance',
+      description: 'A list of all application/offered/accepted counts for all courses in Apply.',
+      class: SupportInterface::TADProviderStatsExport,
+    },
+    unexplained_breaks_in_work_history: {
+      name: 'Unexplained breaks in work history',
+      description: 'A list of candidates with unexplained breaks in their work history.',
+      class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
     },
   }.freeze
 

--- a/app/services/support_interface/candidate_email_send_counts_export.rb
+++ b/app/services/support_interface/candidate_email_send_counts_export.rb
@@ -1,0 +1,24 @@
+module SupportInterface
+  class CandidateEmailSendCountsExport
+    def data_for_export
+      emails_with_counts.map do |email_hash|
+        {
+          'Email' => email_hash['mail_template'],
+          'Send count' => email_hash['send_count'],
+          'Last sent at' => email_hash['last_sent_at'],
+        }
+      end
+    end
+
+  private
+
+    def emails_with_counts
+      Email
+        .select(
+          'mail_template, COUNT(mail_template) AS send_count, MAX(created_at) AS last_sent_at',
+        )
+        .group('mail_template')
+        .order('mail_template ASC')
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1281,4 +1281,14 @@ FactoryBot.define do
       audit.audited_changes = evaluator.changes
     end
   end
+
+  factory :email do
+    application_form
+
+    to { 'me@example.com' }
+    subject { 'Test email' }
+    mailer { 'ActionMailer' }
+    mail_template { 'some_mail_template' }
+    body { 'Hi' }
+  end
 end

--- a/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
+++ b/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CandidateEmailSendCountsExport do
+  describe '#data_for_export' do
+    it 'returns a hash of email counts from the emails table' do
+      yesterday = Time.zone.yesterday
+      two_days_ago = Time.zone.today - 2.days
+      most_recent_app_submitted_email = create(:email, mail_template: 'application_submitted', created_at: yesterday)
+      create(:email, mail_template: 'application_submitted', created_at: two_days_ago)
+      most_recent_conditions_met_email = create(:email, mail_template: 'conditions_met', created_at: two_days_ago)
+
+      expect(described_class.new.data_for_export).to match_array([
+        {
+          'Email' => 'application_submitted',
+          'Send count' => 2,
+          'Last sent at' => most_recent_app_submitted_email.created_at,
+        },
+        {
+          'Email' => 'conditions_met',
+          'Send count' => 1,
+          'Last sent at' => most_recent_conditions_met_email.created_at,
+        },
+      ])
+    end
+  end
+end

--- a/spec/system/support_interface/data_set_documentation_spec.rb
+++ b/spec/system/support_interface/data_set_documentation_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Data set documentation' do
   end
 
   def and_i_click_on_the_tad_export_documentation
-    click_link 'View documentation for Applications for TAD'
+    click_link 'View documentation for TAD applications'
   end
 
   def then_i_see_the_data_set_documentation


### PR DESCRIPTION
## Context

> As a... data analyst
I need to... have a list of all email notifications and how frequently they are sent that we currently send to candidates
In order to... get a better understanding of the 'as is' landscape of email notifications and make an informed decision on the scale of work required to develop data driven email notification tracking
So that... we can understand how effective email notifications are in prompting candidate to take action

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
A data export that provides:

- A list of all email types sent by the service
- The total number of each type that have been logged by the
  EmailLogInterceptor
- The most recent send date of each type


> ![Screenshot_20210218_153635](https://user-images.githubusercontent.com/519250/108381069-5c0eb900-71ff-11eb-9dda-73e50caec504.png)

> ![email-counts-csv](https://user-images.githubusercontent.com/519250/108381145-70eb4c80-71ff-11eb-8131-bfa44fc36d1c.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- We probably have legacy templates that we don't use anymore in production. Rather than provide a hardcoded list of email templates that this export should pick up, for simplicity I've opted to just include the most recent send date of each email type. Anything older than *n* months can be filtered out.
- Does this export meet the goals of the card?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/K7FdnVOg
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
