### PR TITLE
Add new permissions based query service for courses and providers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'ar-sequence'
 
 gem 'active_hash'
 
-# Allows us to use common table expressions / WITH statements
+# Allows the use of common table expressions / WITH statements
 # in active record queries; may eventually be merged into Rails
 gem 'activerecord-cte'
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem 'ar-sequence'
 
 gem 'active_hash'
 
+# Allows us to use common table expressions / WITH statements
+# in active record queries; may eventually be merged into Rails
+gem 'activerecord-cte'
+
 gem 'sentry-raven'
 
 gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (6.0.3.5)
       activemodel (= 6.0.3.5)
       activesupport (= 6.0.3.5)
+    activerecord-cte (0.1.1)
+      activerecord
     activestorage (6.0.3.5)
       actionpack (= 6.0.3.5)
       activejob (= 6.0.3.5)
@@ -570,6 +572,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash
+  activerecord-cte
   ar-sequence
   archive-zip
   audited!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,6 @@ GEM
     activerecord (6.0.3.5)
       activemodel (= 6.0.3.5)
       activesupport (= 6.0.3.5)
-    activerecord-cte (0.1.1)
-      activerecord
     activestorage (6.0.3.5)
       actionpack (= 6.0.3.5)
       activejob (= 6.0.3.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (6.0.3.5)
       activemodel (= 6.0.3.5)
       activesupport (= 6.0.3.5)
+    activerecord-cte (0.1.1)
+      activerecord
     activestorage (6.0.3.5)
       actionpack (= 6.0.3.5)
       activejob (= 6.0.3.5)

--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -1,0 +1,69 @@
+class GetChangeOfferOptions
+  attr_accessor :application_choice, :user
+
+  def initialize(application_choice:, user:)
+    @application_choice = application_choice
+    @user = user
+  end
+
+  def available_providers
+    make_decision_providers = user.provider_permissions.where(make_decisions: true).map(&:provider)
+
+# course -> provider            -> provider_relationship_permissions (training side) -> providers
+#        -> accredited_provider -> provider_relationship_permissions (ratifying side) -> providers
+
+    # provider_id IN (1, 2, 3, 5)
+
+    # .with(
+      # provider_ids: user.provider_permissions.where(make_decisions: true).pluck(:provider_id)
+    # )
+    # .with(
+      # training_providers:
+        # Provider.joins('INNER JOIN courses ON courses.provider_id = providers.id AND courses.provider_id IN provider_ids')
+    # )
+
+    # .with(ratifying_providers: Course.where(accredited_provider: make_decision_providers))
+
+    courses = Course.where(open_on_apply: true,
+                          provider: make_decision_providers,
+                          recruitment_cycle_year: application_choice.offered_course.recruitment_cycle_year,
+                           )
+                          .or(
+                              Course.where(open_on_apply: true,
+                              accredited_provider: make_decision_providers,
+                              recruitment_cycle_year: application_choice.offered_course.recruitment_cycle_year,)
+                            )
+
+    courses.map(&:provider)
+  end
+
+  # GetChangeOfferOptions.new(application_choice: ..., user: ...).available_courses(provider: ...)
+  def available_courses(provider:)
+  end
+
+  # GetChangeOfferOptions.new(application_choice: ..., user: ...).available_study_modes(course: ...)
+  def available_study_modes(course:)
+  end
+  
+  # GetChangeOfferOptions.new(application_choice: ..., user: ...).available_sites(course: ..., study_mode: ...)
+
+  #   @available_courses = Course.where(
+  #     open_on_apply: true,
+  #     provider: application_choice.offered_course.provider,
+  #     study_mode: study_mode_for_other_courses,
+  #     recruitment_cycle_year: application_choice.offered_course.recruitment_cycle_year,
+  #   ).order(:name)
+  #
+  #   @available_study_modes = CourseOption.where(
+  #     course: application_choice.offered_course,
+  #   ).pluck(:study_mode).uniq
+  #
+  #   @available_course_options = CourseOption.where(
+  #     course: application_choice.offered_course,
+  #     study_mode: application_choice.offered_option.study_mode, # preserving study_mode
+  #   ).includes(:site).order('sites.name')
+  # end
+
+private
+
+end

--- a/app/queries/get_change_offer_options.rb
+++ b/app/queries/get_change_offer_options.rb
@@ -1,9 +1,10 @@
 class GetChangeOfferOptions
-  attr_accessor :application_choice, :user
+  attr_accessor :user, :ratifying_provider, :recruitment_cycle_year
 
-  def initialize(application_choice:, user:)
-    @application_choice = application_choice
+  def initialize(user:, ratifying_provider:, recruitment_cycle_year:)
     @user = user
+    @ratifying_provider = ratifying_provider
+    @recruitment_cycle_year = recruitment_cycle_year
   end
 
   def actionable_courses
@@ -11,12 +12,14 @@ class GetChangeOfferOptions
       .joins(training_provider_make_decisions)
       .joins(ratifying_provider_make_decisions)
 
-    courses_with_org_permission_joins
+    same_year_open_courses_with_make_decisions = courses_with_org_permission_joins
       .where(combine_user_and_provider_permissions)
       .where(
         open_on_apply: true,
-        recruitment_cycle_year: application_choice.offered_course.recruitment_cycle_year,
+        recruitment_cycle_year: recruitment_cycle_year,
       )
+
+    same_year_open_courses_with_make_decisions.where(accredited_provider: ratifying_provider)
   end
 
   def available_providers
@@ -25,15 +28,6 @@ class GetChangeOfferOptions
       .joins('INNER JOIN actionable_courses ON providers.id = actionable_courses.provider_id')
       .distinct
   end
-
-  # GetChangeOfferOptions.new(application_choice: ..., user: ...).available_courses(provider: ...)
-  def available_courses(provider:); end
-
-  # GetChangeOfferOptions.new(application_choice: ..., user: ...).available_study_modes(course: ...)
-  def available_study_modes(course:); end
-
-  # GetChangeOfferOptions.new(application_choice: ..., user: ...).available_sites(course: ..., study_mode: ...)
-  def available_sites(course:, study_mode:); end
 
 private
 

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -51,5 +51,12 @@ RSpec.describe GetChangeOfferOptions do
       provider_user.provider_permissions.second.update(make_decisions: true)
       expect(service.available_providers.count).to eq(0)
     end
+
+    it 'does not return duplicate providers' do
+      provider_user.providers << course.provider
+      provider_user.provider_permissions.first.update(make_decisions: true)
+      create(:course, :open_on_apply, provider: course.provider)
+      expect(service.available_providers).to eq([course.provider])
+    end
   end
 end

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe GetChangeOfferOptions do
+  include CourseOptionHelpers
+
+  let(:course) { create(:course, :open_on_apply) }
+  let(:accredited_course) { create(:course, :with_accredited_provider, :open_on_apply) }
+  let(:provider_user) { create(:provider_user) }
+  let(:application_choice) { create(:application_choice, :with_offer, course_option: create(:course_option, course: accredited_course)) }
+
+  let(:service) do
+    GetChangeOfferOptions.new(
+      application_choice: application_choice,
+      user: provider_user,
+    )
+  end
+
+  describe '#available_providers' do
+    it 'returns training providers for courses run or ratified by the user\'s providers' do
+      provider_user.providers << [course.provider, accredited_course.accredited_provider]
+      provider_user.provider_permissions.update_all(make_decisions: true)
+      expect(service.available_providers).to match_array([course.provider, accredited_course.provider])
+    end
+
+    it 'only returns providers for which the user has make_decisions permission' do
+      provider_user.providers << [course.provider, accredited_course.accredited_provider]
+      provider_user.provider_permissions.first.update(make_decisions: true)
+      expect(service.available_providers).to eq([course.provider])
+    end
+
+    it 'returns a self-ratified course' do
+      provider_user.providers << course.provider
+      provider_user.provider_permissions.first.update(make_decisions: true)
+      expect(service.available_providers).to eq([course.provider])
+    end
+
+    it 'excludes providers lacking org-level make_decisions for ratified courses' do
+      provider_user.providers << [course.provider, accredited_course.accredited_provider]
+      provider_user.provider_permissions.second.update(make_decisions: true)
+      expect(service.available_providers.count).to eq(0)
+    end
+  end
+end

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe GetChangeOfferOptions do
 
   let(:service) do
     GetChangeOfferOptions.new(
-      application_choice: application_choice,
       user: provider_user,
+      ratifying_provider: accredited_course.accredited_provider,
+      recruitment_cycle_year: RecruitmentCycle.current_year,
     )
   end
 
@@ -23,6 +24,24 @@ RSpec.describe GetChangeOfferOptions do
       training_provider_can_make_decisions: true,
       ratifying_provider_can_make_decisions: true,
     )
