### PR TITLE
Enable support agents to replace withdrawn application choices

### DIFF
--- a/app/components/support_interface/application_add_course_component.html.erb
+++ b/app/components/support_interface/application_add_course_component.html.erb
@@ -4,7 +4,7 @@
   </p>
 <% elsif application_form.support_cannot_add_course_choice? %>
   <p class='govuk-body'>
-    This application already has the maximum number of active course choices (<%= application_form.maximum_number_of_course_choices %>), so we can't add any more.
+    This application already has the maximum number of active course choices (<%= application_form.maximum_number_of_course_choices %>), so we can't add any more until the candidate withdraws one or more course choices.
   </p>
 <% else %>
   <%= govuk_button_link_to 'Add a course', support_interface_application_form_search_course_new_path(application_form_id: application_form.id), form_class: 'govuk-!-display-inline-block' %>

--- a/app/components/support_interface/application_add_course_component.html.erb
+++ b/app/components/support_interface/application_add_course_component.html.erb
@@ -2,9 +2,9 @@
   <p class='govuk-body'>
     This candidate can add <%= application_form.maximum_number_of_course_choices %> course choices to this application.
   </p>
-<% elsif application_form.has_the_maximum_number_of_course_choices? %>
+<% elsif application_form.support_cannot_add_course_choice? %>
   <p class='govuk-body'>
-    This application already has the maximum number of course choices (<%= application_form.maximum_number_of_course_choices %>), so we can't add any more.
+    This application already has the maximum number of active course choices (<%= application_form.maximum_number_of_course_choices %>), so we can't add any more.
   </p>
 <% else %>
   <%= govuk_button_link_to 'Add a course', support_interface_application_form_search_course_new_path(application_form_id: application_form.id), form_class: 'govuk-!-display-inline-block' %>

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -122,7 +122,7 @@ module SupportInterface
         key: 'Average distance to sites',
         value: format_average_distance(
           application_form,
-          application_form.application_choices.map(&:site),
+          application_form.application_choices.includes([:course_option, :site, :accredited_provider, :interviews]).map(&:site),
         ),
       }
     end

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -122,7 +122,7 @@ module SupportInterface
         key: 'Average distance to sites',
         value: format_average_distance(
           application_form,
-          application_form.application_choices.includes([:course_option, :site, :accredited_provider, :interviews]).map(&:site),
+          application_form.application_choices.includes(%i[course_option site accredited_provider interviews]).map(&:site),
         ),
       }
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -298,6 +298,10 @@ class ApplicationForm < ApplicationRecord
     application_choices.count >= maximum_number_of_course_choices
   end
 
+  def support_cannot_add_course_choice?
+    application_choices.where.not(status: :withdrawn).count >= maximum_number_of_course_choices
+  end
+
   def maximum_number_of_course_choices
     if apply_1?
       MAXIMUM_PHASE_ONE_COURSE_CHOICES

--- a/spec/components/support_interface/application_add_course_component_spec.rb
+++ b/spec/components/support_interface/application_add_course_component_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe SupportInterface::ApplicationAddCourseComponent do
     end
   end
 
+  context 'application is submitted and has three application choices including one that is withdrawn' do
+    it "renders the 'add a course' button" do
+      application_form = create(:completed_application_form)
+      create_list(:submitted_application_choice, 3, application_form_id: application_form.id)
+
+      withdrawn_application_choice = application_form.application_choices.last
+      ApplicationStateChange.new(withdrawn_application_choice).withdraw!
+      withdrawn_application_choice.update(withdrawn_at: Time.zone.now)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-button').text).to include('Add a course')
+    end
+  end
+
   context 'application is submitted and has more than three application choices' do
     it "does not render the 'add a course' button" do
       application_form = create(:completed_application_form)

--- a/spec/system/support_interface/add_course_to_submitted_application_spec.rb
+++ b/spec/system/support_interface/add_course_to_submitted_application_spec.rb
@@ -32,14 +32,6 @@ RSpec.feature 'Add course to submitted application' do
     when_i_select_a_course
     and_i_click_add_course_to_application
     then_i_should_see_the_application_with_the_course_added
