### PR TITLE
Update restructured work history error messaging

### DIFF
--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -21,18 +21,20 @@ module CandidateInterface
       validates :organisation,
                 :role,
                 :commitment,
-                :currently_working,
-                :relevant_skills,
                 presence: true
       validates :role, :organisation, length: { maximum: 60 }
-      validates :start_date_unknown, inclusion: { in: %w[true false] }
-      validates :end_date_unknown, inclusion: { in: %w[true false] }
-      validates :currently_working, inclusion: { in: %w[true false] }
-      validates :relevant_skills, inclusion: { in: %w[true false] }
-
       validates :start_date, date: { future: true, month_and_year: true, presence: true }
       validates :end_date, date: { future: true, month_and_year: true, presence: true }, if: :not_currently_employed_in_this_role?
       validate :start_date_before_end_date, unless: ->(c) { %i[start_date end_date].any? { |d| c.errors.keys.include?(d) } }
+      validates :start_date_unknown, inclusion: { in: %w[true false] }
+      validates :end_date_unknown, inclusion: { in: %w[true false] }
+      # Force the order in which these appear in govuk_error_summary by declaring
+      # separately from presence validations above:
+      validates :currently_working,
+                :relevant_skills,
+                presence: true
+      validates :currently_working, inclusion: { in: %w[true false] }
+      validates :relevant_skills, inclusion: { in: %w[true false] }
 
       def self.build_form(job)
         new(

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -7,7 +7,6 @@ class DateValidator < ActiveModel::EachValidator
     return if value.blank? || (blank?(value) && !options[:presence])
 
     date_validations(record, attribute, value) if !record.errors.keys.include?(attribute)
-
     date_of_birth_validations(record, attribute, value) if options[:date_of_birth] && !record.errors.keys.include?(attribute)
   end
 
@@ -19,9 +18,7 @@ class DateValidator < ActiveModel::EachValidator
 
   def date_validations(record, attribute, value)
     return record.errors.add(attribute, :blank_date, article: article(attribute), attribute: humanize(attribute)) if options[:presence] && blank?(value)
-
     return record.errors.add(attribute, :blank_date_fields, attribute: humanize(attribute), fields: blank_fields(value).to_sentence) if !blank?(value) && blank_fields(value).any?
-
     return record.errors.add(attribute, invalid_date_locale(options), article: article(attribute), attribute: humanize(attribute)) if is_invalid?(value)
 
     record.errors.add(attribute, :future, article: article(attribute), attribute: humanize(attribute)) if value > Time.zone.today && options[:future]

--- a/config/locales/candidate_interface/restructured_work_history.yml
+++ b/config/locales/candidate_interface/restructured_work_history.yml
@@ -55,29 +55,40 @@ en:
             choice:
               blank: Select whether you have any work history
             explanation:
-              blank: Please explain why you’ve been out of the workplace
+              blank: Tell us why you’ve been out of the workplace
+              too_many_words: Why you’ve been out of the workplace must be 400 words or fewer
         candidate_interface/restructured_work_history/job_form:
           attributes:
             role:
-              blank: Enter your job title
-              too_long: Job title must be %{count} characters or fewer
+              blank: Enter role
+              too_long: Role must be %{count} characters or fewer
             organisation:
-              blank: Enter the name of your employer
+              blank: Enter name of employer
               too_long: Name of the employer must be %{count} characters or fewer
             working_with_children:
               blank: Select if this job involves working in a school or with children
             commitment:
-              blank: Select if this job is full time or part time
+              blank: Select if this job was full time or part time
             start_date:
-              before: Enter a start date that is before the end date
+              blank_date: Enter the month and year you started this job
+              before: The month and year you started must be the same as or before the month and year you left
+              future: The month and year you started must not be in the future
+            end_date:
+              blank_date: Enter the month and year you left this job
+              future: The month and year you left must not be in the future
             currently_working:
-              blank: Select if you are still working in this job
+              blank: Select yes if you are still working in this job
             relevant_skills:
-              blank: Select if you use skills relevant to teaching in this job
+              blank: Select yes if you used skills relevant to teaching in this job
         candidate_interface/restructured_work_history/work_history_break_form:
           attributes:
             start_date:
-              before: Enter a start date that is before the end date
+              blank_date: Enter the month and year this break started
+              before: The month and year your break started must be the same as or after the month and year your break ended
+              future: The month and year the break started must not be in the future
+            end_date:
+              blank_date: Enter the month and year this break ended
+              future: The month and year the break ended must not be in the future
             reason:
-              blank: Enter reasons for break in work history
+              blank: Enter the reasons for break in work history
               too_many_words: Reasons for break in work history must be %{count} words or fewer

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -65,5 +65,3 @@ en:
               too_many_words: Skills and experience must be %{count} words or fewer
             working_with_children:
               blank: Select if this role involves working in a school or with children
-            start_date:
-              before: Enter a start date that is before the end date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,6 +415,7 @@ en:
       blank_date: Enter %{article} %{attribute}
       dob_future: Enter a %{attribute} that is in the past, for example 31 3 1980
       dob_below_min_age: Enter a date of birth before %{date} – you must be over %{min_age} years old to Apply for teacher training
+      before: Enter a start date that is before the end date
     application_choices:
       course_not_available: You cannot apply to ‘%{descriptor}’ because it is not running
       course_full: You cannot apply to ‘%{descriptor}’ because it has no vacancies

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
     it { is_expected.to validate_length_of(:role).is_at_most(60) }
     it { is_expected.to validate_length_of(:organisation).is_at_most(60) }
 
-    include_examples 'validation for a start date', 'restructured_work_history/job_form', verify_presence: true
+    include_examples 'validation for a start date', true, 'restructured_work_history/job_form'
 
     context "'currently working' is 'false'" do
       it 'is invalid if left completely blank' do

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
         form.validate
 
-        expect(form.errors[:end_date]).to contain_exactly('Enter an end date')
+        expect(form.errors[:end_date]).to contain_exactly('Enter the month and year you left this job')
       end
 
       it 'is invalid if month left blank' do
@@ -80,7 +80,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
           form.validate
 
-          expect(form.errors[:end_date]).to contain_exactly('Enter an end date that is not in the future')
+          expect(form.errors[:end_date]).to contain_exactly('The month and year you left must not be in the future')
         end
       end
 
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
 
           form.validate
 
-          expect(form.errors[:end_date]).to contain_exactly('Enter an end date that is not in the future')
+          expect(form.errors[:end_date]).to contain_exactly('The month and year you left must not be in the future')
         end
       end
 

--- a/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/job_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::JobForm, type: :mode
     it { is_expected.to validate_length_of(:role).is_at_most(60) }
     it { is_expected.to validate_length_of(:organisation).is_at_most(60) }
 
-    include_examples 'validation for a start date', true, 'restructured_work_history/job_form'
+    include_examples 'validation for a start date', 'restructured_work_history/job_form'
 
     context "'currently working' is 'false'" do
       it 'is invalid if left completely blank' do

--- a/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
     it { is_expected.to allow_value(okay_text).for(:reason) }
     it { is_expected.not_to allow_value(long_text).for(:reason) }
 
-    include_examples 'validation for a start date', 'restructured_work_history/work_history_break_form', verify_presence: true
+    include_examples 'validation for a start date', true, 'restructured_work_history/work_history_break_form'
     include_examples 'validation for an end date that cannot be blank', 'restructured_work_history/work_history_break_form'
   end
 

--- a/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/restructured_work_history/work_history_break_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::RestructuredWorkHistory::WorkHistoryBreakForm
     it { is_expected.to allow_value(okay_text).for(:reason) }
     it { is_expected.not_to allow_value(long_text).for(:reason) }
 
-    include_examples 'validation for a start date', true, 'restructured_work_history/work_history_break_form'
+    include_examples 'validation for a start date', 'restructured_work_history/work_history_break_form'
     include_examples 'validation for an end date that cannot be blank', 'restructured_work_history/work_history_break_form'
   end
 

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', 'volunteering_role_form', verify_presence: true
-    include_examples 'validation for an end date that can be blank', 'volunteering_role_form'
+    include_examples 'validation for a start date', nil, verify_presence: true
+    include_examples 'validation for an end date that can be blank'
   end
 end

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', nil, verify_presence: true
+    include_examples 'validation for a start date', verify_presence: true
     include_examples 'validation for an end date that can be blank'
   end
 end

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', verify_presence: true
+    include_examples 'validation for a start date'
     include_examples 'validation for an end date that can be blank'
   end
 end

--- a/spec/forms/candidate_interface/work_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/work_experience_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', verify_presence: true
+    include_examples 'validation for a start date'
     include_examples 'validation for an end date that can be blank'
 
     it 'does not accept negative integers in the year field' do

--- a/spec/forms/candidate_interface/work_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/work_experience_form_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', 'work_experience_form', verify_presence: true
-    include_examples 'validation for an end date that can be blank', 'work_experience_form'
+    include_examples 'validation for a start date', nil, verify_presence: true
+    include_examples 'validation for an end date that can be blank'
 
     it 'does not accept negative integers in the year field' do
       form_data[:start_date_year] = -1999

--- a/spec/forms/candidate_interface/work_experience_form_spec.rb
+++ b/spec/forms/candidate_interface/work_experience_form_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:details) }
     it { is_expected.not_to allow_value(long_text).for(:details) }
 
