### PR TITLE
Prevent application choices being added to application forms from previous recruitment cycles

### DIFF
--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -9,7 +9,9 @@ module CandidateInterface
     def show
       set_service_and_course(params[:providerCode], params[:courseCode])
 
-      if @service.can_apply_on_apply? && current_candidate.present?
+      if candidate_has_application_in_different_recruitment_cycle_year?
+        redirect_to candidate_interface_application_form_path
+      elsif @service.can_apply_on_apply? && current_candidate.present?
         current_candidate.update!(course_from_find_id: @course.id)
 
         redirect_to candidate_interface_interstitial_path
@@ -80,6 +82,13 @@ module CandidateInterface
     def apply_on_ucas_or_apply_params
       params.require(:candidate_interface_apply_on_ucas_or_apply_form)
         .permit(:service, :provider_code, :course_code)
+    end
+
+    def candidate_has_application_in_different_recruitment_cycle_year?
+      return false if @course.blank?
+      return false if current_candidate.blank?
+
+      current_candidate.current_application.recruitment_cycle_year != @course.recruitment_cycle_year
     end
   end
 end

--- a/app/services/candidate_interface/end_of_cycle_policy.rb
+++ b/app/services/candidate_interface/end_of_cycle_policy.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class EndOfCyclePolicy
     def self.can_add_course_choice?(application_form)
-      return true if Time.zone.now.to_date >= EndOfCycleTimetable.find_reopens
+      return true if Time.zone.now.to_date >= EndOfCycleTimetable.find_reopens && !application_form.must_be_carried_over?
       return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_1_deadline && application_form.apply_1?
       return true if Time.zone.now.to_date <= EndOfCycleTimetable.apply_2_deadline && application_form.apply_2?
 

--- a/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
+++ b/spec/services/candidate_interface/end_of_cycle_policy_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe CandidateInterface::EndOfCyclePolicy do
         end
       end
     end
+
+    context 'application form is from a previous recruitment cycle' do
+      let(:application_form) { build_stubbed(:application_form, recruitment_cycle_year: 2020) }
+
+      it 'returns false' do
+        Timecop.travel('2021-02-03') do
+          expect(execute_service).to eq false
+        end
+      end
+    end
   end
 
   describe '.can_submit?' do

--- a/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
@@ -38,13 +38,14 @@ RSpec.feature 'Candidate attempts to add course via Find to application from pre
   end
 
   def when_i_visit_the_site_with_a_course_id_from_find
-    @current_candidate.update!(course_from_find_id: @course.id)
-    visit candidate_interface_interstitial_path
+    visit candidate_interface_apply_from_find_path(providerCode: @provider.code, courseCode: @course.code)
   end
 
   def then_i_see_that_my_application_must_be_carried_over
     expect(page).to have_content('Carry on with your application for courses starting in the 2021 to 2022 academic year.')
     expect(page).to have_content('Your courses have been removed. You can add them again now.')
+    # Normally we'd avoid a trip directly to the db in a system spec,
+    # this is here to prove a particular bug has been solved.
     expect(@previous_application_form.application_choices).to be_empty
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_attempts_to_add_course_from_find_to_application_from_previous_cycle_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate attempts to add course via Find to application from previous cycle' do
+  include CandidateHelper
+
+  scenario 'The candidate cannot add course to an application from the previous cycle' do
+    given_i_have_made_an_application_in_the_previous_cycle
+
+    Timecop.travel('2021-03-02') do
+      given_i_am_signed_in
+      and_there_are_course_options
+
+      when_i_visit_the_site_with_a_course_id_from_find
+      then_i_see_that_my_application_must_be_carried_over
+    end
+  end
+
+  def given_i_have_made_an_application_in_the_previous_cycle
+    Timecop.travel('2020-08-15') do
+      @previous_application_form = create(
+        :application_form,
+        :minimum_info,
+        candidate: current_candidate,
+        recruitment_cycle_year: 2020,
+        support_reference: 'AB1234',
+        submitted_at: nil,
+      )
+    end
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_are_course_options
+    given_courses_exist
+    @course = Course.find_by_code('2XT2')
+  end
+
+  def when_i_visit_the_site_with_a_course_id_from_find
+    @current_candidate.update!(course_from_find_id: @course.id)
+    visit candidate_interface_interstitial_path
+  end
+
+  def then_i_see_that_my_application_must_be_carried_over
+    expect(page).to have_content('Carry on with your application for courses starting in the 2021 to 2022 academic year.')
+    expect(page).to have_content('Your courses have been removed. You can add them again now.')
+    expect(@previous_application_form.application_choices).to be_empty
+  end
+end


### PR DESCRIPTION
## Context

This PR attempts to fix a bug where a candidate starts an application in the previous recruitment cycle but does not add a course.
They then attempt to **add a course from Find** in the current recruitment cycle.
Currently this will add the course to the application form from the previous recruitment cycle, then redirect the user to the carry over start page.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Modifies `EndOfCyclePolicy.can_add_course_choice?` to check that if the `current_application` (ie the old `ApplicationForm`) needs to be carried over. This has the effect of short-cutting the journey and preventing the candidate from adding the course to the old application form.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

There's potential that changing `EndOfCyclePolicy` will have side effects.
It's a bit of a bumpy candidate journey as they have selected a course and will be re-routed to choose again for the new application form.
Is there a better way? eg. Should `Candidate#current_application` be smarter?
 
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/psRD7rKb/3212-application-choices-being-added-to-application-forms-from-previous-recruitment-cycles
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
