### PR TITLE
Refactor primary navigation component

### DIFF
--- a/app/components/primary_navigation_component.html.erb
+++ b/app/components/primary_navigation_component.html.erb
@@ -4,7 +4,7 @@
       <ul class="app-primary-navigation__list">
         <% @navigation_items.each do |nav_item| %>
           <li class="app-primary-navigation__item <%= nav_item.classes %>">
-            <a class="app-primary-navigation__link"<%= nav_item.active ? ' aria-current=page' : ' ' %>href="<%= nav_item.href %>">
+            <a class="app-primary-navigation__link"<%= nav_item.active ? 'aria-current=page' : '' %> href="<%= nav_item.href %>">
               <%= nav_item.text %>
             </a>
           </li>

--- a/app/components/primary_navigation_component.html.erb
+++ b/app/components/primary_navigation_component.html.erb
@@ -2,11 +2,13 @@
   <div class="govuk-width-container">
     <nav class="app-primary-navigation__nav" aria-label="main menu">
       <ul class="app-primary-navigation__list">
-        <% @navigation_items.each do |nav_item| %>
-          <li class="app-primary-navigation__item <%= nav_item.classes %>">
-            <a class="app-primary-navigation__link"<%= nav_item.active ? 'aria-current=page' : '' %> href="<%= nav_item.href %>">
-              <%= nav_item.text %>
-            </a>
+        <% items.each do |item| %>
+          <li class="app-primary-navigation__item <%= item.classes %>">
+            <% if item.active %>
+              <%= govuk_link_to item.text, item.href, class: 'app-primary-navigation__link', aria: { current: 'page' } %>
+            <% else %>
+              <%= govuk_link_to item.text, item.href, class: 'app-primary-navigation__link' %>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/components/primary_navigation_component.html.erb
+++ b/app/components/primary_navigation_component.html.erb
@@ -1,19 +1,15 @@
 <div class="app-primary-navigation govuk-!-display-none-print">
-  <div class="app-primary-navigation__container">
-    <div class="app-primary-navigation__nav">
-      <nav class="app-primary-navigation" aria-label="main menu">
-        <ul class="app-primary-navigation__list">
-          <% @navigation_items.each do |nav_item| %>
-            <li class="app-primary-navigation__item <%= nav_item.classes %>">
-              <a class="app-primary-navigation__link"
-                <%= nav_item.active ? 'aria-current=page' : '' %>
-                 href="<%= nav_item.href %>">
-                 <%= nav_item.text %>
-              </a>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
-    </div>
+  <div class="govuk-width-container">
+    <nav class="app-primary-navigation__nav" aria-label="main menu">
+      <ul class="app-primary-navigation__list">
+        <% @navigation_items.each do |nav_item| %>
+          <li class="app-primary-navigation__item <%= nav_item.classes %>">
+            <a class="app-primary-navigation__link"<%= nav_item.active ? ' aria-current=page' : ' ' %>href="<%= nav_item.href %>">
+              <%= nav_item.text %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </nav>
   </div>
 </div>

--- a/app/components/primary_navigation_component.rb
+++ b/app/components/primary_navigation_component.rb
@@ -1,5 +1,8 @@
 class PrimaryNavigationComponent < ViewComponent::Base
-  def initialize(navigation_items:)
-    @navigation_items = navigation_items
+  include ViewHelper
+  attr_reader :items
+
+  def initialize(items:)
+    @items = items
   end
 end

--- a/app/frontend/styles/_primary-navigation.scss
+++ b/app/frontend/styles/_primary-navigation.scss
@@ -2,19 +2,6 @@
   background-color: govuk-colour("light-grey");
 }
 
