### PR TITLE
Show interviews that happened today in upcoming interviews sections

### DIFF
--- a/app/components/provider_interface/application_choice_interviews_list_component.html.erb
+++ b/app/components/provider_interface/application_choice_interviews_list_component.html.erb
@@ -1,0 +1,25 @@
+<div class="app-interviews">
+  <% if user_can_create_or_change_interviews %>
+    <%= govuk_button_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(application_choice), class: 'govuk-button--secondary' %>
+  <% end %>
+
+  <% if upcoming_interviews.any? %>
+    <h2 class="govuk-heading-m">
+      <%= t('provider_interface.interviews.upcoming') %>
+    </h2>
+
+    <% upcoming_interviews.each do |interview| %>
+      <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: user_can_create_or_change_interviews) %>
+    <% end %>
+  <% end %>
+
+  <% if past_interviews.any? %>
+    <h2 class="govuk-heading-m">
+      <%= t('provider_interface.interviews.past') %>
+    </h2>
+
+    <% past_interviews.each do |interview| %>
+      <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: user_can_create_or_change_interviews) %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/provider_interface/application_choice_interviews_list_component.rb
+++ b/app/components/provider_interface/application_choice_interviews_list_component.rb
@@ -1,0 +1,20 @@
+module ProviderInterface
+  class ApplicationChoiceInterviewsListComponent < ViewComponent::Base
+    include ViewHelper
+    attr_reader :application_choice, :user_can_create_or_change_interviews
+
+    def initialize(application_choice:, user_can_create_or_change_interviews:)
+      @application_choice = application_choice
+      @interviews = application_choice.interviews.kept.includes(:provider).order(:date_and_time)
+      @user_can_create_or_change_interviews = user_can_create_or_change_interviews
+    end
+
+    def upcoming_interviews
+      @interviews.upcoming
+    end
+
+    def past_interviews
+      @interviews.past
+    end
+  end
+end

--- a/app/controllers/provider_interface/interview_schedules_controller.rb
+++ b/app/controllers/provider_interface/interview_schedules_controller.rb
@@ -5,8 +5,8 @@ module ProviderInterface
     def show
       @interviews = Interview.for_application_choices(application_choices_for_user_providers)
         .undiscarded
+        .upcoming
         .includes([:provider, application_choice: [:course_option, application_form: [:candidate]]])
-        .where('date_and_time >= ?', Time.zone.now)
         .order(:date_and_time)
         .page(params[:page] || 1).per(50)
 
@@ -16,8 +16,8 @@ module ProviderInterface
     def past
       @interviews = Interview.for_application_choices(application_choices_for_user_providers)
         .undiscarded
+        .past
         .includes([:provider, application_choice: [:course_option, application_form: [:candidate]]])
-        .where('date_and_time < ?', Time.zone.now)
         .order(date_and_time: :desc)
         .page(params[:page] || 1).per(50)
 

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -14,12 +14,7 @@ module ProviderInterface
       )
       @interviews_can_be_created_and_edited = application_at_interviewable_stage && @provider_can_make_decisions
 
-      interviews = @application_choice.interviews.kept.includes(:provider).order(:date_and_time)
-
-      @upcoming_interviews = interviews.upcoming
-      @past_interviews = interviews.past
-
-      redirect_to provider_interface_application_choice_path if interviews.none?
+      redirect_to provider_interface_application_choice_path if @application_choice.interviews.none?
     end
 
     def new

--- a/app/controllers/provider_interface/interviews_controller.rb
+++ b/app/controllers/provider_interface/interviews_controller.rb
@@ -16,9 +16,8 @@ module ProviderInterface
 
       interviews = @application_choice.interviews.kept.includes(:provider).order(:date_and_time)
 
