### PR TITLE
Add test that we correctly document the status for TAD

### DIFF
--- a/app/exports/tad_export.yml
+++ b/app/exports/tad_export.yml
@@ -1,3 +1,5 @@
+# TAD rely on this export for analysis and reporting. Let them know if you make
+# changes to the export (a new application status for example).
 common_columns:
 - extract_date
 - candidate_id
@@ -41,6 +43,8 @@ custom_columns:
     - declined
     - declined_by_default
     - offer
+    - offer_deferred
+    - offer_withdrawn
     - pending_conditions
     - recruited
     - rejected

--- a/app/exports/tad_export.yml
+++ b/app/exports/tad_export.yml
@@ -42,6 +42,7 @@ custom_columns:
     - conditions_not_met
     - declined
     - declined_by_default
+    - interviewing
     - offer
     - offer_deferred
     - offer_withdrawn

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -111,6 +111,12 @@ class ApplicationStateChange
     STATES_VISIBLE_TO_PROVIDER - [:interviewing]
   end
 
+  # TAD receive the same applications as providers, but the `rejected` and `declined`
+  # states are more specific when they are rejected or declined by default.
+  def self.states_visible_to_tad
+    states_visible_to_provider + %i[rejected_by_default declined_by_default]
+  end
+
   def self.states_visible_to_provider_without_deferred
     states_visible_to_provider - [:offer_deferred]
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     unless ENV['TEST_ENV_NUMBER']
       puts "ℹ️  If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
-      puts "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default"
+      puts "ℹ️  Running tests with all features #{ENV['DEFAULT_FEATURE_FLAG_STATE'] == 'on' ? 'ON' : 'OFF'} by default (run with DEFAULT_FEATURE_FLAG_STATE=on/off to change)"
     end
   end
 

--- a/spec/services/data_api/tad_export_spec.rb
+++ b/spec/services/data_api/tad_export_spec.rb
@@ -17,4 +17,13 @@ RSpec.describe DataAPI::TADExport do
       expect(result.map { |r| r[:status] }).to match_array(%w[rejected_by_default declined_by_default rejected declined])
     end
   end
+
+  describe '#status' do
+    it 'only includes states that are documented' do
+      documented_columns = DataSetDocumentation.for(described_class)['status']['enum']
+      possible_states_in_export = ApplicationStateChange.states_visible_to_provider.map(&:to_s) + %w[rejected_by_default declined_by_default]
+
+      expect(documented_columns).to match_array(possible_states_in_export)
+    end
+  end
 end

--- a/spec/services/data_api/tad_export_spec.rb
+++ b/spec/services/data_api/tad_export_spec.rb
@@ -20,8 +20,13 @@ RSpec.describe DataAPI::TADExport do
 
   describe '#status' do
     it 'only includes states that are documented' do
-      documented_columns = DataSetDocumentation.for(described_class)['status']['enum']
-      possible_states_in_export = ApplicationStateChange.states_visible_to_provider.map(&:to_s) + %w[rejected_by_default declined_by_default]
+      documented_columns = DataSetDocumentation.for(described_class)['status']['enum'].map(&:to_sym)
+
+      unless FeatureFlag.active?(:interviews)
+        documented_columns -= %i[interviewing]
+      end
+
+      possible_states_in_export = ApplicationStateChange.states_visible_to_tad
 
       expect(documented_columns).to match_array(possible_states_in_export)
     end


### PR DESCRIPTION
## Context

We've recently introduced new states, which breaks the analysis by TAD.

## Changes proposed in this pull request

Having this test will make sure that if we add another status, we also are required to update the documentation for the export. In turn, this should prompt us to warn TAD of the changes.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
