### PR TITLE
SPIKE: Find changed apply again applications

### DIFF
--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -1,9 +1,21 @@
 module CandidateInterface
   class FindChangedApplyAgainApplications
-    def call
+    def all_forms
+      apply_again_forms
+    end
+
+    def changed_forms
       apply_again_forms.find_each.lazy.select do |application_form|
         changed?(application_form)
       end
+    end
+
+    def all_candidate_count
+      all_forms.map(&:candidate_id).uniq.count
+    end
+
+    def changed_candidate_count
+      changed_forms.map(&:candidate_id).uniq.count
     end
 
   private

--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -14,7 +14,7 @@ module CandidateInterface
           phase: 'apply_2',
           recruitment_cycle_year: RecruitmentCycle.current_year,
         )
-        .includes(previous_application_form: [:application_qualifications], application_qualifications: [])
+        .includes(:application_qualifications, previous_application_form: [:application_qualifications])
     end
 
     def changed?(application_form)
@@ -43,11 +43,9 @@ module CandidateInterface
       new_qualifications.all? { |new_qualification| !qualifications_match?(original_qualification, new_qualification) }
     end
 
-    IGNORED_QUALIFICATION_ATTRIBUTES = DuplicateApplication::IGNORED_ATTRIBUTES + %i[application_form_id public_id]
-
     def qualifications_match?(original_qualification, new_qualifications)
-      original_attributes = original_qualification.attributes.reject { |k, _| IGNORED_QUALIFICATION_ATTRIBUTES.include?(k) }
-      new_attributes = new_qualifications.attributes.reject { |k, _| IGNORED_QUALIFICATION_ATTRIBUTES.include?(k) }
+      original_attributes = original_qualification.attributes.reject { |k, _| DuplicateApplication::IGNORED_CHILD_ATTRIBUTES.include?(k) }
+      new_attributes = new_qualifications.attributes.reject { |k, _| DuplicateApplication::IGNORED_CHILD_ATTRIBUTES.include?(k) }
       original_attributes == new_attributes
     end
   end

--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -1,0 +1,54 @@
+module CandidateInterface
+  class FindChangedApplyAgainApplications
+    def call
+      apply_again_forms.find_each.lazy.select do |application_form|
+        changed?(application_form)
+      end
+    end
+
+  private
+
+    def apply_again_forms
+      ApplicationForm
+        .where(
+          phase: 'apply_2',
+          recruitment_cycle_year: RecruitmentCycle.current_year,
+        )
+        .includes(previous_application_form: [:application_qualifications], application_qualifications: [])
+    end
+
+    def changed?(application_form)
+      personal_statement_changed?(application_form) ||
+        subject_knowledge_changed?(application_form) ||
+        qualifications_changed?(application_form)
+    end
+
+    def subject_knowledge_changed?(application_form)
+      application_form.subject_knowledge != application_form.previous_application_form.subject_knowledge
+    end
+
+    def personal_statement_changed?(application_form)
+      application_form.becoming_a_teacher != application_form.previous_application_form.becoming_a_teacher
+    end
+
+    def qualifications_changed?(application_form)
+      original_qualifications = application_form.previous_application_form.application_qualifications.order(:id)
+      new_qualifications = application_form.application_qualifications.order(:id)
+      return true if original_qualifications.size != new_qualifications.size
+
+      original_qualifications.any? { |qualification| any_qualification_differ?(qualification, new_qualifications) }
+    end
+
+    def any_qualification_differ?(original_qualification, new_qualifications)
+      new_qualifications.all? { |new_qualification| !qualifications_match?(original_qualification, new_qualification) }
+    end
+
+    IGNORED_QUALIFICATION_ATTRIBUTES = DuplicateApplication::IGNORED_ATTRIBUTES + %i[application_form_id public_id]
+
+    def qualifications_match?(original_qualification, new_qualifications)
+      original_attributes = original_qualification.attributes.reject { |k, _| IGNORED_QUALIFICATION_ATTRIBUTES.include?(k) }
+      new_attributes = new_qualifications.attributes.reject { |k, _| IGNORED_QUALIFICATION_ATTRIBUTES.include?(k) }
+      original_attributes == new_attributes
+    end
+  end
+end

--- a/app/services/candidate_interface/find_changed_apply_again_applications.rb
+++ b/app/services/candidate_interface/find_changed_apply_again_applications.rb
@@ -18,35 +18,19 @@ module CandidateInterface
     end
 
     def changed?(application_form)
