### PR TITLE
Remove `ApplicationQualification.awarding_body`

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -241,7 +241,7 @@ module VendorAPI
         start_year: qualification.start_year,
         award_year: qualification.award_year,
         institution_details: institution_details(qualification),
-        awarding_body: qualification.awarding_body,
+        awarding_body: nil,
         equivalency_details: qualification.composite_equivalency_details,
       }.merge HesaQualificationFieldsPresenter.new(qualification).to_hash
     end

--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -50,7 +50,7 @@ module ProviderInterface
           'award_year' => application.first_degree.award_year,
           'institution_details' => application.first_degree.institution_name,
           'equivalency_details' => replace_smart_quotes(application.first_degree.composite_equivalency_details),
-          'awarding_body' => application.first_degree.awarding_body,
+          'awarding_body' => nil,
           'gcse_qualifications_summary' => replace_smart_quotes(application.gcse_qualifications_summary),
           'missing_gcses_explanation' => replace_smart_quotes(application.missing_gcses_explanation),
           'disability_disclosure' => application.application_form.disability_disclosure,

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,7 @@
+## 29th February
+
+- deprecate `Qualification.awarding_body` as this field has always been null.
+
 ## 26th February
 
 New attributes:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -851,7 +851,8 @@ components:
           nullable: true
         awarding_body:
           type: string
-          description: Details about the qualification awarding body
+          description: 'Details about the qualification awarding body. DEPRECATED: this field will always be null as Apply does not collect this information.'
+          deprecated: true
           example: University of Amsterdam
           maxLength: 256
           nullable: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -298,7 +298,6 @@ FactoryBot.define do
     award_year { Faker::Date.between(from: 60.years.ago, to: 3.years.from_now).year }
     institution_name { Faker::University.name }
     institution_country { Faker::Address.country_code }
-    awarding_body { Faker::University.name }
     equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
 
     factory :gcse_qualification do
@@ -306,7 +305,6 @@ FactoryBot.define do
       qualification_type { 'gcse' }
       subject { %w[maths english science].sample }
       grade { %w[A B C].sample }
-      awarding_body { Faker::Educator.secondary_school }
 
       trait :non_uk do
         qualification_type { 'non_uk' }
@@ -320,7 +318,6 @@ FactoryBot.define do
       trait :missing do
         qualification_type { 'missing' }
         grade { nil }
-        awarding_body { nil }
         missing_explanation { 'I will be taking an equivalency test in a few weeks' }
       end
     end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe ApplicationQualification, type: :model do
       'award_year',
       'institution_name',
       'institution_country',
-      'awarding_body',
       'equivalency_details',
     )
   end

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
         'award_year' => first_degree&.award_year,
         'institution_details' => first_degree&.institution_name,
         'equivalency_details' => first_degree&.equivalency_details,
-        'awarding_body' => first_degree&.awarding_body,
+        'awarding_body' => nil,
         'gcse_qualifications_summary' => nil,
         'missing_gcses_explanation' => nil,
         'disability_disclosure' => application_choice.application_form.disability_disclosure,


### PR DESCRIPTION
## Context

This field was added but never used. Nevertheless we added it to the Manage CSV export and the API.

`SELECT COUNT(DISTINCT awarding_body) from application_qualifications;` on Blazer in prod returns 0 results.

## Changes proposed in this pull request

Remove the field and hardcode `null`s in those places 😔

## Link to Trello card

Following feedback from Oracle, who found this field populated in test data and got confused as to where it came from.

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
