### PR TITLE
Override teacherTrainingApiBaseUrl in staging

### DIFF
--- a/azure/pipelines/release.yml
+++ b/azure/pipelines/release.yml
@@ -84,6 +84,7 @@ stages:
       logstashSsl: '$(logstashSsl)'
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
+      teacherTrainingApiBaseUrl: '$(teacherTrainingApiBaseUrl)'
       dfeSignInClientId: '$(dfeSignInClientId)'
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'


### PR DESCRIPTION
## Context

Test connection to TTAPI on PaaS as a step in migrating TTAPI to PaaS.

## Changes proposed in this pull request

Point `teacherTrainingApiBaseUrl` parameters in staging to `https://teacher-training-api-prod.london.cloudapps.digital/api/public/v1`

Configured `$(teacherTrainingApiBaseUrl)` in Azure DevOps variable group to `https://teacher-training-api-prod.london.cloudapps.digital/api/public/v1`

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
