### PR TITLE
Substitute smart quotes for straight quotes on free text fields

### DIFF
--- a/app/services/provider_interface/application_data_export.rb
+++ b/app/services/provider_interface/application_data_export.rb
@@ -24,7 +24,7 @@ module ProviderInterface
           'domicile' => application.application_form.domicile,
           'uk_residency_status' => application.application_form.uk_residency_status,
           'english_main_language' => application.application_form.english_main_language,
-          'english_language_qualifications' => application.application_form.english_language_details,
+          'english_language_qualifications' => replace_smart_quotes(application.application_form.english_language_details),
           'email' => application.application_form.candidate.email_address,
           'phone_number' => application.application_form.phone_number,
           'address_line1' => application.application_form.address_line1,
@@ -49,16 +49,20 @@ module ProviderInterface
           'start_year' => application.first_degree.start_year,
           'award_year' => application.first_degree.award_year,
           'institution_details' => application.first_degree.institution_name,
-          'equivalency_details' => application.first_degree.composite_equivalency_details,
+          'equivalency_details' => replace_smart_quotes(application.first_degree.composite_equivalency_details),
           'awarding_body' => application.first_degree.awarding_body,
-          'gcse_qualifications_summary' => application.gcse_qualifications_summary,
-          'missing_gcses_explanation' => application.missing_gcses_explanation,
+          'gcse_qualifications_summary' => replace_smart_quotes(application.gcse_qualifications_summary),
+          'missing_gcses_explanation' => replace_smart_quotes(application.missing_gcses_explanation),
           'disability_disclosure' => application.application_form.disability_disclosure,
         }
       end
 
       header_row ||= rows.first&.keys
       SafeCSV.generate(rows.map(&:values), header_row)
+    end
+
+    def self.replace_smart_quotes(text)
+      text&.gsub(/(“|”)/, '"')&.gsub(/(‘|’)/, "'")
     end
   end
 end

--- a/spec/services/provider_interface/application_data_export_spec.rb
+++ b/spec/services/provider_interface/application_data_export_spec.rb
@@ -82,4 +82,10 @@ RSpec.describe ProviderInterface::ApplicationDataExport do
       end
     end
   end
+
+  describe 'replace_smart_quotes' do
+    it 'replaces smart quotes in text' do
+      expect(described_class.replace_smart_quotes(%(“double-quote” ‘single-quote’))).to eq(%("double-quote" 'single-quote'))
+    end
+  end
 end


### PR DESCRIPTION
## Context

Smart quotes entered in text fields are appearing as odd characters to some provider users when viewing exports.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Attempt to substitute any smart-quotes for straight quotes on text output in the applications export.
The issue was reported by a provider viewing the applications export, though I think this is OS/Application dependent as the same example works fine in LibreOffice, Vim and other text editors.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/eXqfXMCt/3360-csv-export-shows-%C3%A2%E2%82%AC%C5%93-instead-of-in-free-text-fields-where-quotation-marks-are-used
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
