### PR TITLE
Support: Show useful links relating to an application

### DIFF
--- a/app/components/support_interface/application_navigation_component.html.erb
+++ b/app/components/support_interface/application_navigation_component.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-inset-text app-inset-text--important app-inset-text--narrow-border govuk-!-margin-top-0">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Useful links for this application</h2>
+  <ul class="govuk-list govuk-!-font-size-16">
+    <% links.each do |link| %>
+      <li><%= govuk_link_to link[:title], link[:href], class: 'govuk-link--no-visited-state' %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/components/support_interface/application_navigation_component.rb
+++ b/app/components/support_interface/application_navigation_component.rb
@@ -1,0 +1,50 @@
+module SupportInterface
+  class ApplicationNavigationComponent < ViewComponent::Base
+    include ViewHelper
+
+    def initialize(application_form)
+      @application_form = application_form
+    end
+
+    def links
+      [
+        email_log_link,
+        logit_link,
+        sentry_link,
+      ]
+    end
+
+  private
+
+    def email_log_link
+      {
+        title: 'Emails about this application',
+        href: paths.support_interface_email_log_path(application_form_id: @application_form.id),
+      }
+    end
+
+    def sentry_link
+      link = "https://sentry.io/organizations/dfe-bat/issues/?project=1765973&query=user.id%3A%22candidate_#{@application_form.candidate_id}%22"
+
+      {
+        title: 'Sentry errors for this candidate',
+        href: link,
+      }
+    end
+
+    def logit_link
+      environment = HostingEnvironment.environment_name
+      candidate_id = @application_form.candidate_id
+      link = "https://kibana.logit.io/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-14d,to:now))&_a=(columns:!(_source),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'candidate_id:#{candidate_id}+AND+hosting_environment:#{environment}'),sort:!('@timestamp',desc))"
+
+      {
+        title: 'Logit logs for this candidate',
+        href: link,
+      }
+    end
+
+    def paths
+      Rails.application.routes.url_helpers
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/_application_navigation.html.erb
+++ b/app/views/support_interface/application_forms/_application_navigation.html.erb
@@ -15,9 +15,19 @@
   ].concat(title != 'Details' ? [{ text: title }] : [])) %>
 <% end %>
 
-<p class="govuk-body govuk-!-margin-bottom-6">
-  <%= govuk_link_to 'Emails about this application', support_interface_email_log_path(application_form_id: @application_form.id), class: 'govuk-link--no-visited-state' %>
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @application_form.support_reference %></span>
+    <h1 class="govuk-heading-l"><%= break_email_address(@application_form.candidate.email_address) %></h1>
+    <% unless HostingEnvironment.production? %>
+      <%= govuk_button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate) %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render SupportInterface::ApplicationNavigationComponent.new(@application_form) %>
+  </div>
+</div>
 
 <%= render TabNavigationComponent.new(items: [
   { name: 'Details', url: support_interface_application_form_path(@application_form) },

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,6 +1,4 @@
 <% content_for :browser_title, "Application history – Application ##{@application_form.id}" %>
-<% content_for :context, @application_form.support_reference %>
-<% content_for :title, break_email_address(@application_form.candidate.email_address) %>
 
 <%= render 'application_navigation', title: 'History' %>
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,20 +1,14 @@
 <% content_for :browser_title, title_with_success_prefix("Application details – Application ##{@application_form.id}", flash[:success].present?) %>
-<% content_for :context, @application_form.support_reference %>
-<% content_for :title, break_email_address(@application_form.candidate.email_address) %>
 
 <%= render 'application_navigation', title: 'Details' %>
 
 <%= render SupportInterface::ApplicationSummaryComponent.new(application_form: @application_form) %>
 
 <div class="govuk-button-group">
-  <% unless HostingEnvironment.production? %>
-    <%= govuk_button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), form_class: 'govuk-!-display-inline-block' %>
-  <% end %>
-
   <% if @application_form.candidate.hide_in_reporting? %>
-    <%= govuk_button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+    <%= govuk_button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button--secondary' %>
   <% else %>
-    <%= govuk_button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button--secondary', form_class: 'govuk-!-display-inline-block' %>
+    <%= govuk_button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button--secondary' %>
   <% end %>
 </div>
 

--- a/spec/components/support_interface/application_navigation_component_spec.rb
+++ b/spec/components/support_interface/application_navigation_component_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationNavigationComponent do
+  it 'renders a list of links' do
+    form = build_stubbed(:application_form)
+    candidate_id = form.candidate_id
+
+    render_inline(described_class.new(form))
+
+    expect(page).to have_link('Emails about this application', href: %r{email-log.+#{form.id}})
+    expect(page).to have_link('Sentry errors for this candidate', href: %r{sentry.io.+#{candidate_id}})
+    expect(page).to have_link('Logit logs for this candidate', href: %r{logit.io.+#{candidate_id}.+hosting_environment:test})
+  end
+end


### PR DESCRIPTION
## Context

There are a number of places/services where useful information about an application can be found. It can help support agents to have these links available to them from a candidate’s application page.

## Changes proposed in this pull request

* Show additional application links to right of page title
* Move sign in as candidate below header to match design used for provider users

<img width="1004" alt="application" src="https://user-images.githubusercontent.com/813383/109010367-95d03b80-76a7-11eb-8ae5-9c90c0beca9c.png">

## Guidance to review

* Need to add paths for Vendor API requests, Sentry and Logit (as shown in Trello card) – not sure how to do this.

## Link to Trello card

https://trello.com/c/4zc8EbNK/

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
