### PR TITLE
Split First and Last name on application form view in Manage and Support

### DIFF
--- a/app/components/provider_interface/personal_details_component.rb
+++ b/app/components/provider_interface/personal_details_component.rb
@@ -23,7 +23,8 @@ module ProviderInterface
 
     def rows
       [
-        name_row,
+        first_name_row,
+        last_name_row,
         date_of_birth_row,
         nationality_row,
         right_to_work_or_study_row,
@@ -36,10 +37,17 @@ module ProviderInterface
 
   private
 
-    def name_row
+    def first_name_row
       {
-        key: 'Full name',
-        value: "#{first_name} #{last_name}",
+        key: 'First name',
+        value: first_name,
+      }
+    end
+
+    def last_name_row
+      {
+        key: 'Last name',
+        value: last_name,
       }
     end
 

--- a/app/components/support_interface/personal_details_component.rb
+++ b/app/components/support_interface/personal_details_component.rb
@@ -23,7 +23,8 @@ module SupportInterface
 
     def rows
       [
-        name_row,
+        first_name_row,
+        last_name_row,
         date_of_birth_row,
         nationality_row,
         domicile_row,
@@ -37,11 +38,20 @@ module SupportInterface
 
   private
 
-    def name_row
+    def first_name_row
       {
-        key: 'Full name',
-        value: "#{first_name} #{last_name}",
-        action: 'name',
+        key: 'First name',
+        value: first_name,
+        action: 'first name',
+        change_path: support_interface_application_form_edit_applicant_details_path(application_form),
+      }
+    end
+
+    def last_name_row
+      {
+        key: 'Last name',
+        value: last_name,
+        action: 'last name',
         change_path: support_interface_application_form_edit_applicant_details_path(application_form),
       }
     end

--- a/spec/components/provider_interface/personal_details_component_spec.rb
+++ b/spec/components/provider_interface/personal_details_component_spec.rb
@@ -15,13 +15,17 @@ RSpec.describe ProviderInterface::PersonalDetailsComponent do
   subject(:result) { render_inline(ProviderInterface::PersonalDetailsComponent.new(application_form: application_form)) }
 
   it 'renders component with correct labels' do
-    ['Full name', 'Date of birth', 'Nationality', 'Phone number', 'Email address', 'Address'].each do |key|
+    ['First name', 'Last name', 'Date of birth', 'Nationality', 'Phone number', 'Email address', 'Address'].each do |key|
       expect(result.css('.govuk-summary-list__key').text).to include(key)
     end
   end
 
-  it 'renders the candidate name' do
-    expect(result.css('.govuk-summary-list__value').text).to include("#{application_form.first_name} #{application_form.last_name}")
+  it 'renders the candidate first name' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.first_name)
+  end
+
+  it 'renders the candidate last name' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.last_name)
   end
 
   it 'renders the candidate date of birth' do
@@ -59,8 +63,8 @@ RSpec.describe ProviderInterface::PersonalDetailsComponent do
       ProviderInterface::PersonalDetailsComponent::RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.each do |key, value|
         application_form.right_to_work_or_study = key
         result = render_inline(ProviderInterface::PersonalDetailsComponent.new(application_form: application_form))
-        row_title = result.css('.govuk-summary-list__row')[3].css('dt').text
-        row_value = result.css('.govuk-summary-list__row')[3].css('dd').text
+        row_title = result.css('.govuk-summary-list__row')[4].css('dt').text
+        row_value = result.css('.govuk-summary-list__row')[4].css('dd').text
         expect(row_title).to include 'Has the right to work or study in the UK?'
         expect(row_value).to include value
       end

--- a/spec/components/support_interface/personal_details_component_spec.rb
+++ b/spec/components/support_interface/personal_details_component_spec.rb
@@ -15,13 +15,17 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
   subject(:result) { render_inline(SupportInterface::PersonalDetailsComponent.new(application_form: application_form)) }
 
   it 'renders component with correct labels' do
-    ['Full name', 'Date of birth', 'Nationality', 'Phone number', 'Email address', 'Address'].each do |key|
+    ['First name', 'Last name', 'Date of birth', 'Nationality', 'Phone number', 'Email address', 'Address'].each do |key|
       expect(result.css('.govuk-summary-list__key').text).to include(key)
     end
   end
 
