### PR TITLE
Display offer withdrawal reasons in manage

### DIFF
--- a/app/components/provider_interface/application_choice_header_component.rb
+++ b/app/components/provider_interface/application_choice_header_component.rb
@@ -44,7 +44,7 @@ module ProviderInterface
         { name: 'Timeline', url: provider_interface_application_choice_timeline_path(application_choice) },
       )
 
-      unless application_choice.no_feedback?
+      if application_choice.display_provider_feedback?
         sub_navigation_items.push(
           { name: 'Feedback', url: provider_interface_application_choice_feedback_path(application_choice) },
         )

--- a/app/components/provider_interface/application_feedback_component.html.erb
+++ b/app/components/provider_interface/application_feedback_component.html.erb
@@ -2,23 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m govuk-!-font-size-27">Feedback</h2>
 
-    <% if @application_choice.structured_rejection_reasons.present? %>
-      <p class="govuk-body">
-        This application was <%= ('automatically' if @application_choice.rejected_by_default?) %> rejected on <%= @application_choice.rejected_at.to_s(:govuk_date) %>.
-        <% if @application_choice.reject_by_default_feedback_sent_at.present? -%>
-          Feedback was sent on <%= @application_choice.reject_by_default_feedback_sent_at.to_s(:govuk_date) %>.
-        <% else -%>
-          The following feedback was sent to the candidate.
-        <% end -%>
-      </p>
-      <div class="govuk-inset-text">
-        <%= render ReasonsForRejectionComponent.new(
-          application_choice: @application_choice,
-          reasons_for_rejection: ReasonsForRejection.new(@application_choice.structured_rejection_reasons),
-        ) %>
-      </div>
-    <% else %>
-      <%= render SummaryListComponent.new(rows: rejected_rows) %>
-    <% end %>
+    <%= render ProviderInterface::ApplicationRejectionFeedbackComponent.new(application_choice: application_choice) %>
+
   </div>
 </div>

--- a/app/components/provider_interface/application_feedback_component.html.erb
+++ b/app/components/provider_interface/application_feedback_component.html.erb
@@ -1,8 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Feedback</h2>
-
+    <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">Feedback</h2>
     <%= render ProviderInterface::ApplicationRejectionFeedbackComponent.new(application_choice: application_choice) %>
-
+    <%= render ProviderInterface::ApplicationOfferWithdrawnFeedbackComponent.new(application_choice: application_choice) %>
   </div>
 </div>

--- a/app/components/provider_interface/application_feedback_component.rb
+++ b/app/components/provider_interface/application_feedback_component.rb
@@ -1,53 +1,9 @@
 module ProviderInterface
   class ApplicationFeedbackComponent < ViewComponent::Base
-    include ViewHelper
-    include StatusBoxComponents::CourseRows
-
     attr_reader :application_choice
 
-    def initialize(application_choice:, options: {})
+    def initialize(application_choice:)
       @application_choice = application_choice
-      @options = options
-    end
-
-    def render?
-      application_choice.rejected?
-    end
-
-    def rejected_rows
-      if application_choice.rejected_by_default
-        rows = [
-          {
-            key: 'Automatically rejected',
-            value: application_choice.rejected_at.to_s(:govuk_date),
-          },
-        ]
-        if application_choice.reject_by_default_feedback_sent_at.present?
-          rows + [
-            {
-              key: 'Feedback sent',
-              value: application_choice.reject_by_default_feedback_sent_at.to_s(:govuk_date),
-            },
-            {
-              key: 'Feedback for candidate',
-              value: application_choice.rejection_reason,
-            },
-          ]
-        else
-          rows
-        end
-      else
-        [
-          {
-            key: 'Rejected',
-            value: application_choice.rejected_at.to_s(:govuk_date),
-          },
-          {
-            key: 'Feedback for candidate',
-            value: application_choice.rejection_reason,
-          },
-        ]
-      end
     end
   end
 end

--- a/app/components/provider_interface/application_offer_withdrawn_feedback_component.html.erb
+++ b/app/components/provider_interface/application_offer_withdrawn_feedback_component.html.erb
@@ -1,0 +1,6 @@
+<p class="govuk-body">
+  The offer was withdrawn on <%= application_choice.offer_withdrawn_at.to_s(:govuk_date) %>. The following feedback was sent to the candidate.
+</p>
+<div class="govuk-inset-text">
+  <%= application_choice.offer_withdrawal_reason %>
+</div>

--- a/app/components/provider_interface/application_offer_withdrawn_feedback_component.rb
+++ b/app/components/provider_interface/application_offer_withdrawn_feedback_component.rb
@@ -1,0 +1,13 @@
+module ProviderInterface
+  class ApplicationOfferWithdrawnFeedbackComponent < ViewComponent::Base
+    attr_reader :application_choice
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def render?
+      application_choice.offer_withdrawn?
+    end
+  end
+end

