### PR TITLE
Proof of concept - persisted feature metrics dashboard

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -17,10 +17,7 @@ module SupportInterface
     end
 
     def feature_metrics_dashboard
-      @reference_statistics = ReferenceFeatureMetrics.new
-      @work_history_statistics = WorkHistoryFeatureMetrics.new
-      @magic_link_statistics = MagicLinkFeatureMetrics.new
-      @reasons_for_rejection_statistics = ReasonsForRejectionFeatureMetrics.new
+      @dashboard = FeatureMetricsDashboard.last
     end
 
     def reasons_for_rejection_dashboard

--- a/app/models/feature_metrics_dashboard.rb
+++ b/app/models/feature_metrics_dashboard.rb
@@ -1,0 +1,34 @@
+class FeatureMetricsDashboard < ApplicationRecord
+  def load_updated_metrics
+    dashboard.avg_time_to_get_references = reference_statistics.average_time_to_get_references(
+      EndOfCycleTimetable.apply_reopens.beginning_of_day,
+    )
+    dashboard.avg_time_to_get_references_this_month = reference_statistics.average_time_to_get_references(
+      Time.zone.now.beginning_of_month,
+    )
+    dashboard.avg_time_to_get_references_last_month = reference_statistics.average_time_to_get_references(
+      Time.zone.now.beginning_of_month - 1.month,
+      Time.zone.now.beginning_of_month,
+    )
+
+    # and so on, for all columns
+  end
+
+private
+
+  def reference_statistics
+    ReferenceFeatureMetrics.new
+  end
+
+  def work_history_statistics
+    WorkHistoryFeatureMetrics.new
+  end
+
+  def magic_link_statistics
+    MagicLinkFeatureMetrics.new
+  end
+
+  def reasons_for_rejection_statistics
+    ReasonsForRejectionFeatureMetrics.new
+  end
+end

--- a/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
+++ b/app/views/support_interface/performance/feature_metrics_dashboard.html.erb
@@ -14,9 +14,7 @@
   <div class="govuk-grid-column-one-half">
     <div id="headline-stat" class="govuk-!-margin-bottom-4">
       <%= render SupportInterface::TileComponent.new(
-        count: @reference_statistics.average_time_to_get_references(
-          EndOfCycleTimetable.apply_reopens.beginning_of_day,
-        ),
+        count: @dashboard.avg_time_to_get_references,
         label: 'average time to get reference back',
         colour: :blue,
         size: :reduced,
@@ -25,19 +23,14 @@
     <div class="govuk-grid-row govuk-!-margin-bottom-4">
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
-          count: @reference_statistics.average_time_to_get_references(
-            Time.zone.now.beginning_of_month,
-          ),
+          count: @dashboard.avg_time_to_get_references_this_month,
           label: 'this month',
           size: :reduced,
         ) %>
       </div>
       <div class="govuk-grid-column-one-half">
         <%= render SupportInterface::TileComponent.new(
-          count: @reference_statistics.average_time_to_get_references(
-            Time.zone.now.beginning_of_month - 1.month,
-            Time.zone.now.beginning_of_month,
-          ),
+          count: @dashboard.avg_time_to_get_references_last_month,
           label: 'last month',
           size: :reduced,
         ) %>

--- a/app/workers/update_feature_metrics_dashboard.rb
+++ b/app/workers/update_feature_metrics_dashboard.rb
@@ -1,0 +1,11 @@
+class UpdateFeatureMetricsDashboard
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 0, queue: :low_priority
+
+  def perform
+    dashboard = FeatureMetricsDashboard.new
+    dashboard.load_updated_metrics
+    dashboard.save!
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -18,6 +18,8 @@ class Clock
   every(1.hour, 'SendChaseEmailToProviders', at: '**:35') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
 
+  every(1.hour, 'UpdateFeatureMetricsDashboard', at: '**:45') { UpdateFeatureMetricsDashboard.perform_async }
+
   every(1.day, 'Generate export for TAD', at: '23:59') do
     data_export = DataExport.create!(name: 'Daily export of applications for TAD')
     DataExporter.perform_async(SupportInterface::TADExport, data_export.id)

