### PR TITLE
Add end-to-end sandbox docs to Sandbox landing page

### DIFF
--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -16,6 +16,13 @@
 
     <p class="govuk-body">Throughout, you’ll be able to give us feedback so we can improve the service.</p>
 
+    <h2 class="govuk-heading-l">Course data in the sandbox</h2>
+    <p class="govuk-body"><strong>The live Apply service</strong> gets its course data from the <%= govuk_link_to 'Teacher training courses API', t('teacher_training_courses_api.documentation_url') %>. Training providers update those courses using <%= govuk_link_to 'Publish teacher training courses', t('publish_teacher_training_courses.production_url') %>.</p>
+
+    <p class="govuk-body"><strong>The Apply sandbox</strong> gets its course data from a sandbox version of the Teacher training courses API. As a training provider you can access <%= govuk_link_to 'a sandbox version of Publish', t('publish_teacher_training_courses.sandbox_url') %> where you’ll be able to create and edit courses just as you would on the live service, and see them on the <%= govuk_link_to 'sandbox version of Find postgraduate teacher training', t('find_postgraduate_teacher_training.sandbox_url') %>.</p>
+
+    <p class="govuk-body">To request access to the Publish sandbox, email us at <%= bat_contact_mail_to %>.</p>
+
     <h2 class="govuk-heading-l">Get started as a candidate</h2>
 
     <p class="govuk-body">You’ll be asked to enter your email address to open a candidate account in the Apply sandbox.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,14 @@ en:
     support: Support for Apply
     api: Apply for teacher training API
     get_into_teaching: Get Into Teaching
+  teacher_training_courses_api:
+    documentation_url: https://api.publish-teacher-training-courses.service.gov.uk/
+  publish_teacher_training_courses:
+    production_url: https://www.publish-teacher-training-courses.service.gov.uk/
+    sandbox_url: https://sandbox.publish-teacher-training-courses.service.gov.uk/
+  find_postgraduate_teacher_training:
+    production_url: https://www.find-postgraduate-teacher-training.service.gov.uk/
+    sandbox_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk/
   get_into_teaching:
     # TODO: Update to 0800 389 2500 when GIT leaves beta
     tel: 0800 389 2501


### PR DESCRIPTION
## Context

- A provider pointed out we didn't mention the E2E sandbox on the Sandbox landing page. We can!
- Use i18n for the URLs to follow the convention we used for Get Into
Teaching.

## Changes proposed in this pull request

Add docs:

<img width="556" alt="Screenshot 2021-03-02 at 17 14 28" src="https://user-images.githubusercontent.com/642279/109688090-cfa7b300-7b7b-11eb-91f4-3bd6381d9a11.png">

## Guidance to review

Is the wording OK?

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
