### PR TITLE
Add Model to Reverse Map Structured Rejection Reasons

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -110,6 +110,11 @@ class DataExport < ApplicationRecord
       description: 'A list of candidates with unexplained breaks in their work history.',
       class: SupportInterface::UnexplainedBreaksInWorkHistoryExport,
     },
+    structured_reasons_for_rejection: {
+      name: 'Structured reasons for rejection',
+      description: 'Structured reasons for rejection.',
+      class: SupportInterface::StructuredReasonsForRejectionExport,
+    },
   }.freeze
 
   belongs_to :initiator, polymorphic: true, optional: true

--- a/app/models/flat_reasons_for_rejection_extract.rb
+++ b/app/models/flat_reasons_for_rejection_extract.rb
@@ -1,10 +1,53 @@
 class FlatReasonsForRejectionExtract
   include ActiveModel::Model
+  include ReasonsForRejection
 
-  def initialize(application_choice)
+  def initialize(structured_rejection_reasons)
     # @structured_rejection_reasons = application_form.application_choices.structured_rejection_reasons
-    @structured_rejection_reasons = application_choice
+    @structured_rejection_reasons = structured_rejection_reasons
   end
+
+  def separate_high_level_rejection_reasons(structured_rejection_reasons)
+    select_high_level_rejection_reasons(structured_rejection_reasons)
+    .keys
+    .map { |reason| format_reason(reason) }
+  end
+
+  def candidate_behaviour
+    return nil if @structured_rejection_reasons.blank?
+    @structured_rejection_reasons.select { |reason, value| value == 'candidate_behaviour_y_n' }
+
+    select_high_level_rejection_reasons(structured_rejection_reasons)
+    .keys
+    .map { |reason| format_reason(reason) }
+  end
+
+  def candidate_behaviour_sub_reasons
+
+
+  end
+
+  def quality_of_application
+
+
+  end
+
+  def quality_of_application_sub_reasons
+
+
+  end
+
+  def candidate_behaviour
+
+
+  end
+
+  def candidate_behaviour_sub_reasons
+
+
+  end
+
+
 
   # These three methods are copied from the application_choices_export.rb .... currently doesn't provide enough granularity
   def format_structured_rejection_reasons

--- a/app/models/flat_reasons_for_rejection_extract.rb
+++ b/app/models/flat_reasons_for_rejection_extract.rb
@@ -5,66 +5,70 @@ class FlatReasonsForRejectionExtract
     @structured_rejection_reasons = structured_rejection_reasons
   end
 
-  def top_level_reasons
-    I18n.t('reasons_for_rejection_copy.top_level_reasons').keys
-  end
-
-  def top_level_reason_title(reason)
-    I18n.t("reasons_for_rejection_copy.top_level_reasons.#{reason}.title")
-  end
-
-  def separate_high_level_rejection_reasons(structured_rejection_reasons)
-    select_high_level_rejection_reasons(structured_rejection_reasons)
-    .keys
-    .map { |reason| format_reason(reason) }
-  end
-
-  def candidate_behaviour
-    return nil if @structured_rejection_reasons.blank?
-    @structured_rejection_reasons.select { |reason, value| value == 'candidate_behaviour_y_n' }
-
-    select_high_level_rejection_reasons(structured_rejection_reasons)
-    .keys
-    .map { |reason| format_reason(reason) }
-  end
-
-  def qualifications
-
-  end
-
-  def quality_of_application
-
-
-  end
-
-  def quality_of_application_sub_reasons
-
-
-  end
-
   def candidate_behaviour?
-    return nil if @structured_rejection_reasons['candidate_behaviour_y_n'].blank?
-
-    @structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason == 'candidate_behaviour_y_n' }.present?
+    top_level_reasons('candidate_behaviour_y_n')
   end
 
   def didnt_reply_to_interview_offer?
-    return nil if @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].blank?
-
-    @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].include?("didnt_reply_to_interview_offer")
+    sub_level_reasons('candidate_behaviour_what_did_the_candidate_do', 'didnt_reply_to_interview_offer')
   end
 
   def didnt_attend_interview?
-    return nil if @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].blank?
-
-    @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].include?("didnt_attend_interview")
+    sub_level_reasons('candidate_behaviour_what_did_the_candidate_do', 'didnt_attend_interview')
   end
 
   def candidate_behaviour_other_details