-    include_examples 'validation for a start date', nil, verify_presence: true
+    include_examples 'validation for a start date', verify_presence: true
     include_examples 'validation for an end date that can be blank'
 
     it 'does not accept negative integers in the year field' do

--- a/spec/forms/candidate_interface/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/work_history_break_form_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:reason) }
     it { is_expected.not_to allow_value(long_text).for(:reason) }
 
-    include_examples 'validation for a start date', 'work_history_break_form', validate_presence: true
-    include_examples 'validation for an end date that cannot be blank', 'work_history_break_form', validate_presence: true
+    include_examples 'validation for a start date', nil, validate_presence: true
+    include_examples 'validation for an end date that cannot be blank', validate_presence: true
   end
 
   describe '.build_from_break' do

--- a/spec/forms/candidate_interface/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/work_history_break_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:reason) }
     it { is_expected.not_to allow_value(long_text).for(:reason) }
 
-    include_examples 'validation for a start date', validate_presence: true
+    include_examples 'validation for a start date'
     include_examples 'validation for an end date that cannot be blank'
   end
 

--- a/spec/forms/candidate_interface/work_history_break_form_spec.rb
+++ b/spec/forms/candidate_interface/work_history_break_form_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
     it { is_expected.to allow_value(okay_text).for(:reason) }
     it { is_expected.not_to allow_value(long_text).for(:reason) }
 
