### PR TITLE
Add filter and validations to ensure course to be added is open on Apply

### DIFF
--- a/app/views/support_interface/application_forms/courses/new.html.erb
+++ b/app/views/support_interface/application_forms/courses/new.html.erb
@@ -14,7 +14,7 @@
         <%= f.govuk_submit 'Add course to application' %>
       <% end %>
     <% else %>
-      <p class="govuk-body">No results</p>
+      <p class="govuk-body">No open courses found for current recruitment cycle.</p>
       <%= govuk_link_to('Search again', support_interface_application_form_search_course_new_path(course_code: @pick_course.course_code)) %>
     <% end %>
   </div>

--- a/spec/system/support_interface/add_course_to_submitted_application_spec.rb
+++ b/spec/system/support_interface/add_course_to_submitted_application_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Add course to submitted application' do
       application_form_id: @application_form.id,
       course_code: @non_existent_course_code,
     )
-    expect(page).to have_content 'No results'
+    expect(page).to have_content 'No open courses found for current recruitment cycle'
   end
 
   def when_i_click_search_again
@@ -104,7 +104,7 @@ RSpec.feature 'Add course to submitted application' do
   end
 
   def when_i_enter_a_course_code_for_a_course_that_does_exist
-    @course_option = create(:course_option)
+    @course_option = create(:course_option, course: create(:course, :open_on_apply))
     @course_code = @course_option.course.code
     fill_in('Course code', with: @course_code)
   end


### PR DESCRIPTION
## Context

It's possible to add a course to an application which is not open on Apply or visible in Find. This causes emails to be sent which won't make sense to some providers (eg. those yet to be onboarded).

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Filters `CourseOption`s which relate to courses not open on Apply.
- Validates that the course is open on Apply when attempting to save the `PickCourseForm`.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/G63lZVXw/3425-prevent-support-users-from-adding-courses-to-an-application-that-are-either-hidden-in-find-or-that-are-not-for-the-current-cycle
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
