### PR TITLE
Remove duplicate references from the referee survey export and cleanse data

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -8,6 +8,7 @@ class ApplicationReference < ApplicationRecord
 
   belongs_to :application_form, touch: true
   has_many :reference_tokens, dependent: :destroy
+  has_one :candidate, through: :application_form
 
   audited associated_with: :application_form
 

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -15,6 +15,7 @@ class Candidate < ApplicationRecord
   has_one :ucas_match
   has_many :application_forms
   has_many :application_choices, through: :application_forms
+  has_many :application_references, through: :application_forms
   belongs_to :course_from_find, class_name: 'Course', optional: true
 
   def self.for_email(email)

--- a/app/models/reference_feature_metrics.rb
+++ b/app/models/reference_feature_metrics.rb
@@ -37,7 +37,7 @@ private
   def time_to_get_references(start_time, end_time = Time.zone.now)
     applications = ApplicationForm
       .joins(:application_references)
-      .where('"references".feedback_provided_at BETWEEN ? AND ?', start_time, end_time)
+      .where('"references".feedback_provided_at BETWEEN ? AND ? AND "references".duplicate = ?', start_time, end_time, false)
       .group('application_forms.id')
     applications.map { |application| time_to_get_for(application, end_time) }.compact
   end

--- a/app/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at.rb
+++ b/app/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at.rb
@@ -1,0 +1,22 @@
+module CandidateInterface
+  class BackfillDuplicateBooleanAndPopulateFeedbackProvidedAt
+    def self.call
+      references = ApplicationReference
+                    .joins(:application_form)
+                    .where('phase = ? AND feedback_status = ? AND feedback_provided_at is NULL', 'apply_2', 'feedback_provided')
+      references.each do |reference|
+        duplicate_references = ApplicationReference.feedback_provided.where(
+          email_address: reference.email_address,
+          name: reference.name,
+          feedback: reference.feedback,
+        )
+
+        latest_feedback_provided_at = duplicate_references.map(&:feedback_provided_at).compact.min
+        reference.update!(feedback_provided_at: latest_feedback_provided_at)
+      end
+
+      duplicate_references = ApplicationReference.where('feedback_provided_at < "references".created_at')
+      duplicate_references.each { |reference| reference.update!(duplicate: true) }
+    end
+  end
+end

--- a/app/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at.rb
+++ b/app/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at.rb
@@ -4,19 +4,18 @@ module CandidateInterface
       references = ApplicationReference
                     .joins(:application_form)
                     .where('phase = ? AND feedback_status = ? AND feedback_provided_at is NULL', 'apply_2', 'feedback_provided')
-      references.each do |reference|
-        duplicate_references = ApplicationReference.feedback_provided.where(
-          email_address: reference.email_address,
-          name: reference.name,
-          feedback: reference.feedback,
-        )
+      references.find_each do |reference|
+        duplicate_references = ApplicationReference
+        .feedback_provided
+        .joins(:application_form)
+        .where('email_address = ? AND name = ? AND feedback = ? AND application_forms.candidate_id = ?', reference.email_address, reference.name, reference.feedback, reference.candidate.id)
 
         latest_feedback_provided_at = duplicate_references.map(&:feedback_provided_at).compact.min
         reference.update!(feedback_provided_at: latest_feedback_provided_at)
       end
 
       duplicate_references = ApplicationReference.where('feedback_provided_at < "references".created_at')
-      duplicate_references.each { |reference| reference.update!(duplicate: true) }
+      duplicate_references.find_each { |reference| reference.update!(duplicate: true) }
     end
   end
 end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -41,7 +41,7 @@ class DuplicateApplication
 
     original_application_form.application_references.where(feedback_status: %w[feedback_provided not_requested_yet cancelled_at_end_of_cycle]).reject(&:feedback_overdue?).each do |w|
       new_application_form.application_references.create!(
-        w.attributes.except(*IGNORED_CHILD_ATTRIBUTES),
+        w.attributes.except(*IGNORED_CHILD_ATTRIBUTES).merge!(duplicate: true),
       )
 
       references_cancelled_at_eoc = new_application_form.application_references.select(&:cancelled_at_end_of_cycle?)

--- a/app/services/support_interface/referee_survey_export.rb
+++ b/app/services/support_interface/referee_survey_export.rb
@@ -1,8 +1,8 @@
 module SupportInterface
   class RefereeSurveyExport
     def call
-      references = ApplicationReference.includes(:application_form).where.not(questionnaire: nil)
-      references_with_feedback = references.reject do |reference|
+      non_duplicate_references = ApplicationReference.includes(:application_form).where.not(questionnaire: nil, duplicate: true)
+      references_with_feedback = non_duplicate_references.reject do |reference|
         reference.questionnaire.values.all? { |response| response == ' | ' }
       end
 
