### PR TITLE
Happy path for create the new make offer flow

### DIFF
--- a/app/components/provider_interface/offer_summary_component.html.erb
+++ b/app/components/provider_interface/offer_summary_component.html.erb
@@ -1,0 +1,29 @@
+<div class="app-offer-panel app-banner app-banner--details">
+  <h2 class="govuk-heading-m">Course details</h2>
+  <%= render SummaryCardComponent.new(rows: rows, border: false) %>
+
+  <h2 class="govuk-heading-m">Conditions of offer</h2>
+
+  <div class='govuk-body'>
+    <%= govuk_link_to 'Add or change conditions', [:new, :provider_interface, @application_choice, :offer, :conditions] %>
+  </div>
+
+  <% if conditions.any? %>
+    <table class="govuk-table govuk-!-margin-bottom-2 conditions">
+      <tbody class="govuk-table__body">
+        <% conditions.each do |condition| %>
+          <tr class="govuk-table__row conditions-row">
+            <td class="govuk-table__cell"><%= condition %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <strong class="govuk-tag govuk-tag--grey app-tag">Pending</strong>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class='govuk-body'>
+      No conditions have been set for this offer
+    </div>
+  <% end %>
+</div>

--- a/app/components/provider_interface/offer_summary_component.rb
+++ b/app/components/provider_interface/offer_summary_component.rb
@@ -1,0 +1,34 @@
+module ProviderInterface
+  class OfferSummaryComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_accessor :application_choice, :course_option, :conditions
+
+    def initialize(application_choice:, course_option:, conditions:)
+      @application_choice = application_choice
+      @course_option = course_option
+      @conditions = conditions
+    end
+
+    def rows
+      [
+        { key: 'Provider',
+          value: course_option.provider.name_and_code,
+          action: 'Change',
+          change_path: nil },
+        { key: 'Course',
+          value: course_option.course.name_and_code,
+          action: 'Change',
+          change_path: nil },
+        { key: 'Location',
+          value: course_option.site.name_and_address,
+          action: 'Change',
+          change_path: nil },
+        { key: 'Full time or part time',
+          value: course_option.study_mode.humanize,
+          action: 'Change',
+          change_path: nil },
+      ]
+    end
+  end
+end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class DecisionsController < ProviderInterfaceController
     before_action :set_application_choice
+    before_action :confirm_application_is_in_decision_pending_state, only: %i[new create]
     before_action :requires_make_decisions_permission
 
     def new
@@ -165,6 +166,12 @@ module ProviderInterface
         decision: :default,
         standard_conditions: MakeAnOffer::STANDARD_CONDITIONS,
       }
+    end
+
+    def confirm_application_is_in_decision_pending_state
+      return if ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status.to_sym)
+
+      redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
     end
 
     def provider_interface_offer_params

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -157,7 +157,7 @@ module ProviderInterface
         study_mode: course_option.study_mode,
         location_id: course_option.site.id,
         current_context: :default,
-        conditions: MakeAnOffer::STANDARD_CONDITIONS,
+        standard_conditions: MakeAnOffer::STANDARD_CONDITIONS,
       }
     end
 

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -18,8 +18,6 @@ module ProviderInterface
         @wizard.save_state!
 
         if @wizard.decision == 'rejection'
-          @wizard.clear_state!
-
           redirect_to provider_interface_reasons_for_rejection_initial_questions_path(@application_choice)
         else
           redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -3,7 +3,17 @@ module ProviderInterface
     before_action :set_application_choice
     before_action :requires_make_decisions_permission
 
+    def new
+      @wizard = OfferWizard.new(offer_store,
+                                offer_context_params(@application_choice.course_option).merge!(current_step: 'select_option'))
+      @wizard.save_state!
+    end
+
     def respond
+      if FeatureFlag.active?(:updated_offer_flow)
+        redirect_to new_provider_interface_application_choice_decision_path(@application_choice) and return
+      end
+
       @pick_response_form = PickResponseForm.new
       @alternative_study_mode = @application_choice.offered_option.alternative_study_mode
     end
@@ -124,6 +134,23 @@ module ProviderInterface
 
     def make_an_offer_params
       params.require(:make_an_offer)
+    end
+
+    def offer_context_params(course_option)
+      {
+        course_id: course_option.course.id,
+        course_option_id: course_option.id,
+        provider_id: course_option.provider.id,
+        study_mode: course_option.study_mode,
+        location_id: course_option.site.id,
+        current_context: :default,
+        conditions: MakeAnOffer::STANDARD_CONDITIONS,
+      }
+    end
+
+    def offer_store
+      key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+      WizardStateStores::RedisStore.new(key: key)
     end
   end
 end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -12,7 +12,7 @@ module ProviderInterface
     def create
       @wizard = OfferWizard.new(offer_store, { decision: selected_decision })
 
-      if @wizard.valid?
+      if @wizard.valid_for_current_step?
 
         @wizard.save_state!
 

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -18,7 +18,7 @@ module ProviderInterface
 
         redirect_to provider_interface_reasons_for_rejection_initial_questions_path(@application_choice)
       else
-        redirect_to [:new, :provider_interface, :offer, @wizard.next_step]
+        redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
       end
     end
 

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -9,6 +9,19 @@ module ProviderInterface
       @wizard.save_state!
     end
 
+    def create
+      @wizard = OfferWizard.new(offer_store, { current_context: selected_decision })
+      @wizard.save_state!
+
+      if @wizard.current_context == 'rejection'
+        @wizard.clear_state!
+
+        redirect_to provider_interface_reasons_for_rejection_initial_questions_path(@application_choice)
+      else
+        redirect_to [:new, :provider_interface, :offer, @wizard.next_step]
+      end
+    end
+
     def respond
       if FeatureFlag.active?(:updated_offer_flow)
         redirect_to new_provider_interface_application_choice_decision_path(@application_choice) and return
