### PR TITLE
Update date fields for unpaid work

### DIFF
--- a/app/controllers/candidate_interface/volunteering/role_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/role_controller.rb
@@ -41,9 +41,20 @@ module CandidateInterface
       strip_whitespace(
         params.require(:candidate_interface_volunteering_role_form)
         .permit(
-          :id, :role, :organisation, :details, :working_with_children,
-          :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
-          :"end_date(3i)", :"end_date(2i)", :"end_date(1i)"
+          :id,
+          :role,
+          :organisation,
+          :details,
+          :working_with_children,
+          :"start_date(3i)",
+          :"start_date(2i)",
+          :"start_date(1i)",
+          :start_date_unknown,
+          :currently_working,
+          :"end_date(3i)",
+          :"end_date(2i)",
+          :"end_date(1i)",
+          :end_date_unknown,
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) },

--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -114,10 +114,6 @@ module CandidateInterface
       month_and_year_blank?(start_date)
     end
 
-    def not_currently_working_in_this_role?
-      currently_working == 'false'
-    end
-
     def dont_validate_end_date
       restructured_work_history_flag_active? || start_date_blank?
     end

--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -3,16 +3,38 @@ module CandidateInterface
     include ActiveModel::Model
     include DateValidationHelper
 
-    attr_accessor :id, :role, :organisation, :details, :working_with_children,
-                  :start_date_day, :start_date_month, :start_date_year,
-                  :end_date_day, :end_date_month, :end_date_year
+    attr_accessor :id,
+                  :role,
+                  :organisation,
+                  :details,
+                  :working_with_children,
+                  :start_date_day,
+                  :start_date_month,
+                  :start_date_year,
+                  :start_date_unknown,
+                  :currently_working,
+                  :end_date_day,
+                  :end_date_month,
+                  :end_date_year,
+                  :end_date_unknown
 
-    validates :role, :organisation, :working_with_children, presence: true
+    validates :role,
+              :organisation,
+              :working_with_children,
+              presence: true
 
     validates :role, :organisation, length: { maximum: 60 }
-
     validates :start_date, date: { presence: true, future: true, month_and_year: true, before: :end_date }
-    validates :end_date, date: { future: true, month_and_year: true }, unless: :start_date_blank?
+
+    with_options if: :restructured_work_history_flag_active? do |form|
+      form.validates :start_date_unknown, inclusion: { in: %w[true false] }
+      form.validates :end_date_unknown, inclusion: { in: %w[true false] }
+      form.validates :currently_working, presence: true
+      form.validates :currently_working, inclusion: { in: %w[true false] }, if: -> { currently_working.present? }
+      form.validates :end_date, date: { presence: true, future: true, month_and_year: true }, if: -> { currently_working == 'false' }
+    end
+
+    validates :end_date, date: { future: true, month_and_year: true }, unless: :dont_validate_end_date
 
     validates :details, presence: true, word_count: { maximum: 150 }
 
@@ -38,8 +60,11 @@ module CandidateInterface
           working_with_children: volunteering_role.working_with_children,
           start_date_month: volunteering_role.start_date.month,
           start_date_year: volunteering_role.start_date.year,
+          start_date_unknown: volunteering_role.start_date_unknown,
           end_date_month: volunteering_role.end_date&.month || '',
           end_date_year: volunteering_role.end_date&.year || '',
+          end_date_unknown: volunteering_role.end_date_unknown,
+          currently_working: volunteering_role.currently_working.to_s,
         )
       end
     end
@@ -79,11 +104,26 @@ module CandidateInterface
         working_with_children: ActiveModel::Type::Boolean.new.cast(working_with_children),
         start_date: start_date,
         end_date: end_date,
+        start_date_unknown: start_date_unknown,
+        end_date_unknown: end_date_unknown,
+        currently_working: currently_working,
       }
     end
 
     def start_date_blank?
       month_and_year_blank?(start_date)
+    end
+
+    def not_currently_working_in_this_role?
+      currently_working == 'false'
+    end
+
+    def dont_validate_end_date
+      restructured_work_history_flag_active? || start_date_blank?
+    end
+
+    def restructured_work_history_flag_active?
+      FeatureFlag.active?(:restructured_work_history)
     end
   end
 end

--- a/app/forms/candidate_interface/volunteering_role_form.rb
+++ b/app/forms/candidate_interface/volunteering_role_form.rb
@@ -60,10 +60,10 @@ module CandidateInterface
           working_with_children: volunteering_role.working_with_children,
           start_date_month: volunteering_role.start_date.month,
           start_date_year: volunteering_role.start_date.year,