@@ -10,7 +10,7 @@ module SupportInterface
       references_with_feedback.each do |reference|
         hash = {
           'Name' => reference.name,
-          'Reference provided at' => reference.feedback_provided_at&.iso8601,
+          'Reference provided at' => reference.feedback_provided_at&.strftime('%d/%m/%y'),
           'Recruitment cycle year' => reference.application_form.recruitment_cycle_year,
           'Email_address' => reference.email_address,
           'Guidance rating' => extract_rating(reference, RefereeQuestionnaire::GUIDANCE_QUESTION),

--- a/db/migrate/20210304112335_cleanse_feedback_provided_at_data.rb
+++ b/db/migrate/20210304112335_cleanse_feedback_provided_at_data.rb
@@ -1,0 +1,9 @@
+class CleanseFeedbackProvidedAtData < ActiveRecord::Migration[6.0]
+  def up
+    CandidateInterface::BackfillDuplicateBooleanAndPopulateFeedbackProvidedAt.call
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -823,6 +823,7 @@ FactoryBot.define do
     relationship { Faker::Lorem.paragraph(sentence_count: 3) }
     referee_type { %i[academic professional school_based character].sample }
     questionnaire { nil }
+    duplicate { false }
 
     trait :not_requested_yet do
       feedback_status { 'not_requested_yet' }

--- a/spec/models/reference_feature_metrics_spec.rb
+++ b/spec/models/reference_feature_metrics_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe ReferenceFeatureMetrics, with_audited: true do
       Timecop.freeze(@today + 1.day) do
         SubmitReference.new(reference: @references3.first, send_emails: false).save!
       end
+
+      create(:application_choice, :with_rejection, application_form: @application_form1)
+
+      ApplyAgain.new(@application_form1).call
     end
 
     describe '#average_time_to_get_references' do

--- a/spec/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at_spec.rb
+++ b/spec/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::BackfillDuplicateBooleanAndPopulateFeedbackProvidedAt do
+  describe '#call' do
+    around do |example|
+      Timecop.freeze(Time.zone.local(2020, 6, 2, 12, 10, 0)) do
+        example.run
+      end
+    end
+
+    it 'sets duplicated references to true and updates to the latest feedback_provided_at' do
+      feedback_provided_at = Time.zone.local(2020, 6, 1, 11, 10, 0)
+      apply_1_application_form = create(:application_form, phase: :apply_1)
+      apply_again_application_form = create(:application_form, phase: :apply_2)
+      reference = create(
+        :reference,
+        :feedback_provided,
+        feedback_provided_at: feedback_provided_at,
+        application_form: apply_1_application_form,
+        created_at: 1.year.ago,
+      )
+      duplicate_reference = create(
+        :reference,
+        :feedback_provided,
+        feedback_provided_at: nil,
+        name: reference.name,
+        email_address: reference.email_address,
+        feedback: reference.feedback,
+        application_form: apply_again_application_form,
+      )
+
+      described_class.call
+
+      expect(reference.reload.feedback_provided_at).to eq feedback_provided_at
+      expect(duplicate_reference.reload.feedback_provided_at).to eq feedback_provided_at
+      expect(duplicate_reference.reload.duplicate).to eq true
+    end
+  end
+end

--- a/spec/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at_spec.rb
+++ b/spec/services/candidate_interface/backfill_duplicate_boolean_and_populate_feedback_provided_at_spec.rb
@@ -8,15 +8,16 @@ RSpec.describe CandidateInterface::BackfillDuplicateBooleanAndPopulateFeedbackPr
       end
     end
 
-    it 'sets duplicated references to true and updates to the latest feedback_provided_at' do
+    it 'sets duplicated references to true and updates to the earliest feedback_provided_at' do
       feedback_provided_at = Time.zone.local(2020, 6, 1, 11, 10, 0)
-      apply_1_application_form = create(:application_form, phase: :apply_1)
-      apply_again_application_form = create(:application_form, phase: :apply_2)
+      apply_1_application_form1 = create(:application_form, phase: :apply_1)
+      apply1_application_form2 = create(:application_form, phase: :apply_1)
+      apply_again_application_form = create(:application_form, phase: :apply_2, candidate: apply_1_application_form1.candidate)
       reference = create(
         :reference,
         :feedback_provided,
         feedback_provided_at: feedback_provided_at,
-        application_form: apply_1_application_form,
+        application_form: apply_1_application_form1,
         created_at: 1.year.ago,
       )
       duplicate_reference = create(
@@ -29,11 +30,24 @@ RSpec.describe CandidateInterface::BackfillDuplicateBooleanAndPopulateFeedbackPr
         application_form: apply_again_application_form,
       )
 
+      duplicate_reference_with_different_candidate = create(
+        :reference,
+        :feedback_provided,
+        feedback_provided_at: feedback_provided_at - 1.day,
+        application_form: apply1_application_form2,
+        name: reference.name,
+        email_address: reference.email_address,
+        feedback: reference.feedback,
+        created_at: 1.year.ago,
+      )
+
       described_class.call
 
       expect(reference.reload.feedback_provided_at).to eq feedback_provided_at
       expect(duplicate_reference.reload.feedback_provided_at).to eq feedback_provided_at
       expect(duplicate_reference.reload.duplicate).to eq true
+      expect(duplicate_reference_with_different_candidate.feedback_provided_at).to eq feedback_provided_at - 1.day
+      expect(duplicate_reference_with_different_candidate.reload.duplicate).to eq false
     end
   end
 end

--- a/spec/services/duplicate_application_shared_examples.rb
+++ b/spec/services/duplicate_application_shared_examples.rb
@@ -35,9 +35,11 @@ RSpec.shared_examples 'duplicates application form' do |expected_phase, expected
     expect(duplicate_application_form.recruitment_cycle_year).to eq expected_cycle
   end
 
-  it 'copies application references' do
+  it 'copies application references and marks them as duplicates' do
     expect(duplicate_application_form.application_references.count).to eq 2
     expect(duplicate_application_form.application_references).to all(be_feedback_provided.or(be_not_requested_yet))
+    expect(duplicate_application_form.application_references.first.duplicate).to eq true
+    expect(duplicate_application_form.application_references.second.duplicate).to eq true
   end
 
   it 'copies work and volunteering experiences' do

--- a/spec/services/support_interface/referee_survey_export_spec.rb
+++ b/spec/services/support_interface/referee_survey_export_spec.rb
@@ -29,15 +29,16 @@ RSpec.describe SupportInterface::RefereeSurveyExport do
       }
     end
 
