### PR TITLE
Work history error messaging

### DIFF
--- a/app/forms/candidate_interface/restructured_work_history/job_form.rb
+++ b/app/forms/candidate_interface/restructured_work_history/job_form.rb
@@ -21,17 +21,19 @@ module CandidateInterface
       validates :organisation,
                 :role,
                 :commitment,
-                :currently_working,
-                :relevant_skills,
                 presence: true
       validates :role, :organisation, length: { maximum: 60 }
-      validates :start_date_unknown, inclusion: { in: %w[true false] }
-      validates :end_date_unknown, inclusion: { in: %w[true false] }
-      validates :currently_working, inclusion: { in: %w[true false] }
-      validates :relevant_skills, inclusion: { in: %w[true false] }
-
       validates :start_date, date: { future: true, month_and_year: true, presence: true, before: :end_date }
       validates :end_date, date: { future: true, month_and_year: true, presence: true }, if: :not_currently_employed_in_this_role?
+      validates :start_date_unknown, inclusion: { in: %w[true false] }
+      validates :end_date_unknown, inclusion: { in: %w[true false] }
+      # Force the order in which these appear in govuk_error_summary by declaring
+      # separately from presence validations above:
+      validates :currently_working,
+                :relevant_skills,
+                presence: true
+      validates :currently_working, inclusion: { in: %w[true false] }
+      validates :relevant_skills, inclusion: { in: %w[true false] }
 
       def self.build_form(job)
         new(

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -7,7 +7,6 @@ class DateValidator < ActiveModel::EachValidator
     return if value.blank? || (blank?(value) && !options[:presence])
 
     date_validations(record, attribute, value) if !record.errors.keys.include?(attribute)
-
     date_of_birth_validations(record, attribute, value) if options[:date_of_birth] && !record.errors.keys.include?(attribute)
   end
 
@@ -19,11 +18,8 @@ class DateValidator < ActiveModel::EachValidator
 
   def date_validations(record, attribute, value)
     return record.errors.add(attribute, :blank_date, article: article(attribute), attribute: humanize(attribute)) if options[:presence] && blank?(value)
-
     return record.errors.add(attribute, :blank_date_fields, attribute: humanize(attribute), fields: blank_fields(value).to_sentence) if !blank?(value) && blank_fields(value).any?
-
     return record.errors.add(attribute, invalid_date_locale(options), article: article(attribute), attribute: humanize(attribute)) if is_invalid?(value)
-
     return record.errors.add(attribute, :future, article: article(attribute), attribute: humanize(attribute)) if value > Time.zone.today && options[:future]
 
     record.errors.add(attribute, :before, article: article(attribute), attribute: humanize(attribute), compared_attribute: options[:before]) if options[:before] && !before?(record, value, options[:before])

--- a/config/locales/candidate_interface/restructured_work_history.yml
+++ b/config/locales/candidate_interface/restructured_work_history.yml
@@ -55,25 +55,40 @@ en:
             choice:
               blank: Select whether you have any work history
             explanation:
-              blank: Please explain why you’ve been out of the workplace
+              blank: Tell us why you’ve been out of the workplace
+              too_many_words: Why you’ve been out of the workplace must be %{count} words or fewer
         candidate_interface/restructured_work_history/job_form:
           attributes:
             role:
-              blank: Enter your job title
-              too_long: Job title must be %{count} characters or fewer
+              blank: Enter role
+              too_long: Role must be %{count} characters or fewer
             organisation:
-              blank: Enter the name of your employer
+              blank: Enter name of employer
               too_long: Name of the employer must be %{count} characters or fewer
             working_with_children:
               blank: Select if this job involves working in a school or with children
             commitment:
-              blank: Select if this job is full time or part time
+              blank: Select if this job was full time or part time
+            start_date:
+              blank_date: Enter the month and year you started this job
+              before: The month and year you started must be the same as or before the month and year you left
+              future: The month and year you started must not be in the future
+            end_date:
+              blank_date: Enter the month and year you left this job
+              future: The month and year you left must not be in the future
             currently_working:
-              blank: Select if you are still working in this job
+              blank: Select yes if you are still working in this job
             relevant_skills:
-              blank: Select if you use skills relevant to teaching in this job
+              blank: Select yes if you used skills relevant to teaching in this job
         candidate_interface/restructured_work_history/work_history_break_form:
           attributes:
+            start_date:
+              blank_date: Enter the month and year this break started
+              before: The month and year your break started must be the same as or after the month and year your break ended
+              future: The month and year the break started must not be in the future
+            end_date:
+              blank_date: Enter the month and year this break ended
+              future: The month and year the break ended must not be in the future
             reason:
-              blank: Enter reasons for break in work history
+              blank: Enter the reasons for break in work history
               too_many_words: Reasons for break in work history must be %{count} words or fewer


### PR DESCRIPTION
## Context
Replacement for https://github.com/DFE-Digital/apply-for-teacher-training/pull/4197, accounting for recent changes to how date validations are tested.

From the Trello card:

> The error messages in the work history need to be updated to match the new design.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
- Most of the changes described by the Google doc linked in the ticket, [with the exception of](https://docs.google.com/document/d/1zTENV4UewP5jJeRl_jWhto4NEaHWviYyMvetfsR5KQc/edit?disco=AAAAH7fnRS8) the most granular changes that relate solely to the month or solely to the year field.



<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
- Running locally or in the review app, ensure restructured work history feature flag is active, and the current application has feature_restructured_work_history set to true. Easiest way to ensure the latter is to sign up as a new user (rather than log in as an existing one).

- Go through the Add Job and Explain Break flows, testing the scenarios outlined in the doc (except the ones where a month-only or year-only error is expected).
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/pArii32e
<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
