### PR TITLE
Make timeline links unique to address DAC recommendations

### DIFF
--- a/app/components/provider_interface/application_timeline_component.html.erb
+++ b/app/components/provider_interface/application_timeline_component.html.erb
@@ -11,7 +11,9 @@
       </p>
       <div class="app-timeline__event_link">
         <% if event.link_name && event.link_path %>
-          <%= govuk_link_to event.link_name, event.link_path, class: 'govuk-link--no-visited-state' %>
+          <%= govuk_link_to event.link_path, class: 'govuk-link--no-visited-state' do %>
+            <%= event.link_name %> <span class="govuk-visually-hidden"><%= event.date.to_s(:govuk_date_and_time) %></span>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/spec/components/provider_interface/application_timeline_component_spec.rb
+++ b/spec/components/provider_interface/application_timeline_component_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Application received'
       expect(rendered.text).to include 'Candidate'
       expect(rendered.text).to include '6 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View application'
+      expect(rendered.css('a').text).to include 'View application'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '6 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}"
     end
   end
@@ -72,7 +73,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Offer made'
       expect(rendered.text).to include 'Bob Roberts'
       expect(rendered.text).to include '8 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View offer'
+      expect(rendered.css('a').text).to include 'View offer'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '8 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/offer"
     end
   end
@@ -90,7 +92,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       expect(rendered.text).to include 'Note added'
       expect(rendered.text).to include 'Bob Roberts'
       expect(rendered.text).to include '11 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View note'
+      expect(rendered.css('a').text).to include 'View note'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '11 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/notes/#{note.id}"
     end
   end
@@ -101,7 +104,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Feedback sent'
       expect(rendered.text).to include '11 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View feedback'
+      expect(rendered.css('a').text).to include 'View feedback'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '11 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/feedback"
     end
   end
@@ -113,7 +117,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Offer changed'
       expect(rendered.text).to include '11 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View offer'
+      expect(rendered.css('a').text).to include 'View offer'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '11 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/offer"
     end
   end
@@ -132,7 +137,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview set up'
       expect(rendered.text).to include '11 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View interview'
+      expect(rendered.css('a').text).to include 'View interview'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '11 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
 
@@ -149,7 +155,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview updated'
       expect(rendered.text).to include '11 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View interview'
+      expect(rendered.css('a').text).to include 'View interview'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '11 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
 
@@ -166,7 +173,8 @@ RSpec.describe ProviderInterface::ApplicationTimelineComponent do
       rendered = render_inline(described_class.new(application_choice: application_choice))
       expect(rendered.text).to include 'Interview cancelled'
       expect(rendered.text).to include '11 February 2020 at 10pm'
-      expect(rendered.css('a').text).to eq 'View interview'
+      expect(rendered.css('a').text).to include 'View interview'
+      expect(rendered.css('.govuk-visually-hidden').text).to eq '11 February 2020 at 10pm'
       expect(rendered.css('a').attr('href').value).to eq "/provider/applications/#{application_choice.id}/interviews#interview-#{interview.id}"
     end
   end


### PR DESCRIPTION
## Context

Multiple links with the same name could be found on the Timeline page without a
context. This could be confusing for users who want to navigate outside of the
context. We are adding visually hidden date and time information so the purpose
of each link can be identified.
<img width="384" alt="Screenshot 2021-02-23 at 10 58 23" src="https://user-images.githubusercontent.com/38078064/108837030-85499380-75c9-11eb-8baa-4cd29699c8bf.png">
<img width="373" alt="Screenshot 2021-02-23 at 10 58 33" src="https://user-images.githubusercontent.com/38078064/108837040-87abed80-75c9-11eb-9e89-2fec323f0f10.png">

## Changes proposed in this pull request

We are adding visually hidden date and time information so the purpose
of each link can be identified.

<img width="510" alt="Screenshot 2021-02-23 at 11 24 07" src="https://user-images.githubusercontent.com/38078064/108837105-b1651480-75c9-11eb-9a27-eca2cd15315d.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