-          start_date_unknown: volunteering_role.start_date_unknown,
+          start_date_unknown: volunteering_role.start_date_unknown.to_s,
           end_date_month: volunteering_role.end_date&.month || '',
           end_date_year: volunteering_role.end_date&.year || '',
-          end_date_unknown: volunteering_role.end_date_unknown,
+          end_date_unknown: volunteering_role.end_date_unknown.to_s,
           currently_working: volunteering_role.currently_working.to_s,
         )
       end

--- a/app/views/candidate_interface/volunteering/role/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/role/_form.html.erb
@@ -9,13 +9,36 @@
   <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
 <% end %>
 
-<div class="app-work-experience__start-date" data-qa="start-date">
-  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date.label'), size: 'm' }, hint: { text: t('application_form.volunteering.start_date.hint_text') } %>
-</div>
-
-<div class="app-work-experience__end-date" data-qa="end-date">
-  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date.label'), size: 'm' }, hint: { text: t('application_form.volunteering.end_date.hint_text') } %>
-</div>
+<% if FeatureFlag.active?(:restructured_work_history) %>
+  <div class="app-work-experience__start-date" data-qa="start-date">
+    <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date_restructured_work_history.label'), size: 'm' }, hint: { text: t('application_form.volunteering.start_date_restructured_work_history.hint_text') } %>
+    <div class="govuk-form-group">
+      <%= f.hidden_field :start_date_unknown, value: false %>
+      <%= f.govuk_check_box :start_date_unknown, true, multiple: false, label: { text: t('application_form.volunteering.start_date_unknown_checkbox') } %>
+    </div>
+  </div>
+  <div class="app-work-experience__currently_working" data-qa="currently-working">
+    <%= f.govuk_radio_buttons_fieldset :currently_working, legend: { text: t('application_form.volunteering.currently_working.label'), size: 'm' } do %>
+      <%= f.govuk_radio_button :currently_working, true, label: { text: 'Yes' }, link_errors: true %>
+      <%= f.govuk_radio_button :currently_working, false, label: { text: 'No' } do %>
+        <div class="app-work-experience__start-date" data-qa="end-date">
+          <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date_restructured_work_history.label'), size: 'm' }, hint: { text: t('application_form.volunteering.end_date_restructured_work_history.hint_text') } %>
+          <div class="govuk-form-group">
+            <%= f.hidden_field :end_date_unknown, value: false %>
+            <%= f.govuk_check_box :end_date_unknown, true, multiple: false, label: { text: t('application_form.volunteering.end_date_unknown_checkbox') } %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <div class="app-work-experience__start-date" data-qa="start-date">
+    <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date.label'), size: 'm' }, hint: { text: t('application_form.volunteering.start_date.hint_text') } %>
+  </div>
+  <div class="app-work-experience__end-date" data-qa="end-date">
+    <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date.label'), size: 'm' }, hint: { text: t('application_form.volunteering.end_date.hint_text') } %>
+  </div>
+<% end %>
 
 <%= f.govuk_text_area :details, label: { text: t('application_form.volunteering.details.label'), size: 'm' }, hint: { text: t('application_form.volunteering.details.hint_text') }, max_words: 150 %>
 

--- a/app/views/candidate_interface/volunteering/role/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/role/_form.html.erb
@@ -4,10 +4,12 @@
 
 <%= f.govuk_text_field :organisation, label: { text: t('application_form.volunteering.organisation.label'), size: 'm' } %>
 
-<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), size: 'm' }, inline: true do %>
-  <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
-  <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
-<% end %>
+<div class="app-work-experience__working-with-children" data-qa="working-with-children">
+  <%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), size: 'm' }, inline: true do %>
+    <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
+    <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
+  <% end %>
+</div>
 
 <% if FeatureFlag.active?(:restructured_work_history) %>
   <div class="app-work-experience__start-date" data-qa="start-date">

--- a/config/locales/candidate_interface/volunteering.yml
+++ b/config/locales/candidate_interface/volunteering.yml
@@ -44,6 +44,17 @@ en:
         button: Add another role
       review:
         completed_checkbox: I have completed this section
+      start_date_restructured_work_history:
+        label: When did you start this role?
+        hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
+      start_date_unknown_checkbox: I’m not sure the exact month or year I started
+      end_date_unknown_checkbox: I’m not sure the exact month or year I left
+      currently_working:
+        label: Are you still working in this role?
+      end_date_restructured_work_history:
+        label: When did you finish this role?
+        hint_text: For example, 5 2018. If you cannot remember the exact month or year, enter an estimate.
+
 
   activemodel:
     errors:
