### PR TITLE
[WIP] Build an export which lists the column names of all the other exports

### DIFF
--- a/app/controllers/support_interface/docs_controller.rb
+++ b/app/controllers/support_interface/docs_controller.rb
@@ -1,6 +1,39 @@
 module SupportInterface
   class DocsController < SupportInterfaceController
-    def index; end
+    def index
+
+
+        data_for_export = DataExport::EXPORT_TYPES.values.map do |export|
+
+          export_class = export[:class].new
+          export_output = export_class.data_for_export
+          columns = export_output[0].keys.map{|x| x.to_s.humanize}
+
+          output = {
+              'Name' => export[:name],
+          }
+
+          columns_hash = {}
+          columns.each_with_index.map do |x, i|
+            test = {i => x}
+            columns_hash.merge( {i => x})
+          end
+
+
+          output
+        end
+
+        # The DataExport class creates the header row for us so we need to ensure
+        # we sort by longest hash length to ensure all headers appear
+        data_for_export.sort_by(&:length).reverse
+    end
+
+    def column_names(export)
+      class_name = export[:class]
+      if class_name == SupportInterface::UnexplainedBreaksInWorkHistoryExport
+        class_name::COLUMN_NAMES
+      end
+    end
 
     def provider_flow; end
 

--- a/app/controllers/support_interface/docs_controller.rb
+++ b/app/controllers/support_interface/docs_controller.rb
@@ -6,7 +6,7 @@ module SupportInterface
         data_for_export = DataExport::EXPORT_TYPES.values.map do |export|
 
           export_class = export[:class].new
-          export_output = export_class.data_for_export
+          export_output = export_class.data_for_export(true)
           columns = export_output[0].keys.map{|x| x.to_s.humanize}
 
           output = {

--- a/app/controllers/support_interface/docs_controller.rb
+++ b/app/controllers/support_interface/docs_controller.rb
@@ -1,40 +1,6 @@
 module SupportInterface
   class DocsController < SupportInterfaceController
-    def index
-        exports = DataExport::EXPORT_TYPES.except(:export_export)
-        data_for_export = exports.values.map do |export|
-
-          export_class = export[:class].new
-          export_output = export_class.data_for_export(true)
-          columns = export_output[0].keys.map{|x| x.to_s.humanize}
-
-          output = {
-              'Name' => export[:name],
-          }
-
-          binding.pry
-
-          columns_hash = {}
-          columns.each_with_index.map do |x, i|
-            test = {i => x}
-            columns_hash.merge( {i => x})
-          end
-
-
-          output
-        end
-
-        # The DataExport class creates the header row for us so we need to ensure
-        # we sort by longest hash length to ensure all headers appear
-        data_for_export.sort_by(&:length).reverse
-    end
-
-    def column_names(export)
-      class_name = export[:class]
-      if class_name == SupportInterface::UnexplainedBreaksInWorkHistoryExport
-        class_name::COLUMN_NAMES
-      end
-    end
+    def index; end
 
     def provider_flow; end
 

--- a/app/controllers/support_interface/docs_controller.rb
+++ b/app/controllers/support_interface/docs_controller.rb
@@ -1,9 +1,8 @@
 module SupportInterface
   class DocsController < SupportInterfaceController
     def index
-
-
-        data_for_export = DataExport::EXPORT_TYPES.values.map do |export|
+        exports = DataExport::EXPORT_TYPES.except(:export_export)
+        data_for_export = exports.values.map do |export|
 
           export_class = export[:class].new
           export_output = export_class.data_for_export(true)
@@ -12,6 +11,8 @@ module SupportInterface
           output = {
               'Name' => export[:name],
           }
+
+          binding.pry
 
           columns_hash = {}
           columns.each_with_index.map do |x, i|

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -20,36 +20,36 @@ class DataExport < ApplicationRecord
       description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
       class: SupportInterface::ProvidersExport,
     },
-    referee_survey: {
-      name: 'Referee survey',
-      description: 'This provides the compiled results of all the referee surveys.',
-      class: SupportInterface::RefereeSurveyExport,
-    },
+    # referee_survey: {
+    #   name: 'Referee survey',
+    #   description: 'This provides the compiled results of all the referee surveys.',
+    #   class: SupportInterface::RefereeSurveyExport,
+    # },
     candidate_application_feedback: {
       name: 'Candidate application feedback',
       description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
       class: SupportInterface::CandidateApplicationFeedbackExport,
     },