+  end
+
+  describe '#actionable_courses' do
+    it 'returns only courses which are open on apply' do
+
+    end
+
+    it 'returns only courses which are in the same recruitment cycle' do
+
+    end
+
+    it 'returns all courses which the user has make decisions for' do
+
+    end
+
+    it 'returns courses which have the same ratifying provider as the original' do
+
+    end
   end
 
   describe '#available_providers' do

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -3,74 +3,129 @@ require 'rails_helper'
 RSpec.describe GetChangeOfferOptions do
   include CourseOptionHelpers
 
-  let(:for_provider) { create(:provider) }
-  let(:course) { create(:course, :open_on_apply, provider: for_provider) }
-  let(:accredited_course) { create(:course, :open_on_apply, accredited_provider: for_provider) }
+  let(:ratifying_provider) { create(:provider) }
+  let(:self_ratified_course) { create(:course, :open_on_apply, provider: ratifying_provider) }
+  let(:externally_ratified_course) { create(:course, :open_on_apply, accredited_provider: ratifying_provider) }
   let(:provider_user) { create(:provider_user) }
 
-  let(:service) do
-    GetChangeOfferOptions.new(
-      user: provider_user,
-      for_provider: for_provider,
-      recruitment_cycle_year: RecruitmentCycle.current_year,
-    )
+  def service(provider_user, course)
+    described_class.new(user: provider_user, current_course: course)
   end
 
