### PR TITLE
Only send email if edit interview actually changes the interview

### DIFF
--- a/app/services/update_interview.rb
+++ b/app/services/update_interview.rb
@@ -23,12 +23,14 @@ class UpdateInterview
       course_option_id: interview.application_choice.offered_option.id,
     )
 
-    interview.update!(
-      provider: provider,
-      date_and_time: date_and_time,
-      location: location,
-      additional_details: additional_details,
-    )
+    interview.provider = provider
+    interview.date_and_time = date_and_time
+    interview.location = location
+    interview.additional_details = additional_details
+
+    return unless interview.changed?
+
+    interview.save!
 
     CandidateMailer.interview_updated(interview.application_choice, interview).deliver_later
   end


### PR DESCRIPTION
## Context
Currently, an email will be sent even when there are no change to the interview details

## Changes proposed in this pull request
Only save the interview and send an email if the updates actually change the interview

## Guidance to review
Have I missed any edge cases?

## Link to Trello card
https://trello.com/c/UMuoDuKF/3417-dont-send-an-email-following-the-change-interview-flow-if-no-details-were-changed

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
