### PR TITLE
Exclude the application status transition from cancelling an interview

### DIFF
--- a/app/queries/get_activity_log_events.rb
+++ b/app/queries/get_activity_log_events.rb
@@ -52,6 +52,11 @@ class GetActivityLogEvents
     filtered_statuses = ApplicationStateChange::STATES_VISIBLE_TO_PROVIDER - IGNORE_STATUS
     status_transitions_to_include = filtered_statuses.map { |status| "'#{status}'" }.join(', ')
 
-    application_choice_audits_filter + " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"
+    application_choice_audits_filter += " OR audited_changes::json#>>'{status, 1}' IN (#{status_transitions_to_include})"
+    application_choice_audits_filter + ignore_interview_cancelled_application_choice_status_change_sql
+  end
+
+  def self.ignore_interview_cancelled_application_choice_status_change_sql
+    %( AND NOT audited_changes @> '{"status" : ["interviewing", "awaiting_provider_decision"]}')
   end
 end


### PR DESCRIPTION
## Context

When an interview is cancelled the application reverts to `awaiting_provider_decision` status and this update appears in the timeline and activity log, the audit entry for the cancelled interview is more accurate in describing what has happened so we should filter out this status change.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Filter application choice status update from `interviewing` to `awaiting_provider_decision` when cancelling an interview. 
This is consistent with filtering the application status change when creating an interview.


![image](https://user-images.githubusercontent.com/93511/108737266-57f9d880-752a-11eb-8240-efca61f2b33c.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Create an interview on an application and then cancel it, you should only see the setup and cancel events for the interview in the activity log.

Is there a more concise way to compare the status change array from `audited_changes` ? 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Bk1MQA1L/3419-timeline-activity-log-show-an-application-received-event-after-an-interview-was-cancelled
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
