### PR TITLE
Reorder validations, error is displayed in wrong position

### DIFF
--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -7,15 +7,15 @@ module CandidateInterface
                   :start_date_day, :start_date_month, :start_date_year,
                   :end_date_day, :end_date_month, :end_date_year
 
-    validates :role, :organisation, :details, :working_with_children, presence: true
+    validates :role, :organisation, :working_with_children, presence: true
 
     validates :role, :organisation, length: { maximum: 60 }
-
-    validates :details, word_count: { maximum: 150 }
 
     validates :start_date, date: { presence: true, future: true, month_and_year: true }
     validates :end_date, date: { presence: true, future: true, month_and_year: true }, if: :start_date
     validate :start_date_before_end_date, unless: ->(c) { %i[start_date end_date].any? { |d| c.errors.keys.include?(d) } }, if: %i[start_date end_date]
+
+    validates :details, presence: true, word_count: { maximum: 150 }
 
     class << self
       def build_all_from_application(application_form)


### PR DESCRIPTION

## Context

Reorder volunteer form validations so details presence error is displayed in the correct position 

## Changes proposed in this pull request

### Before
<img width="482" alt="before" src="https://user-images.githubusercontent.com/159200/109499645-14a0ec00-7a8d-11eb-9bdc-844da0a2b934.png">

### After
<img width="397" alt="after" src="https://user-images.githubusercontent.com/159200/109499411-c855ac00-7a8c-11eb-8bc8-fbfa0bf142a0.png">