@@ -146,6 +159,10 @@ module ProviderInterface
         current_context: :default,
         conditions: MakeAnOffer::STANDARD_CONDITIONS,
       }
+    end
+
+    def selected_decision
+      params.require(:provider_interface_offer_wizard).permit(:decision)[:decision]
     end
 
     def offer_store

--- a/app/controllers/provider_interface/offer/checks_controller.rb
+++ b/app/controllers/provider_interface/offer/checks_controller.rb
@@ -1,0 +1,10 @@
+module ProviderInterface
+  module Offer
+    class ChecksController < OffersController
+      def new
+        @wizard = OfferWizard.new(offer_store, { current_step: 'check' })
+        @wizard.save_state!
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -8,17 +8,24 @@ module ProviderInterface
         @wizard.save_state!
       end
 
-      def create; end
+      def create
+        @wizard = OfferWizard.new(offer_store, conditions_params.to_h)
+        @wizard.save_state!
+
+        redirect_to [:new, :provider_interface, :offer, @wizard.next_step]
+      end
 
     private
-
-      def conditions_params
-        params.require(:provider_interface_offer_wizard).permit(conditions: [])
-      end
 
       def offer_store
         key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
         WizardStateStores::RedisStore.new(key: key)
+      end
+
+      def conditions_params
+        params.require(:provider_interface_offer_wizard).permit(:further_condition_1, :further_condition_2,
+                                                                :further_condition_3, :further_condition_4,
+                                                                standard_conditions: [])
       end
     end
   end

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -1,8 +1,6 @@
 module ProviderInterface
   module Offer
-    class ConditionsController < ProviderInterfaceController
-      before_action :set_application_choice
-
+    class ConditionsController < OffersController
       def new
         @wizard = OfferWizard.new(offer_store, { current_step: 'conditions' })
         @wizard.save_state!
@@ -12,15 +10,10 @@ module ProviderInterface
         @wizard = OfferWizard.new(offer_store, conditions_params.to_h)
         @wizard.save_state!
 
-        redirect_to [:new, :provider_interface, :offer, @wizard.next_step]
+        redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
       end
 
     private
-
-      def offer_store
-        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
-        WizardStateStores::RedisStore.new(key: key)
-      end
 
       def conditions_params
         params.require(:provider_interface_offer_wizard).permit(:further_condition_1, :further_condition_2,

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -8,9 +8,14 @@ module ProviderInterface
 
       def create
         @wizard = OfferWizard.new(offer_store, conditions_params.to_h)
-        @wizard.save_state!
 
-        redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        if @wizard.valid?
+          @wizard.save_state!
+
+          redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]
+        else
+          render :new
+        end
       end
 
     private

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -1,0 +1,25 @@
+module ProviderInterface
+  module Offer
+    class ConditionsController < ProviderInterfaceController
+      before_action :set_application_choice
+
+      def new
+        @wizard = OfferWizard.new(offer_store, { current_step: 'conditions' })
+        @wizard.save_state!
+      end
+
+      def create; end
+
+    private
+
+      def conditions_params
+        params.require(:provider_interface_offer_wizard).permit(conditions: [])
+      end
+
+      def offer_store
+        key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+        WizardStateStores::RedisStore.new(key: key)
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer/conditions_controller.rb
+++ b/app/controllers/provider_interface/offer/conditions_controller.rb
@@ -9,7 +9,7 @@ module ProviderInterface
       def create
         @wizard = OfferWizard.new(offer_store, conditions_params.to_h)
 
-        if @wizard.valid?
+        if @wizard.valid_for_current_step?
           @wizard.save_state!
 
           redirect_to [:new, :provider_interface, @application_choice, :offer, @wizard.next_step]

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class OffersController < ProviderInterfaceController
     before_action :set_application_choice
+    before_action :application_choice_allowed_to_make_decision
     before_action :requires_make_decisions_permission
 
     def create
@@ -27,6 +28,12 @@ module ProviderInterface
     def offer_store
       key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
       WizardStateStores::RedisStore.new(key: key)
+    end
+
+    def application_choice_allowed_to_make_decision
+      return unless ApplicationStateChange::DECISION_PENDING_STATUSES.include?(@application_choice.status)
+
+      redirect_back(fallback_location: provider_interface_application_choice_path(@application_choice))
     end
   end
 end

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -4,6 +4,11 @@ module ProviderInterface
     before_action :application_choice_allowed_to_make_decision
     before_action :requires_make_decisions_permission
 
+    def new
+      flash[:warning] = t('.failure')
+      redirect_to new_provider_interface_application_choice_decision_path(@application_choice)
+    end
+
     def create
       @wizard = OfferWizard.new(offer_store)
       if @wizard.valid?

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -13,7 +13,7 @@ module ProviderInterface
         @wizard.clear_state!
 
         flash[:success] = t('.success')
-        redirect_to provider_interface_application_choice_path(@application_choice)
+        redirect_to provider_interface_application_choice_offer_path(@application_choice)
       else
         @wizard.clear_state!
 

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -1,8 +1,26 @@
 module ProviderInterface
   class OffersController < ProviderInterfaceController
     before_action :set_application_choice
+    before_action :requires_make_decisions_permission
 
-    def create; end
+    def create
+      @wizard = OfferWizard.new(offer_store)
+      if @wizard.valid?
+        MakeOffer.new(actor: current_provider_user,
+                      application_choice: @application_choice,
+                      course_option: @wizard.course_option,
+                      conditions: @wizard.conditions).save!
+        @wizard.clear_state!
+
+        flash[:success] = t('.success')
+        redirect_to provider_interface_application_choice_path(@application_choice)
+      else
+        @wizard.clear_state!
+
+        flash[:warning] = t('.failure')
+        redirect_to new_provider_interface_application_choice_decision_path(@application_choice)
+      end
+    end
 
   private
 