-    include_examples 'validation for a start date', nil, validate_presence: true
-    include_examples 'validation for an end date that cannot be blank', validate_presence: true
+    include_examples 'validation for a start date', validate_presence: true
+    include_examples 'validation for an end date that cannot be blank'
   end
 
   describe '.build_from_break' do

--- a/spec/support/candidate_interface/shared_examples/end_date_validation.rb
+++ b/spec/support/candidate_interface/shared_examples/end_date_validation.rb
@@ -5,8 +5,14 @@ RSpec.shared_examples 'validation for an end date that cannot be blank' do |erro
 
       form.validate
 
+      expected_message =
+        if error_scope
+          t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.end_date.blank_date")
+        else
+          t('errors.messages.blank_date', article: 'an', attribute: 'end date')
+        end
       expect(form.errors.full_messages_for(:end_date)).to eq(
-        ["End date #{t('errors.messages.blank_date', article: 'an', attribute: 'end date')}"],
+        ["End date #{expected_message}"],
       )
     end
 
@@ -28,7 +34,7 @@ RSpec.shared_examples 'validation for an end date that can be blank' do |error_s
   end
 end
 
-RSpec.shared_examples 'validation for an end date' do |_|
+RSpec.shared_examples 'validation for an end date' do |error_scope|
   it 'is invalid if month left blank' do
     form = described_class.new(end_date_month: '', end_date_year: '2019')
 
@@ -65,8 +71,14 @@ RSpec.shared_examples 'validation for an end date' do |_|
 
       form.validate
 
+      expected_message =
+        if error_scope
+          t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.end_date.future")
+        else
+          t('errors.messages.future', article: 'an', attribute: 'end date')
+        end
       expect(form.errors.full_messages_for(:end_date)).to eq(
-        ["End date #{t('errors.messages.future', article: 'an', attribute: 'end date')}"],
+        ["End date #{expected_message}"],
       )
     end
   end
