### PR TITLE
Add a new make offer service which wraps the old one

### DIFF
--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -1,4 +1,9 @@
 class MakeAnOffer
+  STATE_TRANSITION_ERROR = I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition')
+  MAX_CONDITIONS_COUNT = 20
+  MAX_CONDITION_LENGTH = 255
+  STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
+
   attr_accessor :standard_conditions
   attr_accessor :further_conditions0, :further_conditions1, :further_conditions2, :further_conditions3
   attr_accessor :auth
@@ -6,10 +11,6 @@ class MakeAnOffer
 
   include ActiveModel::Validations
   include ImpersonationAuditHelper
-
-  MAX_CONDITIONS_COUNT = 20
-  MAX_CONDITION_LENGTH = 255
-  STANDARD_CONDITIONS = ['Fitness to train to teach check', 'Disclosure and Barring Service (DBS) check'].freeze
 
   validates :course_option, presence: true
   validate :validate_course_option_is_open_on_apply
@@ -53,7 +54,7 @@ class MakeAnOffer
       else
         errors.add(
           :base,
-          I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+          STATE_TRANSITION_ERROR,
         )
         false
       end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -18,7 +18,7 @@ class MakeOffer
                                     offer_conditions: conditions)
     make_an_offer.save
 
-    if make_an_offer.errors[:base].include?(I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'))
+    if make_an_offer.errors[:base].include?(MakeAnOffer::STATE_TRANSITION_ERROR)
       ApplicationStateChange.new(application_choice).make_offer!
     end
   end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -1,0 +1,20 @@
+class MakeOffer
+  attr_reader :actor, :application_choice, :course_option, :conditions
+
+  def initialize(actor:,
+                 application_choice:,
+                 course_option:,
+                 conditions: [])
+    @actor = actor
+    @application_choice = application_choice
+    @course_option = course_option
+    @conditions = conditions
+  end
+
+  def save!
+    MakeAnOffer.new(actor: actor,
+                    application_choice: application_choice,
+                    course_option: course_option,
+                    offer_conditions: conditions)
+  end
+end

--- a/app/services/make_offer.rb
+++ b/app/services/make_offer.rb
@@ -12,9 +12,14 @@ class MakeOffer
   end
 
   def save!
-    MakeAnOffer.new(actor: actor,
-                    application_choice: application_choice,
-                    course_option: course_option,
-                    offer_conditions: conditions)
+    make_an_offer = MakeAnOffer.new(actor: actor,
+                                    application_choice: application_choice,
+                                    course_option: course_option,
+                                    offer_conditions: conditions)
+    make_an_offer.save
+
+    if make_an_offer.errors[:base].include?(I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'))
+      ApplicationStateChange.new(application_choice).make_offer!
+    end
   end
 end

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -14,12 +14,54 @@ RSpec.describe MakeOffer do
     let(:application_choice) { create(:application_choice) }
     let(:course_option) { course_option_for_provider(provider: application_choice.course_option.provider) }
     let(:provider_user) { create(:provider_user, providers: [build(:provider)]) }
-    let(:conditions) { [ Faker::Lorem.sentence ] }
+    let(:conditions) { [Faker::Lorem.sentence] }
 
-    it 'throws an exception if the actor is not authorised to perform this action' do
-      expect {
+    describe 'if the actor is not authorised to perform this action' do
+      it 'throws an exception' do
+        expect {
+          make_offer.save!
+        }.to raise_error(ProviderAuthorisation::NotAuthorisedError, 'You are not allowed to make decisions')
+      end
+    end
+
+    describe 'if the application choice cannot transition to the offer state' do
+      let(:application_choice) { create(:application_choice, status: :pending_conditions) }
+      let(:provider_user) do
+        create(:provider_user,
+               :with_make_decisions,
+               providers: [application_choice.course_option.provider])
+      end
+
+      it 'throws an exception' do
+        expect {
+          make_offer.save!
+        }.to raise_error(Workflow::NoTransitionAllowed, 'There is no event make_offer defined for the pending_conditions state')
+      end
+    end
+
+    describe 'if the provided details are correct' do
+      let(:application_choice) { create(:application_choice, status: :awaiting_provider_decision) }
+      let(:provider_user) do
+        create(:provider_user,
+               :with_make_decisions,
+               providers: [application_choice.course_option.provider])
+      end
+
+      it 'then it executes the service without errors ' do
+        set_declined_by_default = instance_double(SetDeclineByDefault, call: true)
+        send_new_offer_email_to_candidate = instance_double(SendNewOfferEmailToCandidate, call: true)
+        allow(SetDeclineByDefault)
+          .to receive(:new).with(application_form: application_choice.application_form)
+          .and_return(set_declined_by_default)
+        allow(SendNewOfferEmailToCandidate)
+          .to receive(:new).with(application_choice: application_choice)
+          .and_return(send_new_offer_email_to_candidate)
+
         make_offer.save!
-      }.to raise_error(ProviderAuthorisation::NotAuthorisedError, 'You are not allowed to make decisions')
+
+        expect(SetDeclineByDefault).to have_received(:new).with(application_form: application_choice.application_form)
+        expect(SendNewOfferEmailToCandidate).to have_received(:new).with(application_choice: application_choice)
+      end
     end
   end
 end

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe MakeOffer do
+  include CourseOptionHelpers
+
+  let(:make_offer) do
+    MakeOffer.new(actor: provider_user,
+                  application_choice: application_choice,
+                  course_option: course_option,
+                  conditions: conditions)
+  end
+
+  describe '#save!' do
+    let(:application_choice) { create(:application_choice) }
+    let(:course_option) { course_option_for_provider(provider: application_choice.course_option.provider) }
+    let(:provider_user) { create(:provider_user, providers: [build(:provider)]) }
+    let(:conditions) { [ Faker::Lorem.sentence ] }
+
+    it 'throws an exception if the actor is not authorised to perform this action' do
+      expect {
+        make_offer.save!
+      }.to raise_error(ProviderAuthorisation::NotAuthorisedError, 'You are not allowed to make decisions')
+    end
+  end
+end


### PR DESCRIPTION
## Context
We would like to refactor the legacy make an offer service. To avoid a total rewrite we would like to wrap the old service with a new one which will exercise the practices adopted in newer code.

## Link to Trello card
https://trello.com/c/1b6vJh6N/3432-add-a-new-make-offer-service-which-wraps-the-old-one

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
