### PR TITLE
Support unconditional offers via the API

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -322,6 +322,21 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def unconditional_offer_accepted(application_choice)
+    @course_name_and_code = application_choice.offered_option.course.name_and_code
+    @provider_name = application_choice.offered_option.provider.name
+    @start_date = application_choice.offered_option.course.start_date.to_s(:month_and_year)
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.unconditional_offer_accepted.subject', {
+        course_name_and_code: @course_name_and_code,
+        provider_name: @provider_name,
+        start_date: @start_date,
+      }),
+    )
+  end
+
   def ucas_match_initial_email_duplicate_applications(application_choice)
     @course_name_and_code = application_choice.course_option.course.name_and_code
     @provider_name = application_choice.course_option.course.provider.name

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -61,6 +61,20 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def unconditional_offer_accepted(provider_user, application_choice)
+    @application_choice = application_choice
+
+    email_for_provider(
+      provider_user,
+      application_choice.application_form,
+      subject: I18n.t!(
+        'provider_mailer.unconditional_offer_accepted.subject',
+        candidate_name: application_choice.application_form.full_name,
+        support_reference: @application_choice.application_form.support_reference,
+      ),
+    )
+  end
+
   def declined_by_default(provider_user, application_choice)
     @application_choice = application_choice
     email_for_provider(

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -4,6 +4,8 @@ class AcceptOffer
   end
 
   def save!
+    return AcceptUnconditionalOffer.new(application_choice: @application_choice).save! if unconditional_offer?
+
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).accept!
       @application_choice.update!(accepted_at: Time.zone.now)
@@ -39,5 +41,9 @@ private
     @application_choice
       .self_and_siblings
       .awaiting_provider_decision
+  end
+
+  def unconditional_offer?
+    @application_choice.offer&.fetch('conditions', []).blank?
   end
 end

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -4,7 +4,9 @@ class AcceptOffer
   end
 
   def save!
-    return AcceptUnconditionalOffer.new(application_choice: @application_choice).save! if unconditional_offer?
+    if FeatureFlag.active?(:unconditional_offers_via_api) && unconditional_offer?
+      return AcceptUnconditionalOffer.new(application_choice: @application_choice).save!
+    end
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).accept!

--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -1,0 +1,23 @@
+class AcceptUnconditionalOffer
+  def initialize(application_choice:)
+    @application_choice = application_choice
+  end
+
+  def save!
+    ActiveRecord::Base.transaction do
+      ApplicationStateChange.new(@application_choice).accept!
+      @application_choice.update!(accepted_at: Time.zone.now)
+
+      ApplicationStateChange.new(@application_choice).confirm_conditions_met!
+      @application_choice.update!(recruited_at: Time.zone.now)
+    end
+
+    NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|
+      ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
+    end
+
+    CandidateMailer.offer_accepted(@application_choice).deliver_later
+
+    StateChangeNotifier.new(:recruited, @application_choice).application_outcome_notification
+  end
+end

--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -16,5 +16,7 @@ class AcceptUnconditionalOffer
     CandidateMailer.unconditional_offer_accepted(@application_choice).deliver_later
 
     StateChangeNotifier.new(:recruited, @application_choice).application_outcome_notification
+  rescue Workflow::NoTransitionAllowed
+    false
   end
 end

--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -10,10 +10,10 @@ class AcceptUnconditionalOffer
     end
 
     NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|
-      ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
+      ProviderMailer.unconditional_offer_accepted(provider_user, @application_choice).deliver_later
     end
 
-    CandidateMailer.offer_accepted(@application_choice).deliver_later
+    CandidateMailer.unconditional_offer_accepted(@application_choice).deliver_later
 
     StateChangeNotifier.new(:recruited, @application_choice).application_outcome_notification
   end

--- a/app/services/accept_unconditional_offer.rb
+++ b/app/services/accept_unconditional_offer.rb
@@ -5,11 +5,8 @@ class AcceptUnconditionalOffer
 
   def save!
     ActiveRecord::Base.transaction do