--- a/app/controllers/provider_interface/offers_controller.rb
+++ b/app/controllers/provider_interface/offers_controller.rb
@@ -1,0 +1,14 @@
+module ProviderInterface
+  class OffersController < ProviderInterfaceController
+    before_action :set_application_choice
+
+    def create; end
+
+  private
+
+    def offer_store
+      key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+      WizardStateStores::RedisStore.new(key: key)
+    end
+  end
+end

--- a/app/controllers/provider_interface/reasons_for_rejection_controller.rb
+++ b/app/controllers/provider_interface/reasons_for_rejection_controller.rb
@@ -60,6 +60,7 @@ module ProviderInterface
 
       if service.save
         @wizard.clear_state!
+        OfferWizard.new(offer_store).clear_state!
 
         flash[:success] = success_message
         redirect_to provider_interface_application_choice_feedback_path(@application_choice)
@@ -133,6 +134,11 @@ module ProviderInterface
 
     def rbd_application_with_no_feedback?
       @application_choice.rejected_by_default? && @application_choice.no_feedback?
+    end
+
+    def offer_store
+      key = "offer_wizard_store_#{current_provider_user.id}_#{@application_choice.id}"
+      WizardStateStores::RedisStore.new(key: key)
     end
   end
 end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -6,7 +6,9 @@ module ProviderInterface
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
                   :standard_conditions, :further_condition_1, :further_condition_2,
-                  :further_condition_3, :further_condition_4, :current_step, :current_context
+                  :further_condition_3, :further_condition_4, :current_step, :decision
+
+    validates :decision, presence: true
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
@@ -36,10 +38,10 @@ module ProviderInterface
     end
 
     def next_step
-      index = STEPS[current_context.to_sym].index(current_step.to_sym)
+      index = STEPS[decision.to_sym].index(current_step.to_sym)
 
       if index
-        STEPS[current_context.to_sym][index + 1] if index
+        STEPS[decision.to_sym][index + 1] if index
       else
         :select_option
       end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     STEPS = { make_offer: %i[select_option conditions check] }.freeze
 
-    attr_accessor :provider_id, :course_id, :study_mode, :location_id,
+    attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
                   :conditions, :current_step, :current_context
 
     def initialize(state_store, attrs = {})

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -1,0 +1,49 @@
+module ProviderInterface
+  class OfferWizard
+    include ActiveModel::Model
+
+    STEPS = { make_offer: %i[select_option conditions check] }.freeze
+
+    attr_accessor :provider_id, :course_id, :study_mode, :location_id,
+                  :conditions, :current_step, :current_context
+
+    def initialize(state_store, attrs = {})
+      @state_store = state_store
+
+      super(last_saved_state.deep_merge(attrs))
+    end
+
+    def save_state!
+      @state_store.write(state)
+    end
+
+    def clear_state!
+      @state_store.delete
+    end
+
+    def valid_for_current_step?
+      valid?(current_step.to_sym)
+    end
+
+    def next_step
+      index = STEPS[current_context.to_sym].index(current_step.to_sym)
+
+      if index
+        STEPS[current_context.to_sym][index + 1] if index
+      else
+        :select_option
+      end
+    end
+
+  private
+
+    def last_saved_state
+      saved_state = @state_store.read
+      saved_state ? JSON.parse(saved_state) : {}
+    end
+
+    def state
+      as_json(except: %w[state_store errors validation_context]).to_json
+    end
+  end
+end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -53,7 +53,7 @@ module ProviderInterface
     end
 
     def state
-      as_json(except: %w[state_store errors validation_context]).to_json
+      as_json(except: %w[state_store errors validation_context course_option]).to_json
     end
   end
 end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -19,6 +19,10 @@ module ProviderInterface
                                             further_condition_3, further_condition_4]).reject!(&:blank?)
     end
 
+    def course_option
+      @course_option = CourseOption.find(course_option_id)
+    end
+
     def save_state!
       @state_store.write(state)
     end

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -5,12 +5,18 @@ module ProviderInterface
     STEPS = { make_offer: %i[select_option conditions check] }.freeze
 
     attr_accessor :provider_id, :course_id, :course_option_id, :study_mode, :location_id,
-                  :conditions, :current_step, :current_context
+                  :standard_conditions, :further_condition_1, :further_condition_2,
+                  :further_condition_3, :further_condition_4, :current_step, :current_context
 
     def initialize(state_store, attrs = {})
       @state_store = state_store
 
       super(last_saved_state.deep_merge(attrs))
+    end
+
+    def conditions
+      @conditions = (standard_conditions + [further_condition_1, further_condition_2,
+                                            further_condition_3, further_condition_4]).reject!(&:blank?)
     end
 
     def save_state!

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -41,11 +41,7 @@ module ProviderInterface
     def next_step
       index = STEPS[decision.to_sym].index(current_step.to_sym)
 
-      if index
-        STEPS[decision.to_sym][index + 1] if index
-      else
-        :select_option
-      end
+      STEPS[decision.to_sym][index + 1] if index
     end
 
   private

--- a/app/forms/provider_interface/offer_wizard.rb
+++ b/app/forms/provider_interface/offer_wizard.rb
@@ -9,6 +9,7 @@ module ProviderInterface
                   :further_condition_3, :further_condition_4, :current_step, :decision
 
     validates :decision, presence: true
+    validates :further_condition_1, :further_condition_2, :further_condition_3, :further_condition_4, length: { maximum: 255 }
 
     def initialize(state_store, attrs = {})
       @state_store = state_store