-      @upcoming_interviews, @past_interviews = interviews.partition do |interview|
-        interview.date_and_time > Time.zone.now
-      end
+      @upcoming_interviews = interviews.upcoming
+      @past_interviews = interviews.past
 
       redirect_to provider_interface_application_choice_path if interviews.none?
     end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -14,6 +14,8 @@ class Interview < ApplicationRecord
   delegate :offered_course, to: :application_choice
 
   scope :for_application_choices, ->(application_choices) { joins(:application_choice).merge(application_choices).kept }
+  scope :upcoming, -> { where('date_and_time >= ?', Time.zone.now.beginning_of_day) }
+  scope :past, -> { where('date_and_time < ?', Time.zone.now.beginning_of_day) }
 
   def date
     date_and_time.to_s(:govuk_date)

--- a/app/views/provider_interface/interviews/index.html.erb
+++ b/app/views/provider_interface/interviews/index.html.erb
@@ -4,30 +4,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="app-interviews">
-      <% if @interviews_can_be_created_and_edited %>
-        <%= govuk_link_to 'Set up interview', new_provider_interface_application_choice_interview_path(@application_choice), class: 'govuk-button govuk-button--secondary' %>
-      <% end %>
-
-      <% if @upcoming_interviews.any? %>
-        <h2 class="govuk-heading-m">
-          <%= t('provider_interface.interviews.upcoming') %>
-        </h2>
-
-        <% @upcoming_interviews.each do |interview| %>
-          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @interviews_can_be_created_and_edited) %>
-        <% end %>
-      <% end %>
-
-      <% if @past_interviews.any? %>
-        <h2 class="govuk-heading-m">
-          <%= t('provider_interface.interviews.past') %>
-        </h2>
-
-        <% @past_interviews.each do |interview| %>
-          <%= render ProviderInterface::InterviewAndCourseSummaryComponent.new(interview: interview, user_can_change_interview: @interviews_can_be_created_and_edited) %>
-        <% end %>
-      <% end %>
-    </div>
+    <%= render ProviderInterface::ApplicationChoiceInterviewsListComponent.new(application_choice: @application_choice, user_can_create_or_change_interviews: @interviews_can_be_created_and_edited) %>
   </div>
 </div>

--- a/spec/components/provider_interface/application_choice_interviews_list_component_spec.rb
+++ b/spec/components/provider_interface/application_choice_interviews_list_component_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationChoiceInterviewsListComponent do
+  let(:interview) { create(:interview, date_and_time: 1.hour.from_now) }
+  let(:user_can_create_or_change_interviews) { true }
+  let(:render) { render_inline(described_class.new(application_choice: interview.application_choice, user_can_create_or_change_interviews: user_can_create_or_change_interviews)) }
+
+  describe 'the set up interview button' do
+    context 'user_can_create_or_change_interviews is true' do
+      it 'is displayed' do
+        expect(render.css('.app-interviews > a').first.text).to include('Set up interview')
+      end
+    end
+
+    context 'user_can_create_or_change_interviews is false' do
+      let(:user_can_create_or_change_interviews) { false }
+
+      it 'is not displayed' do
+        expect(render.css('.app-interviews > a').text).not_to include('Set up interview')
+      end
+    end
+  end
+
+  shared_examples_for 'the interview is upcoming' do
+    it 'renders the interview under the upcoming heading' do
+      expect(render.css('.app-interviews > :nth-child(2)').text).to include('Upcoming interviews')
+      expect(render.css('.app-interviews > :nth-child(3)').text).to include(interview.date_and_time.to_s(:govuk_date_and_time))
+    end
+  end
+
+  shared_examples_for 'the interview is in the past' do
+    it 'renders the interview under the past heading' do
+      expect(render.css('.app-interviews > :nth-child(2)').text).to include('Past interviews')
+      expect(render.css('.app-interviews > :nth-child(3)').text).to include(interview.date_and_time.to_s(:govuk_date_and_time))
+    end
+  end
+
+  context 'interview is today and has not happened yet' do
+    it_behaves_like 'the interview is upcoming'
+  end
+
+  context 'interview is today but has happened already' do
+    let(:interview) { create(:interview, date_and_time: 1.hour.ago) }
+
+    it_behaves_like 'the interview is upcoming'
+  end
+
+  context 'interview is tomorrow' do
+    let(:interview) { create(:interview, date_and_time: 1.day.from_now) }
+
+    it_behaves_like 'the interview is upcoming'
+  end
+
+  context 'interview was yesterday' do
+    let(:interview) { create(:interview, date_and_time: 1.day.ago) }
+
+    it_behaves_like 'the interview is in the past'
+  end
+end

