### PR TITLE
Add length validation for ApplicationQualification#other_uk_qualification_type

### DIFF
--- a/app/forms/candidate_interface/other_qualification_details_form.rb
+++ b/app/forms/candidate_interface/other_qualification_details_form.rb
@@ -24,6 +24,7 @@ module CandidateInterface
     validates :award_year, presence: true, year: { future: true }
     validates :subject, :grade, presence: true, if: -> { should_validate_grade? }
     validates :subject, :grade, length: { maximum: 255 }
+    validates :other_uk_qualification_type, length: { maximum: 100 }
     validates :institution_country, presence: true, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
     validates :institution_country, inclusion: { in: COUNTRIES }, if: -> { qualification_type == OtherQualificationTypeForm::NON_UK_TYPE }
     validate :grade_format_is_valid, if: :grade, on: :details

--- a/app/forms/candidate_interface/other_qualification_type_form.rb
+++ b/app/forms/candidate_interface/other_qualification_type_form.rb
@@ -27,6 +27,7 @@ module CandidateInterface
     validates :qualification_type, presence: true
     validates :qualification_type, inclusion: { in: ALL_VALID_TYPES, allow_blank: false }
     validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == OTHER_TYPE }
+    validates :other_uk_qualification_type, length: { maximum: 100 }
     validates :non_uk_qualification_type, presence: true, if: -> { qualification_type == NON_UK_TYPE }
 
     def initialize(current_application = nil, intermediate_data_service = nil, options = nil)

--- a/config/locales/candidate_interface/other_qualification.yml
+++ b/config/locales/candidate_interface/other_qualification.yml
@@ -43,6 +43,7 @@ en:
               blank: Enter the type of qualification
             other_uk_qualification_type:
               blank: Enter the type of qualification
+              too_long: Type of qualification must be %{count} characters or fewer
             qualification_type:
               blank: Enter the type of qualification
               too_long: Type of qualification must be %{count} characters or fewer
@@ -52,6 +53,7 @@ en:
               blank: Enter the type of qualification
             other_uk_qualification_type:
               blank: Enter the type of qualification
+              too_long: Type of qualification must be %{count} characters or fewer
             qualification_type:
               blank: Enter the type of qualification
               too_long: Type of qualification must be %{count} characters or fewer

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     it { is_expected.to validate_presence_of(:award_year).on(:details) }
     it { is_expected.to validate_length_of(:subject).is_at_most(255) }
     it { is_expected.to validate_length_of(:grade).is_at_most(255) }
+    it { is_expected.to validate_length_of(:other_uk_qualification_type).is_at_most(100) }
 
     describe 'subject' do
       it 'validates presence except for non-uk and other qualifications' do

--- a/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_type_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:qualification_type) }
+    it { is_expected.to validate_length_of(:other_uk_qualification_type).is_at_most(100) }
   end
 
   describe '#initialize' do


### PR DESCRIPTION
## Context

There is an unvalidated 100 character limit on the `other_uk_qualification_type` database column. This led to Sentry errors:

https://sentry.io/organizations/dfe-bat/issues/2221389527/?project=1765973

## Changes proposed in this pull request

This PR just adds the necessary validation to the forms.

<img width="530" alt="image" src="https://user-images.githubusercontent.com/450843/108837802-b4143980-75ca-11eb-8bc3-a3f264c82d51.png">

## Guidance to review

- Should be possible to reproduce the error on `qa` right now and confirm it's fixed in the review app. To reproduce add a new 'other qualification' and pick 'Other UK qualification', then enter 101 characters in the type text field.

## Link to Trello card

https://trello.com/c/ws615Bc8/3067-validate-length-of-otherukqualificationtype

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)