-    candidate_feedback: {
-      name: 'Candidate feedback',
-      description: 'This provides the compiled results of all the single-page candidate feedback forms.',
-      class: SupportInterface::CandidateFeedbackExport,
-    },
-    active_provider_users: {
-      name: 'Active provider users',
-      description: 'The list of provider users that have signed in to apply at least once.',
-      class: SupportInterface::ActiveProviderUsersExport,
-    },
-    active_provider_user_permissions: {
-      name: 'Active provider user permissions',
-      description: 'The list of provider users with the permissions they have for each of their organisations.',
-      class: SupportInterface::ActiveProviderUserPermissionsExport,
-    },
-    course_choice_withdrawal: {
-      name: 'Candidate course choice withdrawal survey',
-      description: 'A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.',
-      class: SupportInterface::CourseChoiceWithdrawalSurveyExport,
-    },
+    # candidate_feedback: {
+    #   name: 'Candidate feedback',
+    #   description: 'This provides the compiled results of all the single-page candidate feedback forms.',
+    #   class: SupportInterface::CandidateFeedbackExport,
+    # },
+    # active_provider_users: {
+    #   name: 'Active provider users',
+    #   description: 'The list of provider users that have signed in to apply at least once.',
+    #   class: SupportInterface::ActiveProviderUsersExport,
+    # },
+    # active_provider_user_permissions: {
+    #   name: 'Active provider user permissions',
+    #   description: 'The list of provider users with the permissions they have for each of their organisations.',
+    #   class: SupportInterface::ActiveProviderUserPermissionsExport,
+    # },
+    # course_choice_withdrawal: {
+    #   name: 'Candidate course choice withdrawal survey',
+    #   description: 'A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.',
+    #   class: SupportInterface::CourseChoiceWithdrawalSurveyExport,
+    # },
     tad_provider_performance: {
       name: 'Provider performance for TAD',
       description: 'A list of all application/offered/accepted counts for all courses in Apply.',
@@ -65,11 +65,11 @@ class DataExport < ApplicationRecord
       description: 'A list of all application references which have been selected by candidates to date.',
       class: SupportInterface::ApplicationReferencesExport,
     },
-    tad_applications: {
-      name: 'Applications for TAD',
-      description: 'A list of all applications for TAD.',
-      class: SupportInterface::TADExport,
-    },
+    # tad_applications: {
+    #   name: 'Applications for TAD',
+    #   description: 'A list of all applications for TAD.',
+    #   class: SupportInterface::TADExport,
+    # },
     equality_and_diversity: {
       name: 'Equality and diversity data',
       description: 'Anonymised candidate equality and diversity data.',
@@ -99,6 +99,11 @@ class DataExport < ApplicationRecord
       name: 'Qualifications',
       description: 'A list of qualifications for each application choice',
       class: SupportInterface::QualificationsExport,
+    },
+    export_export: {
+        name: 'Exports',
+        description: 'A list of exports and the columns they contain.',
+        class: SupportInterface::ExportExport,
     },
   }.freeze
 

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -5,31 +5,31 @@ class DataExport < ApplicationRecord
       description: 'The application timings provides data on when an application form attribute was last updated by the candidate.',
       class: SupportInterface::ApplicationsExport,
     },
-    submitted_application_choices: {
-      name: 'Submitted application choices',
-      description: 'The submitted application choices export provides data about which courses candidates applied to, as well as info about offers and candidate decisions.',
-      class: SupportInterface::ApplicationChoicesExport,
-    },
-    candidate_journey_tracking: {
-      name: 'Candidate journey tracking',
-      description: 'Candidate journey tracking provides data on when each application choice progressed through the various steps in the candidate application journey.',
-      class: SupportInterface::CandidateJourneyTrackingExport,
-    },
-    providers_export: {
-      name: 'Providers',
-      description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
-      class: SupportInterface::ProvidersExport,
-    },
+    # submitted_application_choices: {
+    #   name: 'Submitted application choices',
+    #   description: 'The submitted application choices export provides data about which courses candidates applied to, as well as info about offers and candidate decisions.',
+    #   class: SupportInterface::ApplicationChoicesExport,
+    # },
+    # candidate_journey_tracking: {
+    #   name: 'Candidate journey tracking',
+    #   description: 'Candidate journey tracking provides data on when each application choice progressed through the various steps in the candidate application journey.',
+    #   class: SupportInterface::CandidateJourneyTrackingExport,
+    # },
+    # providers_export: {
+    #   name: 'Providers',
+    #   description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
+    #   class: SupportInterface::ProvidersExport,
+    # },
     # referee_survey: {
     #   name: 'Referee survey',
     #   description: 'This provides the compiled results of all the referee surveys.',
     #   class: SupportInterface::RefereeSurveyExport,
     # },