-      ApplicationStateChange.new(@application_choice).accept!
-      @application_choice.update!(accepted_at: Time.zone.now)
-
-      ApplicationStateChange.new(@application_choice).confirm_conditions_met!
-      @application_choice.update!(recruited_at: Time.zone.now)
+      ApplicationStateChange.new(@application_choice).accept_unconditional_offer!
+      @application_choice.update!(accepted_at: Time.zone.now, recruited_at: Time.zone.now)
     end
 
     NotificationsList.for(@application_choice, include_ratifying_provider: true).each do |provider_user|

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -57,6 +57,7 @@ class ApplicationStateChange
       event :make_offer, transitions_to: :offer
       event :withdraw_offer, transitions_to: :offer_withdrawn
       event :accept, transitions_to: :pending_conditions
+      event :accept_unconditional_offer, transitions_to: :recruited
       event :decline, transitions_to: :declined
       event :decline_by_default, transitions_to: :declined
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,7 @@ class FeatureFlag
     [:restructured_work_history, 'Candidates use the new design for the Work History section', 'David Gisbey'],
     [:structured_reasons_for_rejection_on_rbd, 'Allows providers to give specific feedback for applications rejected by default', 'Aga Dufrat'],
     [:updated_offer_flow, 'Activates the new make offer flow for providers', 'Despo Pentara'],
+    [:unconditional_offers_via_api, 'Activates the ability to accept unconditional offers via the API', 'Steve Laing'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/candidate_mailer/unconditional_offer_accepted.text.erb
@@ -1,0 +1,17 @@
+Dear <%= @application_form.first_name %>,
+
+#You’ve accepted <%= @provider_name %>’s offer to study <%= @course_name_and_code %>
+
+If everything goes well with meeting your conditions, you’ll start <%= @course_name_and_code %> <%= @provider_name %> on <%= @start_date %>.
+
+You can check your conditions anytime by signing in to your account:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+#What to do if you’re unable to start training in <%= @start_date %>
+
+Some providers allow you to defer your offer. This means that you could start your course a year later.
+
+Every provider is different, so it may or may not be possible to do this. Find out by contacting <%= @provider_name %>.
+
+Asking if it’s possible to defer will not affect your existing offer.

--- a/app/views/provider_mailer/unconditional_offer_accepted.text.erb
+++ b/app/views/provider_mailer/unconditional_offer_accepted.text.erb
@@ -1,0 +1,16 @@
+<% content_for :additional_footer_content do %><%= render 'unsubscribe' %><% end %>
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+# Offer accepted
+
+<%= @application_choice.application_form.full_name %> has accepted your offer to study <%= @application_choice.offered_course.name_and_code %>.
+
+# Tell us when the candidate has met their conditions
+
+Sign in to Manage teacher training applications to update the application status when they’ve met their conditions:
+
+<%= provider_interface_application_choice_url(@application_choice) %>
+
+# Update the Database of Teacher Training Providers
+
+Enter the candidate’s details into the Database of Teacher Training Providers (DTTP) when they’ve started the course.

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -342,6 +342,14 @@ en:
         - provider_mailer-offer_accepted
         - candidate_mailer-offer_accepted
 
+    offer-accept_unconditional_offer:
+      name: Candidate accepts an unconditional offer
+      by: candidate
+      description: The candidate can accept the offer. All other application choices will be withdrawn.
+      emails:
+        - provider_mailer-offer_accepted
+        - candidate_mailer-offer_accepted
+
     offer-decline:
       name: Candidate declines offer
       by: candidate

--- a/config/locales/emails/candidate_mailer.yml
+++ b/config/locales/emails/candidate_mailer.yml
@@ -22,6 +22,8 @@ en:
       subject: "%{referee_name} has not responded yet"
     offer_accepted:
       subject: "You’ve accepted %{provider_name}’s offer to study %{course_name_and_code}"
+    unconditional_offer_accepted:
+      subject: "You’ve accepted %{provider_name}’s offer to study %{course_name_and_code}"
     new_referee_request:
       not_responded:
         subject: "%{referee_name} has not responded yet"

--- a/config/locales/emails/provider_mailer.yml
+++ b/config/locales/emails/provider_mailer.yml
@@ -2,6 +2,8 @@ en:
   provider_mailer:
     offer_accepted:
       subject: "%{candidate_name} (%{support_reference}) has accepted your offer"
+    unconditional_offer_accepted:
+      subject: "%{candidate_name} (%{support_reference}) has accepted your offer"
     decline_by_default:
       subject: "%{candidate_name}’s (%{support_reference}) application withdrawn automatically"
     declined:

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -242,6 +242,37 @@ RSpec.describe CandidateMailer, type: :mailer do
     )
   end
 