-    return nil if @structured_rejection_reasons['candidate_behaviour_other'].blank?
-
-    @structured_rejection_reasons['candidate_behaviour_other']
+    other_detail_or_what_to_improve('candidate_behaviour_other')
   end
+
+  def quality_of_application?
+    top_level_reasons('quality_of_application_y_n')
+  end
+
+  def personal_statement?
+    sub_level_reasons('quality_of_application_which_parts_needed_improvement', 'personal_statement')
+  end
+
+  def quality_of_application_personal_statement_what_to_improve
+    other_detail_or_what_to_improve('quality_of_application_personal_statement_what_to_improve')
+  end
+
+  def subject_knowledge?
+    sub_level_reasons('quality_of_application_which_parts_needed_improvement', 'subject_knowledge')
+  end
+
+  def quality_of_application_subject_knowledge_what_to_improve
+    other_detail_or_what_to_improve('quality_of_application_subject_knowledge_what_to_improve')
+  end
+
+  def quality_of_application_other_details
+    other_detail_or_what_to_improve('quality_of_application_other_details')
+  end
+
+  def qualifications?
+    top_level_reasons('qualifications_y_n')
+  end
+
+  def no_maths_gcse?
+    sub_level_reasons('qualifications_which_qualifications', 'no_maths_gcse')
+  end
+
+  def no_science_gcse?
+    sub_level_reasons('qualifications_which_qualifications', 'no_science_gcse')
+  end
+
+  def no_english_gcse?
+    sub_level_reasons('qualifications_which_qualifications', 'no_english_gcse')
+  end
+
+  def no_degree?
+    sub_level_reasons('qualifications_which_qualifications', 'no_degree')
+  end
+
+  def qualifications_other_details
+    other_detail_or_what_to_improve('qualifications_other_details')
+  end
+
 
 
   # These three methods are copied from the application_choices_export.rb .... currently doesn't provide enough granularity
@@ -85,5 +89,25 @@ class FlatReasonsForRejectionExtract
     reason
     .delete_suffix('_y_n')
     .humanize
+  end
+
+  private
+
+  def top_level_reasons(key)
+    return nil if @structured_rejection_reasons["#{key}"].blank?
+
+    @structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason == "#{key}" }.present?
+  end
+
+  def sub_level_reasons(key, value)
+    return nil if @structured_rejection_reasons["#{key}"].blank?
+
+    @structured_rejection_reasons["#{key}"].include?("#{value}")
+  end
+
+  def other_detail_or_what_to_improve(key)
+    return nil if @structured_rejection_reasons["#{key}"].blank?
+
+    @structured_rejection_reasons["#{key}"]
   end
 end

--- a/app/models/flat_reasons_for_rejection_extract.rb
+++ b/app/models/flat_reasons_for_rejection_extract.rb
@@ -1,0 +1,30 @@
+class FlatReasonsForRejectionExtract
+  include ActiveModel::Model
+
+  def initialize(application_form)
+    @structured_rejection_reasons = application_form.application_choices.structured_rejection_reasons
+  end
+
+  def structured_rejection_data(structured_rejection_reasons)
+  end
+
+  # These three methods are copied from the application_choices_export.rb .... currently doesn't provide enough granularity
+  def format_structured_rejection_reasons(structured_rejection_reasons)
+    return nil if structured_rejection_reasons.blank?
+
+    select_high_level_rejection_reasons(structured_rejection_reasons)
+    .keys
+    .map { |reason| format_reason(reason) }
+    .join("\n")
+  end
+
+  def select_high_level_rejection_reasons(structured_rejection_reasons)
+    structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
+  end
+
+  def format_reason(reason)
+    reason
+    .delete_suffix('_y_n')
+    .humanize
+  end
+end

--- a/app/models/flat_reasons_for_rejection_extract.rb
+++ b/app/models/flat_reasons_for_rejection_extract.rb
@@ -1,19 +1,19 @@
 class FlatReasonsForRejectionExtract
   include ActiveModel::Model
 
-  def initialize(application_form)
-    @structured_rejection_reasons = application_form.application_choices.structured_rejection_reasons
+  def initialize(application_choice)
+    # @structured_rejection_reasons = application_form.application_choices.structured_rejection_reasons
+    @structured_rejection_reasons = application_choice.structured_rejection_reasons
   end
 
