### PR TITLE
Remove interview info from dashboard when cancelled

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -151,7 +151,7 @@ module CandidateInterface
     end
 
     def interview_row(application_choice)
-      if application_choice.interviews.present?
+      if application_choice.interviews.kept.any?
         {
           key: 'Interview'.pluralize(application_choice.interviews.size),
           value: render(InterviewBookingsComponent.new(application_choice)),

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -353,6 +353,28 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
     end
   end
 
+  context 'when an interview has been scheduled' do
+    it 'renders the component with interview details' do
+      application_choice = create(:application_choice, :with_completed_application_form, :with_scheduled_interview)
+      application_form = application_choice.application_form
+
+      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Interview')
+    end
+  end
+
+  context 'when an interview has been cancelled' do
+    it 'renders the component without interview details' do
+      application_choice = create(:application_choice, :with_completed_application_form, :with_cancelled_interview)
+      application_form = application_choice.application_form
+
+      result = render_inline(described_class.new(application_form: application_form, editable: false, show_status: true))
+
+      expect(result.css('.govuk-summary-list__key').text).not_to include('Interview')
+    end
+  end
+
   def create_application_form_with_course_choices(statuses:)
     application_form = create(:application_form)
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -546,6 +546,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_cancelled_interview do
+      awaiting_provider_decision
+
+      after(:build) do |application_choice, _evaluator|
+        application_choice.status = :awaiting_provider_decision
+        application_choice.interviews << build(:interview, provider: application_choice.provider)
+        application_choice.interviews.each(&:discard)
+      end
+    end
+
     trait :withdrawn do
       status { :withdrawn }
       withdrawn_at { Time.zone.now }
@@ -1197,6 +1207,16 @@ FactoryBot.define do
       changes do
         {
           'status' => %w[awaiting_provider_decision interviewing],
+        }
+      end
+    end
+
+    trait :with_cancelled_interview do
+      association(:application_choice, :with_cancelled_interview)
+
+      changes do
+        {
+          'status' => %w[awaiting_provider_decision],
         }
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -551,8 +551,7 @@ FactoryBot.define do
 
       after(:build) do |application_choice, _evaluator|
         application_choice.status = :awaiting_provider_decision
-        application_choice.interviews << build(:interview, provider: application_choice.provider)
-        application_choice.interviews.each(&:discard)
+        application_choice.interviews << build(:interview, provider: application_choice.provider, cancelled_at: Time.zone.now)
       end
     end
 


### PR DESCRIPTION
## Context

When an interview is cancelled there isn't any indication of this on the dashboard, as we're using the current dashboard design at the moment (but they do get an email). The new dashboard design will address this but in the meantime displaying the cancelled interview details with no indication that it's been cancelled is very confusing,

## Changes proposed in this pull request

- Remove interview info from dashboard when an interview is cancelled
- Create a new FactoryBot trait to make it easier to create an  application choice with a cancelled interview.  

## Guidance to review

- We use the [discard](https://github.com/jhawthorn/discard) gem to soft delete interviews when they are cancelled. When `#kept` is called on the interviews it should only retrieve the active interviews

## Link to Trello card

https://trello.com/c/2OKsz36L/3123-remove-interview-from-dashboard-for-cancelled-interviews

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
