### PR TITLE
Fix focus states for primary navigation, sub navigation and filter links

### DIFF
--- a/app/components/filter_component.html.erb
+++ b/app/components/filter_component.html.erb
@@ -9,7 +9,7 @@
         </div>
       </div>
 
-      <div class="moj-filter__content">
+      <div class="moj-filter__content" tabindex="-1">
         <% if active_filters.any? %>
           <div class="moj-filter__selected">
             <div class="moj-filter__selected-heading">
@@ -36,10 +36,7 @@
             <% end %>
           </div>
         <% end %>
-
-        <!-- Div made focusable to 'catch' focus from checkboxes. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
-         -->
-        <div class="moj-filter__options" tabindex="-1">
+        <div class="moj-filter__options">
           <form method="get">
             <%= submit_tag 'Apply filters', class: 'govuk-button' %>
 

--- a/app/frontend/styles/_primary-navigation.scss
+++ b/app/frontend/styles/_primary-navigation.scss
@@ -60,7 +60,20 @@
     color: govuk-colour("black"); // Focus colour on yellow should really be black.
     position: relative; // Ensure focus sits above everything else.
     z-index: 1;
-    box-shadow: none;
+    outline: 3px solid transparent;
+    background-color: govuk-colour("yellow");
+    text-decoration: none;
+  }
+
+  &:focus:before {
+    background-color: govuk-colour("black");
+    content: "";
+    display: block;
+    height: 5px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
   }
 
   &:hover {
@@ -88,6 +101,7 @@
 
       &:before {
         background-color: govuk-colour("black");
+        height: 7px;
       }
 
     }

--- a/app/frontend/styles/_tab-navigation.scss
+++ b/app/frontend/styles/_tab-navigation.scss
@@ -106,6 +106,7 @@
 
   &:focus:before {
     background-color: govuk-colour("black");
+    height: 7px;
   }
 
 }

--- a/app/frontend/styles/components/_paginated_filter.scss
+++ b/app/frontend/styles/components/_paginated_filter.scss
@@ -84,8 +84,15 @@
 // Fix for focus issue - see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
 
 // We're catching the focus on a second element rather than having the filter component itself flash with focus when checkbox labels are clicked.
-.moj-filter__options:focus {
+.moj-filter__content:focus {
   outline: none;
+}
+
+.moj-filter__tag:focus {
+  outline: 3px solid transparent;
+  background-color: govuk-colour("yellow");
+  text-decoration: none;
+  box-shadow: 0 4px govuk-colour("black");
 }
 
 .moj-pagination__item--prev .moj-pagination__link:before {


### PR DESCRIPTION
## Context

The focus styles are either not there or not very good.

## Changes proposed in this pull request

Add focus states copying the fixes from https://github.com/DFE-Digital/register-trainee-teachers/pull/546

## Link to Trello card

https://trello.com/c/SS0ZVmKm/3413-bug-on-primary-navigation-link-focus