-  def structured_rejection_data(structured_rejection_reasons)
-  end
-
+  # def structured_rejection_data(structured_rejection_reasons)
+  # end
 
   # These three methods are copied from the application_choices_export.rb .... currently doesn't provide enough granularity
-  def format_structured_rejection_reasons(structured_rejection_reasons)
-    return nil if structured_rejection_reasons.blank?
+  def format_structured_rejection_reasons
+    return nil if @structured_rejection_reasons.blank?
 
-    select_high_level_rejection_reasons(structured_rejection_reasons)
+    select_high_level_rejection_reasons(@structured_rejection_reasons)
     .keys
     .map { |reason| format_reason(reason) }
     .join("\n")

--- a/app/models/flat_reasons_for_rejection_extract.rb
+++ b/app/models/flat_reasons_for_rejection_extract.rb
@@ -1,10 +1,16 @@
 class FlatReasonsForRejectionExtract
   include ActiveModel::Model
-  include ReasonsForRejection
 
   def initialize(structured_rejection_reasons)
-    # @structured_rejection_reasons = application_form.application_choices.structured_rejection_reasons
     @structured_rejection_reasons = structured_rejection_reasons
+  end
+
+  def top_level_reasons
+    I18n.t('reasons_for_rejection_copy.top_level_reasons').keys
+  end
+
+  def top_level_reason_title(reason)
+    I18n.t("reasons_for_rejection_copy.top_level_reasons.#{reason}.title")
   end
 
   def separate_high_level_rejection_reasons(structured_rejection_reasons)
@@ -22,8 +28,7 @@ class FlatReasonsForRejectionExtract
     .map { |reason| format_reason(reason) }
   end
 
-  def candidate_behaviour_sub_reasons
-
+  def qualifications
 
   end
 
@@ -37,16 +42,29 @@ class FlatReasonsForRejectionExtract
 
   end
 
-  def candidate_behaviour
+  def candidate_behaviour?
+    return nil if @structured_rejection_reasons['candidate_behaviour_y_n'].blank?
 
-
+    @structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason == 'candidate_behaviour_y_n' }.present?
   end
 
-  def candidate_behaviour_sub_reasons
+  def didnt_reply_to_interview_offer?
+    return nil if @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].blank?
 
-
+    @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].include?("didnt_reply_to_interview_offer")
   end
 
+  def didnt_attend_interview?
+    return nil if @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].blank?
+
+    @structured_rejection_reasons['candidate_behaviour_what_did_the_candidate_do'].include?("didnt_attend_interview")
+  end
+
+  def candidate_behaviour_other_details
+    return nil if @structured_rejection_reasons['candidate_behaviour_other'].blank?
+
+    @structured_rejection_reasons['candidate_behaviour_other']
+  end
 
 
   # These three methods are copied from the application_choices_export.rb .... currently doesn't provide enough granularity

--- a/app/models/flat_reasons_for_rejection_extract.rb
+++ b/app/models/flat_reasons_for_rejection_extract.rb
@@ -3,11 +3,8 @@ class FlatReasonsForRejectionExtract
 
   def initialize(application_choice)
     # @structured_rejection_reasons = application_form.application_choices.structured_rejection_reasons
-    @structured_rejection_reasons = application_choice.structured_rejection_reasons
+    @structured_rejection_reasons = application_choice
   end
-
-  # def structured_rejection_data(structured_rejection_reasons)
-  # end
 
   # These three methods are copied from the application_choices_export.rb .... currently doesn't provide enough granularity
   def format_structured_rejection_reasons

--- a/app/models/flat_reasons_for_rejection_extract.rb
+++ b/app/models/flat_reasons_for_rejection_extract.rb
@@ -8,6 +8,7 @@ class FlatReasonsForRejectionExtract
   def structured_rejection_data(structured_rejection_reasons)
   end
 
+
   # These three methods are copied from the application_choices_export.rb .... currently doesn't provide enough granularity
   def format_structured_rejection_reasons(structured_rejection_reasons)
     return nil if structured_rejection_reasons.blank?

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -24,7 +24,7 @@ module SupportInterface
             offer_response_at: choice.accepted_at || choice.declined_at,
             rejection_reason: choice.rejection_reason,
             # structured_rejection_reasons: format_structured_rejection_reasons(choice.structured_rejection_reasons),