-    candidate_application_feedback: {
-      name: 'Candidate application feedback',
-      description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
-      class: SupportInterface::CandidateApplicationFeedbackExport,
-    },
+    # candidate_application_feedback: {
+    #   name: 'Candidate application feedback',
+    #   description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
+    #   class: SupportInterface::CandidateApplicationFeedbackExport,
+    # },
     # candidate_feedback: {
     #   name: 'Candidate feedback',
     #   description: 'This provides the compiled results of all the single-page candidate feedback forms.',
@@ -50,56 +50,56 @@ class DataExport < ApplicationRecord
     #   description: 'A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.',
     #   class: SupportInterface::CourseChoiceWithdrawalSurveyExport,
     # },
-    tad_provider_performance: {
-      name: 'Provider performance for TAD',
-      description: 'A list of all application/offered/accepted counts for all courses in Apply.',
-      class: SupportInterface::TADProviderStatsExport,
-    },
-    offer_conditions: {
-      name: 'Offer conditions',
-      description: 'A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.',
-      class: SupportInterface::OfferConditionsExport,
-    },
-    application_references: {
-      name: 'Application references',
-      description: 'A list of all application references which have been selected by candidates to date.',
-      class: SupportInterface::ApplicationReferencesExport,
-    },
+    # tad_provider_performance: {
+    #   name: 'Provider performance for TAD',
+    #   description: 'A list of all application/offered/accepted counts for all courses in Apply.',
+    #   class: SupportInterface::TADProviderStatsExport,
+    # },
+    # offer_conditions: {
+    #   name: 'Offer conditions',
+    #   description: 'A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.',
+    #   class: SupportInterface::OfferConditionsExport,
+    # },
+    # application_references: {
+    #   name: 'Application references',
+    #   description: 'A list of all application references which have been selected by candidates to date.',
+    #   class: SupportInterface::ApplicationReferencesExport,
+    # },
     # tad_applications: {
     #   name: 'Applications for TAD',
     #   description: 'A list of all applications for TAD.',
     #   class: SupportInterface::TADExport,
     # },
-    equality_and_diversity: {
-      name: 'Equality and diversity data',
-      description: 'Anonymised candidate equality and diversity data.',
-      class: SupportInterface::EqualityAndDiversityExport,
-    },
-    unexplained_breaks_in_work_history: {
-      name: 'Unexplained breaks in work history',
-      description: 'A list of candidates with unexplained breaks in their work history.',
-      class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
-    },
-    provider_access_controls: {
-      name: 'Provider Access Controls',
-      description: 'A list of providers and information about their permissions',
-      class: SupportInterface::ProviderAccessControlsExport,
-    },
-    locations_export: {
-      name: 'Locations',
-      description: 'A list of application choices with the associated postcodes for the candidate, provider and site.',
-      class: SupportInterface::LocationsExport,
-    },
-    sites_export: {
-      name: 'Sites',
-      description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
-      class: SupportInterface::SitesExport,
-    },
-    qualifications: {
-      name: 'Qualifications',
-      description: 'A list of qualifications for each application choice',
-      class: SupportInterface::QualificationsExport,
-    },
+    # equality_and_diversity: {
+    #   name: 'Equality and diversity data',
+    #   description: 'Anonymised candidate equality and diversity data.',
+    #   class: SupportInterface::EqualityAndDiversityExport,
+    # },
+    # unexplained_breaks_in_work_history: {
+    #   name: 'Unexplained breaks in work history',
+    #   description: 'A list of candidates with unexplained breaks in their work history.',
+    #   class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
+    # },
+    # provider_access_controls: {
+    #   name: 'Provider Access Controls',
+    #   description: 'A list of providers and information about their permissions',
+    #   class: SupportInterface::ProviderAccessControlsExport,
+    # },
+    # locations_export: {
+    #   name: 'Locations',
+    #   description: 'A list of application choices with the associated postcodes for the candidate, provider and site.',
+    #   class: SupportInterface::LocationsExport,
+    # },
+    # sites_export: {
+    #   name: 'Sites',
+    #   description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
+    #   class: SupportInterface::SitesExport,
+    # },
+    # qualifications: {
+    #   name: 'Qualifications',
+    #   description: 'A list of qualifications for each application choice',
+    #   class: SupportInterface::QualificationsExport,
+    # },
     export_export: {
         name: 'Exports',
         description: 'A list of exports and the columns they contain.',

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -5,11 +5,11 @@ class DataExport < ApplicationRecord
       description: 'The application timings provides data on when an application form attribute was last updated by the candidate.',
       class: SupportInterface::ApplicationsExport,
     },