--- a/app/components/provider_interface/application_rejection_feedback_component.html.erb
+++ b/app/components/provider_interface/application_rejection_feedback_component.html.erb
@@ -1,0 +1,18 @@
+<% if application_choice.structured_rejection_reasons.present? %>
+  <p class="govuk-body">
+    This application was <%= ('automatically ' if application_choice.rejected_by_default?) %>rejected on <%= application_choice.rejected_at.to_s(:govuk_date) %>.
+    <% if application_choice.reject_by_default_feedback_sent_at.present? -%>
+      Feedback was sent on <%= application_choice.reject_by_default_feedback_sent_at.to_s(:govuk_date) %>.
+    <% else -%>
+      The following feedback was sent to the candidate.
+    <% end -%>
+  </p>
+  <div class="govuk-inset-text">
+    <%= render ReasonsForRejectionComponent.new(
+      application_choice: application_choice,
+      reasons_for_rejection: ReasonsForRejection.new(application_choice.structured_rejection_reasons),
+    ) %>
+  </div>
+<% else %>
+  <%= render SummaryListComponent.new(rows: rejected_rows) %>
+<% end %>

--- a/app/components/provider_interface/application_rejection_feedback_component.rb
+++ b/app/components/provider_interface/application_rejection_feedback_component.rb
@@ -1,0 +1,49 @@
+module ProviderInterface
+  class ApplicationRejectionFeedbackComponent < ViewComponent::Base
+    attr_reader :application_choice
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def render?
+      application_choice.rejected? && !application_choice.no_feedback?
+    end
+
+    def rejected_rows
+      if application_choice.rejected_by_default
+        rows = [
+          {
+            key: 'Automatically rejected',
+            value: application_choice.rejected_at.to_s(:govuk_date),
+          },
+        ]
+        if application_choice.reject_by_default_feedback_sent_at.present?
+          rows + [
+            {
+              key: 'Feedback sent',
+              value: application_choice.reject_by_default_feedback_sent_at.to_s(:govuk_date),
+            },
+            {
+              key: 'Feedback for candidate',
+              value: application_choice.rejection_reason,
+            },
+          ]
+        else
+          rows
+        end
+      else
+        [
+          {
+            key: 'Rejected',
+            value: application_choice.rejected_at.to_s(:govuk_date),
+          },
+          {
+            key: 'Feedback for candidate',
+            value: application_choice.rejection_reason,
+          },
+        ]
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -51,7 +51,9 @@ module ProviderInterface
 
     def timeline; end
 
-    def feedback; end
+    def feedback
+      redirect_to provider_interface_application_choice_path(@application_choice) unless @application_choice.display_provider_feedback?
+    end
 
     def emails
       if HostingEnvironment.sandbox_mode?

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -95,7 +95,7 @@ module ProviderInterface
       )
       if @withdraw_offer.save
         flash[:success] = 'Offer successfully withdrawn'