-  it 'renders the candidate name' do
-    expect(result.css('.govuk-summary-list__value').text).to include("#{application_form.first_name} #{application_form.last_name}")
+  it 'renders the candidate first name' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.first_name)
+  end
+
+  it 'renders the candidate last name' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.last_name)
   end
 
   it 'renders the candidate date of birth' do
@@ -63,8 +67,8 @@ RSpec.describe SupportInterface::PersonalDetailsComponent do
       SupportInterface::PersonalDetailsComponent::RIGHT_TO_WORK_OR_STUDY_DISPLAY_VALUES.each do |key, value|
         application_form.right_to_work_or_study = key
         result = render_inline(SupportInterface::PersonalDetailsComponent.new(application_form: application_form))
-        row_title = result.css('.govuk-summary-list__row')[4].css('dt').text
-        row_value = result.css('.govuk-summary-list__row')[4].css('dd').text
+        row_title = result.css('.govuk-summary-list__row')[5].css('dt').text
+        row_value = result.css('.govuk-summary-list__row')[5].css('dd').text
         expect(row_title).to include 'Has the right to work or study in the UK?'
         expect(row_value).to include value
       end

--- a/spec/system/support_interface/editing_address_details_spec.rb
+++ b/spec/system/support_interface/editing_address_details_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Editing address' do
   end
 
   def and_i_click_the_change_link_next_to_address
-    all('.govuk-summary-list__actions')[6].click_link 'Change'
+    all('.govuk-summary-list__actions')[7].click_link 'Change'
   end
 
   def then_i_should_see_the_address_type_page

--- a/spec/system/support_interface/editing_applicant_details_spec.rb
+++ b/spec/system/support_interface/editing_applicant_details_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Editing application details' do
     and_an_application_exists
 
     when_i_visit_the_application_page
-    and_i_click_the_change_link_next_to_full_name
+    and_i_click_the_change_link_next_to_first_name
     and_i_fill_in_all_fields_with_blank_values
     and_i_submit_the_update_form
     then_i_should_see_relevant_blank_error_messages
@@ -62,7 +62,7 @@ RSpec.feature 'Editing application details' do
     visit support_interface_application_form_path(@form)
   end
 
-  def and_i_click_the_change_link_next_to_full_name
+  def and_i_click_the_change_link_next_to_first_name
     all('.govuk-summary-list__actions')[0].click_link 'Change'
   end
 
@@ -125,7 +125,8 @@ RSpec.feature 'Editing application details' do
   end
 
   def and_i_should_see_the_new_name_in_full
-    expect(page).to have_content 'Steven Seagal'
+    expect(page).to have_content 'Steven'
+    expect(page).to have_content 'Seagal'
   end
 
   def and_i_should_see_the_new_date_of_birth

--- a/spec/system/support_interface/editing_reference_spec.rb
+++ b/spec/system/support_interface/editing_reference_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_referee_name
-    all('.govuk-summary-list__actions')[11].click_link 'Change'
+    all('.govuk-summary-list__actions')[12].click_link 'Change'
   end
 
   def then_i_should_see_a_prepopulated_details_form
@@ -90,7 +90,7 @@ RSpec.feature 'Editing reference' do
   end
 
   def and_i_click_the_change_link_next_to_feedback
-    all('.govuk-summary-list__actions')[14].click_link 'Change'
+    all('.govuk-summary-list__actions')[15].click_link 'Change'
   end
 
   def then_i_should_see_the_feedback_form


### PR DESCRIPTION
## Context
Providers need to know which name to refer to Candidates with in a clearer way.

## Changes proposed in this pull request
Split first and last name on application choice view in manage, and mirror that in support

<img width="300" alt="Screenshot 2021-03-02 at 14 43 45" src="https://user-images.githubusercontent.com/30071178/109665060-b431ad80-7b65-11eb-805e-d6b98d51ead6.png">

## Guidance to review
Should be straightforward

## Link to Trello card
https://trello.com/c/2vuzyFkO/3446-show-first-name-and-last-name-separately-on-applications-in-manage

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