-    # submitted_application_choices: {
-    #   name: 'Submitted application choices',
-    #   description: 'The submitted application choices export provides data about which courses candidates applied to, as well as info about offers and candidate decisions.',
-    #   class: SupportInterface::ApplicationChoicesExport,
-    # },
+    submitted_application_choices: {
+      name: 'Submitted application choices',
+      description: 'The submitted application choices export provides data about which courses candidates applied to, as well as info about offers and candidate decisions.',
+      class: SupportInterface::ApplicationChoicesExport,
+    },
     # candidate_journey_tracking: {
     #   name: 'Candidate journey tracking',
     #   description: 'Candidate journey tracking provides data on when each application choice progressed through the various steps in the candidate application journey.',
@@ -20,86 +20,86 @@ class DataExport < ApplicationRecord
     #   description: 'The list of providers that are being synced from the Find service, along with when they signed the data sharing agreement.',
     #   class: SupportInterface::ProvidersExport,
     # },
-    # referee_survey: {
-    #   name: 'Referee survey',
-    #   description: 'This provides the compiled results of all the referee surveys.',
-    #   class: SupportInterface::RefereeSurveyExport,
-    # },
-    # candidate_application_feedback: {
-    #   name: 'Candidate application feedback',
-    #   description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
-    #   class: SupportInterface::CandidateApplicationFeedbackExport,
-    # },
-    # candidate_feedback: {
-    #   name: 'Candidate feedback',
-    #   description: 'This provides the compiled results of all the single-page candidate feedback forms.',
-    #   class: SupportInterface::CandidateFeedbackExport,
-    # },
-    # active_provider_users: {
-    #   name: 'Active provider users',
-    #   description: 'The list of provider users that have signed in to apply at least once.',
-    #   class: SupportInterface::ActiveProviderUsersExport,
-    # },
-    # active_provider_user_permissions: {
-    #   name: 'Active provider user permissions',
-    #   description: 'The list of provider users with the permissions they have for each of their organisations.',
-    #   class: SupportInterface::ActiveProviderUserPermissionsExport,
-    # },
-    # course_choice_withdrawal: {
-    #   name: 'Candidate course choice withdrawal survey',
-    #   description: 'A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.',
-    #   class: SupportInterface::CourseChoiceWithdrawalSurveyExport,
-    # },
+    referee_survey: {
+      name: 'Referee survey',
+      description: 'This provides the compiled results of all the referee surveys.',
+      class: SupportInterface::RefereeSurveyExport,
+    },
+    candidate_application_feedback: {
+      name: 'Candidate application feedback',
+      description: 'This provides the compiled results of all feedback received from prompts throughout the application form.',
+      class: SupportInterface::CandidateApplicationFeedbackExport,
+    },
+    candidate_feedback: {
+      name: 'Candidate feedback',
+      description: 'This provides the compiled results of all the single-page candidate feedback forms.',
+      class: SupportInterface::CandidateFeedbackExport,
+    },
+    active_provider_users: {
+      name: 'Active provider users',
+      description: 'The list of provider users that have signed in to apply at least once.',
+      class: SupportInterface::ActiveProviderUsersExport,
+    },
+    active_provider_user_permissions: {
+      name: 'Active provider user permissions',
+      description: 'The list of provider users with the permissions they have for each of their organisations.',
+      class: SupportInterface::ActiveProviderUserPermissionsExport,
+    },
+    course_choice_withdrawal: {
+      name: 'Candidate course choice withdrawal survey',
+      description: 'A list of candidates explanations for withdrawing a course choice. Also includes contact details for candidates who have agreed to be contacted.',
+      class: SupportInterface::CourseChoiceWithdrawalSurveyExport,
+    },
     # tad_provider_performance: {
     #   name: 'Provider performance for TAD',
     #   description: 'A list of all application/offered/accepted counts for all courses in Apply.',
     #   class: SupportInterface::TADProviderStatsExport,
     # },
-    # offer_conditions: {
-    #   name: 'Offer conditions',
-    #   description: 'A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.',
-    #   class: SupportInterface::OfferConditionsExport,
-    # },
-    # application_references: {
-    #   name: 'Application references',
-    #   description: 'A list of all application references which have been selected by candidates to date.',
-    #   class: SupportInterface::ApplicationReferencesExport,
-    # },
+    offer_conditions: {
+      name: 'Offer conditions',
+      description: 'A list of all offers showing offer conditions alongside the qualifications declared by the candidate. One line per offer.',
+      class: SupportInterface::OfferConditionsExport,
+    },
+    application_references: {
+      name: 'Application references',
+      description: 'A list of all application references which have been selected by candidates to date.',
+      class: SupportInterface::ApplicationReferencesExport,
+    },
     # tad_applications: {
     #   name: 'Applications for TAD',
     #   description: 'A list of all applications for TAD.',
     #   class: SupportInterface::TADExport,
     # },
