### PR TITLE
API: Document that domicile is HESA-encoded

### DIFF
--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+## 25th February
+
+- Documentation updated to indicate that the `Candidate.domicile` field is encoded as a HESA DOMICILE code.
+
 ## 5th February
 
 The following experimental/sandbox endpoint has been updated:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -586,7 +586,7 @@ components:
         domicile:
           type: string
           maxLength: 2
-          description: The candidate’s domicile, as extracted from their address
+          description: The candidate’s domicile, extracted from their address. Coded according to [the HESA DOMICILE field](https://www.hesa.ac.uk/collection/c20051/a/domicile).
           example: XF
         uk_residency_status:
           type: string


### PR DESCRIPTION
## Context

A vendor pointed out we didn't tell them this was encoded according to the HESA spec.

## Changes proposed in this pull request

Update the docs

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/G01JAFSSW92/p1614030673001600

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
