### PR TITLE
Add course summary box to make an offer page

### DIFF
--- a/app/components/provider_interface/course_summary_component.html.erb
+++ b/app/components/provider_interface/course_summary_component.html.erb
@@ -1,0 +1,8 @@
+<div class="app-banner app-banner--details govuk-!-margin-bottom-7 govuk-!-padding-4">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Course details</h2>
+  <section class="app-summary-card no-border">
+    <div class="app-summary-card__body">
+      <%= render SummaryListComponent.new(rows: rows) %>
+    </div>
+  </section>
+</div>

--- a/app/components/provider_interface/course_summary_component.rb
+++ b/app/components/provider_interface/course_summary_component.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class CourseSummaryComponent < ViewComponent::Base
+    attr_reader :course_option, :provider_name, :course_name_and_code,
+                :location_name_and_address, :study_mode
+
+    def initialize(course_option:)
+      @course_option = course_option
+      @provider_name = course_option.provider.name
+      @course_name_and_code = course_option.course.name_and_code
+      @location_name_and_address = course_option.site.name_and_address
+      @study_mode = course_option.study_mode.humanize
+    end
+
+    def rows
+      [
+        {
+          key: 'Provider',
+          value: provider_name,
+        },
+        {
+          key: 'Course',
+          value: course_name_and_code,
+        },
+        {
+          key: 'Location',
+          value: location_name_and_address,
+        },
+        {
+          key: 'Full time or part time',
+          value: study_mode,
+        },
+      ]
+    end
+  end
+end

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -3,6 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+      <%= t('page_titles.provider.respond') %>
+    </h1>
+    <%= render ProviderInterface::CourseSummaryComponent.new(course_option: @application_choice.course_option) %>
     <%= form_with model: @pick_response_form, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
       <%- offer_text = 'Make an offer' %>
       <%- reject_text = 'Reject application' %>
@@ -10,8 +15,7 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :decision,
-        caption: { text: @application_choice.application_form.full_name, size: 'xl' },
-        legend: { text: t('page_titles.provider.respond'), size: 'xl', tag: 'h1' } do %>
+        legend: { text: t('page_titles.provider.select_decision'), size: 'm' } do %>
 
         <% if ApplicationStateChange.new(@application_choice).can_make_offer? %>
           <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,7 +179,8 @@ en:
       new_offer: Conditions of offer
       new_reject: Reject application
       new_withdraw_offer: Withdraw offer
-      respond: Respond to application
+      respond: Make a decision
+      select_decision: Select decision
       account: Your account
       profile: Profile
       org_permissions: Organisational permissions

--- a/spec/components/previews/provider_interface/course_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/course_summary_component_preview.rb
@@ -1,0 +1,7 @@
+module ProviderInterface
+  class CourseSummaryComponentPreview < ViewComponent::Preview
+    def course_details
+      render CourseSummaryComponent.new(course_option: CourseOption.limit(10).sample)
+    end
+  end
+end

--- a/spec/components/provider_interface/course_summary_component_spec.rb
+++ b/spec/components/provider_interface/course_summary_component_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::CourseSummaryComponent do
+  let(:provider) do
+    build(:provider, name: 'Best Training')
+  end
+
+  let(:site) do
+    build(
+      :site,
+      provider: provider,
+      name: 'First Road',
+      address_line1: 'Fountain Street',
+      address_line2: 'Morley',
+      address_line3: 'Leeds',
+      postcode: 'LS27 OPD',
+    )
+  end
+
+  let(:course) do
+    build(
+      :course,
+      name: 'Geograpghy',
+      code: 'H234',
+      provider: provider,
+    )
+  end
+
+  let(:course_option) do
+    build(
+      :course_option,
+      :full_time,
+      site: site,
+      course: course,
+    )
+  end
+
+  let(:render) { render_inline(described_class.new(course_option: course_option)) }
+
+  def row_text_selector(row_name, render)
+    rows = {
+      provider: 0,
+      course: 1,
+      location: 2,
+      full_or_part_time: 3,
+    }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  it 'renders the provider name' do
+    render_text = row_text_selector(:provider, render)
+
+    expect(render_text).to include('Provider')
+    expect(render_text).to include('Best Training')
+  end
+
+  it 'renders the course name and code' do
+    render_text = row_text_selector(:course, render)
+
+    expect(render_text).to include('Course')
+    expect(render_text).to include('Geograpghy (H234)')
+  end
+
+  it 'renders the location' do
+    render_text = row_text_selector(:location, render)
+
+    expect(render_text).to include('Location')
+    expect(render_text).to include('First Road, Fountain Street, Morley, Leeds, LS27 OPD')
+  end
+
+  it 'renders the study mode' do
+    render_text = row_text_selector(:full_or_part_time, render)
+
+    expect(render_text).to include('Full time or part time')
+    expect(render_text).to include('Full time')
+  end
+end

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -32,7 +32,8 @@ RSpec.feature 'Provider responds to application' do
     and_i_can_respond_to_the_application
 
     when_i_click_to_respond_to_the_application
-    then_i_am_given_the_option_to_make_an_offer
+    then_i_can_see_the_course_details
+    and_i_am_given_the_option_to_make_an_offer
     and_i_am_given_the_option_to_reject_the_application
   end
 
@@ -90,7 +91,11 @@ RSpec.feature 'Provider responds to application' do
     click_on 'Make decision'
   end
 
-  def then_i_am_given_the_option_to_make_an_offer
+  def then_i_can_see_the_course_details
+    expect(page).to have_content 'Course details'
+  end
+
+  def and_i_am_given_the_option_to_make_an_offer
     expect(page).to have_content 'Make an offer'
   end
 


### PR DESCRIPTION
## Context

When making an offer, a provider sees the radio buttons without seeing what the existing offer looks like. Adding a course summary above the select decision will allow them to see the current course details that a user has selected.

## Changes proposed in this pull request

- Add a new course summary component which wraps the summary list component
- Surface the component on the make offer page
- Amend page title content and question legend on make offer page

## Guidance to review

- Compare the styles with the prototype https://manage-applications-beta.herokuapp.com/applications/P6RGOZC/decision
- Did I miss any common patterns with the proposed styles/classes in the component?

## Link to Trello card

https://trello.com/c/sHdPhNdl/3393-implement-course-details-box-on-make-offer-page-in-manage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