-    # equality_and_diversity: {
-    #   name: 'Equality and diversity data',
-    #   description: 'Anonymised candidate equality and diversity data.',
-    #   class: SupportInterface::EqualityAndDiversityExport,
-    # },
+    equality_and_diversity: {
+      name: 'Equality and diversity data',
+      description: 'Anonymised candidate equality and diversity data.',
+      class: SupportInterface::EqualityAndDiversityExport,
+    },
     # unexplained_breaks_in_work_history: {
     #   name: 'Unexplained breaks in work history',
     #   description: 'A list of candidates with unexplained breaks in their work history.',
     #   class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
     # },
-    # provider_access_controls: {
-    #   name: 'Provider Access Controls',
-    #   description: 'A list of providers and information about their permissions',
-    #   class: SupportInterface::ProviderAccessControlsExport,
-    # },
-    # locations_export: {
-    #   name: 'Locations',
-    #   description: 'A list of application choices with the associated postcodes for the candidate, provider and site.',
-    #   class: SupportInterface::LocationsExport,
-    # },
-    # sites_export: {
-    #   name: 'Sites',
-    #   description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
-    #   class: SupportInterface::SitesExport,
-    # },
-    # qualifications: {
-    #   name: 'Qualifications',
-    #   description: 'A list of qualifications for each application choice',
-    #   class: SupportInterface::QualificationsExport,
-    # },
+    provider_access_controls: {
+      name: 'Provider Access Controls',
+      description: 'A list of providers and information about their permissions',
+      class: SupportInterface::ProviderAccessControlsExport,
+    },
+    locations_export: {
+      name: 'Locations',
+      description: 'A list of application choices with the associated postcodes for the candidate, provider and site.',
+      class: SupportInterface::LocationsExport,
+    },
+    sites_export: {
+      name: 'Sites',
+      description: 'A list of sites that are being synced from Find, along with distances to their respective providers',
+      class: SupportInterface::SitesExport,
+    },
+    qualifications: {
+      name: 'Qualifications',
+      description: 'A list of qualifications for each application choice',
+      class: SupportInterface::QualificationsExport,
+    },
     export_export: {
         name: 'Exports',
         description: 'A list of exports and the columns they contain.',

--- a/app/services/support_interface/active_provider_user_permissions_export.rb
+++ b/app/services/support_interface/active_provider_user_permissions_export.rb
@@ -1,14 +1,14 @@
 module SupportInterface
   class ActiveProviderUserPermissionsExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       active_provider_users = ProviderUser.includes(:providers).where.not(last_signed_in_at: nil)
 
-      active_provider_users.flat_map { |provider_user| data_for_user(provider_user) }
+      active_provider_users.flat_map { |provider_user| data_for_user(provider_user, run_once_flag) }
     end
 
   private
 
-    def data_for_user(provider_user)
+    def data_for_user(provider_user, run_once_flag = false )
       provider_user.providers.map do |provider|
         permissions = provider_user.provider_permissions
         {
@@ -22,6 +22,7 @@ module SupportInterface
           has_manage_users: permissions.manage_users.exists?(provider: provider),
           has_manage_organisations: permissions.manage_organisations.exists?(provider: provider),
         }
+        break if run_once_flag
       end
     end
   end

--- a/app/services/support_interface/active_provider_users_export.rb
+++ b/app/services/support_interface/active_provider_users_export.rb
@@ -1,15 +1,16 @@
 module SupportInterface
   class ActiveProviderUsersExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       active_provider_users = ProviderUser.includes(:providers).where.not(last_signed_in_at: nil)
 
-      active_provider_users.map do |provider_user|
+      active_provider_users.each do |provider_user|
         {
           name: provider_user.full_name,
           email_address: provider_user.email_address,
           providers: provider_user.providers.map(&:name).join(', '),
           last_signed_in_at: provider_user.last_signed_in_at,
         }
+        break if run_once_flag
       end
     end
   end

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class ApplicationChoicesExport
-    def application_choices
+    def data_for_export(run_once_flag = false)
       results = []
 
       relevant_applications.find_each(batch_size: 100) do |application_form|
@@ -26,12 +26,13 @@ module SupportInterface
             structured_rejection_reasons: format_structured_rejection_reasons(choice.structured_rejection_reasons),
           }
         end
+        break if run_once_flag
       end
 
       results
     end
 
-    alias_method :data_for_export, :application_choices
+    # alias_method :data_for_export, :application_choices
 
   private
 

--- a/app/services/support_interface/application_references_export.rb
+++ b/app/services/support_interface/application_references_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class ApplicationReferencesExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       application_forms = ApplicationForm.includes(:application_choices, application_references: :audits)
 
       data_for_export = application_forms.map do |af|
@@ -19,11 +19,12 @@ module SupportInterface
         end
 
         output