-  def allow_all_providers_to_make_decisions(training_provider, ratifying_provider)
+  def set_provider(provider, make_decisions: true)
+    provider_user
+      .provider_permissions
+      .find_or_create_by(provider: provider)
+      .update(make_decisions: make_decisions)
+  end
+
+  def set_provider_permissions(training_provider, make_d1, ratifying_provider, make_d2)
     create(
       :provider_relationship_permissions,
       training_provider: training_provider,
       ratifying_provider: ratifying_provider,
-      training_provider_can_make_decisions: true,
-      ratifying_provider_can_make_decisions: true,
+      training_provider_can_make_decisions: make_d1,
+      ratifying_provider_can_make_decisions: make_d2,
     )
   end
 
   describe '#make_decisions_courses' do
-    it 'returns courses run or ratified by the user\'s providers' do
-      allow_all_providers_to_make_decisions(accredited_course.provider, accredited_course.accredited_provider)
-      provider_user.providers << for_provider
-      provider_user.provider_permissions.update_all(make_decisions: true)
-      expect(service.make_decisions_courses).to match_array([course, accredited_course])
+    it 'returns no courses if user is not associated with the course via a provider' do
+      expect(service(provider_user, self_ratified_course).make_decisions_courses).to be_empty
     end
 
-    it 'only returns courses for which the user has make_decisions permission' do
-      allow_all_providers_to_make_decisions(accredited_course.provider, accredited_course.accredited_provider)
-      new_course = create(:course, :open_on_apply)
-      provider_user.providers << [for_provider, new_course.provider]
-      provider_user.provider_permissions.first.update(make_decisions: true)
-      expect(service.make_decisions_courses).to match_array([course, accredited_course])
+    it 'returns a self-ratified course when a user has user-level make decisions' do
+      set_provider(self_ratified_course.provider, make_decisions: false)
+      expect(service(provider_user, self_ratified_course).make_decisions_courses).to be_empty
+
+      set_provider(self_ratified_course.provider, make_decisions: true)
+      expect(service(provider_user, self_ratified_course).make_decisions_courses)
+        .to eq([self_ratified_course])
     end
 