--- a/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
+++ b/spec/system/provider_interface/provider_can_view_interview_schedule_spec.rb
@@ -60,8 +60,12 @@ RSpec.describe 'A Provider user' do
              :future_date_and_time,
              application_choice: application_choice)
     end
+
     @application_choice = application_choices[3]
+
+    # Both of these interviews should appear as upcoming, since they are arranged for today
     @interviews << create(:interview, application_choice: @application_choice, date_and_time: 2.hours.from_now)
+    @interviews << create(:interview, application_choice: @application_choice, date_and_time: 2.hours.ago)
 
     @past_interviews = application_choices.map do |application_choice|
       create(:interview,

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -31,15 +31,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     then_i_see_a_success_message
     and_an_interview_has_been_created('2 March 2020')
 
-    and_i_set_up_another_interview(days_in_future: 2)
-    and_another_interview_has_been_created('3 March 2020')
-
-    when_the_first_interview_has_only_just_happened
-    then_the_completed_interview_still_shows_as_upcoming
-
-    when_the_first_interview_happened_yesterday
-    then_i_see_the_upcoming_interview_under_the_correct_heading
-    and_i_see_the_past_interview_under_the_correct_heading
+    when_i_set_up_another_interview(days_in_future: 2)
+    then_another_interview_has_been_created('3 March 2020')
 
     when_i_change_the_interview_details
     and_i_confirm_the_interview_details
@@ -60,12 +53,12 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     i_can_see_the_application_is_awaiting_provider_decision
     and_the_interview_tab_is_not_available
 
-    and_i_set_up_another_interview(days_in_future: 3)
-    and_another_interview_has_been_created('6 March 2020')
+    when_i_set_up_another_interview(days_in_future: 4)
+    then_another_interview_has_been_created('5 March 2020')
 
     when_i_click_make_decision
     and_i_make_an_offer
-    then_i_should_see_the_interview_on_the_interview_tab('6 March 2020')
+    then_i_should_see_the_interview_on_the_interview_tab('5 March 2020')
     but_i_should_not_see_the_set_up_change_or_cancel_interview_controls
   end
 
@@ -120,7 +113,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_content('Interview successfully created')
   end
 
-  def and_i_set_up_another_interview(days_in_future:)
+  def when_i_set_up_another_interview(days_in_future:)
     and_i_click_set_up_an_interview
     and_i_fill_out_the_interview_form(days_in_future: days_in_future, time: '7pm')
     and_i_click_send_interview_details
@@ -155,42 +148,15 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   end
 
   alias_method :and_another_interview_has_been_created, :and_an_interview_has_been_created
-
-  def when_the_first_interview_has_only_just_happened
-    Timecop.travel(2020, 3, 2, 13, 0, 0)
-    provider_signs_in_using_dfe_sign_in
-    visit provider_interface_application_choice_interviews_path(application_choice)
-  end
-
-  def then_the_completed_interview_still_shows_as_upcoming
-    expect(page).to have_css('.app-interviews > :nth-child(2)', text: 'Upcoming interviews')
-    expect(page).to have_css('.app-interviews > :nth-child(3)', text: '2 March 2020')
-    expect(page).to have_css('.app-interviews > :nth-child(4)', text: '3 March 2020')
-  end
-
-  def when_the_first_interview_happened_yesterday
-    Timecop.travel(2020, 3, 3, 9, 0, 0)
-    provider_signs_in_using_dfe_sign_in
-    visit provider_interface_application_choice_interviews_path(application_choice)
-  end
-
-  def then_i_see_the_upcoming_interview_under_the_correct_heading
-    expect(page).to have_css('.app-interviews > :nth-child(2)', text: 'Upcoming interviews')
-    expect(page).to have_css('.app-interviews > :nth-child(3)', text: '3 March 2020')
-  end
-
-  def and_i_see_the_past_interview_under_the_correct_heading
-    expect(page).to have_css('.app-interviews > :nth-child(4)', text: 'Past interviews')
-    expect(page).to have_css('.app-interviews > :nth-child(5)', text: '2 March 2020')
-  end
+  alias_method :then_another_interview_has_been_created, :and_an_interview_has_been_created
 
   def when_i_change_the_interview_details
     click_on 'Change details', match: :first
 
-    expect(page).to have_field('Day', with: '3')
+    expect(page).to have_field('Day', with: '2')
     expect(page).to have_field('Month', with: '3')
     expect(page).to have_field('Year', with: '2020')
-    expect(page).to have_field('Time', with: '7:00pm')
+    expect(page).to have_field('Time', with: '12:00pm')
     expect(page).to have_field('Address or online meeting details', with: 'N/A')
     expect(page).to have_field('Additional details (optional)', with: '')
 
@@ -271,7 +237,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def and_i_can_see_the_second_interview
     visit provider_interface_application_choice_interviews_path(application_choice)
 
-    expect(page).to have_content('Past interviews')
+    expect(page).to have_content('Upcoming interviews')
     expect(page).to have_css('.app-interviews__interview')
   end
 

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_i_set_up_another_interview(days_in_future: 2)
     and_another_interview_has_been_created('3 March 2020')
 
-    when_the_first_interview_has_happened
+    when_the_first_interview_has_only_just_happened
+    then_the_completed_interview_still_shows_as_upcoming
+
+    when_the_first_interview_happened_yesterday
     then_i_see_the_upcoming_interview_under_the_correct_heading
     and_i_see_the_past_interview_under_the_correct_heading
 
@@ -57,10 +60,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     i_can_see_the_application_is_awaiting_provider_decision
     and_the_interview_tab_is_not_available
 
-    # TODO: the "make decision" prompt does not show here because of the flash message
-    # should be fixed with https://trello.com/c/dI0l2hyl/3364-call-to-action-inset-text-is-hidden-when-flash-banner-is-shown-on-provider-application-page
-    when_i_reload_the_page
-    and_i_set_up_another_interview(days_in_future: 4)
+    and_i_set_up_another_interview(days_in_future: 3)
     and_another_interview_has_been_created('6 March 2020')
 
     when_i_click_make_decision
@@ -156,8 +156,20 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   alias_method :and_another_interview_has_been_created, :and_an_interview_has_been_created
 
-  def when_the_first_interview_has_happened
+  def when_the_first_interview_has_only_just_happened
     Timecop.travel(2020, 3, 2, 13, 0, 0)
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_application_choice_interviews_path(application_choice)
+  end
+
+  def then_the_completed_interview_still_shows_as_upcoming
+    expect(page).to have_css('.app-interviews > :nth-child(2)', text: 'Upcoming interviews')
+    expect(page).to have_css('.app-interviews > :nth-child(3)', text: '2 March 2020')
+    expect(page).to have_css('.app-interviews > :nth-child(4)', text: '3 March 2020')
+  end
+
+  def when_the_first_interview_happened_yesterday
+    Timecop.travel(2020, 3, 3, 9, 0, 0)
     provider_signs_in_using_dfe_sign_in
     visit provider_interface_application_choice_interviews_path(application_choice)
   end


### PR DESCRIPTION


## Context

This means that a provider can still see interviews that have just happened in the upcoming interviews sections

## Changes proposed in this pull request
Add scopes to select interviews in the past, or interviews that are upcoming

## Guidance to review
Does it make sense?

## Link to Trello card
https://trello.com/c/CGPoJnQM/3418-interviews-should-only-be-marked-as-in-the-past-the-next-day

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