+        break if run_once_flag
       end
 
       # The DataExport class creates the header row for us so we need to ensure
       # we sort by longest hash length to ensure all headers appear
-      data_for_export.sort_by(&:length).reverse
+      data_for_export.sort_by(&:length).reverse if data_for_export.present?
     end
 
   private

--- a/app/services/support_interface/applications_export.rb
+++ b/app/services/support_interface/applications_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class ApplicationsExport
-    def applications
+    def data_for_export(run_once_flag = false)
       applications_of_interest = ApplicationForm.includes(
         :candidate,
       ).preload(
@@ -69,11 +69,12 @@ module SupportInterface
         end
 
         results << output
+        break if run_once_flag
       end
 
       results
     end
 
-    alias_method :data_for_export, :applications
+    # alias_method :data_for_export, :applications
   end
 end

--- a/app/services/support_interface/candidate_application_feedback_export.rb
+++ b/app/services/support_interface/candidate_application_feedback_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class CandidateApplicationFeedbackExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       application_feedback.map do |feedback|
         {
           'Name' => feedback.application_form.full_name,
@@ -13,6 +13,7 @@ module SupportInterface
           'Feedback' => feedback.feedback,
           'Consent to be contacted' => feedback.consent_to_be_contacted,
         }
+        break if run_once_flag
       end
     end
 

--- a/app/services/support_interface/candidate_feedback_export.rb
+++ b/app/services/support_interface/candidate_feedback_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class CandidateFeedbackExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       application_forms.find_each.map do |application_form|
         {
           'Name' => application_form.full_name,
@@ -12,6 +12,7 @@ module SupportInterface
           'CSAT score' => csat_score(application_form.feedback_satisfaction_level),
           'Suggestions' => application_form.feedback_suggestions,
         }
+        break if run_once_flag
       end
     end
 

--- a/app/services/support_interface/candidate_journey_tracking_export.rb
+++ b/app/services/support_interface/candidate_journey_tracking_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class CandidateJourneyTrackingExport
-    def application_choices
+    def data_for_export(run_once_flag = false)
       all_application_choices.find_each.map do |choice|
         {
           id: choice.id,
@@ -11,9 +11,10 @@ module SupportInterface
           phase: choice.application_form.phase,
         }.merge(journey_items(choice))
       end
+      break if run_once_flag
     end
 
-    alias_method :data_for_export, :application_choices
+    # alias_method :data_for_export, :application_choices
 
   private
 

--- a/app/services/support_interface/course_choice_withdrawal_survey_export.rb
+++ b/app/services/support_interface/course_choice_withdrawal_survey_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class CourseChoiceWithdrawalSurveyExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       application_choices = ApplicationChoice.where.not(withdrawal_feedback: nil)
 
       output = []
@@ -13,6 +13,7 @@ module SupportInterface
         }.merge(survey)
 
         output << answer
+        break if run_once_flag
       end
 
       output

--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class EqualityAndDiversityExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       data_for_export = application_forms.includes(:application_choices).map do |application_form|
         rejected_application_choices = application_form.application_choices.rejected
         output = {
@@ -25,11 +25,12 @@ module SupportInterface
         end
 
         output
+        break if run_once_flag
       end
 
       # The DataExport class creates the header row for us so we need to ensure
       # we sort by longest hash length to ensure all headers appear
-      data_for_export.sort_by(&:length).reverse
+      data_for_export.sort_by(&:length).reverse if data_for_export.present?
     end
 
   private

--- a/app/services/support_interface/export_export.rb
+++ b/app/services/support_interface/export_export.rb
@@ -4,7 +4,6 @@ module SupportInterface
     def data_for_export(run_once_flag = false)
       exports = DataExport::EXPORT_TYPES.except(:export_export)
       data_for_export = exports.values.map do |export|
-        # binding.pry
 
         export_class = export[:class].new
         export_output = export_class.data_for_export(true)
@@ -14,12 +13,9 @@ module SupportInterface
             'Name' => export[:name],
         }
 
-        columns_hash = {}
         columns.each_with_index.map do |x, i|
-          columns_hash.merge( {i => x})
+          output = output.merge( { i+1 => x })
         end
-
-        # binding.pry
 
         output
       end

--- a/app/services/support_interface/export_export.rb
+++ b/app/services/support_interface/export_export.rb
@@ -7,14 +7,17 @@ module SupportInterface
 
         export_class = export[:class].new
         export_output = export_class.data_for_export(true)
-        columns = export_output[0].keys.map{|x| x.to_s.humanize}
 
         output = {
-            'Name' => export[:name],
+          'Name' => export[:name],
         }
 
