### PR TITLE
Handle non-integer values for app choice id filter

### DIFF
--- a/app/models/support_interface/applications_filter.rb
+++ b/app/models/support_interface/applications_filter.rb
@@ -23,7 +23,7 @@ module SupportInterface
       end
 
       if applied_filters[:application_choice_id].present?
-        application_forms = application_forms.joins(:application_choices).where('application_choices.id = ?', applied_filters[:application_choice_id])
+        application_forms = application_forms.joins(:application_choices).where('application_choices.id = ?', applied_filters[:application_choice_id].to_i)
       end
 
       if applied_filters[:phase]

--- a/spec/models/support_interface/applications_filter_spec.rb
+++ b/spec/models/support_interface/applications_filter_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe SupportInterface::ApplicationsFilter do
       )
     end
 
+    it 'handles non-integer application choice ids' do
+      verify_filtered_applications_for_params(
+        [],
+        params: {
+          application_choice_id: "ABC#{application_choice_with_offer.id}",
+        },
+      )
+    end
+
     it 'can filter by year' do
       expected_form = application_choice_with_offer.application_form
 


### PR DESCRIPTION
## Context

Inputting a non-integer value for the _Provider application id_ filter in the Support interface application forms page causes a crash.

https://sentry.io/organizations/dfe-bat/issues/2171471392/?project=1765973&referrer=slack

## Changes proposed in this pull request

Convert the input value to an integer in the filter so that it's guaranteed to be valid when it reaches the database.

<img width="716" alt="image" src="https://user-images.githubusercontent.com/450843/109006586-23f5f300-76a3-11eb-9f26-8fef4174e912.png">

## Guidance to review

There is no validation in the filter so I think the correct thing to do is to treat this as a non-matching value by coercing it to an integer before it gets to the database. Because `'ABC'.to_i` evaluates to `0` it leads to no matching application choices which is the 'expected' result. Seem reasonable? Is there a better way?

## Link to Trello card

https://trello.com/c/GwgOI9qU/2915-crash-with-non-integer-value-for-provider-application-id-filter-in-support-interface

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