--- a/db/migrate/20210223114041_create_feature_metrics_dashboard.rb
+++ b/db/migrate/20210223114041_create_feature_metrics_dashboard.rb
@@ -1,0 +1,32 @@
+class CreateFeatureMetricsDashboard < ActiveRecord::Migration[6.0]
+  def change
+    create_table :feature_metrics_dashboards do |t|
+      t.timestamps
+
+      t.float :avg_time_to_get_references
+      t.float :avg_time_to_get_references_this_month
+      t.float :avg_time_to_get_references_last_month
+      t.float :pct_references_completed_within_30_days
+      t.float :pct_references_completed_within_30_days_this_month
+      t.float :pct_references_completed_within_30_days_last_month
+
+      t.float :avg_time_to_complete_work_history
+      t.float :avg_time_to_complete_work_history_this_month
+      t.float :avg_time_to_complete_work_history_last_month
+
+      t.float :avg_sign_ins_before_submitting
+      t.float :avg_sign_ins_before_submitting_this_month
+      t.float :avg_sign_ins_before_submitting_last_month
+      t.float :avg_sign_ins_before_offer
+      t.float :avg_sign_ins_before_offer_this_month
+      t.float :avg_sign_ins_before_offer_last_month
+      t.float :avg_sign_ins_before_recruitment
+      t.float :avg_sign_ins_before_recruitment_this_month
+      t.float :avg_sign_ins_before_recruitment_last_month
+
+      t.integer :num_rejections_due_to_qualifications
+      t.integer :num_rejections_due_to_qualifications_this_month
+      t.integer :num_rejections_due_to_qualifications_last_month
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_17_131741) do
+ActiveRecord::Schema.define(version: 2021_02_23_114041) do
 
   create_sequence "application_choices_id_seq"
   create_sequence "application_experiences_id_seq"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2021_02_17_131741) do
   create_sequence "data_exports_id_seq"
   create_sequence "emails_id_seq"
   create_sequence "english_proficiencies_id_seq"
+  create_sequence "feature_metrics_dashboards_id_seq"
   create_sequence "features_id_seq"
   create_sequence "find_feedback_id_seq"
   create_sequence "ielts_qualifications_id_seq"
@@ -433,6 +434,32 @@ ActiveRecord::Schema.define(version: 2021_02_17_131741) do
     t.text "no_qualification_details"
     t.index ["application_form_id"], name: "index_english_proficiencies_on_application_form_id", unique: true
     t.index ["efl_qualification_type", "efl_qualification_id"], name: "index_elp_on_efl_qualification_type_and_id"
+  end
+
+  create_table "feature_metrics_dashboards", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.float "avg_time_to_get_references"
+    t.float "avg_time_to_get_references_this_month"
+    t.float "avg_time_to_get_references_last_month"
+    t.float "pct_references_completed_within_30_days"
+    t.float "pct_references_completed_within_30_days_this_month"
+    t.float "pct_references_completed_within_30_days_last_month"
+    t.float "avg_time_to_complete_work_history"
+    t.float "avg_time_to_complete_work_history_this_month"
+    t.float "avg_time_to_complete_work_history_last_month"
+    t.float "avg_sign_ins_before_submitting"
+    t.float "avg_sign_ins_before_submitting_this_month"
+    t.float "avg_sign_ins_before_submitting_last_month"
+    t.float "avg_sign_ins_before_offer"
+    t.float "avg_sign_ins_before_offer_this_month"
+    t.float "avg_sign_ins_before_offer_last_month"
+    t.float "avg_sign_ins_before_recruitment"
+    t.float "avg_sign_ins_before_recruitment_this_month"
+    t.float "avg_sign_ins_before_recruitment_last_month"
+    t.integer "num_rejections_due_to_qualifications"
+    t.integer "num_rejections_due_to_qualifications_this_month"
+    t.integer "num_rejections_due_to_qualifications_last_month"
   end
 
   create_table "features", force: :cascade do |t|


### PR DESCRIPTION
## Context
The feature metrics dashboard takes ~1.5 minutes to load. We need to make this faster.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This is a proof of concept which illustrates:

- Using a dedicated table to hold the statistics we display on the dashboard.
- Updating this table hourly via a Sidekiq worker.
- Moving retrieval of all metrics into the FeatureMetricsDashboard ActiveRecord model.
- Calling methods on an instance of this model when rendering the view.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Does this work? Does it make sense?
- Alternatives considered:
  - Optimise the existing SQL queries, especially for work history and magic links. I prioritised the approach in this PR instead, as the existing queries are fairly complex as is. Rather than additional SQL complexity, I've opted for more complexity around the update mechanism for the dashboard. This is probably easier to reason about and gives us the biggest speed increase.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/NAENgBR6
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