@@ -65,3 +76,5 @@ en:
               too_many_words: Skills and experience must be %{count} words or fewer
             working_with_children:
               blank: Select if this role involves working in a school or with children
+            currently_working:
+              blank: Select yes if you are still working in this role

--- a/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
-  FeatureFlag.activate('restructured_work_history')
+  before do
+    FeatureFlag.activate('restructured_work_history')
+  end
 
   let(:data) do
     {

--- a/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
@@ -1,0 +1,176 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
+  let(:data) do
+    {
+        role: 'School Experience Intern',
+        organisation: Faker::Educator.secondary_school,
+        details: Faker::Lorem.paragraph_by_chars(number: 300),
+        working_with_children: true,
+        start_date: Time.zone.local(2018, 5, 1),
+        end_date: Time.zone.local(2019, 5, 1),
+    }
+  end
+
+  let(:form_data) do
+    {
+        role: data[:role],
+        organisation: data[:organisation],
+        details: data[:details],
+        working_with_children: data[:working_with_children],
+        start_date_month: data[:start_date].month,
+        start_date_year: data[:start_date].year,
+        end_date_month: data[:end_date].month,
+        end_date_year: data[:end_date].year,
+    }
+  end
+
+  describe '.build_all_from_application' do
+    it 'creates an array of objects based on the provided ApplicationForm' do
+      application_form = create(:application_form) do |form|
+        form.application_volunteering_experiences.create(attributes: data)
+        form.application_volunteering_experiences.create(
+            role: 'School Experience Intern',
+            organisation: 'A Noice School',
+            details: 'I interned.',
+            working_with_children: true,
+            start_date: Time.zone.local(2018, 8, 1),
+            end_date: Time.zone.local(2019, 10, 1),
+            )
+      end
+
+      volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(application_form)
+
+      expect(volunteering_roles).to match_array([
+                                                    have_attributes(form_data),
+                                                    have_attributes(
+                                                        role: 'School Experience Intern',
+                                                        organisation: 'A Noice School',
+                                                        details: 'I interned.',
+                                                        working_with_children: true,
+                                                        start_date_month: 8,
+                                                        start_date_year: 2018,
+                                                        end_date_month: 10,
+                                                        end_date_year: 2019,
+                                                        ),
+                                                ])
+    end
+  end
+
+  describe '.build_from_experience' do
+    it 'returns a new VolunteeringRoleForm object using an application experience' do
+      application_experience = build_stubbed(:application_volunteering_experience, attributes: data)
+
+      volunteering_role = CandidateInterface::VolunteeringRoleForm.build_from_experience(application_experience)
+
+      expect(volunteering_role).to have_attributes(form_data)
+    end
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      volunteering_role = CandidateInterface::VolunteeringRoleForm.new
+
+      expect(volunteering_role.save(ApplicationForm.new)).to eq(false)
+    end
+
+    context 'when a valid volunteering role' do
+      let(:application_form) { create(:application_form, volunteering_experience: false) }
+      let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(form_data) }
+
+      it 'creates a new work experience if valid' do
+        expect(volunteering_role.save(application_form)).to eq(true)
+        expect(application_form.application_volunteering_experiences.first)
+            .to have_attributes(data)
+      end
+
+      it 'updates volunteering experience if valid' do
+        volunteering_role.save(application_form)
+
+        expect(application_form.volunteering_experience).to eq(true)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:application_form) { create(:application_form) }
+    let(:existing_volunteering) do
+      application_form.application_volunteering_experiences.create(attributes: data)
+    end
+    let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(id: existing_volunteering.id) }
+
+    it 'returns false if not valid' do
+      expect(volunteering_role.update(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm if valid' do
+      form_data[:role] = 'Classroom Volunteer'
+      form_data[:organisation] = 'Some Other School'
+      volunteering_role.assign_attributes(form_data)
+
+      expect(volunteering_role.update(application_form)).to eq(true)
+      expect(application_form.application_volunteering_experiences.first)
+          .to have_attributes(
+                  role: 'Classroom Volunteer',
+                  organisation: 'Some Other School',
+                  details: data[:details],
+                  working_with_children: data[:working_with_children],
+                  start_date: data[:start_date],
+                  end_date: data[:end_date],
+                  )
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:role) }
+    it { is_expected.to validate_presence_of(:organisation) }
+    it { is_expected.to validate_presence_of(:details) }
+    it { is_expected.to validate_presence_of(:working_with_children) }
+
+    it { is_expected.to validate_length_of(:role).is_at_most(60) }
+    it { is_expected.to validate_length_of(:organisation).is_at_most(60) }
+
+    okay_text = Faker::Lorem.sentence(word_count: 150)
+    long_text = Faker::Lorem.sentence(word_count: 151)
+
+    it { is_expected.to allow_value(okay_text).for(:details) }
+    it { is_expected.not_to allow_value(long_text).for(:details) }
+
+    context 'start_date validations' do
+      let(:model) do
+        described_class.new(start_date_day: start_date_day,
+                            start_date_month: start_date_month,
+                            start_date_year: start_date_year)
+      end
+
+      include_examples 'month and year date validations', :start_date, verify_presence: true, future: true, before: :end_date
+    end
+
+    context 'end_date validations' do
+      let(:start_date) { 2.years.ago }
+      let(:model) do
+        described_class.new(end_date_day: end_date_day,
+                            end_date_month: end_date_month,
+                            end_date_year: end_date_year,
+                            start_date_day: start_date.day,
+                            start_date_month: start_date.month,
+                            start_date_year: start_date.year)
+      end
+
+      include_examples 'month and year date validations', :end_date, future: true
+
+      describe 'when start date is not set' do
+        let(:model) do
+          described_class.new(end_date_day: nil, end_date_month: nil, end_date_year: 2000,
+                              start_date_day: nil, start_date_month: nil, start_date_year: nil)
+        end
+
+        it 'end_date is not validated' do
+          model.valid?
+
+          expect(model.errors.added?(:end_date)).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_feature_flag_on_spec.rb
@@ -172,8 +172,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
                             start_date_day: start_date.day,
                             start_date_month: start_date.month,
                             start_date_year: start_date.year,