-    it 'excludes courses for which the user lacks org-level make_decisions' do
-      provider_user.providers << for_provider
-      provider_user.provider_permissions.first.update(make_decisions: true)
-      expect(service.make_decisions_courses.count).to eq(0)
+    it 'returns an externally ratified course when a training provider user has org-level make decisions' do
+      set_provider(externally_ratified_course.provider)
+      expect(service(provider_user, externally_ratified_course).make_decisions_courses).to be_empty
+
+      set_provider_permissions(externally_ratified_course.provider, true,
+                               externally_ratified_course.accredited_provider, false)
+
+      expect(service(provider_user, externally_ratified_course).make_decisions_courses)
+        .to eq([externally_ratified_course])
+    end
+
+    it 'returns an externally ratified course when a ratifying provider user has org-level make decisions' do
+      set_provider(externally_ratified_course.accredited_provider)
+      expect(service(provider_user, externally_ratified_course).make_decisions_courses).to be_empty
+
+      set_provider_permissions(externally_ratified_course.provider, false,
+                               externally_ratified_course.accredited_provider, true)
+
+      expect(service(provider_user, externally_ratified_course).make_decisions_courses)
+        .to eq([externally_ratified_course])
+    end
+
+    it 'externally ratified course (both providers)' do
+      set_provider(externally_ratified_course.provider)
+      set_provider(externally_ratified_course.accredited_provider)
+      expect(service(provider_user, externally_ratified_course).make_decisions_courses).to be_empty
+
+      set_provider_permissions(externally_ratified_course.provider, true,
+                               externally_ratified_course.accredited_provider, true)
+
+      expect(service(provider_user, externally_ratified_course).make_decisions_courses)
+        .to eq([externally_ratified_course])
     end
   end
 
   describe '#offerable_courses' do
-    it 'returns only courses which are open on apply' do; end
+    it 'returns only courses which are open on apply' do
+      service = service(provider_user, externally_ratified_course)
+      create(:course, accredited_provider: ratifying_provider)
+      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
+      expect(service.offerable_courses).to eq([externally_ratified_course])
+    end
 
-    it 'returns only courses which are in the same recruitment cycle' do; end
+    it 'returns only courses which are in the same recruitment cycle' do
+      service = service(provider_user, externally_ratified_course)
+      create(:course, :previous_year, accredited_provider: ratifying_provider)
+      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
+      expect(service.offerable_courses).to eq([externally_ratified_course])
+    end
 
-    it 'returns ratified courses accredited by the same provider' do; end
+    it 'returns all courses ratified by the same ratifying provider as the externally ratified course' do
+      service = service(provider_user, externally_ratified_course)
+      create(:course, :open_on_apply)
+      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
+      expect(service.offerable_courses).to match_array([externally_ratified_course, self_ratified_course])
+    end
 
-    it 'returns self-ratified courses accredited by the same provider' do; end
+    it 'returns externally and self-ratified courses based on an self-ratified course' do
+      service = service(provider_user, self_ratified_course)
+      create(:course, :open_on_apply)
+      allow(service).to receive(:make_decisions_courses).and_return(Course.all)
+      expect(service.offerable_courses).to match_array([externally_ratified_course, self_ratified_course])
+    end
   end
 
   describe '#available_providers' do
+    it 'only returns training providers, even if user is not associated with them' do
+      set_provider(externally_ratified_course.accredited_provider)
+      set_provider_permissions(externally_ratified_course.provider, true,
+                               externally_ratified_course.accredited_provider, true)
+
+      service = service(provider_user, externally_ratified_course)
+      expect(service.available_providers).to eq([externally_ratified_course.provider])
+    end
+
     it 'does not return duplicate providers' do
