### PR TITLE
Add a word limit to interview free text fields

### DIFF
--- a/app/forms/provider_interface/cancel_interview_wizard.rb
+++ b/app/forms/provider_interface/cancel_interview_wizard.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     attr_accessor :cancellation_reason
 
-    validates :cancellation_reason, presence: true, length: { maximum: 10240 }
+    validates :cancellation_reason, presence: true, word_count: { maximum: 2000 }
 
     def initialize(state_store, attrs = {})
       @state_store = state_store

--- a/app/forms/provider_interface/interview_wizard.rb
+++ b/app/forms/provider_interface/interview_wizard.rb
@@ -20,8 +20,8 @@ module ProviderInterface
                                        unless: ->(c) { %i[date time].any? { |d| c.errors.keys.include?(d) } }
     validate :date_after_rbd_date, if: %i[date_and_time date_and_time_in_future]
     validates :provider_id, presence: true, if: %i[application_choice provider_user multiple_application_providers?]
-    validates :location, presence: true, length: { maximum: 10240 }
-    validates :additional_details, length: { maximum: 10240 }
+    validates :location, presence: true, word_count: { maximum: 2000 }
+    validates :additional_details, word_count: { maximum: 2000 }
 
     def initialize(state_store, attrs = {})
       @state_store = state_store

--- a/spec/forms/provider_interface/cancel_interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/cancel_interview_wizard_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe ProviderInterface::CancelInterviewWizard do
   let(:subject) { described_class.new(store) }
 
   describe '.validations' do
+    valid_text = Faker::Lorem.sentence(word_count: 2000)
+    invalid_text = Faker::Lorem.sentence(word_count: 2001)
+
     it { is_expected.to validate_presence_of(:cancellation_reason) }
-    it { is_expected.to validate_length_of(:cancellation_reason).is_at_most(10240) }
+    it { is_expected.to allow_value(valid_text).for(:cancellation_reason) }
+    it { is_expected.not_to allow_value(invalid_text).for(:cancellation_reason) }
   end
 end

--- a/spec/forms/provider_interface/interview_wizard_spec.rb
+++ b/spec/forms/provider_interface/interview_wizard_spec.rb
@@ -35,11 +35,16 @@ RSpec.describe ProviderInterface::InterviewWizard do
       it { is_expected.to validate_presence_of(:application_choice) }
     end
 
-    context 'field length checks' do
+    context 'word count checks' do
       let(:subject) { described_class.new(store) }
 
-      it { is_expected.to validate_length_of(:location).is_at_most(10240) }
-      it { is_expected.to validate_length_of(:additional_details).is_at_most(10240) }
+      valid_text = Faker::Lorem.sentence(word_count: 2000)
+      invalid_text = Faker::Lorem.sentence(word_count: 2001)
+
+      it { is_expected.to allow_value(valid_text).for(:location) }
+      it { is_expected.not_to allow_value(invalid_text).for(:location) }
+      it { is_expected.to allow_value(valid_text).for(:additional_details) }
+      it { is_expected.not_to allow_value(invalid_text).for(:additional_details) }
     end
 
     describe '#date' do


### PR DESCRIPTION
## Context

We use word count for the text fields, as opposed to character limit.
The upper limit on character count is 10240, which is the standard "baggy" limit for free text fields over the API.
We don't want to limit users too much. Given that average length of a word is just over 5 characters, the limit of 2000 words seems reasonable.

## Changes proposed in this pull request

Limit word count to 2000 words.

<img width="470" alt="Screenshot 2021-02-22 at 14 30 54" src="https://user-images.githubusercontent.com/38078064/108817726-41966000-75b0-11eb-9582-f423a7561ff7.png">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Q6GEtZpp/3416-add-a-word-limit-to-interview-free-text-fields

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
