### PR TITLE
Attempt to fix E&D export

### DIFF
--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -18,7 +18,7 @@ module SupportInterface
           'Third structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[2]&.structured_rejection_reasons),
         }
 
-        disabilities = application_form.equality_and_diversity['disabilities']
+        disabilities = application_form.equality_and_diversity['disabilities'].to_a
 
         disabilities.map.with_index(1) do |disability, index|
           output["Disability #{index}"] = disability


### PR DESCRIPTION
## Context

We're seeing this on prod:

https://sentry.io/organizations/dfe-bat/issues/2200848096

## Changes proposed in this pull request

I assume that some records may not have `equality_and_diversity['disabilities']` specified, which this should
fix.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/2200848096

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
