### PR TITLE
Reasons for rejection support interface fix top-level boolean reasons

### DIFF
--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -99,7 +99,7 @@ module SupportInterface
     end
 
     def detail_reason_for(application_choice, top_level_reason)
-      detail_questions = ReasonsForRejection::INITIAL_QUESTIONS[top_level_reason.to_sym]&.keys
+      detail_questions = ReasonsForRejection::ALL_QUESTIONS[top_level_reason.to_sym]&.keys
       return 'Yes' if detail_questions.nil?
 
       values_as_list(

--- a/app/components/support_interface/reasons_for_rejection_search_results_component.rb
+++ b/app/components/support_interface/reasons_for_rejection_search_results_component.rb
@@ -100,7 +100,7 @@ module SupportInterface
 
     def detail_reason_for(application_choice, top_level_reason)
       detail_questions = ReasonsForRejection::INITIAL_QUESTIONS[top_level_reason.to_sym]&.keys
-      return '' if detail_questions.nil?
+      return 'Yes' if detail_questions.nil?
 
       values_as_list(
         detail_questions.map { |detail_question| application_choice.structured_rejection_reasons[detail_question.to_s] }.compact,

--- a/app/models/reasons_for_rejection.rb
+++ b/app/models/reasons_for_rejection.rb
@@ -12,7 +12,7 @@ class ReasonsForRejection
     safeguarding_y_n
   ].freeze
 
-  INITIAL_QUESTIONS = {
+  ALL_QUESTIONS = {
     candidate_behaviour_y_n: {
       candidate_behaviour_what_did_the_candidate_do: {
         other: %i[candidate_behaviour_other candidate_behaviour_what_to_improve],
@@ -47,7 +47,9 @@ class ReasonsForRejection
         other: :safeguarding_concerns_other_details,
       },
     },
+    other_advice_or_feedback_y_n: { other_advice_or_feedback_details: nil },
   }.freeze
+  INITIAL_QUESTIONS = ALL_QUESTIONS.select { |key| INITIAL_TOP_LEVEL_QUESTIONS.include?(key) }.freeze
 
   attr_accessor :candidate_behaviour_y_n
   attr_writer :candidate_behaviour_what_did_the_candidate_do

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
           quality_of_application_which_parts_needed_improvement: %w[other],
           quality_of_application_other_details: 'Too many emojis',
           interested_in_future_applications_y_n: 'Yes',
+          other_advice_or_feedback_y_n: 'Yes',
+          other_advice_or_feedback_details: 'You need a haircut',
         },
         application_form_id: 123,
       )
@@ -56,6 +58,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       expect(@rendered_result.text).to include('No degree')
       expect(@rendered_result.text).to include('Other - Too many emojis')
       expect(@rendered_result.text).to include('Yes')
+      expect(@rendered_result.text).to include('You need a haircut')
       expect(@rendered_result.text).not_to include('No Science GCSE')
       expect(@rendered_result.text).not_to include('No English GCSE')
     end

--- a/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
+++ b/spec/components/support_interface/reasons_for_rejection_search_results_component_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe SupportInterface::ReasonsForRejectionSearchResultsComponent do
       expect(@rendered_result.text).to include('No Maths GCSE')
       expect(@rendered_result.text).to include('No degree')
       expect(@rendered_result.text).to include('Other - Too many emojis')
+      expect(@rendered_result.text).to include('Yes')
       expect(@rendered_result.text).not_to include('No Science GCSE')
       expect(@rendered_result.text).not_to include('No English GCSE')
     end


### PR DESCRIPTION
## Context

On the support interface reasons for rejection search page _Future applications_ and other boolean top-level questions are listed without value as well as _Additional information_.

## Changes proposed in this pull request

- [x] We need to add a _Yes_ value for top-level reasons that have no other sub-value to clarify that these are positive values.
- [x] Include free text detail for _Additional advice_ reason.

<img width="977" alt="image" src="https://user-images.githubusercontent.com/450843/108443832-68236680-7251-11eb-8c09-3533776b630a.png">

## Guidance to review

- Per commit

## Link to Trello card

https://trello.com/c/z6kR9DMp/3011-r4r-support-page-make-the-values-for-boolean-reasons-more-explicit

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