-            structured_rejection_reasons: FlatReasonsForRejectionExtract.new(choice).format_structured_rejection_reasons,
+            structured_rejection_reasons: FlatReasonsForRejectionExtract.new(choice.structured_rejection_reasons).format_structured_rejection_reasons,
           }
         end
       end
@@ -71,23 +71,23 @@ module SupportInterface
         .order('submitted_at asc')
     end
 
-    def format_structured_rejection_reasons(structured_rejection_reasons)
-      return nil if structured_rejection_reasons.blank?
+    # def format_structured_rejection_reasons(structured_rejection_reasons)
+    #   return nil if structured_rejection_reasons.blank?
 
-      select_high_level_rejection_reasons(structured_rejection_reasons)
-      .keys
-      .map { |reason| format_reason(reason) }
-      .join("\n")
-    end
+    #   select_high_level_rejection_reasons(structured_rejection_reasons)
+    #   .keys
+    #   .map { |reason| format_reason(reason) }
+    #   .join("\n")
+    # end
 
-    def select_high_level_rejection_reasons(structured_rejection_reasons)
-      structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
-    end
+    # def select_high_level_rejection_reasons(structured_rejection_reasons)
+    #   structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
+    # end
 
-    def format_reason(reason)
-      reason
-      .delete_suffix('_y_n')
-      .humanize
-    end
+    # def format_reason(reason)
+    #   reason
+    #   .delete_suffix('_y_n')
+    #   .humanize
+    # end
   end
 end

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -23,7 +23,8 @@ module SupportInterface
             offer_response: offer_response_interpretation(choice: choice),
             offer_response_at: choice.accepted_at || choice.declined_at,
             rejection_reason: choice.rejection_reason,
-            structured_rejection_reasons: format_structured_rejection_reasons(choice.structured_rejection_reasons),
+            # structured_rejection_reasons: format_structured_rejection_reasons(choice.structured_rejection_reasons),
+            structured_rejection_reasons: FlatReasonsForRejectionExtract.new(choice).format_structured_rejection_reasons,
           }
         end
       end

--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -3,6 +3,7 @@ module SupportInterface
     def data_for_export
       data_for_export = application_forms.includes(:application_choices).map do |application_form|
         rejected_application_choices = application_form.application_choices.rejected
+
         output = {
           'Month' => application_form.submitted_at&.strftime('%B'),
           'Recruitment cycle year' => application_form.recruitment_cycle_year,
@@ -13,9 +14,12 @@ module SupportInterface
           'First rejection reason' => rejected_application_choices[0]&.rejection_reason,
           'Second rejection reason' => rejected_application_choices[1]&.rejection_reason,
           'Third rejection reason' => rejected_application_choices[2]&.rejection_reason,
-          'First structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[0]&.structured_rejection_reasons),
-          'Second structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[1]&.structured_rejection_reasons),
-          'Third structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[2]&.structured_rejection_reasons),
+          # 'First structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[0]&.structured_rejection_reasons),
+          'First structured rejection reasons' => FlatReasonsForRejectionExtract.new(rejected_application_choices[0]&.structured_rejection_reasons).format_structured_rejection_reasons,
+          # 'Second structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[1]&.structured_rejection_reasons),
+          'Second structured rejection reasons' => FlatReasonsForRejectionExtract.new(rejected_application_choices[1]&.structured_rejection_reasons).format_structured_rejection_reasons,
+          # 'Third structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[2]&.structured_rejection_reasons),
+          'Third structured rejection reasons' => FlatReasonsForRejectionExtract.new(rejected_application_choices[2]&.structured_rejection_reasons).format_structured_rejection_reasons,
         }
 
         disabilities = application_form.equality_and_diversity['disabilities']
@@ -40,23 +44,23 @@ module SupportInterface
         .where.not(equality_and_diversity: nil)
     end
 
-    def format_structured_rejection_reasons(structured_rejection_reasons)
-      return nil if structured_rejection_reasons.blank?
+    # def format_structured_rejection_reasons(structured_rejection_reasons)
+    #   return nil if structured_rejection_reasons.blank?
 
-      select_high_level_rejection_reasons(structured_rejection_reasons)
-      .keys
-      .map { |reason| format_reason(reason) }
-      .join("\n")
-    end
+    #   select_high_level_rejection_reasons(structured_rejection_reasons)
+    #   .keys
+    #   .map { |reason| format_reason(reason) }
+    #   .join("\n")
+    # end
 
