### PR TITLE
Remove repeated footer on the interview emails

### DIFF
--- a/app/views/candidate_mailer/_get_support.text.erb
+++ b/app/views/candidate_mailer/_get_support.text.erb
@@ -1,7 +1,0 @@
-# Get support
-
-You can chat to a <%= t('service_name.get_into_teaching') %> adviser online for help and advice:
-
-<%= t('get_into_teaching.url_online_chat') %>
-
-You can also call for free on <%= t('get_into_teaching.tel') %>, <%= t('get_into_teaching.opening_times') %>.

--- a/app/views/candidate_mailer/interview_cancelled.text.erb
+++ b/app/views/candidate_mailer/interview_cancelled.text.erb
@@ -9,5 +9,3 @@ They’ve given the following reason for cancelling the interview:
 ^ <%= @reason %>
 
 Contact <%= @provider_name %> if you have any questions.
-
-<%= render 'get_support' %>

--- a/app/views/candidate_mailer/interview_updated.text.erb
+++ b/app/views/candidate_mailer/interview_updated.text.erb
@@ -13,5 +13,3 @@ The new details are as follows:
 ^ <%= @interview.additional_details %>
 
 Contact <%= @provider_name %> if you have any questions or you will not be able to attend the interview.
-
-<%= render 'get_support' %>

--- a/app/views/candidate_mailer/new_interview.text.erb
+++ b/app/views/candidate_mailer/new_interview.text.erb
@@ -13,5 +13,3 @@ The details are as follows:
 ^ <%= @interview.additional_details %>
 
 Contact <%= @provider_name %> if you have any questions or you will not be able to attend the interview.
-
-<%= render 'get_support' %>

--- a/app/views/layouts/candidate_email_with_support_footer.text.erb
+++ b/app/views/layouts/candidate_email_with_support_footer.text.erb
@@ -1,3 +1,9 @@
 <%= yield %>
 
-<%= render 'get_support' %>
+# Get support
+
+You can chat to a <%= t('service_name.get_into_teaching') %> adviser online for help and advice:
+
+<%= t('get_into_teaching.url_online_chat') %>
+
+You can also call for free on <%= t('get_into_teaching.tel') %>, <%= t('get_into_teaching.opening_times') %>.


### PR DESCRIPTION
## Context

It's showing twice

## Changes proposed in this pull request

- before
<kbd><img width="388" alt="Screenshot 2021-02-18 at 16 12 05" src="https://user-images.githubusercontent.com/38078064/108386036-27e9c700-7204-11eb-8821-954b630dfbe1.png"></kbd>

- after
<kbd><img width="380" alt="Screenshot 2021-02-18 at 16 12 14" src="https://user-images.githubusercontent.com/38078064/108386070-31732f00-7204-11eb-9f5b-55b5b965c39d.png"></kbd>

## Guidance to review

- /rails/mailers/candidate_mailer/new_interview
- /rails/mailers/candidate_mailer/interview_updated
- /rails/mailers/candidate_mailer/interview_cancelled

## Link to Trello card

https://trello.com/c/e1fxcRF5/3410-remove-duplicated-get-support-footer-from-interview-emails

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