-    it 'returns a hash of referees responses' do
+    it 'returns a hash of non-duplicate referees responses' do
       create(:reference, name: 'A', email_address: 'a@example.com', questionnaire: questionnaire1, feedback_provided_at: '2021-01-01 15:00:00', application_form: create(:application_form, recruitment_cycle_year: 2021))
-      create(:reference, name: 'B', email_address: 'b@example.com', questionnaire: questionnaire2, application_form: create(:application_form, recruitment_cycle_year: 2021))
+      create(:reference, name: 'B', email_address: 'b@example.com', questionnaire: questionnaire2, feedback_provided_at: '2021-02-01 15:00:00', application_form: create(:application_form, recruitment_cycle_year: 2021))
       create(:reference, questionnaire: questionnaire3, application_form: create(:application_form, recruitment_cycle_year: 2021))
+      create(:reference, name: 'A', email_address: 'a@example.com', questionnaire: questionnaire1, duplicate: true, application_form: create(:application_form, recruitment_cycle_year: 2021))
 
       expect(described_class.new.call).to match_array([
         {
           'Name' => 'A',
-          'Reference provided at' => '2021-01-01T15:00:00+00:00',
+          'Reference provided at' => '01/01/21',
           'Recruitment cycle year' => 2021,
           'Email_address' => 'a@example.com',
           'Guidance rating' => 'very_poor',
@@ -49,7 +50,7 @@ RSpec.describe SupportInterface::RefereeSurveyExport do
         },
         {
           'Name' => 'B',
-          'Reference provided at' => nil,
+          'Reference provided at' => '01/02/21',
           'Recruitment cycle year' => 2021,
           'Email_address' => 'b@example.com',
           'Guidance rating' => 'good',


### PR DESCRIPTION
## Context

When we duplicate an application form for apply again or at the end of the cycle, we also duplicate the references. This means that we have quite a few duplicate references in this export.

Additionally, we've currently got invalid data in our system as when I backfilled the `feedback_provided_at` as carried over applications did not have the required audits to populate the values.

## Changes proposed in this pull request

This PR does two things. 
- Marks carried over references as duplicates
- Populates missing feedback_provided_at values

## Guidance to review

Per commit is probably the easiest.

## Link to Trello card

https://trello.com/c/CL1ZO70r/3124-investigate-why-there-are-missing-dates-in-referee-survey-extract

## Things to check

- [x] This code does not rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/docs/environment-variables.md#azure-hosting-devops-pipeline)