-    def select_high_level_rejection_reasons(structured_rejection_reasons)
-      structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
-    end
+    # def select_high_level_rejection_reasons(structured_rejection_reasons)
+    #   structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
+    # end
 
-    def format_reason(reason)
-      reason
-      .delete_suffix('_y_n')
-      .humanize
-    end
+    # def format_reason(reason)
+    #   reason
+    #   .delete_suffix('_y_n')
+    #   .humanize
+    # end
   end
 end

--- a/app/services/support_interface/equality_and_diversity_export.rb
+++ b/app/services/support_interface/equality_and_diversity_export.rb
@@ -14,11 +14,8 @@ module SupportInterface
           'First rejection reason' => rejected_application_choices[0]&.rejection_reason,
           'Second rejection reason' => rejected_application_choices[1]&.rejection_reason,
           'Third rejection reason' => rejected_application_choices[2]&.rejection_reason,
-          # 'First structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[0]&.structured_rejection_reasons),
           'First structured rejection reasons' => FlatReasonsForRejectionExtract.new(rejected_application_choices[0]&.structured_rejection_reasons).format_structured_rejection_reasons,
-          # 'Second structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[1]&.structured_rejection_reasons),
           'Second structured rejection reasons' => FlatReasonsForRejectionExtract.new(rejected_application_choices[1]&.structured_rejection_reasons).format_structured_rejection_reasons,
-          # 'Third structured rejection reasons' => format_structured_rejection_reasons(rejected_application_choices[2]&.structured_rejection_reasons),
           'Third structured rejection reasons' => FlatReasonsForRejectionExtract.new(rejected_application_choices[2]&.structured_rejection_reasons).format_structured_rejection_reasons,
         }
 
@@ -43,24 +40,5 @@ module SupportInterface
         .includes(:application_choices)
         .where.not(equality_and_diversity: nil)
     end
-
-    # def format_structured_rejection_reasons(structured_rejection_reasons)
-    #   return nil if structured_rejection_reasons.blank?
-
-    #   select_high_level_rejection_reasons(structured_rejection_reasons)
-    #   .keys
-    #   .map { |reason| format_reason(reason) }
-    #   .join("\n")
-    # end
-
-    # def select_high_level_rejection_reasons(structured_rejection_reasons)
-    #   structured_rejection_reasons.select { |reason, value| value == 'Yes' && reason.include?('_y_n') }
-    # end
-
-    # def format_reason(reason)
-    #   reason
-    #   .delete_suffix('_y_n')
-    #   .humanize
-    # end
   end
 end

--- a/app/services/support_interface/structured_reasons_for_rejection_export.rb
+++ b/app/services/support_interface/structured_reasons_for_rejection_export.rb
@@ -1,15 +1,26 @@
 module SupportInterface
   class StructuredReasonsForRejectionExport
     def data_for_export
-      data_for_export = application_forms.includes(:application_choices).each do |application_form|
-        structured_reasons_for_rejection = FlatReasonsForRejectionExtract.new(application_form.application_choices.rejected&.structured_rejection_reasons)
+      data_for_export = application_choices.map do |application_choice|
+        structured_reasons_for_rejection = FlatReasonsForRejectionExtract.new(application_choice.structured_rejection_reasons)
 
         output = {
           'Candidate behaviour' => structured_reasons_for_rejection.candidate_behaviour?,
           'Candidate behaviour - didnt_reply_to_interview_offer' => structured_reasons_for_rejection.didnt_reply_to_interview_offer?,
           'Candidate behaviour - didnt_attend_interview' => structured_reasons_for_rejection.didnt_attend_interview?,
           'Candidate behaviour - other detail' => structured_reasons_for_rejection.candidate_behaviour_other_details,
-
+          'Quality of application' => structured_reasons_for_rejection.quality_of_application?,
+          'Quality of application - personal statement' => structured_reasons_for_rejection.personal_statement?,
+          'Quality of application - personal statement details' => structured_reasons_for_rejection.quality_of_application_personal_statement_what_to_improve,
+          'Quality of application - subject knowledge' => structured_reasons_for_rejection.subject_knowledge?,
+          'Quality of application - subject knowledge details' => structured_reasons_for_rejection.quality_of_application_subject_knowledge_what_to_improve,
+          'Quality of application - other details' => structured_reasons_for_rejection.quality_of_application_other_details,
+          'Qualifications' => structured_reasons_for_rejection.qualifications?,
+          'Qualifications - no maths gcse' => structured_reasons_for_rejection.no_maths_gcse?,
+          'Qualifications - no science gcse' => structured_reasons_for_rejection.no_science_gcse?,
+          'Qualifications - no english gcse' => structured_reasons_for_rejection.no_english_gcse?,
+          'Qualifications - no degree' => structured_reasons_for_rejection.no_degree?,
+          'Qualifications - other detail' => structured_reasons_for_rejection.qualifications_other_details,
         }
 
         output
