### PR TITLE
Remove 'banner_about_problems_with_dfe_sign_in' feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -12,7 +12,6 @@ class FeatureFlag
   end
 
   PERMANENT_SETTINGS = [
-    [:banner_about_problems_with_dfe_sign_in, 'Displays a banner to notify users that DfE-Sign is having problems', 'Apply team'],
     [:banner_for_ucas_downtime, 'Displays a banner to notify users that UCAS is having problems', 'Apply team'],
     [:dfe_sign_in_fallback, 'Use this when DfE Sign-in is down', 'Apply team'],
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Apply team'],

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -4,12 +4,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% if FeatureFlag.active?('banner_about_problems_with_dfe_sign_in') %>
-      <%= render NotificationMessageComponent.new(:info,
-                                                  message: 'You might have problems signing in ',
-                                                  secondary_message: 'Some of our users are having trouble signing in. We’re working on the problem now. If you cannot sign in, try again soon.') %>
-    <% end %>
-
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.sign_in') %>
     </h1>


### PR DESCRIPTION
We don't use this any more since we have the magic link fallback.
