### PR TITLE
Spec adds work entry with minimum details

### DIFF
--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -270,11 +270,6 @@ module CandidateHelper
         fill_in 'Year', with: '2014'
       end
 
-      within('[data-qa="end-date"]') do
-        fill_in 'Month', with: '1'
-        fill_in 'Year', with: '2019'
-      end
-
       fill_in locale.t('details.label'), with: 'I learned a lot about teaching'
 
       choose 'No'

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -189,7 +189,7 @@ RSpec.feature 'Vendor receives the application', recruitment_cycle: 2020 do
             {
               id: @application.application_work_experiences.first.id,
               start_date: '2014-05-01',
-              end_date: '2019-01-01',
+              end_date: nil,
               role: 'Teacher',
               organisation_name: 'Oakleaf Primary School',
               working_with_children: false,


### PR DESCRIPTION
**Part of investigation related to adding/modifying specs to prevent incidents caused by issues that should have been identified by the specs**

By only setting the minimum required details it’s easier to identify any possible issues before they get to production. In this instance, updating the spec on branch `3002-dev-update-the-application-review-page-to-show-the-new-work-history-design` correctly causes 6 failures.

Related to incident where candidates were unable to submit their application

## Verifying fix

You can replicate the failure by adding commit 18ee18c to https://github.com/DFE-Digital/apply-for-teacher-training/tree/3002-dev-update-the-application-review-page-to-show-the-new-work-history-design and running the candidate system specs.
 
```bash
Failures:

  1) Submitting an application Candidate submits complete application
     Failure/Error: "to #{@work_experience.end_date.to_s(:short_month_and_year)}"

     ActionView::Template::Error:
       wrong number of arguments (given 1, expected 0)
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `formatted_end_date'
     # ./app/components/candidate_interface/restructured_work_history/job_component.html.erb:12:in `call'
     # (eval):3:in `render_template_for'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:11:in `block in call'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `each'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `call'
     # (eval):3:in `render_template_for'
     # ./app/views/candidate_interface/application_form/_review.html.erb:93:in `_app_views_candidate_interface_application_form__review_html_erb___630289340913149988_225780'
     # ./app/views/candidate_interface/unsubmitted_application_form/review.html.erb:33:in `_app_views_candidate_interface_unsubmitted_application_form_review_html_erb__796732469873497504_225760'
     # ./app/middlewares/vendor_api_request_middleware.rb:27:in `_call'
     # ./app/middlewares/vendor_api_request_middleware.rb:22:in `call'
     # ./app/middlewares/redirect_to_service_gov_uk_middleware.rb:11:in `call'
     # ./spec/system/candidate_interface/references/submitting_an_application_spec.rb:67:in `and_i_submit_the_application'
     # ./spec/system/candidate_interface/references/submitting_an_application_spec.rb:13:in `block (2 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/dates.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/dates.rb:13:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 1, expected 0)
     #   ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'

  2) International candidate submits the application International candidate completes and submits an application
     Failure/Error: "to #{@work_experience.end_date.to_s(:short_month_and_year)}"

     ActionView::Template::Error:
       wrong number of arguments (given 1, expected 0)
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `formatted_end_date'
     # ./app/components/candidate_interface/restructured_work_history/job_component.html.erb:12:in `call'
     # (eval):3:in `render_template_for'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:11:in `block in call'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `each'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `call'
     # (eval):3:in `render_template_for'
     # ./app/views/candidate_interface/application_form/_review.html.erb:93:in `_app_views_candidate_interface_application_form__review_html_erb___630289340913149988_225780'
     # ./app/views/candidate_interface/unsubmitted_application_form/review.html.erb:33:in `_app_views_candidate_interface_unsubmitted_application_form_review_html_erb__796732469873497504_225760'
     # ./app/middlewares/vendor_api_request_middleware.rb:27:in `_call'
     # ./app/middlewares/vendor_api_request_middleware.rb:22:in `call'
     # ./app/middlewares/redirect_to_service_gov_uk_middleware.rb:11:in `call'
     # ./spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb:116:in `when_i_review_my_application'
     # ./spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb:12:in `block (2 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/dates.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/dates.rb:13:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 1, expected 0)
     #   ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'

  3) References The candidate sees errors when they have too many references
     Failure/Error: "to #{@work_experience.end_date.to_s(:short_month_and_year)}"

     ActionView::Template::Error:
       wrong number of arguments (given 1, expected 0)
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `formatted_end_date'
     # ./app/components/candidate_interface/restructured_work_history/job_component.html.erb:12:in `call'
     # (eval):3:in `render_template_for'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:11:in `block in call'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `each'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `call'
     # (eval):3:in `render_template_for'
     # ./app/views/candidate_interface/application_form/_review.html.erb:93:in `_app_views_candidate_interface_application_form__review_html_erb___630289340913149988_225780'
     # ./app/views/candidate_interface/unsubmitted_application_form/review.html.erb:33:in `_app_views_candidate_interface_unsubmitted_application_form_review_html_erb__796732469873497504_225760'
     # ./app/middlewares/vendor_api_request_middleware.rb:27:in `_call'
     # ./app/middlewares/vendor_api_request_middleware.rb:22:in `call'
     # ./app/middlewares/redirect_to_service_gov_uk_middleware.rb:11:in `call'
     # ./spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb:42:in `and_i_see_a_warning_on_the_application_review_page'
     # ./spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb:14:in `block (2 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/dates.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/dates.rb:13:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 1, expected 0)
     #   ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'

  4) Candidate feedback form Candidate completes the feedback form
     Failure/Error: "to #{@work_experience.end_date.to_s(:short_month_and_year)}"

     ActionView::Template::Error:
       wrong number of arguments (given 1, expected 0)
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `formatted_end_date'
     # ./app/components/candidate_interface/restructured_work_history/job_component.html.erb:12:in `call'
     # (eval):3:in `render_template_for'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:11:in `block in call'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `each'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `call'
     # (eval):3:in `render_template_for'
     # ./app/views/candidate_interface/application_form/_review.html.erb:93:in `_app_views_candidate_interface_application_form__review_html_erb___630289340913149988_225780'
     # ./app/views/candidate_interface/unsubmitted_application_form/review.html.erb:33:in `_app_views_candidate_interface_unsubmitted_application_form_review_html_erb__796732469873497504_225760'
     # ./app/middlewares/vendor_api_request_middleware.rb:27:in `_call'
     # ./app/middlewares/vendor_api_request_middleware.rb:22:in `call'
     # ./app/middlewares/redirect_to_service_gov_uk_middleware.rb:11:in `call'
     # ./spec/support/test_helpers/candidate_helper.rb:84:in `candidate_submits_application'
     # ./spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb:26:in `given_i_complete_and_submit_my_application'
     # ./spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/dates.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/dates.rb:13:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 1, expected 0)
     #   ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'

  5) Entering their equality and diversity information Candidate submits equality and diversity information
     Failure/Error: "to #{@work_experience.end_date.to_s(:short_month_and_year)}"

     ActionView::Template::Error:
       wrong number of arguments (given 1, expected 0)
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `formatted_end_date'
     # ./app/components/candidate_interface/restructured_work_history/job_component.html.erb:12:in `call'
     # (eval):3:in `render_template_for'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:11:in `block in call'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `each'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `call'
     # (eval):3:in `render_template_for'
     # ./app/views/candidate_interface/application_form/_review.html.erb:93:in `_app_views_candidate_interface_application_form__review_html_erb___630289340913149988_225780'
     # ./app/views/candidate_interface/unsubmitted_application_form/review.html.erb:33:in `_app_views_candidate_interface_unsubmitted_application_form_review_html_erb__796732469873497504_225760'
     # ./app/middlewares/vendor_api_request_middleware.rb:27:in `_call'
     # ./app/middlewares/vendor_api_request_middleware.rb:22:in `call'
     # ./app/middlewares/redirect_to_service_gov_uk_middleware.rb:11:in `call'
     # ./spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb:99:in `and_i_submit_my_application'
     # ./spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/dates.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/dates.rb:13:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 1, expected 0)
     #   ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'

  6) Candidate submits the application Candidate with a completed application
     Failure/Error: "to #{@work_experience.end_date.to_s(:short_month_and_year)}"

     ActionView::Template::Error:
       wrong number of arguments (given 1, expected 0)
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'
     # ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `formatted_end_date'
     # ./app/components/candidate_interface/restructured_work_history/job_component.html.erb:12:in `call'
     # (eval):3:in `render_template_for'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:11:in `block in call'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `each'
     # ./app/components/candidate_interface/restructured_work_history/review_component.html.erb:8:in `call'
     # (eval):3:in `render_template_for'
     # ./app/views/candidate_interface/application_form/_review.html.erb:93:in `_app_views_candidate_interface_application_form__review_html_erb___630289340913149988_225780'
     # ./app/views/candidate_interface/unsubmitted_application_form/review.html.erb:33:in `_app_views_candidate_interface_unsubmitted_application_form_review_html_erb__796732469873497504_225760'
     # ./app/middlewares/vendor_api_request_middleware.rb:27:in `_call'
     # ./app/middlewares/vendor_api_request_middleware.rb:22:in `call'
     # ./app/middlewares/redirect_to_service_gov_uk_middleware.rb:11:in `call'
     # ./spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb:159:in `when_i_click_on_check_your_answers'
     # ./spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb:72:in `and_i_review_my_application'
     # ./spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb:12:in `block (2 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:21:in `block (4 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/support/sidekiq.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/dates.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/dates.rb:13:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 1, expected 0)
     #   ./app/components/candidate_interface/restructured_work_history/job_component.rb:31:in `to_s'

Finished in 1 minute 34 seconds (files took 12.25 seconds to load)
116 examples, 6 failures, 3 pending

Failed examples:

rspec ./spec/system/candidate_interface/references/submitting_an_application_spec.rb:6 # Submitting an application Candidate submits complete application
rspec ./spec/system/candidate_interface/submitting/international_candidate_submitting_application_spec.rb:7 # International candidate submits the application International candidate completes and submits an application
rspec ./spec/system/candidate_interface/references/candidate_has_too_many_references_spec.rb:10 # References The candidate sees errors when they have too many references
rspec ./spec/system/candidate_interface/feedback/candidate_completes_the_feedback_form_spec.rb:6 # Candidate feedback form Candidate completes the feedback form
rspec ./spec/system/candidate_interface/entering_details/candidate_entering_equality_and_diversity_information_spec.rb:6 # Entering their equality and diversity information Candidate submits equality and diversity information
rspec ./spec/system/candidate_interface/submitting/candidate_submitting_application_spec.rb:6 # Candidate submits the application Candidate with a completed application
```