--- a/app/views/provider_interface/decisions/new.html.erb
+++ b/app/views/provider_interface/decisions/new.html.erb
@@ -1,0 +1,32 @@
+<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.respond'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+      <%= t('page_titles.provider.respond') %>
+    </h1>
+    <%= render ProviderInterface::CourseSummaryComponent.new(course_option: @application_choice.course_option) %>
+
+    <%= form_with model: @wizard, url: '', method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :decision, legend: { text: t('page_titles.provider.select_decision'), size: 'm' } do %>
+        <%= f.govuk_radio_button :decision,
+          'make_offer',
+          label: { text: 'Make an offer' },
+          link_errors: true %>
+
+        <%= f.govuk_radio_button :decision, 'new_reject', label: { text: 'Reject application' } %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+
+    <% end %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice), class: 'govuk-link--no-visited-state' %>
+    </p>
+  </div>
+</div>

--- a/app/views/provider_interface/decisions/new.html.erb
+++ b/app/views/provider_interface/decisions/new.html.erb
@@ -3,22 +3,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
-      <%= t('.title') %>
-    </h1>
-    <%= render ProviderInterface::CourseSummaryComponent.new(course_option: @application_choice.course_option) %>
-
     <%= form_with model: @wizard, url: provider_interface_application_choice_decision_path(@application_choice), method: :post do |f| %>
+
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :decision, legend: { text: t('.select'), size: 'm' } do %>
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
+        <%= t('.title') %>
+      </h1>
+
+      <%= render ProviderInterface::CourseSummaryComponent.new(course_option: @application_choice.course_option) %>
+      <%= f.govuk_radio_buttons_fieldset :decision, legend: { size: 'm' } do %>
         <%= f.govuk_radio_button :decision,
           'make_offer',
-          label: { text: 'Make an offer' },
           link_errors: true %>
 
-        <%= f.govuk_radio_button :decision, 'rejection', label: { text: 'Reject application' } %>
+        <%= f.govuk_radio_button :decision, 'rejection' %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/app/views/provider_interface/decisions/new.html.erb
+++ b/app/views/provider_interface/decisions/new.html.erb
@@ -1,24 +1,24 @@
-<% content_for :browser_title, title_with_error_prefix(t('page_titles.provider.respond'), @wizard.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
       <span class="govuk-caption-l"><%= @application_choice.application_form.full_name %></span>
-      <%= t('page_titles.provider.respond') %>
+      <%= t('.title') %>
     </h1>
     <%= render ProviderInterface::CourseSummaryComponent.new(course_option: @application_choice.course_option) %>
 
-    <%= form_with model: @wizard, url: '', method: :post do |f| %>
+    <%= form_with model: @wizard, url: provider_interface_application_choice_decision_path(@application_choice), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :decision, legend: { text: t('page_titles.provider.select_decision'), size: 'm' } do %>
+      <%= f.govuk_radio_buttons_fieldset :decision, legend: { text: t('.select'), size: 'm' } do %>
         <%= f.govuk_radio_button :decision,
           'make_offer',
           label: { text: 'Make an offer' },
           link_errors: true %>
 
-        <%= f.govuk_radio_button :decision, 'new_reject', label: { text: 'Reject application' } %>
+        <%= f.govuk_radio_button :decision, 'rejection', label: { text: 'Reject application' } %>
       <% end %>
 
       <%= f.govuk_submit t('continue') %>

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -10,55 +10,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
-      <div class="app-offer-panel app-banner app-banner--details">
-        <h2 class="govuk-heading-m">Course details</h2>
-        <% rows = [
-          { key: 'Provider',
-            value: @wizard.course_option.provider.name_and_code,
-            action: 'Change',
-            change_path: nil },
-          { key: 'Course',
-            value: @wizard.course_option.course.name_and_code,
-            action: 'Change',
-            change_path: nil },
-          { key: 'Location',
-            value: @wizard.course_option.site.name_and_address,
-            action: 'Change',
-            change_path: nil },
-          { key: 'Full time or part time',
-            value: @wizard.course_option.study_mode.humanize,
-            action: 'Change',
-            change_path: nil },
-          ] %>
-
-        <%= render SummaryCardComponent.new(rows: rows, border: false) %>
-
-        <h2 class="govuk-heading-m">Conditions of offer</h2>
-
-        <div class='govuk-body'>
-          <%= govuk_link_to 'Add or change conditions', [:new, :provider_interface, @application_choice, :offer, :conditions] %>
-        </div>
-
-        <% if @wizard.conditions.any? %>
-          <table class="govuk-table govuk-!-margin-bottom-2">
-            <tbody class="govuk-table__body">
-              <% @wizard.conditions.each do |condition| %>
-                <tr class="govuk-table__row conditions-row">
-                  <td class="govuk-table__cell"><%= condition %></td>
-                  <td class="govuk-table__cell govuk-table__cell--numeric">
-                    <strong class="govuk-tag govuk-tag--grey app-tag">Pending</strong>
-                  </td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        <% else %>
-          <div class='govuk-body'>
-            No conditions have been set for this offer
-          </div>
-        <% end %>
-
-      </div>
+      <%= render ProviderInterface::OfferSummaryComponent.new(application_choice: @application_choice,
+                                                              course_option: @wizard.course_option,
+                                                              conditions: @wizard.conditions) %>
 
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -1,0 +1,80 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_offer_path(@application_choice.id)) %>
+
+<%= render(FlashMessageComponent.new(flash: flash)) %>
+
+<%= form_with model: @wizard, url: provider_interface_application_choice_offers_path(@application_choice), method: :post do |f| %>
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+      <div class="app-offer-panel app-banner app-banner--details">
+        <h2 class="govuk-heading-m">Course details</h2>
+        <% rows = [
+          { key: 'Provider',
+            value: @wizard.course_option.provider.name_and_code,
+            action: 'Change',
+            change_path: nil },
+          { key: 'Course',
+            value: @wizard.course_option.course.name_and_code,
+            action: 'Change',
+            change_path: nil },
+          { key: 'Location',
+            value: @wizard.course_option.site.name_and_address,
+            action: 'Change',
+            change_path: nil },
+          { key: 'Full time or part time',
+            value: @wizard.course_option.study_mode.humanize,
+            action: 'Change',
+            change_path: nil },
+          ] %>
+
+        <%= render SummaryCardComponent.new(rows: rows, border: false) %>
+
+        <h2 class="govuk-heading-m">Conditions of offer</h2>
+
+        <div class='govuk-body'>
+          <%= govuk_link_to 'Add or change conditions', [:new, :provider_interface, @application_choice, :offer, :conditions] %>
+        </div>
+
+        <% if @wizard.conditions.any? %>
+          <table class="govuk-table govuk-!-margin-bottom-2">
+            <tbody class="govuk-table__body">
+              <% @wizard.conditions.each do |condition| %>
+                <tr class="govuk-table__row conditions-row">
+                  <td class="govuk-table__cell"><%= condition %></td>
+                  <td class="govuk-table__cell govuk-table__cell--numeric">
+                    <strong class="govuk-tag govuk-tag--grey app-tag">Pending</strong>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <div class='govuk-body'>
+            No conditions have been set for this offer
+          </div>
+        <% end %>
+
+      </div>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive"></span>
+          When you send this offer, you guarantee a place on this course as long as the candidate meets the conditions.
+        </strong>
+      </div>
+
+      <%= f.govuk_submit t('.submit') %>
+
+      <p class="govuk-body">
+      <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/provider_interface/offer/checks/new.html.erb
+++ b/app/views/provider_interface/offer/checks/new.html.erb
@@ -1,8 +1,6 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_offer_path(@application_choice.id)) %>
 