-                            currently_working: 'false',
-        )
+                            currently_working: 'false')
       end
 
       include_examples 'month and year date validations', :end_date, future: true

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
+  FeatureFlag.deactivate('restructured_work_history')
+
   let(:data) do
     {
       role: 'School Experience Intern',

--- a/spec/forms/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/forms/candidate_interface/volunteering_role_form_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
-  FeatureFlag.deactivate('restructured_work_history')
+  before do
+    FeatureFlag.deactivate('restructured_work_history')
+  end
 
   let(:data) do
     {

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.feature 'Candidate edits their volunteering section' do
   include CandidateHelper
 
-  scenario 'Candidate adds or deletes a role after completing the section' do
+  before do
     FeatureFlag.deactivate('restructured_work_history')
+  end
 
+  scenario 'Candidate adds or deletes a role after completing the section' do
     given_i_am_signed_in
     and_i_have_completed_the_volunteering_section
 

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
   include CandidateHelper
 
   scenario 'Candidate adds or deletes a role after completing the section' do
-    FeatureFlag.deactivate('restructured_work_history')
+    FeatureFlag.activate('restructured_work_history')
 
     given_i_am_signed_in
     and_i_have_completed_the_volunteering_section
@@ -41,7 +41,11 @@ RSpec.feature 'Candidate edits their volunteering section' do
 
   def and_i_have_completed_the_volunteering_section
     @application_form = create(:application_form, candidate: @candidate)
-    create(:application_volunteering_experience, application_form: @application_form)
+    create(:application_volunteering_experience,
+           application_form: @application_form,
+           start_date: 10.months.ago,
+           end_date: nil,
+           currently_working: true)
     @application_form.update!(volunteering_completed: true)
   end
 
@@ -50,7 +54,7 @@ RSpec.feature 'Candidate edits their volunteering section' do
   end
 
   def then_the_volunteering_section_should_be_marked_as_complete
-    expect(page.text).to include 'Unpaid experience'
+    expect(page.text).to include 'Unpaid experience Completed'
   end
 
   def when_i_click_the_volunteering_section_link
@@ -58,10 +62,12 @@ RSpec.feature 'Candidate edits their volunteering section' do
   end
 
   def and_i_click_to_change_my_role
+    expect(page.text).to include 'Add another role'
     click_change_link('role')
   end
 
   def and_i_change_my_role
+    expect(page.text).to include 'Edit role'
     fill_in t('application_form.volunteering.organisation.label'), with: 'Much Wow School'
   end
 

--- a/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_edits_or_deletes_volunteering_section_with_restructured_work_history_active_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.feature 'Candidate edits their volunteering section' do
   include CandidateHelper
 
-  scenario 'Candidate adds or deletes a role after completing the section' do
+  before do
     FeatureFlag.activate('restructured_work_history')
+  end
 
+  scenario 'Candidate adds or deletes a role after completing the section' do
     given_i_am_signed_in
     and_i_have_completed_the_volunteering_section
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering volunteering and school experience' do
 
   scenario 'Candidate submits their volunteering and school experience' do
     given_i_am_signed_in
+    and_the_restructured_work_history_flag_is_off
     and_i_visit_the_site
 
     when_i_click_on_volunteering_with_children_and_young_people
@@ -66,6 +67,10 @@ RSpec.feature 'Entering volunteering and school experience' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_restructured_work_history_flag_is_off
+    FeatureFlag.deactivate('restructured_work_history')
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.feature 'Entering volunteering experience' do
   include CandidateHelper
 
-  scenario 'Candidate adds volunteering experience' do
+  before do
     FeatureFlag.activate('restructured_work_history')
+  end
 
+  scenario 'Candidate adds volunteering experience' do
     given_i_am_signed_in
     and_i_visit_the_site
 

--- a/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
+++ b/spec/system/candidate_interface/entering_details/candidate_entering_volunteering_experience_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering volunteering experience' do
+  include CandidateHelper
+
+  scenario 'Candidate adds volunteering experience' do
+    FeatureFlag.activate('restructured_work_history')
+
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_unpaid_experience
+    then_i_should_see_the_start_page
+
+    when_i_choose_yes_experience
+    and_i_submit_the_volunteering_experience_form
+    then_i_see_the_add_volunteering_role_form
+
+    when_i_fill_in_the_job_form_with_incorrect_date_fields
+    then_i_should_see_date_validation_errors
+    and_i_should_see_the_incorrect_date_values
+
+    when_i_fill_in_the_job_form_with_valid_details
+    then_i_should_see_the_volunteering_review_page
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_unpaid_experience
+    click_link t('page_titles.volunteering.short')
+  end
+
+  def then_i_should_see_the_start_page
+    expect(page).to have_content(t('application_form.volunteering.experience.label'))
+  end
+
+  def when_i_choose_yes_experience
+    choose 'Yes'
+  end
+
+  def and_i_submit_the_volunteering_experience_form
+    click_button t('save_and_continue')
+  end
+
+  def then_i_see_the_add_volunteering_role_form
+    expect(page).to have_content(t('page_titles.add_volunteering_role'))
+  end
+
+  def when_i_fill_in_the_job_form_with_incorrect_date_fields
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '33'
+      fill_in 'Year', with: '1999'
+    end
+
+    click_button t('save_and_continue')
+  end
+
+  def then_i_should_see_date_validation_errors
+    expect(page).to have_content t('errors.messages.invalid_date', article: 'a', attribute: 'start date')
+  end
+
+  def and_i_should_see_the_incorrect_date_values
+    within('[data-qa="start-date"]') do
+      expect(find_field('Month').value).to eq('33')
+    end
+  end
+
+  def when_i_fill_in_the_job_form_with_valid_details
+    scope = 'application_form.volunteering'
+    fill_in t('organisation.label', scope: scope), with: 'National Trust'
+    fill_in t('role.label', scope: scope), with: 'Tour guide'
+
+    within('[data-qa="working-with-children"]') do
+      choose 'Yes'
+    end
+
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '5'
+      fill_in 'Year', with: '2014'
+    end
+
+    within('[data-qa="currently-working"]') do
+      choose 'No'
+    end
+
+    within('[data-qa="end-date"]') do
+      fill_in 'Month', with: '1'
+      fill_in 'Year', with: '2019'
+    end
+
+    fill_in t('application_form.volunteering.details.label'), with: 'I volunteered.'
+    click_button t('save_and_continue')
+  end
+
+  def then_i_should_see_the_volunteering_review_page
+    expect(page).to have_current_path candidate_interface_review_volunteering_path
+  end
+end


### PR DESCRIPTION
## Context

Edit the date fields for unpaid work to match those on the job form. This work is behind the restructured work history flag.

## Changes proposed in this pull request

### Before
![image](https://user-images.githubusercontent.com/33458055/109843813-668b7280-7c43-11eb-89ba-3bfa814bfb2f.png)

### After

![image](https://user-images.githubusercontent.com/33458055/109843870-7905ac00-7c43-11eb-8fb2-2ca80039785d.png)

## Guidance to review

Go commit by commit

## Link to Trello card

https://trello.com/c/8MQGKSwr/3063-unpaid-work-experience-update-date-fields-to-match-those-used-in-the-add-a-job-form

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
