### PR TITLE
Display a helpful error if you attempt to make an offer on a course you dont run

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -110,7 +110,7 @@ module VendorAPI
         errors: [
           {
             error: 'NotAuthorisedError',
-            message: "#{e.message} failed",
+            message: e.message,
           },
         ],
       }

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -1,9 +1,9 @@
 class ProviderAuthorisation
-  attr_reader :errors, :actor
+  attr_reader :actor
 
   def initialize(actor:)
     @actor = actor
-    @errors = []
+    @errors = {}
   end
 
   # Queries/lookups ----------------------------------------------------------------
@@ -76,10 +76,10 @@ class ProviderAuthorisation
   def can_make_decisions?(application_choice:, course_option_id:)
     course = CourseOption.find(course_option_id).course
 
-    errors << :requires_application_choice_visibility unless
+    add_error(:make_decisions, :requires_application_choice_visibility) unless
       application_choice_visible_to_user?(application_choice: application_choice)
 
-    errors << :requires_user_course_association unless
+    add_error(:make_decisions, :requires_user_course_association) unless
       course_associated_with_user_providers?(course: course)
 
     full_authorisation? permission: :make_decisions, course: course
@@ -90,7 +90,11 @@ class ProviderAuthorisation
   def assert_can_make_decisions!(application_choice:, course_option_id:)
     return if can_make_decisions?(application_choice: application_choice, course_option_id: course_option_id)
 
-    raise NotAuthorisedError, 'You are not allowed to make decisions'
+    raise NotAuthorisedError, full_error_messages.join(' ')
+  end
+
+  def errors
+    @errors.values.flatten
   end
 
   class NotAuthorisedError < StandardError; end
@@ -131,7 +135,7 @@ private
     ratifying_provider = course.accredited_provider
 
     # enforce user-level permissions
-    errors << :requires_provider_user_permission unless
+    add_error(permission, :requires_provider_user_permission) unless
       @actor.is_a?(VendorApiUser) ||
         user_level_can?(permission: permission, provider: training_provider) ||
         user_level_can?(permission: permission, provider: ratifying_provider)
@@ -145,22 +149,22 @@ private
       if @actor.providers.include?(ratifying_provider) && @actor.providers.include?(training_provider)
         # If not, there is something wrong with the setup
         if [training_provider_can, ratifying_provider_can].none?
-          errors << :requires_training_provider_permission
-          errors << :requires_ratifying_provider_permission
+          add_error(permission, :requires_training_provider_permission)
+          add_error(permission, :requires_ratifying_provider_permission)
         # Check org-level and user-level permissions match for ratifying provider
         elsif !training_provider_can
-          errors << :requires_provider_user_permission unless
+          add_error(permission, :requires_provider_user_permission) unless
             user_level_can?(permission: permission, provider: ratifying_provider)
         # Same for training provider
         elsif !ratifying_provider_can
-          errors << :requires_provider_user_permission unless
+          add_error(permission, :requires_provider_user_permission) unless
             user_level_can?(permission: permission, provider: training_provider)
         end
         # No additional checks if both providers have org-level access
       elsif @actor.providers.include?(ratifying_provider)
-        errors << :requires_ratifying_provider_permission unless ratifying_provider_can
+        add_error(permission, :requires_ratifying_provider_permission) unless ratifying_provider_can
       else
-        errors << :requires_training_provider_permission unless training_provider_can
+        add_error(permission, :requires_training_provider_permission) unless training_provider_can
       end
     end
 
@@ -178,6 +182,19 @@ private
 
     [course.provider, course.accredited_provider].compact.any? do |provider|
       @actor.providers.include?(provider)
+    end
+  end
+
+  def add_error(permission, error)
+    @errors[permission] ||= []
+    @errors[permission] << error
+  end
+
+  def full_error_messages
+    [].tap do |ary|
+      @errors.each do |permission, msg_keys|
+        msg_keys.each { |key| ary << I18n.t("provider_authorisation.errors.#{permission}.#{key}") }
+      end
     end
   end
 end

--- a/config/locales/provider_authorisation.yml
+++ b/config/locales/provider_authorisation.yml
@@ -1,0 +1,17 @@
+en:
+  provider_authorisation:
+    errors:
+      make_decisions:
+        requires_provider_user_permission: You do not have the required user level permissions to make decisions on applications.
+        requires_training_provider_permission: You do not have the required organisation level permissions as a training provider to make decisions on applications.
+        requires_ratifying_provider_permission: You do not have the required organisation level permissions as a ratifying provider to make decisions on applications.
+        requires_application_choice_visibility: You are not permitted to view this application.
+        requires_user_course_association: The specified course is not associated with any of your organisations.
+      view_diversity_information:
+        requires_provider_user_permission: You do not have the required user level permissions to view diversity information.
+        requires_training_provider_permission: You do not have the required organisation level permissions as a training provider to view diversity information.
+        requires_ratifying_provider_permission: You do not have the required organisation level permissions as a ratifying provider to view safeguarding information.
+      view_safeguarding_information:
+        requires_provider_user_permission: You do not have the required user level permissions to view safeguarding information.
+        requires_training_provider_permission: You do not have the required organisation level permissions as a training provider to view diversity information.
+        requires_ratifying_provider_permission: You do not have the required organisation level permissions as a ratifying provider to view diversity information.

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'You are not allowed to make decisions'
+      expect(error_response['message']).to match 'The specified course is not associated with any of your organisations.'
     end
 
     it 'logs the actual error in a VendorAPIRequest when a 422 is returned', sidekiq: true do

--- a/spec/services/make_offer_spec.rb
+++ b/spec/services/make_offer_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe MakeOffer do
       it 'throws an exception' do
         expect {
           make_offer.save!
-        }.to raise_error(ProviderAuthorisation::NotAuthorisedError, 'You are not allowed to make decisions')
+        }.to raise_error(
+          ProviderAuthorisation::NotAuthorisedError,
+          'You are not permitted to view this application. The specified course is not associated with any of your organisations. You do not have the required user level permissions to make decisions on applications.',
+        )
       end
     end
 


### PR DESCRIPTION
## Context

Authentication errors for making offers via the vendor API are unhelpful and poorly worded.

eg. _You are not allowed to make decisions failed_

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Amends the way we store errors on the `ProviderAuthorisation` instance so that we can translate these into permissions specific and human readable error messages.
Does not change the return value of the underlying `.errors` method.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

It's possible that multiple errors are stored when checking a single permission (eg. `:make_decisions`) and this raises a problem with formatting descriptive human-readable error messages in a single string. Opinions welcome.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Efj1VIf8/3255-display-a-helpful-error-if-you-attempt-to-make-an-offer-on-a-course-you-dont-run
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