@@ -77,8 +89,14 @@ RSpec.shared_examples 'validation for an end date' do |_|
 
       form.validate
 
+      expected_message =
+        if error_scope
+          t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.end_date.future")
+        else
+          t('errors.messages.future', article: 'an', attribute: 'end date')
+        end
       expect(form.errors.full_messages_for(:end_date)).to eq(
-        ["End date #{t('errors.messages.future', article: 'an', attribute: 'end date')}"],
+        ["End date #{expected_message}"],
       )
     end
   end

--- a/spec/support/candidate_interface/shared_examples/start_date_validation.rb
+++ b/spec/support/candidate_interface/shared_examples/start_date_validation.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'validation for a start date' do |error_scope, verify_presence|
+RSpec.shared_examples 'validation for a start date' do |verify_presence, error_scope|
   describe 'start date' do
     it 'is invalid if the date is not present', if: verify_presence do
       form = described_class.new(start_date_month: nil, start_date_year: nil)

--- a/spec/support/candidate_interface/shared_examples/start_date_validation.rb
+++ b/spec/support/candidate_interface/shared_examples/start_date_validation.rb
@@ -5,8 +5,14 @@ RSpec.shared_examples 'validation for a start date' do |error_scope, verify_pres
 
       form.validate
 
+      expected_message =
+        if error_scope
+          t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.start_date.blank_date")
+        else
+          t('errors.messages.blank_date', article: 'a', attribute: 'start date')
+        end
       expect(form.errors.full_messages_for(:start_date)).to eq(
-        ["Start date #{t('errors.messages.blank_date', article: 'a', attribute: 'start date')}"],
+        ["Start date #{expected_message}"],
       )
     end
 
@@ -28,8 +34,14 @@ RSpec.shared_examples 'validation for a start date' do |error_scope, verify_pres
 
       form.validate
 
+      expected_message =
+        if error_scope
+          t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.start_date.before")
+        else
+          t('errors.messages.before')
+        end
       expect(form.errors.full_messages_for(:start_date)).to eq(
-        ["Start date #{t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.start_date.before")}"],
+        ["Start date #{expected_message}"],
       )
     end
 
@@ -41,8 +53,15 @@ RSpec.shared_examples 'validation for a start date' do |error_scope, verify_pres
 
         form.validate
 
+        expected_message =
+          if error_scope
+            t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.start_date.future")
+          else
+            t('errors.messages.future', article: 'a', attribute: 'start date')
+          end
+
         expect(form.errors.full_messages_for(:start_date)).to eq(
-          ["Start date #{t('errors.messages.future', article: 'a', attribute: 'start date')}"],
+          ["Start date #{expected_message}"],
         )
       end
     end

--- a/spec/support/candidate_interface/shared_examples/start_date_validation.rb
+++ b/spec/support/candidate_interface/shared_examples/start_date_validation.rb
@@ -1,6 +1,6 @@
-RSpec.shared_examples 'validation for a start date' do |verify_presence, error_scope|
+RSpec.shared_examples 'validation for a start date' do |error_scope|
   describe 'start date' do
-    it 'is invalid if the date is not present', if: verify_presence do
+    it 'is invalid if the date is not present' do
       form = described_class.new(start_date_month: nil, start_date_year: nil)
 
       form.validate


### PR DESCRIPTION
## Context
The error messages in the work history need to be updated to match the new design.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Most of the changes described by the Google doc linked in the ticket
- Does not include error messages specifically for the month or specifically for the year, as agreed with @gregknight1 (reason—not just a copy change, needs some non-trivial changes to how we handle date validations).
- Some spec setup changes, mostly related to locale strings and the shared examples we're using for dates.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Running locally or in the review app, ensure restructured work history feature flag is active, and the current application has `feature_restructured_work_history` set to true. Easiest way to ensure the latter is to sign up as a new user (rather than log in as an existing one).
- Go through the Add Job and Explain Break flows, testing the scenarios outlined in the doc (except the ones where a month-only or year-only error is expected).
- Regarding the missing locale string mentioned in one of the commits - I've written up this card to deal with similar cases https://trello.com/c/ouZ2DExb

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/pArii32e/3053-error-messaging-in-the-work-history-section
## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
