### PR TITLE
Show applications count on the index page in the header and title

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -30,6 +30,7 @@ module ProviderInterface
         application_choices: with_includes.where(id: application_choices),
       )
 
+      @application_choices_count = application_choices.count
       @application_choices = application_choices.page(params[:page] || 1).per(30)
     end
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Applications' %>
+<% content_for :browser_title, "Applications (#{@application_choices_count})" %>
 
 <% if FeatureFlag.active?('provider_information_banner') %>
   <div class="govuk-grid-row">
@@ -17,7 +17,7 @@
   </div>
 <% end %>
 
-<h1 class='govuk-heading-xl'>Applications</h1>
+<h1 class='govuk-heading-xl'>Applications (<%= @application_choices_count %>)</h1>
 
 <%= render PaginatedFilterComponent.new(filter: @filter, collection: @application_choices) do %>
   <% if @application_choices.any? %>

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -56,6 +56,8 @@ RSpec.feature 'See applications' do
   alias_method :when_i_visit_the_provider_page, :and_i_visit_the_provider_page
 
   def then_i_should_see_the_applications_from_my_organisation
+    expect(page).to have_title 'Applications (2)'
+    expect(page).to have_content 'Applications (2)'
     expect(page).to have_content @my_provider_choice1.application_form.full_name
     expect(page).to have_content @my_provider_choice2.application_form.full_name
   end


### PR DESCRIPTION

## Context

To address recommendations from the DAC Accessibility Audit Report (WCAG 2.1 standard) from December 2020.

## Changes proposed in this pull request

Show total number of results in the title and header of the Application list irrespective of pagination. 0 results is shown as “Applications (0)"

## Guidance to review

visit `/provider/applications`

## Link to Trello card

https://trello.com/c/d7DmtglF/3408-show-total-number-of-results-in-the-title-and-header-of-the-application-list

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
