### PR TITLE
Hide sensitive HESA codes in support audit trail

### DIFF
--- a/app/components/support_interface/audit_trail_change_component.rb
+++ b/app/components/support_interface/audit_trail_change_component.rb
@@ -2,7 +2,10 @@ module SupportInterface
   class AuditTrailChangeComponent < ViewComponent::Base
     include ViewHelper
 
-    REDACTED_ATTRIBUTES = %w[sex disabilities ethnic_group ethnic_background].freeze
+    REDACTED_ATTRIBUTES = %w[
+      sex disabilities ethnic_group ethnic_background
+      hesa_sex hesa_disabilities hesa_ethnicity
+    ].freeze
 
     def initialize(attribute:, values:, last_change:)
       @attribute = attribute

--- a/spec/components/support_interface/audit_trail_change_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_change_component_spec.rb
@@ -49,5 +49,10 @@ RSpec.describe SupportInterface::AuditTrailChangeComponent do
       expect(render_result(attribute: 'sex', values: [nil, 'male']).text)
         .to include('[REDACTED]')
     end
+
+    it 'redacts HESA codes for sensitive information' do
+      expect(render_result(values: [{ 'hesa_sex' => 2 }, { 'hesa_sex' => 2, 'hesa_ethnicity' => 32 }]).text)
+        .to include('{"hesa_sex"=>"[REDACTED]"} → {"hesa_sex"=>"[REDACTED]", "hesa_ethnicity"=>"[REDACTED]"}')
+    end
   end
 end


### PR DESCRIPTION
## Context

We hide sex, disabilities and ethnicity information in the support audit trail, yet we expose the relevant codes.

![image](https://user-images.githubusercontent.com/107591/109665171-ce6b8b80-7b65-11eb-980d-76f7e5c9159a.png)

## Changes proposed in this pull request

Redact the relevant HESA codes too.

## Guidance to review

Simple change.

## Link to Trello card

None

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