+  describe '.unconditional_offer_accepted' do
+    let(:email) { described_class.unconditional_offer_accepted(application_form.application_choices.first) }
+    let(:application_choices) do
+      [build_stubbed(
+        :application_choice,
+        status: 'pending_conditions',
+        course_option: build_stubbed(
+          :course_option,
+          course: build_stubbed(
+            :course,
+            name: 'Mathematics',
+            code: 'M101',
+            start_date: Time.zone.local(2021, 9, 6),
+            provider: build_stubbed(
+              :provider,
+              name: 'Arithmetic College',
+            ),
+          ),
+        ),
+      )]
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
+      'greeting' => 'Dear Fred,',
+      'offer_details' => 'You’ve accepted Arithmetic College’s offer to study Mathematics (M101)',
+      'course start' => 'September 2021',
+    )
+  end
+
   context 'Interview emails' do
     let(:provider)  { create(:provider, name: 'Hogwards') }
     let(:interview) do

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -104,6 +104,25 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
   end
 
+  describe '.unconditional_offer_accepted' do
+    let(:email) { ProviderMailer.unconditional_offer_accepted(provider_user, application_choice) }
+
+    it_behaves_like('a mail with subject and content',
+                    'Harry Potter (123A) has accepted your offer',
+                    'provider name' => 'Dear Johny English',
+                    'course name and code' => 'Computer Science (6IND)')
+
+    context 'with an alternative course offer' do
+      let(:alternative_course) { build_stubbed(:course, provider: provider, name: 'Welding', code: '9ABC') }
+      let(:offered_course_option) { build_stubbed(:course_option, course: alternative_course, site: site) }
+
+      it_behaves_like('a mail with subject and content',
+                      'Harry Potter (123A) has accepted your offer',
+                      'provider name' => 'Dear Johny English',
+                      'course name and code' => 'Welding (9ABC)')
+    end
+  end
+
   describe '.declined_by_default' do
     let(:email) { ProviderMailer.declined_by_default(provider_user, application_choice) }
 

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AcceptOffer do
       ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
 
       course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
-      application_choice = create(:application_choice, status: :offer, course_option: course_option)
+      application_choice = create(:application_choice, :with_offer, course_option: course_option)
 
       expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(3)
       expect(ActionMailer::Base.deliveries.first.subject).to match(/has accepted your offer/)

--- a/spec/services/accept_offer_spec.rb
+++ b/spec/services/accept_offer_spec.rb
@@ -4,13 +4,24 @@ RSpec.describe AcceptOffer do
   include CourseOptionHelpers
 
   it 'sets the accepted_at date for the application_choice' do
-    application_choice = create(:application_choice, status: :offer)
+    application_choice = create(:application_choice, :with_offer)
 
     Timecop.freeze do
       expect {
         AcceptOffer.new(application_choice: application_choice).save!
       }.to change { application_choice.accepted_at }.to(Time.zone.now)
     end