-      personal_statement_changed?(application_form) ||
-        subject_knowledge_changed?(application_form) ||
-        qualifications_changed?(application_form)
+      significant_values(application_form) !=
+        significant_values(application_form.previous_application_form)
     end
 
-    def subject_knowledge_changed?(application_form)
-      application_form.subject_knowledge != application_form.previous_application_form.subject_knowledge
-    end
-
-    def personal_statement_changed?(application_form)
-      application_form.becoming_a_teacher != application_form.previous_application_form.becoming_a_teacher
-    end
-
-    def qualifications_changed?(application_form)
-      original_qualifications = application_form.previous_application_form.application_qualifications.order(:id)
-      new_qualifications = application_form.application_qualifications.order(:id)
-      return true if original_qualifications.size != new_qualifications.size
-
-      original_qualifications.any? { |qualification| any_qualification_differ?(qualification, new_qualifications) }
-    end
-
-    def any_qualification_differ?(original_qualification, new_qualifications)
-      new_qualifications.all? { |new_qualification| !qualifications_match?(original_qualification, new_qualification) }
-    end
-
-    def qualifications_match?(original_qualification, new_qualifications)
-      original_attributes = original_qualification.attributes.reject { |k, _| DuplicateApplication::IGNORED_CHILD_ATTRIBUTES.include?(k) }
-      new_attributes = new_qualifications.attributes.reject { |k, _| DuplicateApplication::IGNORED_CHILD_ATTRIBUTES.include?(k) }
-      original_attributes == new_attributes
+    def significant_values(application_form)
+      application_form.as_json(
+        only: %i[becoming_a_teacher subject_knowledge],
+        include: {
+          application_qualifications: {
+            except: DuplicateApplication::IGNORED_CHILD_ATTRIBUTES,
+          },
+        },
+      )
     end
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -8,7 +8,7 @@ class DuplicateApplication
   end
 
   IGNORED_ATTRIBUTES = %w[id created_at updated_at submitted_at course_choices_completed phase support_reference].freeze
-  IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id].freeze
+  IGNORED_CHILD_ATTRIBUTES = %w[id created_at updated_at application_form_id public_id].freeze
 
   def duplicate
     attrs = original_application_form.attributes.except(

--- a/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
+++ b/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
@@ -13,34 +13,87 @@ RSpec.describe CandidateInterface::FindChangedApplyAgainApplications do
     ).duplicate
   end
 
