### PR TITLE
Add feature flag for new make offer flow

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,6 +28,7 @@ class FeatureFlag
     [:interviews, 'Providers can filter applications by interviewing state', 'Despo Pentara'],
     [:restructured_work_history, 'Candidates use the new design for the Work History section', 'David Gisbey'],
     [:structured_reasons_for_rejection_on_rbd, 'Allows providers to give specific feedback for applications rejected by default', 'Aga Dufrat'],
+    [:updated_offer_flow, 'Activates the new make offer flow for providers', 'Despo Pentara'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|


### PR DESCRIPTION
## Context

Add a new feature flag for the make new offer flow.
This will unblock further tickets which will be utilising this flag

## Link to Trello card

https://trello.com/c/NiiJPD0p/1293-add-a-feature-flag-for-make-a-new-offer-flow

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
