### PR TITLE
Validate presence of candidate date of birth

### DIFF
--- a/app/forms/candidate_interface/personal_details_form.rb
+++ b/app/forms/candidate_interface/personal_details_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     attr_accessor :first_name, :last_name, :day, :month, :year
 
     validates :first_name, :last_name, presence: true, length: { maximum: 60 }
-    validates :date_of_birth, date: { date_of_birth: true }
+    validates :date_of_birth, date: { date_of_birth: true, presence: true }
 
     def self.build_from_application(application_form)
       new(

--- a/spec/forms/candidate_interface/personal_details_form_spec.rb
+++ b/spec/forms/candidate_interface/personal_details_form_spec.rb
@@ -54,30 +54,6 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
     end
   end
 
-  describe '#date_of_birth' do
-    it 'return a nil for nil day/month/year' do
-      personal_details = CandidateInterface::PersonalDetailsForm.new(day: nil, month: nil, year: nil)
-
-      expect(personal_details.date_of_birth.day).to be_nil
-      expect(personal_details.date_of_birth.month).to be_nil
-      expect(personal_details.date_of_birth.year).to be_nil
-    end
-
-    it 'can return an invalid date object for invalid day/month/year' do
-      personal_details = CandidateInterface::PersonalDetailsForm.new(day: 99, month: 99, year: 99)
-
-      expect(personal_details.date_of_birth.day).to eq(99)
-      expect(personal_details.date_of_birth.month).to eq(99)
-      expect(personal_details.date_of_birth.year).to eq(99)
-    end
-
-    it 'returns a date for a valid day/month/year' do
-      personal_details = CandidateInterface::PersonalDetailsForm.new(day: '2', month: '8', year: '1990')
-
-      expect(personal_details.date_of_birth).to eq(Date.new(1990, 8, 2))
-    end
-  end
-
   describe 'validations' do
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }
@@ -86,57 +62,7 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
     it { is_expected.to validate_length_of(:last_name).is_at_most(60) }
 
     describe 'date of birth' do
-      around do |example|
-        Timecop.freeze(Time.zone.local(2019, 1, 1)) do
-          example.run
-        end
-      end
-
-      it 'is invalid if not well-formed' do
-        personal_details = CandidateInterface::PersonalDetailsForm.new(
-          day: '99', month: '99', year: '99',
-        )
-
-        personal_details.validate
-
-        expect(personal_details.errors.full_messages_for(:date_of_birth)).to eq(
-          ['Date of birth Enter a real date of birth'],
-        )
-      end
-
-      it 'is invalid if the date is in the future' do
-        personal_details = CandidateInterface::PersonalDetailsForm.new(
-          day: '2', month: '8', year: '2999',
-        )
-
-        personal_details.validate
-
-        expect(personal_details.errors.full_messages_for(:date_of_birth)).to eq(
-          ['Date of birth Enter a date of birth that is in the past, for example 31 3 1980'],
-        )
-      end
-
-      it 'is invalid if the candidate is younger than 16' do
-        personal_details = CandidateInterface::PersonalDetailsForm.new(
-          day: '2', month: '1', year: '2003',
-        )
-
-        personal_details.validate
-
-        expect(personal_details.errors.full_messages_for(:date_of_birth)).to eq(
-          ['Date of birth Enter a date of birth before 1 January 2003 – you must be over 16 years old to Apply for teacher training'],
-        )
-      end
-
-      it 'is valid if the candidate is older than 16' do
-        personal_details = CandidateInterface::PersonalDetailsForm.new(
-          day: '31', month: '12', year: '2002',
-        )
-
-        personal_details.validate
-
-        expect(personal_details.errors.full_messages_for(:date_of_birth)).to be_empty
-      end
+      include_examples 'date_of_birth validations', verify_presence: true
     end
   end
 end

--- a/spec/support/shared_examples/date_of_birth.rb
+++ b/spec/support/shared_examples/date_of_birth.rb
@@ -1,0 +1,39 @@
+RSpec.shared_examples 'date_of_birth validations' do |verify_presence|
+  let(:model) { described_class.new(day: day, month: month, year: year) }
+  let(:day) { date_of_birth.day }
+  let(:month) { date_of_birth.month }
+  let(:year) { date_of_birth.year }
+
+  describe 'when date is in the future' do
+    let(:date_of_birth) { 50.years.from_now }
+
+    it 'returns :dob_future error' do
+      expect(model).to be_invalid
+      expect(model.errors[:date_of_birth]).to contain_exactly(I18n.t('errors.messages.dob_future', article: 'a', attribute: 'date of birth'))
+    end
+  end
+
+  describe 'when date is below the minimum age' do
+    let(:date_of_birth) { Time.zone.today - 14.years }
+
+    it 'returns :dob_below_min_age error' do
+      age_limit = Time.zone.today - 16.years
+
+      expect(model).to be_invalid
+      expect(model.errors[:date_of_birth]).to contain_exactly(
+        I18n.t('errors.messages.dob_below_min_age', date: age_limit.to_s(:govuk_date), min_age: 16),
+      )
+    end
+  end
+
+  describe 'when date is not present', if: verify_presence do
+    let(:date_of_birth) { Struct.new(:day, :month, :year).new(nil, nil, nil) }
+
+    it 'returns :blank_date error' do
+      expect(model).to be_invalid
+      expect(model.errors[:date_of_birth]).to contain_exactly(
+        I18n.t('errors.messages.blank_date', article: 'a', attribute: 'date of birth'),
+      )
+    end
+  end
+end


### PR DESCRIPTION
Add missing date of birth presence check to personal details form.

## Context

Resolves sentry error: https://sentry.io/organizations/dfe-bat/issues/2239406103/?project=1765973&referrer=slack

- Add shared examples to verify Date of birth validations and presence (optionally)
- Remove tests duplicating DateValidator checks

## Guidance to review

Attempt to submit the personal details form without filling in the date of bith.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
