### PR TITLE
Add new guidance to course search page on Support UI

### DIFF
--- a/app/views/support_interface/application_forms/courses/new_search.html.erb
+++ b/app/views/support_interface/application_forms/courses/new_search.html.erb
@@ -4,6 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">A candidate can only add up to 3 courses. They cannot add the same course twice.</p>
+
+    <p class="govuk-body">The support team can modify the course selections within the first 5 working days that the application was submitted.</p>
+    <p class="govuk-body">Support team users can add course choices. Candidates should withdraw their own course choices if possible. If this is not possible, and the application was submitted within the first 5 working days, then a course choice can be sent to a developer to remove. The developer or support team could then add course choice(s).</p>
     <p class="govuk-body">You can find the course code by searching on
       <%= govuk_link_to(
         'Find postgraduate teacher training',


### PR DESCRIPTION
## Context

In order to assist the support team in using the support UI more effectively, further guidance needs
to be added to the search course view.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/62567622/108867738-66f58f00-75ed-11eb-97e7-7c502dc27d96.png)

## Guidance to review

Is it worth extracting some of this text into a partial?

## Link to Trello card

https://trello.com/c/GeEcKIP2/3025-dev-support-ui-guidance-to-the-add-course-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