-        columns.each_with_index.map do |x, i|
-          output = output.merge( { i+1 => x })
+        if export_output&.any?
+          columns = export_output.first.keys.map{|x| x.to_s.humanize}
+
+          columns.each_with_index.map do |x, i|
+            output = output.merge( { i+1 => x })
+          end
         end
 
         output
@@ -22,7 +25,7 @@ module SupportInterface
 
       # The DataExport class creates the header row for us so we need to ensure
       # we sort by longest hash length to ensure all headers appear
-      data_for_export.sort_by(&:length).reverse
+      data_for_export.sort_by(&:length).reverse if data_for_export.present?
     end
   end
 end

--- a/app/services/support_interface/export_export.rb
+++ b/app/services/support_interface/export_export.rb
@@ -1,0 +1,28 @@
+
+module SupportInterface
+  class ExportExport
+    def data_for_export
+      data_for_export = DataExport::EXPORT_TYPES.values.map do |export|
+
+        export_class = export[:class].new
+        export_output = export_class.data_for_export
+        columns = export_output[0].keys.map{|x| x.to_s.humanize}
+
+        output = {
+            'Name' => export[:name],
+        }
+
+        columns_hash = {}
+        columns.each_with_index.map do |x, i|
+          columns_hash.merge( {i => x})
+        end
+
+        output
+      end
+
+      # The DataExport class creates the header row for us so we need to ensure
+      # we sort by longest hash length to ensure all headers appear
+      data_for_export.sort_by(&:length).reverse
+    end
+  end
+end

--- a/app/services/support_interface/export_export.rb
+++ b/app/services/support_interface/export_export.rb
@@ -1,11 +1,13 @@
 
 module SupportInterface
   class ExportExport
-    def data_for_export
-      data_for_export = DataExport::EXPORT_TYPES.values.map do |export|
+    def data_for_export(run_once_flag = false)
+      exports = DataExport::EXPORT_TYPES.except(:export_export)
+      data_for_export = exports.values.map do |export|
+        # binding.pry
 
         export_class = export[:class].new
-        export_output = export_class.data_for_export
+        export_output = export_class.data_for_export(true)
         columns = export_output[0].keys.map{|x| x.to_s.humanize}
 
         output = {
@@ -16,6 +18,8 @@ module SupportInterface
         columns.each_with_index.map do |x, i|
           columns_hash.merge( {i => x})
         end
+
+        # binding.pry
 
         output
       end

--- a/app/services/support_interface/locations_export.rb
+++ b/app/services/support_interface/locations_export.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class LocationsExport
     include GeocodeHelper
 
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       application_choices.find_each.map do |application_choice|
         application_form = application_choice.application_form
 
@@ -23,6 +23,7 @@ module SupportInterface
           'Distance from site to candidate' => distance(application_choice),
           'Average distance from all sites to candidate' => average_distance(application_form),
         }
+        break if run_once_flag
       end
     end
 

--- a/app/services/support_interface/offer_conditions_export.rb
+++ b/app/services/support_interface/offer_conditions_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class OfferConditionsExport
-    def offers
+    def data_for_export(run_once_flag = false)
       relevant_choices.flat_map do |choice|
         {
           support_reference: choice.application_form.support_reference,
@@ -28,10 +28,11 @@ module SupportInterface
           application_status: choice.status,
           conditions: conditions(choice),
         }
+        break if run_once_flag
       end
     end
 
-    alias_method :data_for_export, :offers
+    # alias_method :data_for_export, :offers
 
   private
 

--- a/app/services/support_interface/provider_access_controls_export.rb
+++ b/app/services/support_interface/provider_access_controls_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class ProviderAccessControlsExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       providers = Provider.where(sync_courses: true)
 
       providers.map do |provider|
@@ -29,6 +29,7 @@ module SupportInterface
           total_org_relationships_as_trainer: access_controls.total_org_relationships_as_trainer,
           total_org_relationships: access_controls.total_org_relationships,
         }
+        break if run_once_flag
       end
     end
   end

--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class ProvidersExport
     include GeocodeHelper
 
-    def providers
+    def data_for_export(run_once_flag = false)
       relevant_providers.map do |provider|
         {
           'name' => provider.name,
@@ -11,9 +11,10 @@ module SupportInterface
           'Average distance to site' => average_distance_to_site(provider),
         }
       end
+      break if run_once_flag
     end
 
-    alias_method :data_for_export, :providers
+    # alias_method :data_for_export, :providers
 
   private
 

--- a/app/services/support_interface/qualifications_export.rb
+++ b/app/services/support_interface/qualifications_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class QualificationsExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       application_choices = ApplicationChoice
                                 .select(:id, :application_form_id, :rejection_reason, :structured_rejection_reasons, :status, :course_option_id)
                                 .includes(:course_option, :course, :provider)