-      allow_all_providers_to_make_decisions(accredited_course.provider, accredited_course.accredited_provider)
-      provider_user.providers << for_provider
-      provider_user.provider_permissions.first.update(make_decisions: true)
-      create(
-        :course,
-        :open_on_apply,
-        provider: accredited_course.provider,
-        accredited_provider: for_provider
-      )
-      expect(service.available_providers).to eq([accredited_course.provider])
+      service = service(provider_user, externally_ratified_course)
+      create(:course, provider: externally_ratified_course.provider)
+      allow(service).to receive(:offerable_courses).and_return(Course.all)
+
+      training_provider = externally_ratified_course.provider
+      expect(service.offerable_courses.map(&:provider)).to eq([training_provider] * 2)
+      expect(service.available_providers).to eq([training_provider])
     end
   end
 end

--- a/spec/queries/get_change_offer_options_spec.rb
+++ b/spec/queries/get_change_offer_options_spec.rb
@@ -15,14 +15,26 @@ RSpec.describe GetChangeOfferOptions do
     )
   end
 
+  def allow_all_providers_to_make_decisions(training_provider, ratifying_provider)
+    create(
+      :provider_relationship_permissions,
+      training_provider: training_provider,
+      ratifying_provider: ratifying_provider,
+      training_provider_can_make_decisions: true,
+      ratifying_provider_can_make_decisions: true,
+    )
+  end
+
   describe '#available_providers' do
     it 'returns training providers for courses run or ratified by the user\'s providers' do
+      allow_all_providers_to_make_decisions(accredited_course.provider, accredited_course.accredited_provider)
       provider_user.providers << [course.provider, accredited_course.accredited_provider]
       provider_user.provider_permissions.update_all(make_decisions: true)
       expect(service.available_providers).to match_array([course.provider, accredited_course.provider])
     end
 
     it 'only returns providers for which the user has make_decisions permission' do
+      allow_all_providers_to_make_decisions(accredited_course.provider, accredited_course.accredited_provider)
       provider_user.providers << [course.provider, accredited_course.accredited_provider]
       provider_user.provider_permissions.first.update(make_decisions: true)
       expect(service.available_providers).to eq([course.provider])


### PR DESCRIPTION
## Context

When modifying course details when making an offer or changing an offer, we allow provider users to change all aspects of the offer, including the provider. This is subject to their list of providers and `make_decisions` permissions, of course. But the current logic of presenting all providers you're associated with does not work very well when the user represents a ratifying provider (e.g. an HEI), in which case there may be no direct association between the training provider and the user.

To address this, we have come up with a different set of rules for selecting providers to show as part of the change offer flow. The main idea is we work out which courses the current user has permissions to `make_decisions` on first, then work backwards to obtain the corresponding list of training providers.

Requirements:
- I can only see courses that are open on apply
- I can only see courses that I have permission to make_decisions on
- Having chosen a provider in the “Select provider” step, I should only see courses that provider runs
- I can only see courses that are run or ratified by the accredited body to which the application was originally submitted

This PR adds a query service which obtains a list of training providers based on the new rules.

## Changes proposed in this pull request

Add a `GetOfferChangeOptions` query service which returns a list of training providers for a given user and course.

No UI changes and no need for a feature flag, as this service is not yet used anywhere.

## Guidance to review

The new service combines user-level and org-level permissions information for the user with courses to generate a list of `make_decisions_courses`, which is user specific and serves as the foundation for all the other checks.

Another quirk of the new rules is this concept of preserving the ratifying provider, which is why the service accepts a `original_course:` argument. If the current course is self-ratified, we use the training provider as the ratifying providers for this constraint, otherwise we use the ratifying provider of the current course.

The corresponding rspec file provides some interesting examples.

The `activerecord-cte` gem provides an elegant way to combine active record queries from different steps or services. `Provider.with(offerable_courses: offerable_courses)` is a good example of this.

## Link to Trello card

https://trello.com/c/huYAUhqp

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