@@ -22,10 +33,8 @@ module SupportInterface
 
   private
 
-    def application_forms
-      ApplicationForm
-        .includes(:application_choices)
-        .where.not(equality_and_diversity: nil)
+    def application_choices
+      ApplicationChoice.where.not(structured_rejection_reasons: nil)
     end
   end
 end

--- a/app/services/support_interface/structured_reasons_for_rejection_export.rb
+++ b/app/services/support_interface/structured_reasons_for_rejection_export.rb
@@ -1,0 +1,31 @@
+module SupportInterface
+  class StructuredReasonsForRejectionExport
+    def data_for_export
+      data_for_export = application_forms.includes(:application_choices).each do |application_form|
+        structured_reasons_for_rejection = FlatReasonsForRejectionExtract.new(application_form.application_choices.rejected&.structured_rejection_reasons)
+
+        output = {
+          'Candidate behaviour' => structured_reasons_for_rejection.candidate_behaviour?,
+          'Candidate behaviour - didnt_reply_to_interview_offer' => structured_reasons_for_rejection.didnt_reply_to_interview_offer?,
+          'Candidate behaviour - didnt_attend_interview' => structured_reasons_for_rejection.didnt_attend_interview?,
+          'Candidate behaviour - other detail' => structured_reasons_for_rejection.candidate_behaviour_other_details,
+
+        }
+
+        output
+      end
+
+      # The DataExport class creates the header row for us so we need to ensure
+      # we sort by longest hash length to ensure all headers appear
+      data_for_export.sort_by(&:length).reverse
+    end
+
+  private
+
+    def application_forms
+      ApplicationForm
+        .includes(:application_choices)
+        .where.not(equality_and_diversity: nil)
+    end
+  end
+end