+  end
+
+  it 'calls AcceptUnconditionalOffer when the feature is enabled and the offer is unconditional' do
+    FeatureFlag.activate(:unconditional_offers_via_api)
+
+    application_choice = build(:application_choice, status: :offer, offer: { conditions: [] })
+    allow(AcceptUnconditionalOffer).to receive(:new).and_call_original
+
+    described_class.new(application_choice: application_choice).save!
+
+    expect(AcceptUnconditionalOffer).to have_received(:new).with(application_choice: application_choice)
   end
 
   describe 'emails' do

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe AcceptUnconditionalOffer do
+  include CourseOptionHelpers
+
+  it 'sets the accepted_at date for the application_choice' do
+    application_choice = create(:application_choice, status: :offer)
+
+    Timecop.freeze do
+      expect {
+        described_class.new(application_choice: application_choice).save!
+      }.to change { application_choice.accepted_at }.to(Time.zone.now)
+    end
+  end
+
+  describe 'emails' do
+    around { |example| perform_enqueued_jobs(&example) }
+
+    it 'sends a notification email to the training provider and ratifying provider' do
+      training_provider = create(:provider)
+      training_provider_user = create(:provider_user, send_notifications: true, providers: [training_provider])
+
+      ratifying_provider = create(:provider)
+      ratifying_provider_user = create(:provider_user, send_notifications: true, providers: [ratifying_provider])
+
+      course_option = course_option_for_accredited_provider(provider: training_provider, accredited_provider: ratifying_provider)
+      application_choice = create(:application_choice, :with_offer, course_option: course_option)
+
+      expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(3)
+      expect(ActionMailer::Base.deliveries.first.subject).to match(/has accepted your offer/)
+      expect(ActionMailer::Base.deliveries.first.to).to eq [training_provider_user.email_address]
+      expect(ActionMailer::Base.deliveries.second.to).to eq [ratifying_provider_user.email_address]
+    end
+
+    it 'sends a confirmation email to the candidate' do
+      application_choice = create(:application_choice, status: :offer)
+
+      expect { described_class.new(application_choice: application_choice).save! }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.first.to).to eq [application_choice.application_form.candidate.email_address]
+      expect(ActionMailer::Base.deliveries.first.subject).to match(/You’ve accepted/)
+    end
+  end
+end

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe AcceptUnconditionalOffer do
     expect(notifier_double).to have_received(:application_outcome_notification)
   end
 
+  it 'returns false on state transition errors' do
+    state_change_double = instance_double(ApplicationStateChange)
+    allow(state_change_double).to receive(:accept_unconditional_offer!).and_raise(Workflow::NoTransitionAllowed)
+    allow(ApplicationStateChange).to receive(:new).and_return(state_change_double)
+
+    expect(described_class.new(application_choice: build(:application_choice)).save!).to be false
+    expect(state_change_double).to have_received(:accept_unconditional_offer!)
+  end
+
   describe 'emails' do
     around { |example| perform_enqueued_jobs(&example) }
 

--- a/spec/services/accept_unconditional_offer_spec.rb
+++ b/spec/services/accept_unconditional_offer_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.describe AcceptUnconditionalOffer do
   include CourseOptionHelpers
 
-  it 'sets the accepted_at date for the application_choice' do
+  it 'sets the accepted_at and recruited_at dates for the application_choice' do
     application_choice = build(:application_choice, status: :offer)
 
     Timecop.freeze do
       expect {
         described_class.new(application_choice: application_choice).save!
       }.to change { application_choice.accepted_at }.to(Time.zone.now)
+      .and change { application_choice.recruited_at }.to(Time.zone.now)
     end
   end
 

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -50,6 +50,8 @@ RSpec.feature 'Docs' do
       candidate_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-ucas_match_resolved_on_apply_email
       provider_mailer-courses_open_on_apply
