### PR TITLE
Fix layout of application in Support and Manage

### DIFF
--- a/app/components/efl_qualification_card_component.html.erb
+++ b/app/components/efl_qualification_card_component.html.erb
@@ -1,29 +1,28 @@
-<div class="govuk-grid-column-full">
-  <h2 class="govuk-heading-m govuk-!-margin-top-8" id="english-as-a-foreign-language">English as a foreign language</h2>
-  <p class="govuk-body"><%= qualification_status %></p>
+<h3 class="govuk-heading-m govuk-!-margin-top-6" id="english-as-a-foreign-language">English as a foreign language</h3>
 
-  <% if english_proficiency.has_qualification? %>
-    <div class="govuk-grid">
-      <div class="govuk-grid-row app-grid-row--flex">
-        <div class="govuk-grid-column-one-third">
-          <div class="app-card app-card--outline" data-qa="english-proficiency-qualification">
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><%= name %></h3>
-            <dl class="app-qualification">
-              <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
-              <dd class="app-qualification__value app-qualification__value--caption"><%= award_year %></dd>
-              <dt class="app-qualification__key"><%= grade_title %></dt>
-              <dd class="app-qualification__value"><%= grade %></dd>
-              <% if unique_reference_number %>
-                <dt class="app-qualification__key"><%= reference_number_title %></dt>
-                <dd class="app-qualification__value"><%= unique_reference_number %></dd>
-              <% end %>
-            </dl>
-          </div>
+<p class="govuk-body"><%= qualification_status %></p>
+
+<% if english_proficiency.has_qualification? %>
+  <div class="govuk-grid">
+    <div class="govuk-grid-row app-grid-row--flex">
+      <div class="govuk-grid-column-one-third">
+        <div class="app-card app-card--outline" data-qa="english-proficiency-qualification">
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><%= name %></h3>
+          <dl class="app-qualification">
+            <dt class="app-qualification__key govuk-visually-hidden">Awarded</dt>
+            <dd class="app-qualification__value app-qualification__value--caption"><%= award_year %></dd>
+            <dt class="app-qualification__key"><%= grade_title %></dt>
+            <dd class="app-qualification__value"><%= grade %></dd>
+            <% if unique_reference_number %>
+              <dt class="app-qualification__key"><%= reference_number_title %></dt>
+              <dd class="app-qualification__value"><%= unique_reference_number %></dd>
+            <% end %>
+          </dl>
         </div>
       </div>
     </div>
-  <% elsif english_proficiency.no_qualification? %>
-    <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Reason given</h4>
-    <p class="govuk-body govuk-!-margin-bottom-0"><%= no_qualification_details %></p>
-  <% end %>
-</div>
+  </div>
+<% elsif english_proficiency.no_qualification? %>
+  <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Reason given</h4>
+  <p class="govuk-body govuk-!-margin-bottom-0"><%= no_qualification_details %></p>
+<% end %>

--- a/app/components/qualifications_table_component.html.erb
+++ b/app/components/qualifications_table_component.html.erb
@@ -1,19 +1,18 @@
 <% if qualifications.any? %>
-  <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m govuk-!-margin-top-8" id="other-qualifications"><%= header %></h3>
-    <table class="govuk-table" data-qa="qualifications-table-<%= header.parameterize %>">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header govuk-table__header">Qualification</th>
-          <th class="govuk-table__header govuk-table__header">Awarded</th>
-          <th class="govuk-table__header govuk-table__header">Grade</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% qualifications.each do |qualification| %>
-          <%= render QualificationRowComponent.new(qualification: qualification) %>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+  <h3 class="govuk-heading-m govuk-!-margin-top-6" id="other-qualifications"><%= header %></h3>
+
+  <table class="govuk-table govuk-!-width-two-thirds" data-qa="qualifications-table-<%= header.parameterize %>">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header govuk-table__header">Qualification</th>
+        <th class="govuk-table__header govuk-table__header">Awarded</th>
+        <th class="govuk-table__header govuk-table__header">Grade</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% qualifications.each do |qualification| %>
+        <%= render QualificationRowComponent.new(qualification: qualification) %>
+      <% end %>
+    </tbody>
+  </table>
 <% end %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -39,18 +39,14 @@
 
 <%= render QualificationsComponent.new(application_form: @application_form, show_hesa_codes: true) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render WorkHistoryComponent.new(application_form: @application_form) %>
+<%= render WorkHistoryComponent.new(application_form: @application_form) %>
 
-    <%= render VolunteeringHistoryComponent.new(application_form: @application_form) %>
+<%= render VolunteeringHistoryComponent.new(application_form: @application_form) %>
 
-    <%= render LanguageSkillsComponent.new(application_form: @application_form) %>
+<%= render LanguageSkillsComponent.new(application_form: @application_form) %>
 
-    <%= render PersonalStatementComponent.new(application_form: @application_form) %>
+<%= render PersonalStatementComponent.new(application_form: @application_form) %>
 
-    <%= render InterviewPreferencesComponent.new(application_form: @application_form) %>
+<%= render InterviewPreferencesComponent.new(application_form: @application_form) %>
 
-    <%= render SupportInterface::SafeguardingIssuesComponent.new(application_form: @application_form) %>
-  </div>
-</div>
+<%= render SupportInterface::SafeguardingIssuesComponent.new(application_form: @application_form) %>


### PR DESCRIPTION
## Context

Layout of application in support is incorrect; application components now specify their own widths individually, so shouldn’t appear within a two-thirds column as they fo now, which further reduces the width of answers shown.

Thought I had addressed this in #3184, but evidently not.

## Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="520" alt="Screenshot Before" src="https://user-images.githubusercontent.com/813383/108998576-058afa00-7699-11eb-9171-978377bcb3c7.png"> | <img width="520" alt="Screenshot After" src="https://user-images.githubusercontent.com/813383/108998572-0459cd00-7699-11eb-91d3-1fa7b3592950.png"> |

## Guidance to review

* Need to double-check this doesn’t break layout on Manage

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