-        redirect_to provider_interface_application_choice_path(
+        redirect_to provider_interface_application_choice_feedback_path(
           application_choice_id: @application_choice.id,
         )
       else

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -136,6 +136,11 @@ class ApplicationChoice < ApplicationRecord
     rejection_reason.blank? && structured_rejection_reasons.blank?
   end
 
+  def display_provider_feedback?
+    rejected? && (rejection_reason.present? || structured_rejection_reasons.present?) ||
+      offer_withdrawn? && offer_withdrawal_reason.present?
+  end
+
 private
 
   def generate_alphanumeric_id

--- a/spec/components/provider_interface/application_offer_withdrawn_feedback_component_spec.rb
+++ b/spec/components/provider_interface/application_offer_withdrawn_feedback_component_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationOfferWithdrawnFeedbackComponent do
+  let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
+  let(:render) { render_inline described_class.new(application_choice: application_choice) }
+
+  context 'when the application is not in the offer_withdrawn state' do
+    it 'does not render' do
+      expect(render.to_html).to be_blank
+    end
+  end
+
+  context 'when the application is in the offer_withdrawn state' do
+    let(:application_choice) { create(:application_choice, :with_withdrawn_offer) }
+
+    it 'renders the date of offer withdrawal' do
+      expect(render.text).to include('The offer was withdrawn on 31 October 2021')
+    end
+
+    it 'renders the reasons for offer withdrawal' do
+      expect(render.css('.govuk-body').text).to include('The following feedback was sent to the candidate')
+      expect(render.css('.govuk-inset-text').text).to include('There has been a mistake')
+    end
+  end
+end

--- a/spec/components/provider_interface/application_rejection_feedback_component_spec.rb
+++ b/spec/components/provider_interface/application_rejection_feedback_component_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationRejectionFeedbackComponent do
+  let(:application_choice) { create(:application_choice, :awaiting_provider_decision) }
+  let(:render) { render_inline described_class.new(application_choice: application_choice) }
+
+  context 'when the application is not rejected' do
+    it 'does not render' do
+      expect(render.to_html).to be_blank
+    end
+  end
+
+  context 'when the application is rejected but has no feedback' do
+    let(:application_choice) { create(:application_choice, :with_rejection_by_default) }
+
+    it 'does not render' do
+      expect(render.to_html).to be_blank
+    end
+  end
+
+  context 'when the application is rejected with structured reasons' do
+    let(:application_choice) do
+      create(
+        :application_choice,
+        :with_structured_rejection_reasons,
+        rejected_by_default: false,
+        reject_by_default_feedback_sent_at: nil,
+        rejected_at: 1.day.ago,
+      )
+    end
+
+    it 'renders the date of rejection' do
+      expect(render.text).to include('This application was rejected on 31 October 2021')
+    end
+
+    it 'renders the reasons for rejection' do
+      expect(render.css('.govuk-body').text).to include('The following feedback was sent to the candidate')
+      expect(render.css('.app-rejection').text).to include('Persistent scratching')
+      expect(render.css('.app-rejection').text).to include('Lights on but nobody home')
+    end
+  end
+
+  context 'when the application is rejected automatically with structured reasons added' do
+    let(:application_choice) do
+      create(
+        :application_choice,
+        :with_structured_rejection_reasons,
+        rejected_at: 1.day.ago,
+      )
+    end
+
+    it 'renders the date of rejection' do
+      expect(render.text).to include('This application was automatically rejected on 31 October 2021')
+    end
+
+    it 'renders the date of feedback sent' do
+      expect(render.text).to include('Feedback was sent on 1 November 2021')
+    end
+
+    it 'renders the reasons for rejection' do
+      expect(render.css('.app-rejection').text).to include('Persistent scratching')
+      expect(render.css('.app-rejection').text).to include('Lights on but nobody home')
+    end
+  end
+
+  context 'when the application is rejected with no structured rejection reasons' do
+    let(:application_choice) do
+      create(
+        :application_choice,
+        :with_rejection,
+        rejected_at: 1.day.ago,
+      )
+    end
+
+    it 'renders a row with the rejection date' do
+      rejected_at_row = find_summary_row('Rejected')
+      expect(rejected_at_row.text).to include('31 October 2021')
+    end
+
+    it 'renders a row with the rejection reason' do
+      rejection_reason_row = find_summary_row('Feedback for candidate')
+      expect(rejection_reason_row.text).to include(application_choice.rejection_reason)
+    end
+  end
+
+  context 'when the application is rejected automatically with no structured rejection reasons' do
+    let(:application_choice) do
+      create(
+        :application_choice,
+        :with_rejection_by_default_and_feedback,
+        rejected_at: 1.day.ago,
+      )
+    end
+
+    it 'renders a row with the rejection date' do
+      rejected_at_row = find_summary_row('Automatically rejected')
+      expect(rejected_at_row.text).to include('31 October 2021')
+    end
+
+    it 'renders a row with the rejection feedback sent date' do
+      rejection_feedback_sent_at_row = find_summary_row('Feedback sent')
+      expect(rejection_feedback_sent_at_row.text).to include('1 November 2021')
+    end
+
+    it 'renders a row with the rejection reason' do
+      rejection_reason_row = find_summary_row('Feedback for candidate')
+      expect(rejection_reason_row.text).to include(application_choice.rejection_reason)
+    end
+  end
+
+  def find_summary_row(label)
+    render.css('.govuk-summary-list__row').find { |row| row.text.include?(label) }
+  end
+end

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Provider withdraws an offer' do
     then_i_am_asked_to_confirm_withdrawal_of_the_offer
 
     when_i_confirm_withdrawal_of_the_offer
-    then_i_am_back_to_the_application_page
+    then_i_am_sent_to_the_application_feedback_tab
     and_i_can_see_the_application_offer_is_withdrawn
   end
 
@@ -89,14 +89,13 @@ RSpec.feature 'Provider withdraws an offer' do
     click_on 'Withdraw offer'
   end
 
-  def then_i_am_back_to_the_application_page
+  def then_i_am_sent_to_the_application_feedback_tab
     expect(page).to have_current_path(
-      provider_interface_application_choice_path(
+      provider_interface_application_choice_feedback_path(
         @application_offered.id,
       ),
     )
-    expect(page).to have_content @application_offered.application_form.first_name
-    expect(page).to have_content @application_offered.application_form.last_name
+    expect(page).to have_content @application_offered.offer_withdrawal_reason
   end
 
   def and_i_can_see_the_application_offer_is_withdrawn


### PR DESCRIPTION
## Context
Providers will find it useful to view reasons they withdrew offers in manage UI.

## Changes proposed in this pull request
Display reasons for offer withdrawal in manage UI:

<img width="500" alt="Screenshot 2021-02-26 at 12 10 23" src="https://user-images.githubusercontent.com/30071178/109298512-9db8e880-782b-11eb-86fd-ef1341b95927.png">

## Guidance to review
Per commit

## Link to Trello card
https://trello.com/c/JBcKcdvY/3431-show-reasons-why-offer-was-withdrawn-in-the-ui

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
