### PR TITLE
Delete redundant ViewComponent code

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -2,8 +2,6 @@ module CandidateInterface
   class ApplicationCompleteContentComponent < ViewComponent::Base
     include ViewHelper
 
-    validates :application_form, presence: true
-
     def initialize(application_form:)
       @application_form = application_form
       @dates = ApplicationDates.new(@application_form)

--- a/app/components/candidate_interface/application_status_tag_component.rb
+++ b/app/components/candidate_interface/application_status_tag_component.rb
@@ -1,6 +1,5 @@
 module CandidateInterface
   class ApplicationStatusTagComponent < ViewComponent::Base
-    validates :application_choice, presence: true
     delegate :status, to: :application_choice
 
     def initialize(application_choice:)

--- a/app/components/candidate_interface/apply_again_banner_component.rb
+++ b/app/components/candidate_interface/apply_again_banner_component.rb
@@ -3,8 +3,6 @@ module CandidateInterface
     include ViewHelper
     attr_reader :application_form
 
-    validates :application_form, presence: true
-
     def initialize(application_form:)
       @application_form = application_form
     end

--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class BecomingATeacherReviewComponent < ViewComponent::Base
-    validates :application_form, presence: true
-
     def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @becoming_a_teacher_form = CandidateInterface::BecomingATeacherForm.build_from_application(

--- a/app/components/candidate_interface/carry_over_banner_component.rb
+++ b/app/components/candidate_interface/carry_over_banner_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class CarryOverBannerComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(application_form:)
       @application_form = application_form

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    validates :application_form, :path, :request_method, :field_name, presence: true
-
     def initialize(application_form:, path:, request_method:, field_name:)
       @application_form = application_form
       @path = path

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class ContactDetailsReviewComponent < ViewComponent::Base
-    validates :application_form, presence: true
-
     def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @contact_details_form = CandidateInterface::ContactDetailsForm.build_from_application(

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class CourseChoicesReviewComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(
       application_form:,

--- a/app/components/candidate_interface/course_option_review_component.rb
+++ b/app/components/candidate_interface/course_option_review_component.rb
@@ -2,8 +2,6 @@ module CandidateInterface
   class CourseOptionReviewComponent < ViewComponent::Base
     include ViewHelper
 
-    validates :course_option, presence: true
-
     def initialize(course_option:)
       @course_option = course_option
     end

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class DegreesReviewComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
       @application_form = application_form

--- a/app/components/candidate_interface/grouped_provider_courses_component.rb
+++ b/app/components/candidate_interface/grouped_provider_courses_component.rb
@@ -2,8 +2,6 @@ module CandidateInterface
   class GroupedProviderCoursesComponent < ViewComponent::Base
     include ViewHelper
 
-    validates :courses_by_provider_and_region, presence: true
-
     def initialize(courses_by_provider_and_region:)
       @courses_by_provider_and_region = courses_by_provider_and_region
     end

--- a/app/components/candidate_interface/incomplete_section_component.rb
+++ b/app/components/candidate_interface/incomplete_section_component.rb
@@ -2,8 +2,6 @@ module CandidateInterface
   class IncompleteSectionComponent < ViewComponent::Base
     include ViewHelper
 
-    validates :section, :section_path, presence: true
-
     def initialize(
       section:,
       section_path:,

--- a/app/components/candidate_interface/interview_preferences_review_component.rb
+++ b/app/components/candidate_interface/interview_preferences_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class InterviewPreferencesReviewComponent < ViewComponent::Base
-    validates :application_form, presence: true
-
     def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @interview_preferences_form = CandidateInterface::InterviewPreferencesForm.build_from_application(

--- a/app/components/candidate_interface/links_to_previous_applications_component.rb
+++ b/app/components/candidate_interface/links_to_previous_applications_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class LinksToPreviousApplicationsComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(application_form:)
       @application_form = application_form

--- a/app/components/candidate_interface/offer_conditions_review_component.rb
+++ b/app/components/candidate_interface/offer_conditions_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class OfferConditionsReviewComponent < ViewComponent::Base
-    validates :conditions, :provider, presence: true
-
     def initialize(conditions:, provider:)
       @conditions = conditions
       @provider = provider

--- a/app/components/candidate_interface/offer_review_component.html.erb
+++ b/app/components/candidate_interface/offer_review_component.html.erb
@@ -1,1 +1,0 @@
-<%= render(SummaryListComponent.new(rows: offer_rows)) %>

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -1,12 +1,12 @@
 module CandidateInterface
-  class OfferReviewComponent < ViewComponent::Base
+  class OfferReviewComponent < SummaryListComponent
     validates :course_choice, presence: true
 
     def initialize(course_choice:)
       @course_choice = course_choice
     end
 
-    def offer_rows
+    def rows
       [
         provider_row,
         course_row,

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class OfferReviewComponent < SummaryListComponent
-    validates :course_choice, presence: true
-
     def initialize(course_choice:)
       @course_choice = course_choice
     end

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class OtherQualificationsReviewComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, missing_error: false, submitting_application: false)
       @application_form = application_form

--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class PersonalDetailsReviewComponent < ViewComponent::Base
-    validates :application_form, presence: true
-
     def initialize(application_form:, editable: true, missing_error: false)
       @application_form = application_form
       @personal_details_form = CandidateInterface::PersonalDetailsForm.build_from_application(

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class RejectionReasonsComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(application_form:)
       @application_form = application_form

--- a/app/components/candidate_interface/restructured_work_history/review_component.rb
+++ b/app/components/candidate_interface/restructured_work_history/review_component.rb
@@ -1,8 +1,6 @@
 module CandidateInterface
   module RestructuredWorkHistory
     class ReviewComponent < ViewComponent::Base
-      validates :application_form, presence: true
-
       def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
         @application_form = application_form
         @editable = editable

--- a/app/components/candidate_interface/subject_knowledge_review_component.rb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class SubjectKnowledgeReviewComponent < ViewComponent::Base
-    validates :application_form, presence: true
-
     def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @subject_knowledge_form = CandidateInterface::SubjectKnowledgeForm.build_from_application(

--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class TrainingWithADisabilityReviewComponent < ViewComponent::Base
-    validates :application_form, presence: true
-
     def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(

--- a/app/components/candidate_interface/unsubmitted_reference_review_component.html.erb
+++ b/app/components/candidate_interface/unsubmitted_reference_review_component.html.erb
@@ -1,1 +1,0 @@
-<%= render SummaryListComponent.new(rows: reference_rows(@reference)) %>

--- a/app/components/candidate_interface/unsubmitted_reference_review_component.rb
+++ b/app/components/candidate_interface/unsubmitted_reference_review_component.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class UnsubmittedReferenceReviewComponent < SummaryListComponent
-    validates :reference, presence: true
-
     def initialize(reference:)
       @reference = reference
     end

--- a/app/components/candidate_interface/unsubmitted_reference_review_component.rb
+++ b/app/components/candidate_interface/unsubmitted_reference_review_component.rb
@@ -1,12 +1,12 @@
 module CandidateInterface
-  class UnsubmittedReferenceReviewComponent < ViewComponent::Base
+  class UnsubmittedReferenceReviewComponent < SummaryListComponent
     validates :reference, presence: true
 
     def initialize(reference:)
       @reference = reference
     end
 
-    def reference_rows(reference)
+    def rows
       [
         name_row(reference),
         email_address_row(reference),

--- a/app/components/candidate_interface/volunteering_review_component.rb
+++ b/app/components/candidate_interface/volunteering_review_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class VolunteeringReviewComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
       @application_form = application_form

--- a/app/components/candidate_interface/work_history_review_component.rb
+++ b/app/components/candidate_interface/work_history_review_component.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class WorkHistoryReviewComponent < ViewComponent::Base
     include ViewHelper
-    validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
       @application_form = application_form

--- a/app/components/language_skills_component.rb
+++ b/app/components/language_skills_component.rb
@@ -1,7 +1,5 @@
 # NOTE: This component is used by both provider and support UIs
 class LanguageSkillsComponent < ViewComponent::Base
-  validates :application_form, presence: true
-
   delegate :english_main_language,
            :english_language_details,
            :other_language_details,

--- a/app/components/personal_statement_component.rb
+++ b/app/components/personal_statement_component.rb
@@ -2,8 +2,6 @@
 class PersonalStatementComponent < ViewComponent::Base
   include ViewHelper
 
-  validates :application_form, presence: true
-
   delegate :becoming_a_teacher,
            :subject_knowledge,
            :further_information,

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -1,6 +1,5 @@
 module ProviderInterface
   class ApplicationStatusTagComponent < ViewComponent::Base
-    validates :application_choice, presence: true
     delegate :status, to: :application_choice
 
     def initialize(application_choice:)

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -2,7 +2,6 @@ module ProviderInterface
   class ApplicationTimelineComponent < ViewComponent::Base
     include ViewHelper
     attr_reader :application_choice
-    validates :application_choice, presence: true
 
     def initialize(application_choice:)
       @application_choice = application_choice

--- a/app/components/provider_interface/feedback_preview_component.html.erb
+++ b/app/components/provider_interface/feedback_preview_component.html.erb
@@ -1,1 +1,0 @@
-<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/feedback_preview_component.rb
+++ b/app/components/provider_interface/feedback_preview_component.rb
@@ -1,5 +1,5 @@
 module ProviderInterface
-  class FeedbackPreviewComponent < ViewComponent::Base
+  class FeedbackPreviewComponent < SummaryListComponent
     include ViewHelper
 
     attr_reader :rejection_reason

--- a/app/components/provider_interface/interview_details_component.html.erb
+++ b/app/components/provider_interface/interview_details_component.html.erb
@@ -1,1 +1,0 @@
-<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/interview_details_component.rb
+++ b/app/components/provider_interface/interview_details_component.rb
@@ -1,5 +1,5 @@
 module ProviderInterface
-  class InterviewDetailsComponent < ViewComponent::Base
+  class InterviewDetailsComponent < SummaryListComponent
     include ViewHelper
 
     def initialize(interview_form, interview = nil)

--- a/app/components/provider_interface/provider_user_invitation_details_component.html.erb
+++ b/app/components/provider_interface/provider_user_invitation_details_component.html.erb
@@ -1,1 +1,0 @@
-<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/provider_user_invitation_details_component.rb
+++ b/app/components/provider_interface/provider_user_invitation_details_component.rb
@@ -1,5 +1,5 @@
 module ProviderInterface
-  class ProviderUserInvitationDetailsComponent < ViewComponent::Base
+  class ProviderUserInvitationDetailsComponent < SummaryListComponent
     include ViewHelper
     attr_reader :header
 

--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -1,7 +1,5 @@
 module ProviderInterface
   class ReferenceWithFeedbackComponent < ViewComponent::Base
-    validates :reference, presence: true
-
     delegate :feedback,
              :name,
              :email_address,

--- a/app/components/qualification_row_component.rb
+++ b/app/components/qualification_row_component.rb
@@ -1,6 +1,5 @@
 # NOTE: This component is used by both provider and support UIs
 class QualificationRowComponent < ViewComponent::Base
-  validates :qualification, presence: true
   attr_reader :qualification
 
   def initialize(qualification:)

--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -1,6 +1,4 @@
 class SummaryCardComponent < ViewComponent::Base
-  validates :rows, presence: true
-
   def initialize(rows:, border: true, editable: true, ignore_editable: [])
     rows = transform_hash(rows) if rows.is_a?(Hash)
     @rows = rows_including_actions_if_editable(rows, editable, ignore_editable)

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -8,7 +8,7 @@ class SummaryListComponent < ViewComponent::Base
   end
 
   def any_row_has_action_span?
-    @rows.select { |row| row.key?(:action) }.any?
+    rows.select { |row| row.key?(:action) }.any?
   end
 
 private

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -1,6 +1,5 @@
 class SummaryListComponent < ViewComponent::Base
   include ViewHelper
-  validates :rows, presence: true
 
   def initialize(rows:)
     rows = transform_hash(rows) if rows.is_a?(Hash)

--- a/app/components/support_interface/audit_trail_change_component.rb
+++ b/app/components/support_interface/audit_trail_change_component.rb
@@ -4,9 +4,6 @@ module SupportInterface
 
     REDACTED_ATTRIBUTES = %w[sex disabilities ethnic_group ethnic_background].freeze
 
-    validates :attribute, presence: true
-    validates :values, presence: true
-
     def initialize(attribute:, values:, last_change:)
       @attribute = attribute
       @values = values

--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -2,8 +2,6 @@ module SupportInterface
   class AuditTrailComponent < ViewComponent::Base
     include ViewHelper
 
-    validates :audited_thing, presence: true
-
     def initialize(audited_thing:)
       @audited_thing = audited_thing
     end

--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -2,8 +2,6 @@ module SupportInterface
   class AuditTrailItemComponent < ViewComponent::Base
     include ViewHelper
 
-    validates :audit, presence: true
-
     def initialize(audit:)
       @audit = audit
     end

--- a/app/components/support_interface/course_details_component.html.erb
+++ b/app/components/support_interface/course_details_component.html.erb
@@ -1,1 +1,0 @@
-<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/support_interface/course_details_component.rb
+++ b/app/components/support_interface/course_details_component.rb
@@ -1,5 +1,5 @@
 module SupportInterface
-  class CourseDetailsComponent < ViewComponent::Base
+  class CourseDetailsComponent < SummaryListComponent
     include ViewHelper
 
     attr_reader :course

--- a/app/components/support_interface/course_option_details_component.html.erb
+++ b/app/components/support_interface/course_option_details_component.html.erb
@@ -1,1 +1,0 @@
-<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/support_interface/course_option_details_component.rb
+++ b/app/components/support_interface/course_option_details_component.rb
@@ -1,5 +1,5 @@
 module SupportInterface
-  class CourseOptionDetailsComponent < ViewComponent::Base
+  class CourseOptionDetailsComponent < SummaryListComponent
     include ViewHelper
 
     attr_reader :course_option

--- a/app/components/support_interface/feature_audit_trail_component.rb
+++ b/app/components/support_interface/feature_audit_trail_component.rb
@@ -2,8 +2,6 @@ module SupportInterface
   class FeatureAuditTrailComponent < ViewComponent::Base
     include ViewHelper
 
-    validates :feature, presence: true
-
     ACTIVE_LABEL = 'Active'.freeze
     INACTIVE_LABEL = 'Inactive'.freeze
 

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -1,7 +1,6 @@
 module SupportInterface
   class ReferenceWithFeedbackComponent < ViewComponent::Base
     include ViewHelper
-    validates :reference, presence: true
 
     delegate :feedback,
              :name,

--- a/app/components/support_interface/vendor_api_request_details_component.html.erb
+++ b/app/components/support_interface/vendor_api_request_details_component.html.erb
@@ -1,1 +1,0 @@
-<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/support_interface/vendor_api_request_details_component.rb
+++ b/app/components/support_interface/vendor_api_request_details_component.rb
@@ -1,5 +1,5 @@
 module SupportInterface
-  class VendorAPIRequestDetailsComponent < ViewComponent::Base
+  class VendorAPIRequestDetailsComponent < SummaryListComponent
     include ViewHelper
     attr_reader :vendor_api_request
 

--- a/app/components/task_list_item_component.rb
+++ b/app/components/task_list_item_component.rb
@@ -1,8 +1,6 @@
 class TaskListItemComponent < ViewComponent::Base
   include ViewHelper
 
-  validates :path, presence: true
-
   def initialize(
     completed:,
     path:,

--- a/app/components/volunteering_history_component.rb
+++ b/app/components/volunteering_history_component.rb
@@ -1,7 +1,5 @@
 # NOTE: This component is used by both provider and support UIs
 class VolunteeringHistoryComponent < ViewComponent::Base
-  validates :application_form, presence: true
-
   def initialize(application_form:)
     self.application_form = application_form
   end

--- a/app/components/work_history_component.rb
+++ b/app/components/work_history_component.rb
@@ -1,7 +1,5 @@
 # NOTE: This component is used by both provider and support UIs
 class WorkHistoryComponent < ViewComponent::Base
-  validates :application_form, presence: true
-
   def initialize(application_form:)
     self.application_form = application_form
   end

--- a/app/components/work_history_item_component.rb
+++ b/app/components/work_history_item_component.rb
@@ -2,8 +2,6 @@
 class WorkHistoryItemComponent < ViewComponent::Base
   include ViewHelper
 
-  validates :item, presence: true
-
   def initialize(item:)
     self.item = item
   end


### PR DESCRIPTION
## Context

We can simplify our `ViewComponent` code by

- inheriting from `SummaryListComponent`, which lets us delete a bunch of templates which only rendered `SummaryListComponent`s
- removing validations, which don't do anything

## Changes proposed in this pull request

Do both those things!