--- a/config/locales/reasons_for_rejection_copy.yml
+++ b/config/locales/reasons_for_rejection_copy.yml
@@ -1,0 +1,104 @@
+en:
+  reasons_for_rejection_copy:
+    top_level_reasons:
+      candidate_behaviour_y_n:
+        title: Something you did
+        # sub_reasons:
+        #   title:
+        #   question: candidate_behaviour_what_did_the_candidate_do
+        #   values:
+        #     didnt_reply_to_interview_offer:
+        #       title: 'Didn't reply to our interview offer'
+        #     didnt_attend_interview:
+        #       title: 'Didn't attend interview'
+        #     other:
+        #       title: Other
+  activemodel:
+    errors:
+      models:
+        provider_interface/reasons_for_rejection_wizard:
+          attributes:
+            candidate_behaviour_y_n:
+              blank: Select yes if it was related to candidate behaviour
+            candidate_behaviour_what_did_the_candidate_do:
+              blank: Select at least one reason related to candidate behaviour
+            candidate_behaviour_other:
+              blank: Enter details about candidate behaviour
+              too_long: Details about candidate behaviour must be 100 words or fewer
+            candidate_behaviour_what_to_improve:
+              blank: Enter details about how the candidate can improve their behaviour
+              too_long: Details about how the candidate can improve their behaviour must be 100 words or fewer
+            quality_of_application_y_n:
+              blank: Select yes if it was related to the quality of their application
+            quality_of_application_which_parts_needed_improvement:
+              blank: Select at least one reason related to the quality of their application
+            quality_of_application_personal_statement_what_to_improve:
+              blank: Enter details about how they can improve their personal statement
+              too_long: Details about how they can improve their personal statement must be 100 words or fewer
+            quality_of_application_subject_knowledge_what_to_improve:
+              blank: Enter details about how they can improve their subject knowledge
+              too_long: Details about how the candidate can improve their subject knowledge must be 100 words or fewer
+            quality_of_application_other_details:
+              blank: Enter details about the quality of their application
+              too_long: Details about the quality of their application must be 100 words or fewer
+            quality_of_application_other_what_to_improve:
+              blank: Enter how they can improve the quality of their application
+              too_long: Details about how they can improve their application must be 100 words or fewer
+            qualifications_y_n:
+              blank: Select yes if it was related to their qualifications
+            qualifications_which_qualifications:
+              blank: Select at least one reason related to their qualifications
+            qualifications_other_details:
+              blank: Enter details about the problem with their qualifications
+              too_long: Details about the problem with their qualifications must be 100 words or fewer
+            performance_at_interview_y_n:
+              blank: Select yes if it was related to their performance at interview
+            performance_at_interview_what_to_improve:
+              blank: Enter details about how they can improve their performance at interview
+              too_long: Details about how they can improve their performance at interview must be 100 words or fewer
+            course_full_y_n:
+              blank: Select yes if it was because this course is full
+            offered_on_another_course_y_n:
+              blank: Select yes if it was because you offered them a place on another course
+            offered_on_another_course_details:
+              blank: Enter details about the place offered on another course
+              too_long: Details about the place offered on another course must be 100 words or fewer
+            honesty_and_professionalism_y_n:
+              blank: Select yes if it was related to concerns about their honesty and professionalism
+            honesty_and_professionalism_concerns:
+              blank: Select at least one reason related to the candidate’s honesty and professionalism
+            honesty_and_professionalism_concerns_information_false_or_inaccurate_details:
+              blank: Enter details about the inaccurate or false information in the application
+              too_long: Details about inaccurate or false information in the application must be 100 words or fewer
+            honesty_and_professionalism_concerns_plagiarism_details:
+              blank: Enter details related to evidence of plagiarism in the application
+              too_long: The details about evidence of plagiarism in the application must be 100 words or fewer
+            honesty_and_professionalism_concerns_references_details:
+              blank: Enter details about references not supporting the application
+              too_long: Details about references not supporting the application must be 100 words or fewer
+            honesty_and_professionalism_concerns_other_details:
+              blank: Enter details about the candidate’s honesty and professionalism
+              too_long: Details about the candidate’s honesty and professionalism must be 100 words or fewer
+            safeguarding_y_n:
+              blank: Select yes if it was related to safeguarding
+            safeguarding_concerns:
+              blank: Select at least one reason related to safeguarding
+            safeguarding_concerns_candidate_disclosed_information_details:
+              blank: Enter details about information the candidate disclosed which makes them unsuitable to work with children
+              too_long: Details about the information the candidate disclosed must be 100 words or fewer
+            safeguarding_concerns_vetting_disclosed_information_details:
+              blank: Enter details about the information found by your vetting process which makes the candidate unsuitable to work with children
+              too_long: Details about the information found by your vetting process which makes the candidate unsuitable to work with children must be 100 words or fewer
+            safeguarding_concerns_other_details:
+              blank: Enter details about safeguarding
+              too_long: Details about safeguarding must be 100 words or fewer
+            why_are_you_rejecting_this_application:
+              blank: Enter why you’re rejecting this application
+              too_long: Details about why you’re rejecting this application must be 200 words or fewer
+            other_advice_or_feedback_y_n:
+              blank: Select yes if there is any other advice or feedback you‘d like to give
+            other_advice_or_feedback_details:
+              blank: Enter any other advice or feedback
+              too_long: The other advice or feedback must be 200 words or fewer
+            interested_in_future_applications_y_n:
+              blank: Select yes if you’d be interested in future applications from this candidate


### PR DESCRIPTION
## Context

In order to facilitate the creation of new reports we need a reliable model to isolate all of the specific values in the JSON blob stored in the database.

## Changes proposed in this pull request

Model and proto-report added

## Guidance to review

We've proceeded at this point to create a model that maps the first several R4Rs and sub-R4Rs. 

We have a functioning report and will continue to build on this but would like some feedback RE: our approach and any ways we could refactor as the model is already very big.

We did have the thought to perhaps have several smaller models instead of 1 large one but this could defeat the point of doing things in this way.

## Link to Trello card

https://trello.com/c/fqI5eAhg/3031-dev-create-schema-for-reverse-mapping-structured-reasons-for-rejection

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