-<%= render(FlashMessageComponent.new(flash: flash)) %>
-
 <%= form_with model: @wizard, url: provider_interface_application_choice_offers_path(@application_choice), method: :post do |f| %>
   <h1 class="govuk-heading-l">
     <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -1,8 +1,6 @@
 <% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice)) %>
 
-<%= render(FlashMessageComponent.new(flash: flash)) %>
-
 <%= form_with model: @wizard, url: provider_interface_application_choice_offer_conditions_path(@application_choice), method: :post do |f| %>
   <%= f.govuk_error_summary %>
 

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -1,0 +1,38 @@
+<% content_for :browser_title, title_with_error_prefix(t('.title'), @wizard.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice)) %>
+
+<%= render(FlashMessageComponent.new(flash: flash)) %>
+
+<%= form_with model: @wizard, url: provider_interface_offer_conditions_path(@application_choice), method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    <%= t('.title') %>
+  </h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_collection_check_boxes(:standard_conditions,
+                                         standard_conditions_checkboxes,
+                                         :id,
+                                         :name,
+                                         legend: { size: 'm' }) %>
+
+      <%= f.govuk_fieldset legend: { text: 'Further conditions', size: 'm' } do %>
+        <p class="govuk-body">For example, studying a subject knowledge enhancement course.</p>
+
+        <%= f.govuk_text_area :further_condition_1, label: { size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_condition_2, label: { size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_condition_3, label: { size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_condition_4, label: { size: 's' }, rows: 3 %>
+      <% end %>
+
+      <%= f.govuk_submit t('continue') %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to t('cancel'), provider_interface_application_choice_path(@application_choice), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/provider_interface/offer/conditions/new.html.erb
+++ b/app/views/provider_interface/offer/conditions/new.html.erb
@@ -3,7 +3,7 @@
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
 
-<%= form_with model: @wizard, url: provider_interface_offer_conditions_path(@application_choice), method: :post do |f| %>
+<%= form_with model: @wizard, url: provider_interface_application_choice_offer_conditions_path(@application_choice), method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,7 @@ en:
               blank: You have to agree to these terms to use this service
   errors:
     messages:
+      too_long: "%{attribute} must be %{count} characters or fewer"
       too_many_words: Must be %{count} words or fewer
       too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course_name_and_code}.
       apply_again_course_already_chosen: You cannot choose more than 1 course when you apply again. You must delete your existing choice if you want to apply to %{course_name_and_code}

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -13,9 +13,9 @@ en:
           title: Check and send offer
           submit: Send offer
     offers:
+      failure: Sorry, there is a problem with the service.
       create:
         success: Offer successffuly made
-        failure: Something went wrong. Please start over.
   helpers:
     label:
       provider_interface_offer_wizard:

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -1,0 +1,24 @@
+en:
+  provider_interface:
+    decisions:
+      new:
+        title: Make a decision
+        select:  Select decision
+    offer:
+      conditions:
+        new:
+          title: Conditions of offer
+  provider_interface:
+    decisions:
+      new:
+        title: Make a decision
+  helpers:
+    label:
+      provider_interface_offer_wizard:
+        further_condition_1: 'Condition 1'
+        further_condition_2: 'Condition 2'
+        further_condition_3: 'Condition 3'
+        further_condition_4: 'Condition 4'
+    legend:
+      provider_interface_offer_wizard:
+        standard_conditions: 'Standard conditions'

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -31,6 +31,12 @@ en:
         decision: 'Select decision'
         standard_conditions: 'Standard conditions'
   activemodel:
+    attributes:
+      provider_interface/offer_wizard:
+        further_condition_1: 'Condition 1'
+        further_condition_2: 'Condition 2'
+        further_condition_3: 'Condition 3'
+        further_condition_4: 'Condition 4'
     errors:
       models:
         provider_interface/offer_wizard:

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -8,7 +8,10 @@ en:
       conditions:
         new:
           title: Conditions of offer
-  provider_interface:
+      checks:
+        new:
+          title: Check and send offer
+          submit: Send offer
     decisions:
       new:
         title: Make a decision

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -19,10 +19,21 @@ en:
   helpers:
     label:
       provider_interface_offer_wizard:
+        decision_options:
+          make_offer: Make an offer
+          rejection: Reject application
         further_condition_1: 'Condition 1'
         further_condition_2: 'Condition 2'
         further_condition_3: 'Condition 3'
         further_condition_4: 'Condition 4'
     legend:
       provider_interface_offer_wizard:
+        decision: 'Select decision'
         standard_conditions: 'Standard conditions'
+  activemodel:
+    errors:
+      models:
+        provider_interface/offer_wizard:
+          attributes:
+            decision:
+              blank: Select if you want to make an offer or reject the application

--- a/config/locales/provider_interface/make_offer.yml
+++ b/config/locales/provider_interface/make_offer.yml
@@ -12,9 +12,10 @@ en:
         new:
           title: Check and send offer
           submit: Send offer
-    decisions:
-      new:
-        title: Make a decision
+    offers:
+      create:
+        success: Offer successffuly made
+        failure: Something went wrong. Please start over.
   helpers:
     label:
       provider_interface_offer_wizard:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -632,7 +632,11 @@ Rails.application.routes.draw do
       get '/offer/defer' => 'decisions#new_defer_offer', as: :application_choice_new_defer_offer
       post '/offer/defer' => 'decisions#defer_offer', as: :application_choice_defer_offer
 
-      resource :decision, only: %i[new], as: :application_choice_decision
+      resource :decision, only: %i[new create], as: :application_choice_decision
+
+      namespace :offer do
+        resource :conditions, only: %i[new create]
+      end
 
       get '/rbd-feedback' => 'feedback#new', as: :application_choice_new_rbd_feedback
       post '/feedback/check' => 'feedback#check', as: :application_choice_check_feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -634,7 +634,9 @@ Rails.application.routes.draw do
 
       resource :decision, only: %i[new create], as: :application_choice_decision
 
-      resource :offers, only: :create, as: :application_choice_offers
+      resource :offers, only: %i[new], as: :application_choice_offer
+      resource :offers, only: %i[create], as: :application_choice_offers
+
       namespace :offer, as: :application_choice_offer do
         resource :conditions, only: %i[new create]
         resource :check, only: %i[new]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -632,6 +632,8 @@ Rails.application.routes.draw do
       get '/offer/defer' => 'decisions#new_defer_offer', as: :application_choice_new_defer_offer
       post '/offer/defer' => 'decisions#defer_offer', as: :application_choice_defer_offer
 
+      resource :decision, only: %i[new], as: :application_choice_decision
+
       get '/rbd-feedback' => 'feedback#new', as: :application_choice_new_rbd_feedback
       post '/feedback/check' => 'feedback#check', as: :application_choice_check_feedback
       post '/rbd-feedback' => 'feedback#create', as: :application_choice_rbd_feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -634,8 +634,10 @@ Rails.application.routes.draw do
 
       resource :decision, only: %i[new create], as: :application_choice_decision
 
-      namespace :offer do
+      resource :offers, only: :create, as: :application_choice_offers
+      namespace :offer, as: :application_choice_offer do
         resource :conditions, only: %i[new create]
+        resource :check, only: %i[new]
       end
 
       get '/rbd-feedback' => 'feedback#new', as: :application_choice_new_rbd_feedback

--- a/spec/components/previews/provider_interface/offer_summary_component_preview.rb
+++ b/spec/components/previews/provider_interface/offer_summary_component_preview.rb
@@ -1,0 +1,13 @@
+module ProviderInterface
+  class OfferSummaryComponentPreview < ViewComponent::Preview
+    def offer_summary
+      application_choice = ApplicationChoice.limit(5).sample
+      course_option = CourseOption.limit(10).sample
+      conditions =  MakeAnOffer::STANDARD_CONDITIONS + ['Driving license']
+
+      render ProviderInterface::OfferSummaryComponent.new(application_choice: application_choice,
+                                                          course_option: course_option,
+                                                          conditions: conditions)
+    end
+  end
+end

--- a/spec/components/provider_interface/offer_summary_component_spec.rb
+++ b/spec/components/provider_interface/offer_summary_component_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::OfferSummaryComponent do
+  let(:application_choice) { build_stubbed(:application_choice) }
+  let(:course_option) { build_stubbed(:course_option) }
+  let(:render) do
+    render_inline(described_class.new(application_choice: application_choice,
+                                      course_option: course_option,
+                                      conditions: ['condition 1', 'condition 2']))
+  end
+
+  def row_text_selector(row_name, render)
+    rows = {
+      provider: 0,
+      course: 1,
+      location: 2,
+      full_or_part_time: 3,
+    }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
+  it 'renders the new course option details' do
+    expect(row_text_selector(:provider, render)).to include(course_option.provider.name)
+    expect(row_text_selector(:course, render)).to include(course_option.course.name_and_code)
+    expect(row_text_selector(:location, render)).to include(course_option.site.name_and_address)
+    expect(row_text_selector(:full_or_part_time, render)).to include(course_option.study_mode.humanize)
+  end
+
+  it 'renders conditions' do
+    expect(render.css('.conditions').text).to include('condition 1')
+    expect(render.css('.conditions').text).to include('condition 2')
+  end
+end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 RSpec.describe ProviderInterface::OfferWizard do
-  let(:store) { instance_double(WizardStateStores::RedisStore) }
-
-  let(:wizard) do
+  subject(:wizard) do
     described_class.new(store,
                         provider_id: provider_id,
                         course_id: course_id,
@@ -15,9 +13,10 @@ RSpec.describe ProviderInterface::OfferWizard do
                         further_condition_3: further_condition_3,
                         further_condition_4: further_condition_4,
                         current_step: current_step,
-                        current_context: current_context)
+                        decision: decision)
   end
 
+  let(:store) { instance_double(WizardStateStores::RedisStore) }
   let(:provider_id) { nil }
   let(:course_id) { nil }
   let(:course_option_id) { nil }
@@ -29,13 +28,17 @@ RSpec.describe ProviderInterface::OfferWizard do
   let(:further_condition_3) { nil }
   let(:further_condition_4) { nil }
   let(:current_step) { nil }
-  let(:current_context) { nil }
+  let(:decision) { nil }
 
   before { allow(store).to receive(:read) }
 
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:decision) }
+  end
+
   describe '#next_step' do
