### PR TITLE
Stop setting deprecated fields on application form in factory

### DIFF
--- a/app/controllers/provider_interface/application_data_export_controller.rb
+++ b/app/controllers/provider_interface/application_data_export_controller.rb
@@ -14,10 +14,21 @@ module ProviderInterface
         cycle_years = @application_data_export_form.selected_years
         statuses = @application_data_export_form.selected_statuses
 
-        application_choices = GetApplicationChoicesForProviders.call(providers: providers)
-                                .where('courses.recruitment_cycle_year' => cycle_years)
-                                .where('status IN (?)', statuses)
-                                .where('candidates.hide_in_reporting': false)
+        application_choices = GetApplicationChoicesForProviders
+          .call(
+            providers: providers,
+            includes: [
+              :provider,
+              :accredited_provider,
+              :site,
+              course: %i[provider accredited_provider],
+              course_option: %i[course site],
+              application_form: %i[candidate english_proficiency],
+            ],
+          )
+          .where('courses.recruitment_cycle_year' => cycle_years)
+          .where('status IN (?)', statuses)
+          .where('candidates.hide_in_reporting': false)
 
         csv_data = ApplicationDataExport.call(application_choices: application_choices)
         send_data csv_data, filename: csv_filename

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -105,9 +105,6 @@ FactoryBot.define do
       date_of_birth { Faker::Date.birthday }
       first_nationality { 'British' }
       second_nationality { 'American' }
-      english_main_language { %w[true false].sample }
-      english_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
-      other_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
       further_information { Faker::Lorem.paragraph_by_chars(number: 300) }
       disclose_disability { %w[true false].sample }
       disability_disclosure { Faker::Lorem.paragraph_by_chars(number: 300) }


### PR DESCRIPTION
## Context

These fields are deprecated and aren't used in the real flow anymore. Removing these so that test data reflects modern applications

## Guidance to review
There are some applications in existence that do have these set, so this will stop us from detecting if we break those. Is there a better way to not set these for generating test applications, but still doing so in automated tests?

## Link to Trello card
https://trello.com/c/PtWnKrcm/3400-do-we-include-esl-toefl-ielts-information-in-the-api

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
