### PR TITLE
Support: Increase container width

### DIFF
--- a/app/frontend/styles/support/_all.scss
+++ b/app/frontend/styles/support/_all.scss
@@ -12,3 +12,4 @@
 @import "_details";
 @import "_sort";
 @import "_syntax-highlighting";
+@import "_template";

--- a/app/frontend/styles/support/_template.scss
+++ b/app/frontend/styles/support/_template.scss
@@ -1,0 +1,5 @@
+.app-template--support {
+  .govuk-width-container {
+    @include govuk-width-container(1100px);
+  }
+}

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -1,3 +1,5 @@
+<% content_for :body_class, 'app-template--support' %>
+
 <% content_for :content do %>
   <% if yield(:context).present? %>
     <span class="govuk-caption-l"><%= yield :context %></span>


### PR DESCRIPTION
## Context

Many pages in Support are information dense (tables with filters etc). We can improve things for users of desktop computers slightly by increasing the maximum width of the layout container.

## Changes proposed in this pull request

Bit of a blunt instrument this, but adds a class to the support layout template (`app-template--support`), and this modifies any child `govuk-width-container` classes to have the maximum width of 1100px. This matches the maximum width of that used on the [design system](https://design-system.service.gov.uk) site.

## Guidance to review

This doesn’t effect many pages, but there might be cases where we want to reduce the overall width of components.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
