### PR TITLE
Add shared examples for year validations

### DIFF
--- a/spec/forms/candidate_interface/degree_year_form_spec.rb
+++ b/spec/forms/candidate_interface/degree_year_form_spec.rb
@@ -2,26 +2,12 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::DegreeYearForm, type: :model do
   describe 'award year' do
-    ['a year', '200'].each do |invalid_date|
-      it "is invalid if the award year is '#{invalid_date}'" do
-        degree_form = described_class.new(award_year: invalid_date)
-
-        degree_form.validate(:award_year)
-
-        expect(degree_form.errors.full_messages_for(:award_year)).to eq(
-          ['Award year Enter a real graduation year'],
-        )
+    context 'year validations' do
+      let(:model) do
+        described_class.new(award_year: award_year)
       end
-    end
 
-    it 'is valid if the award year is 4 digits' do
-      degree_form = described_class.new(award_year: '2009')
-
-      degree_form.validate(:award_year)
-
-      expect(degree_form.errors.full_messages_for(:award_year)).not_to eq(
-        ['Award year Enter a real graduation year'],
-      )
+      include_examples 'year validations', :award_year
     end
 
     it 'is invalid if the award year is more than one year into the future' do

--- a/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
+++ b/spec/forms/candidate_interface/other_qualification_details_form_spec.rb
@@ -104,37 +104,14 @@ RSpec.describe CandidateInterface::OtherQualificationDetailsForm do
     end
 
     describe 'award year' do
-      it 'is valid if the award year is 4 digits' do
-        qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, award_year: '2009')
-
-        qualification.valid?(:details)
-
-        expect(qualification.errors.full_messages_for(:award_year)).to be_empty
-      end
-
-      ['a year', '200'].each do |invalid_date|
-        it "is invalid if the award year is '#{invalid_date}'" do
-          qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, award_year: invalid_date)
-          error_message = t('errors.messages.invalid_year', attribute: 'award year')
-
-          qualification.valid?(:details)
-
-          expect(qualification.errors.full_messages_for(:award_year)).to eq(
-            ["Award year #{error_message}"],
-          )
+      context 'year validations' do
+        let(:model) do
+          described_class.new(nil, nil, award_year: award_year)
         end
-      end
 
-      it 'is invalid if the award year is in the future' do
-        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
-          qualification = CandidateInterface::OtherQualificationDetailsForm.new(nil, nil, award_year: '2029')
-
-          qualification.valid?(:details)
-
-          expect(qualification.errors.full_messages_for(:award_year)).to eq(
-            ['Award year Assessment year must be this year or a previous year'],
-          )
-        end
+        include_examples 'year validations',
+                         :award_year,
+                         future: true
       end
     end
   end

--- a/spec/support/shared_examples/year_validations.rb
+++ b/spec/support/shared_examples/year_validations.rb
@@ -1,0 +1,37 @@
+RSpec.shared_examples 'year validations' do |year_field, validations|
+  include DateAndYearConcerns
+
+  let(year_field.to_sym) { year }
+
+  describe 'when invalid' do
+    context 'when year is not a number' do
+      let(:year) { 'A950' }
+
+      it 'returns :invalid_date_month_and_year error' do
+        expect(model).to be_invalid
+
+        expect(model.errors.added?(year_field, :invalid_year, attribute: humanize(year_field))).to eq(true)
+      end
+    end
+
+    context 'when year is outside the acceptable year range' do
+      let(:year) { '1850' }
+
+      it 'returns :invalid_year error' do
+        expect(model).to be_invalid
+
+        expect(model.errors.added?(year_field, :invalid_year, attribute: humanize(year_field))).to eq(true)
+      end
+    end
+  end
+
+  describe 'when in the future', if: validations && validations[:future] do
+    let(:year) { 40.years.from_now.year }
+
+    it 'returns :future error' do
+      expect(model).to be_invalid
+
+      expect(model.errors.added?(year_field, :future, article: article(year_field), attribute: humanize(year_field))).to eq(true)
+    end
+  end
+end

--- a/spec/validators/year_validator_spec.rb
+++ b/spec/validators/year_validator_spec.rb
@@ -18,11 +18,21 @@ RSpec.describe YearValidator do
     stub_const('TestYearValidator', test_date_validator)
   end
 
-  context 'when year is nil' do
-    let(:date) { nil }
+  describe 'is valid' do
+    context 'when year is nil' do
+      let(:date) { nil }
 
-    it 'returns valid' do
-      expect(model).to be_valid
+      it 'returns no error' do
+        expect(model).to be_valid
+      end
+    end
+
+    context 'when year is in the correct format' do
+      let(:year) { Time.zone.now.year }
+
+      it 'returns no error' do
+        expect(model).to be_valid
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Add shared examples for year validations to remove duplication and enable consistent testing of fields using the YearValidator.

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