-  it 'does not return identical applications' do
-    setup_apply_again_application
-    expect(described_class.new.call.count).to be(0)
-  end
-
-  it 'returns applications for which the personal_statement was changed' do
-    setup_apply_again_application
-    @apply_again_application.update(becoming_a_teacher: 'new statement')
-    expect(described_class.new.call.count).to be(1)
-  end
-
-  it 'returns applications for which subject_knowledge was changed' do
-    setup_apply_again_application
-    @apply_again_application.update(subject_knowledge: 'new learnings')
-    expect(described_class.new.call.count).to be(1)
-  end
-
-  it 'returns applications for which a new qualification was added' do
-    setup_apply_again_application
-    create(:gcse_qualification, application_form: @apply_again_application)
-    expect(described_class.new.call.count).to be(1)
-  end
-
-  it 'returns applications for which a qualification was changed' do
-    setup_apply_again_application
-    @apply_again_application.application_qualifications.first.update(
-      institution_name: 'University of South Oxfordshire',
+  def setup_multiple_apply_again_applications
+    @original_application = create(
+      :completed_application_form,
+      recruitment_cycle_year: RecruitmentCycle.previous_year,
     )
-    expect(described_class.new.call.count).to be(1)
+    create(:degree_qualification, application_form: @original_application)
+    @apply_again_application = DuplicateApplication.new(
+      @original_application,
+      target_phase: 'apply_2',
+    ).duplicate
+    @second_apply_again_application = DuplicateApplication.new(
+      @apply_again_application,
+      target_phase: 'apply_2',
+    ).duplicate
+  end
+
+  context 'with two apply again applications' do
+    it 'does not return identical applications' do
+      setup_multiple_apply_again_applications
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(0)
+    end
+
+    it 'returns candidates for which the personal_statement was changed in the first apply again application' do
+      setup_multiple_apply_again_applications
+      @apply_again_application.update(becoming_a_teacher: 'new statement')
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(1)
+    end
+
+    it 'returns candidates for which the personal_statement was changed in the second apply again application' do
+      setup_multiple_apply_again_applications
+      @second_apply_again_application.update(becoming_a_teacher: 'new statement')
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(1)
+    end
+
+    it 'returns candidate for which the personal_statement was changed in both apply again application' do
+      setup_multiple_apply_again_applications
+      @apply_again_application.update(becoming_a_teacher: 'new statement')
+      @second_apply_again_application.update(becoming_a_teacher: 'newer statement')
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(1)
+    end
+  end
+
+  context 'with a single apply again application' do
+    it 'does not return identical applications' do
+      setup_apply_again_application
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(0)
+    end
+
+    it 'returns applications for which the personal_statement was changed' do
+      setup_apply_again_application
+      @apply_again_application.update(becoming_a_teacher: 'new statement')
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(1)
+    end
+
+    it 'returns applications for which subject_knowledge was changed' do
+      setup_apply_again_application
+      @apply_again_application.update(subject_knowledge: 'new learnings')
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(1)
+    end
+
+    it 'returns applications for which a new qualification was added' do
+      setup_apply_again_application
+      create(:gcse_qualification, application_form: @apply_again_application)
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(1)
+    end
+
+    it 'returns applications for which a qualification was changed' do
+      setup_apply_again_application
+      @apply_again_application.application_qualifications.first.update(
+        institution_name: 'University of South Oxfordshire',
+      )
+      expect(described_class.new.all_candidate_count).to be(1)
+      expect(described_class.new.changed_candidate_count).to be(1)
+    end
   end
 end

--- a/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
+++ b/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::FindChangedApplyAgainApplications do
+  def setup_apply_again_application
+    @original_application = create(
+      :completed_application_form,
+      recruitment_cycle_year: RecruitmentCycle.previous_year,
+    )
+    create(:degree_qualification, application_form: @original_application)
+    @apply_again_application = DuplicateApplication.new(
+      @original_application,
+      target_phase: 'apply_2',
+    ).duplicate
+  end
+
+  it 'does not return identical applications' do
+    setup_apply_again_application
+    expect(described_class.new.call.count).to be(0)
+  end
+
+  it 'returns applications for which the personal_statement was changed' do
+    setup_apply_again_application
+    @apply_again_application.update(becoming_a_teacher: 'new statement')
+    expect(described_class.new.call.count).to be(1)
+  end
+
+  it 'returns applications for which subject_knowledge was changed' do
+    setup_apply_again_application
+    @apply_again_application.update(subject_knowledge: 'new learnings')
+    expect(described_class.new.call.count).to be(1)
+  end
+
+  it 'returns applications for which a new qualification was added' do
+    setup_apply_again_application
+    create(:gcse_qualification, application_form: @apply_again_application)
+    expect(described_class.new.call.count).to be(1)
+  end
+
+  it 'returns applications for which a new qualification was added' do
+    setup_apply_again_application
+    @apply_again_application.application_qualifications.first.update(
+      awarding_body: 'University of South Oxfordshire',
+    )
+    expect(described_class.new.call.count).to be(1)
+  end
+end

--- a/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
+++ b/spec/services/candidate_interface/find_changed_apply_again_applications_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe CandidateInterface::FindChangedApplyAgainApplications do
     expect(described_class.new.call.count).to be(1)
   end
 
-  it 'returns applications for which a new qualification was added' do
+  it 'returns applications for which a qualification was changed' do
     setup_apply_again_application
     @apply_again_application.application_qualifications.first.update(
-      awarding_body: 'University of South Oxfordshire',
+      institution_name: 'University of South Oxfordshire',
     )
     expect(described_class.new.call.count).to be(1)
   end


### PR DESCRIPTION
## Context

We need to work out a way to find the apply again applications that the candidate changed (in a significant way) since the original application.

This PR is a spike to explore ways to work this out.

## Changes proposed in this pull request

- [x] Add a `FindChangedApplyAgainApplications` query service class.

## Guidance to review

- This is a fairly straightforward (naive) implementation that relies on a Ruby `select` to filter the list of apply again applications. I don't think it would be easy to do this in a database query so some of the logic is happening in memory. This may be fine given that the numbers of apply again applications isn't huge. Using `lazy` enumerator may help.
- Is there an alternative approach? I didn't see how we could use the API to serialise and then diff the two results because we are only interested in a narrow subset of changes.
- The set of changes we regard as significant is very much hard-coded into the filter code here. Is there a way/need to generalise it a bit?

## Link to Trello card

https://trello.com/c/0fMYPksT/2862-dev-use-govuk-view-components-in-find-to-replace-accordion-markup

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
