### PR TITLE
Refactor factories

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -64,8 +64,8 @@ class TestApplications
 
     Audited.audit_class.as_user(candidate) do
       traits = [%i[with_safeguarding_issues_disclosed
-                   with_no_safeguarding_issues_to_declare
-                   with_safeguarding_issues_never_asked].sample]
+                   with_safeguarding_issues_never_asked
+                   minimum_info]].sample
       traits << :with_equality_and_diversity_data if rand < 0.55
 
       simulate_signin(candidate)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -73,11 +73,11 @@ class TestApplications
       @application_form = FactoryBot.create(
         :completed_application_form,
         *traits,
+        :with_degree,
+        :with_gcses,
         application_choices_count: 0,
         full_work_history: true,
         volunteering_experiences_count: 1,
-        with_gcses: true,
-        with_degree: true,
         submitted_at: nil,
         candidate: candidate,
         first_name: first_name,
@@ -94,20 +94,14 @@ class TestApplications
       @application_form.application_work_history_breaks.each { |experience| experience.update!(created_at: time) }
 
       # One reference that will never be requested
-      FactoryBot.create(:reference, :not_requested_yet, application_form: @application_form)
+      @application_form.application_references << FactoryBot.build(:reference, :not_requested_yet)
 
       # 4 will be requested
-      4.times do
-        reference = FactoryBot.create(
-          :reference,
-          :not_requested_yet,
-          application_form: @application_form,
-          created_at: time,
-          updated_at: time,
-        )
-        RequestReference.new.call(reference)
-        reference.update!(requested_at: time)
-      end
+      @application_form.application_references << FactoryBot.build_list(:reference,
+                                                                        4,
+                                                                        :feedback_requested,
+                                                                        created_at: time,
+                                                                        updated_at: time)
 
       fast_forward
 

--- a/spec/components/candidate_interface/carry_over_banner_component_spec.rb
+++ b/spec/components/candidate_interface/carry_over_banner_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::CarryOverBannerComponent do
-  let(:application_form) { create(:completed_application_form) }
+  let(:application_form) { build(:completed_application_form) }
 
   before { allow(RecruitmentCycle).to receive(:current_year).and_return(2021) }
 
@@ -110,8 +110,9 @@ RSpec.describe CandidateInterface::CarryOverBannerComponent do
 
     it 'renders component when references did not come back in time' do
       create(:application_choice, :with_rejection, application_form: application_form)
-      create(:reference, application_form: application_form, feedback_status: :cancelled_at_end_of_cycle)
+      application_form.application_references << build(:reference, feedback_status: :cancelled_at_end_of_cycle)
       application_form.recruitment_cycle_year = 2021
+
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include('Your references did not come back in time')

--- a/spec/components/previews/provider_interface/safeguarding_declaration_component_preview.rb
+++ b/spec/components/previews/provider_interface/safeguarding_declaration_component_preview.rb
@@ -8,7 +8,7 @@ module ProviderInterface
 
     def can_view__with_no_safeguarding_issues
       find_user_and_course safeguarding_access: true
-      build_application_choice :with_no_safeguarding_issues_to_declare
+      build_application_choice :minimum_info
       render_component
     end
 

--- a/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
+++ b/spec/components/provider_interface/interview_and_course_summary_component_spec.rb
@@ -8,8 +8,13 @@ RSpec.describe ProviderInterface::InterviewAndCourseSummaryComponent do
     expect(component).to include(interview.application_choice.course.funding_type.capitalize)
   end
 
-  it 'displays interview preferences' do
-    expect(component).to include(interview.application_choice.application_form.interview_preferences)
+  context 'interview preferences' do
+    let(:application_choice) { create(:application_choice, :with_completed_application_form) }
+    let(:interview) { create(:interview, application_choice: application_choice) }
+
+    it 'displays interview preferences' do
+      expect(component).to include(interview.application_choice.application_form.interview_preferences)
+    end
   end
 
   it 'displays the provider name' do

--- a/spec/components/support_interface/application_choice_component_spec.rb
+++ b/spec/components/support_interface/application_choice_component_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationChoiceComponent do
   it 'displays the date an application was rejected' do
-    application_choice = create(:application_choice, :with_rejection, rejected_at: Time.zone.local(2020, 1, 1, 10, 0, 0))
+    application_choice = create(:application_choice,
+                                :with_completed_application_form,
+                                :with_rejection,
+                                rejected_at: Time.zone.local(2020, 1, 1, 10, 0, 0))
 
     result = render_inline(described_class.new(application_choice))
 
@@ -11,7 +14,10 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   end
 
   it 'displays the date an application was rejected by default' do
-    application_choice = create(:application_choice, :with_rejection_by_default, rejected_at: Time.zone.local(2020, 1, 1, 10, 0, 0))
+    application_choice = create(:application_choice,
+                                :with_completed_application_form,
+                                :with_rejection_by_default,
+                                rejected_at: Time.zone.local(2020, 1, 1, 10, 0, 0))
 
     result = render_inline(described_class.new(application_choice))
 
@@ -20,7 +26,9 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   end
 
   it 'displays reasons for rejection on rejected application with structured reasons' do
-    application_choice = create(:application_choice, :with_structured_rejection_reasons)
+    application_choice = create(:application_choice,
+                                :with_completed_application_form,
+                                :with_structured_rejection_reasons)
 
     result = render_inline(described_class.new(application_choice))
 
@@ -30,7 +38,9 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   end
 
   it 'displays reasons for rejection on rejected application without structured reasons' do
-    application_choice = create(:application_choice, :with_rejection)
+    application_choice = create(:application_choice,
+                                :with_completed_application_form,
+                                :with_rejection)
 
     result = render_inline(described_class.new(application_choice))
 
@@ -41,6 +51,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   it 'displays offer date and DBD date for offered applications' do
     application_choice = create(
       :application_choice,
+      :with_completed_application_form,
       :with_offer,
       offered_at: Time.zone.local(2020, 1, 1, 10),
       decline_by_default_at: Time.zone.local(2020, 1, 10, 10),
@@ -58,6 +69,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   it 'does not display DBD date for offered applications when it has not yet been set' do
     application_choice = create(
       :application_choice,
+      :with_completed_application_form,
       :with_offer,
       offered_at: Time.zone.local(2020, 1, 1, 10),
       decline_by_default_at: nil,
@@ -71,6 +83,7 @@ RSpec.describe SupportInterface::ApplicationChoiceComponent do
   it 'displays the course offered by the provider when the applied course is different' do
     application_choice = create(
       :application_choice,
+      :with_completed_application_form,
       :with_offer,
       offered_course_option: create(:course_option),
       offered_at: Time.zone.local(2020, 1, 1, 10),

--- a/spec/decorators/application_choice_export_decorator_spec.rb
+++ b/spec/decorators/application_choice_export_decorator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ApplicationChoiceExportDecorator do
   describe 'gcse_qualifications_summary' do
     it 'returns a summary of maths, science and english GCSEs for an application form' do
-      application_form = create(:completed_application_form, with_gcses: true)
+      application_form = create(:application_form, :with_gcses)
       application_choice = create(:application_choice, application_form: application_form)
 
       summary = described_class.new(application_choice).gcse_qualifications_summary
@@ -12,7 +12,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
     end
 
     it 'does not include gcses in other subjects' do
-      application_form = create(:completed_application_form, with_gcses: true)
+      application_form = create(:application_form, :with_gcses)
       application_choice = create(:application_choice, application_form: application_form)
       create(:application_qualification, level: :gcse, subject: :french, application_form: application_form)
 
@@ -23,7 +23,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
     end
 
     it 'includes qualifications that are equivalent to gcses' do
-      application_form = create(:completed_application_form)
+      application_form = create(:application_form)
       application_choice = create(:application_choice, application_form: application_form)
       o_level = create(:application_qualification, level: :gcse, qualification_type: 'gce_o_level', subject: :maths, application_form: application_form)
 
@@ -54,7 +54,7 @@ RSpec.describe ApplicationChoiceExportDecorator do
     end
 
     it 'returns nil if a form has no missing gcses' do
-      application_form = create(:completed_application_form, with_gcses: true)
+      application_form = create(:application_form, :with_gcses)
       application_choice = create(:application_choice, application_form: application_form)
 
       explanation = described_class.new(application_choice).missing_gcses_explanation

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -518,10 +518,18 @@ FactoryBot.define do
   end
 
   factory :application_choice do
-    association :application_form, factory: %i[completed_application_form with_completed_references with_degree]
     course_option
+    application_form
 
     status { ApplicationStateChange.valid_states.sample }
+
+    trait :with_completed_application_form do
+      association :application_form, factory: %i[completed_application_form]
+    end
+
+    trait :application_form_with_degree do
+      association :application_form, factory: %i[completed_application_form with_degree]
+    end
 
     factory :submitted_application_choice do
       status { 'awaiting_provider_decision' }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -740,7 +740,8 @@ FactoryBot.define do
     end
 
     trait :previous_year do
-      course_option { create(:course_option, :previous_year) }
+      association :course_option, :previous_year
+
       after(:create) do |choice, _evaluator|
         choice.application_form.update_columns(
           recruitment_cycle_year: RecruitmentCycle.previous_year,
@@ -749,7 +750,8 @@ FactoryBot.define do
     end
 
     trait :previous_year_but_still_available do
-      course_option { create(:course_option, :previous_year_but_still_available) }
+      association :course_option, :previous_year_but_still_available
+
       after(:create) do |choice, _evaluator|
         choice.application_form.update_columns(
           recruitment_cycle_year: RecruitmentCycle.previous_year,
@@ -1052,7 +1054,7 @@ FactoryBot.define do
     end
 
     trait :with_rejection do
-      application_choice { create(:application_choice, :with_rejection) }
+      association(:application_choice, :with_rejection)
 
       changes do
         {
@@ -1076,7 +1078,7 @@ FactoryBot.define do
     end
 
     trait :with_rejection_by_default_and_feedback do
-      application_choice { create(:application_choice, :with_rejection_by_default) }
+      association(:application_choice, :with_rejection_by_default)
 
       changes do
         {
@@ -1090,7 +1092,7 @@ FactoryBot.define do
     end
 
     trait :with_declined_offer do
-      application_choice { create(:application_choice, :with_declined_offer) }
+      association(:application_choice, :with_declined_offer)
 
       changes do
         {
@@ -1100,7 +1102,7 @@ FactoryBot.define do
     end
 
     trait :with_declined_by_default_offer do
-      application_choice { create(:application_choice, :with_declined_by_default_offer) }
+      association(:application_choice, :with_declined_by_default_offer)
 
       changes do
         {
@@ -1114,7 +1116,7 @@ FactoryBot.define do
     end
 
     trait :with_offer do
-      application_choice { create(:application_choice, :with_offer) }
+      association(:application_choice, :with_offer)
 
       changes do
         {
@@ -1125,7 +1127,7 @@ FactoryBot.define do
     end
 
     trait :with_withdrawn_offer do
-      application_choice { create(:application_choice, :with_withdrawn_offer) }
+      association(:application_choice, :with_withdrawn_offer)
 
       changes do
         {
@@ -1135,7 +1137,7 @@ FactoryBot.define do
     end
 
     trait :with_modified_offer do
-      application_choice { create(:application_choice, :with_modified_offer) }
+      association(:application_choice, :with_modified_offer)
 
       changes do
         {
@@ -1146,7 +1148,7 @@ FactoryBot.define do
     end
 
     trait :with_changed_offer do
-      application_choice { create(:application_choice, :with_changed_offer) }
+      association(:application_choice, :with_changed_offer)
 
       changes do
         {
@@ -1157,7 +1159,7 @@ FactoryBot.define do
     end
 
     trait :with_accepted_offer do
-      application_choice { create(:application_choice, :with_accepted_offer) }
+      association(:application_choice, :with_accepted_offer)
 
       changes do
         {
@@ -1167,7 +1169,7 @@ FactoryBot.define do
     end
 
     trait :with_conditions_not_met do
-      application_choice { create(:application_choice, :with_conditions_not_met) }
+      association(:application_choice, :with_conditions_not_met)
 
       changes do
         {
@@ -1177,7 +1179,7 @@ FactoryBot.define do
     end
 
     trait :with_recruited do
-      application_choice { create(:application_choice, :with_recruited) }
+      association(:application_choice, :with_recruited)
 
       changes do
         {
@@ -1187,7 +1189,7 @@ FactoryBot.define do
     end
 
     trait :with_deferred_offer do
-      application_choice { create(:application_choice, :with_deferred_offer) }
+      association(:application_choice, :with_deferred_offer)
 
       changes do
         {
@@ -1197,7 +1199,7 @@ FactoryBot.define do
     end
 
     trait :with_scheduled_interview do
-      application_choice { create(:application_choice, :with_scheduled_interview) }
+      association(:application_choice, :with_scheduled_interview)
 
       changes do
         {

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -158,10 +158,6 @@ FactoryBot.define do
       safeguarding_issues { 'I have a criminal conviction.' }
     end
 
-    trait :with_no_safeguarding_issues_to_declare do
-      safeguarding_issues_status { 'no_safeguarding_issues_to_declare' }
-    end
-
     trait :with_safeguarding_issues_never_asked do
       safeguarding_issues_status { 'never_asked' }
     end

--- a/spec/forms/candidate_interface/application_feedback_form_spec.rb
+++ b/spec/forms/candidate_interface/application_feedback_form_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
     )
   end
 
-  let(:application_form) { create(:application_form) }
-
   describe 'validations' do
+    let(:application_form) { build(:application_form) }
+
     it { is_expected.to validate_presence_of(:path) }
     it { is_expected.to validate_presence_of(:page_title) }
     it { is_expected.to validate_presence_of(:consent_to_be_contacted) }
@@ -33,6 +33,8 @@ RSpec.describe CandidateInterface::ApplicationFeedbackForm, type: :model do
   end
 
   describe '#save' do
+    let(:application_form) { create(:application_form) }
+
     it 'returns false if not valid' do
       application_form = double
       expect(described_class.new.save(application_form)).to eq(false)

--- a/spec/forms/candidate_interface/degree_institution_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_institution_form_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::DegreeInstitutionForm do
         degree = create(
           :degree_qualification,
           international: true,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
         )
         form = described_class.new(
           degree: degree,

--- a/spec/forms/candidate_interface/degree_naric_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_naric_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::DegreeNaricForm do
         degree = create(
           :degree_qualification,
           international: true,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
         )
 
         form = described_class.new(
@@ -26,7 +26,7 @@ RSpec.describe CandidateInterface::DegreeNaricForm do
         degree = create(
           :degree_qualification,
           international: true,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
         )
 
         form = described_class.new(
@@ -47,7 +47,7 @@ RSpec.describe CandidateInterface::DegreeNaricForm do
         degree = create(
           :degree_qualification,
           international: true,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
           naric_reference: '0123456789',
           comparable_uk_degree: 'bachelor_ordinary_degree',
         )

--- a/spec/forms/candidate_interface/degree_subject_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_subject_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CandidateInterface::DegreeSubjectForm do
     context 'when subject matches a HESA entry' do
       it 'updates the degree subject and HESA code' do
         form = described_class.new(
-          degree: create(:degree_qualification), subject: 'Metallurgy',
+          degree: build(:degree_qualification), subject: 'Metallurgy',
         )
 
         form.save
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::DegreeSubjectForm do
     context 'when subject does not match a HESA entry' do
       it 'updates the degree subject' do
         form = described_class.new(
-          degree: create(:degree_qualification), subject: 'Non-HESA subject',
+          degree: build(:degree_qualification), subject: 'Non-HESA subject',
         )
 
         form.save

--- a/spec/forms/candidate_interface/degree_type_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_type_form_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
   describe '#update' do
     context 'when the type description matches an entry in the HESA data' do
       let(:degree) do
-        create(
+        build(
           :degree_qualification,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
           qualification_type: 'BSc',
         )
       end
@@ -81,9 +81,9 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
 
     context 'when the type description does not match an entry in the HESA data' do
       let(:degree) do
-        create(
+        build(
           :degree_qualification,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
           qualification_type: 'BSc',
         )
       end
@@ -119,9 +119,9 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
 
     context 'when UK degree is selected' do
       let(:degree) do
-        create(
+        build(
           :degree_qualification,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
           qualification_type: 'BSc',
         )
       end
@@ -141,9 +141,9 @@ RSpec.describe CandidateInterface::DegreeTypeForm do
 
     context 'when non-UK degree is selected' do
       let(:degree) do
-        create(
+        build(
           :degree_qualification,
-          application_form: create(:application_form),
+          application_form: build(:application_form),
           qualification_type: 'BSc',
         )
       end

--- a/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
   end
 
   describe '#save' do
-    let(:application_form) { create(:application_form) }
+    let(:application_form) { build(:application_form) }
 
     context 'when disabilty status is blank' do
       it 'returns false' do
@@ -73,7 +73,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
       end
 
       it 'updates the existing record of equality and diversity information' do
-        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male' })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
         form.save(application_form)
 
@@ -83,7 +83,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
       end
 
       it 'updates the existing disabilities of equality and diversity information' do
-        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
         form.save(application_form)
 
@@ -93,7 +93,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
       end
 
       it 'resets the disabilities of equality and diversity information if disability status is no' do
-        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
         form.save(application_form)
 
@@ -103,7 +103,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
       end
 
       it 'resets the disabilities of equality and diversity information if disability status is Prefer not to say' do
-        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'Prefer not to say')
         form.save(application_form)
 
@@ -113,7 +113,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
       end
 
       it 'resets the disabilities of equality and diversity information if disability status is yes' do
-        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => ['Prefer not to say'] })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => ['Prefer not to say'] })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
         form.save(application_form)
 

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
   end
 
   describe '#save' do
-    let(:application_form) { create(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British' }) }
+    let(:application_form) { build(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British' }) }
 
     context 'when ethnic background field is blank' do
       it 'returns false' do
@@ -80,7 +80,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
       end
 
       it 'updates the existing record of equality and diversity information' do
-        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'ethnic_group' => 'Asian or Asian British' })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male', 'ethnic_group' => 'Asian or Asian British' })
         form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Bangladeshi')
 
         form.save(application_form)

--- a/spec/forms/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
   end
 
   describe '#save' do
-    let(:application_form) { create(:application_form) }
+    let(:application_form) { build(:application_form) }
 
     context 'when ethnic group is blank' do
       it 'returns false' do
@@ -56,7 +56,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
       end
 
       it 'updates the existing record of equality and diversity information' do
-        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
+        application_form = build(:application_form, equality_and_diversity: { 'sex' => 'male' })
         form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Black, African, Black British or Caribbean')
 
         form.save(application_form)
@@ -67,7 +67,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: 
       end
 
       it 'resets the ethnic background of equality and diversity information if ethnic group is "Prefer not to say"' do
-        application_form = create(
+        application_form = build(
           :application_form,
           equality_and_diversity: {
             'sex' => 'male',

--- a/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
+++ b/spec/forms/candidate_interface/equality_and_diversity/sex_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
   end
 
   describe '#save' do
-    let(:application_form) { create(:application_form) }
+    let(:application_form) { build(:application_form) }
 
     context 'when sex is blank' do
       it 'returns false' do
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model d
       end
 
       it 'updates the existing record of equality and diversity information' do
-        application_form = create(:application_form, equality_and_diversity: { 'disabilities' => [] })
+        application_form = build(:application_form, equality_and_diversity: { 'disabilities' => [] })
         form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'female')
         form.save(application_form)
 

--- a/spec/forms/candidate_interface/further_information_form_spec.rb
+++ b/spec/forms/candidate_interface/further_information_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
       data = {
         further_information: 'Much wow.',
       }
-      application_form = FactoryBot.create(:application_form)
+      application_form = FactoryBot.build(:application_form)
       further_information = CandidateInterface::FurtherInformationForm.new(form_data)
 
       expect(further_information.save(application_form)).to eq(true)
@@ -31,7 +31,7 @@ RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
       data = {
         further_information: '',
       }
-      application_form = FactoryBot.create(:application_form)
+      application_form = FactoryBot.build(:application_form)
       further_information = CandidateInterface::FurtherInformationForm.new(form_data)
 
       further_information.save(application_form)

--- a/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_institution_country_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
 
   describe '#build_from_qualification' do
     it 'sets the institution_country attribute on the form the to qualifications institution_country' do
-      application_qualification = create(:application_qualification)
+      application_qualification = build(:application_qualification)
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.build_from_qualification(application_qualification)
 
       expect(institution_country_form.institution_country).to eq application_qualification.institution_country
@@ -37,7 +37,7 @@ RSpec.describe CandidateInterface::GcseInstitutionCountryForm, type: :model do
     end
 
     it 'updates the provided ApplicationForm if valid' do
-      application_qualification = create(:application_qualification)
+      application_qualification = build(:application_qualification)
       institution_country_form = CandidateInterface::GcseInstitutionCountryForm.new(form_data)
 
       expect(institution_country_form.save(application_qualification)).to eq(true)

--- a/spec/forms/candidate_interface/gcse_naric_form_spec.rb
+++ b/spec/forms/candidate_interface/gcse_naric_form_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CandidateInterface::GcseNaricForm do
       end
 
       it 'updates the provided ApplicationQualification if valid' do
-        qualification = create(:gcse_qualification)
+        qualification = build(:gcse_qualification)
         naric_form = CandidateInterface::GcseNaricForm.new(form_data)
 
         expect(naric_form.save(qualification)).to eq(true)

--- a/spec/forms/candidate_interface/interview_preferences_form_spec.rb
+++ b/spec/forms/candidate_interface/interview_preferences_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
     end
 
     it 'updates the provided ApplicationForm if valid' do
-      application_form = FactoryBot.create(:application_form)
+      application_form = FactoryBot.build(:application_form)
       interview_preferences = CandidateInterface::InterviewPreferencesForm.new(form_data)
 
       expect(interview_preferences.save(application_form)).to eq(true)
@@ -61,7 +61,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
     end
 
     it 'updates the provided ApplicationForm with an empty string if no is selected' do
-      application_form = create(:application_form)
+      application_form = build(:application_form)
       interview_preferences = CandidateInterface::InterviewPreferencesForm.new(
         any_preferences: 'no',
         interview_preferences: '',

--- a/spec/forms/candidate_interface/languages_form_spec.rb
+++ b/spec/forms/candidate_interface/languages_form_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
         english_language_details: 'I have English qualifications',
         other_language_details: 'I also speak French',
       }
-      application_form = FactoryBot.create(:application_form)
+      application_form = FactoryBot.build(:application_form)
       languages_form = CandidateInterface::LanguagesForm.new(form_data)
 
       languages_form.save(application_form)
@@ -57,7 +57,7 @@ RSpec.describe CandidateInterface::LanguagesForm, type: :model do
         english_language_details: 'I have English qualifications',
         other_language_details: 'I also speak French',
       }
-      application_form = FactoryBot.create(:application_form)
+      application_form = FactoryBot.build(:application_form)
       languages_form = CandidateInterface::LanguagesForm.new(form_data)
 
       languages_form.save(application_form)

--- a/spec/forms/candidate_interface/nationalities_form_spec.rb
+++ b/spec/forms/candidate_interface/nationalities_form_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
       end
 
       it 'updates the provided ApplicationForms nationalities and resets the right to work fields to nil' do
-        application_form = FactoryBot.create(:application_form, right_to_work_or_study: 'yes', right_to_work_or_study_details: 'I have a visa.')
+        application_form = FactoryBot.build(:application_form, right_to_work_or_study: 'yes', right_to_work_or_study_details: 'I have a visa.')
         nationalities = CandidateInterface::NationalitiesForm.new(form_data)
 
         expect(nationalities.save(application_form)).to eq(true)
@@ -120,7 +120,7 @@ RSpec.describe CandidateInterface::NationalitiesForm, type: :model do
       end
 
       it 'updates the provided ApplicationForms nationalities and retains the right to work fields' do
-        application_form = FactoryBot.create(:application_form, right_to_work_or_study: 'yes', right_to_work_or_study_details: 'I have a visa.')
+        application_form = FactoryBot.build(:application_form, right_to_work_or_study: 'yes', right_to_work_or_study_details: 'I have a visa.')
         nationalities = CandidateInterface::NationalitiesForm.new(form_data)
 
         expect(nationalities.save(application_form)).to eq(true)

--- a/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
+++ b/spec/forms/candidate_interface/science_gcse_grade_form_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       end
 
       it 'updates qualification details if valid' do
-        application_form = create(:application_form)
+        application_form = build(:application_form)
         qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
         details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
 
@@ -253,7 +253,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       end
 
       it 'sets grade to other_grade if candidate selected "other"' do
-        application_form = create(:application_form)
+        application_form = build(:application_form)
         qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
         details_form = CandidateInterface::ScienceGcseGradeForm.build_from_qualification(qualification)
 
@@ -267,7 +267,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       end
 
       it 'stores a sanitized grade when it is a single or double award' do
-        application_form = create(:application_form)
+        application_form = build(:application_form)
         qualification = ApplicationQualification.create(
           level: 'gcse',
           application_form: application_form,
@@ -285,7 +285,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
       end
 
       it 'stores sanitized grades when it is a triple award' do
-        application_form = create(:application_form)
+        application_form = build(:application_form)
         qualification = ApplicationQualification.create(
           level: 'gcse',
           application_form: application_form,
@@ -310,7 +310,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
 
       context 'updating a GCSE qualification from single to triple award' do
         it "clears 'grade' and populates 'grades'" do
-          application_form = create(:application_form)
+          application_form = build(:application_form)
           qualification = ApplicationQualification.create(
             level: 'gcse',
             grade: 'A',
@@ -334,7 +334,7 @@ RSpec.describe CandidateInterface::ScienceGcseGradeForm, type: :model do
 
       context 'updating a GCSE qualification from triple to single award' do
         it "clears 'grades' and populates 'grade'" do
-          application_form = create(:application_form)
+          application_form = build(:application_form)
           qualification = ApplicationQualification.create(
             level: 'gcse',
             grade: nil,

--- a/spec/forms/provider_interface/change_offer_form_spec.rb
+++ b/spec/forms/provider_interface/change_offer_form_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ProviderInterface::ChangeOfferForm do
   include CourseOptionHelpers
   let(:provider_user) { create(:provider_user, :with_provider) }
   let(:provider) { provider_user.providers.first }
-  let(:course) { create(:course, :open_on_apply, :with_both_study_modes, provider: provider) }
+  let(:course) { build(:course, :open_on_apply, :with_both_study_modes, provider: provider) }
   let(:study_mode) { course_option.study_mode }
   let(:course_option) { course_option_for_provider(provider: provider, course: course) }
 
-  let(:application_choice) { create(:application_choice, :with_modified_offer, course_option: course_option) }
+  let(:application_choice) { build(:application_choice, :with_modified_offer, course_option: course_option) }
   let(:form_with_application_choice) { described_class.new(application_choice: application_choice, step: step) }
 
   def invalid_for_missing(attribute)

--- a/spec/forms/provider_interface/new_note_form_spec.rb
+++ b/spec/forms/provider_interface/new_note_form_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::NewNoteForm do
-  let(:application_choice) { create(:application_choice) }
-  let(:provider_user) { create(:provider_user) }
+  let(:application_choice) { build(:application_choice) }
+  let(:provider_user) { build(:provider_user) }
 
   describe 'validations' do
     it 'validates presence of :application_choice' do

--- a/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
+++ b/spec/forms/support_interface/application_forms/pick_course_form_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model do
   describe '#course_options' do
-    let(:first_site) { create(:site) }
-    let(:second_site) { create(:site) }
-    let(:provider) { create(:provider, sites: [first_site, second_site]) }
-    let(:course) { create(:course, code: 'ABC', provider: provider) }
+    let(:first_site) { build(:site) }
+    let(:second_site) { build(:site) }
+    let(:provider) { build(:provider, sites: [first_site, second_site]) }
+    let(:course) { build(:course, code: 'ABC', provider: provider) }
 
     it 'returns only course options that have vacancies' do
-      course_option_with_vacancies = create(:course_option, site_id: first_site.id, course_id: course.id)
-      create(:course_option, course_id: course.id, site_id: second_site.id, vacancy_status: 'no_vacancies')
-      application_form = create(:completed_application_form)
+      course_option_with_vacancies = create(:course_option, site: first_site, course: course)
+      create(:course_option, course: course, site: second_site, vacancy_status: 'no_vacancies')
+      application_form = create(:application_form)
 
       form_data = {
         application_form_id: application_form.id,
@@ -24,9 +24,9 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
     end
 
     it 'does not return course options that have already been added to an application form' do
-      course_option = create(:course_option, site_id: first_site.id, course_id: course.id)
-      application_choice = create(:application_choice, course_option_id: course_option.id)
-      application_form = create(:completed_application_form, application_choices: [application_choice])
+      course_option = build(:course_option, site: first_site, course: course)
+      application_choice = build(:application_choice, course_option: course_option)
+      application_form = create(:application_form, application_choices: [application_choice])
 
       form_data = {
         application_form_id: application_form.id,
@@ -55,7 +55,7 @@ RSpec.describe SupportInterface::ApplicationForms::PickCourseForm, type: :model 
       }
 
       expect(described_class.new(form_data).save).to be_truthy
-      expect(application_form.reload.application_choices.last.course_option_id).to eq form_data[:course_option_id]
+      expect(application_form.application_choices.last.course_option_id).to eq form_data[:course_option_id]
     end
   end
 

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CandidateMailer, type: :mailer do
   subject(:mailer) { described_class }
 
-  let(:application_form) { build_stubbed(:completed_application_form, application_references: references, references_count: references.count, with_gcses: true) }
+  let(:application_form) { build_stubbed(:completed_application_form, :with_gcses, application_references: references, references_count: references.count) }
   let(:reference) { build_stubbed(:reference, name: 'Scott Knowles') }
   let(:references) { [reference] }
 

--- a/spec/mailers/previews/provider_mailer_preview.rb
+++ b/spec/mailers/previews/provider_mailer_preview.rb
@@ -75,7 +75,7 @@ private
   def application_choice
     course = FactoryBot.create(:course, provider: provider)
     course_option = FactoryBot.create(:course_option, course: course, site: site)
-    FactoryBot.create(:submitted_application_choice, course_option: course_option, course: course)
+    FactoryBot.create(:submitted_application_choice, :with_completed_application_form, course_option: course_option, course: course)
   end
 
   def provider_user

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ApplicationForm do
 
   describe 'after_touch' do
     it 'touches the application choice when touched by a related model' do
-      application_form = create(:completed_application_form, with_gcses: true, application_choices_count: 1)
+      application_form = create(:completed_application_form, :with_gcses, application_choices_count: 1)
 
       expect { application_form.maths_gcse.update!(grade: 'D') }
         .to(change { application_form.application_choices.first.updated_at })
@@ -47,7 +47,7 @@ RSpec.describe ApplicationForm do
 
       it 'invokes geocoding of UK addresses on update' do
         allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
-        application_form = create(:completed_application_form)
+        application_form = create(:application_form, :minimum_info)
 
         address_attributes = %i[address_line1 address_line2 address_line3 address_line4 postcode country]
         address_attributes.each do |address_attr|
@@ -63,7 +63,7 @@ RSpec.describe ApplicationForm do
 
       it 'does not invoke geocoding for international addresses' do
         allow(GeocodeApplicationAddressWorker).to receive(:perform_async)
-        application_form = build(:completed_application_form, :international_address)
+        application_form = build(:application_form, :international_address)
         application_form.save!
 
         expect(GeocodeApplicationAddressWorker).not_to have_received(:perform_async).with(application_form.id)
@@ -150,7 +150,7 @@ RSpec.describe ApplicationForm do
   describe '#science_gcse_needed?' do
     context 'when a candidate has no course choices' do
       it 'returns false' do
-        application_form = build_stubbed(:application_form)
+        application_form = build(:application_form)
 
         expect(application_form.science_gcse_needed?).to eq(false)
       end
@@ -291,7 +291,7 @@ RSpec.describe ApplicationForm do
   describe '#equality_and_diversity_answers_provided?' do
     context 'when minimal expected attributes are present' do
       it 'is true' do
-        application_form = build(:completed_application_form, :with_equality_and_diversity_data)
+        application_form = build(:application_form, :with_equality_and_diversity_data)
         expect(application_form.equality_and_diversity_answers_provided?).to be true
       end
     end
@@ -484,7 +484,7 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#references_did_not_come_back_in_time?' do
-    let(:application_form) { create(:completed_application_form) }
+    let(:application_form) { create(:application_form) }
 
     it 'returns true if all references were cancelled at end of cycle' do
       create(:reference, application_form: application_form, feedback_status: :cancelled_at_end_of_cycle)

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ApplicationsFilter do
-  let!(:application_choice_with_offer) { create(:application_choice, :with_offer, :previous_year) }
+  let!(:application_choice_with_offer) do
+    create(:application_choice, :with_completed_application_form, :with_offer, :previous_year)
+  end
   let!(:application_choice_with_interview) { create(:application_choice, :with_scheduled_interview) }
 
   def verify_filtered_applications_for_params(expected_applications, params:)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#maths_gcse_added?' do
     it 'returns true if maths gcse has been added' do
-      application_form = FactoryBot.build(:completed_application_form, with_gcses: true)
+      application_form = FactoryBot.create(:application_form, :with_gcses)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_maths_gcse_added
@@ -98,7 +98,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#english_gcse_added?' do
     it 'returns true if english gcse has been added' do
-      application_form = FactoryBot.build(:completed_application_form, with_gcses: true)
+      application_form = FactoryBot.create(:application_form, :with_gcses)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_english_gcse_added
@@ -130,7 +130,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#science_gcse_added?' do
     it 'returns true if science gcse has been added' do
-      application_form = FactoryBot.build(:completed_application_form, with_gcses: true)
+      application_form = FactoryBot.create(:application_form, :with_gcses)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_science_gcse_added
@@ -223,7 +223,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#application_choices_added?' do
     it 'returns true if application choices are added' do
-      application_form = FactoryBot.build(:completed_application_form, application_choices_count: 1)
+      application_form = create(:completed_application_form, application_choices_count: 1)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_application_choices_added
@@ -287,7 +287,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#volunteering_added?' do
     it 'returns true if volunteering have been added' do
-      application_form = build(:completed_application_form, volunteering_experiences_count: 1)
+      application_form = create(:completed_application_form, volunteering_experiences_count: 1)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_volunteering_added
@@ -368,7 +368,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       end
 
       it 'returns the review path if work experience' do
-        application_form = build(:completed_application_form, work_experiences_count: 1, work_history_explanation: '')
+        application_form = create(:completed_application_form, work_experiences_count: 1, work_history_explanation: '')
         presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
@@ -401,7 +401,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       end
 
       it 'returns the review path if work experience and feature_restructured_work_history is "false"' do
-        application_form = build(:completed_application_form, work_experiences_count: 1, work_history_explanation: '', feature_restructured_work_history: false)
+        application_form = create(:completed_application_form, work_experiences_count: 1, work_history_explanation: '', feature_restructured_work_history: false)
         presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
         expect(presenter.work_experience_path).to eq(
@@ -428,7 +428,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       end
 
       it 'returns the review path if work experience' do
-        application_form = build(:completed_application_form, work_experiences_count: 1, work_history_explanation: '')
+        application_form = create(:completed_application_form, work_experiences_count: 1, work_history_explanation: '')
         presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
         expect(presenter.work_experience_path).to eq(

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns nil if the status is no_safeguarding_issues_to_declare' do
-      application_form = create(:application_form, :minimum_info, :with_no_safeguarding_issues_to_declare)
+      application_form = build(:application_form, :minimum_info)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   end
 
   describe 'attributes.references' do
-    let(:application_choice) { create(:application_choice, :with_offer) }
+    let(:application_choice) { create(:application_choice, :with_completed_application_form, :with_offer) }
 
     it 'returns only references with feedback' do
       with_feedback = create(
@@ -471,7 +471,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   end
 
   describe 'attributes.qualifications' do
-    let(:application_choice) { create(:application_choice, :with_offer) }
+    let(:application_choice) { create(:application_choice, :with_completed_application_form, :with_offer) }
     let(:presenter) { VendorAPI::SingleApplicationPresenter.new(application_choice) }
 
     it 'uses the public_id of a qualification as the id' do
@@ -632,21 +632,21 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.offer' do
     it 'includes an offer_made_at date for offers' do
-      choice = create(:application_choice, :with_offer)
+      choice = create(:application_choice, :with_completed_application_form, :with_offer)
 
       presenter = VendorAPI::SingleApplicationPresenter.new(choice)
       expect(presenter.as_json[:attributes][:offer][:offer_made_at]).to be_present
     end
 
     it 'includes an accepted_at date for accepted offers' do
-      choice = create(:application_choice, :with_accepted_offer)
+      choice = create(:application_choice, :with_completed_application_form, :with_accepted_offer)
 
       presenter = VendorAPI::SingleApplicationPresenter.new(choice)
       expect(presenter.as_json[:attributes][:offer][:offer_accepted_at]).to be_present
     end
 
     it 'includes a declined_at date for declined offers' do
-      choice = create(:application_choice, :with_declined_offer)
+      choice = create(:application_choice, :with_completed_application_form, :with_declined_offer)
 
       presenter = VendorAPI::SingleApplicationPresenter.new(choice)
       expect(presenter.as_json[:attributes][:offer][:offer_declined_at]).to be_present
@@ -655,7 +655,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.recruited_at' do
     it 'includes the date the candidate was recruited' do
-      choice = create(:application_choice, :with_recruited)
+      choice = create(:application_choice, :with_completed_application_form, :with_recruited)
 
       presenter = VendorAPI::SingleApplicationPresenter.new(choice)
       expect(presenter.as_json[:attributes][:recruited_at]).to be_present
@@ -664,7 +664,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.status' do
     it 'returns awaiting_provider_decision when status is interviewing' do
-      application_choice = build_stubbed(:application_choice, status: :interviewing)
+      application_choice = build_stubbed(:application_choice, :with_completed_application_form, status: :interviewing)
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
       expect(response.dig(:attributes)[:status]).to eq('awaiting_provider_decision')
     end
@@ -681,7 +681,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       )
     end
     let(:non_uk_application_choice) { create(:submitted_application_choice, application_form: non_uk_application_form) }
-    let(:application_choice) { create(:submitted_application_choice) }
+    let(:application_choice) { create(:submitted_application_choice, :with_completed_application_form) }
 
     it 'looks at all fields which cause a touch' do
       # if there is a field on the form that causes a touch but isn't

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   describe 'attributes.withdrawal' do
     it 'returns a withdrawal object' do
       withdrawn_at = Time.zone.local(2019, 1, 1, 0, 0, 0)
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'British', second_nationality: 'American')
+      application_form = create(:application_form,
+                                :with_completed_references)
       application_choice = create(:application_choice, status: 'withdrawn', application_form: application_form, withdrawn_at: withdrawn_at)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -20,7 +21,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   describe 'attributes.rejection' do
     it 'returns a rejection object' do
       rejected_at = Time.zone.local(2019, 1, 1, 0, 0, 0)
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'British', second_nationality: 'American')
+      application_form = create(:application_form,
+                                :with_completed_references)
       application_choice = create(:application_choice, status: 'rejected', application_form: application_form, rejected_at: rejected_at, rejection_reason: 'Course full')
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -33,7 +35,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   describe 'attributes.rejection with a withdrawn offer' do
     it 'returns a rejection object' do
       withdrawn_at = Time.zone.local(2019, 1, 1, 0, 0, 0)
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'British', second_nationality: 'American')
+      application_form = create(:application_form,
+                                :with_completed_references)
       application_choice = create(:application_choice, status: 'rejected', application_form: application_form, offer_withdrawn_at: withdrawn_at, offer_withdrawal_reason: 'Course full')
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -46,7 +49,9 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   describe 'attributes.hesa_itt_data' do
     context "when an application choice has status 'recruited'" do
       let(:application_choice) do
-        application_form = create(:completed_application_form, :with_completed_references, :with_equality_and_diversity_data)
+        application_form = create(:application_form,
+                                  :with_completed_references,
+                                  :with_equality_and_diversity_data)
         create(:application_choice, status: 'recruited', application_form: application_form)
       end
 
@@ -65,7 +70,9 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
     context "when an application choice does not have status 'recruited'" do
       let(:application_choice) do
-        application_form = create(:completed_application_form, :with_completed_references, :with_equality_and_diversity_data)
+        application_form = create(:application_form,
+                                  :with_completed_references,
+                                  :with_equality_and_diversity_data)
         create(:application_choice, status: 'offer', application_form: application_form)
       end
 
@@ -87,7 +94,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'returns the work_history_breaks attribute of an application' do
         breaks = []
         application_form = build_stubbed(
-          :completed_application_form,
+          :application_form,
           :with_completed_references,
           work_history_breaks: 'I was sleeping.',
           application_work_history_breaks: breaks,
@@ -107,7 +114,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         break2 = build_stubbed(:application_work_history_break, start_date: september2019, end_date: december2019, reason: 'I was playing games.')
         breaks = [break1, break2]
         application_form = build_stubbed(
-          :completed_application_form,
+          :application_form,
           :with_completed_references,
           work_history_breaks: nil,
           application_work_history_breaks: breaks,
@@ -127,7 +134,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       it 'returns an empty string' do
         breaks = []
         application_form = build_stubbed(
-          :completed_application_form,
+          :application_form,
           :with_completed_references,
           work_history_breaks: nil,
           application_work_history_breaks: breaks,
@@ -144,7 +151,10 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.candidate.nationality' do
     it 'compacts two nationalities with the same ISO value' do
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'Welsh', second_nationality: 'Scottish')
+      application_form = create(:application_form,
+                                :with_completed_references,
+                                first_nationality: 'Welsh',
+                                second_nationality: 'Scottish')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -153,8 +163,11 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns nationality in the correct format' do
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'British', second_nationality: 'American')
-      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+      application_form = create(:application_form,
+                                :with_completed_references,
+                                first_nationality: 'British',
+                                second_nationality: 'American')
+      application_choice = create(:application_choice, :awaiting_provider_decision, application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
 
@@ -163,7 +176,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns sorted array of nationalties so British or Irish are first' do
-      application_form = create(:completed_application_form,
+      application_form = create(:application_form,
+                                :minimum_info,
                                 first_nationality: 'Canadian',
                                 second_nationality: 'Spanish',
                                 third_nationality: 'Irish',
@@ -178,7 +192,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.candidate.domicile' do
     it 'uses DomicileResolver to return a HESA code' do
-      application_form = create(:completed_application_form, :with_completed_references)
+      application_form = create(:application_form, :with_completed_references)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -189,7 +203,10 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.candidate.uk_residency_status' do
     it 'returns UK Citizen if the candidates nationalties include UK' do
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'Irish', second_nationality: 'British')
+      application_form = create(:application_form,
+                                :with_completed_references,
+                                first_nationality: 'Irish',
+                                second_nationality: 'British')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -198,7 +215,10 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns Irish Citizen if the candidates nationalties is Irish' do
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'Canadian', second_nationality: 'Irish')
+      application_form = create(:application_form,
+                                :with_completed_references,
+                                first_nationality: 'Canadian',
+                                second_nationality: 'Irish')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -207,8 +227,11 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns details of the residency status if the candidates answered the have the right to work/study in the UK' do
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'Canadian',
-                                                                                         right_to_work_or_study: 'yes', right_to_work_or_study_details: 'I have Settled status')
+      application_form = create(:application_form,
+                                :with_completed_references,
+                                first_nationality: 'Canadian',
+                                right_to_work_or_study: 'yes',
+                                right_to_work_or_study_details: 'I have Settled status')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -217,8 +240,10 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns correct message if the candidates answered they do not yet have the right to work/study in the UK' do
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'Canadian',
-                                                                                         right_to_work_or_study: 'no')
+      application_form = create(:application_form,
+                                :with_completed_references,
+                                first_nationality: 'Canadian',
+                                right_to_work_or_study: 'no')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -227,8 +252,10 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns correct message if the candidates answered they do not know if they have the right to work/study in the UK' do
-      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'Canadian',
-                                                                                         right_to_work_or_study: 'decide_later')
+      application_form = create(:application_form,
+                                :with_completed_references,
+                                first_nationality: 'Canadian',
+                                right_to_work_or_study: 'decide_later')
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -288,7 +315,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         postcode: 'SW1P 3BT',
       }
       application_form = create(
-        :completed_application_form,
+        :application_form,
         :with_completed_references,
         application_form_attributes,
       )
@@ -317,7 +344,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         country: 'IN',
       }
       application_form = create(
-        :completed_application_form,
+        :application_form,
         :with_completed_references,
         application_form_attributes,
       )
@@ -353,7 +380,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
         country: 'IN',
       }
       application_form = create(
-        :completed_application_form,
+        :application_form,
         :with_completed_references,
         application_form_attributes,
       )
@@ -380,7 +407,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.safeguarding_issues_status' do
     it 'returns the safeguarding issues status' do
-      application_form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
+      application_form = create(:application_form, :minimum_info, :with_safeguarding_issues_disclosed)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -391,7 +418,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
   describe 'attributes.safeguarding_issues_details_url' do
     it 'returns the url if the status is has_safeguarding_issues_to_declare' do
-      application_form = create(:completed_application_form, :with_safeguarding_issues_disclosed)
+      application_form = create(:application_form, :minimum_info, :with_safeguarding_issues_disclosed)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -400,7 +427,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns nil if the status is no_safeguarding_issues_to_declare' do
-      application_form = create(:completed_application_form, :with_no_safeguarding_issues_to_declare)
+      application_form = create(:application_form, :minimum_info, :with_no_safeguarding_issues_to_declare)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -409,7 +436,7 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     end
 
     it 'returns nil if the status is never_asked' do
-      application_form = create(:completed_application_form, :with_safeguarding_issues_never_asked)
+      application_form = create(:application_form, :minimum_info, :with_safeguarding_issues_never_asked)
       application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
       response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
@@ -673,7 +700,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
   describe 'compliance with models that change updated_at' do
     let(:non_uk_application_form) do
       create(
-        :completed_application_form,
+        :application_form,
+        :minimum_info,
         first_nationality: 'Spanish',
         right_to_work_or_study: :yes,
         address_type: :international,

--- a/spec/requests/data_api/tad_api_spec.rb
+++ b/spec/requests/data_api/tad_api_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'GET /data-api/tad-data-exports/latest', type: :request, sidekiq:
   end
 
   it 'returns the latest data export' do
-    create(:submitted_application_choice, status: 'rejected')
+    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
 
     data_export = DataExport.create!(name: 'Daily export of applications for TAD')
     DataExporter.perform_async(DataAPI::TADExport, data_export.id)

--- a/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
+++ b/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
@@ -7,7 +7,12 @@ RSpec.describe 'POST /provider/candidates/:id/impersonate' do
     let(:provider) { create(:provider, :with_signed_agreement) }
     let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
     let(:course_option) { course_option_for_provider_code(provider_code: provider.code) }
-    let(:application_choice) { create(:application_choice, :awaiting_provider_decision, course_option: course_option) }
+    let(:application_choice) do
+      create(:application_choice,
+             :with_completed_application_form,
+             :awaiting_provider_decision,
+             course_option: course_option)
+    end
 
     before do
       allow(DfESignInUser).to receive(:load_from_session)

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     create_list(
       :submitted_application_choice,
       2,
+      :with_completed_application_form,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
       status: 'awaiting_provider_decision',
     )
@@ -85,6 +86,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     create_list(
       :submitted_application_choice,
       2,
+      :with_completed_application_form,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
       status: :awaiting_provider_decision,
     )

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -329,7 +329,9 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
   describe 'changing offers' do
     it 'can change the offer conditions' do
-      choice = create(:application_choice, :with_offer,
+      choice = create(:application_choice,
+                      :with_completed_application_form,
+                      :with_offer,
                       course_option: course_option_for_provider(provider: currently_authenticated_provider),
                       offer: { 'conditions' => ['DBS check'] })
 
@@ -348,7 +350,9 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
     end
 
     it 'returns 200 OK when sending the same offer & conditions repeatedly' do
-      choice = create(:application_choice, :with_offer,
+      choice = create(:application_choice,
+                      :with_completed_application_form,
+                      :with_offer,
                       course_option: course_option_for_provider(provider: currently_authenticated_provider),
                       offer: { 'conditions' => ['DBS check'] })
 

--- a/spec/requests/vendor_api/post_test_data_clear_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_clear_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/clear', type: :request do
     create(
       :application_choice,
       :awaiting_provider_decision,
+      :with_completed_application_form,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
     )
 

--- a/spec/services/apply_again_spec.rb
+++ b/spec/services/apply_again_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe ApplyAgain do
     Timecop.travel(-1.day) do
       @original_application_form ||= create(
         :completed_application_form,
+        :with_gcses,
         work_experiences_count: 1,
         volunteering_experiences_count: 1,
-        with_gcses: true,
         full_work_history: true,
         recruitment_cycle_year: RecruitmentCycle.current_year,
       )

--- a/spec/services/carry_over_application_spec.rb
+++ b/spec/services/carry_over_application_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe CarryOverApplication do
     @original_application_form ||= Timecop.travel(-1.day) do
       application_form = create(
         :completed_application_form,
+        :with_gcses,
         application_choices_count: 1,
         work_experiences_count: 1,
         volunteering_experiences_count: 1,
-        with_gcses: true,
         full_work_history: true,
       )
       create(:reference, feedback_status: :feedback_provided, application_form: application_form)

--- a/spec/services/data_api/tad_export_spec.rb
+++ b/spec/services/data_api/tad_export_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe DataAPI::TADExport do
   before do
-    create(:submitted_application_choice, status: 'rejected', rejected_by_default: true)
-    create(:submitted_application_choice, status: 'declined', declined_by_default: true)
-    create(:submitted_application_choice, status: 'rejected')
-    create(:submitted_application_choice, status: 'declined')
+    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected', rejected_by_default: true)
+    create(:submitted_application_choice, :with_completed_application_form, status: 'declined', declined_by_default: true)
+    create(:submitted_application_choice, :with_completed_application_form, status: 'rejected')
+    create(:submitted_application_choice, :with_completed_application_form, status: 'declined')
   end
 
   it_behaves_like 'a data export'

--- a/spec/services/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/filter_application_choices_for_providers_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FilterApplicationChoicesForProviders do
   describe '.call' do
     let(:application_choices) do
-      create_list(:application_choice, 2)
+      create_list(:application_choice, 2, :with_completed_application_form)
       ApplicationChoice.all
     end
 

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
     end
 
     it 'returns data for application_choices with a completed form and a degree' do
-      application_form_with_degree = create(:completed_application_form, with_degree: true)
+      application_form_with_degree = create(:completed_application_form, :with_degree)
       choice = create(:application_choice, application_form: application_form_with_degree)
 
       exported_data = CSV.parse(described_class.call(application_choices: choice), headers: true)

--- a/spec/services/provider_interface/hesa_data_export_spec.rb
+++ b/spec/services/provider_interface/hesa_data_export_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe ProviderInterface::HesaDataExport do
       course_option = create(:course_option, course: @course)
       @application_with_offer = create(
         :application_choice,
+        :with_completed_application_form,
         :with_accepted_offer,
         course_option: course_option,
       )

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SendApplicationToProvider do
   it 'sets the status to `awaiting_provider_decision`' do
     SendApplicationToProvider.new(application_choice: application_choice).call
 
-    expect(application_choice.reload.status).to eq 'awaiting_provider_decision'
+    expect(application_choice.status).to eq 'awaiting_provider_decision'
   end
 
   it 'sets the `sent_to_provider` date' do

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SendApplicationToProvider do
   def application_choice(status: 'unsubmitted')
     @application_choice ||= create(
       :submitted_application_choice,
+      :with_completed_application_form,
       status: status,
     )
   end

--- a/spec/services/send_new_application_email_to_provider_spec.rb
+++ b/spec/services/send_new_application_email_to_provider_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SendNewApplicationEmailToProvider, sidekiq: true do
     ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
 
     option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
-    choice = create(:application_choice, :awaiting_provider_decision, course_option: option)
+    choice = create(:application_choice, :with_completed_application_form, :awaiting_provider_decision, course_option: option)
 
     SendNewApplicationEmailToProvider.new(application_choice: choice).call
 

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
       it 'returns formatted high level rejection reasons (those that include y_n)' do
         create(
           :application_choice,
+          :with_completed_application_form,
           structured_rejection_reasons: {
             course_full_y_n: 'No',
             candidate_behaviour_y_n: 'Yes',

--- a/spec/services/support_interface/offer_conditions_export_spec.rb
+++ b/spec/services/support_interface/offer_conditions_export_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe SupportInterface::OfferConditionsExport do
     end
 
     it 'returns phase information for each offer' do
-      apply_1_form = create(:completed_application_form)
-      create(:application_choice, :with_declined_offer, application_form: apply_1_form)
-      create(:application_choice, :withdrawn, application_form: apply_1_form)
+      unsuccessful_application_choices = [build(:application_choice, :with_declined_offer),
+                                          build(:application_choice, :withdrawn)]
+      apply_1_form = create(:completed_application_form,
+                            application_choices: unsuccessful_application_choices)
       apply_2_form = ApplyAgain.new(apply_1_form).call
       create(:application_choice, :with_offer, application_form: apply_2_form)
 
@@ -44,7 +45,7 @@ RSpec.describe SupportInterface::OfferConditionsExport do
     end
 
     it 'contains qualification information' do
-      form = create(:completed_application_form, with_gcses: true, with_degree: true)
+      form = create(:completed_application_form, :with_degree_and_gcses)
       create(:application_choice, :with_offer, application_form: form)
       offers = described_class.new.offers
 

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -49,6 +49,7 @@ module VendorAPISpecHelpers
   def create_application_choice_for_currently_authenticated_provider(attributes = {})
     create(
       :submitted_application_choice,
+      :with_completed_application_form,
       { course_option: course_option_for_provider(provider: currently_authenticated_provider) }.merge(attributes),
     )
   end

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_to_new_cycle_spec.rb
@@ -54,9 +54,9 @@ RSpec.feature 'Manually carry over unsubmitted applications' do
   def when_i_have_an_unsubmitted_application
     @application_form = create(
       :completed_application_form,
+      :with_gcses,
       submitted_at: nil,
       candidate: @candidate,
-      with_gcses: true,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
     )
     @application_choice = create(

--- a/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_carries_over_unsubmitted_application_without_course_to_new_cycle_spec.rb
@@ -49,9 +49,9 @@ RSpec.feature 'Manually carry over unsubmitted applications that do not have cou
   def when_i_have_an_unsubmitted_application_without_a_course
     @application_form = create(
       :completed_application_form,
+      :with_gcses,
       submitted_at: nil,
       candidate: @candidate,
-      with_gcses: true,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
     )
     @first_reference = create(

--- a/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/apply_again/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -44,9 +44,9 @@ RSpec.feature 'Candidate with unsuccessful application' do
   def when_i_have_an_unsuccessful_application
     @application_form = create(
       :completed_application_form,
+      :with_gcses,
       :with_completed_references,
       references_count: 2,
-      with_gcses: true,
       candidate: @candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
     )

--- a/spec/system/candidate_interface/end_of_cycle/candidate_views_unsuccessful_application_between_cycles_spec.rb
+++ b/spec/system/candidate_interface/end_of_cycle/candidate_views_unsuccessful_application_between_cycles_spec.rb
@@ -25,9 +25,9 @@ RSpec.feature 'Candidate with unsuccessful application' do
   def and_i_have_an_unsuccessful_application
     @application_form = create(
       :completed_application_form,
+      :with_gcses,
       :with_completed_references,
       references_count: 2,
-      with_gcses: true,
       candidate: @candidate,
       safeguarding_issues_status: :no_safeguarding_issues_to_declare,
     )

--- a/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/references/candidate_replaces_reference_after_applying_again_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate applying again' do
   end
 
   def when_i_have_an_unsuccessful_application_with_references
-    @application_form = create(:completed_application_form, candidate: @candidate, with_gcses: true, safeguarding_issues_status: :no_safeguarding_issues_to_declare)
+    @application_form = create(:completed_application_form, :with_gcses, candidate: @candidate, safeguarding_issues_status: :no_safeguarding_issues_to_declare)
     create(:application_choice, status: :rejected, application_form: @application_form)
     @completed_references = create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @application_form)
     @refused_reference = create(:reference, feedback_status: :feedback_refused, application_form: @application_form)

--- a/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
+++ b/spec/system/provider_interface/export_applications_in_hesa_format_spec.rb
@@ -28,7 +28,11 @@ RSpec.feature 'Export applications in HESA format' do
     providers = current_provider_user.providers
     course = create(:course, provider: providers.first)
     course_option = create(:course_option, course: course)
-    @applications = create_list(:application_choice, 5, :with_accepted_offer, course_option: course_option)
+    @applications = create_list(:application_choice,
+                                5,
+                                :application_form_with_degree,
+                                :with_accepted_offer,
+                                course_option: course_option)
   end
 
   def when_i_visit_the_export_applications_page

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
     @provider_user = ProviderUser.last
     @provider_user.provider_permissions.update_all(manage_organisations: true)
     @training_provider = Provider.find_by(code: 'ABC')
-    @ratifying_provider = create(:provider)
+    @ratifying_provider = build(:provider)
   end
 
   def and_i_am_permitted_to_view_safeguarding_information
@@ -68,7 +68,7 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
   end
 
   def and_the_provider_has_an_open_application_with_safeguarding_issues_declared
-    @application_form = create(
+    @application_form = build(
       :application_form,
       safeguarding_issues: 'I have a criminal conviction.',
       safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
@@ -76,9 +76,9 @@ RSpec.feature 'Managing provider to provider relationship permissions' do
     @application_choice = create(
       :application_choice,
       status: :unsubmitted,
-      course_option: create(
+      course_option: build(
         :course_option,
-        course: create(:course, accredited_provider_id: @ratifying_provider.id, provider_id: @training_provider.id),
+        course: build(:course, accredited_provider: @ratifying_provider, provider: @training_provider),
       ),
       reject_by_default_at: 20.days.from_now,
       application_form: @application_form,

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'A Provider can sign in as a candidate' do
 
   def and_my_organisation_has_received_an_application
     course_option = course_option_for_provider_code(provider_code: @provider.code)
-    @application_choice = create(:submitted_application_choice, course_option: course_option)
+    @application_choice = create(:submitted_application_choice, :with_completed_application_form, course_option: course_option)
     @candidate = @application_choice.application_form.candidate
   end
 

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -4,11 +4,11 @@ RSpec.feature 'Providers should be able to filter applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  let(:site) { create(:site, name: 'Test site name') }
-  let(:site2) { create(:site, name: 'Second test site') }
-  let(:site3) { create(:site, name: 'Second test site') }
-  let(:site4) { create(:site, name: 'Second test site') }
-  let(:site5) { create(:site, name: 'Second test site') }
+  let(:site) { build(:site, name: 'Test site name') }
+  let(:site2) { build(:site, name: 'Second test site') }
+  let(:site3) { build(:site, name: 'Second test site') }
+  let(:site4) { build(:site, name: 'Second test site') }
+  let(:site5) { build(:site, name: 'Second test site') }
 
   let(:current_provider) { create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training', sites: [site, site2]) }
   let(:second_provider) { create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University', sites: [site3, site4]) }
@@ -105,17 +105,17 @@ RSpec.feature 'Providers should be able to filter applications' do
   def and_my_organisation_has_courses_with_applications_without_accredited_providers
     course_option_one = course_option_for_provider(provider: current_provider,
                                                    site: site,
-                                                   course: create(:course,
-                                                                  name: 'Alchemy',
-                                                                  provider: current_provider))
+                                                   course: build(:course,
+                                                                 name: 'Alchemy',
+                                                                 provider: current_provider))
 
-    course_option_two = course_option_for_provider(provider: second_provider, course: create(:course, name: 'Science', provider: second_provider))
+    course_option_two = course_option_for_provider(provider: second_provider, course: build(:course, name: 'Science', provider: second_provider))
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
-           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 5.days.ago)
+           build(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 5.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
-           create(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
+           build(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
   end
 
   def then_i_do_not_expect_to_see_the_accredited_providers_filter_heading
@@ -185,50 +185,50 @@ RSpec.feature 'Providers should be able to filter applications' do
   def and_my_organisation_has_courses_with_applications
     course_option_one = course_option_for_provider(provider: current_provider,
                                                    site: site,
-                                                   course: create(:course,
-                                                                  name: 'Alchemy',
-                                                                  provider: current_provider,
-                                                                  accredited_provider: accredited_provider1))
+                                                   course: build(:course,
+                                                                 name: 'Alchemy',
+                                                                 provider: current_provider,
+                                                                 accredited_provider: accredited_provider1))
 
-    course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider, accredited_provider: accredited_provider2))
-    course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+    course_option_two = course_option_for_provider(provider: current_provider, course: build(:course, name: 'Divination', provider: current_provider, accredited_provider: accredited_provider2))
+    course_option_three = course_option_for_provider(provider: current_provider, course: build(:course, name: 'English', provider: current_provider))
 
-    course_option_four = course_option_for_provider(provider: second_provider, course: create(:course, name: 'Science', provider: second_provider))
-    course_option_five = course_option_for_provider(provider: second_provider, course: create(:course, name: 'History', provider: second_provider))
+    course_option_four = course_option_for_provider(provider: second_provider, course: build(:course, name: 'Science', provider: second_provider))
+    course_option_five = course_option_for_provider(provider: second_provider, course: build(:course, name: 'History', provider: second_provider))
 
-    course_option_six = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Maths', provider: third_provider))
-    course_option_seven = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Engineering', provider: third_provider))
-    course_option_from_previous_year = course_option_for_provider(provider: current_provider, course: create(:course, :previous_year, name: 'Engineering', provider: current_provider))
+    course_option_six = course_option_for_provider(provider: third_provider, course: build(:course, name: 'Maths', provider: third_provider))
+    course_option_seven = course_option_for_provider(provider: third_provider, course: build(:course, name: 'Engineering', provider: third_provider))
+    course_option_from_previous_year = course_option_for_provider(provider: current_provider, course: build(:course, :previous_year, name: 'Engineering', provider: current_provider))
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
-           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
+           build(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
-           create(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
+           build(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'rejected', application_form:
-           create(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
+           build(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
-           create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+           build(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_four, status: 'offer', application_form:
-           create(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
+           build(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_five, status: 'rejected', application_form:
-           create(:application_form, first_name: 'Paul', last_name: 'Atreides'), updated_at: 5.days.ago)
+           build(:application_form, first_name: 'Paul', last_name: 'Atreides'), updated_at: 5.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_six, status: 'withdrawn', application_form:
-           create(:application_form, first_name: 'Duncan', last_name: 'Idaho'), updated_at: 6.days.ago)
+           build(:application_form, first_name: 'Duncan', last_name: 'Idaho'), updated_at: 6.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_seven, status: 'declined', application_form:
-           create(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
+           build(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer_withdrawn', offer_withdrawn_at: 2.days.ago, application_form:
-           create(:application_form, first_name: 'John', last_name: 'Smith'), updated_at: 8.days.ago)
+           build(:application_form, first_name: 'John', last_name: 'Smith'), updated_at: 8.days.ago)
 
     create(:application_choice, :offer, course_option: course_option_from_previous_year, status: 'offer', application_form:
-           create(:application_form, first_name: 'Anne', last_name: 'Blast'), updated_at: 366.days.ago)
+           build(:application_form, first_name: 'Anne', last_name: 'Blast'), updated_at: 366.days.ago)
   end
 
   def then_i_can_see_applications_from_the_previous_year_too

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -174,39 +174,39 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def and_my_organisation_has_courses_with_applications
-    course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
-    course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
-    course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+    course_option_one = course_option_for_provider(provider: current_provider, course: build(:course, name: 'Alchemy', provider: current_provider))
+    course_option_two = course_option_for_provider(provider: current_provider, course: build(:course, name: 'Divination', provider: current_provider))
+    course_option_three = course_option_for_provider(provider: current_provider, course: build(:course, name: 'English', provider: current_provider))
 
-    course_option_four = course_option_for_provider(provider: second_provider, course: create(:course, name: 'Science', provider: second_provider))
-    course_option_five = course_option_for_provider(provider: second_provider, course: create(:course, name: 'History', provider: second_provider))
+    course_option_four = course_option_for_provider(provider: second_provider, course: build(:course, name: 'Science', provider: second_provider))
+    course_option_five = course_option_for_provider(provider: second_provider, course: build(:course, name: 'History', provider: second_provider))
 
-    course_option_six = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Maths', provider: third_provider))
-    course_option_seven = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Engineering', provider: third_provider))
+    course_option_six = course_option_for_provider(provider: third_provider, course: build(:course, name: 'Maths', provider: third_provider))
+    course_option_seven = course_option_for_provider(provider: third_provider, course: build(:course, name: 'Engineering', provider: third_provider))
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
-           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
+           build(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
-           create(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
+           build(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'rejected', application_form:
-           create(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
+           build(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
-           create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+           build(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_four, status: 'offer', application_form:
-           create(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
+           build(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_five, status: 'rejected', application_form:
-           create(:application_form, first_name: 'Paul', last_name: 'Atreides'), updated_at: 5.days.ago)
+           build(:application_form, first_name: 'Paul', last_name: 'Atreides'), updated_at: 5.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_six, status: 'withdrawn', application_form:
-           create(:application_form, first_name: 'Duncan', last_name: 'Idaho'), updated_at: 6.days.ago)
+           build(:application_form, first_name: 'Duncan', last_name: 'Idaho'), updated_at: 6.days.ago)
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_seven, status: 'declined', application_form:
-           create(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
+           build(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
   end
 
   def then_i_should_see_the_no_filter_results_error_message

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -8,11 +8,17 @@ RSpec.feature 'Provider responds to application' do
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
 
   let(:application_awaiting_provider_decision) do
-    create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    create(:submitted_application_choice,
+           :with_completed_application_form,
+           status: 'awaiting_provider_decision',
+           course_option: course_option)
   end
 
   let(:application_rejected) do
-    create(:submitted_application_choice, status: 'rejected', rejected_at: Time.zone.now, course_option: course_option)
+    create(:submitted_application_choice,
+           status: 'rejected',
+           rejected_at: Time.zone.now,
+           course_option: course_option)
   end
 
   scenario 'Provider can respond to an application' do

--- a/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
+++ b/spec/system/provider_interface/provider_user_exports_applications_to_csv_spec.rb
@@ -38,16 +38,22 @@ RSpec.feature 'Provider user exports applications to a csv' do
     course = create(:course, provider: providers.first)
     course_option = create(:course_option, course: course)
 
-    @application_accepted = create(:application_choice, :with_accepted_offer, course_option: course_option)
-    @application_deferred = create(:application_choice, :with_deferred_offer, course_option: course_option)
-    @application_declined = create(:application_choice, :with_declined_offer, course_option: course_option)
-    @application_withdrawn = create(:application_choice, :with_withdrawn_offer, course_option: course_option)
+    @application_accepted = create(:application_choice, :application_form_with_degree, :with_accepted_offer, course_option: course_option)
+    @application_deferred = create(:application_choice, :application_form_with_degree, :with_deferred_offer, course_option: course_option)
+    @application_declined = create(:application_choice, :application_form_with_degree, :with_declined_offer, course_option: course_option)
+    @application_withdrawn = create(:application_choice, :application_form_with_degree, :with_withdrawn_offer, course_option: course_option)
 
     course_previous_year = create(:course, :previous_year, provider: providers.first)
-    @application_accepted_previous_cycle = create(:application_choice, :with_accepted_offer, course_option: create(:course_option, course: course_previous_year))
+    @application_accepted_previous_cycle = create(:application_choice,
+                                                  :application_form_with_degree,
+                                                  :with_accepted_offer,
+                                                  course_option: create(:course_option, course: course_previous_year))
 
     course_second_provider = create(:course, provider: providers.second)
-    @application_second_provider = create(:application_choice, :with_accepted_offer, course_option: create(:course_option, course: course_second_provider))
+    @application_second_provider = create(:application_choice,
+                                          :application_form_with_degree,
+                                          :with_accepted_offer,
+                                          course_option: create(:course_option, course: course_second_provider))
   end
 
   def when_i_visit_the_export_applications_page

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -45,8 +45,13 @@ RSpec.feature 'See applications' do
   def and_my_organisation_has_applications
     course_option = course_option_for_provider_code(provider_code: 'ABC')
 
-    @my_provider_choice1  = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
-    @my_provider_choice2  = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    @my_provider_choice1  = create(:submitted_application_choice,
+                                   :with_completed_application_form,
+                                   status: 'awaiting_provider_decision',
+                                   course_option: course_option)
+    @my_provider_choice2  = create(:submitted_application_choice,
+                                   status: 'awaiting_provider_decision',
+                                   course_option: course_option)
   end
 
   def and_i_visit_the_provider_page

--- a/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
@@ -24,13 +24,13 @@ RSpec.feature 'Provider sees an application as PDF' do
   end
 
   def and_an_application_exists
-    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    current_provider = build(:provider, :with_signed_agreement, code: 'ABC')
     @course_option = course_option_for_provider(
       provider: current_provider,
-      course: create(:course, name: 'Alchemy', provider: current_provider),
+      course: build(:course, name: 'Alchemy', provider: current_provider),
     )
 
-    @application_form = create(:application_form, first_name: 'Sheila', last_name: 'Jones')
+    @application_form = build(:application_form, first_name: 'Sheila', last_name: 'Jones')
 
     @application_choice = create(
       :application_choice,

--- a/spec/system/support_interface/editing_reference_spec.rb
+++ b/spec/system/support_interface/editing_reference_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_an_application_exists
-    @form = create(:completed_application_form, :with_completed_references)
+    @form = create(:application_form, :with_completed_references)
     create(:reference, :feedback_requested, name: 'Dumbledore', email_address: 'a.dumbledore@hogwarts.ac.uk', relationship: 'Headmaster', application_form: @form)
   end
 

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -30,10 +30,10 @@ RSpec.feature 'See an application' do
   end
 
   def and_there_are_applications_in_the_system
-    @completed_application = create(:completed_application_form, references_count: 2, with_gcses: true)
+    @completed_application = create(:completed_application_form, :with_gcses, references_count: 2)
     SubmitApplication.new(@completed_application).call
     @unsubmitted_application = create(:application_form)
-    @application_with_reference = create(:completed_application_form, references_count: 2, with_gcses: true)
+    @application_with_reference = create(:completed_application_form, :with_gcses, references_count: 2)
   end
 
   def and_an_application_has_received_a_reference

--- a/spec/system/support_interface/view_vendor_api_requests_spec.rb
+++ b/spec/system/support_interface/view_vendor_api_requests_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Vendor API Requests' do
   end
 
   def and_some_applications_exist
-    applications = create_list(:submitted_application_choice, 2)
+    applications = create_list(:submitted_application_choice, 2, :with_completed_application_form)
     @first_application_choice = applications.first
     @last_application_choice = applications.last
   end

--- a/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
+++ b/spec/system/ucas_matching/upload_matching_data_to_ucas_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Uploading of matching data to UCAS', sidekiq: true do
   end
 
   def given_there_is_an_application_in_the_system
-    @application_choice = create(:submitted_application_choice)
+    @application_choice = create(:submitted_application_choice, :with_completed_application_form)
   end
 
   def given_the_access_token_can_not_be_acquired

--- a/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
+++ b/spec/workers/cancel_unsubmitted_applications_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
 
     it 'cancels any unsubmitted applications from the last cycle' do
       unsubmitted_application_from_last_year = create(
-        :completed_application_form,
+        :application_form,
         submitted_at: nil,
         recruitment_cycle_year: RecruitmentCycle.previous_year,
       )
@@ -20,7 +20,7 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
       )
 
       hidden_application_from_this_year = create(
-        :completed_application_form,
+        :application_form,
         submitted_at: nil,
         candidate: create(:candidate, hide_in_reporting: true),
         recruitment_cycle_year: RecruitmentCycle.current_year,
@@ -33,7 +33,7 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
       )
 
       unsubmitted_application_from_this_year = create(
-        :completed_application_form,
+        :application_form,
         submitted_at: nil,
         recruitment_cycle_year: RecruitmentCycle.current_year,
       )
@@ -45,7 +45,7 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
       )
 
       rejected_application_from_this_year = create(
-        :completed_application_form,
+        :application_form,
         recruitment_cycle_year: RecruitmentCycle.current_year,
       )
       create(
@@ -56,7 +56,7 @@ RSpec.describe CancelUnsubmittedApplicationsWorker do
       )
 
       unsubmitted_cancelled_application_from_this_year = create(
-        :completed_application_form,
+        :application_form,
         submitted_at: nil,
         recruitment_cycle_year: RecruitmentCycle.current_year,
       )

--- a/spec/workers/delete_test_applications_spec.rb
+++ b/spec/workers/delete_test_applications_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe DeleteTestApplications do
   it 'removes an application for bob@example.com' do
     application_form = create(
       :completed_application_form,
+      :with_degree,
       application_choices_count: 1,
       work_experiences_count: 1,
       volunteering_experiences_count: 1,
       references_count: 2,
-      with_degree: true,
       full_work_history: true,
     )
     create(

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -11,16 +11,17 @@ RSpec.describe RecalculateDates do
 
   it 'recalculates decline_by_default_at for a submitted application choice with an offer' do
     application_form = create(
-      :completed_application_form,
+      :application_form,
       :with_completed_references,
       submitted_at: Time.zone.now,
     )
 
     application_choice = create(
-      :submitted_application_choice, :with_offer,
+      :submitted_application_choice,
+      :with_offer,
       application_form: application_form,
       decline_by_default_at: nil,
-      offered_at: Time.zone.now
+      offered_at: Time.zone.now,
     )
 
     RecalculateDates.new.perform


### PR DESCRIPTION
## Factory improvements:

- Update ApplicationChoice factory to create an ApplicationForm without any traits by default
- Move ApplicationForm traits nested under `complete_application_form` factory so usage doesn't rely on using a fully completed application form as in most cases it's not required
- Move away from using transients where they can be replaced by traits
- Add `minimum_info` trait to enable setting up a form with the minimum required information
- change `after(:build)` to `after(:create)` where data has to be created (to reflect actual factory behavior, as creating associations forces the factory to be created)
- replace `associated_object { create(:associated_object) }` with `association(:associated_object)` (similar to above, this forces the creation of a factory even when we use `build` in order to satisfy the association)
 - update specs to use new setup
- use `build` whenever possible in specs
   - `create` adds unnecessary overhead of saving to the database
   - wrapping object creation in a single transaction is faster (achieved by only using `create` for the primary object)

## Factory usage
- If you require an application form with information setup, try using the `minum_data` trait as a first step
- Use`build` over `create` unless you have to persist data
- `build` secondary objects and let the primary object deal with the creation as needed

```ruby
let(:provider) { build(:provider) }
let(:course) { build(:course, provider: provider) }
let(:course_option) { build(:course_option, course: course) }
let(:application_choice) { create(:application_choice, course_option: course_option) }
```
- Prefer traits over transients e.g. use transients if you need to create multiple associated factories, use traits if you want to setup data in a particular way.

#### Good
```ruby
 trait :with_degree do
    application_qualifications { [association(:degree_qualification, application_form: instance)] }
  end
```

<details>

<summary>FactoryBot.build(:application_form, :with_degree)</summary>

```bash
> pry(main)> application_form = FactoryBot.build(:application_form, :with_degree)
  SiteSetting Load (0.5ms)  SELECT "site_settings".* FROM "site_settings" WHERE "site_settings"."name" = $1 LIMIT $2  [["name", "cycle_schedule"], ["LIMIT", 1]]
=> #<ApplicationForm:0x00007fdfe74fd1d8
 id: nil,
 candidate_id: nil,
 first_name: nil,
 last_name: nil,
 created_at: nil,
 updated_at: nil,
 first_nationality: nil,
 second_nationality: nil,
 english_main_language: nil,
 english_language_details: nil,
 other_language_details: nil,
 date_of_birth: nil,
 further_information: nil,
 phone_number: nil,
 address_line1: nil,
 address_line2: nil,
 address_line3: nil,
 address_line4: nil,
 country: nil,
 postcode: nil,
 submitted_at: nil,
 support_reference: nil,
 disability_disclosure: nil,
 uk_residency_status: nil,
 work_history_completed: false,
 work_history_explanation: nil,
 degrees_completed: false,
 becoming_a_teacher: nil,
 subject_knowledge: nil,
 interview_preferences: nil,
 other_qualifications_completed: false,
 disclose_disability: nil,
 work_history_breaks: nil,
 course_choices_completed: false,
 volunteering_completed: false,
 volunteering_experience: nil,
 phase: "apply_1",
 equality_and_diversity: nil,
 safeguarding_issues: nil,
 safeguarding_issues_status: "not_answered_yet",
 previous_application_form_id: nil,
 personal_details_completed: false,
 contact_details_completed: false,
 english_gcse_completed: false,
 maths_gcse_completed: false,
 training_with_a_disability_completed: false,
 safeguarding_issues_completed: false,
 becoming_a_teacher_completed: false,
 subject_knowledge_completed: false,
 interview_preferences_completed: false,
 science_gcse_completed: false,
 edit_by: nil,
 address_type: "uk",
 international_address: nil,
 right_to_work_or_study: nil,
 right_to_work_or_study_details: nil,
 efl_completed: false,
 third_nationality: nil,
 fourth_nationality: nil,
 fifth_nationality: nil,
 recruitment_cycle_year: 2021,
 feedback_satisfaction_level: nil,
 feedback_suggestions: nil,
 latitude: nil,
 longitude: nil,
 feature_restructured_work_history: true,
```

```bash
 pry(main)> application_form.application_qualifications
=> [#<ApplicationQualification:0x00007fdfeeccac10
  id: nil,
  application_form_id: nil,
  level: "degree",
  qualification_type: "Bachelor of Metallurgy",
  subject: "Medical statistics",
  grade: "Not applicable",
  predicted_grade: false,
  award_year: "1989",
  institution_name: "University of South Wales",
  institution_country: "GB",
  awarding_body: "Carson Streich College",
  equivalency_details: "Minus nulla voluptatibus. Praesentium fuga vel. Accusamus odit sint. Possimus nisi sit. Odio qui aliquam. Et optio tempora. Libero enim voluptas. Quae consequatur placeat. Deserunt est dicta. Culpa m.",
  created_at: nil,
  updated_at: nil,
  other_uk_qualification_type: nil,
  missing_explanation: nil,
  start_year: "2021",
  qualification_type_hesa_code: 78,
  subject_hesa_code: 101031,
  institution_hesa_code: 90,
  grade_hesa_code: 98,
  international: false,
  naric_reference: nil,
  comparable_uk_degree: nil,
  non_uk_qualification_type: nil,
  comparable_uk_qualification: nil,
  constituent_grades: nil,
  public_id: nil>]
```
</details>

#### Bad

```ruby
trait :with_degree do
    with_degree { true }
 end

after(:build) do |application_form, evaluator|
  if evaluator.with_degree
    create(:degree_qualification, application_form: application_form)
  end
end
```
<details>
<summary>FactoryBot.build(:completed_application_form, :with_degree)</summary>

```bash
[3] pry(main)> application_form = FactoryBot.build(:completed_application_form, :with_degree)
  SiteSetting Load (0.4ms)  SELECT "site_settings".* FROM "site_settings" WHERE "site_settings"."name" = $1 LIMIT $2  [["name", "cycle_schedule"], ["LIMIT", 1]]
   (0.2ms)  BEGIN
  Candidate Exists? (0.3ms)  SELECT 1 AS one FROM "candidates" WHERE LOWER("candidates"."email_address") = LOWER($1) LIMIT $2  [["email_address", "eefad763ae@example.com"], ["LIMIT", 1]]
  Candidate Create (0.2ms)  INSERT INTO "candidates" ("email_address", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"  [["email_address", "eefad763ae@example.com"], ["created_at", "2021-02-23 21:54:03.634064"], ["updated_at", "2021-02-23 21:54:03.634064"]]
  Audited::Audit Create (1.1ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["auditable_id", 81], ["auditable_type", "Candidate"], ["action", "create"], ["audited_changes", "{\"email_address\":\"eefad763ae@example.com\",\"magic_link_token\":null,\"magic_link_token_sent_at\":null,\"hide_in_reporting\":false,\"course_from_find_id\":null,\"sign_up_email_bounced\":false,\"last_signed_in_at\":null}"], ["version", 1], ["request_uuid", "1250bc04-84e3-42a6-8917-e869a97da806"], ["created_at", "2021-02-23 21:54:03.636150"]]
  ApplicationChoice Update All (0.2ms)  UPDATE "application_choices" SET "updated_at" = $1 WHERE "application_choices"."application_form_id" IS NULL AND (1=0)  [["updated_at", "2021-02-23 21:54:03.638432"]]
  ApplicationForm Create (0.6ms)  INSERT INTO "application_forms" ("candidate_id", "first_name", "last_name", "created_at", "updated_at", "first_nationality", "second_nationality", "date_of_birth", "further_information", "phone_number", "address_line1", "address_line2", "address_line3", "address_line4", "country", "postcode", "submitted_at", "support_reference", "disability_disclosure", "work_history_completed", "work_history_explanation", "degrees_completed", "becoming_a_teacher", "subject_knowledge", "interview_preferences", "other_qualifications_completed", "disclose_disability", "course_choices_completed", "volunteering_completed", "volunteering_experience", "safeguarding_issues_status", "personal_details_completed", "contact_details_completed", "english_gcse_completed", "maths_gcse_completed", "training_with_a_disability_completed", "safeguarding_issues_completed", "becoming_a_teacher_completed", "subject_knowledge_completed", "interview_preferences_completed", "science_gcse_completed", "recruitment_cycle_year") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42) RETURNING "id"  [["candidate_id", 81], ["first_name", "Xavier"], ["last_name", "Strosin"], ["created_at", "2021-02-23 21:54:03.639336"], ["updated_at", "2021-02-23 21:54:03.639336"], ["first_nationality", "British"], ["second_nationality", "American"], ["date_of_birth", "1990-05-19"], ["further_information", "Vero veritatis et. Omnis blanditiis veniam. Qui earum illum. Non provident enim. Est dolor expedita. Delectus ut deserunt. Ut voluptas autem. Quam enim quibusdam. Eum mollitia et. Et non nemo. Ipsa inventore impedit. In est officiis. Corporis ut a. Sunt quia placeat. Id molestias minus. Aut nulla s."], ["phone_number", "07997 939970"], ["address_line1", "8204 Dicki Forge"], ["address_line2", "McKenzieburgh"], ["address_line3", "County Londonderry"], ["address_line4", ""], ["country", "GB"], ["postcode", "WF5W 2SL"], ["submitted_at", "2021-02-22 12:45:34"], ["support_reference", "AY3246"], ["disability_disclosure", "In ea enim. Et aperiam nesciunt. Ipsa eum non. Maxime eaque vero. Animi autem aut. Rerum laborum qui. Dolor numquam sunt. Pariatur ipsa dolores. Sed maiores expedita. Quo consectetur sequi. Minus maiores corrupti. Rerum libero cum. Aperiam numquam et. At sunt voluptatem. Qui et quia. Atque recusand."], ["work_history_completed", true], ["work_history_explanation", "Est hic doloribus. Voluptate similique sed. Facilis itaque error. Maiores repellendus voluptatem. Ipsa qui accusamus. Nemo culpa accusamus. Impedit dolor animi. Quia voluptates deleniti. Nam at dolores. Earum debitis qui. Earum porro sed. Consequatur aliquid voluptas. Maiores ea dignissimos. Hic numquam dolores. Sint eum quasi. Quisquam et asperiores. Repudiandae quia est. Eum sunt esse. Est prov."], ["degrees_completed", true], ["becoming_a_teacher", "Voluptatem consectetur quia. Architecto sint officia. Cum possimus commodi. Atque voluptatem sequi. Vitae eaque ut. Illo suscipit et. Corrupti eius provident. A explicabo accusantium. In qui voluptas. Et et facilis. Iure amet id. Dolore rerum aut. Laborum tempore veritatis. Quia et aut. Non veniam laudantium. Aut illo nostrum. Sint voluptatibus odit. Ut voluptatem laborum. Non ea et. Necessitatibus fugiat facere. Sequi libero dolores. Ipsum quasi nam. In quia rerum. Eum voluptatem ut. Debitis p."], ["subject_knowledge", "Similique sunt blanditiis. Facere adipisci quidem. Nemo sed vero. Aliquam corrupti qui. Modi corporis aut. Ducimus ipsa explicabo. Natus et illo. Exercitationem quo dolores. Doloribus et placeat. Quia unde eius. Et nemo impedit. Voluptatem dolorem quod. Itaque placeat in. Eum sit animi. Recusandae ."], ["interview_preferences", "Voluptatem repellat tempore. Corporis praesentium qui. Fuga ut porro. Eaque atque fuga. Laudantium ."], ["other_qualifications_completed", true], ["disclose_disability", true], ["course_choices_completed", true], ["volunteering_completed", true], ["volunteering_experience", false], ["safeguarding_issues_status", "no_safeguarding_issues_to_declare"], ["personal_details_completed", true], ["contact_details_completed", true], ["english_gcse_completed", true], ["maths_gcse_completed", true], ["training_with_a_disability_completed", true], ["safeguarding_issues_completed", true], ["becoming_a_teacher_completed", true], ["subject_knowledge_completed", true], ["interview_preferences_completed", true], ["science_gcse_completed", true], ["recruitment_cycle_year", 2021]]
  Audited::Audit Create (0.8ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["auditable_id", 79], ["auditable_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"candidate_id\":81,\"first_name\":\"Xavier\",\"last_name\":\"Strosin\",\"first_nationality\":\"British\",\"second_nationality\":\"American\",\"english_main_language\":null,\"english_language_details\":null,\"other_language_details\":null,\"date_of_birth\":\"1990-05-19\",\"further_information\":\"Vero veritatis et. Omnis blanditiis veniam. Qui earum illum. Non provident enim. Est dolor expedita. Delectus ut deserunt. Ut voluptas autem. Quam enim quibusdam. Eum mollitia et. Et non nemo. Ipsa inventore impedit. In est officiis. Corporis ut a. Sunt quia placeat. Id molestias minus. Aut nulla s.\",\"phone_number\":\"07997 939970\",\"address_line1\":\"8204 Dicki Forge\",\"address_line2\":\"McKenzieburgh\",\"address_line3\":\"County Londonderry\",\"address_line4\":\"\",\"country\":\"GB\",\"postcode\":\"WF5W 2SL\",\"submitted_at\":\"2021-02-22T12:45:34.000+00:00\",\"support_reference\":\"AY3246\",\"disability_disclosure\":\"In ea enim. Et aperiam nesciunt. Ipsa eum non. Maxime eaque vero. Animi autem aut. Rerum laborum qui. Dolor numquam sunt. Pariatur ipsa dolores. Sed maiores expedita. Quo consectetur sequi. Minus maiores corrupti. Rerum libero cum. Aperiam numquam et. At sunt voluptatem. Qui et quia. Atque recusand.\",\"uk_residency_status\":null,\"work_history_completed\":true,\"work_history_explanation\":\"Est hic doloribus. Voluptate similique sed. Facilis itaque error. Maiores repellendus voluptatem. Ipsa qui accusamus. Nemo culpa accusamus. Impedit dolor animi. Quia voluptates deleniti. Nam at dolores. Earum debitis qui. Earum porro sed. Consequatur aliquid voluptas. Maiores ea dignissimos. Hic numquam dolores. Sint eum quasi. Quisquam et asperiores. Repudiandae quia est. Eum sunt esse. Est prov.\",\"degrees_completed\":true,\"becoming_a_teacher\":\"Voluptatem consectetur quia. Architecto sint officia. Cum possimus commodi. Atque voluptatem sequi. Vitae eaque ut. Illo suscipit et. Corrupti eius provident. A explicabo accusantium. In qui voluptas. Et et facilis. Iure amet id. Dolore rerum aut. Laborum tempore veritatis. Quia et aut. Non veniam laudantium. Aut illo nostrum. Sint voluptatibus odit. Ut voluptatem laborum. Non ea et. Necessitatibus fugiat facere. Sequi libero dolores. Ipsum quasi nam. In quia rerum. Eum voluptatem ut. Debitis p.\",\"subject_knowledge\":\"Similique sunt blanditiis. Facere adipisci quidem. Nemo sed vero. Aliquam corrupti qui. Modi corporis aut. Ducimus ipsa explicabo. Natus et illo. Exercitationem quo dolores. Doloribus et placeat. Quia unde eius. Et nemo impedit. Voluptatem dolorem quod. Itaque placeat in. Eum sit animi. Recusandae .\",\"interview_preferences\":\"Voluptatem repellat tempore. Corporis praesentium qui. Fuga ut porro. Eaque atque fuga. Laudantium .\",\"other_qualifications_completed\":true,\"disclose_disability\":true,\"work_history_breaks\":null,\"course_choices_completed\":true,\"volunteering_completed\":true,\"volunteering_experience\":false,\"phase\":\"apply_1\",\"equality_and_diversity\":null,\"safeguarding_issues\":null,\"safeguarding_issues_status\":\"no_safeguarding_issues_to_declare\",\"previous_application_form_id\":null,\"personal_details_completed\":true,\"contact_details_completed\":true,\"english_gcse_completed\":true,\"maths_gcse_completed\":true,\"training_with_a_disability_completed\":true,\"safeguarding_issues_completed\":true,\"becoming_a_teacher_completed\":true,\"subject_knowledge_completed\":true,\"interview_preferences_completed\":true,\"science_gcse_completed\":true,\"edit_by\":null,\"address_type\":\"uk\",\"international_address\":null,\"right_to_work_or_study\":null,\"right_to_work_or_study_details\":null,\"efl_completed\":false,\"third_nationality\":null,\"fourth_nationality\":null,\"fifth_nationality\":null,\"recruitment_cycle_year\":2021,\"feedback_satisfaction_level\":null,\"feedback_suggestions\":null,\"latitude\":null,\"longitude\":null,\"feature_restructured_work_history\":true,\"work_history_status\":null}"], ["version", 1], ["request_uuid", "63dcb01c-e403-4400-a6e2-2a9cefb17ce4"], ["created_at", "2021-02-23 21:54:03.643138"]]
   (0.2ms)  SELECT nextval('qualifications_public_id_seq')
  ApplicationQualification Create (1.1ms)  INSERT INTO "application_qualifications" ("application_form_id", "level", "qualification_type", "subject", "grade", "predicted_grade", "award_year", "institution_name", "institution_country", "awarding_body", "equivalency_details", "created_at", "updated_at", "start_year", "qualification_type_hesa_code", "subject_hesa_code", "institution_hesa_code", "grade_hesa_code", "public_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) RETURNING "id"  [["application_form_id", 79], ["level", "degree"], ["qualification_type", "Master of Science"], ["subject", "Epidemiology"], ["grade", "Ordinary degree"], ["predicted_grade", false], ["award_year", "2017"], ["institution_name", "St Mary's University, Twickenham"], ["institution_country", "GB"], ["awarding_body", "Prof. Cortez Dicki Institute"], ["equivalency_details", "Numquam nulla nesciunt. Ut eligendi et. Esse odit est. Perferendis ut est. Voluptas ab cumque. Doloremque sequi adipisci. Maxime molestiae iusto. Quae illo alias. Fuga sed nemo. Iure labore corporis.."], ["created_at", "2021-02-23 21:54:03.647436"], ["updated_at", "2021-02-23 21:54:03.647436"], ["start_year", "2021"], ["qualification_type_hesa_code", 205], ["subject_hesa_code", 101335], ["institution_hesa_code", 39], ["grade_hesa_code", 10], ["public_id", 310]]
  Audited::Audit Create (0.7ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 163], ["auditable_type", "ApplicationQualification"], ["associated_id", 79], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"application_form_id\":79,\"level\":\"degree\",\"qualification_type\":\"Master of Science\",\"subject\":\"Epidemiology\",\"grade\":\"Ordinary degree\",\"predicted_grade\":false,\"award_year\":\"2017\",\"institution_name\":\"St Mary's University, Twickenham\",\"institution_country\":\"GB\",\"awarding_body\":\"Prof. Cortez Dicki Institute\",\"equivalency_details\":\"Numquam nulla nesciunt. Ut eligendi et. Esse odit est. Perferendis ut est. Voluptas ab cumque. Doloremque sequi adipisci. Maxime molestiae iusto. Quae illo alias. Fuga sed nemo. Iure labore corporis..\",\"other_uk_qualification_type\":null,\"missing_explanation\":null,\"start_year\":\"2021\",\"qualification_type_hesa_code\":205,\"subject_hesa_code\":101335,\"institution_hesa_code\":39,\"grade_hesa_code\":10,\"international\":false,\"naric_reference\":null,\"comparable_uk_degree\":null,\"non_uk_qualification_type\":null,\"comparable_uk_qualification\":null,\"constituent_grades\":null,\"public_id\":310}"], ["version", 1], ["request_uuid", "f1c72ff7-40a0-44a6-8104-834bbc4974ba"], ["created_at", "2021-02-23 21:54:03.651156"]]
  ApplicationForm Update (0.6ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2021-02-23 21:54:03.649821"], ["id", 79]]
  Candidate Update (0.3ms)  UPDATE "candidates" SET "updated_at" = $1 WHERE "candidates"."id" = $2  [["updated_at", "2021-02-23 21:54:03.654486"], ["id", 81]]
   (0.4ms)  COMMIT
  ApplicationChoice Update All (0.3ms)  UPDATE "application_choices" SET "updated_at" = $1 WHERE "application_choices"."application_form_id" = $2  [["updated_at", "2021-02-23 21:54:03.655953"], ["application_form_id", 79]]
=> #<ApplicationForm:0x00007f897cd83238
 id: 79,
 candidate_id: 81,
 first_name: "Xavier",
 last_name: "Strosin",
 created_at: Tue, 23 Feb 2021 21:54:03 GMT +00:00,
 updated_at: Tue, 23 Feb 2021 21:54:03 GMT +00:00,
 first_nationality: "British",
 second_nationality: "American",
 english_main_language: nil,
 english_language_details: nil,
 other_language_details: nil,
 date_of_birth: Sat, 19 May 1990,
 further_information:
  "Vero veritatis et. Omnis blanditiis veniam. Qui earum illum. Non provident enim. Est dolor expedita. Delectus ut deserunt. Ut voluptas autem. Quam enim quibusdam. Eum mollitia et. Et non nemo. Ipsa inventore impedit. In est officiis. Corporis ut a. Sunt quia placeat. Id molestias minus. Aut nulla s.",
 phone_number: "07997 939970",
 address_line1: "8204 Dicki Forge",
 address_line2: "McKenzieburgh",
 address_line3: "County Londonderry",
 address_line4: "",
 country: "GB",
 postcode: "WF5W 2SL",
 submitted_at: Mon, 22 Feb 2021 12:45:34 GMT +00:00,
 support_reference: "AY3246",
 disability_disclosure:
  "In ea enim. Et aperiam nesciunt. Ipsa eum non. Maxime eaque vero. Animi autem aut. Rerum laborum qui. Dolor numquam sunt. Pariatur ipsa dolores. Sed maiores expedita. Quo consectetur sequi. Minus maiores corrupti. Rerum libero cum. Aperiam numquam et. At sunt voluptatem. Qui et quia. Atque recusand.",
 uk_residency_status: nil,
 work_history_completed: true,
 work_history_explanation:
  "Est hic doloribus. Voluptate similique sed. Facilis itaque error. Maiores repellendus voluptatem. Ipsa qui accusamus. Nemo culpa accusamus. Impedit dolor animi. Quia voluptates deleniti. Nam at dolores. Earum debitis qui. Earum porro sed. Consequatur aliquid voluptas. Maiores ea dignissimos. Hic numquam dolores. Sint eum quasi. Quisquam et asperiores. Repudiandae quia est. Eum sunt esse. Est prov.",
 degrees_completed: true,
 becoming_a_teacher:
  "Voluptatem consectetur quia. Architecto sint officia. Cum possimus commodi. Atque voluptatem sequi. Vitae eaque ut. Illo suscipit et. Corrupti eius provident. A explicabo accusantium. In qui voluptas. Et et facilis. Iure amet id. Dolore rerum aut. Laborum tempore veritatis. Quia et aut. Non veniam laudantium. Aut illo nostrum. Sint voluptatibus odit. Ut voluptatem laborum. Non ea et. Necessitatibus fugiat facere. Sequi libero dolores. Ipsum quasi nam. In quia rerum. Eum voluptatem ut. Debitis p.",
 subject_knowledge:
  "Similique sunt blanditiis. Facere adipisci quidem. Nemo sed vero. Aliquam corrupti qui. Modi corporis aut. Ducimus ipsa explicabo. Natus et illo. Exercitationem quo dolores. Doloribus et placeat. Quia unde eius. Et nemo impedit. Voluptatem dolorem quod. Itaque placeat in. Eum sit animi. Recusandae .",
 interview_preferences: "Voluptatem repellat tempore. Corporis praesentium qui. Fuga ut porro. Eaque atque fuga. Laudantium .",
 other_qualifications_completed: true,
 disclose_disability: true,
 work_history_breaks: nil,
 course_choices_completed: true,
 volunteering_completed: true,
 volunteering_experience: false,
 phase: "apply_1",
 equality_and_diversity: nil,
 safeguarding_issues: nil,
 safeguarding_issues_status: "no_safeguarding_issues_to_declare",
 previous_application_form_id: nil,
 personal_details_completed: true,
 contact_details_completed: true,
 english_gcse_completed: true,
 maths_gcse_completed: true,
 training_with_a_disability_completed: true,
 safeguarding_issues_completed: true,
 becoming_a_teacher_completed: true,
 subject_knowledge_completed: true,
 interview_preferences_completed: true,
 science_gcse_completed: true,
 edit_by: nil,
 address_type: "uk",
 international_address: nil,
 right_to_work_or_study: nil,
 right_to_work_or_study_details: nil,
efl_completed: false,
 third_nationality: nil,
 fourth_nationality: nil,
 fifth_nationality: nil,
 recruitment_cycle_year: 2021,
 feedback_satisfaction_level: nil,
 feedback_suggestions: nil,
 latitude: nil,
 longitude: nil,
 feature_restructured_work_history: true,
 work_history_status: nil>
```

```bash
 application_form.application_qualifications
  ApplicationQualification Load (0.6ms)  SELECT "application_qualifications".* FROM "application_qualifications" WHERE "application_qualifications"."application_form_id" = $1  [["application_form_id", 79]]
=> [#<ApplicationQualification:0x00007f89618b9b00
  id: 163,
  application_form_id: 79,
  level: "degree",
  qualification_type: "Master of Science",
  subject: "Epidemiology",
  grade: "Ordinary degree",
  predicted_grade: false,
  award_year: "2017",
  institution_name: "St Mary's University, Twickenham",
  institution_country: "GB",
  awarding_body: "Prof. Cortez Dicki Institute",
  equivalency_details: "Numquam nulla nesciunt. Ut eligendi et. Esse odit est. Perferendis ut est. Voluptas ab cumque. Doloremque sequi adipisci. Maxime molestiae iusto. Quae illo alias. Fuga sed nemo. Iure labore corporis..",
  created_at: Tue, 23 Feb 2021 21:54:03 GMT +00:00,
  updated_at: Tue, 23 Feb 2021 21:54:03 GMT +00:00,
  other_uk_qualification_type: nil,
  missing_explanation: nil,
  start_year: "2021",
  qualification_type_hesa_code: 205,
  subject_hesa_code: 101335,
  institution_hesa_code: 39,
  grade_hesa_code: 10,
  international: false,
  naric_reference: nil,
  comparable_uk_degree: nil,
  non_uk_qualification_type: nil,
  comparable_uk_qualification: nil,
  constituent_grades: nil,
  public_id: 310>]
```

</details>

## Link to Trello card

https://trello.com/c/Q1NI9TbQ/419-factories

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