-    context 'make offer context' do
-      let(:current_context) { :make_offer }
+    context 'make offer decision' do
+      let(:decision) { :make_offer }
 
       context 'when current_step is :select_option' do
         let(:current_step) { :select_option }

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -6,18 +6,28 @@ RSpec.describe ProviderInterface::OfferWizard do
     described_class.new(store,
                         provider_id: provider_id,
                         course_id: course_id,
+                        course_option_id: course_option_id,
                         study_mode: study_mode,
                         location_id: location_id,
-                        conditions: conditions,
+                        standard_conditions: standard_conditions,
+                        further_condition_1: further_condition_1,
+                        further_condition_2: further_condition_2,
+                        further_condition_3: further_condition_3,
+                        further_condition_4: further_condition_4,
                         current_step: current_step,
                         current_context: current_context)
   end
 
   let(:provider_id) { nil }
   let(:course_id) { nil }
+  let(:course_option_id) { nil }
   let(:study_mode) { nil }
   let(:location_id) { nil }
-  let(:conditions) { nil }
+  let(:standard_conditions) { MakeAnOffer::STANDARD_CONDITIONS }
+  let(:further_condition_1) { nil }
+  let(:further_condition_2) { nil }
+  let(:further_condition_3) { nil }
+  let(:further_condition_4) { nil }
   let(:current_step) { nil }
   let(:current_context) { nil }
 