-
-    when_there_are_two_more_courses_added
-    and_i_visit_the_application_page
-    then_i_should_not_be_able_to_add_further_courses
-
-    when_one_course_is_withdrawn
-    and_i_visit_the_application_page
-    then_i_should_be_able_to_add_further_courses
   end
 
   def given_i_am_a_support_user
@@ -145,28 +137,5 @@ RSpec.feature 'Add course to submitted application' do
   def then_i_should_see_the_application_with_the_course_added
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
     expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
-  end
-
-  def when_there_are_two_more_courses_added
-    create_list(:submitted_application_choice, 2, application_form: @application_form)
-  end
-
-  def and_i_visit_the_application_page
-    visit support_interface_application_form_path(application_form_id: @application_form.id)
-  end
-
-  def then_i_should_not_be_able_to_add_further_courses
-    expect(page).to have_content 'This application already has the maximum number of active course choices'
-    expect(page).not_to have_link 'Add a course'
-  end
-
-  def when_one_course_is_withdrawn
-    application_choice = @application_form.application_choices.last
-    ApplicationStateChange.new(application_choice).withdraw!
-    application_choice.update(withdrawn_at: Time.zone.now)
-  end
-
-  def then_i_should_be_able_to_add_further_courses
-    expect(page).to have_link 'Add a course'
   end
 end

--- a/spec/system/support_interface/add_course_to_submitted_application_spec.rb
+++ b/spec/system/support_interface/add_course_to_submitted_application_spec.rb
@@ -32,6 +32,14 @@ RSpec.feature 'Add course to submitted application' do
     when_i_select_a_course
     and_i_click_add_course_to_application
     then_i_should_see_the_application_with_the_course_added
+
+    when_there_are_two_more_courses_added
+    and_i_visit_the_application_page
+    then_i_should_not_be_able_to_add_further_courses
+
+    when_one_course_is_withdrawn
+    and_i_visit_the_application_page
+    then_i_should_be_able_to_add_further_courses
   end
 
   def given_i_am_a_support_user
@@ -137,5 +145,28 @@ RSpec.feature 'Add course to submitted application' do
   def then_i_should_see_the_application_with_the_course_added
     expect(page).to have_current_path support_interface_application_form_path(application_form_id: @application_form.id)
     expect(page).to have_content("#{RecruitmentCycle.current_year}: #{@course_option.course.name} (#{@course_option.course.code})")
+  end
+
+  def when_there_are_two_more_courses_added
+    create_list(:submitted_application_choice, 2, application_form: @application_form)
+  end
+
+  def and_i_visit_the_application_page
+    visit support_interface_application_form_path(application_form_id: @application_form.id)
+  end
+
+  def then_i_should_not_be_able_to_add_further_courses
+    expect(page).to have_content 'This application already has the maximum number of active course choices'
+    expect(page).not_to have_link 'Add a course'
+  end
+
+  def when_one_course_is_withdrawn
+    application_choice = @application_form.application_choices.last
+    ApplicationStateChange.new(application_choice).withdraw!
+    application_choice.update(withdrawn_at: Time.zone.now)
+  end
+
+  def then_i_should_be_able_to_add_further_courses
+    expect(page).to have_link 'Add a course'
   end
 end


### PR DESCRIPTION
## Context

We have had a few support requests to manually withdraw an application choice for a submitted application and replace it with a new course. This isn't possible in the support interface if the total number of choices (including withdrawn ones) is already at the upper limit (3 for apply 1, 1 for apply 2).

This PR permits additional application choices to be added if there are less than the maximum number of live choices.

## Changes proposed in this pull request

- [x] Refine the logic around whether or not to display the _Add new course_ button to take withdrawn applications into account.
- [x] Fix 1+n query highlighted by Bullet after adding multiple application choices to an application and viewing it in the support interface.
- [ ] Update support guide

## Guidance to review

- Is this a safe thing to allow support agents to do?
- Not sure about the 1+n query fix as it's nothing directly to do with this change.

## Link to Trello card

https://trello.com/c/rYuPHyiQ/3068-enable-support-agents-to-switch-candidates-course-options

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
