### PR TITLE
Allow support users to reinstate a reference that was refused

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,7 +1,7 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows, editable: true) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: 3)) do %>
-      <% if reference.cancelled? || reference.feedback_refused? %>
+      <% if ReferenceActionsPolicy.new(reference).reinstatable? %>
         <div class='app-summary-card__actions'>
           <%= govuk_link_to support_interface_reinstate_reference_path(reference) do %>
           Reinstate reference<span class="govuk-visually-hidden"> for <%= reference.name %></span>

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -189,6 +189,10 @@ module SupportInterface
           value: policy.can_be_destroyed? ? 'Yes' : 'No',
         },
         {
+          key: 'Can be reinstated by support?',
+          value: policy.reinstatable? ? 'Yes' : 'No',
+        },
+        {
           key: 'Can be deleted?',
           value: policy.request_can_be_deleted? ? 'Yes' : 'No',
         },

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -12,10 +12,14 @@ module SupportInterface
       redirect_to support_interface_application_form_path(@reference.application_form)
     end
 
-    def reinstate; end
+    def reinstate
+      render_404 and return unless ReferenceActionsPolicy.new(@reference).reinstatable?
+    end
 
     def confirm_reinstate
-      RequestReference.new.call(@reference)
+      render_404 and return unless ReferenceActionsPolicy.new(@reference).reinstatable?
+
+      ReinstateReference.call(@reference)
       flash[:success] = 'Reference was reinstated'
       redirect_to support_interface_application_form_path(@reference.application_form)
     end

--- a/app/services/reference_actions_policy.rb
+++ b/app/services/reference_actions_policy.rb
@@ -3,6 +3,10 @@ class ReferenceActionsPolicy
     @reference = reference
   end
 
+  def reinstatable?
+    reference.cancelled? || reference.feedback_refused?
+  end
+
   def editable?
     reference.not_requested_yet? && needs_more_references?
   end

--- a/app/services/reinstate_reference.rb
+++ b/app/services/reinstate_reference.rb
@@ -1,0 +1,14 @@
+class ReinstateReference
+  def self.call(reference)
+    raise unless ReferenceActionsPolicy.new(reference).reinstatable?
+
+    reference.update!(
+      feedback_status: 'not_requested_yet',
+      feedback_refused_at: nil,
+      cancelled_at: nil,
+      audit_comment: 'Rolling back to reinstate the reference',
+    )
+
+    RequestReference.new.call(reference)
+  end
+end

--- a/app/views/support_interface/references/reinstate.html.erb
+++ b/app/views/support_interface/references/reinstate.html.erb
@@ -8,7 +8,7 @@
     </h1>
 
     <p class="govuk-body">
-      Reinstating a reference will send an email to the referee, asking for a reference.
+      Reinstating a reference will send an email to the referee asking for a reference.
     </p>
 
     <%= render(SummaryCardComponent.new(rows: [

--- a/app/views/support_interface/references/reinstate.html.erb
+++ b/app/views/support_interface/references/reinstate.html.erb
@@ -8,16 +8,7 @@
     </h1>
 
     <p class="govuk-body">
-      Reinstating a reference will:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>allow this referee to provide a reference</li>
-      <li>prevent the candidate from providing a replacement referee</li>
-    </ul>
-
-    <p class="govuk-body">
-      Reinstating a reference does <strong>not send email notifications</strong>.
+      Reinstating a reference will send an email to the referee, asking for a reference.
     </p>
 
     <%= render(SummaryCardComponent.new(rows: [

--- a/spec/system/support_interface/reinstate_refused_reference_spec.rb
+++ b/spec/system/support_interface/reinstate_refused_reference_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Reinstating references' do
+  include DfESignInHelpers
+
+  scenario 'Support agent reinstates a refused reference' do
+    given_i_am_a_support_user
+    and_there_is_an_application_with_a_refused_reference
+    and_i_visit_the_application
+
+    when_i_click_to_reinstate_the_reference
+    and_i_confirm_i_really_want_to_reinstate_the_reference
+    then_the_reference_is_reinstated
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_with_a_refused_reference
+    @application_with_reference = create(:completed_application_form)
+    create(:reference, :feedback_requested, name: 'Harry', application_form: @application_with_reference)
+    RefereeInterface::RefuseFeedbackForm.new(choice: 'yes').save(@application_with_reference.application_references.first)
+  end
+
+  def and_i_visit_the_application
+    visit support_interface_application_form_path(@application_with_reference)
+  end
+
+  def when_i_click_to_reinstate_the_reference
+    click_on 'Reinstate reference for Harry'
+  end
+
+  def and_i_confirm_i_really_want_to_reinstate_the_reference
+    click_on 'Reinstate reference'
+  end
+
+  def then_the_reference_is_reinstated
+    expect(page).to have_content 'Reference was reinstated'
+    expect(page).to have_content 'Requested'
+  end
+end


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-teacher-training/pull/3325 I added functionality to allow support users to reinstate a reference that was accidentally refused. This doesn't actually work because we check the status of the reference before sending, and don't allow it in the `feedback_refused` state.

## Changes proposed in this pull request

- Centralise the decision whether or not the reference can be reinstated
- When reinstating a reference, first roll back to the `not_requested_yet` state and clear the cancel/refuse date, so that the data is clear
- Add a test for the above

## Guidance to review

Test you can reinstate a refused reference.

## Link to Trello card

https://trello.com/c/FO63rUtR/258-support-console-not-letting-me-reinstate-a-referee-ticket-number-12170

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