@@ -50,6 +60,18 @@ RSpec.describe ProviderInterface::OfferWizard do
           expect(wizard.next_step).to eq(:select_option)
         end
       end
+    end
+  end
+
+  describe '#conditions' do
+    let(:standard_conditions) { ['', MakeAnOffer::STANDARD_CONDITIONS.last] }
+    let(:further_condition_3) { 'They must graduate from their current course with an Honors' }
+    let(:further_condition_1) { 'Receiving an A* on their Maths A Level' }
+
+    it 'constructs an array with the offer conditions' do
+      expect(wizard.conditions).to eq([MakeAnOffer::STANDARD_CONDITIONS.last,
+                                       further_condition_1,
+                                       further_condition_3])
     end
   end
 end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -59,14 +59,6 @@ RSpec.describe ProviderInterface::OfferWizard do
           expect(wizard.next_step).to eq(:check)
         end
       end
-
-      context 'when the current step does not exist' do
-        let(:current_step) { :not_existing }
-
-        it 'returns :select_option' do
-          expect(wizard.next_step).to eq(:select_option)
-        end
-      end
     end
   end
 

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+RSpec.describe ProviderInterface::OfferWizard do
+  let(:store) { instance_double(WizardStateStores::RedisStore) }
+
+  let(:wizard) do
+    described_class.new(store,
+                        provider_id: provider_id,
+                        course_id: course_id,
+                        study_mode: study_mode,
+                        location_id: location_id,
+                        conditions: conditions,
+                        current_step: current_step,
+                        current_context: current_context)
+  end
+
+  let(:provider_id) { nil }
+  let(:course_id) { nil }
+  let(:study_mode) { nil }
+  let(:location_id) { nil }
+  let(:conditions) { nil }
+  let(:current_step) { nil }
+  let(:current_context) { nil }
+
+  before { allow(store).to receive(:read) }
+
+  describe '#next_step' do
+    context 'make offer context' do
+      let(:current_context) { :make_offer }
+
+      context 'when current_step is :select_option' do
+        let(:current_step) { :select_option }
+
+        it 'returns :conditions' do
+          expect(wizard.next_step).to eq(:conditions)
+        end
+      end
+
+      context 'when current_step is :conditions' do
+        let(:current_step) { :conditions }
+
+        it 'returns :conditions' do
+          expect(wizard.next_step).to eq(:check)
+        end
+      end
+
+      context 'when the current step does not exist' do
+        let(:current_step) { :not_existing }
+
+        it 'returns :select_option' do
+          expect(wizard.next_step).to eq(:select_option)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/provider_interface/offer_wizard_spec.rb
+++ b/spec/forms/provider_interface/offer_wizard_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe ProviderInterface::OfferWizard do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:decision) }
+    it { is_expected.to validate_length_of(:further_condition_1).is_at_most(255) }
+    it { is_expected.to validate_length_of(:further_condition_2).is_at_most(255) }
+    it { is_expected.to validate_length_of(:further_condition_3).is_at_most(255) }
+    it { is_expected.to validate_length_of(:further_condition_4).is_at_most(255) }
   end
 
   describe '#next_step' do

--- a/spec/requests/provider_interface/decisions_controller_spec.rb
+++ b/spec/requests/provider_interface/decisions_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::DecisionsController, type: :request do
+  include DfESignInHelpers
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in, :with_make_decisions) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  describe 'if application choice is not in a pending decision state' do
+    let!(:application_choice) do
+      create(:application_choice, :withdrawn,
+             application_form: application_form,
+             course_option: course_option)
+    end
+
+    before do
+      user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+    end
+
+    context 'GET new' do
+      it 'responds with 302' do
+        get new_provider_interface_application_choice_decision_path(application_choice)
+
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_add_further_conditions
-    fill_in('make_an_offer[further_conditions0]', with: 'A further condition')
+    fill_in('provider_interface_offer_wizard[further_condition_1]', with: 'A further condition')
   end
 
   def and_i_click_continue

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_send_the_offer
-    click 'Send offer'
+    click_on 'Send offer'
   end
 
   def then_i_see_that_the_offer_was_successfuly_made

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_add_further_conditions
-    fill_in('provider_interface_offer_wizard[further_condition_1]', with: 'A further condition')
+    fill_in('provider_interface_offer_wizard[further_condition_1]', with: 'A* on Maths A Level')
   end
 
   def and_i_click_continue
