### PR TITLE
Add additional column to CandidateEmailSendCountsExport

### DIFF
--- a/app/services/support_interface/candidate_email_send_counts_export.rb
+++ b/app/services/support_interface/candidate_email_send_counts_export.rb
@@ -2,35 +2,21 @@ module SupportInterface
   class CandidateEmailSendCountsExport
     def data_for_export
       emails_with_total_send_counts.map do |send_count_record|
-        unique_recipients = unique_recipients_hash[send_count_record.mail_template]
         {
           'Email' => send_count_record.mail_template,
           'Send count' => send_count_record.send_count,
           'Last sent at' => send_count_record.last_sent_at,
-          'Unique recipients' => unique_recipients,
+          'Unique recipients' => send_count_record.unique_recipients,
         }
       end
     end
 
   private
 
-    def unique_recipients_per_email
-      distinct_mail_templates_and_recipients = Email.select('DISTINCT "to", "mail_template"').to_sql
-      Email
-        .select('mail_template, COUNT(mail_template) AS unique_recipients')
-        .from("(#{distinct_mail_templates_and_recipients}) AS template_recipient_combos GROUP BY template_recipient_combos.mail_template")
-    end
-
-    def unique_recipients_hash
-      unique_recipients_per_email.each_with_object({}) do |recipient_count_record, hash|
-        hash[recipient_count_record.mail_template] = recipient_count_record.unique_recipients
-      end
-    end
-
     def emails_with_total_send_counts
       Email
         .select(
-          'mail_template, COUNT(mail_template) AS send_count, MAX(created_at) AS last_sent_at',
+          'mail_template, COUNT(mail_template) AS send_count, COUNT(DISTINCT "to") AS unique_recipients, MAX(created_at) AS last_sent_at',
         )
         .group('mail_template')
         .order('mail_template ASC')

--- a/app/services/support_interface/candidate_email_send_counts_export.rb
+++ b/app/services/support_interface/candidate_email_send_counts_export.rb
@@ -1,18 +1,33 @@
 module SupportInterface
   class CandidateEmailSendCountsExport
     def data_for_export
-      emails_with_counts.map do |email_hash|
+      emails_with_total_send_counts.map do |send_count_record|
+        unique_recipients = unique_recipients_hash[send_count_record.mail_template]
         {
-          'Email' => email_hash['mail_template'],
-          'Send count' => email_hash['send_count'],
-          'Last sent at' => email_hash['last_sent_at'],
+          'Email' => send_count_record.mail_template,
+          'Send count' => send_count_record.send_count,
+          'Last sent at' => send_count_record.last_sent_at,
+          'Unique recipients' => unique_recipients,
         }
       end
     end
 
   private
 
-    def emails_with_counts
+    def unique_recipients_per_email
+      distinct_mail_templates_and_recipients = Email.select('DISTINCT "to", "mail_template"').to_sql
+      Email
+        .select('mail_template, COUNT(mail_template) AS unique_recipients')
+        .from("(#{distinct_mail_templates_and_recipients}) AS template_recipient_combos GROUP BY template_recipient_combos.mail_template")
+    end
+
+    def unique_recipients_hash
+      unique_recipients_per_email.each_with_object({}) do |recipient_count_record, hash|
+        hash[recipient_count_record.mail_template] = recipient_count_record.unique_recipients
+      end
+    end
+
+    def emails_with_total_send_counts
       Email
         .select(
           'mail_template, COUNT(mail_template) AS send_count, MAX(created_at) AS last_sent_at',

--- a/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
+++ b/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
@@ -3,26 +3,32 @@ require 'rails_helper'
 RSpec.describe SupportInterface::CandidateEmailSendCountsExport do
   describe '#data_for_export' do
     it 'returns a hash of email counts from the emails table' do
-      yesterday = Time.zone.yesterday
-      two_days_ago = Time.zone.today - 2.days
-      most_recent_app_submitted_email = create(:email, mail_template: 'application_submitted', created_at: yesterday)
-      create(:email, mail_template: 'application_submitted', created_at: two_days_ago)
-      most_recent_conditions_met_email = create(:email, mail_template: 'conditions_met', created_at: two_days_ago)
+      Timecop.freeze(Time.zone.now.round) do
+        yesterday = Time.zone.now - 1.day
+        two_days_ago = Time.zone.now - 2.days
 
-      expect(described_class.new.data_for_export).to match_array([
-        {
-          'Email' => 'application_submitted',
-          'Send count' => 2,
-          'Last sent at' => most_recent_app_submitted_email.created_at,
-          'Unique recipients' => 1,
-        },
-        {
-          'Email' => 'conditions_met',
-          'Send count' => 1,
-          'Last sent at' => most_recent_conditions_met_email.created_at,
-          'Unique recipients' => 1,
-        },
-      ])
+        'application_submitted'.tap do |mail_template|
+          create(:email, mail_template: mail_template, created_at: yesterday)
+          create(:email, mail_template: mail_template, created_at: two_days_ago)
+          create(:email, mail_template: mail_template, created_at: two_days_ago, to: 'another_recipient@email.com')
+        end
+        create(:email, mail_template: 'conditions_met', created_at: two_days_ago)
+
+        expect(described_class.new.data_for_export).to match_array([
+          {
+            'Email' => 'application_submitted',
+            'Send count' => 3,
+            'Last sent at' => yesterday.utc,
+            'Unique recipients' => 2,
+          },
+          {
+            'Email' => 'conditions_met',
+            'Send count' => 1,
+            'Last sent at' => two_days_ago.utc,
+            'Unique recipients' => 1,
+          },
+        ])
+      end
     end
   end
 end

--- a/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
+++ b/spec/services/support_interface/candidate_email_send_counts_export_spec.rb
@@ -14,11 +14,13 @@ RSpec.describe SupportInterface::CandidateEmailSendCountsExport do
           'Email' => 'application_submitted',
           'Send count' => 2,
           'Last sent at' => most_recent_app_submitted_email.created_at,
+          'Unique recipients' => 1,
         },
         {
           'Email' => 'conditions_met',
           'Send count' => 1,
           'Last sent at' => most_recent_conditions_met_email.created_at,
+          'Unique recipients' => 1,
         },
       ])
     end


### PR DESCRIPTION
## Context

Following feedback on https://github.com/DFE-Digital/apply-for-teacher-training/pull/4120, this export would benefit from a count of how many unique candidates have received each email type.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Include an additional query that counts unique recipient email addresses per mail_template
- Clean up some of the naming and object access (ie—unnecessary use of hash syntax)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Review diff
- Download the export from the review app

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/K7FdnVOg
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
