### PR TITLE
Really fix the TAD export clockwork job

### DIFF
--- a/app/services/data_api/tad_export.rb
+++ b/app/services/data_api/tad_export.rb
@@ -4,7 +4,7 @@ module DataAPI
 
     def self.run_daily
       data_export = DataExport.create!(name: EXPORT_NAME)
-      DataExporter.perform_async(TADExport::TADExport, data_export.id)
+      DataExporter.perform_async(DataAPI::TADExport, data_export.id)
     end
 
     def self.latest

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -3,15 +3,6 @@ require 'clockwork/test'
 require 'sidekiq'
 
 RSpec.describe Clockwork do
-  around do |example|
-    Sidekiq::Testing.inline! do
-      timecop_safe_mode = Timecop.safe_mode?
-      Timecop.safe_mode = false # cannot pass a timecop block to clockwork/test
-      example.run
-      Timecop.safe_mode = timecop_safe_mode
-    end
-  end
-
   [
     { worker: DeclineOffersByDefaultWorker, task: 'DeclineOffersByDefault' },
     { worker: SendChaseEmailToProvidersWorker, task: 'SendChaseEmailToProviders' },

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -2,15 +2,13 @@ require 'rails_helper'
 require 'clockwork/test'
 require 'sidekiq'
 
-RSpec.describe Clockwork do
-  after(:each) { Clockwork::Test.clear! }
-
+RSpec.describe Clockwork, clockwork: true do
   [
     { worker: DeclineOffersByDefaultWorker, task: 'DeclineOffersByDefault' },
     { worker: SendChaseEmailToProvidersWorker, task: 'SendChaseEmailToProviders' },
     { worker: SendChaseEmailToCandidatesWorker, task: 'SendChaseEmailToCandidates' },
   ].each do |worker|
-    describe 'worker schedule', clockwork: true do
+    describe 'worker schedule' do
       it 'runs the job every hour' do
         start_time = Time.zone.local(2020, 1, 2, 0, 0, 0)
         end_time = Time.zone.local(2020, 1, 2, 3, 0, 0)
@@ -33,8 +31,8 @@ RSpec.describe Clockwork do
   end
 
   it 'executes all defined jobs without error' do
-    start_time = Time.now.beginning_of_day
-    end_time = Time.now.end_of_day
+    start_time = Time.zone.now.beginning_of_day
+    end_time = Time.zone.now.end_of_day
 
     Clockwork::Test.run(
       start_time: start_time,


### PR DESCRIPTION
## Context

I tried to fix this in https://github.com/DFE-Digital/apply-for-teacher-training/pull/4143, and @duncanjbrown suggested in the PR to add a test - which I didn't do (actually I looked at it but it seemed complicated).

In the least surprising event of the year, my fix didn't fix the issue - and a test would have totally caught this.

## Changes proposed in this pull request

Add a test that loops through all clockwork jobs, and see if they raise any error. And fix the original issue.

## Guidance to review

Ok?

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/2234062504

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