+      candidate_mailer-unconditional_offer_accepted
+      provider_mailer-unconditional_offer_accepted
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Vendor makes unconditional offer' do
   include CandidateHelper
 
   scenario 'A vendor makes an unconditional offer and this is accepted by the candidate' do
+    FeatureFlag.activate(:unconditional_offers_via_api)
     given_a_candidate_has_submitted_their_application
     when_i_make_an_unconditional_offer_for_the_application_over_the_api
     then_i_can_see_the_offer_was_made_successfully

--- a/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
+++ b/spec/system/vendor_api/vendor_makes_unconditional_offer_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.feature 'Vendor makes unconditional offer' do
+  include CandidateHelper
+
+  scenario 'A vendor makes an unconditional offer and this is accepted by the candidate' do
+    given_a_candidate_has_submitted_their_application
+    when_i_make_an_unconditional_offer_for_the_application_over_the_api
+    then_i_can_see_the_offer_was_made_successfully
+
+    when_the_candidate_accepts_the_unconditional_offer
+    then_the_candidate_sees_that_they_have_accepted_the_offer
+  end
+
+  def given_a_candidate_has_submitted_their_application
+    Capybara.session_name = 'candidate_interaction'
+    Capybara.using_session('candidate_interaction') do
+      candidate_completes_application_form
+      candidate_submits_application
+    end
+  end
+
+  def when_i_make_an_unconditional_offer_for_the_application_over_the_api
+    Capybara.session_name = 'api_request'
+    Capybara.using_session('api_request') do
+      api_token = VendorAPIToken.create_with_random_token!(provider: @provider)
+      page.driver.header 'Authorization', "Bearer #{api_token}"
+      page.driver.header 'Content-Type', 'application/json'
+      @application_choice = @application.application_choices.first
+      @course_option = @application_choice.course_option
+      @provider_user = create(:provider_user, send_notifications: true, providers: [@provider])
+      uri = "/api/v1/applications/#{@application_choice.id}/offer"
+
+      @api_response = page.driver.post(uri, unconditional_offer_payload)
+    end
+  end
+
+  def then_i_can_see_the_offer_was_made_successfully
+    parsed_response_body = JSON.parse(@api_response.body)
+    application_attrs = parsed_response_body.dig('data', 'attributes')
+
+    expect(@api_response.status).to eq 200
+    expect(application_attrs['status']).to eq('offer')
+    expect(application_attrs.dig('offer', 'conditions')).to eq([])
+  end
+
+  def when_the_candidate_accepts_the_unconditional_offer
+    Capybara.using_session('candidate_interaction') do
+      visit candidate_interface_offer_path(@application_choice)
+
+      choose 'Accept offer and conditions'
+      click_button 'Continue'
+
+      click_button 'Accept offer'
+    end
+  end
+
+  def then_the_candidate_sees_that_they_have_accepted_the_offer
+    Capybara.using_session('candidate_interaction') do
+      expect(page).to have_content "You have accepted your offer for #{@application_choice.course.name_and_code} at #{@application_choice.provider.name}"
+    end
+  end
+
+  def unconditional_offer_payload
+    {
+      meta: {
+        attribution: {
+          full_name: 'Jane Smith',
+          email: 'jane.smith@example.com',
+          user_id: '12345',
+        },
+        timestamp: Time.zone.now.iso8601,
+      },
+      data: {
+        conditions: [],
+        course: nil,
+      },
+    }.to_json
+  end
+end


### PR DESCRIPTION
## Context

We'd like to allow vendors to make unconditional offers via the API

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Branches out of the `AcceptOffer` service into an unconditional offers specific service so that we can avoid unnecessary Provider conditions checking states. (ie. transitions directly from `:offer` to `:recruited`) this is behind a feature flag.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Is the API specific feature flag name necessary? This could apply to any unconditional offer flow.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/AuQprcmF/3422-support-unconditional-offers-via-the-api
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
