### PR TITLE
Expose docs for the TAD data export

### DIFF
--- a/app/controllers/data_api/tad_docs_controller.rb
+++ b/app/controllers/data_api/tad_docs_controller.rb
@@ -1,0 +1,5 @@
+module DataAPI
+  class TADDocsController < ApplicationController
+    def docs; end
+  end
+end

--- a/app/views/data_api/tad_docs/docs.html.erb
+++ b/app/views/data_api/tad_docs/docs.html.erb
@@ -1,0 +1,20 @@
+<%= content_for :title, 'TAD export documentation' %>
+
+<h1 class="govuk-heading-l">TAD export documentation</h1>
+
+<p class="govuk-body">
+  This page describes the columns that are exported as part of the TAD data export.
+</p>
+
+<% DataSetDocumentation.for(DataAPI::TADExport).each do |column_name, column| %>
+  <%= render DataSetAttributeComponent.new(column_name: column_name, column: column) %>
+<% end %>
+
+<%# Add some cheeky styling here directly, to avoid having to set up stylesheets just for this page %>
+<style>
+.app-data-set-documentation--datatype {
+  color: #505a5f;
+  margin: 0;
+  font-weight: normal;
+}
+</style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -753,6 +753,7 @@ Rails.application.routes.draw do
   end
 
   namespace :data_api, path: '/data-api' do
+    get '/tad-data-exports/docs' => 'tad_docs#docs'
     get '/tad-data-exports/latest' => 'tad_data_exports#latest'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -753,7 +753,7 @@ Rails.application.routes.draw do
   end
 
   namespace :data_api, path: '/data-api' do
-    get '/tad-data-exports/docs' => 'tad_docs#docs'
+    get '/docs/tad-data-exports' => 'tad_docs#docs'
     get '/tad-data-exports/latest' => 'tad_data_exports#latest'
   end
 

--- a/spec/system/data_api/tad_data_docs_spec.rb
+++ b/spec/system/data_api/tad_data_docs_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'TAD data docs' do
   end
 
   def when_i_visit_the_tad_data_docs
-    visit '/data-api/tad-data-exports/docs'
+    visit '/data-api/docs/tad-data-exports'
   end
 
   def then_i_can_see_the_docs

--- a/spec/system/data_api/tad_data_docs_spec.rb
+++ b/spec/system/data_api/tad_data_docs_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature 'TAD data docs' do
+  scenario 'User visits TAD data docs' do
+    when_i_visit_the_tad_data_docs
+    then_i_can_see_the_docs
+  end
+
+  def when_i_visit_the_tad_data_docs
+    visit '/data-api/tad-data-exports/docs'
+  end
+
+  def then_i_can_see_the_docs
+    expect(page).to have_content 'TAD export documentation'
+  end
+end


### PR DESCRIPTION
## Context

This is a page that describes the columns and values for the TAD data export. Because TAD will start consuming our API, they won't have access to the docs in the support section of the site anymore.

## Changes proposed in this pull request

Add a new page, reusing the existing docs component.

## Guidance to review

Does it make sense? URL okay?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