@@ -57,6 +57,7 @@ module SupportInterface
           'Number of other qualifications provided' => other_qualification_count(qualifications),
         }
         output
+        break if run_once_flag
       end
     end
 

--- a/app/services/support_interface/referee_survey_export.rb
+++ b/app/services/support_interface/referee_survey_export.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class RefereeSurveyExport
-    def call
+    def data_for_export(run_once_flag = false)
       references = ApplicationReference.includes(:application_form).where.not(questionnaire: nil)
       references_with_feedback = references.reject do |reference|
         reference.questionnaire.values.all? { |response| response == ' | ' }
@@ -21,12 +21,13 @@ module SupportInterface
         }
 
         output << hash
+        break if run_once_flag
       end
 
       output
     end
 
-    alias_method :data_for_export, :call
+    # alias_method :data_for_export, :call
 
   private
 

--- a/app/services/support_interface/sites_export.rb
+++ b/app/services/support_interface/sites_export.rb
@@ -2,7 +2,7 @@ module SupportInterface
   class SitesExport
     include GeocodeHelper
 
-    def sites
+    def data_for_export(run_once_flag = false)
       relevant_sites.map do |site|
         {
           'id' => site.id,
@@ -10,10 +10,11 @@ module SupportInterface
           'provider code' => site.provider.code,
           'distance from provider' => format_distance(site, site.provider, with_units: false),
         }
+        break if run_once_flag
       end
     end
 
-    alias_method :data_for_export, :sites
+    # alias_method :data_for_export, :sites
 
   private
 

--- a/app/services/support_interface/tad_export.rb
+++ b/app/services/support_interface/tad_export.rb
@@ -1,11 +1,12 @@
 module SupportInterface
   class TADExport
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       relevant_applications.flat_map do |application_form|
         application_form.application_choices.map do |application_choice|
           TADApplicationExport.new(application_choice).as_json
         end
       end
+      break if run_once_flag
     end
 
   private

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -1,13 +1,13 @@
 module SupportInterface
   class TADProviderStatsExport
-    def call
+    def data_for_export(run_once_flag = false)
       Course
         .includes(:provider)
-        .map { |c| course_to_row(c) }
+        .map { |c| course_to_row(c) break if run_once_flag }
         .sort_by { |r| r[:provider_code] }
     end
 
-    alias_method :data_for_export, :call
+    # alias_method :data_for_export, :call
 
   private
 

--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -31,7 +31,7 @@ module SupportInterface
       end
     end
 
-    def data_for_export
+    def data_for_export(run_once_flag = false)
       applications = ApplicationForm
                          .where.not(date_of_birth: nil)
                          .select(:id, :candidate_id, :submitted_at, :date_of_birth, :work_history_completed)
@@ -65,6 +65,7 @@ module SupportInterface
           'Course choice statuses' => application_form.application_choices.map(&:status).sort,
         }
         output
+        break if run_once_flag && output.present?
       end
 
       data_for_export.compact

--- a/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
+++ b/app/services/support_interface/unexplained_breaks_in_work_history_export.rb
@@ -1,5 +1,18 @@
 module SupportInterface
   class UnexplainedBreaksInWorkHistoryExport
+
+    COLUMN_NAMES = [
+        'Candidate id',
+        'Application id',
+        'Start of working life',
+        'Total unexplained time (months)',
+        'Number of unexplained breaks',
+        'Number of unexplained breaks in last 5 years',
+        'Number of unexplained breaks that coincide with studying for a degree',
+        'Work history completed',
+        'Course choice statuses',
+    ]
+
     class UnexplainedBreak
       def initialize(month_range:)
         @month_range = month_range


### PR DESCRIPTION
## Context

In order to keep track of what we have in each export, so that team members can be better directed to the information they require, we are building an export that will contain the name of each export and the column names they contain.

## Changes proposed in this pull request

This includes the (WIP) approach we intend to take in order to implement this functionality:

We've built an `ExportExport` class that performs two actions: 

- Collects the name of each export and store these in a hash called `output`.
- Then - provided the export contains data - grab the name of each column and append these to the `output` hash using the index position + 1 as the key value. 

The raw output is similar to the below:
`{ "name" => "Application Export", 1 => "First column name", 2 => "Second column name" }`

And the CSV output is:
![Screenshot 2021-02-18 at 15 40 56](https://user-images.githubusercontent.com/47917431/108392721-e4df2200-720a-11eb-9527-72ea94dbc4dd.png)
_(limited output due to the quality of local data)_

## Guidance to review

What is the consensus on our approach so far? 

There's still more work required in order to get some of the individual exports working.

## Link to Trello card

https://trello.com/c/O5zre0vT/3040-dev-create-export-which-lists-the-column-names-of-all-the-other-exports

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
