### PR TITLE
Add custom I18n exception handler in application.rb 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ module ApplyForPostgraduateTeacherTraining
 
     config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
+    config.i18n.exception_handler = Proc.new { |exception| raise exception.to_exception }
     config.action_view.raise_on_missing_translations = true
     config.action_view.form_with_generates_remote_forms = false
 

--- a/config/locales/candidate_interface/other_qualification.yml
+++ b/config/locales/candidate_interface/other_qualification.yml
@@ -15,6 +15,7 @@ en:
         change_action: subject
       institution_country:
         label: Country where you studied
+        change_action: institution country
       country:
         label: Country
         change_action: country

--- a/config/locales/provider_interface/reasons_for_rejection.yml
+++ b/config/locales/provider_interface/reasons_for_rejection.yml
@@ -47,6 +47,7 @@ en:
       no_english_gcse: 'No English GCSE grade 4 (C) or above, or valid equivalent'
       no_science_gcse: 'No Science GCSE grade 4 (C) or above, or valid equivalent (for primary applicants)'
       no_degree: 'No degree'
+      no_phd: 'No PhD'
       other: Other
   activemodel:
     errors:

--- a/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
       result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
 
-      expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_science'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
     end
 
     it 'does not display the guidance around english literature and multiple english qualifications' do
@@ -23,8 +23,8 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
       result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
 
-      expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
-      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
     end
   end
 
@@ -42,8 +42,8 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
       result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
 
-      expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
-      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
     end
 
     context 'and a GCSE' do
@@ -78,7 +78,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
 
         expect(result.text).to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
-        expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
         result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
 
         expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
-        expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
       end
     end
   end
@@ -110,7 +110,7 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
       result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
 
-      expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_science'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.o_level_triple_gcse_science'))
     end
 
     context 'and a Scottish National 5' do
@@ -120,8 +120,8 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
         result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
 
-        expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
-        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
       end
     end
 
@@ -132,8 +132,8 @@ RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
 
         result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
 
-        expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
-        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.main'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_gcses.secondary'))
       end
     end
   end


### PR DESCRIPTION
## Context
We're already raising exceptions for missing locale strings when using
the `t` helper in views. Adding this additional config here will ensure
we also raise exceptions when locale strings for model attributes can't
be resolved.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Add the exception handler in application.rb 
- Fix a few missing locale string errors

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Ok for this to be applied to all environments?
- Do the fixes make sense? 
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/ouZ2DExb
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
