### PR TITLE
Correct error messages for date validations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,8 +407,8 @@ en:
       too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course_name_and_code}.
       apply_again_course_already_chosen: You cannot choose more than 1 course when you apply again. You must delete your existing choice if you want to apply to %{course_name_and_code}
       invalid_year: Enter a real %{attribute}
-      invalid_date: Enter %{article} %{attribute} in the correct format
-      invalid_date_month_and_year: Enter %{article} %{attribute} in the correct format, for example 5 2019
+      invalid_date: Enter a real %{attribute}
+      invalid_date_month_and_year: Enter a real %{attribute}, for example 5 2019
       future: Enter %{article} %{attribute} that is not in the future
       blank_date_fields: The %{attribute} must include a %{fields}
       blank_date: Enter %{article} %{attribute}

--- a/config/locales/interview.yml
+++ b/config/locales/interview.yml
@@ -55,12 +55,15 @@ en:
         provider_interface/interview_wizard:
           attributes:
             date:
-              past: Date must be today or in the future
-              after_rdb: Date must be before the application closing date
+              past: Interview date must be today or in the future
+              after_rdb: Interview date must be before the application closing date
+              invalid_date: Interview date must be a real date
+              blank_date_fields: Interview date must include a %{fields}
+              blank_date: Enter interview date
             time:
-              invalid: Enter a time in the correct format
-              blank: Enter time
-              past: Time must be in the future
+              invalid: Enter an interview time in the correct format
+              blank: Enter interview time
+              past: Interview time must be in the future
             location:
               blank: Enter address or online meeting details
               too_long: Address or online meeting details must be %{count} characters or fewer

--- a/spec/forms/candidate_interface/personal_details_form_spec.rb
+++ b/spec/forms/candidate_interface/personal_details_form_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
         personal_details.validate
 
         expect(personal_details.errors.full_messages_for(:date_of_birth)).to eq(
-          ['Date of birth Enter a date of birth in the correct format'],
+          ['Date of birth Enter a real date of birth'],
         )
       end
 

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
         form.validate
 
-        expect(form.errors[:end_date]).to contain_exactly('Enter an end date in the correct format, for example 5 2019')
+        expect(form.errors[:end_date]).to contain_exactly('Enter a real end date, for example 5 2019')
       end
 
       it 'is invalid if year is beyond the current year' do
@@ -122,8 +122,8 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
       expect(job).not_to be_valid
       errors = job.errors.messages
-      expect(errors[:start_date].pop).to eq 'Enter a start date in the correct format, for example 5 2019'
-      expect(errors[:end_date].pop).to eq 'Enter an end date in the correct format, for example 5 2019'
+      expect(errors[:start_date].pop).to eq 'Enter a real start date, for example 5 2019'
+      expect(errors[:end_date].pop).to eq 'Enter a real end date, for example 5 2019'
     end
   end
 

--- a/spec/forms/candidate_interface/work_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/work_experience_form_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
 
       expect(work_experience).not_to be_valid
       errors = work_experience.errors.messages
-      expect(errors[:start_date].pop).to eq 'Enter a start date in the correct format, for example 5 2019'
-      expect(errors[:end_date].pop).to eq 'Enter an end date in the correct format, for example 5 2019'
+      expect(errors[:start_date].pop).to eq 'Enter a real start date, for example 5 2019'
+      expect(errors[:end_date].pop).to eq 'Enter a real end date, for example 5 2019'
     end
   end
 

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
 
         it 'is invalid with the correct error' do
           expect(wizard).to be_invalid
-          expect(wizard.errors[:date]).to contain_exactly('Enter a date')
+          expect(wizard.errors[:date]).to contain_exactly('Enter interview date')
         end
       end
 
@@ -59,7 +59,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
 
         it 'is invalid with the correct error' do
           expect(wizard).to be_invalid
-          expect(wizard.errors[:date]).to contain_exactly('Enter a date in the correct format')
+          expect(wizard.errors[:date]).to contain_exactly('Interview date must be a real date')
         end
       end
 
@@ -70,7 +70,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
         it 'is invalid with the correct error' do
           Timecop.freeze(2021, 1, 13) do
             expect(wizard).to be_invalid
-            expect(wizard.errors[:date]).to contain_exactly('Date must be before the application closing date')
+            expect(wizard.errors[:date]).to contain_exactly('Interview date must be before the application closing date')
           end
         end
       end
@@ -81,7 +81,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
 
       it 'is invalid with the correct error when blank' do
         expect(wizard).to be_invalid
-        expect(wizard.errors[:time]).to contain_exactly('Enter time')
+        expect(wizard.errors[:time]).to contain_exactly('Enter interview time')
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
           invalid_times.each do |time|
             wizard.time = time
             expect(wizard).to be_invalid
-            expect(wizard.errors[:time]).to contain_exactly('Enter a time in the correct format')
+            expect(wizard.errors[:time]).to contain_exactly('Enter an interview time in the correct format')
           end
         end
 
@@ -137,7 +137,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
         it 'returns false and adds a date error' do
           Timecop.freeze(2021, 2, 13, 11, 0, 0) do
             expect(wizard).to be_invalid
-            expect(wizard.errors[:date]).to contain_exactly('Date must be today or in the future')
+            expect(wizard.errors[:date]).to contain_exactly('Interview date must be today or in the future')
           end
         end
       end
@@ -149,7 +149,7 @@ RSpec.describe ProviderInterface::InterviewWizard do
         it 'returns false and adds a time error' do
           Timecop.freeze(2021, 2, 13, 11, 0, 0) do
             expect(wizard).to be_invalid
-            expect(wizard.errors[:time]).to contain_exactly('Time must be in the future')
+            expect(wizard.errors[:time]).to contain_exactly('Interview time must be in the future')
           end
         end
       end


### PR DESCRIPTION
## Context

1. Override date error messages for the interview form as it should be referred to as `interview date` and not use the exact structure of default date errors.

2. Update interview time field validation messages to ensure field is referred to as `Interview time`

3. Amend default invalid date error message to reflect design system documentation - https://design-system.service.gov.uk/components/date-input/#if-the-date-entered-can-t-be-correct

## Changes proposed in this pull request

<img width="677" alt="blank-date-and-time" src="https://user-images.githubusercontent.com/159200/108523148-7f9c3700-72c5-11eb-9afd-d781c1612a54.png">
<img width="523" alt="date-past" src="https://user-images.githubusercontent.com/159200/108523129-7ca14680-72c5-11eb-94b8-e8b2d0ba2fdb.png">
<img width="662" alt="time-past" src="https://user-images.githubusercontent.com/159200/108523133-7d39dd00-72c5-11eb-8565-aede7881ef02.png">
<img width="739" alt="invalid-date" src="https://user-images.githubusercontent.com/159200/108523136-7dd27380-72c5-11eb-9142-5d87ae13e191.png">
<img width="671" alt="invalid-time" src="https://user-images.githubusercontent.com/159200/108523140-7e6b0a00-72c5-11eb-9f43-2ff9289ccee9.png">
<img width="710" alt="date-missing-fields" src="https://user-images.githubusercontent.com/159200/108523145-7f03a080-72c5-11eb-97fd-8bdeef5ad291.png">

## Link to Trello card

https://trello.com/c/oXMXm0uG/1258-correct-error-messages-for-date-validations

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