-.app-primary-navigation__container {
-  @include govuk-width-container;
-  font-size: 0; // Hide whitespace between elements
-  text-align: justify; // Trick to remove the need for floats
-
-  &:after {
-    content: '';
-    display: inline-block;
-    width: 100%;
-  }
-
-}
-
 .app-primary-navigation__list {
   list-style: none;
   margin: 0;

--- a/app/frontend/styles/_primary-navigation.scss
+++ b/app/frontend/styles/_primary-navigation.scss
@@ -3,16 +3,16 @@
 }
 
 .app-primary-navigation__list {
+  @include govuk-clearfix;
   list-style: none;
   margin: 0;
   padding: 0;
-  @include govuk-clearfix;
 }
 
 .app-primary-navigation__item {
   @include govuk-font($size: 19);
-  margin-right: govuk-spacing(3);
   float: left;
+  margin-right: govuk-spacing(3);
   margin-top: 0;
 
   &:last-child {
@@ -22,7 +22,6 @@
   @include govuk-media-query($from: tablet) {
     margin-right: govuk-spacing(4);
   }
-
 }
 
 .app-primary-navigation__item--align-right {
@@ -32,74 +31,33 @@
 }
 
 .app-primary-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
   display: block;
-  padding-bottom: 15px;
-  padding-top: 15px;
-  text-decoration: none;
   font-weight: bold;
-
-  &:link,
-  &:visited {
-    color: govuk-colour("blue");
-  }
+  padding-bottom: govuk-spacing(3);
+  padding-top: govuk-spacing(3);
+  text-decoration: none;
 
   &:focus {
-    color: govuk-colour("black"); // Focus colour on yellow should really be black.
-    position: relative; // Ensure focus sits above everything else.
-    z-index: 1;
-    outline: 3px solid transparent;
-    background-color: govuk-colour("yellow");
-    text-decoration: none;
-  }
-
-  &:focus:before {
-    background-color: govuk-colour("black");
-    content: "";
-    display: block;
-    height: 5px;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-  }
-
-  &:hover {
-    color: $govuk-link-hover-colour;
+    background-color: $govuk-focus-colour;
+    box-shadow: inset 0 -5px 0 0 $govuk-focus-text-colour;
+    color: $govuk-focus-text-colour;
+    outline: $govuk-focus-width solid transparent;
   }
 
   &[aria-current] {
-    color: govuk-colour("blue");
-    position: relative;
-    text-decoration: none;
-    font-weight: bold;
-    &:before {
-      background-color: govuk-colour("blue");
-      content: "";
-      display: block;
-      height: 5px;
-      position: absolute; bottom: 0; left: 0;
-      width: 100%;
+    box-shadow: inset 0 -5px 0 0 $govuk-link-colour;
+    color: $govuk-link-colour;
+
+    &:hover {
+      box-shadow: inset 0 -5px 0 0 $govuk-link-hover-colour;
+      color: $govuk-link-hover-colour;
     }
 
     &:focus {
-      color: govuk-colour("black"); // Focus colour on yellow should really be black.
-      position: relative; // Ensure focus sits above everything else.
-      border: none;
-
-      &:before {
-        background-color: govuk-colour("black");
-        height: 7px;
-      }
-
+      box-shadow: inset 0 -7px 0 0 $govuk-focus-text-colour;
+      color: $govuk-focus-text-colour;
     }
-
-    &:hover {
-      color: $govuk-link-hover-colour;
-      &:before {
-        background-color: $govuk-link-hover-colour;
-      }
-    }
-
   }
-
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
     navigation_items: NavigationItems.for_support_account_nav(try(:current_support_user)),
   )) %>
   <%= render(PrimaryNavigationComponent.new(
-    navigation_items: NavigationItems.for_support_primary_nav(try(:current_support_user), controller),
+    items: NavigationItems.for_support_primary_nav(try(:current_support_user), controller),
   )) %>
   <%= yield(:navigation) if content_for?(:navigation) %>
 <% when 'provider_interface' %>
@@ -40,7 +40,7 @@
       feedback_link: ProviderInterface::FEEDBACK_LINK,
     )) %>
     <%= render(PrimaryNavigationComponent.new(
-      navigation_items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, @provider_setup&.pending?),
+      items: NavigationItems.for_provider_primary_nav(try(:current_provider_user), controller, @provider_setup&.pending?),
     )) %>
   <% end %>
 <% when 'api_docs' %>
@@ -52,7 +52,7 @@
     navigation_items: [],
   )) %>
   <%= render(PrimaryNavigationComponent.new(
-    navigation_items: NavigationItems.for_api_docs(controller),
+    items: NavigationItems.for_api_docs(controller),
   )) %>
 <% else %>
   <% components_url = '/rails/view_components' if request.path.match(/^\/rails\/view_components/) %>


### PR DESCRIPTION
## Context

Inadvertently found myself looking at the markup and styles for this component and finding a lot of extraneous markup and CSS – possibly die to the design being inherited from the MoJ pattern which had other requirements.

## Changes proposed in this pull request

* Remove extraneous `div`s on markup
* Use `govuk-width-container` instead of custom container styles (where this all started – we may want to override this within support, and having this use a different class was causing issues)
* Refactor CSS; rather than use generated content to draw the underline, use inset box shadow instead (this is what’s used elsewhere in the design system). This massively reduced the complexity and verbosity of the CSS for this component.
* Also use mixins and variables from `govuk-frontend` which means styles are self documented 

## Guidance to review

@adamsilver @simonwhatley No visual changes – anything in this change look problematic?

@edwardhorsford You may want to see if these changes are relevant to the same component in Register

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