@@ -99,7 +99,7 @@ RSpec.feature 'Provider makes an offer' do
 
   def and_i_can_confirm_my_answers
     within('.app-offer-panel') do
-      expect(page).to have_content('A further condition')
+      expect(page).to have_content('A* on Maths A Level')
     end
   end
 

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes an offer' do
+  include DfESignInHelpers
+  include ProviderUserPermissionsHelper
+
+  let(:provider_user) { create(:provider_user, :with_dfe_sign_in) }
+  let(:provider) { provider_user.providers.first }
+  let(:application_form) { build(:application_form, :minimum_info) }
+  let!(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision,
+           application_form: application_form,
+           course_option: course_option)
+  end
+  let(:course) { build(:course, :open_on_apply, provider: provider) }
+  let(:course_option) { build(:course_option, course: course) }
+
+  before do
+    FeatureFlag.activate(:updated_offer_flow)
+  end
+
+  scenario 'Making an offer for the requested course option' do
+    given_i_am_a_provider_user
+    and_i_am_permitted_to_make_decisions_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_interface
+    and_i_click_an_application_choice_awaiting_decision
+    and_i_click_on_make_decision
+    then_i_see_the_decision_page
+
+    when_i_choose_to_make_an_offer
+    then_the_conditions_page_is_loaded
+    and_the_default_conditions_are_checked
+
+    when_i_add_further_conditions
+    and_i_click_continue
+    then_the_review_page_is_loaded
+    and_i_can_confirm_my_answers
+
+    when_i_send_the_offer
+    then_i_see_that_the_offer_was_successfuly_made
+  end
+
+  def given_i_am_a_provider_user
+    user_exists_in_dfe_sign_in(email_address: provider_user.email_address)
+  end
+
+  def and_i_am_permitted_to_make_decisions_for_my_provider
+    permit_make_decisions!
+  end
+
+  def and_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def and_i_click_an_application_choice_awaiting_decision
+    click_on application_choice.application_form.full_name
+  end
+
+  def and_i_click_on_make_decision
+    click_on 'Make decision'
+  end
+
+  def then_i_see_the_decision_page
+    expect(page).to have_content('Make a decision')
+    expect(page).to have_content('Course details')
+  end
+
+  def when_i_choose_to_make_an_offer
+    choose 'Make an offer'
+    and_i_click_continue
+  end
+
+  def then_the_conditions_page_is_loaded
+    expect(page).to have_content('Conditions of offer')
+  end
+
+  def and_the_default_conditions_are_checked
+    expect(find("input[value='Fitness to train to teach check']")).to be_checked
+    expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
+  end
+
+  def when_i_add_further_conditions
+    fill_in('make_an_offer[further_conditions0]', with: 'A further condition')
+  end
+
+  def and_i_click_continue
+    click_on t('continue')
+  end
+
+  def then_the_review_page_is_loaded
+    expect(page).to have_content('Check and send offer')
+  end
+
+  def and_i_can_confirm_my_answers
+    within('.app-offer-panel') do
+      expect(page).to have_content('A further condition')
+    end
+  end
+
+  def when_i_send_the_offer
+    click 'Send offer'
+  end
+
+  def then_i_see_that_the_offer_was_successfuly_made
+    within('.govuk-notification_banner--success') do
+      expect(page).to have_content('Offer succesffuly made')
+    end
+  end
+end

--- a/spec/system/provider_interface/make_offer_spec.rb
+++ b/spec/system/provider_interface/make_offer_spec.rb
@@ -108,8 +108,8 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def then_i_see_that_the_offer_was_successfuly_made
-    within('.govuk-notification_banner--success') do
-      expect(page).to have_content('Offer succesffuly made')
+    within('.govuk-notification-banner--success') do
+      expect(page).to have_content('Offer successffuly made')
     end
   end
 end

--- a/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
+++ b/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature 'Provider makes an offer' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
+  before do
+    FeatureFlag.deactivate(:updated_offer_flow)
+  end
+
   scenario 'Provider fails to select a response (offer/reject)' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_application_choices_exist_for_my_provider

--- a/spec/system/provider_interface/provider_makes_an_offer_on_rejected_application_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_on_rejected_application_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature 'Provider makes an offer' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
+  before do
+    FeatureFlag.deactivate(:updated_offer_flow)
+  end
+
   scenario 'Provider makes an offer' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_application_choices_exist_for_my_provider

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature 'Provider makes an offer' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
+  before do
+    FeatureFlag.deactivate(:updated_offer_flow)
+  end
+
   scenario 'Provider makes an offer' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_application_choices_exist_for_my_provider

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature 'Provider makes changes before making an offer' do
   include DfESignInHelpers
   include ProviderUserPermissionsHelper
 
+  before do
+    FeatureFlag.deactivate(:updated_offer_flow)
+  end
+
   scenario 'Provider makes changes to course and location' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_a_provider

--- a/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
+++ b/spec/system/provider_interface/provider_manages_application_interviews_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   before do
     FeatureFlag.activate(:interviews)
+    FeatureFlag.deactivate(:updated_offer_flow)
   end
 
   scenario 'can view, create and cancel interviews' do


### PR DESCRIPTION
## Context

Implement a new offer flow (happy path only), including basic validations for condition length. 

This feature is done when: 
> A provider can make a new offer, enter the conditions required and send the offer to the candidate using the new flow.
> Add new views/controllers and routes, add a feature flag to the main start page for make an offer.

## Guidance to review

Go to support page and enable the updated make offer flow flag. Then log in as a provider and select an application choice that is in either the received or interviewing status and make a decision on it. 

## Link to Trello card

https://trello.com/c/6Ay7XJYu/3458-happy-path-for-create-the-new-make-offer-flow

## Things to check

- [X] This code does not rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
